### PR TITLE
Implement agent launcher buttons in toolbar

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -41,6 +41,7 @@ export const CHANNELS = {
   SYSTEM_OPEN_EXTERNAL: 'system:open-external',
   SYSTEM_OPEN_PATH: 'system:open-path',
   SYSTEM_GET_CONFIG: 'system:get-config',
+  SYSTEM_CHECK_COMMAND: 'system:check-command',
 
   // PR detection channels
   PR_DETECTED: 'pr:detected',

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -12,6 +12,8 @@ export interface TerminalSpawnOptions {
   shell?: string
   cols: number
   rows: number
+  /** Command to execute after shell starts (e.g., 'claude' for AI agents) */
+  command?: string
 }
 
 export interface TerminalDataPayload {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -56,6 +56,7 @@ export interface ElectronAPI {
     openExternal(url: string): Promise<void>
     openPath(path: string): Promise<void>
     getConfig(): Promise<CanopyConfig>
+    checkCommand(command: string): Promise<boolean>
   }
 }
 
@@ -182,6 +183,9 @@ const api: ElectronAPI = {
 
     getConfig: () =>
       ipcRenderer.invoke(CHANNELS.SYSTEM_GET_CONFIG),
+
+    checkCommand: (command: string) =>
+      ipcRenderer.invoke(CHANNELS.SYSTEM_CHECK_COMMAND, command),
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@octokit/graphql": "^9.0.3",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-webgl": "^0.18.0",

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1,5 +1,13 @@
 import { Button } from '@/components/ui/button'
-import { RefreshCw, Settings, Terminal, Bot, Sparkles, Plus } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { RefreshCw, Settings, Terminal, Bot, Sparkles, Plus, Command } from 'lucide-react'
 
 interface ToolbarProps {
   onLaunchAgent: (type: 'claude' | 'gemini' | 'shell') => void
@@ -20,6 +28,7 @@ export function Toolbar({ onLaunchAgent, onRefresh, onSettings }: ToolbarProps) 
           size="sm"
           onClick={() => onLaunchAgent('claude')}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"
+          title="Launch Claude (Ctrl+Shift+C)"
         >
           <Bot className="h-4 w-4" />
           <span>Claude</span>
@@ -29,6 +38,7 @@ export function Toolbar({ onLaunchAgent, onRefresh, onSettings }: ToolbarProps) 
           size="sm"
           onClick={() => onLaunchAgent('gemini')}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"
+          title="Launch Gemini (Ctrl+Shift+G)"
         >
           <Sparkles className="h-4 w-4" />
           <span>Gemini</span>
@@ -38,18 +48,46 @@ export function Toolbar({ onLaunchAgent, onRefresh, onSettings }: ToolbarProps) 
           size="sm"
           onClick={() => onLaunchAgent('shell')}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"
+          title="Launch Shell (Ctrl+T)"
         >
           <Terminal className="h-4 w-4" />
           <span>Shell</span>
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
-          aria-label="Add new terminal"
-        >
-          <Plus className="h-4 w-4" aria-hidden="true" />
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
+              aria-label="Add new terminal"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem onClick={() => onLaunchAgent('claude')}>
+              <Bot className="mr-2 h-4 w-4" />
+              <span>Claude</span>
+              <DropdownMenuShortcut>Ctrl+Shift+C</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onLaunchAgent('gemini')}>
+              <Sparkles className="mr-2 h-4 w-4" />
+              <span>Gemini</span>
+              <DropdownMenuShortcut>Ctrl+Shift+G</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onLaunchAgent('shell')}>
+              <Terminal className="mr-2 h-4 w-4" />
+              <span>Shell</span>
+              <DropdownMenuShortcut>Ctrl+T</DropdownMenuShortcut>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem disabled>
+              <Command className="mr-2 h-4 w-4" />
+              <span>Custom Command...</span>
+              <DropdownMenuShortcut>Ctrl+Shift+N</DropdownMenuShortcut>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {/* Title - centered */}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,149 @@
+/**
+ * Dropdown Menu Component
+ *
+ * Based on Radix UI Dropdown Menu primitive with Canopy styling.
+ */
+
+import * as React from 'react'
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
+import { cn } from '@/lib/utils'
+
+const DropdownMenu = DropdownMenuPrimitive.Root
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-canopy-border data-[state=open]:bg-canopy-border',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </DropdownMenuPrimitive.SubTrigger>
+))
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      'z-50 min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+))
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-canopy-border', className)}
+    {...props}
+  />
+))
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      'px-2 py-1.5 text-sm font-semibold text-canopy-text/70',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+))
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn('ml-auto text-xs tracking-widest text-canopy-text/50', className)}
+      {...props}
+    />
+  )
+}
+DropdownMenuShortcut.displayName = 'DropdownMenuShortcut'
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,3 +10,6 @@ export type { UseWorktreesReturn } from './useWorktrees'
 export { useDevServer, useDevServerStates } from './useDevServer'
 
 export { useElectron, isElectronAvailable } from './useElectron'
