### PR TITLE
Add compact mode for WorktreeCard with expand/collapse

### DIFF
--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -12,6 +12,8 @@ interface WorktreeSelectionState {
   activeWorktreeId: string | null;
   /** Currently focused worktree ID (for keyboard navigation) */
   focusedWorktreeId: string | null;
+  /** Set of worktree IDs that are expanded (showing full details) */
+  expandedWorktrees: Set<string>;
 
   /** Set the active worktree */
   setActiveWorktree: (id: string | null) => void;
@@ -19,11 +21,18 @@ interface WorktreeSelectionState {
   setFocusedWorktree: (id: string | null) => void;
   /** Select and focus a worktree */
   selectWorktree: (id: string) => void;
+  /** Toggle expanded state for a worktree */
+  toggleWorktreeExpanded: (id: string) => void;
+  /** Set expanded state for a worktree */
+  setWorktreeExpanded: (id: string, expanded: boolean) => void;
+  /** Collapse all worktrees */
+  collapseAllWorktrees: () => void;
 }
 
 const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set) => ({
   activeWorktreeId: null,
   focusedWorktreeId: null,
+  expandedWorktrees: new Set<string>(),
 
   setActiveWorktree: (id) => {
     set({ activeWorktreeId: id });
@@ -44,6 +53,30 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set)
       console.error("Failed to persist active worktree:", error);
     });
   },
+
+  toggleWorktreeExpanded: (id) =>
+    set((state) => {
+      const next = new Set(state.expandedWorktrees);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return { expandedWorktrees: next };
+    }),
+
+  setWorktreeExpanded: (id, expanded) =>
+    set((state) => {
+      const next = new Set(state.expandedWorktrees);
+      if (expanded) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return { expandedWorktrees: next };
+    }),
+
+  collapseAllWorktrees: () => set({ expandedWorktrees: new Set<string>() }),
 });
 
 export const useWorktreeSelectionStore = create<WorktreeSelectionState>()(


### PR DESCRIPTION
## Summary

Implements compact mode for WorktreeCard to reduce visual clutter when managing many worktrees. Cards now default to showing only essential information (identity, activity, dominant agent state, and summary metrics), with expandable details behind a chevron button.

Closes #203

## Changes Made

- Add expandedWorktrees Set state to worktreeStore with toggle/set/collapseAll methods
- Refactor WorktreeCard to show compact summary by default (identity, activity, metrics)
- Add chevron button to expand/collapse detailed information
- Implement smooth CSS transitions for expand/collapse animation
- Optimize re-renders with per-id subscription (only affected card re-renders)
- Fix accessibility: move aria-expanded to chevron, add aria-controls and aria-hidden
- Include AI summary and loading state in expandable content detection
- Add inert attribute to prevent focus on collapsed content
- Target 50% height reduction for better sidebar density with many worktrees

## Implementation Details

**Compact Mode (Default):**
- Chevron button for expand/collapse (when expandable content exists)
- Branch name with agent status indicator
- Issue/PR badges
- Summary metrics row: terminal count, file changes (+/-), dev server status, errors

**Expanded Mode (On Click):**
- File path
- AI summary
- AI note (if present)
- Detailed file change list
- Dev server controls with start/stop
- Detailed error banners

**Performance & Accessibility:**
- Per-worktree subscription prevents unnecessary re-renders across all cards
- Proper ARIA attributes (aria-expanded, aria-controls, aria-hidden)
- Inert attribute prevents focus on collapsed content
- Smooth transitions with optimized CSS properties