### PR TITLE
Implement Multi-Project Support for rapid project switching

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -68,6 +68,16 @@ export const CHANNELS = {
   ERROR_NOTIFY: 'error:notify',
   ERROR_RETRY: 'error:retry',
   ERROR_OPEN_LOGS: 'error:open-logs',
+
+  // Project channels
+  PROJECT_GET_ALL: 'project:get-all',
+  PROJECT_GET_CURRENT: 'project:get-current',
+  PROJECT_CREATE: 'project:create',
+  PROJECT_UPDATE: 'project:update',
+  PROJECT_REMOVE: 'project:remove',
+  PROJECT_SWITCH: 'project:switch',
+  PROJECT_GET_STATE: 'project:get-state',
+  PROJECT_SAVE_STATE: 'project:save-state',
 } as const
 
 export type ChannelName = typeof CHANNELS[keyof typeof CHANNELS]

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -165,3 +165,61 @@ export interface DirectoryOpenPayload {
 export interface DirectoryRemoveRecentPayload {
   path: string
 }
+
+// Project types
+export interface Project {
+  id: string                    // UUID or path hash
+  path: string                  // Git repository root path
+  name: string                  // User-editable display name
+  emoji: string                 // User-editable emoji (default: 🌲)
+  aiGeneratedName?: string      // AI-suggested name (from folder)
+  aiGeneratedEmoji?: string     // AI-suggested emoji
+  lastOpened: number            // Timestamp for sorting
+  color?: string                // Theme color/gradient (optional)
+}
+
+export interface ProjectState {
+  projectId: string
+  activeWorktreeId?: string
+  sidebarWidth: number
+  terminals: Array<{
+    id: string
+    type: 'shell' | 'claude' | 'gemini' | 'custom'
+    title: string
+    cwd: string
+    worktreeId?: string
+  }>
+}
+
+export interface ProjectIdentity {
+  name: string
+  emoji: string
+  gradient?: string
+}
+
+// Project operation payloads
+export interface ProjectCreatePayload {
+  path: string
+  name?: string
+  emoji?: string
+}
+
+export interface ProjectUpdatePayload {
+  id: string
+  name?: string
+  emoji?: string
+  color?: string
+}
+
+export interface ProjectRemovePayload {
+  id: string
+}
+
+export interface ProjectSwitchPayload {
+  id: string
+}
+
+export interface ProjectStatePayload {
+  projectId: string
+  state: ProjectState
+}

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -1,0 +1,358 @@
+/**
+ * ProjectStore
+ *
+ * Manages project persistence and state in the filesystem.
+ * Projects are stored in ~/.config/canopy/projects.json
+ * Per-project state is stored in ~/.config/canopy/projects/<project-id>/state.json
+ */
+
+import { promises as fs } from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import os from 'os'
+import type { Project, ProjectState } from '../ipc/types.js'
+
+const CONFIG_DIR = path.join(os.homedir(), '.config', 'canopy')
+const PROJECTS_FILE = path.join(CONFIG_DIR, 'projects.json')
+const PROJECTS_STATE_DIR = path.join(CONFIG_DIR, 'projects')
+const CURRENT_PROJECT_FILE = path.join(CONFIG_DIR, 'current-project.txt')
+
+interface ProjectsData {
+  projects: Project[]
+}
+
+export class ProjectStore {
+  private projectsCache: Project[] | null = null
+  private currentProjectId: string | null = null
+
+  /**
+   * Initialize the ProjectStore
+   * Ensures config directory and files exist
+   */
+  async initialize(): Promise<void> {
+    try {
+      await fs.mkdir(CONFIG_DIR, { recursive: true })
+      await fs.mkdir(PROJECTS_STATE_DIR, { recursive: true })
+
+      // Load current project ID
+      try {
+        this.currentProjectId = (await fs.readFile(CURRENT_PROJECT_FILE, 'utf8')).trim()
+      } catch {
+        // No current project set yet
+        this.currentProjectId = null
+      }
+
+      // Ensure projects file exists
+      try {
+        await fs.access(PROJECTS_FILE)
+      } catch {
+        await fs.writeFile(PROJECTS_FILE, JSON.stringify({ projects: [] }, null, 2))
+      }
+
+      // Load projects cache
+      await this.loadProjects()
+    } catch (error) {
+      console.error('[ProjectStore] Failed to initialize:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Load projects from disk
+   */
+  private async loadProjects(): Promise<Project[]> {
+    try {
+      const data = await fs.readFile(PROJECTS_FILE, 'utf8')
+      const parsed: ProjectsData = JSON.parse(data)
+      this.projectsCache = parsed.projects || []
+      return this.projectsCache
+    } catch (error) {
+      console.error('[ProjectStore] Failed to load projects:', error)
+      this.projectsCache = []
+      return []
+    }
+  }
+
+  /**
+   * Save projects to disk
+   */
+  private async saveProjects(projects: Project[]): Promise<void> {
+    try {
+      const data: ProjectsData = { projects }
+      await fs.writeFile(PROJECTS_FILE, JSON.stringify(data, null, 2))
+      this.projectsCache = projects
+    } catch (error) {
+      console.error('[ProjectStore] Failed to save projects:', error)
+      throw error
+    }
+  }
+
+  /**
+   * Generate a deterministic project ID from path
+   */
+  private generateId(projectPath: string): string {
+    return crypto.createHash('sha256').update(projectPath).digest('hex').slice(0, 16)
+  }
+
+  /**
+   * Validate project ID format to prevent path traversal
+   */
+  private validateProjectId(id: string): boolean {
+    // IDs must be 16-character hex strings (from generateId)
+    return /^[a-f0-9]{16}$/.test(id)
+  }
+
+  /**
+   * Validate that a resolved path is within the projects directory
+   */
+  private validateProjectStatePath(projectId: string): string {
+    if (!this.validateProjectId(projectId)) {
+      throw new Error(`Invalid project ID format: ${projectId}`)
+    }
+
+    const stateDir = path.join(PROJECTS_STATE_DIR, projectId)
+    const resolvedPath = path.resolve(stateDir)
+
+    // Ensure the path is within PROJECTS_STATE_DIR
+    if (!resolvedPath.startsWith(path.resolve(PROJECTS_STATE_DIR) + path.sep)) {
+      throw new Error(`Project state path outside allowed directory: ${projectId}`)
+    }
+
+    return resolvedPath
+  }
+
+  /**
+   * Get all projects
+   */
+  async getAllProjects(): Promise<Project[]> {
+    if (!this.projectsCache) {
+      await this.loadProjects()
+    }
+    return this.projectsCache || []
+  }
+
+  /**
+   * Get a project by ID
+   */
+  async getProjectById(id: string): Promise<Project | null> {
+    const projects = await this.getAllProjects()
+    return projects.find(p => p.id === id) || null
+  }
+
+  /**
+   * Get a project by path
+   */
+  async getProjectByPath(projectPath: string): Promise<Project | null> {
+    const projects = await this.getAllProjects()
+    return projects.find(p => p.path === projectPath) || null
+  }
+
+  /**
+   * Add or update a project
+   * If a project with the same path exists, updates it; otherwise creates new
+   */
+  async addProject(projectPath: string, name?: string, emoji?: string): Promise<Project> {
+    const projects = await this.getAllProjects()
+
+    // Check if project already exists
+    const existing = projects.find(p => p.path === projectPath)
+    if (existing) {
+      // Update lastOpened timestamp
+      existing.lastOpened = Date.now()
+      if (name) existing.name = name
+      if (emoji) existing.emoji = emoji
+      await this.saveProjects(projects)
+      return existing
+    }
+
+    // Create new project
+    const id = this.generateId(projectPath)
+    const displayName = name || path.basename(projectPath)
+    const project: Project = {
+      id,
+      path: projectPath,
+      name: displayName,
+      emoji: emoji || '🌲',
+      lastOpened: Date.now(),
+    }
+
+    projects.push(project)
+    await this.saveProjects(projects)
+
+    // Create project state directory
+    const stateDir = path.join(PROJECTS_STATE_DIR, id)
+    await fs.mkdir(stateDir, { recursive: true })
+
+    return project
+  }
+
+  /**
+   * Update a project
+   */
+  async updateProject(id: string, updates: Partial<Pick<Project, 'name' | 'emoji' | 'color'>>): Promise<void> {
+    const projects = await this.getAllProjects()
+    const project = projects.find(p => p.id === id)
+
+    if (!project) {
+      throw new Error(`Project not found: ${id}`)
+    }
+
+    if (updates.name !== undefined) project.name = updates.name
+    if (updates.emoji !== undefined) project.emoji = updates.emoji
+    if (updates.color !== undefined) project.color = updates.color
+
+    await this.saveProjects(projects)
+  }
+
+  /**
+   * Remove a project
+   */
+  async removeProject(id: string): Promise<void> {
+    // Validate project ID format first
+    if (!this.validateProjectId(id)) {
+      throw new Error(`Invalid project ID format: ${id}`)
+    }
+
+    const projects = await this.getAllProjects()
+    const filtered = projects.filter(p => p.id !== id)
+
+    if (filtered.length === projects.length) {
+      throw new Error(`Project not found: ${id}`)
+    }
+
+    await this.saveProjects(filtered)
+
+    // Remove project state directory with path validation
+    try {
+      const stateDir = this.validateProjectStatePath(id)
+      await fs.rm(stateDir, { recursive: true, force: true })
+    } catch (error) {
+      console.warn(`[ProjectStore] Failed to remove project state directory for ${id}:`, error)
+    }
+
+    // Clear current project if it was removed
+    if (this.currentProjectId === id) {
+      this.currentProjectId = null
+      try {
+        await fs.unlink(CURRENT_PROJECT_FILE)
+      } catch {
+        // File may not exist
+      }
+    }
+  }
+
+  /**
+   * Get the current project ID
+   */
+  getCurrentProjectId(): string | null {
+    return this.currentProjectId
+  }
+
+  /**
+   * Set the current project
+   */
+  async setCurrentProject(id: string): Promise<void> {
+    const project = await this.getProjectById(id)
+    if (!project) {
+      throw new Error(`Project not found: ${id}`)
+    }
+
+    this.currentProjectId = id
+
+    // Save to disk
+    try {
+      await fs.writeFile(CURRENT_PROJECT_FILE, id, 'utf8')
+    } catch (error) {
+      console.error('[ProjectStore] Failed to save current project:', error)
+      throw error
+    }
+
+    // Update lastOpened timestamp
+    const projects = await this.getAllProjects()
+    const projectToUpdate = projects.find(p => p.id === id)
+    if (projectToUpdate) {
+      projectToUpdate.lastOpened = Date.now()
+      await this.saveProjects(projects)
+    }
+  }
+
+  /**
+   * Get project state
+   */
+  async getProjectState(projectId: string): Promise<ProjectState | null> {
+    try {
+      const stateDir = this.validateProjectStatePath(projectId)
+      const stateFile = path.join(stateDir, 'state.json')
+
+      const data = await fs.readFile(stateFile, 'utf8')
+      return JSON.parse(data) as ProjectState
+    } catch (error) {
+      if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+        // State file doesn't exist yet - this is expected for new projects
+        return null
+      }
+      // Log other errors (parse errors, permission issues) but still return null
+      console.error(`[ProjectStore] Failed to load project state for ${projectId}:`, error)
+      return null
+    }
+  }
+
+  /**
+   * Save project state
+   */
+  async saveProjectState(projectId: string, state: ProjectState): Promise<void> {
+    try {
+      const stateDir = this.validateProjectStatePath(projectId)
+      const stateFile = path.join(stateDir, 'state.json')
+
+      await fs.mkdir(stateDir, { recursive: true })
+      // TODO: Use atomic write (temp file + rename) to prevent corruption
+      await fs.writeFile(stateFile, JSON.stringify(state, null, 2))
+    } catch (error) {
+      console.error(`[ProjectStore] Failed to save project state for ${projectId}:`, error)
+      throw error
+    }
+  }
+
+  /**
+   * Migrate from old appState to project model
+   * Creates a project from lastDirectory if it exists
+   */
+  async migrateFromAppState(lastDirectory?: string, recentDirectories?: Array<{ path: string; lastOpened: number; displayName: string }>): Promise<Project | null> {
+    // If lastDirectory exists and is not already a project, create one
+    if (lastDirectory) {
+      try {
+        await fs.access(lastDirectory)
+        const existing = await this.getProjectByPath(lastDirectory)
+        if (!existing) {
+          const project = await this.addProject(lastDirectory)
+          await this.setCurrentProject(project.id)
+          return project
+        }
+        return existing
+      } catch {
+        // Directory doesn't exist, skip
+      }
+    }
+
+    // Try to create projects from recent directories
+    if (recentDirectories && recentDirectories.length > 0) {
+      for (const recent of recentDirectories) {
+        try {
+          await fs.access(recent.path)
+          const existing = await this.getProjectByPath(recent.path)
+          if (!existing) {
+            await this.addProject(recent.path, recent.displayName)
+          }
+        } catch {
+          // Directory doesn't exist, skip
+        }
+      }
+    }
+
+    return null
+  }
+}
+
+// Singleton instance
+export const projectStore = new ProjectStore()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,8 @@ import { AppLayout } from './components/Layout'
 import { TerminalGrid } from './components/Terminal'
 import { WorktreeCard } from './components/Worktree'
 import { ProblemsPanel } from './components/Errors'
-import { useTerminalStore, useWorktreeSelectionStore, useLogsStore } from './store'
+import { ProjectSwitcher } from './components/Project/ProjectSwitcher'
+import { useTerminalStore, useWorktreeSelectionStore, useLogsStore, useErrorStore } from './store'
 import type { WorktreeState } from './types'
 
 function SidebarContent() {
@@ -77,23 +78,31 @@ function SidebarContent() {
   }
 
   return (
-    <div className="p-4">
-      <h2 className="text-canopy-text font-semibold text-sm mb-4">Worktrees</h2>
-      <div className="space-y-2">
-        {worktrees.map((worktree) => (
-          <WorktreeCard
-            key={worktree.id}
-            worktree={worktree}
-            isActive={worktree.id === activeWorktreeId}
-            isFocused={worktree.id === focusedWorktreeId}
-            onSelect={() => selectWorktree(worktree.id)}
-            onCopyTree={() => handleCopyTree(worktree)}
-            onOpenEditor={() => handleOpenEditor(worktree)}
-            onToggleServer={() => handleToggleServer(worktree)}
-            onInjectContext={focusedTerminalId ? () => handleInjectContext(worktree.id) : undefined}
-            isInjecting={isInjecting}
-          />
-        ))}
+    <div className="flex flex-col h-full">
+      {/* Project Switcher */}
+      <div className="px-4 pt-4 pb-2 border-b border-canopy-border">
+        <ProjectSwitcher />
+      </div>
+
+      {/* Worktrees */}
+      <div className="flex-1 overflow-y-auto p-4">
+        <h2 className="text-canopy-text font-semibold text-sm mb-4">Worktrees</h2>
+        <div className="space-y-2">
+          {worktrees.map((worktree) => (
+            <WorktreeCard
+              key={worktree.id}
+              worktree={worktree}
+              isActive={worktree.id === activeWorktreeId}
+              isFocused={worktree.id === focusedWorktreeId}
+              onSelect={() => selectWorktree(worktree.id)}
+              onCopyTree={() => handleCopyTree(worktree)}
+              onOpenEditor={() => handleOpenEditor(worktree)}
+              onToggleServer={() => handleToggleServer(worktree)}
+              onInjectContext={focusedTerminalId ? () => handleInjectContext(worktree.id) : undefined}
+              isInjecting={isInjecting}
+            />
+          ))}
+        </div>
       </div>
     </div>
   )
@@ -105,6 +114,8 @@ function App() {
   const { activeWorktreeId, setActiveWorktree } = useWorktreeSelectionStore()
   const { inject, isInjecting } = useContextInjection()
   const toggleLogsPanel = useLogsStore((state) => state.togglePanel)
+  const isPanelOpen = useErrorStore((state) => state.isPanelOpen)
+  const setPanelOpen = useErrorStore((state) => state.setPanelOpen)
 
   // Track if state has been restored (prevent StrictMode double-execution)
   const hasRestoredState = useRef(false)
@@ -261,7 +272,7 @@ function App() {
       onSettings={handleSettings}
     >
       <TerminalGrid className="h-full w-full bg-canopy-bg" />
-      <ProblemsPanel />
+      <ProblemsPanel isOpen={isPanelOpen} onClose={() => setPanelOpen(false)} />
     </AppLayout>
   )
 }

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -1,0 +1,140 @@
+/**
+ * ProjectSwitcher Component
+ *
+ * Dropdown menu for switching between projects
+ */
+
+import { useState } from 'react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu'
+import { useProjects } from '../../hooks/useProjects'
+
+export function ProjectSwitcher() {
+  const { projects, currentProject, switchProject, openDirectoryDialog } = useProjects()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleSwitchProject = async (projectId: string) => {
+    try {
+      await switchProject(projectId)
+      setIsOpen(false)
+    } catch (error) {
+      console.error('Failed to switch project:', error)
+    }
+  }
+
+  const handleOpenDialog = async () => {
+    try {
+      await openDirectoryDialog()
+      setIsOpen(false)
+    } catch (error) {
+      console.error('Failed to open directory:', error)
+    }
+  }
+
+  if (!currentProject && projects.length === 0) {
+    return (
+      <button
+        onClick={handleOpenDialog}
+        className="flex items-center gap-2 px-3 py-2 rounded-md hover:bg-zinc-800 transition-colors"
+      >
+        <span className="text-sm text-zinc-400">Open Project...</span>
+      </button>
+    )
+  }
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger asChild>
+        <button className="flex items-center gap-2 px-3 py-2 rounded-md hover:bg-zinc-800 transition-colors text-left w-full">
+          <span className="text-lg">{currentProject?.emoji || '🌲'}</span>
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-zinc-200 truncate">
+              {currentProject?.name || 'No Project'}
+            </div>
+            <div className="text-xs text-zinc-500 truncate">
+              {currentProject?.path || ''}
+            </div>
+          </div>
+          <svg
+            className="w-4 h-4 text-zinc-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="w-64 bg-zinc-900 border-zinc-800">
+        {projects.length > 0 && (
+          <>
+            {projects.map((project) => (
+              <DropdownMenuItem
+                key={project.id}
+                onClick={() => handleSwitchProject(project.id)}
+                className={`flex items-start gap-2 px-3 py-2 ${
+                  project.id === currentProject?.id
+                    ? 'bg-zinc-800'
+                    : 'hover:bg-zinc-800'
+                }`}
+              >
+                <span className="text-lg flex-shrink-0">{project.emoji}</span>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-zinc-200 truncate">
+                    {project.name}
+                  </div>
+                  <div className="text-xs text-zinc-500 truncate">
+                    {project.path}
+                  </div>
+                  <div className="text-xs text-zinc-600">
+                    Last opened: {new Date(project.lastOpened).toLocaleDateString()}
+                  </div>
+                </div>
+                {project.id === currentProject?.id && (
+                  <svg
+                    className="w-4 h-4 text-green-500 flex-shrink-0 mt-1"
+                    fill="currentColor"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                )}
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator className="bg-zinc-800" />
+          </>
+        )}
+
+        <DropdownMenuItem
+          onClick={handleOpenDialog}
+          className="flex items-center gap-2 px-3 py-2 hover:bg-zinc-800 text-zinc-400"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 4v16m8-8H4"
+            />
+          </svg>
+          <span className="text-sm">Open Other...</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,0 +1,132 @@
+/**
+ * useProjects Hook
+ *
+ * React hook for managing project state
+ */
+
+import { useEffect, useState, useCallback } from 'react'
+
+interface Project {
+  id: string
+  path: string
+  name: string
+  emoji: string
+  aiGeneratedName?: string
+  aiGeneratedEmoji?: string
+  lastOpened: number
+  color?: string
+}
+
+export function useProjects() {
+  const [projects, setProjects] = useState<Project[]>([])
+  const [currentProject, setCurrentProject] = useState<Project | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load projects on mount
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        setLoading(true)
+        const [allProjects, current] = await Promise.all([
+          window.electron.project.getAll(),
+          window.electron.project.getCurrent(),
+        ])
+
+        setProjects(allProjects.sort((a, b) => b.lastOpened - a.lastOpened))
+        setCurrentProject(current)
+        setError(null)
+      } catch (err) {
+        console.error('Failed to load projects:', err)
+        setError(err instanceof Error ? err.message : 'Failed to load projects')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadProjects()
+  }, [])
+
+  // Create a new project
+  const createProject = useCallback(async (path: string, name?: string, emoji?: string) => {
+    try {
+      const project = await window.electron.project.create(path, name, emoji)
+      setProjects(prev => [project, ...prev.filter(p => p.id !== project.id)])
+      setCurrentProject(project)
+      return project
+    } catch (err) {
+      console.error('Failed to create project:', err)
+      throw err
+    }
+  }, [])
+
+  // Update a project
+  const updateProject = useCallback(async (id: string, updates: { name?: string; emoji?: string; color?: string }) => {
+    try {
+      await window.electron.project.update(id, updates)
+      setProjects(prev => prev.map(p => p.id === id ? { ...p, ...updates } : p))
+      if (currentProject?.id === id) {
+        setCurrentProject(prev => prev ? { ...prev, ...updates } : null)
+      }
+    } catch (err) {
+      console.error('Failed to update project:', err)
+      throw err
+    }
+  }, [currentProject])
+
+  // Remove a project
+  const removeProject = useCallback(async (id: string) => {
+    try {
+      await window.electron.project.remove(id)
+      setProjects(prev => prev.filter(p => p.id !== id))
+      if (currentProject?.id === id) {
+        setCurrentProject(null)
+      }
+    } catch (err) {
+      console.error('Failed to remove project:', err)
+      throw err
+    }
+  }, [currentProject])
+
+  // Switch to a project
+  const switchProject = useCallback(async (id: string) => {
+    try {
+      await window.electron.project.switch(id)
+      const project = projects.find(p => p.id === id)
+      if (project) {
+        setCurrentProject(project)
+        // Reload page to reflect new project state
+        window.location.reload()
+      }
+    } catch (err) {
+      console.error('Failed to switch project:', err)
+      throw err
+    }
+  }, [projects])
+
+  // Open directory dialog and create project
+  const openDirectoryDialog = useCallback(async () => {
+    try {
+      const path = await window.electron.directory.openDialog()
+      if (path) {
+        return await createProject(path)
+      }
+      return null
+    } catch (err) {
+      console.error('Failed to open directory:', err)
+      throw err
+    }
+  }, [createProject])
+
+  return {
+    projects,
+    currentProject,
+    loading,
+    error,
+    createProject,
+    updateProject,
+    removeProject,
+    switchProject,
+    openDirectoryDialog,
+  }
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -151,7 +151,6 @@ export interface ElectronAPI {
     getState(): Promise<AppState>
     setState(partialState: Partial<AppState>): Promise<void>
   }
-<<<<<<< HEAD
   logs: {
     getAll(filters?: LogFilterOptions): Promise<LogEntry[]>
     getSources(): Promise<string[]>
@@ -164,12 +163,70 @@ export interface ElectronAPI {
     open(path: string): Promise<void>
     openDialog(): Promise<string | null>
     removeRecent(path: string): Promise<void>
-=======
+  }
   errors: {
     onError(callback: (error: AppError) => void): () => void
     retry(errorId: string, action: RetryAction, args?: Record<string, unknown>): Promise<void>
     openLogs(): Promise<void>
->>>>>>> feature/issue-47-error-ui-recovery
+  }
+  project: {
+    getAll(): Promise<Array<{
+      id: string
+      path: string
+      name: string
+      emoji: string
+      aiGeneratedName?: string
+      aiGeneratedEmoji?: string
+      lastOpened: number
+      color?: string
+    }>>
+    getCurrent(): Promise<{
+      id: string
+      path: string
+      name: string
+      emoji: string
+      aiGeneratedName?: string
+      aiGeneratedEmoji?: string
+      lastOpened: number
+      color?: string
+    } | null>
+    create(path: string, name?: string, emoji?: string): Promise<{
+      id: string
+      path: string
+      name: string
+      emoji: string
+      aiGeneratedName?: string
+      aiGeneratedEmoji?: string
+      lastOpened: number
+      color?: string
+    }>
+    update(id: string, updates: { name?: string; emoji?: string; color?: string }): Promise<void>
+    remove(id: string): Promise<void>
+    switch(id: string): Promise<void>
+    getState(projectId: string): Promise<{
+      projectId: string
+      activeWorktreeId?: string
+      sidebarWidth: number
+      terminals: Array<{
+        id: string
+        type: 'shell' | 'claude' | 'gemini' | 'custom'
+        title: string
+        cwd: string
+        worktreeId?: string
+      }>
+    } | null>
+    saveState(projectId: string, state: {
+      projectId: string
+      activeWorktreeId?: string
+      sidebarWidth: number
+      terminals: Array<{
+        id: string
+        type: 'shell' | 'claude' | 'gemini' | 'custom'
+        title: string
+        cwd: string
+        worktreeId?: string
+      }>
+    }): Promise<void>
   }
 }
 


### PR DESCRIPTION
## Summary

Implements comprehensive multi-project support enabling rapid switching between Git repositories while preserving terminal sessions, worktree states, and UI layouts per project.

Closes #59

## Changes Made

**Backend Implementation:**
- Add ProjectStore service for project CRUD and state management with file-based persistence
- Implement path traversal protection with project ID validation (security fix)
- Add project switching with automatic state snapshot and restore
- Save project state on window close and app quit to prevent data loss
- Validate project existence before state operations

**IPC Layer:**
- Add project channels and handlers for all CRUD operations
- Implement project switch handler with proper terminal/worktree cleanup
- Add project state persistence handlers with validation
- Expose project API through preload bridge

**Frontend Implementation:**
- Add ProjectSwitcher component for visual project selection with emoji/name display
- Implement useProjects hook for project state management
- Integrate ProjectSwitcher into sidebar header
- Add project type definitions to electron.d.ts

**Security Fixes:**
- Validate project IDs to prevent path traversal attacks
- Ensure state directory paths stay within allowed directory
- Add project existence checks before file operations
- Distinguish parse errors from missing files in error handling

**Bug Fixes:**
- Fix terminal double-spawn by removing duplicate restoration during switch
- Reset sidebar width to default when no saved state exists
- Add proper error logging for parse/permission failures

## Technical Details

**Architecture:**
- Projects stored in `~/.config/canopy/projects.json`
- Per-project state in `~/.config/canopy/projects/<project-id>/state.json`
- Deterministic project IDs (16-char hex hash of path)
- Automatic migration from old `lastDirectory` appState

**State Preservation:**
- Terminal snapshots (IDs, types, cwds, titles)
- Active worktree selection
- Sidebar width
- Proper cleanup of monitors and dev servers on switch