### PR TITLE
Create App Layout skeleton with sidebar and terminal grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,22 @@ import { useEffect, useRef } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
-import { useElectron } from './hooks/useElectron'
+import { useElectron, isElectronAvailable } from './hooks/useElectron'
+import { AppLayout } from './components/Layout'
 
 const DEFAULT_TERMINAL_ID = 'default'
 
-function App() {
+function TerminalPane() {
+  if (!isElectronAvailable()) {
+    return (
+      <div className="h-full w-full flex items-center justify-center">
+        <div className="text-canopy-text/60 text-sm">
+          Terminal unavailable - Electron API not loaded
+        </div>
+      </div>
+    )
+  }
+
   const electron = useElectron()
   const terminalRef = useRef<HTMLDivElement>(null)
   const xtermRef = useRef<Terminal | null>(null)
@@ -21,27 +32,27 @@ function App() {
       fontSize: 14,
       fontFamily: 'JetBrains Mono, Menlo, Monaco, Consolas, monospace',
       theme: {
-        background: '#09090b',
-        foreground: '#fafafa',
-        cursor: '#fafafa',
-        cursorAccent: '#09090b',
-        selectionBackground: '#27272a',
-        black: '#09090b',
-        red: '#ef4444',
-        green: '#22c55e',
-        yellow: '#eab308',
-        blue: '#3b82f6',
-        magenta: '#a855f7',
-        cyan: '#06b6d4',
-        white: '#fafafa',
-        brightBlack: '#71717a',
-        brightRed: '#f87171',
-        brightGreen: '#4ade80',
-        brightYellow: '#facc15',
-        brightBlue: '#60a5fa',
-        brightMagenta: '#c084fc',
-        brightCyan: '#22d3ee',
-        brightWhite: '#ffffff',
+        background: '#1a1b26',
+        foreground: '#c0caf5',
+        cursor: '#c0caf5',
+        cursorAccent: '#1a1b26',
+        selectionBackground: '#2d2f3a',
+        black: '#1a1b26',
+        red: '#f7768e',
+        green: '#9ece6a',
+        yellow: '#e0af68',
+        blue: '#7aa2f7',
+        magenta: '#bb9af7',
+        cyan: '#7dcfff',
+        white: '#c0caf5',
+        brightBlack: '#414868',
+        brightRed: '#f7768e',
+        brightGreen: '#9ece6a',
+        brightYellow: '#e0af68',
+        brightBlue: '#7aa2f7',
+        brightMagenta: '#bb9af7',
+        brightCyan: '#7dcfff',
+        brightWhite: '#c0caf5',
       },
     })
 
@@ -96,18 +107,27 @@ function App() {
     }
   }, [electron])
 
