### PR TITLE
Connect folder picker in New Worktree dialog

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -217,10 +217,23 @@ export function NewWorktreeDialog({
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => {
-                      // TODO: Implement file picker dialog
+                    onClick={async () => {
+                      if (!window.electron?.directory?.openDialog) {
+                        setError("Directory picker is not available");
+                        return;
+                      }
+                      try {
+                        const selected = await window.electron.directory.openDialog();
+                        if (selected) {
+                          setWorktreePath(selected);
+                          setError(null); // Clear any previous errors
+                        }
+                      } catch (err: any) {
+                        console.error("Failed to open directory picker:", err);
+                        setError(`Failed to open directory picker: ${err.message || "Unknown error"}`);
+                      }
                     }}
-                    disabled={creating}
+                    disabled={creating || !window.electron?.directory?.openDialog}
                   >
                     <FolderOpen className="w-4 h-4" />
                   </Button>


### PR DESCRIPTION
## Summary
Implements the directory picker functionality for the New Worktree dialog folder button. Users can now click the folder icon to open a native OS directory picker and select a custom worktree path.

Closes #133

## Changes Made
- Wire folder button onClick to window.electron.directory.openDialog IPC
- Add runtime guard to check for window.electron API availability
- Clear error state when valid directory is selected
- Disable button when directory picker API is unavailable
- Handle picker errors with user-friendly error messages

## Testing
- TypeScript type checking passes
- All existing lint warnings remain (no new issues introduced)
- Code reviewed by Codex for edge cases and error handling