### PR TITLE
Add UI actions for extracted code artifacts in terminals

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -38,6 +38,11 @@ export const CHANNELS = {
   AGENT_STATE_CHANGED: "agent:state-changed",
   AGENT_GET_STATE: "agent:get-state",
 
+  // Artifact channels
+  ARTIFACT_DETECTED: "artifact:detected",
+  ARTIFACT_SAVE_TO_FILE: "artifact:save-to-file",
+  ARTIFACT_APPLY_PATCH: "artifact:apply-patch",
+
   // CopyTree channels
   COPYTREE_GENERATE: "copytree:generate",
   COPYTREE_INJECT: "copytree:inject",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -123,6 +123,12 @@ export function registerIpcHandlers(
   });
   handlers.push(unsubAgentState);
 
+  // Forward artifact detection events to renderer
+  const unsubArtifactDetected = events.on("artifact:detected", (payload) => {
+    sendToRenderer(mainWindow, CHANNELS.ARTIFACT_DETECTED, payload);
+  });
+  handlers.push(unsubArtifactDetected);
+
   // ==========================================
   // Worktree Handlers
   // ==========================================
@@ -429,6 +435,197 @@ export function registerIpcHandlers(
   };
   ipcMain.handle(CHANNELS.TERMINAL_KILL, handleTerminalKill);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_KILL));
