### PR TITLE
Add progress reporting for context generation

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -36,6 +36,8 @@ export const CHANNELS = {
   COPYTREE_GENERATE: "copytree:generate",
   COPYTREE_INJECT: "copytree:inject",
   COPYTREE_AVAILABLE: "copytree:available",
+  COPYTREE_PROGRESS: "copytree:progress",
+  COPYTREE_CANCEL: "copytree:cancel",
 
   // System channels
   SYSTEM_OPEN_EXTERNAL: "system:open-external",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -21,6 +21,7 @@ import type {
   CopyTreeGeneratePayload,
   CopyTreeInjectPayload,
   CopyTreeResult,
+  CopyTreeProgress,
   SystemOpenExternalPayload,
   SystemOpenPathPayload,
   WorktreeSetActivePayload,
@@ -347,7 +348,12 @@ export function registerIpcHandlers(
       };
     }
 
-    return copyTreeService.generate(worktree.path, payload.options);
+    // Progress callback to send updates to renderer
+    const onProgress = (progress: CopyTreeProgress) => {
+      sendToRenderer(mainWindow, CHANNELS.COPYTREE_PROGRESS, progress);
+    };
+
+    return copyTreeService.generate(worktree.path, payload.options, onProgress);
   };
   ipcMain.handle(CHANNELS.COPYTREE_GENERATE, handleCopyTreeGenerate);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GENERATE));
@@ -398,8 +404,13 @@ export function registerIpcHandlers(
         };
       }
 
-      // Generate context
-      const result = await copyTreeService.generate(worktree.path);
+      // Progress callback to send updates to renderer
+      const onProgress = (progress: CopyTreeProgress) => {
+        sendToRenderer(mainWindow, CHANNELS.COPYTREE_PROGRESS, progress);
+      };
+
+      // Generate context with progress reporting
+      const result = await copyTreeService.generate(worktree.path, {}, onProgress);
 
       if (result.error) {
         return result;
@@ -442,6 +453,12 @@ export function registerIpcHandlers(
   };
   ipcMain.handle(CHANNELS.COPYTREE_AVAILABLE, handleCopyTreeAvailable);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_AVAILABLE));
+
+  const handleCopyTreeCancel = async (): Promise<void> => {
+    copyTreeService.cancelAll();
+  };
+  ipcMain.handle(CHANNELS.COPYTREE_CANCEL, handleCopyTreeCancel);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_CANCEL));
 
   // ==========================================
   // System Handlers

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -133,6 +133,21 @@ export interface CopyTreeInjectPayload {
   worktreeId: string;
 }
 
