### PR TITLE
Add run orchestration events and EventContext for multi-agent workflows

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -112,6 +112,20 @@ export const CHANNELS = {
   AI_SET_ENABLED: "ai:set-enabled",
   AI_VALIDATE_KEY: "ai:validate-key",
   AI_GENERATE_PROJECT_IDENTITY: "ai:generate-project-identity",
+
+  // Run orchestration channels
+  RUN_START: "run:start",
+  RUN_UPDATE_PROGRESS: "run:update-progress",
+  RUN_PAUSE: "run:pause",
+  RUN_RESUME: "run:resume",
+  RUN_COMPLETE: "run:complete",
+  RUN_FAIL: "run:fail",
+  RUN_CANCEL: "run:cancel",
+  RUN_GET: "run:get",
+  RUN_GET_ALL: "run:get-all",
+  RUN_GET_ACTIVE: "run:get-active",
+  RUN_CLEAR_FINISHED: "run:clear-finished",
+  RUN_EVENT: "run:event",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -41,6 +41,8 @@ import type {
   AgentStateChangePayload,
   ElectronAPI,
   CreateWorktreeOptions,
+  EventContext,
+  RunMetadata,
 } from "@shared/types";
 
 // Re-export ElectronAPI for type declarations
@@ -158,6 +160,20 @@ const CHANNELS = {
   AI_SET_ENABLED: "ai:set-enabled",
   AI_VALIDATE_KEY: "ai:validate-key",
   AI_GENERATE_PROJECT_IDENTITY: "ai:generate-project-identity",
+
+  // Run orchestration channels
+  RUN_START: "run:start",
+  RUN_UPDATE_PROGRESS: "run:update-progress",
+  RUN_PAUSE: "run:pause",
+  RUN_RESUME: "run:resume",
+  RUN_COMPLETE: "run:complete",
+  RUN_FAIL: "run:fail",
+  RUN_CANCEL: "run:cancel",
+  RUN_GET: "run:get",
+  RUN_GET_ALL: "run:get-all",
+  RUN_GET_ACTIVE: "run:get-active",
+  RUN_CLEAR_FINISHED: "run:clear-finished",
+  RUN_EVENT: "run:event",
 } as const;
 
 const api: ElectronAPI = {
@@ -487,6 +503,49 @@ const api: ElectronAPI = {
 
     generateProjectIdentity: (projectPath: string): Promise<ProjectIdentity | null> =>
       ipcRenderer.invoke(CHANNELS.AI_GENERATE_PROJECT_IDENTITY, projectPath),
+  },
+
+  // ==========================================
+  // Run Orchestration API
+  // ==========================================
+  run: {
+    start: (name: string, context?: EventContext, description?: string): Promise<string> =>
+      ipcRenderer.invoke(CHANNELS.RUN_START, { name, context, description }),
+
+    updateProgress: (runId: string, progress: number, message?: string): Promise<void> =>
+      ipcRenderer.invoke(CHANNELS.RUN_UPDATE_PROGRESS, { runId, progress, message }),
+
+    pause: (runId: string, reason?: string): Promise<void> =>
+      ipcRenderer.invoke(CHANNELS.RUN_PAUSE, { runId, reason }),
+
+    resume: (runId: string): Promise<void> => ipcRenderer.invoke(CHANNELS.RUN_RESUME, runId),
+
+    complete: (runId: string): Promise<void> => ipcRenderer.invoke(CHANNELS.RUN_COMPLETE, runId),
+
+    fail: (runId: string, error: string): Promise<void> =>
+      ipcRenderer.invoke(CHANNELS.RUN_FAIL, { runId, error }),
+
+    cancel: (runId: string, reason?: string): Promise<void> =>
+      ipcRenderer.invoke(CHANNELS.RUN_CANCEL, { runId, reason }),
+
+    get: (runId: string): Promise<RunMetadata | undefined> =>
+      ipcRenderer.invoke(CHANNELS.RUN_GET, runId),
+
+    getAll: (): Promise<RunMetadata[]> => ipcRenderer.invoke(CHANNELS.RUN_GET_ALL),
+
+    getActive: (): Promise<RunMetadata[]> => ipcRenderer.invoke(CHANNELS.RUN_GET_ACTIVE),
+
+    clearFinished: (olderThan?: number): Promise<number> =>
+      ipcRenderer.invoke(CHANNELS.RUN_CLEAR_FINISHED, olderThan),
+
+    onEvent: (callback: (event: { type: string; payload: unknown }) => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { type: string; payload: unknown }
+      ) => callback(data);
+      ipcRenderer.on(CHANNELS.RUN_EVENT, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.RUN_EVENT, handler);
+    },
   },
 };
 