+
+  // ==========================================
+  // Artifact Handlers
+  // ==========================================
+
+  const handleArtifactSaveToFile = async (
+    _event: Electron.IpcMainInvokeEvent,
+    options: unknown
+  ): Promise<{ filePath: string; success: boolean } | null> => {
+    try {
+      // Validate payload
+      if (
+        typeof options !== "object" ||
+        options === null ||
+        !("content" in options) ||
+        typeof (options as any).content !== "string"
+      ) {
+        throw new Error("Invalid saveToFile payload: missing or invalid content");
+      }
+
+      const { content, suggestedFilename, cwd } = options as {
+        content: string;
+        suggestedFilename?: string;
+        cwd?: string;
+      };
+
+      // Validate content size (max 10MB)
+      if (content.length > 10 * 1024 * 1024) {
+        throw new Error("Artifact content exceeds maximum size (10MB)");
+      }
+
+      // Validate and sanitize cwd if provided
+      let safeCwd = os.homedir();
+      if (cwd && typeof cwd === "string") {
+        const fs = await import("fs/promises");
+        try {
+          // Resolve to absolute path and check if it exists
+          const resolvedCwd = path.resolve(cwd);
+          const stat = await fs.stat(resolvedCwd);
+          if (stat.isDirectory()) {
+            safeCwd = resolvedCwd;
+          }
+        } catch {
+          // If cwd is invalid, fall back to homedir
+          safeCwd = os.homedir();
+        }
+      }
+
+      // Show save dialog
+      const result = await dialog.showSaveDialog(mainWindow, {
+        title: "Save Artifact",
+        defaultPath: suggestedFilename
+          ? path.join(safeCwd, path.basename(suggestedFilename)) // Only use basename to prevent traversal
+          : path.join(safeCwd, "artifact.txt"),
+        properties: ["createDirectory", "showOverwriteConfirmation"],
+      });
+
+      if (result.canceled || !result.filePath) {
+        return null;
+      }
+
+      // Write content to file
+      const fs = await import("fs/promises");
+      await fs.writeFile(result.filePath, content, "utf-8");
+
+      return {
+        filePath: result.filePath,
+        success: true,
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error("[Artifact] Failed to save to file:", errorMessage);
+      throw new Error(`Failed to save artifact: ${errorMessage}`);
+    }
+  };
+  ipcMain.handle(CHANNELS.ARTIFACT_SAVE_TO_FILE, handleArtifactSaveToFile);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.ARTIFACT_SAVE_TO_FILE));
+
+  const handleArtifactApplyPatch = async (
+    _event: Electron.IpcMainInvokeEvent,
+    options: unknown
+  ): Promise<{ success: boolean; error?: string; modifiedFiles?: string[] }> => {
+    try {
+      // Validate payload
+      if (
+        typeof options !== "object" ||
+        options === null ||
+        !("patchContent" in options) ||
+        !("cwd" in options) ||
+        typeof (options as any).patchContent !== "string" ||
+        typeof (options as any).cwd !== "string"
+      ) {
+        throw new Error("Invalid applyPatch payload: missing or invalid patchContent/cwd");
+      }
+
+      const { patchContent, cwd } = options as { patchContent: string; cwd: string };
+
+      // Validate patch content size (max 5MB)
+      if (patchContent.length > 5 * 1024 * 1024) {
+        throw new Error("Patch content exceeds maximum size (5MB)");
+      }
+
+      // Validate and sanitize cwd
+      const fs = await import("fs/promises");
+      let resolvedCwd: string;
+      try {
+        // Resolve to absolute path
+        resolvedCwd = path.resolve(cwd);
+
+        // Check if directory exists
+        const stat = await fs.stat(resolvedCwd);
+        if (!stat.isDirectory()) {
+          return {
+            success: false,
+            error: "Provided cwd is not a directory",
+          };
+        }
+
+        // Check if it's a git repository
+        const gitPath = path.join(resolvedCwd, ".git");
+        try {
+          await fs.stat(gitPath);
+        } catch {
+          return {
+            success: false,
+            error: "Provided cwd is not a git repository",
+          };
+        }
+
+        // Optional: Verify cwd is within allowed worktrees
+        if (worktreeService) {
+          const worktrees = worktreeService.getAllStates();
+          const isValidWorktree = Array.from(worktrees.values()).some(
+            (wt) => path.resolve(wt.worktreePath) === resolvedCwd
+          );
+          if (!isValidWorktree) {
+            return {
+              success: false,
+              error: "Directory is not a known worktree",
+            };
+          }
+        }
+      } catch (error) {
+        return {
+          success: false,
+          error: `Invalid cwd: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+
+      // Write patch to temporary file
+      const tmpPatchPath = path.join(os.tmpdir(), `canopy-patch-${Date.now()}.patch`);
+      await fs.writeFile(tmpPatchPath, patchContent, "utf-8");
+
+      try {
+        // Apply patch using git apply
+        const { execa } = await import("execa");
+        await execa("git", ["apply", tmpPatchPath], { cwd: resolvedCwd });
+
+        // Get modified files by parsing the patch
+        const modifiedFiles: string[] = [];
+        const lines = patchContent.split("\n");
+        for (const line of lines) {
+          if (line.startsWith("+++")) {
+            const match = line.match(/\+\+\+ b\/(.+)/);
+            if (match) {
+              modifiedFiles.push(match[1]);
+            }
+          }
+        }
+
+        return {
+          success: true,
+          modifiedFiles,
+        };
+      } finally {
+        // Clean up temp patch file
+        await fs.unlink(tmpPatchPath).catch(() => {
+          /* ignore cleanup errors */
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error("[Artifact] Failed to apply patch:", errorMessage);
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  };
+  ipcMain.handle(CHANNELS.ARTIFACT_APPLY_PATCH, handleArtifactApplyPatch);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.ARTIFACT_APPLY_PATCH));
 
   // ==========================================
   // CopyTree Handlers

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -40,6 +40,11 @@ import type {
   AIServiceState,
   ProjectIdentity,
   AgentStateChangePayload,
+  ArtifactDetectedPayload,
+  SaveArtifactOptions,
+  SaveArtifactResult,
+  ApplyPatchOptions,
+  ApplyPatchResult,
   ElectronAPI,
   CreateWorktreeOptions,
   EventContext,
@@ -86,6 +91,11 @@ const CHANNELS = {
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",
   AGENT_GET_STATE: "agent:get-state",
+
+  // Artifact channels
+  ARTIFACT_DETECTED: "artifact:detected",
+  ARTIFACT_SAVE_TO_FILE: "artifact:save-to-file",
+  ARTIFACT_APPLY_PATCH: "artifact:apply-patch",
 
   // CopyTree channels
   COPYTREE_GENERATE: "copytree:generate",
@@ -308,6 +318,50 @@ const api: ElectronAPI = {
       ipcRenderer.on(CHANNELS.AGENT_STATE_CHANGED, handler);
       return () => ipcRenderer.removeListener(CHANNELS.AGENT_STATE_CHANGED, handler);
     },
+  },
+
+  // ==========================================
+  // Artifact API
+  // ==========================================
+  artifact: {
+    onDetected: (callback: (data: ArtifactDetectedPayload) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: unknown) => {
+        // Type guard - validate payload structure deeply
+        if (
+          typeof data === "object" &&
+          data !== null &&
+          "agentId" in data &&
+          "terminalId" in data &&
+          "artifacts" in data &&
+          "timestamp" in data &&
+          typeof (data as any).agentId === "string" &&
+          typeof (data as any).terminalId === "string" &&
+          typeof (data as any).timestamp === "number" &&
+          Array.isArray((data as any).artifacts) &&
+          // Validate each artifact object
+          (data as any).artifacts.every((artifact: any) =>
+            typeof artifact === "object" &&
+            artifact !== null &&
+            typeof artifact.id === "string" &&
+            typeof artifact.type === "string" &&
+            typeof artifact.content === "string" &&
+            typeof artifact.extractedAt === "number"
+          )
+        ) {
+          callback(data as ArtifactDetectedPayload);
+        } else {
+          console.warn("[Preload] Invalid artifact:detected payload, dropping event");
+        }
+      };
+      ipcRenderer.on(CHANNELS.ARTIFACT_DETECTED, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.ARTIFACT_DETECTED, handler);
+    },
+
+    saveToFile: (options: SaveArtifactOptions): Promise<SaveArtifactResult | null> =>
+      ipcRenderer.invoke(CHANNELS.ARTIFACT_SAVE_TO_FILE, options),
+
+    applyPatch: (options: ApplyPatchOptions): Promise<ApplyPatchResult> =>
+      ipcRenderer.invoke(CHANNELS.ARTIFACT_APPLY_PATCH, options),
   },
 
   // ==========================================

--- a/electron/services/TranscriptManager.ts
+++ b/electron/services/TranscriptManager.ts
@@ -125,6 +125,17 @@ export class TranscriptManager {
     const newArtifacts = extractArtifacts(cleanData, session.artifacts);
     session.artifacts.push(...newArtifacts);
 
+    // Emit artifact:detected event if new artifacts were found
+    if (newArtifacts.length > 0) {
+      events.emit("artifact:detected", {
+        agentId: payload.agentId,
+        terminalId: session.metadata.terminalId,
+        worktreeId: session.worktreeId,
+        artifacts: newArtifacts,
+        timestamp: payload.timestamp,
+      });
+    }
+
     // Debounce write to disk
     this.scheduleWrite(payload.agentId);
   }

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -197,6 +197,25 @@ export type CanopyEventMap = {
     traceId?: string;
   };
 
+  /**
+   * Emitted when artifacts (code blocks or patches) are extracted from agent output.
+   */
+  "artifact:detected": {
+    agentId: string;
+    terminalId: string;
+    worktreeId?: string;
+    artifacts: Array<{
+      id: string;
+      type: "code" | "patch" | "file" | "summary" | "other";
+      language?: string;
+      filename?: string;
+      content: string;
+      extractedAt: number;
+    }>;
+    timestamp: number;
+    traceId?: string;
+  };
+
   // ============================================================================
   // Task Lifecycle Events (Future-proof for task management)
   // ============================================================================
@@ -341,6 +360,7 @@ export const ALL_EVENT_TYPES: Array<keyof CanopyEventMap> = [
   "agent:completed",
   "agent:failed",
   "agent:killed",
+  "artifact:detected",
   "task:created",
   "task:assigned",
   "task:state-changed",

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -435,6 +435,60 @@ export interface AgentStateChangePayload {
 }
 
 // ============================================================================
+// Artifact IPC Types
+// ============================================================================
+
+/** Payload for artifact detection events */
+export interface ArtifactDetectedPayload {
+  /** Agent ID that generated the artifacts */
+  agentId: string;
+  /** Terminal ID where the artifacts appeared */
+  terminalId: string;
+  /** Associated worktree ID (if any) */
+  worktreeId?: string;
+  /** Array of detected artifacts */
+  artifacts: Artifact[];
+  /** Timestamp when artifacts were detected */
+  timestamp: number;
+}
+
+/** Options for saving an artifact to a file */
+export interface SaveArtifactOptions {
+  /** Artifact content to save */
+  content: string;
+  /** Suggested filename */
+  suggestedFilename?: string;
+  /** Working directory for the save dialog */
+  cwd?: string;
+}
+
+/** Result from saving an artifact */
+export interface SaveArtifactResult {
+  /** Path where the file was saved */
+  filePath: string;
+  /** Whether the operation succeeded */
+  success: boolean;
+}
+
+/** Options for applying a patch */
+export interface ApplyPatchOptions {
+  /** Patch content in unified diff format */
+  patchContent: string;
+  /** Working directory to apply the patch in */
+  cwd: string;
+}
+
+/** Result from applying a patch */
+export interface ApplyPatchResult {
+  /** Whether the patch applied successfully */
+  success: boolean;
+  /** Error message if the patch failed */
+  error?: string;
+  /** Files that were modified */
+  modifiedFiles?: string[];
+}
+
+// ============================================================================
 // Worktree Creation Types
 // ============================================================================
 
@@ -504,6 +558,11 @@ export interface ElectronAPI {
     onData(id: string, callback: (data: string) => void): () => void;
     onExit(callback: (id: string, exitCode: number) => void): () => void;
     onAgentStateChanged(callback: (data: AgentStateChangePayload) => void): () => void;
+  };
+  artifact: {
+    onDetected(callback: (data: ArtifactDetectedPayload) => void): () => void;
+    saveToFile(options: SaveArtifactOptions): Promise<SaveArtifactResult | null>;
+    applyPatch(options: ApplyPatchOptions): Promise<ApplyPatchResult>;
   };
   copyTree: {
     generate(worktreeId: string, options?: CopyTreeOptions): Promise<CopyTreeResult>;

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -1,0 +1,284 @@
+/**
+ * ArtifactOverlay Component
+ *
+ * Floating overlay showing extracted artifacts from agent output in a terminal.
+ * Displays a compact badge that expands to show artifact details and actions.
+ */
+
+import { useState, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { useArtifacts } from "@/hooks/useArtifacts";
+import type { Artifact } from "@shared/types";
+
+interface ArtifactOverlayProps {
+  terminalId: string;
+  worktreeId?: string;
+  cwd?: string;
+  className?: string;
+}
+
+const ARTIFACT_TYPE_COLORS: Record<string, string> = {
+  code: "border-blue-500 bg-blue-500/10 text-blue-400",
+  patch: "border-green-500 bg-green-500/10 text-green-400",
+  file: "border-purple-500 bg-purple-500/10 text-purple-400",
+  summary: "border-yellow-500 bg-yellow-500/10 text-yellow-400",
+  other: "border-gray-500 bg-gray-500/10 text-gray-400",
+};
+
+const ARTIFACT_TYPE_ICONS: Record<string, string> = {
+  code: "{ }",
+  patch: "+/-",
+  file: "[ ]",
+  summary: "#",
+  other: "...",
+};
+
+interface ArtifactItemProps {
+  artifact: Artifact;
+  onCopy: (artifact: Artifact) => Promise<boolean>;
+  onSave: (artifact: Artifact) => Promise<{ filePath: string; success: boolean } | null>;
+  onApplyPatch: (artifact: Artifact) => Promise<{ success: boolean; error?: string; modifiedFiles?: string[] }>;
+  canApplyPatch: boolean;
+  isProcessing: boolean;
+}
+
+function ArtifactItem({
+  artifact,
+  onCopy,
+  onSave,
+  onApplyPatch,
+  canApplyPatch,
+  isProcessing,
+}: ArtifactItemProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+
+  const showFeedback = useCallback((message: string) => {
+    setFeedbackMessage(message);
+    setTimeout(() => setFeedbackMessage(null), 2000);
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    const success = await onCopy(artifact);
+    if (success) {
+      showFeedback("Copied!");
+    } else {
+      showFeedback("Copy failed");
+    }
+  }, [artifact, onCopy, showFeedback]);
+
+  const handleSave = useCallback(async () => {
+    const result = await onSave(artifact);
+    if (result) {
+      showFeedback("Saved!");
+    } else {
+      showFeedback("Save failed");
+    }
+  }, [artifact, onSave, showFeedback]);
+
+  const handleApplyPatch = useCallback(async () => {
+    const result = await onApplyPatch(artifact);
+    if (result.success) {
+      showFeedback("Patch applied!");
+    } else {
+      showFeedback(result.error || "Patch failed");
+    }
+  }, [artifact, onApplyPatch, showFeedback]);
+
+  const colorClass = ARTIFACT_TYPE_COLORS[artifact.type] || ARTIFACT_TYPE_COLORS.other;
+  const icon = ARTIFACT_TYPE_ICONS[artifact.type] || ARTIFACT_TYPE_ICONS.other;
+  const title = artifact.filename || artifact.language || artifact.type;
+  const previewLines = artifact.content.split("\n").slice(0, 2);
+  const hasMore = artifact.content.split("\n").length > 2;
+  const lineCount = artifact.content.split("\n").length;
+
+  return (
+    <div className={cn("border rounded-md overflow-hidden", colorClass.split(" ")[0])}>
+      {/* Header */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className={cn(
+          "w-full flex items-center justify-between px-3 py-2 text-left",
+          colorClass.split(" ")[1],
+          "hover:brightness-110 transition-all"
+        )}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span className={cn("font-mono text-xs shrink-0", colorClass.split(" ")[2])}>{icon}</span>
+          <span className="text-sm text-gray-200 font-medium truncate">{title}</span>
+          {artifact.language && artifact.language !== artifact.type && (
+            <span className="text-xs text-gray-500 shrink-0">{artifact.language}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-xs text-gray-500">{lineCount} line{lineCount !== 1 ? "s" : ""}</span>
+          <span className="text-gray-400">{isExpanded ? "▼" : "▶"}</span>
+        </div>
+      </button>
+
+      {/* Expanded Content */}
+      {isExpanded && (
+        <div className="bg-gray-900/50">
+          {/* Preview */}
+          <pre className="font-mono text-xs p-3 overflow-x-auto max-h-32 overflow-y-auto">
+            <code className="text-gray-300">
+              {previewLines.join("\n")}
+              {hasMore && <span className="text-gray-500">{"\n"}...</span>}
+            </code>
+          </pre>
+
+          {/* Action Buttons */}
+          <div className="flex items-center gap-2 px-3 py-2 bg-gray-800/50 border-t border-gray-700">
+            <button
+              onClick={handleCopy}
+              disabled={isProcessing}
+              className={cn(
+                "px-3 py-1 text-xs rounded transition-colors",
+                "bg-blue-600 hover:bg-blue-700 text-white",
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              )}
+            >
+              Copy Code
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={isProcessing}
+              className={cn(
+                "px-3 py-1 text-xs rounded transition-colors",
+                "bg-gray-600 hover:bg-gray-700 text-white",
+                "disabled:opacity-50 disabled:cursor-not-allowed"
+              )}
+            >
+              Save to File
+            </button>
+            {artifact.type === "patch" && (
+              <button
+                onClick={handleApplyPatch}
+                disabled={isProcessing || !canApplyPatch}
+                className={cn(
+                  "px-3 py-1 text-xs rounded transition-colors",
+                  "bg-green-600 hover:bg-green-700 text-white",
+                  "disabled:opacity-50 disabled:cursor-not-allowed"
+                )}
+                title={!canApplyPatch ? "No worktree context available" : "Apply patch to worktree"}
+              >
+                Apply Patch
+              </button>
+            )}
+            {feedbackMessage && (
+              <span className="ml-auto text-xs text-green-400 animate-pulse">{feedbackMessage}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: ArtifactOverlayProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const {
+    artifacts,
+    actionInProgress,
+    hasArtifacts,
+    copyToClipboard,
+    saveToFile,
+    applyPatch,
+    clearArtifacts,
+    canApplyPatch,
+  } = useArtifacts(terminalId, worktreeId, cwd);
+
+  const handleCopy = useCallback(
+    async (artifact: Artifact) => {
+      await copyToClipboard(artifact);
+    },
+    [copyToClipboard]
+  );
+
+  const handleSave = useCallback(
+    async (artifact: Artifact) => {
+      await saveToFile(artifact);
+    },
+    [saveToFile]
+  );
+
+  const handleApplyPatch = useCallback(
+    async (artifact: Artifact) => {
+      await applyPatch(artifact);
+    },
+    [applyPatch]
+  );
+
+  if (!hasArtifacts) {
+    return null;
+  }
+
+  return (
+    <div className={cn("absolute bottom-4 right-4 z-10", className)}>
+      {!isExpanded ? (
+        // Compact Badge
+        <button
+          onClick={() => setIsExpanded(true)}
+          className={cn(
+            "px-3 py-2 rounded-md shadow-lg",
+            "bg-blue-600 hover:bg-blue-700 text-white",
+            "text-sm font-medium transition-all",
+            "flex items-center gap-2"
+          )}
+        >
+          <span className="font-mono">{ }</span>
+          <span>{artifacts.length} artifact{artifacts.length !== 1 ? "s" : ""}</span>
+        </button>
+      ) : (
+        // Expanded Overlay
+        <div
+          className={cn(
+            "bg-gray-800 border border-gray-700 rounded-lg shadow-2xl",
+            "w-96 max-h-96 flex flex-col overflow-hidden"
+          )}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 bg-gray-900 border-b border-gray-700">
+            <div className="flex items-center gap-2">
+              <span className="font-mono text-blue-400">{ }</span>
+              <span className="text-sm font-medium text-gray-200">
+                {artifacts.length} Artifact{artifacts.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={clearArtifacts}
+                className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                Clear
+              </button>
+              <button
+                onClick={() => setIsExpanded(false)}
+                className="text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                ×
+              </button>
+            </div>
+          </div>
+
+          {/* Artifact List */}
+          <div className="flex-1 overflow-y-auto p-3 space-y-2">
+            {artifacts.map((artifact) => (
+              <ArtifactItem
+                key={artifact.id}
+                artifact={artifact}
+                onCopy={handleCopy}
+                onSave={handleSave}
+                onApplyPatch={handleApplyPatch}
+                canApplyPatch={canApplyPatch(artifact)}
+                isProcessing={actionInProgress === artifact.id}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ArtifactOverlay;

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -30,6 +30,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { XtermAdapter } from "./XtermAdapter";
+import { ArtifactOverlay } from "./ArtifactOverlay";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { useErrorStore, useTerminalStore, type RetryAction } from "@/store";
 import type { CopyTreeProgress } from "@/hooks/useContextInjection";
@@ -94,7 +95,7 @@ export function TerminalPane({
   title,
   type,
   worktreeId,
-  cwd: _cwd, // Reserved for terminal spawning integration
+  cwd,
   isFocused,
   isMaximized,
   isInjecting,
@@ -429,6 +430,12 @@ export function TerminalPane({
           onReady={handleReady}
           onExit={handleExit}
           className="absolute inset-0"
+        />
+        {/* Artifact Overlay */}
+        <ArtifactOverlay
+          terminalId={id}
+          worktreeId={worktreeId}
+          cwd={cwd}
         />
       </div>
     </div>

--- a/src/hooks/useArtifacts.ts
+++ b/src/hooks/useArtifacts.ts
@@ -1,0 +1,203 @@
+/**
+ * useArtifacts Hook
+ *
+ * Manages artifacts extracted from agent terminal output.
+ * Subscribes to artifact detection events and provides actions for
+ * copying, saving, and applying artifacts.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { isElectronAvailable } from "./useElectron";
+import type { Artifact, ArtifactDetectedPayload } from "@shared/types";
+
+// Global state for artifacts (shared across all hook instances)
+const artifactStore = new Map<string, Artifact[]>();
+const listeners = new Set<(terminalId: string, artifacts: Artifact[]) => void>();
+
+// Reference count for IPC listener management
+let listenerRefCount = 0;
+let ipcUnsubscribe: (() => void) | null = null;
+
+function notifyListeners(terminalId: string, artifacts: Artifact[]) {
+  listeners.forEach((listener) => listener(terminalId, artifacts));
+}
+
+/**
+ * Hook to manage artifacts for a specific terminal
+ *
+ * @param terminalId - The terminal ID to filter artifacts for
+ * @param worktreeId - Optional worktree ID for patch application
+ * @param cwd - Current working directory for save dialog
+ * @returns Artifacts and actions
+ */
+export function useArtifacts(terminalId: string, worktreeId?: string, cwd?: string) {
+  const [artifacts, setArtifacts] = useState<Artifact[]>(() => artifactStore.get(terminalId) || []);
+  const [actionInProgress, setActionInProgress] = useState<string | null>(null);
+
+  // Subscribe to global artifact detection events (reference-counted singleton)
+  useEffect(() => {
+    if (!isElectronAvailable()) return;
+
+    // Increment reference count
+    listenerRefCount++;
+
+    // Set up IPC listener if this is the first instance
+    if (listenerRefCount === 1 && !ipcUnsubscribe) {
+      ipcUnsubscribe = window.electron.artifact.onDetected((payload: ArtifactDetectedPayload) => {
+        // Update artifact store
+        const currentArtifacts = artifactStore.get(payload.terminalId) || [];
+        const newArtifacts = [...currentArtifacts, ...payload.artifacts];
+        artifactStore.set(payload.terminalId, newArtifacts);
+
+        // Notify all listeners
+        notifyListeners(payload.terminalId, newArtifacts);
+      });
+    }
+
+    return () => {
+      // Decrement reference count
+      listenerRefCount--;
+
+      // Clean up IPC listener when no more instances exist
+      if (listenerRefCount === 0 && ipcUnsubscribe) {
+        ipcUnsubscribe();
+        ipcUnsubscribe = null;
+      }
+    };
+  }, []);
+
+  // Subscribe to changes for this specific terminal
+  useEffect(() => {
+    const listener = (tid: string, arts: Artifact[]) => {
+      if (tid === terminalId) {
+        setArtifacts(arts);
+      }
+    };
+
+    listeners.add(listener);
+
+    return () => {
+      listeners.delete(listener);
+    };
+  }, [terminalId]);
+
+  // Copy artifact content to clipboard
+  const copyToClipboard = useCallback(
+    async (artifact: Artifact) => {
+      if (!navigator.clipboard) {
+        console.error("Clipboard API not available");
+        return false;
+      }
+
+      try {
+        setActionInProgress(artifact.id);
+        await navigator.clipboard.writeText(artifact.content);
+        return true;
+      } catch (error) {
+        console.error("Failed to copy to clipboard:", error);
+        return false;
+      } finally {
+        setActionInProgress(null);
+      }
+    },
+    []
+  );
+
+  // Save artifact to file
+  const saveToFile = useCallback(
+    async (artifact: Artifact) => {
+      if (!isElectronAvailable()) return null;
+
+      try {
+        setActionInProgress(artifact.id);
+
+        // Determine suggested filename
+        let suggestedFilename = artifact.filename;
+        if (!suggestedFilename) {
+          const ext = artifact.language ? `.${artifact.language}` : ".txt";
+          suggestedFilename = `artifact-${Date.now()}${ext}`;
+        }
+
+        const result = await window.electron.artifact.saveToFile({
+          content: artifact.content,
+          suggestedFilename,
+          cwd,
+        });
+
+        return result;
+      } catch (error) {
+        console.error("Failed to save artifact:", error);
+        return null;
+      } finally {
+        setActionInProgress(null);
+      }
+    },
+    [cwd]
+  );
+
+  // Apply patch artifact
+  const applyPatch = useCallback(
+    async (artifact: Artifact) => {
+      if (!isElectronAvailable() || artifact.type !== "patch") {
+        return { success: false, error: "Invalid artifact type or Electron not available" };
+      }
+
+      if (!worktreeId || !cwd) {
+        return { success: false, error: "No worktree context available" };
+      }
+
+      try {
+        setActionInProgress(artifact.id);
+
+        const result = await window.electron.artifact.applyPatch({
+          patchContent: artifact.content,
+          cwd,
+        });
+
+        return result;
+      } catch (error) {
+        console.error("Failed to apply patch:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      } finally {
+        setActionInProgress(null);
+      }
+    },
+    [worktreeId, cwd]
+  );
+
+  // Clear artifacts for this terminal
+  const clearArtifacts = useCallback(() => {
+    artifactStore.delete(terminalId);
+    setArtifacts([]);
+    notifyListeners(terminalId, []);
+  }, [terminalId]);
+
+  // Check if an artifact can be applied (must be a patch and have worktree context)
+  const canApplyPatch = useCallback(
+    (artifact: Artifact) => {
+      return artifact.type === "patch" && !!worktreeId && !!cwd;
+    },
+    [worktreeId, cwd]
+  );
+
+  return {
+    // State
+    artifacts,
+    actionInProgress,
+    hasArtifacts: artifacts.length > 0,
+
+    // Actions
+    copyToClipboard,
+    saveToFile,
+    applyPatch,
+    clearArtifacts,
+
+    // Utilities
+    canApplyPatch,
+  };
+}
+
+export default useArtifacts;


### PR DESCRIPTION
## Summary
Implements a floating artifact overlay that exposes code blocks and patches extracted from agent terminal output with actionable buttons (Copy Code, Save to File, Apply Patch). Users can now immediately interact with generated code without manual copy-paste.

Closes #98

## Changes Made
- Added IPC channels for artifact detection and operations (save/apply)
- Emit artifact:detected events when TranscriptManager extracts new artifacts
- Created secure IPC handlers with comprehensive validation and security checks
- Built useArtifacts hook with reference-counted listener management
- Created ArtifactOverlay component with compact badge and expandable UI
- Integrated overlay into TerminalPane with worktree context awareness

## Security Enhancements
- Runtime payload validation with deep type guards
- Path sanitization to prevent directory traversal attacks
- Artifact size limits (code: 10MB, patches: 5MB)
- Git repository validation before patch application
- Worktree whitelist enforcement for patch operations

## Test Coverage
Codex review identified test needs for follow-up PR:
- Unit tests for useArtifacts lifecycle and cleanup
- Integration tests for IPC validation and git apply failures
- UI tests for error feedback surfacing