### PR TITLE
Replace CopyTree CLI with native SDK integration

### DIFF
--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -88,9 +88,29 @@ export interface DevServerErrorPayload {
 
 // CopyTree types
 export interface CopyTreeOptions {
+  /** Output format */
+  format?: 'xml' | 'json' | 'markdown' | 'tree' | 'ndjson'
+
+  /** Pattern filtering */
+  filter?: string | string[]
+  exclude?: string | string[]
+  always?: string[]
+
+  /** Git filtering */
+  modified?: boolean
+  changed?: string
+
+  /** Size limits */
+  maxFileSize?: number
+  maxTotalSize?: number
+  maxFileCount?: number
+
+  /** Formatting */
+  withLineNumbers?: boolean
+  charLimit?: number
+
+  /** Profile (load from .copytree file) - legacy option */
   profile?: string
-  extraArgs?: string[]
-  files?: string[]
 }
 
 export interface CopyTreeGeneratePayload {
@@ -102,6 +122,10 @@ export interface CopyTreeResult {
   content: string
   fileCount: number
   error?: string
+  stats?: {
+    totalSize: number
+    duration: number
+  }
 }
 
 export interface CopyTreeInjectPayload {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -148,16 +148,39 @@ interface TerminalSpawnOptions {
 }
 
 interface CopyTreeOptions {
+  /** Output format */
+  format?: 'xml' | 'json' | 'markdown' | 'tree' | 'ndjson'
+
+  /** Pattern filtering */
+  filter?: string | string[]
+  exclude?: string | string[]
+  always?: string[]
+
+  /** Git filtering */
+  modified?: boolean
+  changed?: string
+
+  /** Size limits */
+  maxFileSize?: number
+  maxTotalSize?: number
+  maxFileCount?: number
+
+  /** Formatting */
+  withLineNumbers?: boolean
+  charLimit?: number
+
+  /** Profile (load from .copytree file) - legacy option */
   profile?: string
-  extraArgs?: string[]
-  files?: string[]
 }
 
 interface CopyTreeResult {
-  success: boolean
-  content?: string
-  fileCount?: number
+  content: string
+  fileCount: number
   error?: string
+  stats?: {
+    totalSize: number
+    duration: number
+  }
 }
 
 interface CanopyConfig {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@xterm/xterm": "^5.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "copytree": "github:gregpriday/copytree#develop",
     "electron-store": "^11.0.2",
     "execa": "^9.6.0",
     "lucide-react": "^0.555.0",
@@ -79,11 +80,15 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["universal"]
+          "arch": [
+            "universal"
+          ]
         },
         {
           "target": "zip",
-          "arch": ["universal"]
+          "arch": [
+            "universal"
+          ]
         }
       ],
       "hardenedRuntime": true,
@@ -110,11 +115,15 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "portable",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ]
     },
@@ -127,7 +136,10 @@
     },
     "linux": {
       "icon": "build/icon.png",
-      "target": ["AppImage", "deb"],
+      "target": [
+        "AppImage",
+        "deb"
+      ],
       "category": "Development"
     }
   }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -31,16 +31,39 @@ interface TerminalSpawnOptions {
 }
 
 interface CopyTreeOptions {
+  /** Output format */
+  format?: 'xml' | 'json' | 'markdown' | 'tree' | 'ndjson'
+
+  /** Pattern filtering */
+  filter?: string | string[]
+  exclude?: string | string[]
+  always?: string[]
+
+  /** Git filtering */
+  modified?: boolean
+  changed?: string
+
+  /** Size limits */
+  maxFileSize?: number
+  maxTotalSize?: number
+  maxFileCount?: number
+
+  /** Formatting */
+  withLineNumbers?: boolean
+  charLimit?: number
+
+  /** Profile (load from .copytree file) - legacy option */
   profile?: string
-  extraArgs?: string[]
-  files?: string[]
 }
 
 interface CopyTreeResult {
-  success: boolean
-  content?: string
-  fileCount?: number
+  content: string
+  fileCount: number
   error?: string
+  stats?: {
+    totalSize: number
+    duration: number
+  }
 }
 
 interface TerminalState {
@@ -151,7 +174,6 @@ export interface ElectronAPI {
     getState(): Promise<AppState>
     setState(partialState: Partial<AppState>): Promise<void>
   }
-<<<<<<< HEAD
   logs: {
     getAll(filters?: LogFilterOptions): Promise<LogEntry[]>
     getSources(): Promise<string[]>
@@ -164,12 +186,11 @@ export interface ElectronAPI {
     open(path: string): Promise<void>
     openDialog(): Promise<string | null>
     removeRecent(path: string): Promise<void>
-=======
+  }
   errors: {
     onError(callback: (error: AppError) => void): () => void
     retry(errorId: string, action: RetryAction, args?: Record<string, unknown>): Promise<void>
     openLogs(): Promise<void>
->>>>>>> feature/issue-47-error-ui-recovery
   }
 }
 


### PR DESCRIPTION
## Summary
Replaces the CLI-based CopyTree integration (spawning external process via execa) with direct SDK usage for better performance, richer features, and improved error handling.

Closes #56

## Changes Made
- Replace execa CLI spawning with direct SDK usage via npm package
- Add ConfigManager.create() for isolated concurrent operations
- Implement AbortController-based cancellation with operation tracking
- Enhance error handling with SDK-specific error types (ValidationError, CopyTreeError)
- Expand CopyTreeOptions with SDK features (format selection, filters, git options, size limits)
- Add performance stats (totalSize, duration) to CopyTreeResult
- Update type definitions across main, preload, and renderer processes
- Remove CLI availability check (SDK is always bundled)
- Fix merge conflict in src/types/electron.d.ts

## Technical Details
**Before:** CopyTreeService spawned the `copytree` CLI as a child process, requiring global installation and providing limited error handling.

**After:** Direct SDK integration via `npm install copytree` with:
- In-process execution (no process overhead)
- Isolated ConfigManager instances for concurrent operations
- AbortSignal-based cancellation
- Typed error classes (ValidationError, CopyTreeError)
- Rich SDK options (format, filters, git integration, size limits)
- Performance metrics in response

## Benefits
- No global CLI installation required
- Better performance (eliminates process spawn overhead)
- Richer error handling with typed error classes
- Access to full SDK feature set
- Future-ready for progress reporting (#57) and format selection (#58)