### PR TITLE
Migrate WorktreeCard component from Ink to React DOM

### DIFF
--- a/src/components/Worktree/ActivityTrafficLight.tsx
+++ b/src/components/Worktree/ActivityTrafficLight.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import { getHeatColor } from '../../utils/colorInterpolation.js';
+
+interface ActivityTrafficLightProps {
+  timestamp?: number | null;
+}
+
+export function ActivityTrafficLight({ timestamp }: ActivityTrafficLightProps) {
+  const [color, setColor] = useState(getHeatColor(timestamp));
+
+  useEffect(() => {
+    // Immediately update color when timestamp changes (or on mount)
+    // This ensures the color reflects the current state without waiting for interval
+    const currentColor = getHeatColor(timestamp);
+    setColor(currentColor);
+
+    if (!timestamp) {
+      // No timestamp = gray, no interval needed
+      return;
+    }
+
+    // Only run the high-frequency timer if within the active window (< 90 seconds)
+    // This saves CPU when the dashboard is idle
+    const isIdle = Date.now() - timestamp > 90000;
+    if (isIdle) {
+      // Already set to gray via getHeatColor above, no interval needed
+      return;
+    }
+
+    // Start interval for smooth color transitions
+    // The interval also checks for idle state and clears itself when the timestamp ages past 90s
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - timestamp;
+      if (elapsed > 90000) {
+        // Timestamp is now stale - set to gray and stop the interval
+        setColor('#6B7280');
+        clearInterval(interval);
+        return;
+      }
+      setColor(getHeatColor(timestamp));
+    }, 200); // 5 FPS update rate is sufficient
+
+    return () => clearInterval(interval);
+  }, [timestamp]);
+
+  return (
+    <span style={{ color }} className="inline-block">
+      ●
+    </span>
+  );
+}

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+import path from 'path';
+import type { FileChangeDetail, GitStatus } from '../../types/index.js';
+
+const STATUS_ICONS: Record<GitStatus, { icon: string; color: string }> = {
+  added: { icon: 'A', color: 'text-green-400' },
+  modified: { icon: 'M', color: 'text-yellow-400' },
+  deleted: { icon: 'D', color: 'text-red-400' },
+  renamed: { icon: 'R', color: 'text-blue-400' },
+  untracked: { icon: '?', color: 'text-gray-400' },
+  ignored: { icon: 'I', color: 'text-gray-500' },
+};
+
+const STATUS_PRIORITY: Record<GitStatus, number> = {
+  modified: 0,
+  added: 1,
+  deleted: 2,
+  renamed: 3,
+  untracked: 4,
+  ignored: 5,
+};
+
+interface FileChangeListProps {
+  changes: FileChangeDetail[];
+  maxVisible?: number;
+  rootPath: string;
+}
+
+function truncateMiddle(value: string, maxLength = 42): string {
+  if (value.length <= maxLength) return value;
+  const half = Math.floor((maxLength - 3) / 2);
+  return `${value.slice(0, half)}...${value.slice(-half)}`;
+}
+
+export function FileChangeList({ changes, maxVisible = 4, rootPath }: FileChangeListProps) {
+  // Sort changes by churn (most changes first), then by status priority as tiebreaker
+  const sortedChanges = useMemo(() => {
+    return [...changes].sort((a, b) => {
+      // Primary sort: by churn (insertions + deletions), descending
+      const churnA = (a.insertions ?? 0) + (a.deletions ?? 0);
+      const churnB = (b.insertions ?? 0) + (b.deletions ?? 0);
+      if (churnA !== churnB) {
+        return churnB - churnA;
+      }
+
+      // Secondary sort: by status priority
+      const priorityA = STATUS_PRIORITY[a.status] ?? 99;
+      const priorityB = STATUS_PRIORITY[b.status] ?? 99;
+      if (priorityA !== priorityB) {
+        return priorityA - priorityB;
+      }
+
+      return a.path.localeCompare(b.path);
+    });
+  }, [changes]);
+
+  const visibleChanges = sortedChanges.slice(0, maxVisible);
+  const remainingCount = Math.max(0, sortedChanges.length - maxVisible);
+  const remainingFiles = sortedChanges.slice(maxVisible, maxVisible + 2); // Show up to 2 additional filenames
+
+  if (changes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 space-y-1">
+      {visibleChanges.map((change) => {
+        const { icon, color } = STATUS_ICONS[change.status] || { icon: '?', color: 'text-gray-400' };
+        const relativePath = path.isAbsolute(change.path)
+          ? path.relative(rootPath, change.path)
+          : change.path;
+        const displayPath = truncateMiddle(relativePath, 42);
+        const additionsLabel = change.insertions !== null ? `+${change.insertions}` : '';
+        const deletionsLabel = change.deletions !== null ? `-${change.deletions}` : '';
+
+        return (
+          <div key={`${change.path}-${change.status}`} className="flex items-center justify-between text-sm">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className={`${color} font-mono font-bold flex-shrink-0`}>{icon}</span>
+              <span className="text-gray-200 truncate">{displayPath}</span>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+              {additionsLabel && <span className="text-green-400 text-xs font-mono">{additionsLabel}</span>}
+              {deletionsLabel && <span className="text-red-400 text-xs font-mono">{deletionsLabel}</span>}
+            </div>
+          </div>
+        );
+      })}
+      {remainingCount > 0 && (
+        <div className="text-gray-500 text-sm">
+          ...and {remainingCount} more
+          {remainingFiles.length > 0 && (
+            <span className="ml-1">
+              ({remainingFiles.map((f) => path.basename(f.path)).join(', ')}
+              {sortedChanges.length > maxVisible + 2 && ', ...'})
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -1,0 +1,395 @@
+import { useMemo, useCallback, useState, useEffect } from 'react';
+import type { WorktreeState, WorktreeMood } from '../../types/index.js';
+import { ActivityTrafficLight } from './ActivityTrafficLight.js';
+import { FileChangeList } from './FileChangeList.js';
+import { useDevServer } from '../../hooks/useDevServer.js';
+import { cn } from '../../lib/utils.js';
+
+export interface WorktreeCardProps {
+  worktree: WorktreeState;
+  isActive: boolean;
+  isFocused: boolean;
+  onSelect: () => void;
+  onCopyTree: () => void;
+  onOpenEditor: () => void;
+  onOpenIssue?: () => void;
+  onOpenPR?: () => void;
+  onToggleServer: () => void;
+}
+
+const MOOD_BORDER_COLORS: Record<WorktreeMood, string> = {
+  active: 'border-blue-400',
+  stable: 'border-green-400',
+  stale: 'border-yellow-400',
+  error: 'border-red-400',
+};
+
+const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+
+function parseNoteWithLinks(text: string): Array<{ type: 'text' | 'link'; content: string }> {
+  const segments: Array<{ type: 'text' | 'link'; content: string }> = [];
+  let lastIndex = 0;
+  const regex = new RegExp(URL_REGEX.source, 'g');
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: 'link', content: match[1] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', content: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+function formatPath(targetPath: string): string {
+  const home = process.env.HOME || '';
+  if (home && targetPath.startsWith(home)) {
+    return targetPath.replace(home, '~');
+  }
+  return targetPath;
+}
+
+const MAIN_WORKTREE_NOTE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+export function WorktreeCard({
+  worktree,
+  isActive,
+  isFocused,
+  onSelect,
+  onCopyTree,
+  onOpenEditor,
+  onOpenIssue,
+  onOpenPR,
+  onToggleServer,
+}: WorktreeCardProps) {
+  const mood = worktree.mood || 'stable';
+  const borderColor = MOOD_BORDER_COLORS[mood];
+
+  const { state: serverState, hasDevScript, isLoading: serverLoading } = useDevServer({
+    worktreeId: worktree.id,
+    worktreePath: worktree.path,
+  });
+
+  // For main worktree, notes expire after 10 minutes (real-time)
+  const [now, setNow] = useState(() => Date.now());
+  const isMainWorktree = worktree.branch === 'main' || worktree.branch === 'master';
+
+  // Set up timer to re-check note expiration for main worktree
+  useEffect(() => {
+    if (!isMainWorktree || !worktree.aiNote || !worktree.aiNoteTimestamp) {
+      return;
+    }
+
+    const expiresAt = worktree.aiNoteTimestamp + MAIN_WORKTREE_NOTE_TTL_MS;
+    const timeUntilExpiry = expiresAt - Date.now();
+
+    if (timeUntilExpiry <= 0) {
+      setNow(Date.now());
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setNow(Date.now());
+    }, timeUntilExpiry);
+
+    return () => clearTimeout(timer);
+  }, [isMainWorktree, worktree.aiNote, worktree.aiNoteTimestamp]);
+
+  // Calculate effective note (applying TTL for main worktree)
+  const effectiveNote = useMemo(() => {
+    const trimmed = worktree.aiNote?.trim();
+    if (!trimmed) return undefined;
+
+    if (isMainWorktree && worktree.aiNoteTimestamp) {
+      const age = now - worktree.aiNoteTimestamp;
+      if (age > MAIN_WORKTREE_NOTE_TTL_MS) {
+        return undefined;
+      }
+    }
+
+    return trimmed;
+  }, [worktree.aiNote, isMainWorktree, worktree.aiNoteTimestamp, now]);
+
+  const parsedNoteSegments = useMemo(() => {
+    return effectiveNote ? parseNoteWithLinks(effectiveNote) : [];
+  }, [effectiveNote]);
+
+  const handlePathClick = useCallback(() => {
+    if (window.electron?.system?.openPath) {
+      window.electron.system.openPath(worktree.path);
+    }
+  }, [worktree.path]);
+
+  const handleOpenIssue = useCallback(() => {
+    if (worktree.issueNumber && onOpenIssue) {
+      onOpenIssue();
+    }
+  }, [worktree.issueNumber, onOpenIssue]);
+
+  const handleOpenPR = useCallback(() => {
+    if (worktree.prNumber && onOpenPR) {
+      onOpenPR();
+    }
+  }, [worktree.prNumber, onOpenPR]);
+
+  const displayPath = formatPath(worktree.path);
+  const branchLabel = worktree.branch ?? worktree.name;
+  const hasChanges = (worktree.worktreeChanges?.changedFileCount ?? 0) > 0;
+
+  // Summary component
+  let summaryContent: React.ReactNode;
+  const isCommitMessage = worktree.summary?.startsWith('Last commit:') || worktree.summary?.startsWith('✅');
+
+  if (worktree.summary) {
+    if (isCommitMessage) {
+      summaryContent = <span className="text-gray-500">{worktree.summary}</span>;
+    } else if (hasChanges) {
+      summaryContent = <span className="text-gray-300">{worktree.summary}</span>;
+    } else {
+      summaryContent = <span className="text-gray-500">{worktree.summary}</span>;
+    }
+  } else if (worktree.aiStatus === 'loading') {
+    summaryContent = <span className="text-gray-500">Generating summary...</span>;
+  } else {
+    const fallbackText = worktree.branch ? `Clean: ${worktree.branch}` : 'Ready';
+    summaryContent = <span className="text-gray-500">{fallbackText}</span>;
+  }
+
+  // Server status helpers
+  const getServerStatusIndicator = () => {
+    if (!serverState) return null;
+    switch (serverState.status) {
+      case 'stopped':
+        return <span className="text-gray-500">○</span>;
+      case 'starting':
+        return <span className="text-yellow-400">◐</span>;
+      case 'running':
+        return <span className="text-green-400">●</span>;
+      case 'error':
+        return <span className="text-red-400">●</span>;
+      default:
+        return <span className="text-gray-500">○</span>;
+    }
+  };
+
+  const getServerStatusText = () => {
+    if (!serverState) return null;
+    switch (serverState.status) {
+      case 'stopped':
+        return <span className="text-gray-500">Dev Server</span>;
+      case 'starting':
+        return <span className="text-yellow-400">Starting...</span>;
+      case 'running':
+        return serverState.url ? (
+          <span className="text-green-400">{serverState.url}</span>
+        ) : (
+          <span className="text-green-400">Running</span>
+        );
+      case 'error':
+        return (
+          <span className="text-red-400">
+            {serverState.errorMessage ? `Error: ${serverState.errorMessage.slice(0, 40)}` : 'Error'}
+          </span>
+        );
+      default:
+        return <span className="text-gray-500">Dev Server</span>;
+    }
+  };
+
+  const getServerButtonLabel = () => {
+    if (!serverState) return 'Start';
+    switch (serverState.status) {
+      case 'stopped':
+        return 'Start';
+      case 'starting':
+        return '...';
+      case 'running':
+        return 'Stop';
+      case 'error':
+        return 'Retry';
+      default:
+        return 'Start';
+    }
+  };
+
+  const getServerButtonColor = () => {
+    if (!serverState) return 'text-green-400';
+    switch (serverState.status) {
+      case 'stopped':
+        return 'text-green-400';
+      case 'starting':
+        return 'text-yellow-400';
+      case 'running':
+        return 'text-red-400';
+      case 'error':
+        return 'text-green-400';
+      default:
+        return 'text-gray-400';
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'border-2 rounded-lg p-3 mb-3 cursor-pointer transition-all',
+        borderColor,
+        isFocused && 'ring-2 ring-blue-500 ring-offset-2 ring-offset-gray-900',
+        'hover:shadow-lg hover:shadow-blue-500/20'
+      )}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if ((e.key === 'Enter' || e.key === ' ') && e.target === e.currentTarget) {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      tabIndex={0}
+      role="button"
+      aria-label={`Worktree: ${branchLabel}`}
+    >
+      {/* Action buttons */}
+      <div className="flex gap-2 mb-3 border-b border-gray-700 pb-2">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onCopyTree();
+          }}
+          className="text-xs px-2 py-1 border border-gray-600 rounded hover:bg-gray-800 hover:border-gray-500 text-gray-300"
+        >
+          Copy
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpenEditor();
+          }}
+          className="text-xs px-2 py-1 border border-gray-600 rounded hover:bg-gray-800 hover:border-gray-500 text-gray-300"
+        >
+          Code
+        </button>
+        {worktree.issueNumber && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              handleOpenIssue();
+            }}
+            className="text-xs px-2 py-1 border border-blue-600 rounded hover:bg-blue-900 hover:border-blue-500 text-blue-400"
+          >
+            Issue
+          </button>
+        )}
+        {worktree.prNumber && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              handleOpenPR();
+            }}
+            className="text-xs px-2 py-1 border border-green-600 rounded hover:bg-green-900 hover:border-green-500 text-green-400"
+          >
+            PR
+          </button>
+        )}
+      </div>
+
+      {/* Header: Traffic light + Branch */}
+      <div className="mb-1 flex items-center gap-2">
+        <ActivityTrafficLight timestamp={worktree.lastActivityTimestamp} />
+        {isActive && <span className="text-blue-400">●</span>}
+        <span className={cn('font-bold', mood === 'active' ? 'text-yellow-400' : 'text-gray-200')}>
+          {branchLabel}
+        </span>
+        {!worktree.branch && <span className="text-yellow-400">(detached)</span>}
+        {worktree.aiStatus === 'disabled' && <span className="text-gray-500">[AI off]</span>}
+        {worktree.aiStatus === 'error' && <span className="text-red-400">[AI err]</span>}
+      </div>
+
+      {/* Path (clickable) */}
+      <div className="mb-2">
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            handlePathClick();
+          }}
+          className={cn(
+            'text-sm text-gray-500 hover:text-gray-400 hover:underline text-left',
+            isFocused && 'underline'
+          )}
+        >
+          {displayPath}
+        </button>
+      </div>
+
+      {/* Summary */}
+      <div className="mt-3 text-sm">{summaryContent}</div>
+
+      {/* Files */}
+      {hasChanges && worktree.worktreeChanges && (
+        <FileChangeList
+          changes={worktree.worktreeChanges.changes}
+          rootPath={worktree.worktreeChanges.rootPath}
+          maxVisible={4}
+        />
+      )}
+
+      {/* Server status */}
+      {hasDevScript && serverState && (
+        <div className="mt-3 flex items-center justify-between text-sm">
+          <div className="flex items-center gap-2">
+            {getServerStatusIndicator()}
+            {getServerStatusText()}
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!serverLoading && serverState.status !== 'starting') {
+                onToggleServer();
+              }
+            }}
+            disabled={serverLoading || serverState.status === 'starting'}
+            className={cn(
+              'text-xs px-2 py-1 border rounded font-bold',
+              getServerButtonColor(),
+              (serverLoading || serverState.status === 'starting') ? 'opacity-50 cursor-not-allowed' : 'hover:bg-gray-800'
+            )}
+          >
+            [{getServerButtonLabel()}]
+          </button>
+        </div>
+      )}
+
+      {/* Agent note */}
+      {effectiveNote && (
+        <div className="mt-3 text-sm text-gray-300">
+          {parsedNoteSegments.map((segment, index) =>
+            segment.type === 'link' ? (
+              <a
+                key={index}
+                href={segment.content}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-400 underline hover:text-blue-300"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (window.electron?.system?.openExternal) {
+                    e.preventDefault();
+                    window.electron.system.openExternal(segment.content);
+                  }
+                }}
+              >
+                {segment.content}
+              </a>
+            ) : (
+              <span key={index}>{segment.content}</span>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Worktree/index.ts
+++ b/src/components/Worktree/index.ts
@@ -1,0 +1,3 @@
+export { WorktreeCard } from './WorktreeCard.js';
+export { ActivityTrafficLight } from './ActivityTrafficLight.js';
+export { FileChangeList } from './FileChangeList.js';

--- a/src/utils/colorInterpolation.ts
+++ b/src/utils/colorInterpolation.ts
@@ -1,0 +1,58 @@
+/**
+ * Interpolates between two hex colors.
+ * @param startHex - Start color (e.g. "#00FF00")
+ * @param endHex - End color (e.g. "#808080")
+ * @param factor - 0.0 to 1.0 (0 = start, 1 = end)
+ */
+export function interpolateColor(startHex: string, endHex: string, factor: number): string {
+  const f = Math.max(0, Math.min(1, factor));
+
+  const r1 = parseInt(startHex.substring(1, 3), 16);
+  const g1 = parseInt(startHex.substring(3, 5), 16);
+  const b1 = parseInt(startHex.substring(5, 7), 16);
+
+  const r2 = parseInt(endHex.substring(1, 3), 16);
+  const g2 = parseInt(endHex.substring(3, 5), 16);
+  const b2 = parseInt(endHex.substring(5, 7), 16);
+
+  const r = Math.round(r1 + f * (r2 - r1));
+  const g = Math.round(g1 + f * (g2 - g1));
+  const b = Math.round(b1 + f * (b2 - b1));
+
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`;
+}
+
+/**
+ * Calculates the heat color based on time elapsed.
+ *
+ * Strategy:
+ * 0s - 5s:   Neon Green (High Activity) -> Pure Green
+ * 5s - 30s:  Pure Green -> Dull Green/Yellowish
+ * 30s - 90s: Dull Green -> Gray (Cooling down)
+ */
+export function getHeatColor(lastActivity: number | undefined | null): string {
+  if (!lastActivity) return '#808080'; // Default Gray
+
+  const elapsed = Date.now() - lastActivity;
+
+  // Phase 1: The "Flash" (0s to 5s)
+  // From Neon Green (#4ADE80) to Solid Green (#22C55E)
+  if (elapsed < 5000) {
+    return interpolateColor('#4ADE80', '#22C55E', elapsed / 5000);
+  }
+
+  // Phase 2: Active Working (5s to 30s)
+  // From Solid Green (#22C55E) to Dull Olive (#859F3D)
+  if (elapsed < 30000) {
+    return interpolateColor('#22C55E', '#859F3D', (elapsed - 5000) / 25000);
+  }
+
+  // Phase 3: Cooling Down (30s to 90s)
+  // From Dull Olive (#859F3D) to Idle Gray (#6B7280)
+  if (elapsed < 90000) {
+    return interpolateColor('#859F3D', '#6B7280', (elapsed - 30000) / 60000);
+  }
+
+  // Phase 4: Idle
+  return '#6B7280'; // Gray-500
+}


### PR DESCRIPTION
## Summary

Migrates the WorktreeCard component from the original Ink-based CLI to React DOM with Tailwind CSS styling. This provides a visual card component for displaying worktree state in the Electron app sidebar.

Closes #10

## Changes Made

- Create WorktreeCard component with Tailwind styling
- Add ActivityTrafficLight with color interpolation for recent activity visualization
- Implement FileChangeList with status icons and truncation
- Add mood-based border colors (active/stable/stale/error) and focus states
- Integrate with useDevServer hook for dev server controls
- Support AI note display with clickable links
- Include accessibility features (ARIA labels, keyboard navigation)
- Add Windows path compatibility with path.relative()
- Guard Electron API calls for test/Storybook compatibility

## Technical Details

**Components:**
- `WorktreeCard`: Main card component displaying worktree data
- `ActivityTrafficLight`: Time-based color indicator (neon green → gray decay)
- `FileChangeList`: Truncated file list with git status icons

**Features:**
- Mood-based border colors matching worktree state
- Click handlers for path, issue, PR, and action buttons
- Dev server status display with start/stop controls
- AI note parsing with automatic link detection
- Keyboard navigation with proper focus management
- Cross-platform path handling (Windows + macOS)