+export interface CopyTreeProgress {
+  /** Current stage name (e.g., 'FileDiscoveryStage', 'FormatterStage') */
+  stage: string;
+  /** Progress percentage (0-1) */
+  progress: number;
+  /** Human-readable progress message */
+  message: string;
+  /** Files processed so far (if known) */
+  filesProcessed?: number;
+  /** Total files estimated (if known) */
+  totalFiles?: number;
+  /** Current file being processed (if known) */
+  currentFile?: string;
+}
+
 // PR detection types
 export interface PRDetectedPayload {
   worktreeId: string;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -48,6 +48,8 @@ const CHANNELS = {
   COPYTREE_GENERATE: "copytree:generate",
   COPYTREE_INJECT: "copytree:inject",
   COPYTREE_AVAILABLE: "copytree:available",
+  COPYTREE_PROGRESS: "copytree:progress",
+  COPYTREE_CANCEL: "copytree:cancel",
 
   // System channels
   SYSTEM_OPEN_EXTERNAL: "system:open-external",
@@ -191,6 +193,21 @@ interface CopyTreeResult {
   };
 }
 
+interface CopyTreeProgress {
+  /** Current stage name (e.g., 'FileDiscoveryStage', 'FormatterStage') */
+  stage: string;
+  /** Progress percentage (0-1) */
+  progress: number;
+  /** Human-readable progress message */
+  message: string;
+  /** Files processed so far (if known) */
+  filesProcessed?: number;
+  /** Total files estimated (if known) */
+  totalFiles?: number;
+  /** Current file being processed (if known) */
+  currentFile?: string;
+}
+
 interface CanopyConfig {
   editor?: string;
   editorArgs?: string[];
@@ -326,6 +343,8 @@ export interface ElectronAPI {
     generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
     injectToTerminal(terminalId: string, worktreeId: string): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
+    cancel(): Promise<void>;
+    onProgress(callback: (progress: CopyTreeProgress) => void): () => void;
   };
   system: {
     openExternal(url: string): Promise<void>;
@@ -472,6 +491,15 @@ const api: ElectronAPI = {
       ipcRenderer.invoke(CHANNELS.COPYTREE_INJECT, { terminalId, worktreeId }),
 
     isAvailable: (): Promise<boolean> => ipcRenderer.invoke(CHANNELS.COPYTREE_AVAILABLE),
+
+    cancel: (): Promise<void> => ipcRenderer.invoke(CHANNELS.COPYTREE_CANCEL),
+
+    onProgress: (callback: (progress: CopyTreeProgress) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, progress: CopyTreeProgress) =>
+        callback(progress);
+      ipcRenderer.on(CHANNELS.COPYTREE_PROGRESS, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.COPYTREE_PROGRESS, handler);
+    },
   },
 
   // ==========================================

--- a/src/components/ContextInjection/ProgressBar.tsx
+++ b/src/components/ContextInjection/ProgressBar.tsx
@@ -1,0 +1,110 @@
+/**
+ * ProgressBar Component
+ *
+ * Displays progress information during CopyTree context generation.
+ * Shows a progress bar, current stage/message, and optional cancel button.
+ */
+
+import { cn } from "@/lib/utils";
+import { Loader2, X } from "lucide-react";
+import type { CopyTreeProgress } from "@/hooks/useContextInjection";
+
+export interface ProgressBarProps {
+  /** Current progress information */
+  progress: CopyTreeProgress;
+  /** Called when cancel button is clicked */
+  onCancel?: () => void;
+  /** Whether to show in compact mode (inline) */
+  compact?: boolean;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+export function ProgressBar({ progress, onCancel, compact = false, className }: ProgressBarProps) {
+  const percentage = Math.round(progress.progress * 100);
+
+  if (compact) {
+    return (
+      <div
+        className={cn("flex items-center gap-2 text-sm text-canopy-text-muted", className)}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percentage}
+        aria-valuetext={progress.message || progress.stage}
+        aria-live="polite"
+      >
+        <Loader2 className="h-3 w-3 animate-spin text-canopy-accent shrink-0" aria-hidden="true" />
+        <span className="truncate max-w-[200px]">{progress.message}</span>
+        <span className="font-mono text-xs shrink-0">{percentage}%</span>
+        {onCancel && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel();
+            }}
+            className="p-0.5 hover:bg-red-900/50 rounded text-gray-400 hover:text-red-400 transition-colors shrink-0"
+            title="Cancel"
+            aria-label="Cancel context generation"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5 p-2 bg-canopy-bg/80 rounded", className)}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percentage}
+      aria-valuetext={`${progress.stage}: ${progress.message || percentage + "%"}`}
+      aria-live="polite"
+    >
+      {/* Header with message and percentage */}
+      <div className="flex justify-between items-center text-xs">
+        <span className="text-canopy-text-muted truncate pr-2">{progress.message}</span>
+        <span className="text-canopy-text font-mono shrink-0">{percentage}%</span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-1.5 bg-canopy-sidebar rounded-full overflow-hidden">
+        <div
+          className="h-full bg-canopy-accent transition-all duration-150 ease-out"
+          style={{ width: `${percentage}%` }}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Footer with stage info and cancel button */}
+      <div className="flex justify-between items-center text-xs">
+        <span className="text-canopy-text-muted/70 truncate">
+          {progress.stage}
+          {progress.filesProcessed !== undefined && progress.totalFiles !== undefined && (
+            <span className="ml-1">
+              ({progress.filesProcessed}/{progress.totalFiles} files)
+            </span>
+          )}
+        </span>
+        {onCancel && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onCancel();
+            }}
+            className="text-red-400 hover:text-red-300 transition-colors shrink-0"
+            title="Cancel"
+            aria-label="Cancel context generation"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ProgressBar;

--- a/src/components/ContextInjection/index.ts
+++ b/src/components/ContextInjection/index.ts
@@ -1,0 +1,1 @@
+export { ProgressBar, type ProgressBarProps } from "./ProgressBar";

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -3,16 +3,37 @@
  *
  * Provides context injection functionality for worktrees into terminals.
  * Generates CopyTree output and injects it into the focused terminal.
+ * Includes progress reporting and cancellation support.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect, useRef } from "react";
 import { useTerminalStore } from "@/store/terminalStore";
+
+/** Progress information for context generation */
+export interface CopyTreeProgress {
+  /** Current stage name (e.g., 'FileDiscoveryStage', 'FormatterStage') */
+  stage: string;
+  /** Progress percentage (0-1) */
+  progress: number;
+  /** Human-readable progress message */
+  message: string;
+  /** Files processed so far (if known) */
+  filesProcessed?: number;
+  /** Total files estimated (if known) */
+  totalFiles?: number;
+  /** Current file being processed (if known) */
+  currentFile?: string;
+}
 
 export interface UseContextInjectionReturn {
   /** Inject context from a worktree into a terminal */
   inject: (worktreeId: string, terminalId?: string) => Promise<void>;
+  /** Cancel the current injection operation */
+  cancel: () => void;
   /** Whether an injection is currently in progress */
   isInjecting: boolean;
+  /** Current progress information (null when not injecting) */
+  progress: CopyTreeProgress | null;
   /** Error message from the last injection attempt */
   error: string | null;
   /** Clear the error state */
@@ -21,8 +42,29 @@ export interface UseContextInjectionReturn {
 
 export function useContextInjection(): UseContextInjectionReturn {
   const [isInjecting, setIsInjecting] = useState(false);
+  const [progress, setProgress] = useState<CopyTreeProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
   const focusedId = useTerminalStore((state) => state.focusedId);
+
+  // Track injection state to filter stale progress events
+  const isInjectingRef = useRef(false);
+  const lastProgressAtRef = useRef(0);
+
+  // Subscribe to progress events from the main process
+  useEffect(() => {
+    const unsubscribe = window.electron.copyTree.onProgress((p) => {
+      // Ignore progress updates when not injecting (prevents stale events)
+      if (!isInjectingRef.current) return;
+
+      // Throttle progress updates to prevent excessive re-renders (100ms)
+      const now = performance.now();
+      if (now - lastProgressAtRef.current < 100) return;
+      lastProgressAtRef.current = now;
+
+      setProgress(p);
+    });
+    return unsubscribe;
+  }, []);
 
   const inject = useCallback(
     async (worktreeId: string, terminalId?: string) => {
@@ -34,7 +76,9 @@ export function useContextInjection(): UseContextInjectionReturn {
       }
 
       setIsInjecting(true);
+      isInjectingRef.current = true;
       setError(null);
+      setProgress({ stage: "Starting", progress: 0, message: "Initializing..." });
 
       try {
         // Check if CopyTree is available
@@ -64,14 +108,23 @@ export function useContextInjection(): UseContextInjectionReturn {
         console.error("Context injection failed:", message);
       } finally {
         setIsInjecting(false);
+        isInjectingRef.current = false;
+        setProgress(null);
       }
     },
     [focusedId]
   );
 
+  const cancel = useCallback(() => {
+    window.electron.copyTree.cancel().catch(console.error);
+    setIsInjecting(false);
+    isInjectingRef.current = false;
+    setProgress(null);
+  }, []);
+
   const clearError = useCallback(() => {
     setError(null);
   }, []);
 
-  return { inject, isInjecting, error, clearError };
+  return { inject, cancel, isInjecting, progress, error, clearError };
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -62,6 +62,21 @@ interface CopyTreeResult {
   };
 }
 
+interface CopyTreeProgress {
+  /** Current stage name (e.g., 'FileDiscoveryStage', 'FormatterStage') */
+  stage: string;
+  /** Progress percentage (0-1) */
+  progress: number;
+  /** Human-readable progress message */
+  message: string;
+  /** Files processed so far (if known) */
+  filesProcessed?: number;
+  /** Total files estimated (if known) */
+  totalFiles?: number;
+  /** Current file being processed (if known) */
+  currentFile?: string;
+}
+
 interface TerminalState {
   id: string;
   type: "shell" | "claude" | "gemini" | "custom";
@@ -177,6 +192,8 @@ export interface ElectronAPI {
     generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;
     injectToTerminal(terminalId: string, worktreeId: string): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
+    cancel(): Promise<void>;
+    onProgress(callback: (progress: CopyTreeProgress) => void): () => void;
   };
   system: {
     openExternal(url: string): Promise<void>;


### PR DESCRIPTION
## Summary
Adds real-time progress feedback during CopyTree context generation, showing users what files are being processed and how much of the operation is complete.

Closes #57

## Changes Made
- Added `CopyTreeProgress` type with stage, percentage, message, and file count
- Implemented progress event emission from `CopyTreeService` via IPC
- Added progress throttling (100ms) and cancellation guard in SDK callback
- Created `useContextInjection` hook with stale event filtering and throttling
- Built accessible `ProgressBar` component with compact and full modes
- Integrated progress display in `TerminalPane` header during injection
- Added cancel button to abort ongoing context generation
- Included ARIA attributes for screen reader support

## Technical Details
- **Backend**: Progress events flow from CopyTree SDK → CopyTreeService → IPC → Renderer
- **Throttling**: SDK throttles at 100ms, renderer adds additional 100ms throttle to prevent excessive re-renders
- **Cancellation**: AbortController guards prevent stale progress updates after cancel
- **Accessibility**: Full ARIA progressbar semantics with live region announcements
- **Type Safety**: Consistent types across IPC boundary (main → preload → renderer)