### PR TITLE
Implement uppercase tracking-wide section headers in sidebar

### DIFF
--- a/src/components/Errors/ProblemsPanel.tsx
+++ b/src/components/Errors/ProblemsPanel.tsx
@@ -193,7 +193,7 @@ export function ProblemsPanel({ isOpen, onClose, onRetry, className }: ProblemsP
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 bg-canopy-sidebar border-b border-canopy-border">
         <div className="flex items-center gap-3">
-          <h2 className="text-sm font-semibold text-canopy-text">Problems</h2>
+          <h2 className="section-header">Problems</h2>
           <span className="px-2 py-0.5 text-xs bg-red-900/50 text-red-300 rounded-full">
             {activeErrors.length}
           </span>

--- a/src/components/EventInspector/EventInspectorPanel.tsx
+++ b/src/components/EventInspector/EventInspectorPanel.tsx
@@ -124,7 +124,7 @@ export function EventInspectorPanel({ className }: EventInspectorPanelProps) {
       {/* Header */}
       <div className="flex-shrink-0 flex items-center justify-between px-4 py-2 border-b bg-muted/30">
         <div className="flex items-center gap-2">
-          <h2 className="text-sm font-semibold">Event Inspector</h2>
+          <h2 className="section-header">Event Inspector</h2>
           <span className="text-xs text-muted-foreground">
             {filteredEvents.length} {filteredEvents.length === 1 ? "event" : "events"}
           </span>

--- a/src/components/History/HistoryPanel.tsx
+++ b/src/components/History/HistoryPanel.tsx
@@ -357,7 +357,7 @@ export function HistoryPanel({ className }: HistoryPanelProps) {
     <div className={cn("flex flex-col h-full", className)}>
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-gray-700">
-        <h2 className="text-sm font-semibold text-gray-200">History</h2>
+        <h2 className="section-header">History</h2>
         <button
           onClick={refresh}
           disabled={isLoading}

--- a/src/components/Logs/LogsPanel.tsx
+++ b/src/components/Logs/LogsPanel.tsx
@@ -141,7 +141,7 @@ export function LogsPanel({ className }: LogsPanelProps) {
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800 bg-gray-900">
         <div className="flex items-center gap-2">
-          <h3 className="text-sm font-medium text-gray-200">Logs</h3>
+          <h3 className="section-header">Logs</h3>
           <span className="text-xs text-gray-500">({filteredLogs.length})</span>
         </div>
         <div className="flex items-center gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -284,6 +284,11 @@ body,
   }
 }
 
+/* Section header pattern - for organizing content hierarchically */
+.section-header {
+  @apply text-xs font-bold tracking-widest text-muted-foreground uppercase;
+}
+
 /* --- Electron Window Controls --- */
 
 /* The draggable area (Title Bar) */


### PR DESCRIPTION
## Summary
Implements uppercase section headers with wide letter-spacing across all sidebar panels for a more polished, organized appearance. This creates clear visual separation between sections and content, following modern interface design patterns (Linear, GitHub Projects, Raycast).

Closes #147

## Changes Made
- Added `.section-header` utility class in `index.css` with uppercase, bold, tracking-widest styling
- Applied section-header styling to History, Logs, Problems, and Event Inspector panels
- Used accessible `text-xs` (12px) instead of 10px for better readability and WCAG compliance
- Removed spacing overrides for cleaner, more maintainable implementation

## Technical Details
- **Typography**: text-xs (12px), bold weight, tracking-widest, uppercase transform
- **Color**: muted-foreground for subtle hierarchy
- **Accessibility**: Uses relative font sizing (text-xs) for better user scaling support
- **Consistency**: Single utility class ensures uniform styling across all section headers