--- a/electron/services/EventBuffer.ts
+++ b/electron/services/EventBuffer.ts
@@ -25,6 +25,14 @@ export interface FilterOptions {
   agentId?: string;
   /** Filter by task ID if present in payload */
   taskId?: string;
+  /** Filter by run ID if present in payload (for multi-agent orchestration) */
+  runId?: string;
+  /** Filter by terminal ID if present in payload */
+  terminalId?: string;
+  /** Filter by GitHub issue number if present in payload */
+  issueNumber?: number;
+  /** Filter by GitHub PR number if present in payload */
+  prNumber?: number;
   /** Filter by trace ID to track event chains */
   traceId?: string;
   /** Text search in payload (JSON stringified) */
@@ -184,6 +192,38 @@ export class EventBuffer {
       filtered = filtered.filter((event) => {
         const payload = event.payload;
         return payload && payload.taskId === options.taskId;
+      });
+    }
+
+    // Filter by run ID (for multi-agent orchestration)
+    if (options.runId) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.runId === options.runId;
+      });
+    }
+
+    // Filter by terminal ID
+    if (options.terminalId) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.terminalId === options.terminalId;
+      });
+    }
+
+    // Filter by GitHub issue number
+    if (options.issueNumber !== undefined) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.issueNumber === options.issueNumber;
+      });
+    }
+
+    // Filter by GitHub PR number
+    if (options.prNumber !== undefined) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.prNumber === options.prNumber;
       });
     }
 

