### PR TITLE
Auto-detect project run commands from package.json and build tools

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -97,6 +97,7 @@ export const CHANNELS = {
   PROJECT_ON_SWITCH: "project:on-switch",
   PROJECT_GET_SETTINGS: "project:get-settings",
   PROJECT_SAVE_SETTINGS: "project:save-settings",
+  PROJECT_DETECT_RUNNERS: "project:detect-runners",
 
   // History channels (agent transcripts & artifacts)
   HISTORY_GET_SESSIONS: "history:get-sessions",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -22,6 +22,7 @@ import type {
   DevServerState,
   Project,
   ProjectSettings,
+  RunCommand,
   TerminalSpawnOptions,
   CopyTreeOptions,
   CopyTreeResult,
@@ -143,6 +144,7 @@ const CHANNELS = {
   PROJECT_ON_SWITCH: "project:on-switch",
   PROJECT_GET_SETTINGS: "project:get-settings",
   PROJECT_SAVE_SETTINGS: "project:save-settings",
+  PROJECT_DETECT_RUNNERS: "project:detect-runners",
 
   // History channels (agent transcripts & artifacts)
   HISTORY_GET_SESSIONS: "history:get-sessions",
@@ -448,6 +450,9 @@ const api: ElectronAPI = {
 
     saveSettings: (projectId: string, settings: ProjectSettings): Promise<void> =>
       ipcRenderer.invoke(CHANNELS.PROJECT_SAVE_SETTINGS, { projectId, settings }),
+
+    detectRunners: (projectId: string): Promise<RunCommand[]> =>
+      ipcRenderer.invoke(CHANNELS.PROJECT_DETECT_RUNNERS, projectId),
   },
 
   // ==========================================

--- a/electron/services/ai/RunCommandDetector.ts
+++ b/electron/services/ai/RunCommandDetector.ts
@@ -1,0 +1,172 @@
+/**
+ * RunCommandDetector Service
+ *
+ * Scans project directories for available run commands from various
+ * build tools and frameworks including package.json, Makefile, Django, and Composer.
+ */
+
+import path from "path";
+import fs from "fs/promises";
+import { existsSync } from "fs";
+import type { RunCommand } from "../../types/index.js";
+
+export class RunCommandDetector {
+  /**
+   * Scans a directory for available run commands from various frameworks.
+   * Runs all detectors in parallel for performance.
+   *
+   * @param projectPath - Absolute path to the project root
+   * @returns Array of detected run commands
+   */
+  async detect(projectPath: string): Promise<RunCommand[]> {
+    // Run detectors in parallel
+    const results = await Promise.all([
+      this.detectNpm(projectPath),
+      this.detectMakefile(projectPath),
+      this.detectDjango(projectPath),
+      this.detectComposer(projectPath),
+    ]);
+
+    // Flatten results
+    return results.flat();
+  }
+
+  /**
+   * Detect npm/yarn/pnpm/bun scripts from package.json
+   */
+  private async detectNpm(root: string): Promise<RunCommand[]> {
+    const pkgPath = path.join(root, "package.json");
+    if (!existsSync(pkgPath)) return [];
+
+    try {
+      const content = await fs.readFile(pkgPath, "utf-8");
+      const pkg = JSON.parse(content);
+      if (!pkg.scripts || typeof pkg.scripts !== "object") return [];
+
+      // Determine runner (npm, yarn, pnpm, bun) by checking for lock files
+      let runner = "npm run";
+      if (existsSync(path.join(root, "bun.lockb"))) {
+        runner = "bun run";
+      } else if (existsSync(path.join(root, "pnpm-lock.yaml"))) {
+        runner = "pnpm run";
+      } else if (existsSync(path.join(root, "yarn.lock"))) {
+        runner = "yarn";
+      }
+
+      const escapeShellArg = (value: string) => value.replace(/(["\\$`])/g, "\\$1");
+
+      return Object.entries(pkg.scripts)
+        .filter(([_, script]) => typeof script === "string")
+        .map(([name, script]) => {
+          const safeName = escapeShellArg(name);
+          return {
+            id: `npm-${name}`,
+            name,
+            command: `${runner} "${safeName}"`,
+            icon: "npm",
+            description: script,
+          };
+        });
+    } catch (error) {
+      console.warn(`[RunCommandDetector] Failed to parse ${pkgPath}:`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Detect Makefile targets
+   */
+  private async detectMakefile(root: string): Promise<RunCommand[]> {
+    const makePath = path.join(root, "Makefile");
+    if (!existsSync(makePath)) return [];
+
+    try {
+      const content = await fs.readFile(makePath, "utf-8");
+      // Match targets at line start, allowing dots, and skip assignment lines (:=, ?=, +=)
+      const targetRegex = /^([A-Za-z0-9][\w.+-]*)\s*:(?![=])/gm;
+      const commands: RunCommand[] = [];
+      const seen = new Set<string>();
+
+      let match;
+      while ((match = targetRegex.exec(content)) !== null) {
+        const target = match[1];
+        // Skip internal targets (starting with .) and .PHONY
+        if (target.startsWith(".") || target === "PHONY" || seen.has(target)) {
+          continue;
+        }
+        seen.add(target);
+        commands.push({
+          id: `make-${target}`,
+          name: `make ${target}`,
+          command: `make ${target}`,
+          icon: "terminal",
+        });
+      }
+      return commands;
+    } catch (error) {
+      console.warn(`[RunCommandDetector] Failed to parse ${makePath}:`, error);
+      return [];
+    }
+  }
+
+  /**
+   * Detect Django management commands (if manage.py exists)
+   */
+  private async detectDjango(root: string): Promise<RunCommand[]> {
+    if (!existsSync(path.join(root, "manage.py"))) return [];
+
+    // Standard Django commands
+    const commonCommands = ["runserver", "migrate", "makemigrations", "test", "shell"];
+
+    const pythonBin = process.platform === "win32" ? "python" : "python3";
+
+    return commonCommands.map((cmd) => ({
+      id: `django-${cmd}`,
+      name: `Django ${cmd}`,
+      command: `${pythonBin} manage.py ${cmd}`,
+      icon: "python",
+    }));
+  }
+
+  /**
+   * Detect Composer (PHP) scripts from composer.json
+   */
+  private async detectComposer(root: string): Promise<RunCommand[]> {
+    const composerPath = path.join(root, "composer.json");
+    if (!existsSync(composerPath)) return [];
+
+    try {
+      const content = await fs.readFile(composerPath, "utf-8");
+      const json = JSON.parse(content);
+      if (!json.scripts || typeof json.scripts !== "object") return [];
+
+      return Object.keys(json.scripts)
+        .filter((name) => {
+          // Filter out lifecycle scripts that aren't meant to be run directly
+          const lifecycleScripts = [
+            "pre-install-cmd",
+            "post-install-cmd",
+            "pre-update-cmd",
+            "post-update-cmd",
+            "post-autoload-dump",
+            "pre-autoload-dump",
+            "post-root-package-install",
+            "post-create-project-cmd",
+          ];
+          return !lifecycleScripts.includes(name);
+        })
+        .map((name) => ({
+          id: `composer-${name}`,
+          name: `composer ${name}`,
+          command: `composer run-script ${name}`,
+          icon: "php",
+        }));
+    } catch (error) {
+      console.warn(`[RunCommandDetector] Failed to parse ${composerPath}:`, error);
+      return [];
+    }
+  }
+}
+
+// Singleton instance
+export const runCommandDetector = new RunCommandDetector();

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -428,6 +428,8 @@ export interface RunCommand {
   command: string;
   /** Optional icon name for UI display */
   icon?: string;
+  /** Optional description (e.g. the script content from package.json) */
+  description?: string;
 }
 
 /** Project-level settings that persist per repository */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -61,6 +61,7 @@ export type {
   CopyTreeOptions,
   CopyTreeResult,
   CopyTreeProgress,
+  FileTreeNode,
   // App state types
   RecentDirectory,
   SavedRecipeTerminal,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -11,6 +11,7 @@ import type {
   WorktreeState,
   Project,
   ProjectSettings,
+  RunCommand,
 } from "./domain.js";
 
 // ============================================================================
@@ -552,6 +553,7 @@ export interface ElectronAPI {
     onSwitch(callback: (project: Project) => void): () => void;
     getSettings(projectId: string): Promise<ProjectSettings>;
     saveSettings(projectId: string, settings: ProjectSettings): Promise<void>;
+    detectRunners(projectId: string): Promise<RunCommand[]>;
   };
   history: {
     getSessions(filters?: HistoryGetSessionsPayload): Promise<AgentSession[]>;

--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -2,10 +2,12 @@
  * Project Settings Dialog Component
  *
  * Modal UI for editing project-level settings including run commands.
+ * Shows auto-detected commands from project configuration files (package.json, Makefile, etc.)
+ * with the ability to promote them to saved commands.
  */
 
 import { useState, useEffect } from "react";
-import { Plus, Trash2, X } from "lucide-react";
+import { Plus, Trash2, X, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import type { RunCommand } from "@/types";
@@ -18,10 +20,12 @@ interface ProjectSettingsDialogProps {
 }
 
 export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSettingsDialogProps) {
-  const { settings, saveSettings, isLoading, error } = useProjectSettings(projectId);
+  const { settings, detectedRunners, saveSettings, promoteToSaved, isLoading, error } =
+    useProjectSettings(projectId);
   const [commands, setCommands] = useState<RunCommand[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [promotingIds, setPromotingIds] = useState<Set<string>>(new Set());
 
   // Sync local state when settings load OR when dialog opens (reset unsaved changes)
   useEffect(() => {
@@ -104,61 +108,133 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
             </div>
           )}
           {!isLoading && !error && (
-            <div className="mb-4">
-              <h3 className="text-sm font-semibold text-canopy-text/80 mb-2">Run Commands</h3>
-              <p className="text-xs text-gray-500 mb-4">
-                Configure quick commands to run in terminals. These will appear as buttons in the
-                sidebar.
-              </p>
-              <div className="space-y-2">
-                {commands.map((cmd) => (
-                  <div key={cmd.id} className="flex gap-2 items-center">
-                    <input
-                      className={cn(
-                        "bg-canopy-bg border border-canopy-border rounded px-2 py-1.5 text-sm text-canopy-text w-1/3",
-                        "focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
-                      )}
-                      value={cmd.name}
-                      onChange={(e) => handleChange(cmd.id, "name", e.target.value)}
-                      placeholder="Name (e.g. Dev Server)"
-                    />
-                    <input
-                      className={cn(
-                        "bg-canopy-bg border border-canopy-border rounded px-2 py-1.5 text-sm text-canopy-text flex-1 font-mono",
-                        "focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
-                      )}
-                      value={cmd.command}
-                      onChange={(e) => handleChange(cmd.id, "command", e.target.value)}
-                      placeholder="Command (e.g. npm run dev)"
-                    />
-                    <Button
-                      onClick={() => handleRemove(cmd.id)}
-                      variant="ghost"
-                      size="icon"
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 h-8 w-8"
-                      title="Remove command"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
+            <>
+              {/* Saved Commands Section */}
+              <div className="mb-6">
+                <h3 className="text-sm font-semibold text-canopy-text/80 mb-2">Run Commands</h3>
+                <p className="text-xs text-gray-500 mb-4">
+                  Configure quick commands to run in terminals. These will appear as buttons in the
+                  sidebar.
+                </p>
+                <div className="space-y-2">
+                  {commands.map((cmd) => (
+                    <div key={cmd.id} className="flex gap-2 items-center">
+                      <input
+                        className={cn(
+                          "bg-canopy-bg border border-canopy-border rounded px-2 py-1.5 text-sm text-canopy-text w-1/3",
+                          "focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
+                        )}
+                        value={cmd.name}
+                        onChange={(e) => handleChange(cmd.id, "name", e.target.value)}
+                        placeholder="Name (e.g. Dev Server)"
+                      />
+                      <input
+                        className={cn(
+                          "bg-canopy-bg border border-canopy-border rounded px-2 py-1.5 text-sm text-canopy-text flex-1 font-mono",
+                          "focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
+                        )}
+                        value={cmd.command}
+                        onChange={(e) => handleChange(cmd.id, "command", e.target.value)}
+                        placeholder="Command (e.g. npm run dev)"
+                      />
+                      <Button
+                        onClick={() => handleRemove(cmd.id)}
+                        variant="ghost"
+                        size="icon"
+                        className="text-red-400 hover:text-red-300 hover:bg-red-900/20 h-8 w-8"
+                        title="Remove command"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ))}
 
-                {commands.length === 0 && (
-                  <div className="text-sm text-gray-500 text-center py-4 border border-dashed border-canopy-border rounded">
-                    No run commands configured
-                  </div>
-                )}
+                  {commands.length === 0 && (
+                    <div className="text-sm text-gray-500 text-center py-4 border border-dashed border-canopy-border rounded">
+                      No run commands configured
+                    </div>
+                  )}
+                </div>
+
+                <Button
+                  onClick={handleAddCommand}
+                  variant="outline"
+                  className="mt-3 w-full border-dashed border-canopy-border text-gray-400 hover:text-canopy-text hover:border-canopy-accent/50"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Command
+                </Button>
               </div>
 
-              <Button
-                onClick={handleAddCommand}
-                variant="outline"
-                className="mt-3 w-full border-dashed border-canopy-border text-gray-400 hover:text-canopy-text hover:border-canopy-accent/50"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                Add Command
-              </Button>
-            </div>
+              {/* Suggested Commands Section */}
+              {detectedRunners.length > 0 && (
+                <div className="mb-4">
+                  <h3 className="text-sm font-semibold text-canopy-text/80 mb-2 flex items-center gap-2">
+                    <Sparkles className="h-4 w-4 text-yellow-400" />
+                    Suggested Commands
+                  </h3>
+                  <p className="text-xs text-gray-500 mb-3">
+                    These commands were detected from your project files. Click + to add them to
+                    your saved commands.
+                  </p>
+                  <div className="space-y-1.5">
+                    {detectedRunners.map((cmd) => (
+                      <div
+                        key={cmd.id}
+                        className="flex items-center gap-2 p-2 rounded bg-canopy-bg/50 border border-canopy-border/50 hover:border-canopy-border transition-colors"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-medium text-canopy-text truncate">
+                              {cmd.name}
+                            </span>
+                            {cmd.icon && (
+                              <span className="text-xs text-gray-500 px-1.5 py-0.5 bg-canopy-border/30 rounded">
+                                {cmd.icon}
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-xs text-gray-500 font-mono truncate">
+                            {cmd.command}
+                          </div>
+                          {cmd.description && (
+                            <div className="text-xs text-gray-600 truncate mt-0.5">
+                              {cmd.description}
+                            </div>
+                          )}
+                        </div>
+                        <Button
+                          onClick={async () => {
+                            setPromotingIds((prev) => new Set(prev).add(cmd.id));
+                            setSaveError(null);
+                            try {
+                              await promoteToSaved(cmd);
+                              // Command will be removed from detectedRunners by the hook
+                            } catch (err) {
+                              const errorMsg = err instanceof Error ? err.message : "Failed to add command";
+                              setSaveError(errorMsg);
+                            } finally {
+                              setPromotingIds((prev) => {
+                                const next = new Set(prev);
+                                next.delete(cmd.id);
+                                return next;
+                              });
+                            }
+                          }}
+                          variant="ghost"
+                          size="icon"
+                          disabled={promotingIds.has(cmd.id)}
+                          className="text-green-400 hover:text-green-300 hover:bg-green-900/20 h-8 w-8 flex-shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                          title="Add to saved commands"
+                        >
+                          <Plus className="h-4 w-4" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
Implements automatic detection of run commands from project configuration files (package.json, Makefile, Django manage.py, composer.json) with a "Suggested Commands" UI section that allows users to promote detected commands to their saved project settings.

Closes #95

## Changes Made
- Add RunCommandDetector service to scan package.json, Makefile, Django manage.py, and composer.json
- Implement npm/yarn/pnpm/bun package manager detection via lock files
- Add shell escaping for npm script names to prevent command injection
- Fix Makefile regex to skip assignment lines and support targets with dots
- Add PROJECT_DETECT_RUNNERS IPC channel and handler
- Update ProjectSettings hook to fetch and deduplicate detected commands
- Add Suggested Commands UI section with promote-to-saved functionality
- Implement per-command loading state and error feedback
- Fix race condition in promoteToSaved with proper state management
- Export FileTreeNode type from shared types index

## Security & Testing
- Shell escaping prevents command injection from malicious script names
- Proper error handling with graceful degradation for missing/corrupted files
- Race condition protection for concurrent command promotions
- Per-command loading states prevent duplicate promotions