### PR TITLE
Add typed IPC contract maps for compile-time safety

### DIFF
--- a/electron/services/EventBuffer.ts
+++ b/electron/services/EventBuffer.ts
@@ -175,9 +175,7 @@ export class EventBuffer {
           // Prefer event payload timestamp if present (event-time semantics)
           // Fall back to current time (receipt-time) if not provided
           const eventTimestamp =
-            payload && typeof payload.timestamp === "number"
-              ? payload.timestamp
-              : Date.now();
+            payload && typeof payload.timestamp === "number" ? payload.timestamp : Date.now();
 
           this.push({
             id: this.generateId(),

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -336,9 +336,7 @@ export function getEventCategory(eventType: keyof CanopyEventMap): EventCategory
 /**
  * Get all event types for a specific category.
  */
-export function getEventTypesForCategory(
-  category: EventCategory
-): Array<keyof CanopyEventMap> {
+export function getEventTypesForCategory(category: EventCategory): Array<keyof CanopyEventMap> {
   return (Object.keys(EVENT_META) as Array<keyof CanopyEventMap>).filter(
     (key) => EVENT_META[key].category === category
   );
@@ -358,15 +356,16 @@ export type WithBase<T> = T & BaseEventPayload;
  * Helper type to enforce both BaseEventPayload and EventContext fields.
  * Use for events that require correlation context (worktreeId, agentId, etc.).
  */
-export type WithContext<T> = T & BaseEventPayload & {
-  worktreeId?: string;
-  agentId?: string;
-  taskId?: string;
-  runId?: string;
-  terminalId?: string;
-  issueNumber?: number;
-  prNumber?: number;
-};
+export type WithContext<T> = T &
+  BaseEventPayload & {
+    worktreeId?: string;
+    agentId?: string;
+    taskId?: string;
+    runId?: string;
+    terminalId?: string;
+    issueNumber?: number;
+    prNumber?: number;
+  };
 
 // ============================================================================
 // Event Type Unions by Category

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -128,6 +128,12 @@ export type {
   CreateWorktreeOptions,
   // Adaptive backoff
   AdaptiveBackoffMetrics,
+  // IPC Contract Maps
+  IpcInvokeMap,
+  IpcEventMap,
+  IpcInvokeArgs,
+  IpcInvokeResult,
+  IpcEventPayload,
 } from "./ipc.js";
 
 // Config types - application configuration

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -209,8 +209,14 @@ export function AppLayout({
         onToggleFocusMode={handleToggleFocusMode}
         isRefreshing={isRefreshing}
       />
-      <div className="flex-1 flex flex-col overflow-hidden" style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <div className="flex-1 flex overflow-hidden" style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+      <div
+        className="flex-1 flex flex-col overflow-hidden"
+        style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
+      >
+        <div
+          className="flex-1 flex overflow-hidden"
+          style={{ flex: 1, display: "flex", overflow: "hidden" }}
+        >
           {!isFocusMode && (
             <Sidebar
               width={effectiveSidebarWidth}
@@ -220,7 +226,10 @@ export function AppLayout({
               {sidebarContent}
             </Sidebar>
           )}
-          <main className="flex-1 overflow-hidden bg-canopy-bg" style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}>
+          <main
+            className="flex-1 overflow-hidden bg-canopy-bg"
+            style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}
+          >
             {children}
           </main>
         </div>


### PR DESCRIPTION
## Summary

This PR adds comprehensive type-safe IPC contract maps that provide compile-time safety for all IPC communication between main and renderer processes. The implementation defines explicit contracts for 140+ IPC channels, ensuring handler signatures, preload wrappers, and renderer usage all agree on channel signatures.

Closes #183

## Changes Made

- Add `IpcInvokeMap` interface mapping all invoke channels to their argument and result types
- Add `IpcEventMap` interface mapping all event channels to their payload types
- Add `typedInvoke()` and `typedOn()` helpers in preload.ts for type-safe renderer-side IPC calls
- Add `typedHandle()` and `typedSend()` helpers in handlers.ts for type-safe main-process handlers
- Export helper types (`IpcInvokeArgs`, `IpcInvokeResult`, `IpcEventPayload`) for convenient type extraction
- All changes pass typecheck, lint, and format checks

## Benefits

- **Compile-time safety**: TypeScript will catch mismatched arguments or return types
- **Better IDE support**: Full autocomplete for channel names and their signatures
- **Self-documenting**: The contract maps serve as a single source of truth for IPC APIs
- **Gradual adoption**: Existing code continues to work; new code can use typed helpers
- **Maintainability**: Changes to channel signatures are enforced across all call sites