### PR TITLE
feat(ui): enhance AI summary UX with guided error states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,11 @@ import { useRecipeStore } from "./store/recipeStore";
 import { cleanupTerminalStoreListeners } from "./store/terminalStore";
 import type { WorktreeState } from "./types";
 
-function SidebarContent() {
+interface SidebarContentProps {
+  onOpenSettings: (tab?: "ai" | "general" | "troubleshooting") => void;
+}
+
+function SidebarContent({ onOpenSettings }: SidebarContentProps) {
   const { worktrees, isLoading, error, refresh } = useWorktrees();
   const { inject, isInjecting } = useContextInjection();
   const { activeWorktreeId, focusedWorktreeId, selectWorktree, setActiveWorktree } =
@@ -149,6 +153,7 @@ function SidebarContent() {
             onInjectContext={focusedTerminalId ? () => handleInjectContext(worktree.id) : undefined}
             isInjecting={isInjecting}
             onCreateRecipe={() => handleCreateRecipe(worktree.id)}
+            onOpenSettings={onOpenSettings}
           />
         ))}
       </div>
@@ -192,6 +197,7 @@ function App() {
 
   // Settings dialog state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [settingsTab, setSettingsTab] = useState<"general" | "ai" | "troubleshooting">("general");
 
   // Track if state has been restored (prevent StrictMode double-execution)
   const hasRestoredState = useRef(false);
@@ -265,6 +271,14 @@ function App() {
   }, []);
 
   const handleSettings = useCallback(() => {
+    setSettingsTab("general"); // Always open to General tab when clicking toolbar button
+    setIsSettingsOpen(true);
+  }, []);
+
+  const handleOpenSettings = useCallback((tab?: "ai" | "general" | "troubleshooting") => {
+    if (tab) {
+      setSettingsTab(tab);
+    }
     setIsSettingsOpen(true);
   }, []);
 
@@ -400,7 +414,7 @@ function App() {
   return (
     <>
       <AppLayout
-        sidebarContent={<SidebarContent />}
+        sidebarContent={<SidebarContent onOpenSettings={handleOpenSettings} />}
         historyContent={<HistoryPanel />}
         onLaunchAgent={handleLaunchAgent}
         onRefresh={handleRefresh}
@@ -428,7 +442,11 @@ function App() {
       />
 
       {/* Settings dialog */}
-      <SettingsDialog isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
+      <SettingsDialog
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        defaultTab={settingsTab}
+      />
     </>
   );
 }

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -27,6 +27,7 @@ import type { AIServiceState } from "@/types";
 interface SettingsDialogProps {
   isOpen: boolean;
   onClose: () => void;
+  defaultTab?: SettingsTab;
 }
 
 type SettingsTab = "general" | "ai" | "troubleshooting";
@@ -92,8 +93,8 @@ const formatKey = (key: string): string => {
   return key.replace(/Cmd\+/g, "Ctrl+");
 };
 
-export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
-  const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogProps) {
+  const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab ?? "general");
   const { openLogs } = useErrors();
   const clearLogs = useLogsStore((state) => state.clearLogs);
 
@@ -109,6 +110,13 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
     "success" | "error" | "test-success" | "test-error" | null
   >(null);
   const [selectedModel, setSelectedModel] = useState("gpt-5-nano");
+
+  // Update active tab when defaultTab changes while dialog is open
+  useEffect(() => {
+    if (isOpen && defaultTab && defaultTab !== activeTab) {
+      setActiveTab(defaultTab);
+    }
+  }, [isOpen, defaultTab, activeTab]);
 
   // Load app version on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
Enhances the AI summary UX in worktree cards to provide clear, actionable guidance when AI features are disabled or encounter errors. Users can now easily navigate to Settings → AI to configure the feature or view detailed errors in the Problems panel.

Closes #141

## Changes Made
- Add AI status renderer with visual indicators for disabled/error/loading/active states
- Implement clickable "Configure in Settings" link that opens Settings → AI tab
- Add "See Problems panel" link for AI errors with proper panel toggle
- Add accessibility improvements (aria-hidden for decorative icons)
- Guard Settings link when onOpenSettings callback is undefined
- Fix Settings dialog tab flash by initializing from defaultTab
- Reset to General tab when opening Settings from toolbar
- Improve useCallback dependencies to prevent stale closures