### PR TITLE
Add visual agent status indicators to worktree cards

### DIFF
--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -1,0 +1,140 @@
+/**
+ * AgentStatusIndicator displays a visual indicator of agent lifecycle state.
+ *
+ * States:
+ * - idle: No indicator (agent spawned but not active)
+ * - working: Spinner icon with blue pulse (agent processing)
+ * - waiting: Question mark icon with yellow pulse (needs user input)
+ * - completed: Checkmark icon in green (agent finished successfully)
+ * - failed: X icon in red (agent encountered error)
+ */
+
+import { cn } from "../../lib/utils";
+import type { AgentState } from "@/types";
+
+interface AgentStatusIndicatorProps {
+  /** Current agent state (null or undefined shows no indicator) */
+  state: AgentState | null | undefined;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Maps agent states to their visual properties.
+ * idle is excluded as it doesn't show an indicator.
+ */
+const STATE_CONFIG: Record<
+  Exclude<AgentState, "idle">,
+  {
+    icon: string;
+    color: string;
+    pulse: boolean;
+    label: string;
+    tooltip: string;
+  }
+> = {
+  working: {
+    icon: "⟳",
+    color: "text-blue-400",
+    pulse: true,
+    label: "working",
+    tooltip: "Agent is processing",
+  },
+  waiting: {
+    icon: "?",
+    color: "text-yellow-400",
+    pulse: true,
+    label: "waiting",
+    tooltip: "Agent is waiting for input",
+  },
+  completed: {
+    icon: "✓",
+    color: "text-green-400",
+    pulse: false,
+    label: "completed",
+    tooltip: "Agent completed successfully",
+  },
+  failed: {
+    icon: "✗",
+    color: "text-red-400",
+    pulse: false,
+    label: "failed",
+    tooltip: "Agent encountered an error",
+  },
+};
+
+export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorProps) {
+  // Don't render for idle or no state
+  if (!state || state === "idle") {
+    return null;
+  }
+
+  const config = STATE_CONFIG[state];
+  if (!config) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center w-5 h-5 rounded-full text-xs font-bold",
+        config.color,
+        config.pulse && "animate-agent-pulse",
+        className
+      )}
+      role="status"
+      aria-label={`Agent status: ${config.label}`}
+      title={config.tooltip}
+    >
+      {config.icon}
+    </span>
+  );
+}
+
+/**
+ * Priority order for aggregating multiple agent states.
+ * Higher priority states take precedence when multiple agents are present.
+ *
+ * 1. waiting - needs user attention
+ * 2. working - actively processing
+ * 3. failed - has errors to address
+ * 4. completed - finished successfully
+ * 5. idle - default state
+ */
+const STATE_PRIORITY: Record<AgentState, number> = {
+  waiting: 5,
+  working: 4,
+  failed: 3,
+  completed: 2,
+  idle: 1,
+};
+
+/**
+ * Aggregates multiple agent states to determine the dominant state.
+ * Prioritizes states that need user attention (waiting) over others.
+ *
+ * @param states - Array of agent states to aggregate
+ * @returns The highest-priority state, or null if all are idle/empty
+ */
+export function getDominantAgentState(states: (AgentState | undefined)[]): AgentState | null {
+  const validStates = states.filter((s): s is AgentState => s !== undefined);
+
+  if (validStates.length === 0) {
+    return null;
+  }
+
+  // Find the state with highest priority
+  let dominant: AgentState = "idle";
+  let highestPriority = 0;
+
+  for (const state of validStates) {
+    const priority = STATE_PRIORITY[state] ?? 0;
+    if (priority > highestPriority) {
+      highestPriority = priority;
+      dominant = state;
+    }
+  }
+
+  // Return null if only idle states found
+  return dominant === "idle" ? null : dominant;
+}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect, useMemo } from "react";
 import type { WorktreeState, WorktreeMood } from "../../types";
 import { ActivityLight } from "./ActivityLight";
+import { AgentStatusIndicator } from "./AgentStatusIndicator";
 import { FileChangeList } from "./FileChangeList";
 import { TerminalCountBadge } from "./TerminalCountBadge";
 import { ErrorBanner } from "../Errors/ErrorBanner";
@@ -99,8 +100,8 @@ export function WorktreeCard({
   const recipes = getRecipesForWorktree(worktree.id);
   const [runningRecipeId, setRunningRecipeId] = useState<string | null>(null);
 
-  // Terminal counts
-  const { counts: terminalCounts } = useWorktreeTerminals(worktree.id);
+  // Terminal counts and agent state
+  const { counts: terminalCounts, dominantAgentState } = useWorktreeTerminals(worktree.id);
 
   // Terminal bulk actions
   const bulkCloseByWorktree = useTerminalStore((state) => state.bulkCloseByWorktree);
@@ -528,9 +529,10 @@ export function WorktreeCard({
         )}
       </div>
 
-      {/* Header: Activity light + Branch */}
+      {/* Header: Activity light + Agent status + Branch */}
       <div className="mb-1 flex items-center gap-2">
         <ActivityLight timestamp={worktree.lastActivityTimestamp} />
+        <AgentStatusIndicator state={dominantAgentState} />
         {isActive && <span className="text-blue-400">●</span>}
         <span className={cn("font-bold", mood === "active" ? "text-yellow-400" : "text-gray-200")}>
           {branchLabel}

--- a/src/index.css
+++ b/src/index.css
@@ -193,6 +193,33 @@ body,
   will-change: opacity, transform;
 }
 
+/* Agent status indicator pulse animation */
+@keyframes agent-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.animate-agent-pulse {
+  animation: agent-pulse 1.5s ease-in-out infinite;
+  will-change: opacity;
+}
+
+/* Respect user's motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .animate-activity-pulse,
+  .animate-agent-pulse {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    will-change: auto;
+  }
+}
+
 /* --- Electron Window Controls --- */
 
 /* The draggable area (Title Bar) */


### PR DESCRIPTION
## Summary
Adds real-time agent status indicators to worktree cards in the sidebar, allowing users to monitor agent activity (working, waiting, completed, failed) at a glance without switching terminals.

Closes #99

## Changes Made
- Created `AgentStatusIndicator` component with state-based icons and pulse animations
- Enhanced `useWorktreeTerminals` hook with priority-based dominant state aggregation (waiting > working > failed > completed > idle)
- Integrated status indicator into WorktreeCard header alongside ActivityLight
- Added agent-pulse CSS animation with accessibility support (prefers-reduced-motion)

## Implementation Details
**Visual Indicators:**
- Working: Spinner icon (⟳) with blue pulse
- Waiting: Question mark (?) with yellow pulse (needs user input)
- Completed: Checkmark (✓) in green
- Failed: X icon (✗) in red
- Idle: No indicator shown

**Priority Aggregation:**
When multiple agents are active in a worktree, the indicator shows the highest-priority state to ensure users see what needs attention most.