+
+export { useAgentLauncher } from './useAgentLauncher'
+export type { AgentType, AgentAvailability, UseAgentLauncherReturn } from './useAgentLauncher'

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -1,0 +1,171 @@
+/**
+ * useAgentLauncher Hook
+ *
+ * Provides agent launcher functionality with proper configuration for AI agents.
+ * Handles spawning terminals pre-configured for Claude, Gemini, or plain shell.
+ *
+ * Features:
+ * - Spawns terminal with agent command (claude, gemini) or plain shell
+ * - Uses active worktree path as CWD when available
+ * - Checks CLI availability and caches results
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { useTerminalStore, type AddTerminalOptions } from '@/store/terminalStore'
+import { useWorktrees } from './useWorktrees'
+import { isElectronAvailable } from './useElectron'
+
+export type AgentType = 'claude' | 'gemini' | 'shell'
+
+interface AgentConfig {
+  type: AgentType
+  title: string
+  command?: string
+}
+
+const AGENT_CONFIGS: Record<AgentType, AgentConfig> = {
+  claude: {
+    type: 'claude',
+    title: 'Claude',
+    command: 'claude',
+  },
+  gemini: {
+    type: 'gemini',
+    title: 'Gemini',
+    command: 'gemini',
+  },
+  shell: {
+    type: 'shell',
+    title: 'Shell',
+    command: undefined, // Plain shell, no command
+  },
+}
+
+export interface AgentAvailability {
+  claude: boolean
+  gemini: boolean
+}
+
+export interface UseAgentLauncherReturn {
+  /** Launch an agent terminal */
+  launchAgent: (type: AgentType) => Promise<string | null>
+  /** CLI availability status */
+  availability: AgentAvailability
+  /** Whether availability check is in progress */
+  isCheckingAvailability: boolean
+}
+
+/**
+ * Hook for launching AI agent terminals
+ *
+ * @example
+ * ```tsx
+ * function Toolbar() {
+ *   const { launchAgent, availability } = useAgentLauncher()
+ *
+ *   return (
+ *     <div>
+ *       <button
+ *         onClick={() => launchAgent('claude')}
+ *         disabled={!availability.claude}
+ *       >
+ *         Claude
+ *       </button>
+ *       <button
+ *         onClick={() => launchAgent('gemini')}
+ *         disabled={!availability.gemini}
+ *       >
+ *         Gemini
+ *       </button>
+ *       <button onClick={() => launchAgent('shell')}>
+ *         Shell
+ *       </button>
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export function useAgentLauncher(): UseAgentLauncherReturn {
+  const { addTerminal } = useTerminalStore()
+  const { worktreeMap, activeId } = useWorktrees()
+
+  const [availability, setAvailability] = useState<AgentAvailability>({
+    claude: true, // Optimistically assume available until checked
+    gemini: true,
+  })
+  const [isCheckingAvailability, setIsCheckingAvailability] = useState(true)
+
+  // Check CLI availability on mount
+  useEffect(() => {
+    if (!isElectronAvailable()) {
+      setIsCheckingAvailability(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function checkAvailability() {
+      try {
+        const [claudeAvailable, geminiAvailable] = await Promise.all([
+          window.electron.system.checkCommand('claude'),
+          window.electron.system.checkCommand('gemini'),
+        ])
+
+        if (!cancelled) {
+          setAvailability({
+            claude: claudeAvailable,
+            gemini: geminiAvailable,
+          })
+        }
+      } catch (error) {
+        console.error('Failed to check CLI availability:', error)
+        // Keep optimistic defaults on error
+      } finally {
+        if (!cancelled) {
+          setIsCheckingAvailability(false)
+        }
+      }
+    }
+
+    checkAvailability()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const launchAgent = useCallback(async (type: AgentType): Promise<string | null> => {
+    if (!isElectronAvailable()) {
+      console.warn('Electron API not available')
+      return null
+    }
+
+    const config = AGENT_CONFIGS[type]
+
+    // Get CWD from active worktree or fall back to home directory
+    const activeWorktree = activeId ? worktreeMap.get(activeId) : null
+    const cwd = activeWorktree?.path || process.env.HOME || '/'
+
+    const options: AddTerminalOptions = {
+      type: config.type,
+      title: config.title,
+      cwd,
+      worktreeId: activeId || undefined,
+      command: config.command,
+    }
+
+    try {
+      const terminalId = await addTerminal(options)
+      return terminalId
+    } catch (error) {
+      console.error(`Failed to launch ${type} agent:`, error)
+      return null
+    }
+  }, [activeId, worktreeMap, addTerminal])
+
+  return {
+    launchAgent,
+    availability,
+    isCheckingAvailability,
+  }
+}

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -22,6 +22,8 @@ export interface AddTerminalOptions {
   worktreeId?: string
   cwd: string
   shell?: string
+  /** Command to execute after shell starts (e.g., 'claude' for AI agents) */
+  command?: string
 }
 
 interface TerminalGridState {
@@ -60,6 +62,7 @@ const createTerminalStore: StateCreator<TerminalGridState> = (set) => ({
         shell: options.shell,
         cols: 80,
         rows: 24,
+        command: options.command,
       })
 
       const terminal: TerminalInstance = {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -48,6 +48,7 @@ export interface ElectronAPI {
     openExternal(url: string): Promise<void>
     openPath(path: string): Promise<void>
     getConfig(): Promise<CanopyConfig>
+    checkCommand(command: string): Promise<boolean>
   }
 }
 


### PR DESCRIPTION
## Summary
Implements agent launcher buttons in the toolbar for spawning terminals pre-configured for AI agents (Claude, Gemini) or plain shell, with comprehensive security hardening and improved UX.

Closes #18

## Changes Made
- Add agent launcher buttons (Claude, Gemini, Shell) to toolbar with keyboard shortcuts (Ctrl+Shift+C, Ctrl+Shift+G, Ctrl+T)
- Implement command whitelisting to prevent command injection attacks
- Add CLI availability checking via IPC with input validation using execFileSync
- Create dropdown menu component with keyboard shortcut hints using Radix UI
- Use active worktree path as CWD for spawned terminals
- Fix terminal existence check to prevent race conditions
- Fix keyboard shortcuts to not hijack terminal input (skip when focus is in terminal)
- Fix React lifecycle cleanup in useAgentLauncher hook
- Add dropdown menu component using Radix UI primitives

## Security Hardening
- Command injection prevention: Whitelist allowed commands ('claude', 'gemini')
- Shell injection prevention: Input validation + execFileSync in checkCommand handler
- Race condition fix: Check terminal exists before writing command