### PR TITLE
Show real app version from Electron in Settings dialog

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -64,6 +64,7 @@ export const CHANNELS = {
   // App state channels
   APP_GET_STATE: "app:get-state",
   APP_SET_STATE: "app:set-state",
+  APP_GET_VERSION: "app:get-version",
 
   // Directory channels
   DIRECTORY_GET_RECENTS: "directory:get-recents",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -5,7 +5,7 @@
  * Provides a single initialization function to wire up all IPC communication.
  */
 
-import { ipcMain, BrowserWindow, shell, dialog } from "electron";
+import { ipcMain, BrowserWindow, shell, dialog, app } from "electron";
 import crypto from "crypto";
 import os from "os";
 import path from "path";
@@ -1017,6 +1017,12 @@ export function registerIpcHandlers(
   };
   ipcMain.handle(CHANNELS.APP_SET_STATE, handleAppSetState);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_SET_STATE));
+
+  const handleAppGetVersion = async () => {
+    return app.getVersion();
+  };
+  ipcMain.handle(CHANNELS.APP_GET_VERSION, handleAppGetVersion);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_GET_VERSION));
 
   // ==========================================
   // Logs Handlers

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -118,6 +118,7 @@ const CHANNELS = {
   // App state channels
   APP_GET_STATE: "app:get-state",
   APP_SET_STATE: "app:set-state",
+  APP_GET_VERSION: "app:get-version",
 
   // Logs channels
   LOGS_GET_ALL: "logs:get-all",
@@ -419,6 +420,8 @@ const api: ElectronAPI = {
 
     setState: (partialState: Partial<AppState>) =>
       ipcRenderer.invoke(CHANNELS.APP_SET_STATE, partialState),
+
+    getVersion: () => ipcRenderer.invoke(CHANNELS.APP_GET_VERSION),
   },
 
   // ==========================================

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -591,6 +591,7 @@ export interface ElectronAPI {
   app: {
     getState(): Promise<AppState>;
     setState(partialState: Partial<AppState>): Promise<void>;
+    getVersion(): Promise<string>;
   };
   logs: {
     getAll(filters?: LogFilterOptions): Promise<LogEntry[]>;

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -46,6 +46,9 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
   const { openLogs } = useErrors();
   const clearLogs = useLogsStore((state) => state.clearLogs);
 
+  // App version state
+  const [appVersion, setAppVersion] = useState<string>("Loading...");
+
   // AI settings state
   const [aiConfig, setAiConfig] = useState<AIServiceState | null>(null);
   const [apiKey, setApiKey] = useState("");
@@ -55,6 +58,24 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
     "success" | "error" | "test-success" | "test-error" | null
   >(null);
   const [selectedModel, setSelectedModel] = useState("gpt-5-nano");
+
+  // Load app version on mount
+  useEffect(() => {
+    if (isOpen) {
+      if (window.electron?.app) {
+        window.electron.app
+          .getVersion()
+          .then(setAppVersion)
+          .catch((error) => {
+            console.error("Failed to fetch app version:", error);
+            setAppVersion("Unavailable");
+          });
+      } else {
+        // Not in Electron environment (e.g., tests, storybook)
+        setAppVersion("N/A");
+      }
+    }
+  }, [isOpen]);
 
   // Load AI config on mount
   useEffect(() => {
@@ -227,7 +248,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                     <div className="space-y-2 text-sm">
                       <div className="flex justify-between text-gray-400">
                         <span>Version</span>
-                        <span className="font-mono text-canopy-text">0.0.1</span>
+                        <span className="font-mono text-canopy-text">{appVersion}</span>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
Display the actual application version from Electron's `app.getVersion()` instead of the hard-coded "0.0.1" string in the Settings dialog. This ensures the version displayed matches the version in `package.json` and updates automatically when the app is rebuilt.

Closes #136

## Changes Made
- Add APP_GET_VERSION IPC channel and handler
- Expose app.getVersion() in preload bridge
- Update Settings dialog to fetch version dynamically
- Replace hard-coded "0.0.1" with version from package.json
- Add error handling for IPC failures
- Add fallback for non-Electron environments