### PR TITLE
feat(events): Add EventContext for event correlation and filtering

### DIFF
--- a/electron/schemas/agent.ts
+++ b/electron/schemas/agent.ts
@@ -18,14 +18,36 @@ export const TerminalTypeSchema = z.enum(["shell", "claude", "gemini", "custom"]
 export const AgentStateSchema = z.enum(["idle", "working", "waiting", "completed", "failed"]);
 
 /**
+ * Schema for EventContext fields.
+ * These optional fields enable filtering and correlation across the event stream.
+ *
+ * @see shared/types/events.ts for the TypeScript interface definition.
+ */
+export const EventContextSchema = z.object({
+  /** ID of the worktree this event relates to */
+  worktreeId: z.string().optional(),
+  /** ID of the agent executing work */
+  agentId: z.string().optional(),
+  /** ID of the task being performed */
+  taskId: z.string().optional(),
+  /** ID of the run (multi-step workflow) */
+  runId: z.string().optional(),
+  /** ID of the terminal involved */
+  terminalId: z.string().optional(),
+  /** GitHub issue number if applicable */
+  issueNumber: z.number().int().positive().optional(),
+  /** GitHub PR number if applicable */
+  prNumber: z.number().int().positive().optional(),
+});
+
+/**
  * Schema for agent spawned event payload.
  * Emitted when a new agent terminal is created.
  */
-export const AgentSpawnedSchema = z.object({
+export const AgentSpawnedSchema = EventContextSchema.extend({
   agentId: z.string().min(1),
   terminalId: z.string().min(1),
   type: TerminalTypeSchema,
-  worktreeId: z.string().optional(),
   timestamp: z.number().int().positive(),
   traceId: z.string().optional(),
 });
@@ -33,11 +55,12 @@ export const AgentSpawnedSchema = z.object({
 /**
  * Schema for agent state change event payload.
  * Emitted when an agent transitions between lifecycle states.
+ * Includes EventContext fields for filtering and correlation.
  */
-export const AgentStateChangedSchema = z.object({
+export const AgentStateChangedSchema = EventContextSchema.extend({
   agentId: z.string().min(1),
   state: AgentStateSchema,
-  previousState: AgentStateSchema,
+  previousState: AgentStateSchema.optional(),
   timestamp: z.number().int().positive(),
   traceId: z.string().optional(),
 });
@@ -45,8 +68,9 @@ export const AgentStateChangedSchema = z.object({
 /**
  * Schema for agent output event payload.
  * Emitted when an agent produces terminal output.
+ * Includes EventContext fields for filtering and correlation.
  */
-export const AgentOutputSchema = z.object({
+export const AgentOutputSchema = EventContextSchema.extend({
   agentId: z.string().min(1),
   data: z.string().min(1), // Require non-empty output
   timestamp: z.number().int().positive(),
@@ -56,8 +80,9 @@ export const AgentOutputSchema = z.object({
 /**
  * Schema for agent completed event payload.
  * Emitted when an agent finishes successfully.
+ * Includes EventContext fields for filtering and correlation.
  */
-export const AgentCompletedSchema = z.object({
+export const AgentCompletedSchema = EventContextSchema.extend({
   agentId: z.string().min(1),
   exitCode: z.number().int(),
   duration: z.number().int().nonnegative(),
@@ -68,8 +93,9 @@ export const AgentCompletedSchema = z.object({
 /**
  * Schema for agent failed event payload.
  * Emitted when an agent encounters an unrecoverable error.
+ * Includes EventContext fields for filtering and correlation.
  */
-export const AgentFailedSchema = z.object({
+export const AgentFailedSchema = EventContextSchema.extend({
   agentId: z.string().min(1),
   error: z.string().trim().min(1), // Require non-empty error message
   timestamp: z.number().int().positive(),
@@ -79,8 +105,9 @@ export const AgentFailedSchema = z.object({
 /**
  * Schema for agent killed event payload.
  * Emitted when an agent is explicitly terminated.
+ * Includes EventContext fields for filtering and correlation.
  */
-export const AgentKilledSchema = z.object({
+export const AgentKilledSchema = EventContextSchema.extend({
   agentId: z.string().min(1),
   reason: z.string().optional(),
   timestamp: z.number().int().positive(),
@@ -100,6 +127,7 @@ export const AgentEventPayloadSchema = z.union([
 ]);
 
 // Export inferred types
+export type EventContext = z.infer<typeof EventContextSchema>;
 export type AgentSpawned = z.infer<typeof AgentSpawnedSchema>;
 export type AgentStateChanged = z.infer<typeof AgentStateChangedSchema>;
 export type AgentOutput = z.infer<typeof AgentOutputSchema>;

--- a/electron/services/EventBuffer.ts
+++ b/electron/services/EventBuffer.ts
@@ -175,9 +175,7 @@ export class EventBuffer {
           // Prefer event payload timestamp if present (event-time semantics)
           // Fall back to current time (receipt-time) if not provided
           const eventTimestamp =
-            payload && typeof payload.timestamp === "number"
-              ? payload.timestamp
-              : Date.now();
+            payload && typeof payload.timestamp === "number" ? payload.timestamp : Date.now();
 
           this.push({
             id: this.generateId(),

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -153,13 +153,16 @@ export class PtyManager extends EventEmitter {
       terminal.agentState = newState;
       terminal.lastStateChange = getStateChangeTimestamp();
 
-      // Build and validate state change payload
+      // Build and validate state change payload with EventContext fields
       const stateChangePayload = {
         agentId: terminal.agentId,
         state: newState,
         previousState,
         timestamp: terminal.lastStateChange,
         traceId: terminal.traceId,
+        // EventContext fields for correlation and filtering
+        terminalId: terminal.id,
+        worktreeId: terminal.worktreeId,
       };
 
       const validatedStateChange = AgentStateChangedSchema.safeParse(stateChangePayload);
@@ -179,6 +182,9 @@ export class PtyManager extends EventEmitter {
           error: event.error,
           timestamp: terminal.lastStateChange,
           traceId: terminal.traceId,
+          // EventContext fields for correlation and filtering
+          terminalId: terminal.id,
+          worktreeId: terminal.worktreeId,
         };
 
         const validatedFailed = AgentFailedSchema.safeParse(failedPayload);
@@ -343,6 +349,9 @@ export class PtyManager extends EventEmitter {
             data,
             timestamp: Date.now(),
             traceId: terminal.traceId,
+            // EventContext fields for correlation and filtering
+            terminalId: id,
+            worktreeId: options.worktreeId,
           };
 
           const validatedOutput = AgentOutputSchema.safeParse(outputPayload);
@@ -390,6 +399,9 @@ export class PtyManager extends EventEmitter {
           duration,
           timestamp: completedAt,
           traceId: terminal.traceId,
+          // EventContext fields for correlation and filtering
+          terminalId: id,
+          worktreeId: terminal.worktreeId,
         };
 
         const validatedCompleted = AgentCompletedSchema.safeParse(completedPayload);
@@ -557,6 +569,9 @@ export class PtyManager extends EventEmitter {
           reason,
           timestamp: Date.now(),
           traceId: terminal.traceId,
+          // EventContext fields for correlation and filtering
+          terminalId: terminal.id,
+          worktreeId: terminal.worktreeId,
         };
 
         const validatedKilled = AgentKilledSchema.safeParse(killedPayload);
@@ -671,6 +686,9 @@ export class PtyManager extends EventEmitter {
             reason: "cleanup",
             timestamp: Date.now(),
             traceId: terminal.traceId,
+            // EventContext fields for correlation and filtering
+            terminalId: terminal.id,
+            worktreeId: terminal.worktreeId,
           };
 
           const validatedKilled = AgentKilledSchema.safeParse(killedPayload);

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -13,6 +13,7 @@ import type {
   RunPausedPayload,
   RunResumedPayload,
 } from "../types/index.js";
+import type { EventContext } from "../../shared/types/events.js";
 import type { WorktreeState } from "./WorktreeMonitor.js";
 
 // ============================================================================
@@ -336,9 +337,7 @@ export function getEventCategory(eventType: keyof CanopyEventMap): EventCategory
 /**
  * Get all event types for a specific category.
  */
-export function getEventTypesForCategory(
-  category: EventCategory
-): Array<keyof CanopyEventMap> {
+export function getEventTypesForCategory(category: EventCategory): Array<keyof CanopyEventMap> {
   return (Object.keys(EVENT_META) as Array<keyof CanopyEventMap>).filter(
     (key) => EVENT_META[key].category === category
   );
@@ -357,16 +356,9 @@ export type WithBase<T> = T & BaseEventPayload;
 /**
  * Helper type to enforce both BaseEventPayload and EventContext fields.
  * Use for events that require correlation context (worktreeId, agentId, etc.).
+ * Note: Since BaseEventPayload now extends EventContext, this is equivalent to WithBase<T>.
  */
-export type WithContext<T> = T & BaseEventPayload & {
-  worktreeId?: string;
-  agentId?: string;
-  taskId?: string;
-  runId?: string;
-  terminalId?: string;
-  issueNumber?: number;
-  prNumber?: number;
-};
+export type WithContext<T> = T & BaseEventPayload;
 
 // ============================================================================
 // Event Type Unions by Category
@@ -394,10 +386,21 @@ export interface ModalContextMap {
 }
 
 /**
- * Base event payload with optional trace correlation ID.
- * All events can optionally include a traceId to track event chains.
+ * Base event payload with optional trace correlation ID and event context.
+ * All domain events extend this interface to enable filtering and correlation
+ * across the event stream.
+ *
+ * @example
+ * // Event payload with full context
+ * const payload: BaseEventPayload = {
+ *   timestamp: Date.now(),
+ *   traceId: 'trace-123',
+ *   worktreeId: 'wt-abc',
+ *   agentId: 'agent-456',
+ *   terminalId: 'term-789',
+ * };
  */
-export interface BaseEventPayload {
+export interface BaseEventPayload extends EventContext {
   /** UUID to track related events across the system */
   traceId?: string;
   /** Unix timestamp in milliseconds when the event occurred */
@@ -460,7 +463,7 @@ export type CanopyEventMap = {
   "sys:worktree:cycle": WorktreeCyclePayload;
   "sys:worktree:selectByName": WorktreeSelectByNamePayload;
   "sys:worktree:update": WorktreeState;
-  "sys:worktree:remove": { worktreeId: string };
+  "sys:worktree:remove": { worktreeId: string; timestamp: number };
 
   "watcher:change": WatcherChangePayload;
 
@@ -490,7 +493,7 @@ export type CanopyEventMap = {
    * Emitted when a new AI agent (Claude, Gemini, etc.) is spawned in a terminal.
    * Use this to track agent creation and associate agents with worktrees.
    */
-  "agent:spawned": {
+  "agent:spawned": WithContext<{
     /** Unique identifier for this agent instance */
     agentId: string;
     /** ID of the terminal where the agent is running */
@@ -499,24 +502,21 @@ export type CanopyEventMap = {
     type: TerminalType;
     /** Optional worktree this agent is associated with */
     worktreeId?: string;
-    /** Unix timestamp (ms) when the agent was spawned */
-    timestamp: number;
-    /** Optional trace ID to track event chains */
-    traceId?: string;
-  };
+  }>;
 
   /**
    * Emitted when an agent's state changes (e.g., idle → working → completed).
    * Use this for status indicators and monitoring agent activity.
    */
-  "agent:state-changed": {
+  "agent:state-changed": WithContext<{
     agentId: string;
     state: AgentState;
     previousState?: AgentState;
-    timestamp: number;
-    /** Optional trace ID to track event chains */
-    traceId?: string;
-  };
+    /** EventContext: ID of the terminal where the agent is running */
+    terminalId?: string;
+    /** EventContext: Associated worktree ID */
+    worktreeId?: string;
+  }>;
 
   /**
    * Emitted when an agent produces output.
@@ -524,55 +524,59 @@ export type CanopyEventMap = {
    * WARNING: The data field may contain sensitive information (API keys, secrets, etc.).
    * Consumers should sanitize or redact before logging/persisting.
    */
-  "agent:output": {
+  "agent:output": WithContext<{
     agentId: string;
     data: string;
-    timestamp: number;
-    /** Optional trace ID to track event chains */
-    traceId?: string;
-  };
+    /** EventContext: ID of the terminal where the agent is running */
+    terminalId?: string;
+    /** EventContext: Associated worktree ID */
+    worktreeId?: string;
+  }>;
 
   /**
    * Emitted when an agent completes its work successfully.
    */
-  "agent:completed": {
+  "agent:completed": WithContext<{
     agentId: string;
     /** Exit code from the underlying process */
     exitCode: number;
     /** Duration in milliseconds */
     duration: number;
-    timestamp: number;
-    /** Optional trace ID to track event chains */
-    traceId?: string;
-  };
+    /** EventContext: ID of the terminal where the agent is running */
+    terminalId?: string;
+    /** EventContext: Associated worktree ID */
+    worktreeId?: string;
+  }>;
 
   /**
    * Emitted when an agent encounters an error and cannot continue.
    */
-  "agent:failed": {
+  "agent:failed": WithContext<{
     agentId: string;
     error: string;
-    timestamp: number;
-    /** Optional trace ID to track event chains */
-    traceId?: string;
-  };
+    /** EventContext: ID of the terminal where the agent is running */
+    terminalId?: string;
+    /** EventContext: Associated worktree ID */
+    worktreeId?: string;
+  }>;
 
   /**
    * Emitted when an agent is explicitly killed (by user action or system).
    */
-  "agent:killed": {
+  "agent:killed": WithContext<{
     agentId: string;
     /** Optional reason for killing (e.g., 'user-request', 'timeout', 'cleanup') */
     reason?: string;
-    timestamp: number;
-    /** Optional trace ID to track event chains */
-    traceId?: string;
-  };
+    /** EventContext: ID of the terminal where the agent is running */
+    terminalId?: string;
+    /** EventContext: Associated worktree ID */
+    worktreeId?: string;
+  }>;
 
   /**
    * Emitted when artifacts (code blocks or patches) are extracted from agent output.
    */
-  "artifact:detected": {
+  "artifact:detected": WithContext<{
     agentId: string;
     terminalId: string;
     worktreeId?: string;
@@ -584,9 +588,7 @@ export type CanopyEventMap = {
       content: string;
       extractedAt: number;
     }>;
-    timestamp: number;
-    traceId?: string;
-  };
+  }>;
 
   // ============================================================================
   // Task Lifecycle Events (Future-proof for task management)
@@ -598,36 +600,33 @@ export type CanopyEventMap = {
    * WARNING: The description field may contain sensitive information.
    * Consumers should sanitize before logging/persisting.
    */
-  "task:created": {
+  "task:created": WithContext<{
     taskId: string;
     description: string;
     worktreeId?: string;
-    timestamp: number;
-  };
+  }>;
 
   /**
    * Emitted when a task is assigned to an agent.
    */
-  "task:assigned": {
+  "task:assigned": WithContext<{
     taskId: string;
     agentId: string;
-    timestamp: number;
-  };
+  }>;
 
   /**
    * Emitted when a task's state changes.
    */
-  "task:state-changed": {
+  "task:state-changed": WithContext<{
     taskId: string;
     state: TaskState;
     previousState?: TaskState;
-    timestamp: number;
-  };
+  }>;
 
   /**
    * Emitted when a task is completed successfully.
    */
-  "task:completed": {
+  "task:completed": WithContext<{
     taskId: string;
     /** ID of the agent that completed this task */
     agentId?: string;
@@ -638,13 +637,12 @@ export type CanopyEventMap = {
     result: string;
     /** Paths to any generated artifacts */
     artifacts?: string[];
-    timestamp: number;
-  };
+  }>;
 
   /**
    * Emitted when a task fails.
    */
-  "task:failed": {
+  "task:failed": WithContext<{
     taskId: string;
     /** ID of the agent that failed this task */
     agentId?: string;
@@ -653,8 +651,7 @@ export type CanopyEventMap = {
     /** Worktree where task was executed */
     worktreeId?: string;
     error: string;
-    timestamp: number;
-  };
+  }>;
 
   // ============================================================================
   // Run Events (Multi-agent orchestration workflows)

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -209,8 +209,14 @@ export function AppLayout({
         onToggleFocusMode={handleToggleFocusMode}
         isRefreshing={isRefreshing}
       />
-      <div className="flex-1 flex flex-col overflow-hidden" style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <div className="flex-1 flex overflow-hidden" style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+      <div
+        className="flex-1 flex flex-col overflow-hidden"
+        style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
+      >
+        <div
+          className="flex-1 flex overflow-hidden"
+          style={{ flex: 1, display: "flex", overflow: "hidden" }}
+        >
           {!isFocusMode && (
             <Sidebar
               width={effectiveSidebarWidth}
@@ -220,7 +226,10 @@ export function AppLayout({
               {sidebarContent}
             </Sidebar>
           )}
-          <main className="flex-1 overflow-hidden bg-canopy-bg" style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}>
+          <main
+            className="flex-1 overflow-hidden bg-canopy-bg"
+            style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}
+          >
             {children}
           </main>
         </div>


### PR DESCRIPTION
## Summary
This PR implements EventContext for all domain events, enabling powerful event correlation and filtering across the entire event stream. Events can now be filtered by worktree, agent, task, run, terminal, issue, or PR number.

Closes #193

## Changes Made
- Extend `BaseEventPayload` to include `EventContext` fields (worktreeId, agentId, taskId, runId, terminalId, issueNumber, prNumber)
- Wrap all domain event types (agent, task, artifact) with `WithContext<T>` helper for proper type inheritance
- Refactor Zod schemas to extend `EventContextSchema` for consistent runtime validation
- Add EventContext fields to all agent event emissions in PtyManager
- Fix `AgentStateChangedSchema` to make `previousState` optional (aligning schema with TypeScript types)
- Enable comprehensive event filtering and correlation across the entire event stream through EventBuffer