### PR TITLE
Implement agent lifecycle state tracking

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -32,6 +32,9 @@ export const CHANNELS = {
   TERMINAL_EXIT: 'terminal:exit',
   TERMINAL_ERROR: 'terminal:error',
 
+  // Agent state channels
+  AGENT_STATE_CHANGED: 'agent:state-changed',
+
   // CopyTree channels
   COPYTREE_GENERATE: 'copytree:generate',
   COPYTREE_INJECT: 'copytree:inject',

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -14,6 +14,12 @@ export interface TerminalSpawnOptions {
   rows: number
   /** Command to execute after shell starts (e.g., 'claude' for AI agents) */
   command?: string
+  /** Terminal type (derived from command if not provided) */
+  type?: 'shell' | 'claude' | 'gemini' | 'custom'
+  /** Display title */
+  title?: string
+  /** Associated worktree ID */
+  worktreeId?: string
 }
 
 export interface TerminalDataPayload {
@@ -39,6 +45,18 @@ export interface TerminalExitPayload {
 export interface TerminalErrorPayload {
   id: string
   error: string
+}
+
+// Agent state types
+export type AgentState = 'idle' | 'working' | 'waiting' | 'completed' | 'failed'
+
+export interface AgentStateChangedPayload {
+  agentId: string
+  terminalId: string
+  previousState: AgentState
+  newState: AgentState
+  timestamp: number
+  error?: string
 }
 
 // Worktree types (imported from core types)

--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -1,0 +1,180 @@
+/**
+ * Agent State Machine
+ *
+ * Pure state machine logic for agent lifecycle tracking.
+ * Enforces valid state transitions and provides prompt detection heuristics.
+ */
+
+import type { AgentState } from '../types/index.js';
+
+/**
+ * Events that can trigger agent state transitions
+ */
+export type AgentEvent =
+  | { type: 'start' }
+  | { type: 'output'; data: string }
+  | { type: 'prompt' }
+  | { type: 'input' }
+  | { type: 'exit'; code: number }
+  | { type: 'error'; error: string };
+
+/**
+ * Valid state transition matrix.
+ * Maps current state to allowed next states.
+ */
+const STATE_TRANSITIONS: Record<AgentState, AgentState[]> = {
+  idle: ['working', 'failed'],
+  working: ['waiting', 'completed', 'failed'],
+  waiting: ['working', 'completed', 'failed'], // Can complete or fail from waiting
+  completed: [], // Terminal state
+  failed: [], // Terminal state
+};
+
+/**
+ * Prompt detection patterns for identifying when an agent is waiting for input.
+ * These patterns indicate the agent is in a 'waiting' state.
+ */
+const PROMPT_PATTERNS = [
+  /\?\s*$/m, // Question mark at end of line (e.g., "Continue? ")
+  /\(y\/n\)/i, // Yes/no prompts
+  /\(yes\/no\)/i, // Yes/no prompts (full words)
+  /press\s+enter/i, // "Press Enter" prompts
+  /enter\s+to\s+continue/i, // "Enter to continue"
+  /waiting\s+for\s+input/i, // Explicit waiting message
+  /:\s*$/m, // Colon at end of line (common prompt indicator)
+];
+
+/**
+ * Check if a state transition is valid according to the state machine.
+ *
+ * @param from - Current state
+ * @param to - Desired next state
+ * @returns true if transition is allowed, false otherwise
+ */
+export function isValidTransition(from: AgentState, to: AgentState): boolean {
+  const allowedTransitions = STATE_TRANSITIONS[from];
+  return allowedTransitions.includes(to);
+}
+
+/**
+ * Detect if output contains a prompt pattern indicating the agent is waiting for input.
+ *
+ * @param data - Terminal output data
+ * @returns true if a prompt pattern is detected
+ */
+export function detectPrompt(data: string): boolean {
+  return PROMPT_PATTERNS.some((pattern) => pattern.test(data));
+}
+
+/**
+ * Compute the next agent state based on the current state and an event.
+ * Enforces valid transitions only - invalid transitions return the current state.
+ *
+ * @param current - Current agent state
+ * @param event - Event triggering the potential state change
+ * @returns Next agent state (may be same as current if transition is invalid)
+ */
+export function nextAgentState(current: AgentState, event: AgentEvent): AgentState {
+  switch (event.type) {
+    case 'start':
+      // Transition from idle to working when agent starts
+      if (current === 'idle' && isValidTransition('idle', 'working')) {
+        return 'working';
+      }
+      return current;
+
+    case 'output':
+      // Check if output contains a prompt pattern
+      if (current === 'working' && detectPrompt(event.data)) {
+        if (isValidTransition('working', 'waiting')) {
+          return 'waiting';
+        }
+      }
+      // Otherwise stay in working state (or current state if not working)
+      return current;
+
+    case 'prompt':
+      // Explicit prompt event - transition working to waiting
+      if (current === 'working' && isValidTransition('working', 'waiting')) {
+        return 'waiting';
+      }
+      return current;
+
+    case 'input':
+      // User provided input - transition waiting back to working
+      if (current === 'waiting' && isValidTransition('waiting', 'working')) {
+        return 'working';
+      }
+      return current;
+
+    case 'exit':
+      // Process exited - transition to completed or failed based on exit code
+      if (current === 'working' || current === 'waiting') {
+        const nextState = event.code === 0 ? 'completed' : 'failed';
+        if (isValidTransition(current, nextState)) {
+          return nextState;
+        }
+      }
+      return current;
+
+    case 'error':
+      // Error event - can transition from any non-terminal state to failed
+      if (current !== 'completed' && current !== 'failed') {
+        if (isValidTransition(current, 'failed')) {
+          return 'failed';
+        }
+      }
+      return current;
+
+    default:
+      return current;
+  }
+}
+
+/**
+ * Get a human-readable label for an agent state.
+ *
+ * @param state - Agent state
+ * @returns Human-readable label
+ */
+export function getStateLabel(state: AgentState): string {
+  switch (state) {
+    case 'idle':
+      return 'Idle';
+    case 'working':
+      return 'Working';
+    case 'waiting':
+      return 'Waiting';
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+      return 'Failed';
+    default:
+      return 'Unknown';
+  }
+}
+
+/**
+ * Get a color classification for an agent state (for UI rendering).
+ *
+ * @param state - Agent state
+ * @returns Color category (matches Tailwind color names)
+ */
+export function getStateColor(
+  state: AgentState,
+): 'gray' | 'blue' | 'yellow' | 'green' | 'red' {
+  switch (state) {
+    case 'idle':
+      return 'gray';
+    case 'working':
+      return 'blue';
+    case 'waiting':
+      return 'yellow';
+    case 'completed':
+      return 'green';
+    case 'failed':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -116,9 +116,11 @@ export type CanopyEventMap = {
    */
   'agent:state-changed': {
     agentId: string;
-    state: AgentState;
-    previousState?: AgentState;
+    terminalId: string;
+    newState: AgentState;
+    previousState: AgentState;
     timestamp: number;
+    error?: string;
   };
 
   /**

--- a/electron/types/index.ts
+++ b/electron/types/index.ts
@@ -257,6 +257,12 @@ export interface TerminalInstance {
   cols: number;
   /** Number of rows in the terminal */
   rows: number;
+  /** Current agent lifecycle state (for AI agent terminals) */
+  agentState?: AgentState;
+  /** Timestamp of last agent state change (milliseconds since epoch) */
+  lastStateChange?: number;
+  /** Error message if agent state is 'failed' */
+  error?: string;
 }
 
 /** Options for spawning a new PTY process */

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -101,6 +101,9 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
             cwd={terminal.cwd}
             isFocused={true}
             isMaximized={true}
+            agentState={terminal.agentState}
+            lastStateChange={terminal.lastStateChange}
+            error={terminal.error}
             onFocus={() => setFocused(terminal.id)}
             onClose={() => removeTerminal(terminal.id)}
             onInjectContext={
@@ -143,6 +146,9 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
           cwd={terminal.cwd}
           isFocused={terminal.id === focusedId}
           isMaximized={false}
+          agentState={terminal.agentState}
+          lastStateChange={terminal.lastStateChange}
+          error={terminal.error}
           onFocus={() => setFocused(terminal.id)}
           onClose={() => removeTerminal(terminal.id)}
           onInjectContext={

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -12,6 +12,7 @@ import type {
   WorktreeState,
   DevServerState,
   CanopyConfig,
+  AgentState,
 } from './index'
 
 // Additional types specific to the Electron API that may not be in the main types
@@ -40,6 +41,15 @@ interface CopyTreeResult {
   success: boolean
   content?: string
   fileCount?: number
+  error?: string
+}
+
+interface AgentStateChangedPayload {
+  agentId: string
+  terminalId: string
+  previousState: AgentState
+  newState: AgentState
+  timestamp: number
   error?: string
 }
 
@@ -136,6 +146,9 @@ export interface ElectronAPI {
     onData(id: string, callback: (data: string) => void): () => void
     onExit(callback: (id: string, exitCode: number) => void): () => void
   }
+  agent: {
+    onStateChanged(callback: (payload: AgentStateChangedPayload) => void): () => void
+  }
   copyTree: {
     generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>
     injectToTerminal(terminalId: string, worktreeId: string): Promise<CopyTreeResult>
@@ -151,7 +164,6 @@ export interface ElectronAPI {
     getState(): Promise<AppState>
     setState(partialState: Partial<AppState>): Promise<void>
   }
-<<<<<<< HEAD
   logs: {
     getAll(filters?: LogFilterOptions): Promise<LogEntry[]>
     getSources(): Promise<string[]>
@@ -164,12 +176,11 @@ export interface ElectronAPI {
     open(path: string): Promise<void>
     openDialog(): Promise<string | null>
     removeRecent(path: string): Promise<void>
-=======
+  }
   errors: {
     onError(callback: (error: AppError) => void): () => void
     retry(errorId: string, action: RetryAction, args?: Record<string, unknown>): Promise<void>
     openLogs(): Promise<void>
->>>>>>> feature/issue-47-error-ui-recovery
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,12 @@ export interface Notification {
 export type NotificationPayload = Omit<Notification, 'id'> & { id?: string };
 
 // ============================================================================
+// Agent/Task Types
+// ============================================================================
+
+export type AgentState = 'idle' | 'working' | 'waiting' | 'completed' | 'failed';
+
+// ============================================================================
 // Terminal Types
 // ============================================================================
 
@@ -129,6 +135,9 @@ export interface TerminalInstance {
   pid?: number;
   cols: number;
   rows: number;
+  agentState?: AgentState;
+  lastStateChange?: number;
+  error?: string;
 }
 
 export interface PtySpawnOptions {


### PR DESCRIPTION
## Summary
Adds state machine-based lifecycle tracking for AI agent terminals (Claude, Gemini) to monitor execution states: idle → working → waiting → completed/failed. This enables real-time UI status indicators and lays the groundwork for retry/cancel functionality.

Closes #46

## Changes Made
- Create AgentStateMachine with transition logic and prompt detection heuristics
- Extend PtyManager to track state changes on spawn/data/input/exit/kill events
- Add agent:state-changed IPC channel for main-to-renderer communication
- Extend TerminalInstance type with agentState, lastStateChange, and error fields
- Update terminalStore to handle state updates with timestamp-based deduplication
- Add AgentStateBadge component with color-coded states and duration tooltips
- Forward terminal type/title/worktreeId through IPC handlers to enable agent detection
- Allow waiting → completed/failed transitions for graceful exit handling
- Add accessibility labels (aria-label) for screen reader support

## Test Plan
- Spawn Claude/Gemini terminals and verify state transitions appear in UI badges
- Check that state colors match: idle (gray), working (blue), waiting (yellow), completed (green), failed (red)
- Verify duration tooltips update correctly
- Test edge cases: rapid state changes, out-of-order events, process crashes