### PR TITLE
Add terminal recipes for one-click terminal setups

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -68,6 +68,17 @@ export const CHANNELS = {
   ERROR_NOTIFY: 'error:notify',
   ERROR_RETRY: 'error:retry',
   ERROR_OPEN_LOGS: 'error:open-logs',
+
+  // Recipe channels
+  RECIPE_GET_ALL: 'recipe:get-all',
+  RECIPE_GET: 'recipe:get',
+  RECIPE_GET_FOR_WORKTREE: 'recipe:get-for-worktree',
+  RECIPE_CREATE: 'recipe:create',
+  RECIPE_UPDATE: 'recipe:update',
+  RECIPE_DELETE: 'recipe:delete',
+  RECIPE_RUN: 'recipe:run',
+  RECIPE_EXPORT: 'recipe:export',
+  RECIPE_IMPORT: 'recipe:import',
 } as const
 
 export type ChannelName = typeof CHANNELS[keyof typeof CHANNELS]

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -165,3 +165,60 @@ export interface DirectoryOpenPayload {
 export interface DirectoryRemoveRecentPayload {
   path: string
 }
+
+// Recipe types
+export type { TerminalRecipe, RecipeTerminal, CreateRecipeInput, UpdateRecipeInput, RecipeExport } from '../types/recipe.js'
+
+export interface RecipeGetPayload {
+  id: string
+}
+
+export interface RecipeGetForWorktreePayload {
+  worktreeId: string | null
+}
+
+export interface RecipeCreatePayload {
+  name: string
+  worktreeId: string | null
+  terminals: Array<{
+    type: 'shell' | 'claude' | 'gemini' | 'custom'
+    title?: string
+    command?: string
+    env?: Record<string, string>
+  }>
+}
+
+export interface RecipeUpdatePayload {
+  id: string
+  updates: {
+    name?: string
+    worktreeId?: string | null
+    terminals?: Array<{
+      type: 'shell' | 'claude' | 'gemini' | 'custom'
+      title?: string
+      command?: string
+      env?: Record<string, string>
+    }>
+  }
+}
+
+export interface RecipeDeletePayload {
+  id: string
+}
+
+export interface RecipeRunPayload {
+  id: string
+  worktreeId: string
+  worktreePath: string
+}
+
+export interface RecipeRunResult {
+  success: boolean
+  terminalIds: string[]
+  error?: string
+}
+
+export interface RecipeImportPayload {
+  json: string
+  worktreeId: string | null
+}

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -1,5 +1,6 @@
 import Store from 'electron-store';
 import type { RecentDirectory } from './ipc/types.js';
+import type { TerminalRecipe } from './types/recipe.js';
 
 export type { RecentDirectory };
 
@@ -24,6 +25,7 @@ export interface StoreSchema {
       worktreeId?: string;
     }>;
   };
+  recipes: TerminalRecipe[];
 }
 
 export const store = new Store<StoreSchema>({
@@ -40,5 +42,6 @@ export const store = new Store<StoreSchema>({
       recentDirectories: [],
       terminals: [],
     },
+    recipes: [],
   },
 });

