### PR TITLE
feat: implement CopyTreeService for context generation

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -29,6 +29,7 @@ export const CHANNELS = {
   // CopyTree channels
   COPYTREE_GENERATE: 'copytree:generate',
   COPYTREE_INJECT: 'copytree:inject',
+  COPYTREE_AVAILABLE: 'copytree:available',
 
   // System channels
   SYSTEM_OPEN_EXTERNAL: 'system:open-external',

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -16,9 +16,11 @@ import type {
   DevServerTogglePayload,
   CopyTreeGeneratePayload,
   CopyTreeInjectPayload,
+  CopyTreeResult,
   SystemOpenExternalPayload,
   SystemOpenPathPayload,
 } from './types.js'
+import { copyTreeService } from '../services/CopyTreeService.js'
 
 /**
  * Initialize all IPC handlers
@@ -123,20 +125,37 @@ export function registerIpcHandlers(
   // CopyTree Handlers
   // ==========================================
 
-  const handleCopyTreeGenerate = async (_event: Electron.IpcMainInvokeEvent, payload: CopyTreeGeneratePayload): Promise<string> => {
-    // TODO: Implement when CopyTree integration is migrated
-    console.log('CopyTree generate requested:', payload)
-    return ''
+  const handleCopyTreeGenerate = async (_event: Electron.IpcMainInvokeEvent, _payload: CopyTreeGeneratePayload): Promise<CopyTreeResult> => {
+    // TODO: When WorktreeService is implemented, look up rootPath from worktreeId
+    // For now, return an error indicating the service is not yet fully integrated
+    return {
+      content: '',
+      fileCount: 0,
+      error: 'CopyTree generation requires WorktreeService integration (not yet implemented)',
+    }
+
+    // Future implementation will be:
+    // const worktree = await worktreeService.getWorktree(payload.worktreeId)
+    // if (!worktree) {
+    //   return { content: '', fileCount: 0, error: 'Worktree not found' }
+    // }
+    // return copyTreeService.generate(worktree.path, payload.options)
   }
   ipcMain.handle(CHANNELS.COPYTREE_GENERATE, handleCopyTreeGenerate)
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GENERATE))
 
   const handleCopyTreeInject = async (_event: Electron.IpcMainInvokeEvent, payload: CopyTreeInjectPayload) => {
-    // TODO: Implement when CopyTree integration is migrated
+    // TODO: Implement when terminal multiplexing and CopyTree integration is complete
     console.log('CopyTree inject requested:', payload)
   }
   ipcMain.handle(CHANNELS.COPYTREE_INJECT, handleCopyTreeInject)
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_INJECT))
+
+  const handleCopyTreeAvailable = async (): Promise<boolean> => {
+    return copyTreeService.isAvailable()
+  }
+  ipcMain.handle(CHANNELS.COPYTREE_AVAILABLE, handleCopyTreeAvailable)
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_AVAILABLE))
 
   // ==========================================
   // System Handlers

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -68,9 +68,8 @@ export interface DevServerErrorPayload {
   error: string
 }
 
-// CopyTree types (placeholders - will be fully defined when services are migrated)
+// CopyTree types
 export interface CopyTreeOptions {
-  rootPath?: string
   profile?: string
   extraArgs?: string[]
   files?: string[]
@@ -79,6 +78,12 @@ export interface CopyTreeOptions {
 export interface CopyTreeGeneratePayload {
   worktreeId: string
   options?: CopyTreeOptions
+}
+
+export interface CopyTreeResult {
+  content: string
+  fileCount: number
+  error?: string
 }
 
 export interface CopyTreeInjectPayload {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -17,6 +17,7 @@ import type {
   DevServerState,
   TerminalSpawnOptions,
   CopyTreeOptions,
+  CopyTreeResult,
   CanopyConfig,
 } from './ipc/types.js'
 
@@ -42,8 +43,9 @@ export interface ElectronAPI {
     onData(id: string, callback: (data: string) => void): () => void
   }
   copyTree: {
-    generate(worktreeId: string, options?: CopyTreeOptions): Promise<string>
+    generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>
     injectToTerminal(terminalId: string, worktreeId: string): Promise<void>
+    isAvailable(): Promise<boolean>
   }
   system: {
     openExternal(url: string): Promise<void>
@@ -137,6 +139,9 @@ const api: ElectronAPI = {
 
     injectToTerminal: (terminalId: string, worktreeId: string) =>
       ipcRenderer.invoke(CHANNELS.COPYTREE_INJECT, { terminalId, worktreeId }),
+
+    isAvailable: () =>
+      ipcRenderer.invoke(CHANNELS.COPYTREE_AVAILABLE),
   },
 
   // ==========================================

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -1,0 +1,134 @@
+/**
+ * CopyTree Service
+ *
+ * Interfaces with the external CopyTree CLI tool to generate context for AI agents.
+ * CopyTree generates a text representation of a codebase suitable for injection
+ * into AI chat interfaces.
+ */
+
+import { execa } from 'execa';
+import stripAnsi from 'strip-ansi';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { CopyTreeOptions, CopyTreeResult } from '../ipc/types.js';
+
+// Re-export types for convenience
+export type { CopyTreeOptions, CopyTreeResult };
+
+class CopyTreeService {
+  /**
+   * Generate context for a worktree
+   *
+   * @param rootPath - Absolute path to the worktree root
+   * @param options - CopyTree options (profile, extraArgs, files)
+   * @returns CopyTreeResult with content, file count, and optional error
+   */
+  async generate(rootPath: string, options: CopyTreeOptions = {}): Promise<CopyTreeResult> {
+    // Validate rootPath before calling copytree
+    if (!path.isAbsolute(rootPath)) {
+      return {
+        content: '',
+        fileCount: 0,
+        error: 'rootPath must be an absolute path',
+      };
+    }
+
+    try {
+      await fs.access(rootPath);
+    } catch {
+      return {
+        content: '',
+        fileCount: 0,
+        error: `Path does not exist or is not accessible: ${rootPath}`,
+      };
+    }
+
+    const args = ['-r'];
+
+    if (options.profile) {
+      args.push('-p', options.profile);
+    }
+
+    if (options.extraArgs) {
+      args.push(...options.extraArgs);
+    }
+
+    if (options.files?.length) {
+      args.push(...options.files);
+    }
+
+    try {
+      const { stdout, stderr } = await execa('copytree', args, {
+        cwd: rootPath,
+        timeout: 60000, // 60s timeout for large repos
+      });
+
+      // Strip ANSI codes for clean display
+      const cleanContent = stripAnsi(stdout);
+
+      // Parse file count from output (if available)
+      // CopyTree typically outputs something like "Processed 42 files"
+      const fileCountMatch = cleanContent.match(/(\d+)\s+files?/i);
+      const fileCount = fileCountMatch ? parseInt(fileCountMatch[1], 10) : 0;
+
+      // Log stderr if present (warnings, debug info)
+      if (stderr) {
+        console.warn('[CopyTree] stderr:', stderr);
+      }
+
+      return {
+        content: cleanContent,
+        fileCount,
+      };
+    } catch (error) {
+      // Handle various error scenarios
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+      // Check if copytree CLI is not installed
+      // Use execa-specific error properties to distinguish CLI missing from path issues
+      if (
+        (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') ||
+        errorMessage.includes('command not found')
+      ) {
+        return {
+          content: '',
+          fileCount: 0,
+          error: 'CopyTree CLI not found in PATH. Please install copytree to use this feature.',
+        };
+      }
+
+      // Timeout error - use execa's timedOut property
+      if (error && typeof error === 'object' && 'timedOut' in error && error.timedOut === true) {
+        return {
+          content: '',
+          fileCount: 0,
+          error: 'CopyTree operation timed out. The repository may be too large or the operation is taking too long.',
+        };
+      }
+
+      // Generic error
+      return {
+        content: '',
+        fileCount: 0,
+        error: `CopyTree error: ${errorMessage}`,
+      };
+    }
+  }
+
+  /**
+   * Check if copytree CLI is available
+   *
+   * @returns True if copytree command is available in PATH
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      await execa('copytree', ['--version'], { timeout: 5000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/** Singleton instance of CopyTreeService */
+export const copyTreeService = new CopyTreeService();

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "execa": "^9.6.0",
     "lucide-react": "^0.555.0",
     "node-pty": "^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "simple-git": "^3.30.0",
+    "strip-ansi": "^7.1.2",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -10,6 +10,7 @@ type WorktreeState = import('../../electron/ipc/types.js').WorktreeState
 type DevServerState = import('../../electron/ipc/types.js').DevServerState
 type TerminalSpawnOptions = import('../../electron/ipc/types.js').TerminalSpawnOptions
 type CopyTreeOptions = import('../../electron/ipc/types.js').CopyTreeOptions
+type CopyTreeResult = import('../../electron/ipc/types.js').CopyTreeResult
 type CanopyConfig = import('../../electron/ipc/types.js').CanopyConfig
 
 export interface ElectronAPI {
@@ -34,8 +35,9 @@ export interface ElectronAPI {
     onData(id: string, callback: (data: string) => void): () => void
   }
   copyTree: {
-    generate(worktreeId: string, options?: CopyTreeOptions): Promise<string>
+    generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>
     injectToTerminal(terminalId: string, worktreeId: string): Promise<void>
+    isAvailable(): Promise<boolean>
   }
   system: {
     openExternal(url: string): Promise<void>


### PR DESCRIPTION
## Summary

Implements a new CopyTreeService to interface with the external CopyTree CLI tool for generating codebase context suitable for AI agent injection.

Closes #8

## Changes Made

- Add CopyTreeService with copytree CLI integration
- Implement path validation and robust error handling
- Add timeout detection using execa properties
- Register IPC handlers for copytree:generate and copytree:available
- Add CopyTreeResult type and update preload bridge
- Install execa and strip-ansi dependencies
- Add isAvailable() method to check CLI presence

## Technical Details

The service provides:
- `generate(rootPath, options)`: Generates context from a directory
- `isAvailable()`: Checks if copytree CLI is installed
- Proper error handling for missing CLI, invalid paths, and timeouts
- ANSI code stripping for clean output
- File count parsing from copytree output

The IPC integration includes:
- `copytree:generate` channel for context generation
- `copytree:available` channel for CLI availability check
- Full type safety across main/renderer boundary

## Future Work

When WorktreeService is implemented, the handler will be updated to look up worktree paths from worktreeId instead of requiring explicit paths.