### PR TITLE
Wire toolbar Refresh button to worktree refresh IPC

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -16,6 +16,8 @@ interface AppLayoutProps {
   errorCount?: number;
   /** Called when user clicks the problems button */
   onToggleProblems?: () => void;
+  /** Whether worktree refresh is in progress */
+  isRefreshing?: boolean;
 }
 
 const MIN_SIDEBAR_WIDTH = 200;
@@ -31,6 +33,7 @@ export function AppLayout({
   onSettings,
   errorCount,
   onToggleProblems,
+  isRefreshing,
 }: AppLayoutProps) {
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
 
@@ -194,6 +197,7 @@ export function AppLayout({
         onToggleProblems={onToggleProblems}
         isFocusMode={isFocusMode}
         onToggleFocusMode={handleToggleFocusMode}
+        isRefreshing={isRefreshing}
       />
       <div className="flex-1 flex flex-col overflow-hidden">
         <div className="flex-1 flex overflow-hidden">

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -36,6 +36,8 @@ interface ToolbarProps {
   isFocusMode?: boolean;
   /** Called when focus mode button is clicked */
   onToggleFocusMode?: () => void;
+  /** Whether worktree refresh is in progress */
+  isRefreshing?: boolean;
 }
 
 export function Toolbar({
@@ -46,6 +48,7 @@ export function Toolbar({
   onToggleProblems,
   isFocusMode = false,
   onToggleFocusMode,
+  isRefreshing = false,
 }: ToolbarProps) {
   const currentProject = useProjectStore((state) => state.currentProject);
 
@@ -213,10 +216,14 @@ export function Toolbar({
           variant="ghost"
           size="icon"
           onClick={onRefresh}
-          className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
+          disabled={isRefreshing}
+          className={cn(
+            "text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8",
+            isRefreshing && "cursor-not-allowed opacity-50"
+          )}
           aria-label="Refresh worktrees"
         >
-          <RefreshCw className="h-4 w-4" />
+          <RefreshCw className={cn("h-4 w-4", isRefreshing && "animate-spin")} />
         </Button>
       </div>
     </header>


### PR DESCRIPTION
## Summary
This PR implements the toolbar Refresh button functionality by wiring it to the worktree refresh IPC. The button was previously stubbed with a TODO comment and only logged to the console.

Closes #132

## Changes Made
- Implement handleRefresh to call window.electron.worktree.refresh()
- Add isRefreshing state to prevent race conditions
- Guard against non-Electron environments with isElectronAvailable check
- Add error handling with try/catch for IPC failures
- Display spinner animation on refresh button during operation
- Disable refresh button while operation is in progress

## Implementation Details
The implementation follows existing patterns in the codebase:
- Calls IPC directly (similar to other handlers in App.tsx)
- Adds loading state for visual feedback and race condition prevention
- Includes Electron availability guard (consistent with other handlers)
- Provides proper error handling without disrupting the UI

## UI Enhancements
- Refresh button shows a spinning animation while refresh is in progress
- Button is disabled during refresh to prevent multiple simultaneous operations
- Visual feedback improves user experience