### PR TITLE
feat(agent): add trigger and confidence metadata to state changes

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -310,15 +310,29 @@ const api: ElectronAPI = {
 
     onAgentStateChanged: (callback: (data: AgentStateChangePayload) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: unknown) => {
-        // Type guard
+        // Type guard - validate all required fields including new metadata
+        const record = data as Record<string, unknown>;
         if (
           typeof data === "object" &&
           data !== null &&
           "agentId" in data &&
           "state" in data &&
-          "timestamp" in data
+          "previousState" in data &&
+          "timestamp" in data &&
+          "trigger" in data &&
+          "confidence" in data &&
+          typeof record.agentId === "string" &&
+          typeof record.state === "string" &&
+          typeof record.previousState === "string" &&
+          typeof record.timestamp === "number" &&
+          typeof record.trigger === "string" &&
+          typeof record.confidence === "number" &&
+          record.confidence >= 0 &&
+          record.confidence <= 1
         ) {
           callback(data as AgentStateChangePayload);
+        } else {
+          console.warn("[Preload] Invalid agent:state-changed payload, dropping event", data);
         }
       };
       ipcRenderer.on(CHANNELS.AGENT_STATE_CHANGED, handler);

--- a/electron/schemas/agent.ts
+++ b/electron/schemas/agent.ts
@@ -18,6 +18,18 @@ export const TerminalTypeSchema = z.enum(["shell", "claude", "gemini", "custom"]
 export const AgentStateSchema = z.enum(["idle", "working", "waiting", "completed", "failed"]);
 
 /**
+ * Valid triggers for agent state changes.
+ */
+export const AgentStateChangeTriggerSchema = z.enum([
+  "input",
+  "output",
+  "heuristic",
+  "ai-classification",
+  "timeout",
+  "exit",
+]);
+
+/**
  * Schema for agent spawned event payload.
  * Emitted when a new agent terminal is created.
  */
@@ -40,6 +52,10 @@ export const AgentStateChangedSchema = z.object({
   previousState: AgentStateSchema,
   timestamp: z.number().int().positive(),
   traceId: z.string().optional(),
+  /** What caused this state change */
+  trigger: AgentStateChangeTriggerSchema,
+  /** Confidence in the state detection (0.0 = uncertain, 1.0 = certain) */
+  confidence: z.number().min(0).max(1),
 });
 
 /**
@@ -102,6 +118,7 @@ export const AgentEventPayloadSchema = z.union([
 // Export inferred types
 export type AgentSpawned = z.infer<typeof AgentSpawnedSchema>;
 export type AgentStateChanged = z.infer<typeof AgentStateChangedSchema>;
+export type AgentStateChangeTrigger = z.infer<typeof AgentStateChangeTriggerSchema>;
 export type AgentOutput = z.infer<typeof AgentOutputSchema>;
 export type AgentCompleted = z.infer<typeof AgentCompletedSchema>;
 export type AgentFailed = z.infer<typeof AgentFailedSchema>;

--- a/electron/services/EventBuffer.ts
+++ b/electron/services/EventBuffer.ts
@@ -175,9 +175,7 @@ export class EventBuffer {
           // Prefer event payload timestamp if present (event-time semantics)
           // Fall back to current time (receipt-time) if not provided
           const eventTimestamp =
-            payload && typeof payload.timestamp === "number"
-              ? payload.timestamp
-              : Date.now();
+            payload && typeof payload.timestamp === "number" ? payload.timestamp : Date.now();
 
           this.push({
             id: this.generateId(),

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -24,6 +24,7 @@ import {
   AgentCompletedSchema,
   AgentFailedSchema,
   AgentKilledSchema,
+  type AgentStateChangeTrigger,
 } from "../schemas/agent.js";
 
 export interface PtySpawnOptions {
@@ -129,12 +130,99 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Infer the trigger type from an agent event.
+   * @param event - Agent event that triggers the state transition
+   * @returns The inferred trigger type
+   * @private
+   */
+  private inferTrigger(event: AgentEvent): AgentStateChangeTrigger {
+    switch (event.type) {
+      case "input":
+        return "input";
+      case "output":
+        return "output";
+      case "busy":
+        return "heuristic";
+      case "prompt":
+        return "heuristic";
+      case "exit":
+        return "exit";
+      case "start":
+        // Start events occur at spawn, before any actual output
+        return "heuristic";
+      case "error":
+        // Error events are detected via output patterns, not actual exits
+        return "heuristic";
+      default:
+        return "output";
+    }
+  }
+
+  /**
+   * Infer the confidence level for a state change.
+   * @param event - Agent event that triggers the state transition
+   * @param trigger - The trigger type for this state change
+   * @returns Confidence value between 0.0 and 1.0
+   * @private
+   */
+  private inferConfidence(event: AgentEvent, trigger: AgentStateChangeTrigger): number {
+    // Deterministic triggers have perfect confidence
+    if (trigger === "input" || trigger === "exit") {
+      return 1.0;
+    }
+
+    // Output triggers are deterministic (we know output happened)
+    if (trigger === "output") {
+      return 1.0;
+    }
+
+    // Heuristic triggers have varying confidence based on pattern type
+    if (trigger === "heuristic") {
+      // Busy patterns are high confidence (specific indicators like "esc to interrupt")
+      if (event.type === "busy") {
+        return 0.9;
+      }
+      // Prompt patterns are medium confidence (more false positives)
+      if (event.type === "prompt") {
+        return 0.75;
+      }
+      // Start events (initial spawn) are lower confidence - no real output yet
+      if (event.type === "start") {
+        return 0.7;
+      }
+      // Error events detected via patterns are medium-low confidence
+      if (event.type === "error") {
+        return 0.65;
+      }
+    }
+
+    // AI classification confidence should be passed explicitly (handled in caller)
+    if (trigger === "ai-classification") {
+      return 0.85; // Default if not specified
+    }
+
+    // Timeout triggers depend on context (caller should specify)
+    if (trigger === "timeout") {
+      return 0.6; // Default conservative value
+    }
+
+    return 0.5; // Unknown confidence
+  }
+
+  /**
    * Update agent state for a terminal and emit state-changed event
    * @param id - Terminal identifier
    * @param event - Agent event that triggers the state transition
+   * @param trigger - Optional explicit trigger type (if not provided, inferred from event)
+   * @param confidence - Optional explicit confidence value (if not provided, inferred from event and trigger)
    * @private
    */
-  private updateAgentState(id: string, event: AgentEvent): void {
+  private updateAgentState(
+    id: string,
+    event: AgentEvent,
+    trigger?: AgentStateChangeTrigger,
+    confidence?: number
+  ): void {
     const terminal = this.terminals.get(id);
     if (!terminal || !terminal.agentId) {
       return;
@@ -153,6 +241,10 @@ export class PtyManager extends EventEmitter {
       terminal.agentState = newState;
       terminal.lastStateChange = getStateChangeTimestamp();
 
+      // Infer trigger from event type if not explicitly provided
+      const inferredTrigger = trigger ?? this.inferTrigger(event);
+      const inferredConfidence = confidence ?? this.inferConfidence(event, inferredTrigger);
+
       // Build and validate state change payload
       const stateChangePayload = {
         agentId: terminal.agentId,
@@ -160,6 +252,8 @@ export class PtyManager extends EventEmitter {
         previousState,
         timestamp: terminal.lastStateChange,
         traceId: terminal.traceId,
+        trigger: inferredTrigger,
+        confidence: inferredConfidence,
       };
 
       const validatedStateChange = AgentStateChangedSchema.safeParse(stateChangePayload);

--- a/electron/services/__tests__/EventBuffer.test.ts
+++ b/electron/services/__tests__/EventBuffer.test.ts
@@ -142,7 +142,10 @@ describe("EventBuffer", () => {
       events.emit("agent:state-changed", {
         agentId: "agent-1",
         state: "working",
+        previousState: "idle",
         timestamp: Date.now() - 4000,
+        trigger: "output",
+        confidence: 1.0,
       });
       events.emit("sys:worktree:update", {
         id: "wt-1",
@@ -331,6 +334,8 @@ describe("EventBuffer", () => {
         state: "working",
         previousState: "idle",
         timestamp: Date.now(),
+        trigger: "heuristic",
+        confidence: 0.9,
       });
 
       const all = buffer.getAll();
@@ -339,6 +344,9 @@ describe("EventBuffer", () => {
       expect(stateEvent).toBeDefined();
       expect(stateEvent?.payload.state).toBe("working");
       expect(stateEvent?.payload.previousState).toBe("idle");
+      // Verify trigger and confidence metadata survive sanitization
+      expect(stateEvent?.payload.trigger).toBe("heuristic");
+      expect(stateEvent?.payload.confidence).toBe(0.9);
     });
   });
 
@@ -506,8 +514,11 @@ describe("EventBuffer", () => {
       events.emit("agent:state-changed", {
         agentId: "agent-1",
         state: "working",
+        previousState: "idle",
         timestamp: Date.now(),
         traceId: "trace-alpha",
+        trigger: "output",
+        confidence: 1.0,
       });
       events.emit("agent:spawned", {
         agentId: "agent-2",
@@ -541,8 +552,11 @@ describe("EventBuffer", () => {
       events.emit("agent:state-changed", {
         agentId: "agent-1",
         state: "working",
+        previousState: "idle",
         timestamp: Date.now(),
         traceId: "trace-1",
+        trigger: "output",
+        confidence: 1.0,
       });
       events.emit("agent:spawned", {
         agentId: "agent-2",
@@ -615,7 +629,10 @@ describe("EventBuffer", () => {
       events.emit("agent:state-changed", {
         agentId: "agent-1",
         state: "working",
+        previousState: "idle",
         timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
       });
       events.emit("server:update", {
         worktreeId: "wt-1",
@@ -691,7 +708,10 @@ describe("EventBuffer", () => {
       events.emit("agent:state-changed", {
         agentId: "agent-1",
         state: "working",
+        previousState: "idle",
         timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
       });
       events.emit("server:update", {
         worktreeId: "wt-1",

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -266,6 +266,15 @@ export interface RunRecord {
 /** Type of terminal instance */
 export type TerminalType = "shell" | "claude" | "gemini" | "custom";
 
+/** Valid triggers for agent state changes */
+export type AgentStateChangeTrigger =
+  | "input"
+  | "output"
+  | "heuristic"
+  | "ai-classification"
+  | "timeout"
+  | "exit";
+
 /** Represents a terminal instance in the application */
 export interface TerminalInstance {
   /** Unique identifier for this terminal */
@@ -290,6 +299,10 @@ export interface TerminalInstance {
   lastStateChange?: number;
   /** Error message if agentState is 'failed' */
   error?: string;
+  /** What triggered the most recent state change */
+  stateChangeTrigger?: AgentStateChangeTrigger;
+  /** Confidence in the most recent state detection (0.0-1.0) */
+  stateChangeConfidence?: number;
 }
 
 /** Options for spawning a new PTY process */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -35,6 +35,7 @@ export type {
   RunRecord,
   // Terminal types
   TerminalType,
+  AgentStateChangeTrigger,
   TerminalInstance,
   PtySpawnOptions,
   TerminalDimensions,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -586,16 +586,34 @@ export interface ProjectIdentity {
 // Agent State Change Payload
 // ============================================================================
 
+/**
+ * Trigger types for agent state changes.
+ * Indicates what caused an agent's state to change.
+ */
+export type AgentStateChangeTrigger =
+  | "input"
+  | "output"
+  | "heuristic"
+  | "ai-classification"
+  | "timeout"
+  | "exit";
+
 /** Payload for agent state change events */
 export interface AgentStateChangePayload {
   /** Agent/terminal ID */
   agentId: string;
-  /** New state (string to allow for runtime flexibility) */
+  /** New state */
   state: string;
   /** Previous state */
-  previousState?: string;
+  previousState: string;
   /** Timestamp of state change */
   timestamp: number;
+  /** Optional trace ID to track event chains */
+  traceId?: string;
+  /** What caused this state change */
+  trigger: AgentStateChangeTrigger;
+  /** Confidence in the state detection (0.0 = uncertain, 1.0 = certain) */
+  confidence: number;
 }
 
 // ============================================================================

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -209,8 +209,14 @@ export function AppLayout({
         onToggleFocusMode={handleToggleFocusMode}
         isRefreshing={isRefreshing}
       />
-      <div className="flex-1 flex flex-col overflow-hidden" style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}>
-        <div className="flex-1 flex overflow-hidden" style={{ flex: 1, display: "flex", overflow: "hidden" }}>
+      <div
+        className="flex-1 flex flex-col overflow-hidden"
+        style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}
+      >
+        <div
+          className="flex-1 flex overflow-hidden"
+          style={{ flex: 1, display: "flex", overflow: "hidden" }}
+        >
           {!isFocusMode && (
             <Sidebar
               width={effectiveSidebarWidth}
@@ -220,7 +226,10 @@ export function AppLayout({
               {sidebarContent}
             </Sidebar>
           )}
-          <main className="flex-1 overflow-hidden bg-canopy-bg" style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}>
+          <main
+            className="flex-1 overflow-hidden bg-canopy-bg"
+            style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}
+          >
             {children}
           </main>
         </div>

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -143,6 +143,14 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
             isInjecting={isInjecting}
             injectionProgress={progress}
             agentState={terminal.agentState}
+            stateDebugInfo={
+              terminal.stateChangeTrigger
+                ? {
+                    trigger: terminal.stateChangeTrigger,
+                    confidence: terminal.stateChangeConfidence ?? 0,
+                  }
+                : null
+            }
             onFocus={() => setFocused(terminal.id)}
             onClose={() => removeTerminal(terminal.id)}
             onInjectContext={
@@ -192,6 +200,14 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
           isInjecting={isInjecting}
           injectionProgress={progress}
           agentState={terminal.agentState}
+          stateDebugInfo={
+            terminal.stateChangeTrigger
+              ? {
+                  trigger: terminal.stateChangeTrigger,
+                  confidence: terminal.stateChangeConfidence ?? 0,
+                }
+              : null
+          }
           onFocus={() => setFocused(terminal.id)}
           onClose={() => removeTerminal(terminal.id)}
           onInjectContext={

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -34,9 +34,15 @@ import { ArtifactOverlay } from "./ArtifactOverlay";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { useErrorStore, useTerminalStore, type RetryAction } from "@/store";
 import { useContextInjection, type CopyTreeProgress } from "@/hooks/useContextInjection";
-import type { AgentState } from "@/types";
+import type { AgentState, AgentStateChangeTrigger } from "@/types";
 
 export type TerminalType = "shell" | "claude" | "gemini" | "custom";
+
+/** Debug info for state changes */
+export interface StateDebugInfo {
+  trigger: AgentStateChangeTrigger;
+  confidence: number;
+}
 
 export interface TerminalPaneProps {
   /** Unique terminal identifier */
@@ -59,6 +65,8 @@ export interface TerminalPaneProps {
   injectionProgress?: CopyTreeProgress | null;
   /** Current agent state (for agent terminals) */
   agentState?: AgentState;
+  /** Debug info about state detection (trigger and confidence) */
+  stateDebugInfo?: StateDebugInfo | null;
   /** Called when the pane is clicked/focused */
   onFocus: () => void;
   /** Called when the close button is clicked */
@@ -101,6 +109,7 @@ export function TerminalPane({
   isInjecting,
   injectionProgress,
   agentState,
+  stateDebugInfo,
   onFocus,
   onClose,
   onInjectContext,
@@ -348,6 +357,18 @@ export function TerminalPane({
               <span className="text-xs font-mono">Working</span>
             </div>
           )}
+
+          {/* State debug info - shown when CANOPY_STATE_DEBUG is set in localStorage */}
+          {stateDebugInfo &&
+            typeof localStorage !== "undefined" &&
+            localStorage.getItem("CANOPY_STATE_DEBUG") === "1" && (
+              <span
+                className="text-xs font-mono text-gray-500 ml-1"
+                title={`Trigger: ${stateDebugInfo.trigger}\nConfidence: ${(stateDebugInfo.confidence * 100).toFixed(0)}%`}
+              >
+                ({stateDebugInfo.trigger}, {(stateDebugInfo.confidence * 100).toFixed(0)}%)
+              </span>
+            )}
 
           {/* Queue count indicator */}
           {queueCount > 0 && (

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -10,7 +10,12 @@
  */
 
 import type { StateCreator } from "zustand";
-import type { TerminalInstance as TerminalInstanceType, AgentState, TerminalType } from "@/types";
+import type {
+  TerminalInstance as TerminalInstanceType,
+  AgentState,
+  TerminalType,
+  AgentStateChangeTrigger,
+} from "@/types";
 
 // Re-export the shared type
 export type TerminalInstance = TerminalInstanceType;
@@ -42,7 +47,9 @@ export interface TerminalRegistrySlice {
     id: string,
     agentState: AgentState,
     error?: string,
-    lastStateChange?: number
+    lastStateChange?: number,
+    trigger?: AgentStateChangeTrigger,
+    confidence?: number
   ) => void;
   getTerminal: (id: string) => TerminalInstance | undefined;
 }
@@ -164,7 +171,7 @@ export const createTerminalRegistrySlice =
       });
     },
 
-    updateAgentState: (id, agentState, error, lastStateChange) => {
+    updateAgentState: (id, agentState, error, lastStateChange, trigger, confidence) => {
       set((state) => {
         const terminal = state.terminals.find((t) => t.id === id);
         if (!terminal) {
@@ -179,6 +186,8 @@ export const createTerminalRegistrySlice =
                 agentState,
                 error,
                 lastStateChange: lastStateChange ?? Date.now(),
+                stateChangeTrigger: trigger,
+                stateChangeConfidence: confidence,
               }
             : t
         );

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -102,7 +102,7 @@ let agentStateUnsubscribe: (() => void) | null = null;
 if (typeof window !== "undefined" && window.electron?.terminal?.onAgentStateChanged) {
   agentStateUnsubscribe = window.electron.terminal.onAgentStateChanged((data) => {
     // The IPC event uses 'agentId' which corresponds to the terminal ID
-    const { agentId, state, timestamp } = data;
+    const { agentId, state, timestamp, trigger, confidence } = data;
 
     // Validate state is a valid AgentState
     const validStates: AgentState[] = ["idle", "working", "waiting", "completed", "failed"];
@@ -111,10 +111,10 @@ if (typeof window !== "undefined" && window.electron?.terminal?.onAgentStateChan
       return;
     }
 
-    // Update the terminal's agent state
+    // Update the terminal's agent state with trigger and confidence metadata
     useTerminalStore
       .getState()
-      .updateAgentState(agentId, state as AgentState, undefined, timestamp);
+      .updateAgentState(agentId, state as AgentState, undefined, timestamp, trigger, confidence);
 
     // Process any queued commands when agent becomes idle or waiting
     if (state === "waiting" || state === "idle") {


### PR DESCRIPTION
## Summary

Enhances `agent:state-changed` events with metadata tracking to answer "what caused this state change?" and "how confident are we in this detection?"

This implementation adds trigger categorization (input, output, heuristic, ai-classification, timeout, exit) and confidence scoring (0.0-1.0) to every agent state transition, enabling better debugging and future AI-powered state classification.

Closes #196

## Changes Made

### Type System
- Added `AgentStateChangeTrigger` type with 6 trigger categories: `input`, `output`, `heuristic`, `ai-classification`, `timeout`, `exit`
- Extended `agent:state-changed` event type with required `trigger` and `confidence` fields
- Made `previousState` required (was optional) for consistency
- Added Zod schema validation for new metadata fields

### PtyManager Enhancements
- Implemented `inferTrigger()` helper to categorize event types into trigger categories
- Implemented `inferConfidence()` helper with nuanced confidence scoring:
  - Deterministic triggers (input, output, exit): 1.0 confidence
  - High-confidence heuristics (busy patterns): 0.9 confidence
  - Medium-confidence heuristics (prompt patterns): 0.75 confidence
  - Lower-confidence heuristics (start, error): 0.65-0.7 confidence
- Updated `updateAgentState()` signature to accept optional explicit trigger/confidence

### IPC Layer
- Extended `AgentStateChangePayload` with `trigger`, `confidence`, and `traceId` fields
- Added comprehensive runtime validation in preload.ts to ensure payload integrity
- Added validation warnings for malformed payloads (logged and dropped)

### UI Integration
- Extended `TerminalInstance` domain type with `stateChangeTrigger` and `stateChangeConfidence`
- Updated terminal store to propagate metadata from IPC to UI state
- Added optional debug display in `TerminalPane` header (enabled via `CANOPY_STATE_DEBUG=1` in localStorage)
- Debug display shows trigger type and confidence percentage on hover

### Testing
- Updated all test fixtures in `EventBuffer.test.ts` to include required metadata fields
- Added assertions to verify trigger and confidence preservation through event pipeline
- Ensured backward compatibility with existing event handling

## Technical Details

**Trigger Categorization Logic:**
- `input`: User sent keystrokes to terminal (deterministic)
- `output`: PTY emitted output (deterministic)
- `heuristic`: Pattern matching detected state (confidence varies by pattern quality)
- `ai-classification`: Future AI model classified state (placeholder, not yet implemented)
- `timeout`: Silence timeout triggered check (placeholder, not yet implemented)
- `exit`: Process exited (deterministic)

**Confidence Scoring:**
- 1.0: Deterministic triggers (we know for certain)
- 0.9: High-quality heuristics (e.g., "esc to interrupt" pattern)
- 0.75: Medium-quality heuristics (e.g., prompt patterns)
- 0.65-0.7: Lower-quality heuristics (e.g., start/error detection)
- 0.5: Unknown/default fallback

**Debug Mode:**
To enable state debug display, set in browser console:
```javascript
localStorage.setItem('CANOPY_STATE_DEBUG', '1')
```

This will show trigger and confidence in terminal headers like: `(heuristic, 90%)`

## Testing

- All TypeScript type checks pass
- All existing tests updated and passing
- Event pipeline preserves metadata correctly from PtyManager → IPC → Store → UI
- Payload validation prevents malformed events from reaching renderer

## Future Work

This foundation enables:
- AI-powered state classification (using the `ai-classification` trigger)
- Timeout-based state detection (using the `timeout` trigger)
- Analytics on state detection accuracy
- Adaptive confidence thresholds based on historical accuracy