### PR TITLE
Create useDevServer hook for dev server control

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -18,6 +18,7 @@ export const CHANNELS = {
   DEVSERVER_TOGGLE: 'devserver:toggle',
   DEVSERVER_GET_STATE: 'devserver:get-state',
   DEVSERVER_GET_LOGS: 'devserver:get-logs',
+  DEVSERVER_HAS_DEV_SCRIPT: 'devserver:has-dev-script',
   DEVSERVER_UPDATE: 'devserver:update',
   DEVSERVER_ERROR: 'devserver:error',
 

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -135,6 +135,15 @@ export function registerIpcHandlers(
   ipcMain.handle(CHANNELS.DEVSERVER_GET_LOGS, handleDevServerGetLogs)
   handlers.push(() => ipcMain.removeHandler(CHANNELS.DEVSERVER_GET_LOGS))
 
+  const handleDevServerHasDevScript = async (_event: Electron.IpcMainInvokeEvent, worktreePath: string) => {
+    if (!devServerManager) {
+      throw new Error('DevServerManager not initialized')
+    }
+    return devServerManager.hasDevScriptAsync(worktreePath)
+  }
+  ipcMain.handle(CHANNELS.DEVSERVER_HAS_DEV_SCRIPT, handleDevServerHasDevScript)
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEVSERVER_HAS_DEV_SCRIPT))
+
   // ==========================================
   // Terminal Handlers
   // ==========================================

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -34,6 +34,7 @@ export interface ElectronAPI {
     toggle(worktreeId: string, worktreePath: string, command?: string): Promise<DevServerState>
     getState(worktreeId: string): Promise<DevServerState>
     getLogs(worktreeId: string): Promise<string[]>
+    hasDevScript(worktreePath: string): Promise<boolean>
     onUpdate(callback: (state: DevServerState) => void): () => void
     onError(callback: (data: { worktreeId: string; error: string }) => void): () => void
   }
