### PR TITLE
Reduce visual prominence of WorktreeCard border

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -361,7 +361,7 @@ export function WorktreeCard({
       className={cn(
         "group relative overflow-hidden rounded-lg bg-card/30 border border-border/60 px-3 py-2.5 mb-2 cursor-pointer transition-all",
         isActive
-          ? "border-canopy-accent bg-canopy-accent/5 shadow-sm"
+          ? "border-canopy-accent/50 bg-canopy-accent/3"
           : "hover:border-canopy-accent/60 hover:bg-card/60",
         isFocused && "ring-1 ring-canopy-accent"
       )}


### PR DESCRIPTION
## Summary
Reduces the visual prominence of the WorktreeCard active border to address user feedback that the bright border draws too much attention in single-worktree scenarios.

Closes #178

## Changes Made
- Reduce active border opacity from 100% to 50%
- Reduce background accent opacity from /5 to /3
- Remove shadow-sm effect for cleaner appearance
- Maintains accessibility with sufficient contrast ratio (adjusted from initial 40% to 50% based on code review)