### PR TITLE
Display auto-detected run commands in collapsible footer

### DIFF
--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -130,9 +130,6 @@ export function Sidebar({
           </div>
         </div>
 
-        {/* Project Runners - displays configured run commands */}
-        {currentProject && <ProjectRunners projectId={currentProject.id} />}
-
         {/* Tab bar */}
         <div className="shrink-0 flex border-b border-canopy-border">
           <button
@@ -163,6 +160,9 @@ export function Sidebar({
         <div className="flex-1 overflow-y-auto min-h-0">
           {currentTab === "worktrees" ? children : historyContent}
         </div>
+
+        {/* Project Runners - displays saved and auto-detected run commands */}
+        {currentProject && <ProjectRunners projectId={currentProject.id} />}
 
         {/* Resize handle */}
         <div

--- a/src/components/Project/ProjectRunners.tsx
+++ b/src/components/Project/ProjectRunners.tsx
@@ -1,11 +1,13 @@
 /**
  * Project Runners Component
  *
- * Displays configured run commands as buttons in the sidebar.
+ * Displays both saved and auto-detected run commands in a collapsible footer.
+ * Auto-detected commands are merged with saved commands and deduplicated.
  * Clicking a button spawns a terminal with that command.
  */
 
-import { Play } from "lucide-react";
+import { useState, useMemo } from "react";
+import { Play, ChevronDown, ChevronRight, Zap } from "lucide-react";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -17,12 +19,28 @@ interface ProjectRunnersProps {
 }
 
 export function ProjectRunners({ projectId }: ProjectRunnersProps) {
-  const { settings, isLoading } = useProjectSettings(projectId);
+  const { settings, detectedRunners, isLoading } = useProjectSettings(projectId);
   const currentProject = useProjectStore((state) => state.currentProject);
   const addTerminal = useTerminalStore((state) => state.addTerminal);
 
-  // Don't render if no commands configured
-  if (isLoading || !settings?.runCommands?.length) {
+  // State for expand/collapse
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  // Merge saved commands and detected runners
+  const allCommands = useMemo(() => {
+    const saved = settings?.runCommands || [];
+
+    // Create a Set of saved command strings to deduplicate
+    const savedCmdStrings = new Set(saved.map((c) => c.command));
+
+    // Only add detected runners that aren't already saved
+    const uniqueDetected = detectedRunners.filter((d) => !savedCmdStrings.has(d.command));
+
+    return [...saved, ...uniqueDetected];
+  }, [settings?.runCommands, detectedRunners]);
+
+  // Don't render if no commands exist at all
+  if (isLoading || allCommands.length === 0) {
     return null;
   }
 
@@ -45,27 +63,47 @@ export function ProjectRunners({ projectId }: ProjectRunnersProps) {
   };
 
   return (
-    <div className="p-3 border-b border-canopy-border">
-      <div className="text-xs font-semibold text-canopy-text/60 mb-2 uppercase tracking-wide">
-        Quick Actions
-      </div>
-      <div className="grid grid-cols-2 gap-2">
-        {settings.runCommands.map((cmd) => (
-          <button
-            key={cmd.id}
-            onClick={() => handleRun(cmd)}
-            className={cn(
-              "flex items-center gap-2 px-2 py-1.5 bg-canopy-bg border border-canopy-border rounded",
-              "hover:border-canopy-accent/50 hover:bg-canopy-accent/5 transition-colors",
-              "text-xs text-canopy-text text-left group"
-            )}
-            title={cmd.command}
-          >
-            <Play className="h-2.5 w-2.5 text-[var(--color-status-success)] group-hover:text-green-300 transition-colors flex-shrink-0" />
-            <span className="truncate">{cmd.name}</span>
-          </button>
-        ))}
-      </div>
+    <div className="border-t border-canopy-border bg-canopy-sidebar shrink-0">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        aria-expanded={isExpanded}
+        aria-controls="runners-panel"
+        className="w-full flex items-center justify-between px-3 py-2 text-xs font-semibold text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent transition-colors"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <Zap className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+          <span className="uppercase tracking-wide truncate">Runners ({allCommands.length})</span>
+        </div>
+        {isExpanded ? (
+          <ChevronDown className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+        )}
+      </button>
+
+      {isExpanded && (
+        <div id="runners-panel" className="p-2 grid grid-cols-1 gap-1 max-h-[200px] overflow-y-auto">
+          {allCommands.map((cmd) => (
+            <button
+              key={cmd.id}
+              onClick={() => handleRun(cmd)}
+              className={cn(
+                "flex items-center gap-2 px-2 py-1.5 rounded",
+                "bg-canopy-bg/50 border border-canopy-border/50",
+                "hover:border-canopy-accent/50 hover:bg-canopy-accent/5 transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent",
+                "text-xs text-canopy-text text-left group w-full"
+              )}
+              title={cmd.description || cmd.command}
+            >
+              <Play className="h-3 w-3 text-green-400 group-hover:text-green-300 transition-colors flex-shrink-0" />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium">{cmd.name}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR enables the ProjectRunners component to display auto-detected run commands from package.json immediately, without requiring manual configuration. Commands now appear in a collapsible footer at the bottom of the sidebar, making the feature discoverable and usable by default.

Closes #131

## Changes Made

- Merge saved commands with auto-detected runners from package.json
- Move ProjectRunners component from header to footer position in sidebar
- Add collapsible UI with expand/collapse state and chevron icons
- Implement deduplication to prevent duplicate commands
- Add ARIA attributes for accessibility (aria-expanded, aria-controls)
- Add focus-visible styles for keyboard navigation
- Fix race condition in useProjectSettings using useRef
- Change layout to single column with scrollable container (max 200px)