### PR TITLE
Fix terminal resize handling during rapid window changes

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -155,6 +155,9 @@ function applyJankFix(terminal: Terminal): () => void {
   };
 }
 
+/** Maximum retries when container has zero dimensions */
+const MAX_ZERO_RETRIES = 10;
+
 export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAdapterProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -162,6 +165,9 @@ export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAd
   const throttledWriterRef = useRef<ReturnType<typeof createThrottledWriter> | null>(null);
   const jankFixDisposeRef = useRef<(() => void) | null>(null);
   const resizeFrameIdRef = useRef<number | null>(null);
+  const prevDimensionsRef = useRef<{ cols: number; rows: number } | null>(null);
+  const zeroRetryCountRef = useRef<number>(0);
+  const clearScreenTimeoutRef = useRef<number | null>(null);
 
   // Memoize terminal options
   const terminalOptions = useMemo(
@@ -285,6 +291,74 @@ export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAd
     const { cols, rows } = terminal;
     window.electron.terminal.resize(terminalId, cols, rows);
 
+    // Helper to perform the actual resize check and fit
+    const performResize = () => {
+      if (!containerRef.current) {
+        resizeFrameIdRef.current = null;
+        return;
+      }
+
+      // If dimensions are zero, schedule explicit retry with polling
+      if (containerRef.current.clientWidth === 0 || containerRef.current.clientHeight === 0) {
+        if (zeroRetryCountRef.current < MAX_ZERO_RETRIES) {
+          zeroRetryCountRef.current++;
+          // Schedule explicit dimension check on next frame
+          resizeFrameIdRef.current = requestAnimationFrame(performResize);
+        } else {
+          // Give up after max retries
+          console.warn(
+            `Terminal container has zero dimensions after ${MAX_ZERO_RETRIES} retries`
+          );
+          zeroRetryCountRef.current = 0;
+          resizeFrameIdRef.current = null;
+        }
+        return;
+      }
+
+      // Reset retry count on successful resize
+      zeroRetryCountRef.current = 0;
+
+      if (fitAddonRef.current && terminalRef.current) {
+        try {
+          fitAddonRef.current.fit();
+          const { cols, rows } = terminalRef.current;
+
+          // Clear screen if terminal shrunk (debounced to avoid flicker)
+          if (prevDimensionsRef.current) {
+            const shrunk =
+              cols < prevDimensionsRef.current.cols || rows < prevDimensionsRef.current.rows;
+
+            if (shrunk) {
+              // Clear any pending clear timeout
+              if (clearScreenTimeoutRef.current !== null) {
+                clearTimeout(clearScreenTimeoutRef.current);
+              }
+
+              // Debounce screen clearing to avoid repeated wipes during drag-resize
+              clearScreenTimeoutRef.current = window.setTimeout(() => {
+                if (terminalRef.current) {
+                  // Send ANSI escape sequence to clear screen
+                  // ESC[2J clears screen, ESC[H moves cursor to home
+                  terminalRef.current.write("\x1B[2J\x1B[H");
+                }
+                clearScreenTimeoutRef.current = null;
+              }, 150); // Wait 150ms for resize to settle
+            }
+          }
+
+          // Update previous dimensions
+          prevDimensionsRef.current = { cols, rows };
+
+          // Send resize to backend
+          window.electron.terminal.resize(terminalId, cols, rows);
+        } catch (e) {
+          // Suppress fit errors during rapid resizing
+          console.warn("Terminal fit failed:", e);
+        }
+      }
+      resizeFrameIdRef.current = null;
+    };
+
     // Set up resize handling with ResizeObserver
     const resizeObserver = new ResizeObserver(() => {
       // Cancel any pending resize animation frame
@@ -293,30 +367,7 @@ export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAd
       }
 
       // Use requestAnimationFrame to debounce rapid resize events
-      resizeFrameIdRef.current = requestAnimationFrame(() => {
-        // Guard against fitting when container has zero dimensions
-        // This prevents xterm crashes during layout thrashing or initial render
-        if (
-          !containerRef.current ||
-          containerRef.current.clientWidth === 0 ||
-          containerRef.current.clientHeight === 0
-        ) {
-          resizeFrameIdRef.current = null;
-          return;
-        }
-
-        if (fitAddonRef.current && terminalRef.current) {
-          try {
-            fitAddonRef.current.fit();
-            const { cols, rows } = terminalRef.current;
-            window.electron.terminal.resize(terminalId, cols, rows);
-          } catch (e) {
-            // Suppress fit errors during rapid resizing
-            console.warn("Terminal fit failed:", e);
-          }
-        }
-        resizeFrameIdRef.current = null;
-      });
+      resizeFrameIdRef.current = requestAnimationFrame(performResize);
     });
     resizeObserver.observe(containerRef.current);
 
@@ -337,6 +388,12 @@ export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAd
         resizeFrameIdRef.current = null;
       }
 
+      // Clear pending screen clear timeout
+      if (clearScreenTimeoutRef.current !== null) {
+        clearTimeout(clearScreenTimeoutRef.current);
+        clearScreenTimeoutRef.current = null;
+      }
+
       // Dispose jank fix listeners and timers
       if (jankFixDisposeRef.current) {
         jankFixDisposeRef.current();
@@ -350,10 +407,12 @@ export function XtermAdapter({ terminalId, onReady, onExit, className }: XtermAd
       inputDisposable.dispose();
       throttledWriter.dispose();
       terminal.dispose();
-      // Reset refs to allow re-initialization
+      // Reset refs to allow re-initialization (prevents StrictMode issues)
       terminalRef.current = null;
       fitAddonRef.current = null;
       throttledWriterRef.current = null;
+      prevDimensionsRef.current = null;
+      zeroRetryCountRef.current = 0;
     };
   }, [terminalId, terminalOptions, handleResize, onReady, onExit]);
 


### PR DESCRIPTION
## Summary

Fixes terminal resize failures during rapid window changes or layout thrashing by improving zero-dimension handling, adding screen clearing on shrink, and strengthening backend validation.

Closes #130

## Changes Made

- Add explicit polling for zero-dimension retries instead of ResizeObserver re-subscription (fixes retry spin issue)
- Debounce screen clearing (150ms) to prevent flicker during drag-resize
- Add strict dimension validation in PtyManager (NaN, Infinity, integer checks)
- Skip no-op resizes to reduce PTY churn and log spam
- Reset resize refs in cleanup to prevent StrictMode issues
- Add optional verbose logging for resize events (CANOPY_VERBOSE env var)

## Technical Details

**Frontend (XtermAdapter.tsx):**
- Replaced ResizeObserver re-subscription with explicit requestAnimationFrame polling when container has zero dimensions
- Added dimension tracking to detect terminal shrinking
- Implemented debounced screen clearing (ESC[2J ESC[H) after 150ms settle time to match CLI behavior
- Added proper ref cleanup to prevent state leakage in React StrictMode

**Backend (PtyManager.ts):**
- Added comprehensive dimension validation (finite, positive, integer checks)
- Added no-op resize detection to skip unnecessary PTY operations
- Added optional verbose logging for debugging resize issues
- Improved error handling with try-catch around resize calls

## Testing

- TypeScript type checking passes
- ESLint passes with no new warnings
- Code review completed with all Codex recommendations applied