### PR TITLE
feat(pr-detection): implement automated pull request polling service

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -14,6 +14,7 @@ export const CHANNELS = {
   WORKTREE_REMOVE: "worktree:remove",
   WORKTREE_CREATE: "worktree:create",
   WORKTREE_LIST_BRANCHES: "worktree:list-branches",
+  WORKTREE_PR_REFRESH: "worktree:pr-refresh",
 
   // Dev server channels
   DEVSERVER_START: "devserver:start",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -152,6 +152,15 @@ export function registerIpcHandlers(
   ipcMain.handle(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_REFRESH));
 
+  const handleWorktreePRRefresh = async () => {
+    if (!worktreeService) {
+      return;
+    }
+    await worktreeService.refreshPullRequests();
+  };
+  ipcMain.handle(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_REFRESH));
+
   const handleWorktreeSetActive = async (
     _event: Electron.IpcMainInvokeEvent,
     payload: WorktreeSetActivePayload

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -65,6 +65,7 @@ const CHANNELS = {
   WORKTREE_REMOVE: "worktree:remove",
   WORKTREE_CREATE: "worktree:create",
   WORKTREE_LIST_BRANCHES: "worktree:list-branches",
+  WORKTREE_PR_REFRESH: "worktree:pr-refresh",
   WORKTREE_SET_ADAPTIVE_BACKOFF_CONFIG: "worktree:set-adaptive-backoff-config",
   WORKTREE_IS_CIRCUIT_BREAKER_TRIPPED: "worktree:is-circuit-breaker-tripped",
   WORKTREE_GET_ADAPTIVE_BACKOFF_METRICS: "worktree:get-adaptive-backoff-metrics",
@@ -197,6 +198,8 @@ const api: ElectronAPI = {
     getAll: () => ipcRenderer.invoke(CHANNELS.WORKTREE_GET_ALL),
 
     refresh: () => ipcRenderer.invoke(CHANNELS.WORKTREE_REFRESH),
+
+    refreshPullRequests: () => ipcRenderer.invoke(CHANNELS.WORKTREE_PR_REFRESH),
 
     setActive: (worktreeId: string) =>
       ipcRenderer.invoke(CHANNELS.WORKTREE_SET_ACTIVE, { worktreeId }),

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -1,0 +1,464 @@
+/**
+ * PullRequestService - Centralized polling for PR detection across all worktrees.
+ *
+ * Architecture:
+ * - Singleton service that subscribes to sys:worktree:update events
+ * - Detects context changes (branch/issue) and emits sys:pr:cleared immediately
+ * - Batches all worktree checks into a single GraphQL query
+ * - Stops checking worktrees once a PR is found (resolved state)
+ * - Emits sys:pr:detected and sys:pr:cleared events for UI updates
+ *
+ * Rate Limit Safety:
+ * - Default 60s polling = 60 requests/hour = 1.2% of 5000 point budget
+ * - Single GraphQL query checks all worktrees (batched)
+ * - Exponential backoff on errors with circuit breaker protection
+ *
+ * Migrated from Canopy CLI with Electron-specific patterns.
+ */
+
+import { events } from "./events.js";
+import { batchCheckLinkedPRs, type PRCheckCandidate, type LinkedPR } from "../utils/github.js";
+import { logInfo, logWarn, logDebug } from "../utils/logger.js";
+import type { WorktreeState } from "./WorktreeMonitor.js";
+
+// Default polling interval: 60 seconds (safe for rate limits - uses ~1.2% of hourly budget)
+const DEFAULT_POLL_INTERVAL_MS = 60 * 1000;
+
+// Backoff intervals for error handling
+const ERROR_BACKOFF_INTERVALS = [
+  5 * 60 * 1000, // 5 minutes after first error
+  10 * 60 * 1000, // 10 minutes after second error
+  30 * 60 * 1000, // 30 minutes after third+ error
+];
+
+// Maximum consecutive errors before disabling polling (circuit breaker)
+const MAX_CONSECUTIVE_ERRORS = 3;
+
+// Debounce delay for batching worktree updates
+const UPDATE_DEBOUNCE_MS = 100;
+
+/**
+ * Tracked context for a worktree - used to detect when branch/issue changes.
+ */
+interface WorktreeContext {
+  issueNumber?: number;
+  branchName?: string;
+}
+
+/**
+ * PR detection result for a single worktree.
+ */
+export interface PRDetectionResult {
+  worktreeId: string;
+  prNumber: number;
+  prUrl: string;
+  prState: "open" | "merged" | "closed";
+}
+
+/**
+ * PullRequestService manages centralized polling for PR detection across all worktrees.
+ *
+ * Usage:
+ * ```typescript
+ * // Initialize with repo root path
+ * pullRequestService.initialize('/path/to/repo');
+ *
+ * // Start polling (automatically registers candidates from worktree events)
+ * pullRequestService.start();
+ *
+ * // Manual refresh (e.g., after fixing auth issues)
+ * await pullRequestService.refresh();
+ *
+ * // Stop polling
+ * pullRequestService.stop();
+ *
+ * // Clean up on shutdown
+ * pullRequestService.destroy();
+ * ```
+ *
+ * Events emitted:
+ * - sys:pr:detected - When a PR is found for a worktree
+ * - sys:pr:cleared - When PR data should be cleared (context change)
+ *
+ * Events consumed:
+ * - sys:worktree:update - Registers/updates candidates, detects context changes
+ * - sys:worktree:remove - Cleans up removed worktrees
+ */
+class PullRequestService {
+  private pollTimer: NodeJS.Timeout | null = null;
+  private pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS;
+  private cwd: string = "";
+  private isPolling: boolean = false;
+  private consecutiveErrors: number = 0;
+  private isEnabled: boolean = true;
+
+  // Track worktrees that need PR checking
+  // Key: worktreeId, Value: { issueNumber, branchName }
+  private candidates = new Map<string, WorktreeContext>();
+
+  // Track resolved worktrees (already have a PR detected)
+  // These are excluded from future polling
+  private resolvedWorktrees = new Set<string>();
+
+  // Store detected PRs for quick lookup
+  private detectedPRs = new Map<string, LinkedPR>();
+
+  // Timer for debounced check after worktree updates
+  private updateDebounceTimer: NodeJS.Timeout | null = null;
+
+  // Event unsubscribe functions
+  private unsubscribers: (() => void)[] = [];
+
+  constructor() {
+    // Subscribe to worktree events directly - this is the source of truth
+    this.unsubscribers.push(events.on("sys:worktree:update", this.handleWorktreeUpdate.bind(this)));
+    this.unsubscribers.push(events.on("sys:worktree:remove", this.handleWorktreeRemove.bind(this)));
+  }
+
+  /**
+   * Handle worktree update events - the core of reactive state management.
+   * Detects context changes and immediately clears/updates PR data.
+   */
+  private handleWorktreeUpdate(state: WorktreeState): void {
+    if (!this.isPolling) {
+      return;
+    }
+
+    const currentContext = this.candidates.get(state.worktreeId);
+    const newIssueNumber = state.issueNumber;
+    const newBranchName = state.branch;
+
+    // Detect if the "identity" of the work context changed
+    const contextChanged =
+      currentContext?.issueNumber !== newIssueNumber || currentContext?.branchName !== newBranchName;
+
+    if (contextChanged && currentContext) {
+      // Context changed - CLEAR immediately
+      logInfo("Worktree context changed - clearing PR state", {
+        worktreeId: state.worktreeId,
+        oldIssue: currentContext.issueNumber,
+        newIssue: newIssueNumber,
+        oldBranch: currentContext.branchName,
+        newBranch: newBranchName,
+      });
+
+      this.resolvedWorktrees.delete(state.worktreeId);
+      this.detectedPRs.delete(state.worktreeId);
+
+      // Emit clear event so UI removes the PR button immediately
+      events.emit("sys:pr:cleared", { worktreeId: state.worktreeId });
+    }
+
+    // Update or register the candidate
+    if (newIssueNumber) {
+      // Has an issue number - track as candidate
+      this.candidates.set(state.worktreeId, {
+        issueNumber: newIssueNumber,
+        branchName: newBranchName,
+      });
+
+      // Schedule a debounced check if context changed or this is a new candidate
+      if (contextChanged || !currentContext) {
+        this.scheduleDebounceCheck();
+      }
+    } else {
+      // No issue number - stop tracking this worktree
+      if (currentContext) {
+        this.candidates.delete(state.worktreeId);
+        logDebug("Worktree no longer has issue number - removed from candidates", {
+          worktreeId: state.worktreeId,
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle worktree removal events.
+   */
+  private handleWorktreeRemove({ worktreeId }: { worktreeId: string }): void {
+    if (this.candidates.has(worktreeId) || this.detectedPRs.has(worktreeId)) {
+      this.candidates.delete(worktreeId);
+      this.resolvedWorktrees.delete(worktreeId);
+      this.detectedPRs.delete(worktreeId);
+
+      // Emit clear event
+      events.emit("sys:pr:cleared", { worktreeId });
+
+      logDebug("Worktree removed - cleared PR state", { worktreeId });
+    }
+  }
+
+  /**
+   * Schedule a debounced PR check.
+   * This batches rapid updates (e.g., multiple worktrees updating at once).
+   */
+  private scheduleDebounceCheck(): void {
+    if (this.updateDebounceTimer) {
+      clearTimeout(this.updateDebounceTimer);
+    }
+
+    this.updateDebounceTimer = setTimeout(() => {
+      this.updateDebounceTimer = null;
+
+      if (this.hasUnresolvedCandidates()) {
+        logDebug("Running debounced PR check", { candidateCount: this.candidates.size });
+        void this.checkForPRs();
+
+        // Ensure polling continues if it was paused
+        if (!this.pollTimer) {
+          this.scheduleNextPoll();
+        }
+      }
+    }, UPDATE_DEBOUNCE_MS);
+  }
+
+  /**
+   * Initialize the service with the working directory.
+   * @param cwd - Working directory (repo root)
+   */
+  public initialize(cwd: string): void {
+    this.cwd = cwd;
+    logInfo("PullRequestService initialized", { cwd });
+  }
+
+  /**
+   * Start the polling loop.
+   * Note: Candidates are now registered automatically via sys:worktree:update events.
+   * @param intervalMs - Optional custom polling interval (default: 60000ms, minimum: 60000ms)
+   */
+  public start(intervalMs?: number): void {
+    if (this.isPolling) {
+      logWarn("PullRequestService already polling");
+      return;
+    }
+
+    if (!this.cwd) {
+      logWarn("PullRequestService not initialized - call initialize() first");
+      return;
+    }
+
+    if (intervalMs) {
+      // Enforce minimum 60s interval for rate limit safety
+      if (intervalMs < DEFAULT_POLL_INTERVAL_MS) {
+        logWarn("PR polling interval too short - clamping to minimum 60s for rate limit safety", {
+          requested: intervalMs,
+          clamped: DEFAULT_POLL_INTERVAL_MS,
+        });
+        this.pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+      } else {
+        this.pollIntervalMs = intervalMs;
+      }
+    }
+
+    this.isPolling = true;
+    this.isEnabled = true;
+    this.consecutiveErrors = 0;
+
+    logInfo("PullRequestService started", { intervalMs: this.pollIntervalMs });
+
+    // Start polling loop - initial check will happen when worktree updates arrive
+    this.scheduleNextPoll();
+  }
+
+  /**
+   * Stop the polling loop.
+   */
+  public stop(): void {
+    if (this.pollTimer) {
+      clearTimeout(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.updateDebounceTimer) {
+      clearTimeout(this.updateDebounceTimer);
+      this.updateDebounceTimer = null;
+    }
+    this.isPolling = false;
+    logInfo("PullRequestService stopped");
+  }
+
+  /**
+   * Force an immediate PR check (e.g., on manual refresh).
+   * Re-enables polling if it was disabled due to errors.
+   */
+  public async refresh(): Promise<void> {
+    if (!this.cwd) {
+      return;
+    }
+    // Re-enable if disabled due to errors
+    this.isEnabled = true;
+    this.consecutiveErrors = 0;
+    await this.checkForPRs();
+
+    // Resume polling if it was paused
+    if (this.isPolling && !this.pollTimer && this.hasUnresolvedCandidates()) {
+      this.scheduleNextPoll();
+    }
+  }
+
+  /**
+   * Clear all state and stop polling.
+   */
+  public reset(): void {
+    this.stop();
+    this.candidates.clear();
+    this.resolvedWorktrees.clear();
+    this.detectedPRs.clear();
+    this.consecutiveErrors = 0;
+    this.isEnabled = true;
+  }
+
+  /**
+   * Clean up event subscriptions.
+   * Should be called on app shutdown.
+   */
+  public destroy(): void {
+    this.reset();
+    for (const unsubscribe of this.unsubscribers) {
+      unsubscribe();
+    }
+    this.unsubscribers = [];
+  }
+
+  /**
+   * Schedule the next poll with appropriate interval.
+   * Uses exponential backoff if errors have occurred.
+   */
+  private scheduleNextPoll(): void {
+    if (!this.isPolling || !this.isEnabled) {
+      return;
+    }
+
+    // Don't schedule if there's nothing to check
+    if (!this.hasUnresolvedCandidates()) {
+      logDebug("All candidates resolved - pausing polling until new candidates appear");
+      return;
+    }
+
+    // Calculate backoff if we have errors
+    let interval = this.pollIntervalMs;
+    if (this.consecutiveErrors > 0) {
+      const backoffIndex = Math.min(this.consecutiveErrors - 1, ERROR_BACKOFF_INTERVALS.length - 1);
+      interval = ERROR_BACKOFF_INTERVALS[backoffIndex];
+      logDebug("Using backoff interval", { errors: this.consecutiveErrors, intervalMs: interval });
+    }
+
+    this.pollTimer = setTimeout(() => {
+      this.pollTimer = null;
+      void this.checkForPRs().then(() => this.scheduleNextPoll());
+    }, interval);
+  }
+
+  /**
+   * Check if there are any unresolved candidates that need checking.
+   */
+  private hasUnresolvedCandidates(): boolean {
+    for (const worktreeId of this.candidates.keys()) {
+      if (!this.resolvedWorktrees.has(worktreeId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Execute a PR check for all registered candidates.
+   */
+  private async checkForPRs(): Promise<void> {
+    // Get candidates that haven't been resolved yet
+    const activeCandidates: PRCheckCandidate[] = [];
+    for (const [worktreeId, context] of this.candidates) {
+      if (!this.resolvedWorktrees.has(worktreeId)) {
+        activeCandidates.push({
+          worktreeId,
+          issueNumber: context.issueNumber,
+          branchName: context.branchName,
+        });
+      }
+    }
+
+    if (activeCandidates.length === 0) {
+      logDebug("No candidates to check for PRs - all resolved or none registered");
+      return;
+    }
+
+    logDebug("Checking PRs for candidates", { count: activeCandidates.length });
+
+    try {
+      const result = await batchCheckLinkedPRs(this.cwd, activeCandidates);
+
+      if (result.error) {
+        this.handleError(result.error);
+        return;
+      }
+
+      // Reset error count on success
+      this.consecutiveErrors = 0;
+
+      // Process results
+      for (const [worktreeId, checkResult] of result.results) {
+        if (checkResult.pr) {
+          // PR found! Mark as resolved and emit event
+          this.resolvedWorktrees.add(worktreeId);
+          this.detectedPRs.set(worktreeId, checkResult.pr);
+
+          logInfo("PR detected for worktree", {
+            worktreeId,
+            prNumber: checkResult.pr.number,
+            prState: checkResult.pr.state,
+          });
+
+          // Emit event for UI update
+          events.emit("sys:pr:detected", {
+            worktreeId,
+            prNumber: checkResult.pr.number,
+            prUrl: checkResult.pr.url,
+            prState: checkResult.pr.state,
+            issueNumber: checkResult.issueNumber!,
+          });
+        }
+      }
+    } catch (error) {
+      this.handleError(error instanceof Error ? error.message : "Unknown error");
+    }
+  }
+
+  /**
+   * Handle errors with backoff logic and circuit breaker.
+   */
+  private handleError(errorMsg: string): void {
+    this.consecutiveErrors++;
+    logWarn("PR check failed", { error: errorMsg, consecutiveErrors: this.consecutiveErrors });
+
+    if (this.consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+      logWarn("Too many consecutive errors - disabling PR polling until manual refresh");
+      this.isEnabled = false;
+      events.emit("ui:notify", {
+        type: "warning",
+        message: "PR detection paused due to errors. Refresh to retry.",
+        id: "pr-service-circuit-breaker",
+      });
+    }
+  }
+
+  /**
+   * Get current service status for debugging.
+   */
+  public getStatus(): {
+    isPolling: boolean;
+    isEnabled: boolean;
+    candidateCount: number;
+    resolvedCount: number;
+    consecutiveErrors: number;
+  } {
+    return {
+      isPolling: this.isPolling,
+      isEnabled: this.isEnabled,
+      candidateCount: this.candidates.size,
+      resolvedCount: this.resolvedWorktrees.size,
+      consecutiveErrors: this.consecutiveErrors,
+    };
+  }
+}
+
+// Export singleton instance
+export const pullRequestService = new PullRequestService();

--- a/electron/utils/github.ts
+++ b/electron/utils/github.ts
@@ -1,0 +1,466 @@
+/**
+ * GitHub CLI utilities for Canopy Electron.
+ * Provides GraphQL-based PR detection and repository operations.
+ *
+ * Migrated from Canopy CLI with Electron-specific patterns.
+ */
+
+import { execa } from "execa";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository Statistics
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RepoStats {
+  issueCount: number;
+  prCount: number;
+}
+
+export interface RepoStatsResult {
+  stats: RepoStats | null;
+  error?: string;
+}
+
+/**
+ * Get issue and PR counts using a single GraphQL API call.
+ * Much more efficient than fetching full lists - uses only 1 API call instead of 2.
+ * Handles auth errors gracefully without needing a separate auth check.
+ * @param cwd - Working directory
+ * @returns Issue and PR counts with optional error message
+ */
+export async function getRepoStats(cwd: string): Promise<RepoStatsResult> {
+  try {
+    // GraphQL query to get both counts in a single API call
+    const query = `
+      query {
+        repository(owner: "{owner}", name: "{repo}") {
+          issues(states: OPEN) { totalCount }
+          pullRequests(states: OPEN) { totalCount }
+        }
+      }
+    `;
+
+    // First get the owner/repo from the current directory
+    const { stdout: repoInfo } = await execa(
+      "gh",
+      ["repo", "view", "--json", "owner,name", "-q", '.owner.login + "/" + .name'],
+      { cwd }
+    );
+    const [owner, repo] = repoInfo.trim().split("/");
+
+    if (!owner || !repo) {
+      return { stats: null, error: "not a GitHub repository" };
+    }
+
+    // Execute the GraphQL query
+    const { stdout } = await execa(
+      "gh",
+      ["api", "graphql", "-f", `query=${query.replace("{owner}", owner).replace("{repo}", repo)}`],
+      { cwd }
+    );
+
+    const data = JSON.parse(stdout);
+    const repository = data?.data?.repository;
+
+    if (!repository) {
+      return { stats: null, error: "repository not found" };
+    }
+
+    return {
+      stats: {
+        issueCount: repository.issues?.totalCount ?? 0,
+        prCount: repository.pullRequests?.totalCount ?? 0,
+      },
+    };
+  } catch (error: any) {
+    // Check if gh CLI is not installed
+    if (error.code === "ENOENT") {
+      return { stats: null, error: "gh CLI not installed" };
+    }
+
+    // Parse stderr for common errors
+    const stderr = error.stderr || error.message || "";
+
+    if (stderr.includes("auth") || stderr.includes("login") || stderr.includes("token")) {
+      return { stats: null, error: "gh auth required - run: gh auth login" };
+    }
+    if (stderr.includes("Could not resolve to a Repository")) {
+      return { stats: null, error: "not a GitHub repository" };
+    }
+    if (stderr.includes("rate limit")) {
+      return { stats: null, error: "GitHub rate limit exceeded" };
+    }
+
+    // Generic failure
+    return { stats: null, error: "GitHub API unavailable" };
+  }
+}
+
+/**
+ * @deprecated Use getRepoStats() instead for efficiency (single API call)
+ */
+export async function getIssueCount(cwd: string): Promise<number | null> {
+  const result = await getRepoStats(cwd);
+  return result.stats?.issueCount ?? null;
+}
+
+/**
+ * @deprecated Use getRepoStats() instead for efficiency (single API call)
+ */
+export async function getPrCount(cwd: string): Promise<number | null> {
+  const result = await getRepoStats(cwd);
+  return result.stats?.prCount ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// URL Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Opens the GitHub repository in the default browser.
+ * @param cwd - Working directory
+ * @param page - Optional page to navigate to ('issues' or 'pulls')
+ */
+export async function openGitHubUrl(cwd: string, page?: "issues" | "pulls"): Promise<void> {
+  try {
+    // gh CLI doesn't support appending paths directly, so we need to get the URL and open it
+    if (page) {
+      // Get the repo URL first
+      const { stdout } = await execa("gh", ["repo", "view", "--json", "url", "-q", ".url"], {
+        cwd,
+      });
+      const repoUrl = stdout.trim();
+      const targetUrl = `${repoUrl}/${page}`;
+
+      // Open the URL directly using Electron's shell
+      const { shell } = await import("electron");
+      await shell.openExternal(targetUrl);
+    } else {
+      // Just open the repo homepage via gh CLI
+      await execa("gh", ["repo", "view", "--web"], { cwd, stdio: "ignore" });
+    }
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      throw new Error("GitHub CLI (gh) not found. Please install it.");
+    }
+    throw new Error(error.message || "Failed to open GitHub. Are you logged in via `gh auth login`?");
+  }
+}
+
+/**
+ * Opens the current repository in the default browser using the GitHub CLI.
+ * @param cwd - The current working directory (root of the worktree)
+ */
+export async function openGitHubRepo(cwd: string): Promise<void> {
+  return openGitHubUrl(cwd);
+}
+
+/**
+ * Gets the GitHub issue URL for a specific issue number.
+ * @param cwd - Working directory (to get repo info)
+ * @param issueNumber - Issue number to get URL for
+ * @returns The full GitHub issue URL
+ */
+export async function getIssueUrl(cwd: string, issueNumber: number): Promise<string> {
+  const { stdout } = await execa("gh", ["repo", "view", "--json", "url", "-q", ".url"], { cwd });
+  const repoUrl = stdout.trim();
+  return `${repoUrl}/issues/${issueNumber}`;
+}
+
+/**
+ * Opens a specific GitHub issue in the default browser.
+ * @param cwd - Working directory (to get repo info)
+ * @param issueNumber - Issue number to open
+ */
+export async function openGitHubIssue(cwd: string, issueNumber: number): Promise<void> {
+  try {
+    const issueUrl = await getIssueUrl(cwd, issueNumber);
+    const { shell } = await import("electron");
+    await shell.openExternal(issueUrl);
+  } catch (error: any) {
+    if (error.code === "ENOENT") {
+      throw new Error("GitHub CLI (gh) not found. Please install it.");
+    }
+    throw new Error(error.message || "Failed to open GitHub issue.");
+  }
+}
+
+/**
+ * Opens a specific GitHub pull request in the default browser.
+ * @param prUrl - Full URL of the pull request
+ */
+export async function openGitHubPR(prUrl: string): Promise<void> {
+  try {
+    const { shell } = await import("electron");
+    await shell.openExternal(prUrl);
+  } catch (error: any) {
+    throw new Error(error.message || "Failed to open GitHub pull request.");
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR Detection via GraphQL
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Represents a detected pull request linked to an issue or branch.
+ */
+export interface LinkedPR {
+  number: number;
+  url: string;
+  state: "open" | "merged" | "closed";
+  isDraft: boolean;
+}
+
+/**
+ * Result of checking for linked PRs for a single issue/branch.
+ */
+export interface PRCheckResult {
+  issueNumber?: number;
+  branchName?: string;
+  pr: LinkedPR | null;
+}
+
+/**
+ * Result of batch PR detection.
+ */
+export interface BatchPRCheckResult {
+  results: Map<string, PRCheckResult>; // keyed by worktree ID
+  error?: string;
+}
+
+/**
+ * Input for batch PR check - worktree candidates.
+ */
+export interface PRCheckCandidate {
+  worktreeId: string;
+  issueNumber?: number;
+  branchName?: string;
+}
+
+/**
+ * Get repository owner and name from a working directory.
+ * Caches result to avoid repeated CLI calls.
+ */
+let repoInfoCache: { cwd: string; owner: string; repo: string } | null = null;
+
+export async function getRepoInfo(cwd: string): Promise<{ owner: string; repo: string } | null> {
+  // Return cached result if same cwd
+  if (repoInfoCache && repoInfoCache.cwd === cwd) {
+    return { owner: repoInfoCache.owner, repo: repoInfoCache.repo };
+  }
+
+  try {
+    const { stdout: repoInfo } = await execa(
+      "gh",
+      ["repo", "view", "--json", "owner,name", "-q", '.owner.login + "/" + .name'],
+      { cwd }
+    );
+    const [owner, repo] = repoInfo.trim().split("/");
+
+    if (!owner || !repo) {
+      return null;
+    }
+
+    repoInfoCache = { cwd, owner, repo };
+    return { owner, repo };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a batched GraphQL query to check multiple issues for linked PRs.
+ * Uses aliases to batch multiple issue checks into one API call.
+ *
+ * The query checks:
+ * 1. Issue timeline for CrossReferencedEvent where source is a PullRequest
+ * 2. PRs with matching headRefName (fallback for unlinked PRs)
+ */
+function buildBatchPRQuery(
+  owner: string,
+  repo: string,
+  candidates: PRCheckCandidate[]
+): string {
+  const issueQueries: string[] = [];
+  const branchQueries: string[] = [];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    // Use index-based alias to avoid collisions (e.g., "a-1" vs "a_1" both becoming "wt_a_1")
+    const alias = `wt_${i}`;
+
+    // Query by issue number (check timeline for cross-references)
+    if (candidate.issueNumber) {
+      issueQueries.push(`
+        ${alias}_issue: repository(owner: "${owner}", name: "${repo}") {
+          issue(number: ${candidate.issueNumber}) {
+            timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], last: 10) {
+              nodes {
+                ... on CrossReferencedEvent {
+                  source {
+                    ... on PullRequest {
+                      number
+                      url
+                      state
+                      isDraft
+                      merged
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `);
+    }
+
+    // Also query by branch name (fallback for PRs not linked via "Closes #X")
+    // Include CLOSED state to detect all PRs on the branch
+    if (candidate.branchName) {
+      // Escape branch name for GraphQL by using JSON.stringify
+      const escapedBranch = JSON.stringify(candidate.branchName).slice(1, -1);
+      branchQueries.push(`
+        ${alias}_branch: repository(owner: "${owner}", name: "${repo}") {
+          pullRequests(first: 1, states: [OPEN, MERGED, CLOSED], headRefName: "${escapedBranch}", orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes {
+              number
+              url
+              state
+              isDraft
+              merged
+            }
+          }
+        }
+      `);
+    }
+  }
+
+  return `query { ${issueQueries.join("\n")} ${branchQueries.join("\n")} }`;
+}
+
+/**
+ * Parse GraphQL response to extract PR information per worktree.
+ */
+function parseBatchPRResponse(data: any, candidates: PRCheckCandidate[]): Map<string, PRCheckResult> {
+  const results = new Map<string, PRCheckResult>();
+
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    const alias = `wt_${i}`;
+    let foundPR: LinkedPR | null = null;
+
+    // Check issue timeline results first (more reliable linkage)
+    const issueData = data?.[`${alias}_issue`]?.issue?.timelineItems?.nodes;
+    if (issueData && Array.isArray(issueData)) {
+      // Filter for valid PR sources, prefer OPEN > MERGED > CLOSED
+      const prs: LinkedPR[] = [];
+      for (const node of issueData) {
+        const source = node?.source;
+        if (source?.number && source?.url) {
+          prs.push({
+            number: source.number,
+            url: source.url,
+            state: source.merged ? "merged" : ((source.state?.toLowerCase() as "open" | "closed") || "open"),
+            isDraft: source.isDraft ?? false,
+          });
+        }
+      }
+
+      // Pick best PR: prefer open, then merged, then closed (most recent within each category)
+      const openPRs = prs.filter((pr) => pr.state === "open");
+      const mergedPRs = prs.filter((pr) => pr.state === "merged");
+      const closedPRs = prs.filter((pr) => pr.state === "closed");
+
+      if (openPRs.length > 0) {
+        foundPR = openPRs[openPRs.length - 1]; // Latest open
+      } else if (mergedPRs.length > 0) {
+        foundPR = mergedPRs[mergedPRs.length - 1]; // Latest merged
+      } else if (closedPRs.length > 0) {
+        foundPR = closedPRs[closedPRs.length - 1]; // Latest closed
+      }
+    }
+
+    // If no PR found via issue, check branch-based lookup
+    if (!foundPR) {
+      const branchData = data?.[`${alias}_branch`]?.pullRequests?.nodes;
+      if (branchData && Array.isArray(branchData) && branchData.length > 0) {
+        const pr = branchData[0];
+        if (pr?.number && pr?.url) {
+          foundPR = {
+            number: pr.number,
+            url: pr.url,
+            state: pr.merged ? "merged" : ((pr.state?.toLowerCase() as "open" | "closed") || "open"),
+            isDraft: pr.isDraft ?? false,
+          };
+        }
+      }
+    }
+
+    results.set(candidate.worktreeId, {
+      issueNumber: candidate.issueNumber,
+      branchName: candidate.branchName,
+      pr: foundPR,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Batch check for PRs linked to multiple worktrees.
+ * Executes a single GraphQL query that checks all candidates.
+ *
+ * @param cwd - Working directory (to determine repo context)
+ * @param candidates - Worktrees to check for linked PRs
+ * @returns Map of worktree ID to PR check result
+ */
+export async function batchCheckLinkedPRs(
+  cwd: string,
+  candidates: PRCheckCandidate[]
+): Promise<BatchPRCheckResult> {
+  if (candidates.length === 0) {
+    return { results: new Map() };
+  }
+
+  try {
+    // Get repo info
+    const repoInfo = await getRepoInfo(cwd);
+    if (!repoInfo) {
+      return { results: new Map(), error: "not a GitHub repository" };
+    }
+
+    // Build and execute the batched query
+    const query = buildBatchPRQuery(repoInfo.owner, repoInfo.repo, candidates);
+
+    const { stdout } = await execa("gh", ["api", "graphql", "-f", `query=${query}`], { cwd });
+
+    const response = JSON.parse(stdout);
+
+    // Check for GraphQL errors
+    if (response.errors && response.errors.length > 0) {
+      const errorMsg = response.errors[0]?.message || "GraphQL query failed";
+      return { results: new Map(), error: errorMsg };
+    }
+
+    // Parse results
+    const results = parseBatchPRResponse(response.data, candidates);
+    return { results };
+  } catch (error: any) {
+    // Handle common errors
+    if (error.code === "ENOENT") {
+      return { results: new Map(), error: "gh CLI not installed" };
+    }
+
+    const stderr = error.stderr || error.message || "";
+
+    if (stderr.includes("auth") || stderr.includes("login") || stderr.includes("token")) {
+      return { results: new Map(), error: "gh auth required" };
+    }
+    if (stderr.includes("rate limit")) {
+      return { results: new Map(), error: "rate limit exceeded" };
+    }
+
+    return { results: new Map(), error: "GitHub API unavailable" };
+  }
+}

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -533,6 +533,7 @@ export interface ElectronAPI {
   worktree: {
     getAll(): Promise<WorktreeState[]>;
     refresh(): Promise<void>;
+    refreshPullRequests(): Promise<void>;
     setActive(worktreeId: string): Promise<void>;
     create(options: CreateWorktreeOptions, rootPath: string): Promise<void>;
     listBranches(rootPath: string): Promise<BranchInfo[]>;


### PR DESCRIPTION
## Summary

Implements automated pull request detection and polling service that automatically detects and links GitHub PRs to worktrees based on issue numbers and branch names. This brings sophisticated PR tracking capabilities from the original Canopy CLI to the Electron app.

Closes #151

## Changes Made

### Core Services
- **GitHub CLI utilities** (`electron/utils/github.ts`): Batched GraphQL queries for efficient PR detection with proper escaping and error handling
- **PullRequestService** (`electron/services/PullRequestService.ts`): Centralized polling service with 60s intervals, exponential backoff, and circuit breaker protection

### Integration
- **WorktreeService integration**: Automatic initialization and lifecycle management of PR service
- **WorktreeMonitor event subscriptions**: React to `sys:pr:detected` and `sys:pr:cleared` events to update UI
- **IPC handlers**: Manual PR refresh capability via `worktree:pr-refresh` channel

### Code Review Fixes
- Fixed GraphQL injection vulnerability by properly escaping branch names
- Fixed alias collision issues using index-based aliases
- Enforced minimum 60s polling interval for rate limit safety
- Added CLOSED PR state detection with orderBy for latest PRs
- Prevented memory leaks with proper event subscription cleanup

## Technical Highlights

- **Rate limit safe**: 60s polling = ~1.2% of GitHub's hourly rate limit budget
- **Efficient batching**: Single GraphQL query checks all worktrees
- **Smart caching**: Stops checking once PR is found for a worktree
- **Circuit breaker**: Disables polling after 3 consecutive failures
- **Context-aware**: Immediately clears PR data when branch/issue changes

## UI Impact

The WorktreeCard UI already has PR button support - it will automatically show when `prNumber` is populated by the service. No UI changes were needed.