### PR TITLE
Add bulk terminal actions for managing many terminals

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -426,7 +426,11 @@ export function registerIpcHandlers(
       };
 
       // Generate context with options (format can be specified) and progress reporting
-      const result = await copyTreeService.generate(worktree.path, payload.options || {}, onProgress);
+      const result = await copyTreeService.generate(
+        worktree.path,
+        payload.options || {},
+        onProgress
+      );
 
       if (result.error) {
         return result;

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -18,6 +18,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { BulkActionsMenu } from "@/components/Terminal";
 
 interface ToolbarProps {
   onLaunchAgent: (type: "claude" | "gemini" | "shell") => void;
@@ -108,6 +109,7 @@ export function Toolbar({
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <BulkActionsMenu />
       </div>
 
       {/* Title - centered */}

--- a/src/components/Terminal/BulkActionsMenu.tsx
+++ b/src/components/Terminal/BulkActionsMenu.tsx
@@ -1,0 +1,209 @@
+/**
+ * Bulk Actions Menu Component
+ *
+ * Dropdown menu for bulk terminal management actions like closing
+ * all completed/failed terminals or restarting failed agents.
+ */
+
+import { useState, useCallback } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { ChevronDown, CheckCircle, XCircle, Clock, Trash2, RefreshCw } from "lucide-react";
+import { useTerminalStore } from "@/store/terminalStore";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+export interface BulkActionsMenuProps {
+  /** Optional worktree ID to scope actions to a specific worktree */
+  worktreeId?: string;
+  /** Custom trigger element (if not provided, uses default button) */
+  trigger?: React.ReactNode;
+  /** Additional class name for the trigger button */
+  className?: string;
+}
+
+export function BulkActionsMenu({ worktreeId, trigger, className }: BulkActionsMenuProps) {
+  const terminals = useTerminalStore((state) => state.terminals);
+  const bulkCloseByState = useTerminalStore((state) => state.bulkCloseByState);
+  const bulkCloseByWorktree = useTerminalStore((state) => state.bulkCloseByWorktree);
+  const bulkCloseAll = useTerminalStore((state) => state.bulkCloseAll);
+  const restartFailedAgents = useTerminalStore((state) => state.restartFailedAgents);
+
+  // Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<{
+    isOpen: boolean;
+    title: string;
+    description: string;
+    onConfirm: () => void;
+  }>({
+    isOpen: false,
+    title: "",
+    description: "",
+    onConfirm: () => {},
+  });
+
+  // Calculate counts based on scope
+  const scopedTerminals = worktreeId
+    ? terminals.filter((t) => t.worktreeId === worktreeId)
+    : terminals;
+
+  const completedCount = scopedTerminals.filter((t) => t.agentState === "completed").length;
+  const failedCount = scopedTerminals.filter((t) => t.agentState === "failed").length;
+  const idleCount = scopedTerminals.filter((t) => t.agentState === "idle").length;
+  const totalCount = scopedTerminals.length;
+
+  // Failed agents that can be restarted (only agent terminals)
+  const restartableCount = scopedTerminals.filter(
+    (t) => t.agentState === "failed" && (t.type === "claude" || t.type === "gemini")
+  ).length;
+
+  const closeConfirmDialog = useCallback(() => {
+    setConfirmDialog((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const handleCloseCompleted = useCallback(() => {
+    if (worktreeId) {
+      bulkCloseByWorktree(worktreeId, "completed");
+    } else {
+      bulkCloseByState("completed");
+    }
+  }, [worktreeId, bulkCloseByState, bulkCloseByWorktree]);
+
+  const handleCloseFailed = useCallback(() => {
+    if (worktreeId) {
+      bulkCloseByWorktree(worktreeId, "failed");
+    } else {
+      bulkCloseByState("failed");
+    }
+  }, [worktreeId, bulkCloseByState, bulkCloseByWorktree]);
+
+  const handleCloseIdle = useCallback(() => {
+    if (worktreeId) {
+      bulkCloseByWorktree(worktreeId, "idle");
+    } else {
+      bulkCloseByState("idle");
+    }
+  }, [worktreeId, bulkCloseByState, bulkCloseByWorktree]);
+
+  const handleCloseAll = useCallback(() => {
+    const count = worktreeId ? totalCount : terminals.length;
+    setConfirmDialog({
+      isOpen: true,
+      title: "Close All Terminals",
+      description: `This will close ${count} terminal${count !== 1 ? "s" : ""}. This action cannot be undone.`,
+      onConfirm: () => {
+        if (worktreeId) {
+          bulkCloseByWorktree(worktreeId);
+        } else {
+          bulkCloseAll();
+        }
+        closeConfirmDialog();
+      },
+    });
+  }, [
+    worktreeId,
+    totalCount,
+    terminals.length,
+    bulkCloseByWorktree,
+    bulkCloseAll,
+    closeConfirmDialog,
+  ]);
+
+  const handleRestartFailed = useCallback(() => {
+    // Note: This restarts ALL failed agents globally, not just for this worktree
+    const globalRestartMessage = worktreeId
+      ? `This will restart ${restartableCount} failed agent${restartableCount !== 1 ? "s" : ""} across ALL worktrees (not just this one). The terminals will be closed and new ones will be spawned with the same configuration.`
+      : `This will restart ${restartableCount} failed agent${restartableCount !== 1 ? "s" : ""}. The terminals will be closed and new ones will be spawned with the same configuration.`;
+
+    setConfirmDialog({
+      isOpen: true,
+      title: "Restart Failed Agents",
+      description: globalRestartMessage,
+      onConfirm: async () => {
+        await restartFailedAgents();
+        closeConfirmDialog();
+      },
+    });
+  }, [worktreeId, restartableCount, restartFailedAgents, closeConfirmDialog]);
+
+  const defaultTrigger = (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={className || "text-canopy-text hover:bg-canopy-border hover:text-canopy-accent"}
+    >
+      <span>Actions</span>
+      <ChevronDown className="h-4 w-4 ml-1" />
+    </Button>
+  );
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>{trigger || defaultTrigger}</DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuItem
+            onClick={handleCloseCompleted}
+            disabled={completedCount === 0}
+            className="flex items-center gap-2"
+          >
+            <CheckCircle className="h-4 w-4 text-green-400" />
+            <span>Close Completed</span>
+            <span className="ml-auto text-xs text-canopy-text/50">({completedCount})</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={handleCloseFailed}
+            disabled={failedCount === 0}
+            className="flex items-center gap-2"
+          >
+            <XCircle className="h-4 w-4 text-red-400" />
+            <span>Close Failed</span>
+            <span className="ml-auto text-xs text-canopy-text/50">({failedCount})</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={handleCloseIdle}
+            disabled={idleCount === 0}
+            className="flex items-center gap-2"
+          >
+            <Clock className="h-4 w-4 text-gray-400" />
+            <span>Close Idle</span>
+            <span className="ml-auto text-xs text-canopy-text/50">({idleCount})</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={handleRestartFailed}
+            disabled={restartableCount === 0}
+            className="flex items-center gap-2"
+          >
+            <RefreshCw className="h-4 w-4 text-yellow-400" />
+            <span>Restart Failed Agents</span>
+            <span className="ml-auto text-xs text-canopy-text/50">({restartableCount})</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={handleCloseAll}
+            disabled={totalCount === 0}
+            className="flex items-center gap-2 text-red-400 focus:text-red-400"
+          >
+            <Trash2 className="h-4 w-4" />
+            <span>Close All Terminals...</span>
+            <span className="ml-auto text-xs text-canopy-text/50">({totalCount})</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmDialog
+        isOpen={confirmDialog.isOpen}
+        title={confirmDialog.title}
+        description={confirmDialog.description}
+        onConfirm={confirmDialog.onConfirm}
+        onCancel={closeConfirmDialog}
+      />
+    </>
+  );
+}

--- a/src/components/Terminal/ConfirmDialog.tsx
+++ b/src/components/Terminal/ConfirmDialog.tsx
@@ -1,0 +1,123 @@
+/**
+ * Confirm Dialog Component
+ *
+ * Simple modal dialog for confirming destructive actions.
+ */
+
+import { useEffect, useCallback, useRef, useId } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface ConfirmDialogProps {
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Dialog title */
+  title: string;
+  /** Dialog description/message */
+  description: string;
+  /** Label for the confirm button */
+  confirmLabel?: string;
+  /** Label for the cancel button */
+  cancelLabel?: string;
+  /** Whether the confirm action is destructive (shows red button) */
+  destructive?: boolean;
+  /** Called when the user confirms */
+  onConfirm: () => void;
+  /** Called when the user cancels */
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = true,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const dialogTitleId = useId();
+  const dialogDescriptionId = useId();
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Handle escape key only; let buttons handle Enter to avoid accidental confirms
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    },
+    [onCancel]
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, handleKeyDown]);
+
+  // Auto-focus cancel button when dialog opens
+  useEffect(() => {
+    if (!isOpen) return;
+    cancelButtonRef.current?.focus();
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={dialogTitleId}
+      aria-describedby={dialogDescriptionId}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCancel();
+        }}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        className="relative z-10 w-full max-w-md rounded-lg border border-canopy-border bg-canopy-sidebar p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id={dialogTitleId} className="text-lg font-semibold text-canopy-text mb-2">
+          {title}
+        </h2>
+        <p id={dialogDescriptionId} className="text-sm text-canopy-text/70 mb-6">
+          {description}
+        </p>
+
+        <div className="flex justify-end gap-3">
+          <Button
+            variant="ghost"
+            onClick={onCancel}
+            className="text-canopy-text hover:bg-canopy-border"
+            ref={cancelButtonRef}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            onClick={onConfirm}
+            className={cn(
+              "font-medium",
+              destructive
+                ? "bg-red-600 hover:bg-red-700 text-white"
+                : "bg-canopy-accent hover:bg-canopy-accent/90 text-white"
+            )}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/index.ts
+++ b/src/components/Terminal/index.ts
@@ -4,3 +4,7 @@ export { TerminalPane } from "./TerminalPane";
 export type { TerminalPaneProps, TerminalType } from "./TerminalPane";
 export { TerminalGrid } from "./TerminalGrid";
 export type { TerminalGridProps } from "./TerminalGrid";
+export { BulkActionsMenu } from "./BulkActionsMenu";
+export type { BulkActionsMenuProps } from "./BulkActionsMenu";
+export { ConfirmDialog } from "./ConfirmDialog";
+export type { ConfirmDialogProps } from "./ConfirmDialog";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,6 +115,20 @@ export interface Notification {
 export type NotificationPayload = Omit<Notification, "id"> & { id?: string };
 
 // ============================================================================
+// Agent Types
+// ============================================================================
+
+/**
+ * State of an AI agent lifecycle.
+ * - 'idle': Agent is spawned but not actively working
+ * - 'working': Agent is actively processing/executing
+ * - 'waiting': Agent is waiting for input or external response
+ * - 'completed': Agent has finished successfully
+ * - 'failed': Agent encountered an unrecoverable error
+ */
+export type AgentState = "idle" | "working" | "waiting" | "completed" | "failed";
+
+// ============================================================================
 // Terminal Types
 // ============================================================================
 
@@ -129,6 +143,10 @@ export interface TerminalInstance {
   pid?: number;
   cols: number;
   rows: number;
+  /** Current agent lifecycle state (for agent-type terminals) */
+  agentState?: AgentState;
+  /** Error message if agentState is 'failed' */
+  error?: string;
 }
 
 export interface PtySpawnOptions {


### PR DESCRIPTION
## Summary
Implements bulk actions for terminal management to help users maintain a clean workspace when running many terminals. Users can now close all completed/failed/idle terminals, or restart failed agents with one click.

Closes #55

## Changes Made
- Add AgentState type and agent lifecycle tracking to terminals
- Implement bulk close operations (by state: completed/failed/idle)
- Add bulkCloseByWorktree for worktree-scoped terminal cleanup
- Add restartFailedAgents to respawn failed agent terminals
- Create BulkActionsMenu component with confirmation dialogs
- Add bulk actions dropdown to Toolbar for global actions
- Add worktree-scoped terminal actions to WorktreeCard
- Implement ConfirmDialog with accessibility features (unique IDs, focus management, event bubbling fixes)
- Add IPC listener for agent state changes from main process
- Forward type/title/worktreeId to terminal spawn for proper agent tracking

## Code Review Improvements
Applied Codex review feedback to fix:
- Dialog accessibility (unique IDs with useId, auto-focus, keyboard handling)
- Event bubbling prevention in confirmation dialogs
- Race condition in restartFailedAgents (await kill before respawn)
- Agent state validation in IPC listener
- Terminal type forwarding to enable proper agent lifecycle tracking
- Global scope clarification in restart confirmation message