+  return <div ref={terminalRef} className="h-full w-full" />
+}
+
+function SidebarContent() {
   return (
-    <div className="h-screen w-screen bg-background flex flex-col">
-      <header className="h-10 bg-card flex items-center px-4 border-b border-border drag-region shrink-0">
-        <div className="w-20" /> {/* Space for traffic lights on macOS */}
-        <span className="text-foreground font-semibold text-sm">
-          Canopy Command Center
-        </span>
-      </header>
-      <main className="flex-1 p-2 overflow-hidden bg-[#09090b]">
-        <div ref={terminalRef} className="h-full w-full" />
-      </main>
+    <div className="p-4">
+      <h2 className="text-canopy-text font-semibold text-sm mb-4">Worktrees</h2>
+      <div className="text-canopy-text/60 text-sm">
+        No worktrees loaded yet.
+      </div>
     </div>
+  )
+}
+
+function App() {
+  return (
+    <AppLayout sidebarContent={<SidebarContent />}>
+      <div className="h-full w-full p-2 bg-canopy-bg">
+        <TerminalPane />
+      </div>
+    </AppLayout>
   )
 }
 

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,0 +1,54 @@
+import { useState, useCallback, type ReactNode } from 'react'
+import { Toolbar } from './Toolbar'
+import { Sidebar } from './Sidebar'
+
+interface AppLayoutProps {
+  children?: ReactNode
+  sidebarContent?: ReactNode
+}
+
+const MIN_SIDEBAR_WIDTH = 200
+const MAX_SIDEBAR_WIDTH = 600
+const DEFAULT_SIDEBAR_WIDTH = 350
+
+export function AppLayout({ children, sidebarContent }: AppLayoutProps) {
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH)
+
+  const handleSidebarResize = useCallback((newWidth: number) => {
+    const clampedWidth = Math.min(Math.max(newWidth, MIN_SIDEBAR_WIDTH), MAX_SIDEBAR_WIDTH)
+    setSidebarWidth(clampedWidth)
+  }, [])
+
+  const handleLaunchAgent = (type: 'claude' | 'gemini' | 'shell') => {
+    // TODO: Implement agent launching via IPC
+    console.log('Launch agent:', type)
+  }
+
+  const handleRefresh = () => {
+    // TODO: Implement refresh via IPC
+    console.log('Refresh')
+  }
+
+  const handleSettings = () => {
+    // TODO: Implement settings modal
+    console.log('Settings')
+  }
+
+  return (
+    <div className="h-screen flex flex-col bg-canopy-bg">
+      <Toolbar
+        onLaunchAgent={handleLaunchAgent}
+        onRefresh={handleRefresh}
+        onSettings={handleSettings}
+      />
+      <div className="flex-1 flex overflow-hidden">
+        <Sidebar width={sidebarWidth} onResize={handleSidebarResize}>
+          {sidebarContent}
+        </Sidebar>
+        <main className="flex-1 overflow-hidden bg-canopy-bg">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { cn } from '@/lib/utils'
+
+interface SidebarProps {
+  width: number
+  onResize: (width: number) => void
+  children?: ReactNode
+  className?: string
+}
+
+const RESIZE_STEP = 10
+
+export function Sidebar({ width, onResize, children, className }: SidebarProps) {
+  const [isResizing, setIsResizing] = useState(false)
+  const sidebarRef = useRef<HTMLElement>(null)
+
+  const startResizing = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+  }, [])
+
+  const stopResizing = useCallback(() => {
+    setIsResizing(false)
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        onResize(width - RESIZE_STEP)
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        onResize(width + RESIZE_STEP)
+      }
+    },
+    [width, onResize]
+  )
+
+  const resize = useCallback(
+    (e: MouseEvent) => {
+      if (isResizing && sidebarRef.current) {
+        const newWidth = e.clientX - sidebarRef.current.getBoundingClientRect().left
+        onResize(newWidth)
+      }
+    },
+    [isResizing, onResize]
+  )
+
+  useEffect(() => {
+    if (isResizing) {
+      document.addEventListener('mousemove', resize)
+      document.addEventListener('mouseup', stopResizing)
+      // Add cursor style to body during resize
+      document.body.style.cursor = 'col-resize'
+      document.body.style.userSelect = 'none'
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', resize)
+      document.removeEventListener('mouseup', stopResizing)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+  }, [isResizing, resize, stopResizing])
+
+  return (
+    <aside
+      ref={sidebarRef}
+      className={cn(
+        'relative border-r border-canopy-border bg-canopy-sidebar overflow-y-auto shrink-0',
+        className
+      )}
+      style={{ width }}
+    >
+      {/* Sidebar content */}
+      <div className="h-full overflow-y-auto">
+        {children}
+      </div>
+
+      {/* Resize handle */}
+      <div
+        role="separator"
+        aria-label="Resize sidebar"
+        aria-orientation="vertical"
+        aria-valuenow={width}
+        tabIndex={0}
+        className={cn(
+          'absolute top-0 right-0 w-1 h-full cursor-col-resize',
+          'hover:bg-canopy-accent/50 transition-colors focus:outline-none focus:bg-canopy-accent',
+          isResizing && 'bg-canopy-accent'
+        )}
+        onMouseDown={startResizing}
+        onKeyDown={handleKeyDown}
+      />
+    </aside>
+  )
+}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1,0 +1,85 @@
+import { Button } from '@/components/ui/button'
+import { RefreshCw, Settings, Terminal, Bot, Sparkles, Plus } from 'lucide-react'
+
+interface ToolbarProps {
+  onLaunchAgent: (type: 'claude' | 'gemini' | 'shell') => void
+  onRefresh: () => void
+  onSettings: () => void
+}
+
+export function Toolbar({ onLaunchAgent, onRefresh, onSettings }: ToolbarProps) {
+  return (
+    <header className="h-12 flex items-center px-4 border-b border-canopy-border bg-canopy-sidebar drag-region shrink-0">
+      {/* Space for traffic lights on macOS */}
+      <div className="w-20 shrink-0" />
+
+      {/* Agent launcher buttons */}
+      <div className="flex gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onLaunchAgent('claude')}
+          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"
+        >
+          <Bot className="h-4 w-4" />
+          <span>Claude</span>
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onLaunchAgent('gemini')}
+          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"
+        >
+          <Sparkles className="h-4 w-4" />
+          <span>Gemini</span>
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onLaunchAgent('shell')}
+          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"
+        >
+          <Terminal className="h-4 w-4" />
+          <span>Shell</span>
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
+          aria-label="Add new terminal"
+        >
+          <Plus className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+
+      {/* Title - centered */}
+      <div className="flex-1 flex justify-center">
+        <span className="text-canopy-text font-semibold text-sm">
+          Canopy Command Center
+        </span>
+      </div>
+
+      {/* Right side actions */}
+      <div className="flex gap-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onSettings}
+          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
+          aria-label="Open settings"
+        >
+          <Settings className="h-4 w-4" aria-hidden="true" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onRefresh}
+          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
+          aria-label="Refresh worktrees"
+        >
+          <RefreshCw className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </div>
+    </header>
+  )
+}

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,0 +1,3 @@
+export { AppLayout } from './AppLayout'
+export { Toolbar } from './Toolbar'
+export { Sidebar } from './Sidebar'

--- a/src/index.css
+++ b/src/index.css
@@ -37,6 +37,16 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* Canopy theme colors */
+  --color-canopy-bg: #1a1b26;
+  --color-canopy-sidebar: #16171f;
+  --color-canopy-border: #2d2f3a;
+  --color-canopy-text: #c0caf5;
+  --color-canopy-accent: #7aa2f7;
+  --color-canopy-success: #9ece6a;
+  --color-canopy-warning: #e0af68;
+  --color-canopy-error: #f7768e;
 }
 
 :root {


### PR DESCRIPTION
## Summary

Implements the foundational UI structure for Canopy Command Center with a resizable sidebar on the left and a terminal grid area on the right. This establishes the main application layout that will house worktree cards in the sidebar and terminal panes in the main area.

Closes #9

## Changes Made

- Create AppLayout component with toolbar and resizable sidebar
- Add Toolbar with agent launcher buttons (Claude, Gemini, Shell)
- Implement Sidebar with mouse drag-to-resize and keyboard navigation
- Add Canopy theme colors to CSS (Tokyo Night inspired palette)
- Refactor App.tsx to use new layout structure
- Add Electron API guard for terminal rendering
- Improve accessibility with ARIA labels and keyboard support
- Memoize resize callback to prevent listener churn during drag