--- a/electron/types/index.ts
+++ b/electron/types/index.ts
@@ -289,3 +289,4 @@ export interface TerminalDimensions {
 
 export * from './config.js';
 export * from './keymap.js';
+export * from './recipe.js';

--- a/electron/types/recipe.ts
+++ b/electron/types/recipe.ts
@@ -1,0 +1,62 @@
+/**
+ * Terminal Recipe Types
+ *
+ * Defines the structure for terminal recipes - preset configurations
+ * that spawn multiple pre-configured terminals with one click.
+ */
+
+import type { TerminalType } from './index.js'
+
+/**
+ * Configuration for a single terminal in a recipe
+ */
+export interface RecipeTerminal {
+  /** Type of terminal to spawn */
+  type: TerminalType
+  /** Custom title for this terminal (optional, defaults to type-based title) */
+  title?: string
+  /** Command to execute after shell starts (for custom type) */
+  command?: string
+  /** Environment variables to set (optional) */
+  env?: Record<string, string>
+}
+
+/**
+ * A terminal recipe - a preset configuration that spawns multiple terminals
+ */
+export interface TerminalRecipe {
+  /** Unique identifier for this recipe */
+  id: string
+  /** Display name for the recipe */
+  name: string
+  /** ID of the worktree this recipe is associated with (null = global recipe) */
+  worktreeId: string | null
+  /** List of terminals to spawn when this recipe runs */
+  terminals: RecipeTerminal[]
+  /** Timestamp when the recipe was created */
+  createdAt: number
+  /** Timestamp when the recipe was last updated */
+  updatedAt: number
+}
+
+/**
+ * Input for creating a new recipe (id and timestamps are auto-generated)
+ */
+export type CreateRecipeInput = Omit<TerminalRecipe, 'id' | 'createdAt' | 'updatedAt'>
+
+/**
+ * Input for updating an existing recipe
+ */
+export type UpdateRecipeInput = Partial<Omit<TerminalRecipe, 'id' | 'createdAt' | 'updatedAt'>>
+
+/**
+ * Recipe export format for sharing
+ */
+export interface RecipeExport {
+  /** Version of the export format */
+  version: 1
+  /** The recipe data */
+  recipe: Omit<TerminalRecipe, 'id' | 'worktreeId' | 'createdAt' | 'updatedAt'>
+  /** Timestamp when exported */
+  exportedAt: number
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@octokit/graphql": "^9.0.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-slot": "^1.2.4",
     "@xterm/addon-fit": "^0.10.0",
@@ -79,11 +80,15 @@
       "target": [
         {
           "target": "dmg",
-          "arch": ["universal"]
+          "arch": [
+            "universal"
+          ]
         },
         {
           "target": "zip",
-          "arch": ["universal"]
+          "arch": [
+            "universal"
+          ]
         }
       ],
       "hardenedRuntime": true,
@@ -110,11 +115,15 @@
       "target": [
         {
           "target": "nsis",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         },
         {
           "target": "portable",
-          "arch": ["x64"]
+          "arch": [
+            "x64"
+          ]
         }
       ]
     },
@@ -127,7 +136,10 @@
     },
     "linux": {
       "icon": "build/icon.png",
-      "target": ["AppImage", "deb"],
+      "target": [
+        "AppImage",
+        "deb"
+      ],
       "category": "Development"
     }
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import '@xterm/xterm/css/xterm.css'
 import { isElectronAvailable, useAgentLauncher, useWorktrees, useContextInjection } from './hooks'
 import { AppLayout } from './components/Layout'
