### PR TITLE
Select optimal output format based on target AI agent

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -398,8 +398,8 @@ export function registerIpcHandlers(
         };
       }
 
-      // Generate context
-      const result = await copyTreeService.generate(worktree.path);
+      // Generate context with options (format can be specified)
+      const result = await copyTreeService.generate(worktree.path, payload.options);
 
       if (result.error) {
         return result;

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -131,6 +131,7 @@ export interface CopyTreeResult {
 export interface CopyTreeInjectPayload {
   terminalId: string;
   worktreeId: string;
+  options?: CopyTreeOptions;
 }
 
 // PR detection types

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -324,7 +324,11 @@ export interface ElectronAPI {
   };
   copyTree: {
     generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
-    injectToTerminal(terminalId: string, worktreeId: string): Promise<CopyTreeResult>;
+    injectToTerminal(
+      terminalId: string,
+      worktreeId: string,
+      options?: CopyTreeOptions
+    ): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
   };
   system: {
@@ -468,8 +472,12 @@ const api: ElectronAPI = {
     generate: (worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult> =>
       ipcRenderer.invoke(CHANNELS.COPYTREE_GENERATE, { worktreeId, options }),
 
-    injectToTerminal: (terminalId: string, worktreeId: string): Promise<CopyTreeResult> =>
-      ipcRenderer.invoke(CHANNELS.COPYTREE_INJECT, { terminalId, worktreeId }),
+    injectToTerminal: (
+      terminalId: string,
+      worktreeId: string,
+      options?: CopyTreeOptions
+    ): Promise<CopyTreeResult> =>
+      ipcRenderer.invoke(CHANNELS.COPYTREE_INJECT, { terminalId, worktreeId, options }),
 
     isAvailable: (): Promise<boolean> => ipcRenderer.invoke(CHANNELS.COPYTREE_AVAILABLE),
   },

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -175,7 +175,11 @@ export interface ElectronAPI {
   };
   copyTree: {
     generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
-    injectToTerminal(terminalId: string, worktreeId: string): Promise<CopyTreeResult>;
+    injectToTerminal(
+      terminalId: string,
+      worktreeId: string,
+      options?: CopyTreeOptions
+    ): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
   };
   system: {


### PR DESCRIPTION
## Summary
Automatically optimize CopyTree output format based on the target AI agent terminal type, improving response quality by selecting the format each model handles best.

Closes #58

## Changes Made
- Add AGENT_FORMAT_MAP in useContextInjection hook to define optimal formats per agent (Claude: XML, Gemini: Markdown)
- Detect terminal type and pass format option through complete IPC chain
- Update CopyTreeInjectPayload to accept optional CopyTreeOptions
- Add validation for missing terminals with clear error messages
- Log format selection in injection success message
- Maintain backward compatibility with optional format parameter

## Implementation Details
- **Format Mapping**: Claude receives XML (structured parsing), Gemini receives Markdown (natural reading), Shell/Custom default to XML
- **Type Safety**: Updated types across IPC boundary (handlers.ts, types.ts, preload.ts, electron.d.ts)
- **Error Handling**: Explicit errors when terminal not found, warnings for unknown terminal types
- **User Feedback**: Console logs now include format information (e.g., "Injected 42 files as MARKDOWN")

## Testing
- TypeScript compilation passes (`npm run typecheck`)
- ESLint checks pass with no new warnings (`npm run lint`)
- Format check passes (`npm run format:check`)