--- a/electron/services/RunManager.ts
+++ b/electron/services/RunManager.ts
@@ -1,0 +1,356 @@
+/**
+ * RunManager - Manages run lifecycle for multi-agent orchestration
+ *
+ * A "run" is a multi-step workflow that groups related agent/terminal operations
+ * into a cohesive unit. This enables tracking of operations like "work on issue #42"
+ * through multiple spawned agents, context injections, and terminal commands.
+ *
+ * @example
+ * // Start a new run
+ * const runId = runManager.startRun('Work on Issue #42', {
+ *   worktreeId: 'wt-1',
+ *   issueNumber: 42,
+ * });
+ *
+ * // Update progress
+ * runManager.updateProgress(runId, 0.5, 'Generating context...');
+ *
+ * // Complete the run
+ * runManager.completeRun(runId);
+ */
+
+import { events } from "./events.js";
+import type { EventContext, RunMetadata, RunState } from "@shared/types/index.js";
+
+/**
+ * Manages run lifecycle and emits run events.
+ * A "run" is a multi-step workflow (e.g., "work on issue #42").
+ */
+export class RunManager {
+  private runs = new Map<string, RunMetadata>();
+
+  /**
+   * Start a new run.
+   *
+   * @param name - Human-readable name for the run
+   * @param context - Event context for filtering and correlation
+   * @param description - Optional description of what the run does
+   * @returns The unique run ID
+   */
+  public startRun(name: string, context: EventContext = {}, description?: string): string {
+    const runId = this.generateRunId();
+    const startedAt = Date.now();
+
+    // Remove runId from context if provided to prevent override
+    const { runId: _ignored, ...sanitizedContext } = context;
+
+    const metadata: RunMetadata = {
+      runId,
+      name,
+      description,
+      context: { ...sanitizedContext, runId }, // Include generated runId in context
+      startedAt,
+      state: "running",
+      progress: 0,
+    };
+
+    this.runs.set(runId, metadata);
+
+    // Emit run:started event with sanitized context
+    events.emit("run:started", {
+      runId,
+      name,
+      description,
+      ...sanitizedContext,
+      timestamp: startedAt,
+    });
+
+    return runId;
+  }
+
+  /**
+   * Update run progress.
+   *
+   * @param runId - The run to update
+   * @param progress - Progress percentage (0-1)
+   * @param message - Optional progress message
+   */
+  public updateProgress(runId: string, progress: number, message?: string): void {
+    const run = this.runs.get(runId);
+    if (!run) {
+      console.warn(`[RunManager] Cannot update progress for unknown run: ${runId}`);
+      return;
+    }
+
+    // Only update progress for active runs
+    if (run.state !== "running" && run.state !== "paused") {
+      console.warn(
+        `[RunManager] Cannot update progress for run in terminal state: ${run.state}`
+      );
+      return;
+    }
+
+    // Validate progress is finite and clamp to 0-1
+    if (!Number.isFinite(progress)) {
+      console.warn(`[RunManager] Invalid progress value: ${progress}, ignoring`);
+      return;
+    }
+    run.progress = Math.max(0, Math.min(1, progress));
+
+    events.emit("run:progress", {
+      runId,
+      progress: run.progress,
+      message,
+      ...run.context,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Pause a run (waiting for input).
+   *
+   * @param runId - The run to pause
+   * @param reason - Optional reason for pausing
+   */
+  public pauseRun(runId: string, reason?: string): void {
+    const run = this.runs.get(runId);
+    if (!run) {
+      console.warn(`[RunManager] Cannot pause unknown run: ${runId}`);
+      return;
+    }
+
+    if (run.state !== "running") {
+      console.warn(`[RunManager] Cannot pause run in state: ${run.state}`);
+      return;
+    }
+
+    run.state = "paused";
+
+    events.emit("run:paused", {
+      runId,
+      reason,
+      ...run.context,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Resume a paused run.
+   *
+   * @param runId - The run to resume
+   */
+  public resumeRun(runId: string): void {
+    const run = this.runs.get(runId);
+    if (!run) {
+      console.warn(`[RunManager] Cannot resume unknown run: ${runId}`);
+      return;
+    }
+
+    if (run.state !== "paused") {
+      console.warn(`[RunManager] Cannot resume run in state: ${run.state}`);
+      return;
+    }
+
+    run.state = "running";
+
+    events.emit("run:resumed", {
+      runId,
+      ...run.context,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Complete a run successfully.
+   *
+   * @param runId - The run to complete
+   */
+  public completeRun(runId: string): void {
+    const run = this.runs.get(runId);
+    if (!run) {
+      console.warn(`[RunManager] Cannot complete unknown run: ${runId}`);
+      return;
+    }
+
+    // Idempotent: only transition if not already in a terminal state
+    if (run.state === "completed" || run.state === "failed" || run.state === "cancelled") {
+      console.warn(`[RunManager] Run already in terminal state: ${run.state}`);
+      return;
+    }
+
+    const completedAt = Date.now();
+    run.completedAt = completedAt;
+    run.duration = completedAt - run.startedAt;
+    run.state = "completed";
+    run.progress = 1;
+
+    events.emit("run:completed", {
+      runId,
+      duration: run.duration,
+      ...run.context,
+      timestamp: completedAt,
+    });
+  }
+
+  /**
+   * Mark run as failed.
+   *
+   * @param runId - The run that failed
+   * @param error - Error message describing the failure
+   */
+  public failRun(runId: string, error: string): void {
+    const run = this.runs.get(runId);
+    if (!run) {
+      console.warn(`[RunManager] Cannot fail unknown run: ${runId}`);
+      return;
+    }
+
+    // Idempotent: only transition if not already in a terminal state
+    if (run.state === "completed" || run.state === "failed" || run.state === "cancelled") {
+      console.warn(`[RunManager] Run already in terminal state: ${run.state}`);
+      return;
+    }
+
+    const failedAt = Date.now();
+    run.completedAt = failedAt;
+    run.duration = failedAt - run.startedAt;
+    run.state = "failed";
+    run.error = error;
+
+    events.emit("run:failed", {
+      runId,
+      error,
+      duration: run.duration,
+      ...run.context,
+      timestamp: failedAt,
+    });
+  }
+
+  /**
+   * Cancel a run.
+   *
+   * @param runId - The run to cancel
+   * @param reason - Optional reason for cancellation
+   */
+  public cancelRun(runId: string, reason?: string): void {
+    const run = this.runs.get(runId);
+    if (!run) {
+      console.warn(`[RunManager] Cannot cancel unknown run: ${runId}`);
+      return;
+    }
+
+    // Idempotent: only transition if not already in a terminal state
+    if (run.state === "completed" || run.state === "failed" || run.state === "cancelled") {
+      console.warn(`[RunManager] Run already in terminal state: ${run.state}`);
+      return;
+    }
+
+    const cancelledAt = Date.now();
+    run.completedAt = cancelledAt;
+    run.duration = cancelledAt - run.startedAt;
+    run.state = "cancelled";
+
+    events.emit("run:cancelled", {
+      runId,
+      reason,
+      duration: run.duration,
+      ...run.context,
+      timestamp: cancelledAt,
+    });
+  }
+
+  /**
+   * Get run metadata.
+   *
+   * @param runId - The run to retrieve
+   * @returns Run metadata or undefined if not found
+   */
+  public getRun(runId: string): RunMetadata | undefined {
+    return this.runs.get(runId);
+  }
+
+  /**
+   * Get all runs.
+   *
+   * @returns Array of all run metadata
+   */
+  public getAllRuns(): RunMetadata[] {
+    return Array.from(this.runs.values());
+  }
+
+  /**
+   * Get all active runs (running or paused).
+   *
+   * @returns Array of active run metadata
+   */
+  public getActiveRuns(): RunMetadata[] {
+    return Array.from(this.runs.values()).filter(
+      (r) => r.state === "running" || r.state === "paused"
+    );
+  }
+
+  /**
+   * Get runs by state.
+   *
+   * @param state - The state to filter by
+   * @returns Array of run metadata matching the state
+   */
+  public getRunsByState(state: RunState): RunMetadata[] {
+    return Array.from(this.runs.values()).filter((r) => r.state === state);
+  }
+
+  /**
+   * Get runs by context field.
+   *
+   * @param field - The context field to filter by
+   * @param value - The value to match
+   * @returns Array of run metadata matching the filter
+   */
+  public getRunsByContext<K extends keyof EventContext>(
+    field: K,
+    value: EventContext[K]
+  ): RunMetadata[] {
+    return Array.from(this.runs.values()).filter((r) => r.context[field] === value);
+  }
+
+  /**
+   * Clear completed/failed/cancelled runs from memory.
+   * Useful for garbage collection after runs are no longer needed.
+   *
+   * @param olderThan - Optional timestamp; only clear runs completed before this time
+   * @returns Number of runs cleared
+   */
+  public clearFinishedRuns(olderThan?: number): number {
+    const terminalStates: RunState[] = ["completed", "failed", "cancelled"];
+    let cleared = 0;
+
+    for (const [runId, run] of this.runs.entries()) {
+      if (terminalStates.includes(run.state)) {
+        if (olderThan === undefined || (run.completedAt && run.completedAt < olderThan)) {
+          this.runs.delete(runId);
+          cleared++;
+        }
+      }
+    }
+
+    return cleared;
+  }
+
+  /**
+   * Clear all runs from memory.
+   * Use with caution - typically only for testing or shutdown.
+   */
+  public clearAllRuns(): void {
+    this.runs.clear();
+  }
+
+  /**
+   * Generate a unique run ID.
+   */
+  private generateRunId(): string {
+    return `run-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  }
+}
+
+/** Singleton instance of RunManager */
+export const runManager = new RunManager();

--- a/shared/types/events.ts
+++ b/shared/types/events.ts
@@ -1,0 +1,207 @@
+/**
+ * Event system types for Canopy Command Center
+ *
+ * These types support multi-agent orchestration and run tracking,
+ * enabling correlation of related operations through the event stream.
+ */
+
+// ============================================================================
+// EventContext - Common context embedded in all domain events
+// ============================================================================
+
+/**
+ * Common context embedded in all domain events.
+ * Enables filtering and correlation across the event stream.
+ *
+ * @example
+ * // Filtering events by run
+ * eventBuffer.getFiltered({ runId: 'run-123' });
+ *
+ * // Filtering events by issue
+ * eventBuffer.getFiltered({ issueNumber: 42 });
+ */
+export interface EventContext {
+  /** ID of the worktree this event relates to */
+  worktreeId?: string;
+
+  /** ID of the agent executing work */
+  agentId?: string;
+
+  /** ID of the task being performed */
+  taskId?: string;
+
+  /** ID of the run (multi-step workflow) */
+  runId?: string;
+
+  /** ID of the terminal involved */
+  terminalId?: string;
+
+  /** GitHub issue number if applicable */
+  issueNumber?: number;
+
+  /** GitHub PR number if applicable */
+  prNumber?: number;
+}
+
+// ============================================================================
+// Run State and Metadata
+// ============================================================================
+
+/**
+ * State of a run (multi-agent workflow).
+ * - 'queued': Run is scheduled but not started
+ * - 'running': Run is actively executing
+ * - 'paused': Run is paused (waiting for input)
+ * - 'completed': Run finished successfully
+ * - 'failed': Run encountered unrecoverable error
+ * - 'cancelled': Run was cancelled by user
+ */
+export type RunState = "queued" | "running" | "paused" | "completed" | "failed" | "cancelled";
+
+/**
+ * Metadata about a run (multi-step workflow).
+ * A "run" groups related agent/terminal operations into a cohesive workflow.
+ *
+ * @example
+ * // Example run for "work on issue #42"
+ * const run: RunMetadata = {
+ *   runId: 'run-123',
+ *   name: 'Work on Issue #42',
+ *   context: { worktreeId: 'wt-1', issueNumber: 42 },
+ *   startedAt: Date.now(),
+ *   state: 'running',
+ *   progress: 0.5,
+ * };
+ */
+export interface RunMetadata {
+  /** Unique identifier for this run */
+  runId: string;
+
+  /** Human-readable name for the run */
+  name: string;
+
+  /** Optional description of what the run does */
+  description?: string;
+
+  /** Context for filtering and correlation */
+  context: EventContext;
+
+  /** Unix timestamp (ms) when the run started */
+  startedAt: number;
+
+  /** Unix timestamp (ms) when the run completed/failed/cancelled */
+  completedAt?: number;
+
+  /** Duration in milliseconds (computed when run ends) */
+  duration?: number;
+
+  /** Current state of the run */
+  state: RunState;
+
+  /** Error message if state is 'failed' */
+  error?: string;
+
+  /** Progress percentage (0-1), if available */
+  progress?: number;
+}
+
+// ============================================================================
+// Run Event Payloads
+// ============================================================================
+
+/**
+ * Payload for run:started event.
+ * Emitted when a new run (multi-step workflow) begins.
+ */
+export interface RunStartedPayload extends EventContext {
+  /** Unique identifier for this run */
+  runId: string;
+  /** Human-readable name for the run */
+  name: string;
+  /** Optional description */
+  description?: string;
+  /** Unix timestamp (ms) when the run started */
+  timestamp: number;
+}
+
+/**
+ * Payload for run:progress event.
+ * Emitted to report run progress updates.
+ */
+export interface RunProgressPayload extends EventContext {
+  /** Run identifier */
+  runId: string;
+  /** Progress percentage (0-1) */
+  progress: number;
+  /** Optional progress message */
+  message?: string;
+  /** Unix timestamp (ms) */
+  timestamp: number;
+}
+
+/**
+ * Payload for run:completed event.
+ * Emitted when a run finishes successfully.
+ */
+export interface RunCompletedPayload extends EventContext {
+  /** Run identifier */
+  runId: string;
+  /** Duration in milliseconds */
+  duration: number;
+  /** Unix timestamp (ms) when completed */
+  timestamp: number;
+}
+
+/**
+ * Payload for run:failed event.
+ * Emitted when a run encounters an unrecoverable error.
+ */
+export interface RunFailedPayload extends EventContext {
+  /** Run identifier */
+  runId: string;
+  /** Error message describing the failure */
+  error: string;
+  /** Duration in milliseconds until failure */
+  duration: number;
+  /** Unix timestamp (ms) when failed */
+  timestamp: number;
+}
+
+/**
+ * Payload for run:cancelled event.
+ * Emitted when a run is cancelled by user action.
+ */
+export interface RunCancelledPayload extends EventContext {
+  /** Run identifier */
+  runId: string;
+  /** Optional reason for cancellation */
+  reason?: string;
+  /** Duration in milliseconds until cancellation */
+  duration: number;
+  /** Unix timestamp (ms) when cancelled */
+  timestamp: number;
+}
+
+/**
+ * Payload for run:paused event.
+ * Emitted when a run is paused (waiting for input).
+ */
+export interface RunPausedPayload extends EventContext {
+  /** Run identifier */
+  runId: string;
+  /** Optional reason for pausing */
+  reason?: string;
+  /** Unix timestamp (ms) when paused */
+  timestamp: number;
+}
+
+/**
+ * Payload for run:resumed event.
+ * Emitted when a paused run is resumed.
+ */
+export interface RunResumedPayload extends EventContext {
+  /** Run identifier */
+  runId: string;
+  /** Unix timestamp (ms) when resumed */
+  timestamp: number;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -61,6 +61,7 @@ export type {
   CopyTreeOptions,
   CopyTreeResult,
   CopyTreeProgress,
+  FileTreeNode,
   // App state types
   RecentDirectory,
   SavedRecipeTerminal,
@@ -118,3 +119,20 @@ export type {
 
 // Keymap types - keyboard shortcuts
 export type { KeyAction, KeymapPreset, KeyMapConfig } from "./keymap.js";
+
+// Event types - run orchestration and event context
+export type {
+  // Event context for correlation
+  EventContext,
+  // Run state and metadata
+  RunState,
+  RunMetadata,
+  // Run event payloads
+  RunStartedPayload,
+  RunProgressPayload,
+  RunCompletedPayload,
+  RunFailedPayload,
+  RunCancelledPayload,
+  RunPausedPayload,
+  RunResumedPayload,
+} from "./events.js";

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -12,6 +12,7 @@ import type {
   Project,
   ProjectSettings,
 } from "./domain.js";
+import type { EventContext, RunMetadata } from "./events.js";
 
 // ============================================================================
 // Terminal IPC Types
@@ -265,6 +266,16 @@ export interface EventFilterOptions {
   agentId?: string;
   /** Filter by task ID */
   taskId?: string;
+  /** Filter by run ID (for multi-agent orchestration) */
+  runId?: string;
+  /** Filter by terminal ID */
+  terminalId?: string;
+  /** Filter by GitHub issue number */
+  issueNumber?: number;
+  /** Filter by GitHub PR number */
+  prNumber?: number;
+  /** Filter by trace ID */
+  traceId?: string;
   /** Search string */
   search?: string;
   /** After timestamp filter */
@@ -567,6 +578,20 @@ export interface ElectronAPI {
     setEnabled(enabled: boolean): Promise<void>;
     validateKey(apiKey: string): Promise<boolean>;
     generateProjectIdentity(projectPath: string): Promise<ProjectIdentity | null>;
+  };
+  run: {
+    start(name: string, context?: EventContext, description?: string): Promise<string>;
+    updateProgress(runId: string, progress: number, message?: string): Promise<void>;
+    pause(runId: string, reason?: string): Promise<void>;
+    resume(runId: string): Promise<void>;
+    complete(runId: string): Promise<void>;
+    fail(runId: string, error: string): Promise<void>;
+    cancel(runId: string, reason?: string): Promise<void>;
+    get(runId: string): Promise<RunMetadata | undefined>;
+    getAll(): Promise<RunMetadata[]>;
+    getActive(): Promise<RunMetadata[]>;
+    clearFinished(olderThan?: number): Promise<number>;
+    onEvent(callback: (event: { type: string; payload: unknown }) => void): () => void;
   };
 }
 


### PR DESCRIPTION
## Summary

This PR implements run orchestration events and a shared EventContext type to support multi-agent workflows. It enables tracking groups of related operations (spawning terminals, injecting context, running commands) as cohesive "runs" that can be linked to GitHub issues.

Closes #90

## Changes Made

- Add EventContext type for event correlation with fields: worktreeId, agentId, taskId, runId, terminalId, issueNumber, prNumber
- Implement RunManager service for complete run lifecycle management with states: queued, running, paused, completed, failed, cancelled
- Add 7 run event types: run:started, run:progress, run:completed, run:failed, run:cancelled, run:paused, run:resumed
- Update EventBuffer with filtering support for all new context fields (runId, terminalId, issueNumber, prNumber)
- Add complete IPC integration with 11 handlers and event forwarding to renderer process
- Apply idempotency guards to prevent duplicate terminal state transitions
- Add NaN validation and state guards to progress updates
- Sanitize context input to prevent runId override

## Architecture

**New Files:**
- `shared/types/events.ts` - EventContext, RunState, RunMetadata, and all run event payload types
- `electron/services/RunManager.ts` - Core run lifecycle management service

**Modified Files:**
- `electron/services/events.ts` - Updated event map with typed run events
- `electron/services/EventBuffer.ts` - Enhanced filtering capabilities
- `electron/ipc/channels.ts` - Added 12 run orchestration channels
- `electron/ipc/handlers.ts` - Added 11 IPC handlers with validation
- `electron/preload.ts` - Exposed run API namespace
- `shared/types/ipc.ts` - Added EventContext and RunMetadata to IPC types
- `shared/types/index.ts` - Exported new event types