### PR TITLE
Increase terminal padding for improved readability

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -361,10 +361,9 @@ export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAd
     <div
       ref={containerRef}
       className={cn(
-        "w-full h-full min-h-0 overflow-hidden", // Remove padding, add overflow-hidden
+        "w-full h-full min-h-0 overflow-hidden p-2.5", // Balanced padding for comfortable reading
         className
       )}
-      style={{ padding: "4px 0 0 8px" }} // Apply padding via style to avoid box model issues
     />
   );
 }


### PR DESCRIPTION
## Summary
Updates terminal container padding from asymmetric inline styles to balanced Tailwind padding for improved readability and visual comfort.

Closes #149

## Changes Made
- Changed terminal container padding from inline style (4px top, 8px left) to Tailwind p-2.5 (10px all sides)
- Removed asymmetric padding that caused text to sit too close to container edges
- Improved visual comfort and terminal boundary distinction