@@ -105,6 +105,7 @@ function App() {
   const { activeWorktreeId, setActiveWorktree } = useWorktreeSelectionStore()
   const { inject, isInjecting } = useContextInjection()
   const toggleLogsPanel = useLogsStore((state) => state.togglePanel)
+  const [problemsPanelOpen, setProblemsPanelOpen] = useState(false)
 
   // Track if state has been restored (prevent StrictMode double-execution)
   const hasRestoredState = useRef(false)
@@ -261,7 +262,10 @@ function App() {
       onSettings={handleSettings}
     >
       <TerminalGrid className="h-full w-full bg-canopy-bg" />
-      <ProblemsPanel />
+      <ProblemsPanel
+        isOpen={problemsPanelOpen}
+        onClose={() => setProblemsPanelOpen(false)}
+      />
     </AppLayout>
   )
 }

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -1,0 +1,284 @@
+/**
+ * Recipe Editor Component
+ *
+ * Modal dialog for creating and editing terminal recipes.
+ * Allows adding/removing terminals with type and title configuration.
+ */
+
+import { useState, useCallback, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../ui/dialog'
+import { Button } from '../ui/button'
+import { cn } from '@/lib/utils'
+import type { TerminalRecipe, RecipeTerminal, TerminalType } from '@/store/recipeStore'
+
+export interface RecipeEditorProps {
+  /** Whether the dialog is open */
+  open: boolean
+  /** Callback when dialog open state changes */
+  onOpenChange: (open: boolean) => void
+  /** Existing recipe to edit (null for creating new) */
+  recipe: TerminalRecipe | null
+  /** Worktree ID for new recipes (null for global) */
+  worktreeId: string | null
+  /** Callback when recipe is saved */
+  onSave: (name: string, terminals: RecipeTerminal[]) => Promise<void>
+}
+
+const TERMINAL_TYPES: { value: TerminalType; label: string; description: string }[] = [
+  { value: 'shell', label: 'Shell', description: 'Standard terminal shell' },
+  { value: 'claude', label: 'Claude', description: 'Claude AI agent' },
+  { value: 'gemini', label: 'Gemini', description: 'Gemini AI agent' },
+  { value: 'custom', label: 'Custom', description: 'Custom command' },
+]
+
+interface TerminalItem {
+  id: string
+  type: TerminalType
+  title: string
+}
+
+export function RecipeEditor({
+  open,
+  onOpenChange,
+  recipe,
+  worktreeId,
+  onSave,
+}: RecipeEditorProps) {
+  const [name, setName] = useState('')
+  const [terminals, setTerminals] = useState<TerminalItem[]>([])
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset form when dialog opens/closes or recipe changes
+  useEffect(() => {
+    if (open) {
+      if (recipe) {
+        setName(recipe.name)
+        setTerminals(
+          recipe.terminals.map((t, i) => ({
+            id: `terminal-${i}`,
+            type: t.type,
+            title: t.title || '',
+          }))
+        )
+      } else {
+        setName('')
+        setTerminals([{ id: 'terminal-0', type: 'shell', title: '' }])
+      }
+      setError(null)
+    }
+  }, [open, recipe])
+
+  const handleAddTerminal = useCallback(() => {
+    if (terminals.length >= 10) {
+      setError('Maximum 10 terminals per recipe')
+      return
+    }
+    setTerminals(prev => [
+      ...prev,
+      { id: `terminal-${Date.now()}`, type: 'shell', title: '' },
+    ])
+  }, [terminals.length])
+
+  const handleRemoveTerminal = useCallback((id: string) => {
+    setTerminals(prev => {
+      if (prev.length <= 1) {
+        setError('At least one terminal is required')
+        return prev
+      }
+      return prev.filter(t => t.id !== id)
+    })
+  }, [])
+
+  const handleUpdateTerminal = useCallback(
+    (id: string, field: 'type' | 'title', value: string) => {
+      setTerminals(prev =>
+        prev.map(t =>
+          t.id === id
+            ? { ...t, [field]: field === 'type' ? (value as TerminalType) : value }
+            : t
+        )
+      )
+    },
+    []
+  )
+
+  const handleSave = useCallback(async () => {
+    setError(null)
+
+    if (!name.trim()) {
+      setError('Recipe name is required')
+      return
+    }
+    if (terminals.length === 0) {
+      setError('At least one terminal is required')
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      const recipeTerminals: RecipeTerminal[] = terminals.map(t => ({
+        type: t.type,
+        title: t.title.trim() || undefined,
+      }))
+      await onSave(name.trim(), recipeTerminals)
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save recipe')
+    } finally {
+      setIsSaving(false)
+    }
+  }, [name, terminals, onSave, onOpenChange])
+
+  const isEditing = recipe !== null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? 'Edit Recipe' : 'Create Recipe'}</DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'Update your terminal recipe configuration.'
+              : 'Create a terminal recipe to spawn multiple terminals with one click.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Recipe Name */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text" htmlFor="recipe-name">
+              Recipe Name
+            </label>
+            <input
+              id="recipe-name"
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="e.g., Full Stack Dev"
+              className="w-full rounded-md border border-canopy-border bg-canopy-bg px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/50 focus:border-canopy-accent focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+            />
+          </div>
+
+          {/* Terminals List */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-canopy-text">
+                Terminals ({terminals.length}/10)
+              </label>
+              <button
+                type="button"
+                onClick={handleAddTerminal}
+                disabled={terminals.length >= 10}
+                className={cn(
+                  'text-xs px-2 py-1 rounded border border-canopy-accent text-canopy-accent',
+                  terminals.length >= 10
+                    ? 'opacity-50 cursor-not-allowed'
+                    : 'hover:bg-canopy-accent/10'
+                )}
+              >
+                + Add Terminal
+              </button>
+            </div>
+
+            <div className="space-y-2 max-h-64 overflow-y-auto">
+              {terminals.map((terminal, index) => (
+                <div
+                  key={terminal.id}
+                  className="flex items-center gap-2 p-2 rounded border border-canopy-border bg-canopy-bg/50"
+                >
+                  <span className="text-xs text-canopy-text/50 w-5">{index + 1}.</span>
+
+                  {/* Type Select */}
+                  <select
+                    value={terminal.type}
+                    onChange={e => handleUpdateTerminal(terminal.id, 'type', e.target.value)}
+                    className="flex-shrink-0 rounded border border-canopy-border bg-canopy-bg px-2 py-1 text-sm text-canopy-text focus:border-canopy-accent focus:outline-none"
+                  >
+                    {TERMINAL_TYPES.map(type => (
+                      <option key={type.value} value={type.value}>
+                        {type.label}
+                      </option>
+                    ))}
+                  </select>
+
+                  {/* Title Input */}
+                  <input
+                    type="text"
+                    value={terminal.title}
+                    onChange={e => handleUpdateTerminal(terminal.id, 'title', e.target.value)}
+                    placeholder="Custom title (optional)"
+                    className="flex-1 min-w-0 rounded border border-canopy-border bg-canopy-bg px-2 py-1 text-sm text-canopy-text placeholder:text-canopy-text/50 focus:border-canopy-accent focus:outline-none"
+                  />
+
+                  {/* Remove Button */}
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveTerminal(terminal.id)}
+                    disabled={terminals.length <= 1}
+                    className={cn(
+                      'p-1 rounded text-canopy-text/50',
+                      terminals.length <= 1
+                        ? 'opacity-30 cursor-not-allowed'
+                        : 'hover:text-red-400 hover:bg-red-400/10'
+                    )}
+                    title="Remove terminal"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </svg>
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Error Message */}
+          {error && (
+            <div
+              className="text-sm text-red-400 bg-red-400/10 px-3 py-2 rounded"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </div>
+          )}
+
+          {/* Scope Indicator */}
+          <div className="text-xs text-canopy-text/50">
+            {worktreeId
+              ? 'This recipe will be saved for the current worktree.'
+              : 'This recipe will be saved globally (available for all worktrees).'}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? 'Saving...' : isEditing ? 'Update Recipe' : 'Create Recipe'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/TerminalRecipe/RecipeList.tsx
+++ b/src/components/TerminalRecipe/RecipeList.tsx
@@ -1,0 +1,204 @@
+/**
+ * Recipe List Component
+ *
+ * Displays a list of saved terminal recipes with actions to run, edit, and delete.
+ */
+
+import { useCallback, useState, useRef, useEffect } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
+import { cn } from '@/lib/utils'
+import type { TerminalRecipe } from '@/store/recipeStore'
+
+export interface RecipeListProps {
+  /** List of recipes to display */
+  recipes: TerminalRecipe[]
+  /** Currently running recipe ID */
+  runningRecipeId: string | null
+  /** Callback when a recipe is selected to run */
+  onRun: (recipe: TerminalRecipe) => void
+  /** Callback when a recipe is selected to edit */
+  onEdit: (recipe: TerminalRecipe) => void
+  /** Callback when a recipe is selected to delete */
+  onDelete: (recipe: TerminalRecipe) => void
+  /** Callback when a recipe is selected to export */
+  onExport: (recipe: TerminalRecipe) => void
+}
+
+const TERMINAL_TYPE_ICONS: Record<string, string> = {
+  shell: '⬛',
+  claude: '🤖',
+  gemini: '💎',
+  custom: '⚙️',
+}
+
+export function RecipeList({
+  recipes,
+  runningRecipeId,
+  onRun,
+  onEdit,
+  onDelete,
+  onExport,
+}: RecipeListProps) {
+  if (recipes.length === 0) {
+    return (
+      <div className="text-sm text-canopy-text/50 py-2 text-center">
+        No recipes saved
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      {recipes.map(recipe => (
+        <RecipeItem
+          key={recipe.id}
+          recipe={recipe}
+          isRunning={recipe.id === runningRecipeId}
+          onRun={() => onRun(recipe)}
+          onEdit={() => onEdit(recipe)}
+          onDelete={() => onDelete(recipe)}
+          onExport={() => onExport(recipe)}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface RecipeItemProps {
+  recipe: TerminalRecipe
+  isRunning: boolean
+  onRun: () => void
+  onEdit: () => void
+  onDelete: () => void
+  onExport: () => void
+}
+
+function RecipeItem({
+  recipe,
+  isRunning,
+  onRun,
+  onEdit,
+  onDelete,
+  onExport,
+}: RecipeItemProps) {
+  const [showConfirmDelete, setShowConfirmDelete] = useState(false)
+  const confirmTimerRef = useRef<NodeJS.Timeout | null>(null)
+
+  const handleDelete = useCallback(() => {
+    if (showConfirmDelete) {
+      onDelete()
+      setShowConfirmDelete(false)
+      if (confirmTimerRef.current) {
+        clearTimeout(confirmTimerRef.current)
+        confirmTimerRef.current = null
+      }
+    } else {
+      setShowConfirmDelete(true)
+      // Auto-reset after 3 seconds
+      if (confirmTimerRef.current) {
+        clearTimeout(confirmTimerRef.current)
+      }
+      confirmTimerRef.current = setTimeout(() => setShowConfirmDelete(false), 3000)
+    }
+  }, [showConfirmDelete, onDelete])
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (confirmTimerRef.current) {
+        clearTimeout(confirmTimerRef.current)
+      }
+    }
+  }, [])
+
+  const terminalIcons = recipe.terminals.map((t, i) => (
+    <span key={i} title={t.title || t.type}>
+      {TERMINAL_TYPE_ICONS[t.type] || '⬛'}
+    </span>
+  ))
+
+  return (
+    <div className="flex items-center justify-between gap-2 p-2 rounded border border-canopy-border bg-canopy-bg/50 hover:bg-canopy-bg/80 group">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-sm text-canopy-text truncate">
+            {recipe.name}
+          </span>
+          {recipe.worktreeId === null && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-canopy-accent/20 text-canopy-accent">
+              global
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1 text-xs text-canopy-text/50">
+          <span className="flex gap-0.5">{terminalIcons}</span>
+          <span className="ml-1">({recipe.terminals.length} terminals)</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        {/* Run Button */}
+        <button
+          onClick={onRun}
+          disabled={isRunning}
+          className={cn(
+            'px-2 py-1 text-xs rounded border font-medium',
+            isRunning
+              ? 'border-canopy-border text-canopy-text/50 cursor-not-allowed'
+              : 'border-green-600 text-green-400 hover:bg-green-900/50'
+          )}
+        >
+          {isRunning ? '...' : '▶ Run'}
+        </button>
+
+        {/* More Actions Dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="p-1 rounded text-canopy-text/50 hover:text-canopy-text hover:bg-canopy-border">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="1" />
+                <circle cx="19" cy="12" r="1" />
+                <circle cx="5" cy="12" r="1" />
+              </svg>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={onEdit}>
+              Edit Recipe
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={onExport}>
+              Export Recipe
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={handleDelete}
+              className={cn(
+                showConfirmDelete
+                  ? 'text-red-400 focus:text-red-400'
+                  : ''
+              )}
+            >
+              {showConfirmDelete ? 'Click again to confirm' : 'Delete Recipe'}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TerminalRecipe/index.ts
+++ b/src/components/TerminalRecipe/index.ts
@@ -1,0 +1,5 @@
+export { RecipeEditor } from './RecipeEditor'
+export type { RecipeEditorProps } from './RecipeEditor'
+
+export { RecipeList } from './RecipeList'
+export type { RecipeListProps } from './RecipeList'

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,137 @@
+/**
+ * Dialog Component
+ *
+ * Based on Radix UI Dialog primitive with Canopy styling.
+ */
+
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cn } from '@/lib/utils'
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-canopy-border bg-canopy-sidebar p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <span className="sr-only">Close</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-1.5 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = 'DialogHeader'
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = 'DialogFooter'
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      'text-lg font-semibold leading-none tracking-tight text-canopy-text',
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-canopy-text/70', className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,3 +7,6 @@ export { useLogsStore, filterLogs } from './logsStore'
 
 export { useErrorStore } from './errorStore'
 export type { AppError, ErrorType, RetryAction } from './errorStore'
+
+export { useRecipeStore } from './recipeStore'
+export type { TerminalRecipe, RecipeTerminal, TerminalType } from './recipeStore'

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1,0 +1,204 @@
+/**
+ * Recipe Store
+ *
+ * Zustand store for managing terminal recipes in the renderer process.
+ * Handles recipe CRUD operations, running recipes, and export/import.
+ */
+
+import { create } from 'zustand'
+import { useTerminalStore } from './terminalStore'
+
+// Types matching the preload API
+export type TerminalType = 'shell' | 'claude' | 'gemini' | 'custom'
+
+export interface RecipeTerminal {
+  type: TerminalType
+  title?: string
+  command?: string
+  env?: Record<string, string>
+}
+
+export interface TerminalRecipe {
+  id: string
+  name: string
+  worktreeId: string | null
+  terminals: RecipeTerminal[]
+  createdAt: number
+  updatedAt: number
+}
+
+interface RecipeRunResult {
+  success: boolean
+  terminalIds: string[]
+  error?: string
+}
+
+interface RecipeState {
+  recipes: TerminalRecipe[]
+  isLoading: boolean
+  error: string | null
+  runningRecipeId: string | null
+
+  // Actions
+  fetchRecipes: () => Promise<void>
+  fetchRecipesForWorktree: (worktreeId: string | null) => Promise<TerminalRecipe[]>
+  createRecipe: (name: string, worktreeId: string | null, terminals: RecipeTerminal[]) => Promise<TerminalRecipe>
+  updateRecipe: (id: string, updates: { name?: string; worktreeId?: string | null; terminals?: RecipeTerminal[] }) => Promise<TerminalRecipe>
+  deleteRecipe: (id: string) => Promise<void>
+  runRecipe: (id: string, worktreeId: string, worktreePath: string) => Promise<RecipeRunResult>
+  runRecipeLocally: (recipe: TerminalRecipe, worktreeId: string, worktreePath: string) => Promise<RecipeRunResult>
+  exportRecipe: (id: string) => Promise<string>
+  importRecipe: (json: string, worktreeId: string | null) => Promise<TerminalRecipe>
+}
+
+export const useRecipeStore = create<RecipeState>((set, get) => ({
+  recipes: [],
+  isLoading: false,
+  error: null,
+  runningRecipeId: null,
+
+  fetchRecipes: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const recipes = await window.electron.recipe.getAll()
+      set({ recipes, isLoading: false })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch recipes'
+      set({ error: message, isLoading: false })
+    }
+  },
+
+  fetchRecipesForWorktree: async (worktreeId: string | null) => {
+    try {
+      return await window.electron.recipe.getForWorktree(worktreeId)
+    } catch (error) {
+      console.error('Failed to fetch recipes for worktree:', error)
+      return []
+    }
+  },
+
+  createRecipe: async (name: string, worktreeId: string | null, terminals: RecipeTerminal[]) => {
+    set({ error: null })
+    try {
+      const recipe = await window.electron.recipe.create(name, worktreeId, terminals)
+      set(state => ({ recipes: [...state.recipes, recipe] }))
+      return recipe
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to create recipe'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  updateRecipe: async (id: string, updates: { name?: string; worktreeId?: string | null; terminals?: RecipeTerminal[] }) => {
+    set({ error: null })
+    try {
+      const recipe = await window.electron.recipe.update(id, updates)
+      set(state => ({
+        recipes: state.recipes.map(r => r.id === id ? recipe : r)
+      }))
+      return recipe
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update recipe'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  deleteRecipe: async (id: string) => {
+    set({ error: null })
+    try {
+      await window.electron.recipe.delete(id)
+      set(state => ({
+        recipes: state.recipes.filter(r => r.id !== id)
+      }))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to delete recipe'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  runRecipe: async (id: string, worktreeId: string, worktreePath: string) => {
+    // Find the recipe first
+    const recipes = get().recipes
+    let recipe = recipes.find(r => r.id === id)
+
+    // If not in local state, fetch from backend
+    if (!recipe) {
+      recipe = await window.electron.recipe.get(id) ?? undefined
+    }
+
+    if (!recipe) {
+      set({ error: 'Recipe not found' })
+      return { success: false, terminalIds: [], error: 'Recipe not found' }
+    }
+
+    return get().runRecipeLocally(recipe, worktreeId, worktreePath)
+  },
+
+  runRecipeLocally: async (recipe: TerminalRecipe, worktreeId: string, worktreePath: string) => {
+    set({ runningRecipeId: recipe.id, error: null })
+
+    const terminalIds: string[] = []
+    const addTerminal = useTerminalStore.getState().addTerminal
+
+    try {
+      // Spawn terminals sequentially using the terminalStore
+      for (const terminal of recipe.terminals) {
+        // Determine command for AI agent types
+        let command: string | undefined
+        if (terminal.type === 'claude') {
+          command = 'claude'
+        } else if (terminal.type === 'gemini') {
+          command = 'gemini'
+        }
+
+        const id = await addTerminal({
+          type: terminal.type,
+          title: terminal.title,
+          worktreeId,
+          cwd: worktreePath,
+          command,
+        })
+
+        terminalIds.push(id)
+
+        // Small delay between spawns to prevent buffer overflow
+        if (recipe.terminals.indexOf(terminal) < recipe.terminals.length - 1) {
+          await new Promise(resolve => setTimeout(resolve, 100))
+        }
+      }
+
+      set({ runningRecipeId: null })
+      return { success: true, terminalIds }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to run recipe'
+      set({ runningRecipeId: null, error: message })
+      return { success: false, terminalIds, error: message }
+    }
+  },
+
+  exportRecipe: async (id: string) => {
+    try {
+      return await window.electron.recipe.export(id)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to export recipe'
+      set({ error: message })
+      throw error
+    }
+  },
+
+  importRecipe: async (json: string, worktreeId: string | null) => {
+    set({ error: null })
+    try {
+      const recipe = await window.electron.recipe.import(json, worktreeId)
+      set(state => ({ recipes: [...state.recipes, recipe] }))
+      return recipe
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to import recipe'
+      set({ error: message })
+      throw error
+    }
+  },
+}))

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -110,6 +110,31 @@ interface AppError {
   retryArgs?: Record<string, unknown>
 }
 
+// Recipe types
+type TerminalType = 'shell' | 'claude' | 'gemini' | 'custom'
+
+interface RecipeTerminal {
+  type: TerminalType
+  title?: string
+  command?: string
+  env?: Record<string, string>
+}
+
+interface TerminalRecipe {
+  id: string
+  name: string
+  worktreeId: string | null
+  terminals: RecipeTerminal[]
+  createdAt: number
+  updatedAt: number
+}
+
+interface RecipeRunResult {
+  success: boolean
+  terminalIds: string[]
+  error?: string
+}
+
 export interface ElectronAPI {
   worktree: {
     getAll(): Promise<WorktreeState[]>
@@ -151,7 +176,6 @@ export interface ElectronAPI {
     getState(): Promise<AppState>
     setState(partialState: Partial<AppState>): Promise<void>
   }
-<<<<<<< HEAD
   logs: {
     getAll(filters?: LogFilterOptions): Promise<LogEntry[]>
     getSources(): Promise<string[]>
@@ -164,12 +188,22 @@ export interface ElectronAPI {
     open(path: string): Promise<void>
     openDialog(): Promise<string | null>
     removeRecent(path: string): Promise<void>
-=======
+  }
   errors: {
     onError(callback: (error: AppError) => void): () => void
     retry(errorId: string, action: RetryAction, args?: Record<string, unknown>): Promise<void>
     openLogs(): Promise<void>
->>>>>>> feature/issue-47-error-ui-recovery
+  }
+  recipe: {
+    getAll(): Promise<TerminalRecipe[]>
+    get(id: string): Promise<TerminalRecipe | null>
+    getForWorktree(worktreeId: string | null): Promise<TerminalRecipe[]>
+    create(name: string, worktreeId: string | null, terminals: RecipeTerminal[]): Promise<TerminalRecipe>
+    update(id: string, updates: { name?: string; worktreeId?: string | null; terminals?: RecipeTerminal[] }): Promise<TerminalRecipe>
+    delete(id: string): Promise<void>
+    run(id: string, worktreeId: string, worktreePath: string): Promise<RecipeRunResult>
+    export(id: string): Promise<string>
+    import(json: string, worktreeId: string | null): Promise<TerminalRecipe>
   }
 }
 


### PR DESCRIPTION
## Summary

Implements terminal recipes feature that allows users to save and run preset terminal configurations with one click. Users can create recipes that spawn multiple terminals (shell, Claude, Gemini, or custom) simultaneously, either globally or scoped to specific worktrees.

Closes #54

## Changes Made

- Add recipe type definitions with RecipeTerminal and TerminalRecipe interfaces
- Implement IPC handlers for recipe CRUD operations with electron-store persistence
- Add recipe IPC channels and preload API exposure to renderer
- Create RecipeEditor modal component for creating/editing recipes (supports 1-10 terminals per recipe)
- Create RecipeList component for viewing and managing saved recipes
- Integrate recipe actions into WorktreeCard with dropdown menu (Create Recipe, Run Recipe)
- Add recipeStore for managing recipe state and execution logic
- Implement recipe execution that spawns multiple terminals with proper configuration
- Add Dialog UI component for modal interactions
- Fix race condition in recipe fetch with cleanup flag
- Add payload validation and worktree path security checks in IPC handlers
- Add error display and accessibility improvements (ARIA attributes)
- Fix timer cleanup to prevent memory leaks in delete confirmation