### PR TITLE
Consolidate diagnostics panels into unified tabbed dock

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1210,11 +1210,34 @@ export function registerIpcHandlers(
         if (
           panelState &&
           typeof panelState === "object" &&
-          typeof panelState.sidebarWidth === "number" &&
-          typeof panelState.logsOpen === "boolean" &&
-          typeof panelState.eventInspectorOpen === "boolean"
+          typeof panelState.sidebarWidth === "number"
         ) {
-          updates.focusPanelState = panelState;
+          // Support both new format (diagnosticsOpen) and legacy format (logsOpen/eventInspectorOpen)
+          if ("diagnosticsOpen" in panelState && typeof panelState.diagnosticsOpen === "boolean") {
+            // New format
+            updates.focusPanelState = {
+              sidebarWidth: panelState.sidebarWidth,
+              diagnosticsOpen: panelState.diagnosticsOpen,
+            };
+          } else if (
+            "logsOpen" in panelState &&
+            typeof panelState.logsOpen === "boolean" &&
+            "eventInspectorOpen" in panelState &&
+            typeof panelState.eventInspectorOpen === "boolean"
+          ) {
+            // Legacy format - migrate to new format
+            updates.focusPanelState = {
+              sidebarWidth: panelState.sidebarWidth,
+              diagnosticsOpen: panelState.logsOpen || panelState.eventInspectorOpen,
+            };
+          }
+        }
+      }
+
+      if ("diagnosticsHeight" in partialState) {
+        const height = Number(partialState.diagnosticsHeight);
+        if (!isNaN(height) && height >= 128 && height <= 1000) {
+          updates.diagnosticsHeight = height;
         }
       }
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -21,9 +21,10 @@ export interface StoreSchema {
     /** Saved panel state before entering focus mode (for restoration) */
     focusPanelState?: {
       sidebarWidth: number;
-      logsOpen: boolean;
-      eventInspectorOpen: boolean;
+      diagnosticsOpen: boolean;
     };
+    /** Height of diagnostics dock in pixels */
+    diagnosticsHeight?: number;
     terminals: Array<{
       id: string;
       type: "shell" | "claude" | "gemini" | "custom";

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -344,9 +344,10 @@ export interface AppState {
   /** Saved panel state before entering focus mode (for restoration) */
   focusPanelState?: {
     sidebarWidth: number;
-    logsOpen: boolean;
-    eventInspectorOpen: boolean;
+    diagnosticsOpen: boolean;
   };
+  /** Height of the diagnostics dock in pixels */
+  diagnosticsHeight?: number;
   /** Recently opened directories */
   recentDirectories?: RecentDirectory[];
   /** Saved terminal recipes */

--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -1,0 +1,125 @@
+/**
+ * DiagnosticsActions Components
+ *
+ * Tab-specific action buttons for the diagnostics dock toolbar.
+ */
+
+import { useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { useLogsStore, useErrorStore } from "@/store";
+import { useEventStore } from "@/store/eventStore";
+
+interface ActionButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+  className?: string;
+  title?: string;
+}
+
+function ActionButton({ onClick, disabled, children, className, title }: ActionButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "px-2 py-0.5 text-xs rounded transition-colors",
+        "bg-gray-800 text-gray-400 hover:text-gray-200 hover:bg-gray-700",
+        disabled && "opacity-50 cursor-not-allowed",
+        className
+      )}
+      title={title}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function ProblemsActions() {
+  const activeErrors = useErrorStore((state) => state.errors.filter((e) => !e.dismissed));
+  const clearAll = useErrorStore((state) => state.clearAll);
+
+  const handleOpenLogs = useCallback(() => {
+    window.electron?.errors?.openLogs();
+  }, []);
+
+  return (
+    <div className="flex items-center gap-2">
+      <ActionButton onClick={handleOpenLogs} title="Open log file">
+        Open Logs
+      </ActionButton>
+      <ActionButton
+        onClick={clearAll}
+        disabled={activeErrors.length === 0}
+        title="Clear all errors"
+      >
+        Clear All
+      </ActionButton>
+    </div>
+  );
+}
+
+export function LogsActions() {
+  const autoScroll = useLogsStore((state) => state.autoScroll);
+  const setAutoScroll = useLogsStore((state) => state.setAutoScroll);
+  const clearLogs = useLogsStore((state) => state.clearLogs);
+
+  const handleOpenFile = useCallback(async () => {
+    if (window.electron?.logs) {
+      await window.electron.logs.openFile();
+    }
+  }, []);
+
+  const handleClearLogs = useCallback(async () => {
+    clearLogs();
+    if (window.electron?.logs) {
+      await window.electron.logs.clear();
+    }
+  }, [clearLogs]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => setAutoScroll(!autoScroll)}
+        className={cn(
+          "px-2 py-0.5 text-xs rounded transition-colors",
+          autoScroll
+            ? "bg-blue-600 text-white"
+            : "bg-gray-800 text-gray-400 hover:text-gray-200 hover:bg-gray-700"
+        )}
+        title={autoScroll ? "Auto-scroll enabled" : "Auto-scroll disabled"}
+      >
+        Auto-scroll
+      </button>
+      <ActionButton onClick={handleOpenFile} title="Open log file">
+        Open File
+      </ActionButton>
+      <ActionButton onClick={handleClearLogs} title="Clear logs">
+        Clear
+      </ActionButton>
+    </div>
+  );
+}
+
+export function EventsActions() {
+  const clearEvents = useEventStore((state) => state.clearEvents);
+
+  const handleClearEvents = async () => {
+    if (window.confirm("Clear all events? This cannot be undone.")) {
+      // Clear local state
+      clearEvents();
+      // Clear main process buffer
+      if (window.electron?.eventInspector) {
+        await window.electron.eventInspector.clear();
+      }
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <ActionButton onClick={handleClearEvents} title="Clear all events">
+        Clear
+      </ActionButton>
+    </div>
+  );
+}

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -1,0 +1,257 @@
+/**
+ * DiagnosticsDock Component
+ *
+ * Unified bottom dock containing Problems, Logs, and Events tabs.
+ * Consolidates three separate panels into one organized interface.
+ */
+
+import { useCallback, useRef, useState, useEffect, memo } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  useDiagnosticsStore,
+  type DiagnosticsTab,
+  DIAGNOSTICS_MIN_HEIGHT,
+  DIAGNOSTICS_MAX_HEIGHT_RATIO,
+} from "@/store/diagnosticsStore";
+import { useErrorStore } from "@/store";
+import { ProblemsContent } from "./ProblemsContent";
+import { LogsContent } from "./LogsContent";
+import { EventsContent } from "./EventsContent";
+import { ProblemsActions, LogsActions, EventsActions } from "./DiagnosticsActions";
+import type { RetryAction } from "@/store";
+
+interface TabButtonProps {
+  tab: DiagnosticsTab;
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  badge?: number;
+}
+
+const TabButton = memo(function TabButton({
+  tab,
+  label,
+  isActive,
+  onClick,
+  badge,
+}: TabButtonProps) {
+  return (
+    <button
+      id={`diagnostics-${tab}-tab`}
+      onClick={onClick}
+      className={cn(
+        "px-3 py-1.5 text-sm font-medium transition-colors relative",
+        "hover:text-canopy-text",
+        isActive ? "text-canopy-text" : "text-gray-400"
+      )}
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={`diagnostics-${tab}-panel`}
+    >
+      {label}
+      {badge !== undefined && badge > 0 && (
+        <span className="ml-1.5 px-1.5 py-0.5 text-xs bg-red-900/50 text-red-300 rounded-full">
+          {badge}
+        </span>
+      )}
+      {isActive && <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-canopy-accent" />}
+    </button>
+  );
+});
+
+interface DiagnosticsDockProps {
+  onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
+  className?: string;
+}
+
+export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
+  const { isOpen, activeTab, height, openDock, closeDock, setActiveTab, setHeight } =
+    useDiagnosticsStore();
+  const errorCount = useErrorStore((state) => state.errors.filter((e) => !e.dismissed).length);
+  const prevErrorCountRef = useRef(0);
+
+  // Auto-open dock to Problems tab when first error appears
+  useEffect(() => {
+    // Only auto-open when going from 0 to 1+ errors and dock is closed
+    if (errorCount > 0 && prevErrorCountRef.current === 0 && !isOpen) {
+      openDock("problems");
+    }
+    prevErrorCountRef.current = errorCount;
+  }, [errorCount, isOpen, openDock]);
+
+  // Resize state
+  const [isResizing, setIsResizing] = useState(false);
+  const resizeStartY = useRef(0);
+  const resizeStartHeight = useRef(0);
+
+  // Handle resize drag
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsResizing(true);
+      resizeStartY.current = e.clientY;
+      resizeStartHeight.current = height;
+    },
+    [height]
+  );
+
+  // Handle resize drag move
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const deltaY = resizeStartY.current - e.clientY;
+      const newHeight = resizeStartHeight.current + deltaY;
+      const maxHeight = window.innerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO;
+      const clampedHeight = Math.min(Math.max(newHeight, DIAGNOSTICS_MIN_HEIGHT), maxHeight);
+      setHeight(clampedHeight);
+    };
+
+    const handleMouseUp = () => {
+      setIsResizing(false);
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isResizing, setHeight]);
+
+  // Persist height changes
+  useEffect(() => {
+    if (!isResizing && isOpen) {
+      const timer = setTimeout(async () => {
+        try {
+          await window.electron?.app.setState({ diagnosticsHeight: height });
+        } catch (error) {
+          console.error("Failed to persist diagnostics height:", error);
+        }
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [height, isResizing, isOpen]);
+
+  // Restore height from persisted state
+  useEffect(() => {
+    const restoreHeight = async () => {
+      try {
+        const appState = await window.electron?.app.getState();
+        if (appState?.diagnosticsHeight) {
+          setHeight(appState.diagnosticsHeight);
+        }
+      } catch (error) {
+        console.error("Failed to restore diagnostics height:", error);
+      }
+    };
+    restoreHeight();
+  }, [setHeight]);
+
+  if (!isOpen) return null;
+
+  const tabs: { id: DiagnosticsTab; label: string; badge?: number }[] = [
+    { id: "problems", label: "Problems", badge: errorCount },
+    { id: "logs", label: "Logs" },
+    { id: "events", label: "Events" },
+  ];
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col border-t border-canopy-border bg-canopy-bg",
+        "transition-[height] duration-200 ease-out",
+        isResizing && "select-none",
+        className
+      )}
+      style={{ height }}
+      role="region"
+      aria-label="Diagnostics dock"
+    >
+      {/* Resize handle */}
+      <div
+        className={cn(
+          "h-1 cursor-ns-resize transition-colors",
+          "hover:bg-canopy-accent/50",
+          isResizing && "bg-canopy-accent"
+        )}
+        onMouseDown={handleResizeStart}
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize diagnostics dock"
+      />
+
+      {/* Header with tabs */}
+      <div className="flex items-center justify-between px-4 h-10 border-b border-canopy-border bg-canopy-sidebar shrink-0">
+        {/* Tabs */}
+        <div className="flex items-center gap-2" role="tablist" aria-label="Diagnostics tabs">
+          {tabs.map((tab) => (
+            <TabButton
+              key={tab.id}
+              tab={tab.id}
+              label={tab.label}
+              isActive={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              badge={tab.badge}
+            />
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          {/* Tab-specific actions */}
+          {activeTab === "problems" && <ProblemsActions />}
+          {activeTab === "logs" && <LogsActions />}
+          {activeTab === "events" && <EventsActions />}
+
+          {/* Close button */}
+          <button
+            onClick={closeDock}
+            className="p-1.5 hover:bg-gray-800 rounded transition-colors text-gray-400 hover:text-gray-200"
+            title="Close diagnostics dock"
+            aria-label="Close diagnostics dock"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-hidden">
+        {activeTab === "problems" && (
+          <div
+            id="diagnostics-problems-panel"
+            role="tabpanel"
+            aria-labelledby="diagnostics-problems-tab"
+            className="h-full"
+          >
+            <ProblemsContent onRetry={onRetry} />
+          </div>
+        )}
+        {activeTab === "logs" && (
+          <div
+            id="diagnostics-logs-panel"
+            role="tabpanel"
+            aria-labelledby="diagnostics-logs-tab"
+            className="h-full"
+          >
+            <LogsContent />
+          </div>
+        )}
+        {activeTab === "events" && (
+          <div
+            id="diagnostics-events-panel"
+            role="tabpanel"
+            aria-labelledby="diagnostics-events-tab"
+            className="h-full"
+          >
+            <EventsContent />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Diagnostics/EventsContent.tsx
+++ b/src/components/Diagnostics/EventsContent.tsx
@@ -1,0 +1,139 @@
+/**
+ * EventsContent Component
+ *
+ * Content component for the Events tab in the diagnostics dock.
+ * Displays event timeline extracted from the original EventInspectorPanel.
+ */
+
+import { useCallback, useEffect, useRef, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { useEventStore } from "@/store/eventStore";
+import { EventTimeline } from "../EventInspector/EventTimeline";
+import { EventDetail } from "../EventInspector/EventDetail";
+import { EventFilters } from "../EventInspector/EventFilters";
+
+export interface EventsContentProps {
+  className?: string;
+}
+
+export function EventsContent({ className }: EventsContentProps) {
+  const {
+    events,
+    filters,
+    selectedEventId,
+    autoScroll,
+    setAutoScroll,
+    addEvent,
+    setEvents,
+    setFilters,
+    setSelectedEvent,
+    getFilteredEvents,
+  } = useEventStore();
+
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const isUserScrolling = useRef(false);
+  const isProgrammaticScroll = useRef(false);
+  const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  // Load initial events and set up subscription
+  useEffect(() => {
+    if (!window.electron?.eventInspector) return;
+
+    // Notify main process that we're subscribing
+    window.electron.eventInspector.subscribe();
+
+    // Load existing events
+    window.electron.eventInspector
+      .getEvents()
+      .then((existingEvents) => {
+        setEvents(existingEvents);
+      })
+      .catch((error) => {
+        console.error("Failed to load events:", error);
+      });
+
+    // Subscribe to new events
+    const unsubscribe = window.electron.eventInspector.onEvent((event) => {
+      addEvent(event);
+    });
+
+    return () => {
+      unsubscribe();
+      // Notify main process that we're unsubscribing
+      window.electron.eventInspector.unsubscribe();
+    };
+  }, [addEvent, setEvents]);
+
+  // Auto-scroll to bottom when new events arrive
+  useEffect(() => {
+    if (autoScroll && timelineRef.current && !isUserScrolling.current) {
+      isProgrammaticScroll.current = true;
+      timelineRef.current.scrollTop = timelineRef.current.scrollHeight;
+      // Reset flag after scroll completes
+      setTimeout(() => {
+        isProgrammaticScroll.current = false;
+      }, 50);
+    }
+  }, [events, autoScroll]);
+
+  // Handle user scrolling
+  const handleScroll = useCallback(() => {
+    if (!timelineRef.current) return;
+
+    // Ignore programmatic scrolls
+    if (isProgrammaticScroll.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = timelineRef.current;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
+
+    // Detect if user is scrolling
+    isUserScrolling.current = true;
+    if (scrollTimeout.current) {
+      clearTimeout(scrollTimeout.current);
+    }
+    scrollTimeout.current = setTimeout(() => {
+      isUserScrolling.current = false;
+    }, 100);
+
+    // Auto-scroll is disabled when user scrolls up, enabled when at bottom
+    if (!isAtBottom && autoScroll) {
+      setAutoScroll(false);
+    } else if (isAtBottom && !autoScroll) {
+      setAutoScroll(true);
+    }
+  }, [autoScroll, setAutoScroll]);
+
+  // Memoize filtered events to avoid unnecessary re-renders
+  const filteredEvents = useMemo(() => getFilteredEvents(), [getFilteredEvents]);
+  const selectedEvent = selectedEventId
+    ? events.find((e) => e.id === selectedEventId) || null
+    : null;
+
+  return (
+    <div className={cn("flex flex-col h-full", className)}>
+      {/* Filters */}
+      <EventFilters
+        events={events}
+        filters={filters}
+        onFiltersChange={(newFilters) => setFilters(newFilters)}
+      />
+
+      {/* Main content area */}
+      <div className="flex-1 flex min-h-0">
+        {/* Timeline (left) */}
+        <div ref={timelineRef} onScroll={handleScroll} className="w-1/2 border-r overflow-y-auto">
+          <EventTimeline
+            events={filteredEvents}
+            selectedId={selectedEventId}
+            onSelectEvent={setSelectedEvent}
+          />
+        </div>
+
+        {/* Detail view (right) */}
+        <div className="w-1/2 overflow-hidden">
+          <EventDetail event={selectedEvent} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -1,0 +1,179 @@
+/**
+ * LogsContent Component
+ *
+ * Content component for the Logs tab in the diagnostics dock.
+ * Displays log entries extracted from the original LogsPanel.
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { useLogsStore, filterLogs } from "@/store";
+import { LogEntry } from "../Logs/LogEntry";
+import { LogFilters } from "../Logs/LogFilters";
+import type { LogEntry as LogEntryType } from "@/types";
+
+export interface LogsContentProps {
+  className?: string;
+  /** Expose sources for toolbar actions */
+  onSourcesChange?: (sources: string[]) => void;
+}
+
+export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
+  const {
+    logs,
+    filters,
+    autoScroll,
+    expandedIds,
+    addLog,
+    setLogs,
+    setFilters,
+    clearFilters,
+    setAutoScroll,
+    toggleExpanded,
+  } = useLogsStore();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isUserScrolling = useRef(false);
+  const isProgrammaticScroll = useRef(false);
+  const scrollTimeout = useRef<NodeJS.Timeout | null>(null);
+  const sourcesRef = useRef<string[]>([]);
+
+  // Load initial logs and set up subscription
+  useEffect(() => {
+    if (!window.electron?.logs) return;
+
+    // Load existing logs
+    window.electron.logs
+      .getAll()
+      .then((existingLogs) => {
+        setLogs(existingLogs);
+      })
+      .catch((error) => {
+        console.error("Failed to load logs:", error);
+      });
+
+    // Load sources
+    window.electron.logs
+      .getSources()
+      .then((existingSources) => {
+        sourcesRef.current = existingSources;
+        onSourcesChange?.(existingSources);
+      })
+      .catch((error) => {
+        console.error("Failed to load log sources:", error);
+      });
+
+    // Subscribe to new log entries
+    const unsubscribe = window.electron.logs.onEntry((entry: LogEntryType) => {
+      addLog(entry);
+      // Update sources if new
+      if (entry.source && !sourcesRef.current.includes(entry.source)) {
+        sourcesRef.current = [...sourcesRef.current, entry.source].sort();
+        onSourcesChange?.(sourcesRef.current);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [addLog, setLogs, onSourcesChange]);
+
+  // Auto-scroll to bottom when new logs arrive
+  useEffect(() => {
+    if (autoScroll && containerRef.current && !isUserScrolling.current) {
+      isProgrammaticScroll.current = true;
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+      // Reset flag after scroll completes
+      setTimeout(() => {
+        isProgrammaticScroll.current = false;
+      }, 50);
+    }
+  }, [logs, autoScroll]);
+
+  // Handle user scrolling
+  const handleScroll = useCallback(() => {
+    if (!containerRef.current) return;
+
+    // Ignore programmatic scrolls
+    if (isProgrammaticScroll.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 50;
+
+    // Detect if user is scrolling
+    isUserScrolling.current = true;
+    if (scrollTimeout.current) {
+      clearTimeout(scrollTimeout.current);
+    }
+    scrollTimeout.current = setTimeout(() => {
+      isUserScrolling.current = false;
+    }, 100);
+
+    // Re-enable auto-scroll if user scrolls to bottom
+    if (isAtBottom && !autoScroll) {
+      setAutoScroll(true);
+    } else if (!isAtBottom && autoScroll) {
+      setAutoScroll(false);
+    }
+  }, [autoScroll, setAutoScroll]);
+
+  // Filter logs (memoized for performance)
+  const filteredLogs = useMemo(() => filterLogs(logs, filters), [logs, filters]);
+
+  return (
+    <div className={cn("flex flex-col h-full", className)}>
+      {/* Filters */}
+      <LogFilters
+        filters={filters}
+        onFiltersChange={setFilters}
+        onClear={clearFilters}
+        availableSources={sourcesRef.current}
+      />
+
+      {/* Log entries */}
+      <div
+        ref={containerRef}
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto overflow-x-hidden font-mono relative"
+      >
+        {filteredLogs.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+            {logs.length === 0 ? "No logs yet" : "No logs match filters"}
+          </div>
+        ) : (
+          filteredLogs.map((entry) => (
+            <LogEntry
+              key={entry.id}
+              entry={entry}
+              isExpanded={expandedIds.has(entry.id)}
+              onToggle={() => toggleExpanded(entry.id)}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Scroll to bottom indicator (when not at bottom) */}
+      {!autoScroll && filteredLogs.length > 0 && (
+        <button
+          onClick={() => {
+            setAutoScroll(true);
+            if (containerRef.current) {
+              isProgrammaticScroll.current = true;
+              containerRef.current.scrollTop = containerRef.current.scrollHeight;
+              setTimeout(() => {
+                isProgrammaticScroll.current = false;
+              }, 50);
+            }
+          }}
+          className={cn(
+            "absolute bottom-4 right-4 px-3 py-1.5 text-xs rounded-full",
+            "bg-blue-600 text-white shadow-lg",
+            "hover:bg-blue-500 transition-colors"
+          )}
+        >
+          Scroll to bottom
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -1,0 +1,188 @@
+/**
+ * ProblemsContent Component
+ *
+ * Content component for the Problems tab in the diagnostics dock.
+ * Displays errors table extracted from the original ProblemsPanel.
+ */
+
+import { useMemo, useCallback, useState } from "react";
+import { cn } from "@/lib/utils";
+import { useErrorStore, type AppError, type RetryAction } from "@/store";
+
+const ERROR_TYPE_LABELS: Record<string, string> = {
+  git: "Git",
+  process: "Process",
+  filesystem: "File",
+  network: "Network",
+  config: "Config",
+  unknown: "Other",
+};
+
+const ERROR_TYPE_COLORS: Record<string, string> = {
+  git: "text-orange-400",
+  process: "text-[var(--color-status-warning)]",
+  filesystem: "text-[var(--color-status-info)]",
+  network: "text-purple-400",
+  config: "text-amber-400",
+  unknown: "text-[var(--color-status-error)]",
+};
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+interface ErrorRowProps {
+  error: AppError;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onDismiss: () => void;
+  onRetry?: () => void;
+}
+
+function ErrorRow({ error, isExpanded, onToggleExpand, onDismiss, onRetry }: ErrorRowProps) {
+  const typeLabel = ERROR_TYPE_LABELS[error.type] || "Error";
+  const typeColor = ERROR_TYPE_COLORS[error.type] || "text-[var(--color-status-error)]";
+  const canRetry = error.isTransient && error.retryAction && onRetry;
+
+  return (
+    <>
+      <tr className={cn("hover:bg-gray-800/50 transition-colors", isExpanded && "bg-gray-800/30")}>
+        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+          {formatTimestamp(error.timestamp)}
+        </td>
+        <td className={cn("px-3 py-2 text-xs whitespace-nowrap font-medium", typeColor)}>
+          {typeLabel}
+        </td>
+        <td className="px-3 py-2 text-sm text-gray-300 max-w-md">
+          <button
+            onClick={onToggleExpand}
+            className="text-left w-full hover:text-white transition-colors"
+            aria-expanded={isExpanded}
+            aria-controls={`error-details-${error.id}`}
+          >
+            <span className="truncate block">{error.message}</span>
+          </button>
+        </td>
+        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{error.source || "-"}</td>
+        <td className="px-3 py-2 whitespace-nowrap">
+          <div className="flex items-center gap-1">
+            {canRetry && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRetry();
+                }}
+                className="px-2 py-0.5 text-xs text-green-300 hover:text-green-200 border border-green-600 hover:bg-green-800/50 rounded"
+              >
+                Retry
+              </button>
+            )}
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDismiss();
+              }}
+              className="p-1 text-gray-500 hover:text-gray-300"
+              aria-label="Dismiss error"
+            >
+              ×
+            </button>
+          </div>
+        </td>
+      </tr>
+      {isExpanded && error.details && (
+        <tr className="bg-gray-900/50" id={`error-details-${error.id}`}>
+          <td colSpan={5} className="px-3 py-2">
+            <pre className="text-xs text-gray-400 whitespace-pre-wrap break-all font-mono max-h-40 overflow-y-auto">
+              {error.details}
+            </pre>
+            {error.context && Object.keys(error.context).length > 0 && (
+              <div className="mt-2 text-xs text-gray-500">
+                <span className="font-medium">Context: </span>
+                {Object.entries(error.context)
+                  .filter(([, v]) => v !== undefined)
+                  .map(([k, v]) => `${k}=${v}`)
+                  .join(", ")}
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+export interface ProblemsContentProps {
+  onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
+  className?: string;
+}
+
+export function ProblemsContent({ onRetry, className }: ProblemsContentProps) {
+  const errors = useErrorStore((state) => state.errors);
+  const dismissError = useErrorStore((state) => state.dismissError);
+
+  // Track expanded rows
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+
+  const activeErrors = useMemo(() => {
+    return errors.filter((e) => !e.dismissed);
+  }, [errors]);
+
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className={cn("h-full overflow-auto", className)}>
+      {activeErrors.length === 0 ? (
+        <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+          No problems detected
+        </div>
+      ) : (
+        <table className="w-full">
+          <thead className="sticky top-0 bg-canopy-sidebar border-b border-canopy-border">
+            <tr>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-24">Time</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-20">Type</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400">Message</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-28">Source</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-24">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {activeErrors.map((error) => (
+              <ErrorRow
+                key={error.id}
+                error={error}
+                isExpanded={expandedIds.has(error.id)}
+                onToggleExpand={() => handleToggleExpand(error.id)}
+                onDismiss={() => dismissError(error.id)}
+                onRetry={
+                  error.retryAction && onRetry
+                    ? () => onRetry(error.id, error.retryAction!, error.retryArgs)
+                    : undefined
+                }
+              />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/src/components/Diagnostics/index.ts
+++ b/src/components/Diagnostics/index.ts
@@ -1,0 +1,5 @@
+export { DiagnosticsDock } from "./DiagnosticsDock";
+export { ProblemsContent } from "./ProblemsContent";
+export { LogsContent } from "./LogsContent";
+export { EventsContent } from "./EventsContent";
+export { ProblemsActions, LogsActions, EventsActions } from "./DiagnosticsActions";

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -90,20 +90,34 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     description: "Inject context into focused terminal",
   },
 
-  // Panels
+  // Panels - unified diagnostics dock
   {
     actionId: "panel.logs",
     combo: "Ctrl+Shift+L",
     scope: "global",
     priority: 0,
-    description: "Toggle logs panel",
+    description: "Open diagnostics dock to Logs tab",
   },
   {
     actionId: "panel.events",
     combo: "Ctrl+Shift+E",
     scope: "global",
     priority: 0,
-    description: "Toggle event inspector",
+    description: "Open diagnostics dock to Events tab",
+  },
+  {
+    actionId: "panel.problems",
+    combo: "Ctrl+Shift+M",
+    scope: "global",
+    priority: 0,
+    description: "Open diagnostics dock to Problems tab",
+  },
+  {
+    actionId: "panel.diagnostics",
+    combo: "Ctrl+`",
+    scope: "global",
+    priority: 0,
+    description: "Toggle diagnostics dock",
   },
 
   // === Modal shortcuts (active in dialogs) ===

--- a/src/store/diagnosticsStore.ts
+++ b/src/store/diagnosticsStore.ts
@@ -1,0 +1,81 @@
+/**
+ * Diagnostics Store
+ *
+ * Zustand store for managing the unified diagnostics dock state.
+ * The dock consolidates Problems, Logs, and Events tabs.
+ */
+
+import { create, type StateCreator } from "zustand";
+
+export type DiagnosticsTab = "problems" | "logs" | "events";
+
+interface DiagnosticsState {
+  // Whether the dock is open
+  isOpen: boolean;
+
+  // Currently active tab
+  activeTab: DiagnosticsTab;
+
+  // Dock height (resizable)
+  height: number;
+
+  // Actions
+  toggleDock: () => void;
+  openDock: (tab?: DiagnosticsTab) => void;
+  closeDock: () => void;
+  setActiveTab: (tab: DiagnosticsTab) => void;
+  setOpen: (open: boolean) => void;
+  setHeight: (height: number) => void;
+}
+
+const DEFAULT_HEIGHT = 256;
+const MIN_HEIGHT = 128;
+const MAX_HEIGHT_RATIO = 0.5; // 50% of viewport
+
+const createDiagnosticsStore: StateCreator<DiagnosticsState> = (set) => ({
+  isOpen: false,
+  activeTab: "problems",
+  height: DEFAULT_HEIGHT,
+
+  toggleDock: () =>
+    set((state) => ({
+      isOpen: !state.isOpen,
+    })),
+
+  openDock: (tab) =>
+    set((state) => ({
+      isOpen: true,
+      activeTab: tab ?? state.activeTab,
+    })),
+
+  closeDock: () =>
+    set({
+      isOpen: false,
+    }),
+
+  setActiveTab: (tab) =>
+    set({
+      activeTab: tab,
+    }),
+
+  setOpen: (isOpen) =>
+    set({
+      isOpen,
+    }),
+
+  setHeight: (height) => {
+    // Clamp height between min and max
+    // Guard for SSR/test environments
+    const maxHeight =
+      typeof window !== "undefined" ? window.innerHeight * MAX_HEIGHT_RATIO : height;
+    const clampedHeight = Math.min(Math.max(height, MIN_HEIGHT), maxHeight);
+    set({ height: clampedHeight });
+  },
+});
+
+export const useDiagnosticsStore = create<DiagnosticsState>(createDiagnosticsStore);
+
+// Export constants for use in components
+export const DIAGNOSTICS_MIN_HEIGHT = MIN_HEIGHT;
+export const DIAGNOSTICS_MAX_HEIGHT_RATIO = MAX_HEIGHT_RATIO;
+export const DIAGNOSTICS_DEFAULT_HEIGHT = DEFAULT_HEIGHT;

--- a/src/store/focusStore.ts
+++ b/src/store/focusStore.ts
@@ -2,16 +2,15 @@
  * Focus Mode Store
  *
  * Zustand store for managing focus mode state.
- * Focus mode collapses all panels (sidebar, logs, event inspector)
+ * Focus mode collapses all panels (sidebar, diagnostics dock)
  * to maximize terminal workspace.
  */
 
 import { create, type StateCreator } from "zustand";
 
-interface PanelState {
+export interface PanelState {
   sidebarWidth: number;
-  logsOpen: boolean;
-  eventInspectorOpen: boolean;
+  diagnosticsOpen: boolean;
 }
 
 interface FocusState {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,6 +13,15 @@ export { useEventStore } from "./eventStore";
 export { useProjectStore } from "./projectStore";
 
 export { useFocusStore } from "./focusStore";
+export type { PanelState } from "./focusStore";
 
 export { useNotificationStore } from "./notificationStore";
 export type { Notification, NotificationType } from "./notificationStore";
+
+export { useDiagnosticsStore } from "./diagnosticsStore";
+export type { DiagnosticsTab } from "./diagnosticsStore";
+export {
+  DIAGNOSTICS_MIN_HEIGHT,
+  DIAGNOSTICS_MAX_HEIGHT_RATIO,
+  DIAGNOSTICS_DEFAULT_HEIGHT,
+} from "./diagnosticsStore";


### PR DESCRIPTION
## Summary

Consolidates the separate Problems, Logs, and Events panels into a unified DiagnosticsDock component with tabbed navigation. This provides a cleaner, more organized interface for viewing application diagnostics.

Closes #204

## Changes Made

- Add DiagnosticsDock component with resizable height and tab navigation
- Create diagnosticsStore for managing dock state (isOpen, activeTab, height)
- Extract content components (ProblemsContent, LogsContent, EventsContent) from original panels
- Add tab-specific action buttons in DiagnosticsActions component
- Update AppLayout to render DiagnosticsDock instead of separate panels
- Add keyboard shortcuts for tab switching (Ctrl+Shift+M/L/E, Ctrl+`)
- Implement auto-open on first error functionality
- Update focusStore PanelState from logsOpen/eventInspectorOpen to diagnosticsOpen
- Add backward compatibility for legacy focusPanelState format migration
- Add diagnosticsHeight persistence to electron store schema
- Fix accessibility with proper ARIA attributes for tabs and panels
- Add error handling for IPC calls in content components
- Optimize EventsContent with memoized filtered events for better performance

## Implementation Details

The unified dock replaces three separate panels with:
- **Problems tab**: Error tracking with retry actions
- **Logs tab**: Application log viewer with filtering
- **Events tab**: Event inspector with timeline

The dock features:
- Resizable height with drag handle (persisted to electron-store)
- Tab-specific toolbar actions (clear, open file, etc.)
- Keyboard shortcuts for quick navigation
- Auto-open to Problems tab when first error occurs
- Smooth transitions and proper ARIA accessibility