@@ -96,6 +97,9 @@ const api: ElectronAPI = {
 
     getLogs: (worktreeId: string) =>
       ipcRenderer.invoke(CHANNELS.DEVSERVER_GET_LOGS, worktreeId),
+
+    hasDevScript: (worktreePath: string) =>
+      ipcRenderer.invoke(CHANNELS.DEVSERVER_HAS_DEV_SCRIPT, worktreePath),
 
     onUpdate: (callback: (state: DevServerState) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, state: DevServerState) => callback(state)

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -1,0 +1,229 @@
+/**
+ * useDevServer Hook
+ *
+ * Provides dev server control for a specific worktree via IPC.
+ * Manages state, start/stop/toggle actions, and dev script detection.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import type { DevServerState } from '../../electron/ipc/types.js'
+
+interface UseDevServerOptions {
+  worktreeId: string
+  worktreePath?: string
+}
+
+interface UseDevServerReturn {
+  /** Current dev server state for this worktree */
+  state: DevServerState | null
+  /** Whether the worktree has a detectable dev script */
+  hasDevScript: boolean
+  /** Start the dev server (optionally with custom command) */
+  start: (command?: string) => Promise<void>
+  /** Stop the dev server */
+  stop: () => Promise<void>
+  /** Toggle the dev server state */
+  toggle: () => Promise<void>
+  /** Whether an action is currently in progress */
+  isLoading: boolean
+  /** Any error that occurred during the last action */
+  error: string | null
+}
+
+/**
+ * Hook for controlling a dev server for a specific worktree
+ *
+ * @example
+ * ```tsx
+ * const { state, hasDevScript, toggle, isLoading } = useDevServer({
+ *   worktreeId: worktree.id,
+ *   worktreePath: worktree.path,
+ * })
+ *
+ * if (!hasDevScript) return null
+ *
+ * return (
+ *   <button onClick={toggle} disabled={isLoading}>
+ *     {state?.status === 'running' ? 'Stop' : 'Start'}
+ *   </button>
+ * )
+ * ```
+ */
+export function useDevServer({ worktreeId, worktreePath }: UseDevServerOptions): UseDevServerReturn {
+  const [state, setState] = useState<DevServerState | null>(null)
+  const [hasDevScript, setHasDevScript] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Check for dev script availability on mount or when path changes
+  useEffect(() => {
+    if (!worktreePath) {
+      setHasDevScript(false)
+      return
+    }
+
+    let cancelled = false
+
+    window.electron.devServer.hasDevScript(worktreePath)
+      .then(result => {
+        if (!cancelled) {
+          setHasDevScript(result)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setHasDevScript(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [worktreePath])
+
+  // Get initial state on mount or when worktreeId changes
+  useEffect(() => {
+    let cancelled = false
+
+    window.electron.devServer.getState(worktreeId)
+      .then(state => {
+        if (!cancelled) {
+          setState(state)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [worktreeId])
+
+  // Subscribe to state updates for this worktree
+  useEffect(() => {
+    const unsubUpdate = window.electron.devServer.onUpdate((newState) => {
+      if (newState.worktreeId === worktreeId) {
+        setState(newState)
+        // Clear loading state when update arrives
+        setIsLoading(false)
+      }
+    })
+
+    const unsubError = window.electron.devServer.onError((data) => {
+      if (data.worktreeId === worktreeId) {
+        setError(data.error)
+        setIsLoading(false)
+      }
+    })
+
+    return () => {
+      unsubUpdate()
+      unsubError()
+    }
+  }, [worktreeId])
+
+  const start = useCallback(async (command?: string) => {
+    if (!worktreePath) {
+      setError('Worktree path is required to start dev server')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const newState = await window.electron.devServer.start(worktreeId, worktreePath, command)
+      setState(newState)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start dev server'
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [worktreeId, worktreePath])
+
+  const stop = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const newState = await window.electron.devServer.stop(worktreeId)
+      setState(newState)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to stop dev server'
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [worktreeId])
+
+  const toggle = useCallback(async () => {
+    if (!worktreePath) {
+      setError('Worktree path is required to toggle dev server')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const newState = await window.electron.devServer.toggle(worktreeId, worktreePath)
+      setState(newState)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to toggle dev server'
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [worktreeId, worktreePath])
+
+  return {
+    state,
+    hasDevScript,
+    start,
+    stop,
+    toggle,
+    isLoading,
+    error,
+  }
+}
+
+/**
+ * Hook for managing all dev server states globally
+ *
+ * Use this when you need to track dev servers across multiple worktrees,
+ * such as in a dashboard view.
+ *
+ * @example
+ * ```tsx
+ * const devServerStates = useDevServerStates()
+ *
+ * return (
+ *   <ul>
+ *     {Array.from(devServerStates.entries()).map(([id, state]) => (
+ *       <li key={id}>{state.status}: {state.url}</li>
+ *     ))}
+ *   </ul>
+ * )
+ * ```
+ */
+export function useDevServerStates(): Map<string, DevServerState> {
+  const [states, setStates] = useState<Map<string, DevServerState>>(new Map())
+
+  useEffect(() => {
+    const unsub = window.electron.devServer.onUpdate((state) => {
+      setStates(prev => {
+        const next = new Map(prev)
+        next.set(state.worktreeId, state)
+        return next
+      })
+    })
+
+    return unsub
+  }, [])
+
+  return states
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -21,9 +21,12 @@ export interface ElectronAPI {
     onRemove(callback: (data: { worktreeId: string }) => void): () => void
   }
   devServer: {
-    start(worktreeId: string, command?: string): Promise<void>
-    stop(worktreeId: string): Promise<void>
-    toggle(worktreeId: string): Promise<void>
+    start(worktreeId: string, worktreePath: string, command?: string): Promise<DevServerState>
+    stop(worktreeId: string): Promise<DevServerState>
+    toggle(worktreeId: string, worktreePath: string, command?: string): Promise<DevServerState>
+    getState(worktreeId: string): Promise<DevServerState>
+    getLogs(worktreeId: string): Promise<string[]>
+    hasDevScript(worktreePath: string): Promise<boolean>
     onUpdate(callback: (state: DevServerState) => void): () => void
     onError(callback: (data: { worktreeId: string; error: string }) => void): () => void
   }


### PR DESCRIPTION
## Summary

Implements a React hook that connects the renderer UI to the DevServerManager in the main process via IPC, enabling dev server control for individual worktrees.

Closes #14

## Changes Made

- Created `useDevServer` hook with IPC-based state management for per-worktree dev server control
- Added `hasDevScript` detection with proper async cancellation guards to prevent race conditions
- Implemented start/stop/toggle actions with loading states and error handling
- Created `useDevServerStates` hook for tracking all dev servers globally
- Updated TypeScript declarations (`electron.d.ts`) to match the actual preload API
- Added `DEVSERVER_HAS_DEV_SCRIPT` IPC channel and handler in the main process
- Fixed async effect race conditions by adding cancellation flags to prevent stale state updates

## Technical Details

The hook provides:
- Dev script availability detection per worktree
- Real-time state synchronization via IPC events
- Graceful error handling with user-facing error states
- Proper cleanup of event listeners and async operations
- Race condition prevention for rapid worktree switching