### PR TITLE
Add dedicated settings page for AI agent CLIs

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -138,6 +138,11 @@ export const CHANNELS = {
   RUN_GET_ACTIVE: "run:get-active",
   RUN_CLEAR_FINISHED: "run:clear-finished",
   RUN_EVENT: "run:event",
+
+  // Agent settings channels
+  AGENT_SETTINGS_GET: "agent-settings:get",
+  AGENT_SETTINGS_SET: "agent-settings:set",
+  AGENT_SETTINGS_RESET: "agent-settings:reset",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -51,6 +51,10 @@ import type {
   RunMetadata,
   IpcInvokeMap,
   IpcEventMap,
+  AgentSettings,
+  ClaudeSettings,
+  GeminiSettings,
+  CodexSettings,
 } from "@shared/types";
 
 // Re-export ElectronAPI for type declarations
@@ -243,6 +247,11 @@ const CHANNELS = {
   RUN_GET_ACTIVE: "run:get-active",
   RUN_CLEAR_FINISHED: "run:clear-finished",
   RUN_EVENT: "run:event",
+
+  // Agent settings channels
+  AGENT_SETTINGS_GET: "agent-settings:get",
+  AGENT_SETTINGS_SET: "agent-settings:set",
+  AGENT_SETTINGS_RESET: "agent-settings:reset",
 } as const;
 
 const api: ElectronAPI = {
@@ -694,6 +703,25 @@ const api: ElectronAPI = {
       ipcRenderer.on(CHANNELS.RUN_EVENT, handler);
       return () => ipcRenderer.removeListener(CHANNELS.RUN_EVENT, handler);
     },
+  },
+
+  // ==========================================
+  // Agent Settings API
+  // ==========================================
+  agentSettings: {
+    get: (): Promise<AgentSettings> => ipcRenderer.invoke(CHANNELS.AGENT_SETTINGS_GET),
+
+    setClaude: (settings: Partial<ClaudeSettings>): Promise<AgentSettings> =>
+      ipcRenderer.invoke(CHANNELS.AGENT_SETTINGS_SET, { agentType: "claude", settings }),
+
+    setGemini: (settings: Partial<GeminiSettings>): Promise<AgentSettings> =>
+      ipcRenderer.invoke(CHANNELS.AGENT_SETTINGS_SET, { agentType: "gemini", settings }),
+
+    setCodex: (settings: Partial<CodexSettings>): Promise<AgentSettings> =>
+      ipcRenderer.invoke(CHANNELS.AGENT_SETTINGS_SET, { agentType: "codex", settings }),
+
+    reset: (agentType?: "claude" | "gemini" | "codex"): Promise<AgentSettings> =>
+      ipcRenderer.invoke(CHANNELS.AGENT_SETTINGS_RESET, agentType),
   },
 };
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -1,6 +1,8 @@
 import Store from "electron-store";
 import type { RecentDirectory } from "./types/index.js";
 import type { Project } from "./types/index.js";
+import type { AgentSettings } from "@shared/types/index.js";
+import { DEFAULT_AGENT_SETTINGS } from "@shared/types/index.js";
 
 export type { RecentDirectory };
 
@@ -57,6 +59,8 @@ export interface StoreSchema {
     /** Whether AI features are enabled */
     aiEnabled?: boolean;
   };
+  /** Agent CLI settings for Claude, Gemini, and Codex */
+  agentSettings: AgentSettings;
 }
 
 export const store = new Store<StoreSchema>({
@@ -84,5 +88,6 @@ export const store = new Store<StoreSchema>({
       aiModel: "gpt-5-nano",
       aiEnabled: true,
     },
+    agentSettings: DEFAULT_AGENT_SETTINGS,
   },
 });

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1,0 +1,269 @@
+/**
+ * Agent Settings Type Definitions
+ *
+ * Types for configuring AI agent CLI options (Claude, Gemini, Codex).
+ * These settings allow users to customize agent behavior through CLI flags
+ * like approval modes, models, sandbox policies, and other advanced options.
+ */
+
+// ============================================================================
+// Claude Settings
+// ============================================================================
+
+/**
+ * Permission/approval mode for Claude CLI
+ * - "default": Standard permission prompts
+ * - "bypass": Bypass permission checks (--permission-mode bypassPermissions)
+ * - "yolo": Don't ask for permissions (--permission-mode dontAsk)
+ */
+export type ClaudeApprovalMode = "default" | "bypass" | "yolo";
+
+/**
+ * Settings for Claude CLI configuration
+ */
+export interface ClaudeSettings {
+  /** Model selection (e.g., "sonnet", "opus", "haiku", or full name) */
+  model?: string;
+  /** Permission handling mode */
+  approvalMode?: ClaudeApprovalMode;
+  /** Skip all permission checks (⚠️ dangerous) */
+  dangerouslySkipPermissions?: boolean;
+  /** Whitelist of allowed tools (comma-separated when passed to CLI) */
+  allowedTools?: string[];
+  /** Blacklist of denied tools (comma-separated when passed to CLI) */
+  disallowedTools?: string[];
+  /** Custom system prompt */
+  systemPrompt?: string;
+  /** Freeform additional CLI flags */
+  customFlags?: string;
+}
+
+// ============================================================================
+// Gemini Settings
+// ============================================================================
+
+/**
+ * Approval mode for Gemini CLI
+ * - "default": Standard approval prompts
+ * - "auto_edit": Auto-approve edits
+ * - "yolo": Auto-accept all actions (⚠️ dangerous)
+ */
+export type GeminiApprovalMode = "default" | "auto_edit" | "yolo";
+
+/**
+ * Settings for Gemini CLI configuration
+ */
+export interface GeminiSettings {
+  /** Model selection */
+  model?: string;
+  /** Approval mode */
+  approvalMode?: GeminiApprovalMode;
+  /** Auto-accept all actions (⚠️ dangerous) - shortcut for yolo mode */
+  yolo?: boolean;
+  /** Run in sandbox mode */
+  sandbox?: boolean;
+  /** Freeform additional CLI flags */
+  customFlags?: string;
+}
+
+// ============================================================================
+// Codex Settings
+// ============================================================================
+
+/**
+ * Sandbox policy for Codex CLI
+ * - "read-only": Can only read files
+ * - "workspace-write": Can write to workspace
+ * - "danger-full-access": Full filesystem access (⚠️ dangerous)
+ */
+export type CodexSandboxPolicy = "read-only" | "workspace-write" | "danger-full-access";
+
+/**
+ * Approval policy for Codex CLI
+ * - "untrusted": Requires approval for all commands
+ * - "on-failure": Only requires approval on failures
+ * - "on-request": Only when explicitly requested
+ * - "never": Never ask for approval
+ */
+export type CodexApprovalPolicy = "untrusted" | "on-failure" | "on-request" | "never";
+
+/**
+ * Settings for Codex CLI configuration
+ */
+export interface CodexSettings {
+  /** Model selection (e.g., "o3", "o4-mini") */
+  model?: string;
+  /** Sandbox policy */
+  sandbox?: CodexSandboxPolicy;
+  /** Approval policy for shell commands */
+  approvalPolicy?: CodexApprovalPolicy;
+  /** Low-friction sandboxed execution */
+  fullAuto?: boolean;
+  /** Skip all checks (⚠️ EXTREMELY DANGEROUS) */
+  dangerouslyBypassApprovalsAndSandbox?: boolean;
+  /** Enable web search */
+  search?: boolean;
+  /** Freeform additional CLI flags */
+  customFlags?: string;
+}
+
+// ============================================================================
+// Unified Agent Settings
+// ============================================================================
+
+/**
+ * Complete agent settings configuration
+ */
+export interface AgentSettings {
+  claude: ClaudeSettings;
+  gemini: GeminiSettings;
+  codex: CodexSettings;
+}
+
+/**
+ * Default agent settings with safe values
+ */
+export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
+  claude: {
+    model: "",
+    approvalMode: "default",
+    dangerouslySkipPermissions: false,
+    allowedTools: [],
+    disallowedTools: [],
+    systemPrompt: "",
+    customFlags: "",
+  },
+  gemini: {
+    model: "",
+    approvalMode: "default",
+    yolo: false,
+    sandbox: false,
+    customFlags: "",
+  },
+  codex: {
+    model: "",
+    sandbox: "workspace-write",
+    approvalPolicy: "untrusted",
+    fullAuto: false,
+    dangerouslyBypassApprovalsAndSandbox: false,
+    search: false,
+    customFlags: "",
+  },
+};
+
+// ============================================================================
+// CLI Flag Generation
+// ============================================================================
+
+/**
+ * Generate CLI flags for Claude from settings
+ */
+export function generateClaudeFlags(settings: ClaudeSettings): string[] {
+  const flags: string[] = [];
+
+  if (settings.model) {
+    flags.push("--model", settings.model);
+  }
+
+  if (settings.dangerouslySkipPermissions) {
+    flags.push("--dangerously-skip-permissions");
+  } else if (settings.approvalMode === "bypass") {
+    flags.push("--permission-mode", "bypassPermissions");
+  } else if (settings.approvalMode === "yolo") {
+    flags.push("--permission-mode", "dontAsk");
+  }
+
+  if (settings.allowedTools && settings.allowedTools.length > 0) {
+    flags.push("--allowed-tools", settings.allowedTools.join(","));
+  }
+
+  if (settings.disallowedTools && settings.disallowedTools.length > 0) {
+    flags.push("--disallowed-tools", settings.disallowedTools.join(","));
+  }
+
+  if (settings.systemPrompt) {
+    flags.push("--system-prompt", settings.systemPrompt);
+  }
+
+  // Append custom flags (split on spaces, basic parsing)
+  if (settings.customFlags) {
+    const trimmed = settings.customFlags.trim();
+    if (trimmed) {
+      flags.push(...trimmed.split(/\s+/));
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Generate CLI flags for Gemini from settings
+ */
+export function generateGeminiFlags(settings: GeminiSettings): string[] {
+  const flags: string[] = [];
+
+  if (settings.model) {
+    flags.push("--model", settings.model);
+  }
+
+  if (settings.yolo || settings.approvalMode === "yolo") {
+    flags.push("--yolo");
+  } else if (settings.approvalMode && settings.approvalMode !== "default") {
+    flags.push("--approval-mode", settings.approvalMode);
+  }
+
+  if (settings.sandbox) {
+    flags.push("--sandbox");
+  }
+
+  // Append custom flags
+  if (settings.customFlags) {
+    const trimmed = settings.customFlags.trim();
+    if (trimmed) {
+      flags.push(...trimmed.split(/\s+/));
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Generate CLI flags for Codex from settings
+ */
+export function generateCodexFlags(settings: CodexSettings): string[] {
+  const flags: string[] = [];
+
+  if (settings.model) {
+    flags.push("--model", settings.model);
+  }
+
+  if (settings.dangerouslyBypassApprovalsAndSandbox) {
+    flags.push("--dangerously-bypass-approvals-and-sandbox");
+  } else {
+    if (settings.sandbox) {
+      flags.push("--sandbox", settings.sandbox);
+    }
+
+    if (settings.approvalPolicy) {
+      flags.push("--ask-for-approval", settings.approvalPolicy);
+    }
+
+    if (settings.fullAuto) {
+      flags.push("--full-auto");
+    }
+  }
+
+  if (settings.search) {
+    flags.push("--search");
+  }
+
+  // Append custom flags
+  if (settings.customFlags) {
+    const trimmed = settings.customFlags.trim();
+    if (trimmed) {
+      flags.push(...trimmed.split(/\s+/));
+    }
+  }
+
+  return flags;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -165,6 +165,30 @@ export type {
 // Keymap types - keyboard shortcuts
 export type { KeyAction, KeymapPreset, KeyMapConfig } from "./keymap.js";
 
+// Agent settings types - AI agent CLI configuration
+export type {
+  // Claude settings
+  ClaudeApprovalMode,
+  ClaudeSettings,
+  // Gemini settings
+  GeminiApprovalMode,
+  GeminiSettings,
+  // Codex settings
+  CodexSandboxPolicy,
+  CodexApprovalPolicy,
+  CodexSettings,
+  // Unified settings
+  AgentSettings,
+} from "./agentSettings.js";
+
+// Agent settings helpers
+export {
+  DEFAULT_AGENT_SETTINGS,
+  generateClaudeFlags,
+  generateGeminiFlags,
+  generateCodexFlags,
+} from "./agentSettings.js";
+
 // Event types - run orchestration and event context
 export type {
   // Event context for correlation

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -18,6 +18,12 @@ import type {
   RunCommand,
 } from "./domain.js";
 import type { EventContext, RunMetadata } from "./events.js";
+import type {
+  AgentSettings,
+  ClaudeSettings,
+  GeminiSettings,
+  CodexSettings,
+} from "./agentSettings.js";
 
 // ============================================================================
 // Terminal IPC Types
@@ -1178,6 +1184,24 @@ export interface IpcInvokeMap {
     args: [olderThan?: number];
     result: number;
   };
+
+  // ============================================
+  // Agent settings channels
+  // ============================================
+  "agent-settings:get": {
+    args: [];
+    result: AgentSettings;
+  };
+  "agent-settings:set": {
+    args: [
+      payload: { agentType: "claude" | "gemini" | "codex"; settings: Record<string, unknown> },
+    ];
+    result: AgentSettings;
+  };
+  "agent-settings:reset": {
+    args: [agentType?: "claude" | "gemini" | "codex"];
+    result: AgentSettings;
+  };
 }
 
 /**
@@ -1432,5 +1456,12 @@ export interface ElectronAPI {
     getActive(): Promise<RunMetadata[]>;
     clearFinished(olderThan?: number): Promise<number>;
     onEvent(callback: (event: { type: string; payload: unknown }) => void): () => void;
+  };
+  agentSettings: {
+    get(): Promise<AgentSettings>;
+    setClaude(settings: Partial<ClaudeSettings>): Promise<AgentSettings>;
+    setGemini(settings: Partial<GeminiSettings>): Promise<AgentSettings>;
+    setCodex(settings: Partial<CodexSettings>): Promise<AgentSettings>;
+    reset(agentType?: "claude" | "gemini" | "codex"): Promise<AgentSettings>;
   };
 }

--- a/src/clients/agentSettingsClient.ts
+++ b/src/clients/agentSettingsClient.ts
@@ -1,0 +1,46 @@
+/**
+ * Agent Settings IPC Client
+ *
+ * Provides a typed interface for agent settings IPC operations.
+ * Wraps window.electron.agentSettings.* calls for testability and maintainability.
+ */
+
+import type { AgentSettings, ClaudeSettings, GeminiSettings, CodexSettings } from "@shared/types";
+
+/**
+ * Client for agent settings IPC operations.
+ *
+ * @example
+ * ```typescript
+ * import { agentSettingsClient } from "@/clients/agentSettingsClient";
+ *
+ * const settings = await agentSettingsClient.get();
+ * await agentSettingsClient.setClaude({ model: "opus" });
+ * ```
+ */
+export const agentSettingsClient = {
+  /** Get all agent settings */
+  get: (): Promise<AgentSettings> => {
+    return window.electron.agentSettings.get();
+  },
+
+  /** Update Claude settings */
+  setClaude: (settings: Partial<ClaudeSettings>): Promise<AgentSettings> => {
+    return window.electron.agentSettings.setClaude(settings);
+  },
+
+  /** Update Gemini settings */
+  setGemini: (settings: Partial<GeminiSettings>): Promise<AgentSettings> => {
+    return window.electron.agentSettings.setGemini(settings);
+  },
+
+  /** Update Codex settings */
+  setCodex: (settings: Partial<CodexSettings>): Promise<AgentSettings> => {
+    return window.electron.agentSettings.setCodex(settings);
+  },
+
+  /** Reset agent settings to defaults */
+  reset: (agentType?: "claude" | "gemini" | "codex"): Promise<AgentSettings> => {
+    return window.electron.agentSettings.reset(agentType);
+  },
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -35,6 +35,7 @@
  * ```
  */
 
+export { agentSettingsClient } from "./agentSettingsClient";
 export { aiClient } from "./aiClient";
 export { appClient } from "./appClient";
 export { artifactClient } from "./artifactClient";

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -1,0 +1,680 @@
+/**
+ * Agent Settings Component
+ *
+ * Settings panel for configuring AI agent CLI options (Claude, Gemini, Codex).
+ * Provides UI for approval modes, models, sandbox policies, and advanced options.
+ */
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { RotateCcw, AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
+import type {
+  AgentSettings as AgentSettingsType,
+  ClaudeApprovalMode,
+  GeminiApprovalMode,
+  CodexSandboxPolicy,
+  CodexApprovalPolicy,
+} from "@shared/types";
+import { agentSettingsClient } from "@/clients";
+
+type AgentTab = "claude" | "gemini" | "codex";
+
+interface AgentSettingsProps {
+  onSettingsChange?: () => void;
+}
+
+export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
+  const [activeTab, setActiveTab] = useState<AgentTab>("claude");
+  const [settings, setSettings] = useState<AgentSettingsType | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  // Load settings on mount
+  useEffect(() => {
+    loadSettings();
+  }, []);
+
+  const loadSettings = async () => {
+    try {
+      const loaded = await agentSettingsClient.get();
+      setSettings(loaded);
+    } catch (error) {
+      console.error("Failed to load agent settings:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleClaudeChange = async (updates: Record<string, unknown>) => {
+    try {
+      const updated = await agentSettingsClient.setClaude(updates);
+      setSettings(updated);
+      onSettingsChange?.();
+    } catch (error) {
+      console.error("Failed to update Claude settings:", error);
+    }
+  };
+
+  const handleGeminiChange = async (updates: Record<string, unknown>) => {
+    try {
+      const updated = await agentSettingsClient.setGemini(updates);
+      setSettings(updated);
+      onSettingsChange?.();
+    } catch (error) {
+      console.error("Failed to update Gemini settings:", error);
+    }
+  };
+
+  const handleCodexChange = async (updates: Record<string, unknown>) => {
+    try {
+      const updated = await agentSettingsClient.setCodex(updates);
+      setSettings(updated);
+      onSettingsChange?.();
+    } catch (error) {
+      console.error("Failed to update Codex settings:", error);
+    }
+  };
+
+  const handleReset = async (agentType: AgentTab) => {
+    try {
+      const updated = await agentSettingsClient.reset(agentType);
+      setSettings(updated);
+      onSettingsChange?.();
+    } catch (error) {
+      console.error(`Failed to reset ${agentType} settings:`, error);
+    }
+  };
+
+  if (isLoading || !settings) {
+    return (
+      <div className="flex items-center justify-center h-32">
+        <div className="text-gray-400 text-sm">Loading settings...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Agent Tabs */}
+      <div className="flex gap-2 border-b border-canopy-border pb-2">
+        {(["claude", "gemini", "codex"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={cn(
+              "px-4 py-2 text-sm font-medium rounded-t-md transition-colors capitalize",
+              activeTab === tab
+                ? "bg-canopy-accent/10 text-canopy-accent border-b-2 border-canopy-accent"
+                : "text-gray-400 hover:text-canopy-text hover:bg-canopy-border/50"
+            )}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      {/* Claude Settings */}
+      {activeTab === "claude" && (
+        <div className="space-y-4">
+          {/* Model */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Model</label>
+            <input
+              type="text"
+              value={settings.claude.model || ""}
+              onChange={(e) => handleClaudeChange({ model: e.target.value })}
+              placeholder="e.g., sonnet, opus, haiku"
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+            />
+            <p className="text-xs text-gray-500">
+              Leave empty to use Claude CLI default. Options: sonnet, opus, haiku, or full model
+              names.
+            </p>
+          </div>
+
+          {/* Approval Mode */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Approval Mode</label>
+            <div className="space-y-2">
+              {[
+                {
+                  value: "default" as const,
+                  label: "Default",
+                  desc: "Standard permission prompts",
+                  warning: false,
+                },
+                {
+                  value: "bypass" as const,
+                  label: "Bypass Permissions",
+                  desc: "Skip standard permission checks",
+                  warning: false,
+                },
+                {
+                  value: "yolo" as const,
+                  label: "Don't Ask",
+                  desc: "Don't ask for any permissions",
+                  warning: true,
+                },
+              ].map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
+                    settings.claude.approvalMode === option.value
+                      ? "border-canopy-accent bg-canopy-accent/10"
+                      : "border-canopy-border hover:border-gray-500"
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="claude-approval"
+                    value={option.value}
+                    checked={settings.claude.approvalMode === option.value}
+                    onChange={() =>
+                      handleClaudeChange({ approvalMode: option.value as ClaudeApprovalMode })
+                    }
+                    className="sr-only"
+                  />
+                  <div
+                    className={cn(
+                      "w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5",
+                      settings.claude.approvalMode === option.value
+                        ? "border-canopy-accent"
+                        : "border-gray-500"
+                    )}
+                  >
+                    {settings.claude.approvalMode === option.value && (
+                      <div className="w-2 h-2 rounded-full bg-canopy-accent" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <div className="text-sm font-medium text-canopy-text flex items-center gap-2">
+                      {option.label}
+                      {option.warning && <AlertTriangle className="w-3.5 h-3.5 text-yellow-500" />}
+                    </div>
+                    <div className="text-xs text-gray-500">{option.desc}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Advanced Section */}
+          <div className="border-t border-canopy-border pt-4">
+            <button
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="flex items-center gap-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+            >
+              {showAdvanced ? (
+                <ChevronUp className="w-4 h-4" />
+              ) : (
+                <ChevronDown className="w-4 h-4" />
+              )}
+              Advanced Options
+            </button>
+
+            {showAdvanced && (
+              <div className="mt-4 space-y-4">
+                {/* Dangerously Skip Permissions */}
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <button
+                    onClick={() =>
+                      handleClaudeChange({
+                        dangerouslySkipPermissions: !settings.claude.dangerouslySkipPermissions,
+                      })
+                    }
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors",
+                      settings.claude.dangerouslySkipPermissions ? "bg-red-500" : "bg-gray-600"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                        settings.claude.dangerouslySkipPermissions && "translate-x-5"
+                      )}
+                    />
+                  </button>
+                  <div>
+                    <span className="text-sm text-canopy-text flex items-center gap-2">
+                      Dangerously Skip All Permissions
+                      <AlertTriangle className="w-3.5 h-3.5 text-red-500" />
+                    </span>
+                    <p className="text-xs text-gray-500">
+                      Skip all permission checks entirely (DANGEROUS)
+                    </p>
+                  </div>
+                </label>
+
+                {/* System Prompt */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-canopy-text">System Prompt</label>
+                  <textarea
+                    value={settings.claude.systemPrompt || ""}
+                    onChange={(e) => handleClaudeChange({ systemPrompt: e.target.value })}
+                    placeholder="Custom system instructions..."
+                    rows={3}
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent resize-none"
+                  />
+                </div>
+
+                {/* Custom Flags */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-canopy-text">Custom Flags</label>
+                  <input
+                    type="text"
+                    value={settings.claude.customFlags || ""}
+                    onChange={(e) => handleClaudeChange({ customFlags: e.target.value })}
+                    placeholder="e.g., --verbose --no-color"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                  />
+                  <p className="text-xs text-gray-500">
+                    Additional CLI flags to pass to Claude (space-separated)
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Reset Button */}
+          <div className="flex justify-end pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleReset("claude")}
+              className="text-gray-400 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+            >
+              <RotateCcw className="w-4 h-4 mr-2" />
+              Reset to Defaults
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Gemini Settings */}
+      {activeTab === "gemini" && (
+        <div className="space-y-4">
+          {/* Model */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Model</label>
+            <input
+              type="text"
+              value={settings.gemini.model || ""}
+              onChange={(e) => handleGeminiChange({ model: e.target.value })}
+              placeholder="e.g., gemini-2.0-flash"
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+            />
+            <p className="text-xs text-gray-500">Leave empty to use Gemini CLI default.</p>
+          </div>
+
+          {/* Approval Mode */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Approval Mode</label>
+            <div className="space-y-2">
+              {[
+                {
+                  value: "default" as const,
+                  label: "Default",
+                  desc: "Standard approval prompts",
+                  warning: false,
+                },
+                {
+                  value: "auto_edit" as const,
+                  label: "Auto Edit",
+                  desc: "Auto-approve file edits",
+                  warning: false,
+                },
+                {
+                  value: "yolo" as const,
+                  label: "YOLO Mode",
+                  desc: "Auto-accept all actions",
+                  warning: true,
+                },
+              ].map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
+                    settings.gemini.approvalMode === option.value
+                      ? "border-canopy-accent bg-canopy-accent/10"
+                      : "border-canopy-border hover:border-gray-500"
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="gemini-approval"
+                    value={option.value}
+                    checked={settings.gemini.approvalMode === option.value}
+                    onChange={() =>
+                      handleGeminiChange({ approvalMode: option.value as GeminiApprovalMode })
+                    }
+                    className="sr-only"
+                  />
+                  <div
+                    className={cn(
+                      "w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5",
+                      settings.gemini.approvalMode === option.value
+                        ? "border-canopy-accent"
+                        : "border-gray-500"
+                    )}
+                  >
+                    {settings.gemini.approvalMode === option.value && (
+                      <div className="w-2 h-2 rounded-full bg-canopy-accent" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <div className="text-sm font-medium text-canopy-text flex items-center gap-2">
+                      {option.label}
+                      {option.warning && <AlertTriangle className="w-3.5 h-3.5 text-yellow-500" />}
+                    </div>
+                    <div className="text-xs text-gray-500">{option.desc}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Advanced Section */}
+          <div className="border-t border-canopy-border pt-4">
+            <button
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="flex items-center gap-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+            >
+              {showAdvanced ? (
+                <ChevronUp className="w-4 h-4" />
+              ) : (
+                <ChevronDown className="w-4 h-4" />
+              )}
+              Advanced Options
+            </button>
+
+            {showAdvanced && (
+              <div className="mt-4 space-y-4">
+                {/* Sandbox */}
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <button
+                    onClick={() => handleGeminiChange({ sandbox: !settings.gemini.sandbox })}
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors",
+                      settings.gemini.sandbox ? "bg-canopy-accent" : "bg-gray-600"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                        settings.gemini.sandbox && "translate-x-5"
+                      )}
+                    />
+                  </button>
+                  <div>
+                    <span className="text-sm text-canopy-text">Enable Sandbox Mode</span>
+                    <p className="text-xs text-gray-500">Run Gemini in a sandboxed environment</p>
+                  </div>
+                </label>
+
+                {/* Custom Flags */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-canopy-text">Custom Flags</label>
+                  <input
+                    type="text"
+                    value={settings.gemini.customFlags || ""}
+                    onChange={(e) => handleGeminiChange({ customFlags: e.target.value })}
+                    placeholder="e.g., --verbose"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                  />
+                  <p className="text-xs text-gray-500">
+                    Additional CLI flags to pass to Gemini (space-separated)
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Reset Button */}
+          <div className="flex justify-end pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleReset("gemini")}
+              className="text-gray-400 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+            >
+              <RotateCcw className="w-4 h-4 mr-2" />
+              Reset to Defaults
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Codex Settings */}
+      {activeTab === "codex" && (
+        <div className="space-y-4">
+          {/* Model */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Model</label>
+            <input
+              type="text"
+              value={settings.codex.model || ""}
+              onChange={(e) => handleCodexChange({ model: e.target.value })}
+              placeholder="e.g., o3, o4-mini"
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+            />
+            <p className="text-xs text-gray-500">Leave empty to use Codex CLI default.</p>
+          </div>
+
+          {/* Sandbox Policy */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Sandbox Policy</label>
+            <div className="space-y-2">
+              {[
+                {
+                  value: "read-only" as const,
+                  label: "Read Only",
+                  desc: "Can only read files",
+                  warning: false,
+                },
+                {
+                  value: "workspace-write" as const,
+                  label: "Workspace Write",
+                  desc: "Can write to workspace",
+                  warning: false,
+                },
+                {
+                  value: "danger-full-access" as const,
+                  label: "Full Access",
+                  desc: "Full filesystem access",
+                  warning: true,
+                },
+              ].map((option) => (
+                <label
+                  key={option.value}
+                  className={cn(
+                    "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
+                    settings.codex.sandbox === option.value
+                      ? "border-canopy-accent bg-canopy-accent/10"
+                      : "border-canopy-border hover:border-gray-500"
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="codex-sandbox"
+                    value={option.value}
+                    checked={settings.codex.sandbox === option.value}
+                    onChange={() =>
+                      handleCodexChange({ sandbox: option.value as CodexSandboxPolicy })
+                    }
+                    className="sr-only"
+                  />
+                  <div
+                    className={cn(
+                      "w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5",
+                      settings.codex.sandbox === option.value
+                        ? "border-canopy-accent"
+                        : "border-gray-500"
+                    )}
+                  >
+                    {settings.codex.sandbox === option.value && (
+                      <div className="w-2 h-2 rounded-full bg-canopy-accent" />
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    <div className="text-sm font-medium text-canopy-text flex items-center gap-2">
+                      {option.label}
+                      {option.warning && <AlertTriangle className="w-3.5 h-3.5 text-yellow-500" />}
+                    </div>
+                    <div className="text-xs text-gray-500">{option.desc}</div>
+                  </div>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Approval Policy */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-canopy-text">Approval Policy</label>
+            <select
+              value={settings.codex.approvalPolicy || "untrusted"}
+              onChange={(e) =>
+                handleCodexChange({ approvalPolicy: e.target.value as CodexApprovalPolicy })
+              }
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+            >
+              <option value="untrusted">Untrusted (require approval)</option>
+              <option value="on-failure">On Failure (approve on errors)</option>
+              <option value="on-request">On Request (approve when asked)</option>
+              <option value="never">Never Ask</option>
+            </select>
+            <p className="text-xs text-gray-500">
+              When to ask for approval before executing shell commands
+            </p>
+          </div>
+
+          {/* Advanced Section */}
+          <div className="border-t border-canopy-border pt-4">
+            <button
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="flex items-center gap-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+            >
+              {showAdvanced ? (
+                <ChevronUp className="w-4 h-4" />
+              ) : (
+                <ChevronDown className="w-4 h-4" />
+              )}
+              Advanced Options
+            </button>
+
+            {showAdvanced && (
+              <div className="mt-4 space-y-4">
+                {/* Full Auto */}
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <button
+                    onClick={() => handleCodexChange({ fullAuto: !settings.codex.fullAuto })}
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors",
+                      settings.codex.fullAuto ? "bg-canopy-accent" : "bg-gray-600"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                        settings.codex.fullAuto && "translate-x-5"
+                      )}
+                    />
+                  </button>
+                  <div>
+                    <span className="text-sm text-canopy-text">Full Auto Mode</span>
+                    <p className="text-xs text-gray-500">Low-friction sandboxed execution</p>
+                  </div>
+                </label>
+
+                {/* Search */}
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <button
+                    onClick={() => handleCodexChange({ search: !settings.codex.search })}
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors",
+                      settings.codex.search ? "bg-canopy-accent" : "bg-gray-600"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                        settings.codex.search && "translate-x-5"
+                      )}
+                    />
+                  </button>
+                  <div>
+                    <span className="text-sm text-canopy-text">Enable Web Search</span>
+                    <p className="text-xs text-gray-500">Allow Codex to search the web</p>
+                  </div>
+                </label>
+
+                {/* Dangerously Bypass */}
+                <label className="flex items-center gap-3 cursor-pointer">
+                  <button
+                    onClick={() =>
+                      handleCodexChange({
+                        dangerouslyBypassApprovalsAndSandbox:
+                          !settings.codex.dangerouslyBypassApprovalsAndSandbox,
+                      })
+                    }
+                    className={cn(
+                      "relative w-11 h-6 rounded-full transition-colors",
+                      settings.codex.dangerouslyBypassApprovalsAndSandbox
+                        ? "bg-red-500"
+                        : "bg-gray-600"
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                        settings.codex.dangerouslyBypassApprovalsAndSandbox && "translate-x-5"
+                      )}
+                    />
+                  </button>
+                  <div>
+                    <span className="text-sm text-canopy-text flex items-center gap-2">
+                      Bypass All Checks
+                      <AlertTriangle className="w-3.5 h-3.5 text-red-500" />
+                    </span>
+                    <p className="text-xs text-gray-500">
+                      Skip sandbox and approval checks (EXTREMELY DANGEROUS)
+                    </p>
+                  </div>
+                </label>
+
+                {/* Custom Flags */}
+                <div className="space-y-2">
+                  <label className="text-sm font-medium text-canopy-text">Custom Flags</label>
+                  <input
+                    type="text"
+                    value={settings.codex.customFlags || ""}
+                    onChange={(e) => handleCodexChange({ customFlags: e.target.value })}
+                    placeholder="e.g., --verbose"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                  />
+                  <p className="text-xs text-gray-500">
+                    Additional CLI flags to pass to Codex (space-separated)
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Reset Button */}
+          <div className="flex justify-end pt-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => handleReset("codex")}
+              className="text-gray-400 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+            >
+              <RotateCcw className="w-4 h-4 mr-2" />
+              Reset to Defaults
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -20,10 +20,12 @@ import {
   Sparkles,
   FlaskConical,
   TreePine,
+  Bot,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AIServiceState } from "@/types";
 import { appClient, aiClient, logsClient } from "@/clients";
+import { AgentSettings } from "./AgentSettings";
 
 interface SettingsDialogProps {
   isOpen: boolean;
@@ -31,7 +33,7 @@ interface SettingsDialogProps {
   defaultTab?: SettingsTab;
 }
 
-type SettingsTab = "general" | "ai" | "troubleshooting";
+type SettingsTab = "general" | "agents" | "ai" | "troubleshooting";
 
 // Keyboard shortcuts organized by category
 const KEYBOARD_SHORTCUTS = [
@@ -246,6 +248,18 @@ export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogPr
             General
           </button>
           <button
+            onClick={() => setActiveTab("agents")}
+            className={cn(
+              "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
+              activeTab === "agents"
+                ? "bg-canopy-accent/10 text-canopy-accent"
+                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+            )}
+          >
+            <Bot className="w-4 h-4" />
+            Agents
+          </button>
+          <button
             onClick={() => setActiveTab("ai")}
             className={cn(
               "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
@@ -274,7 +288,11 @@ export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogPr
         <div className="flex-1 flex flex-col min-w-0">
           <div className="flex items-center justify-between p-6 border-b border-canopy-border">
             <h3 className="text-lg font-medium text-canopy-text capitalize">
-              {activeTab === "ai" ? "AI Features" : activeTab}
+              {activeTab === "ai"
+                ? "AI Features"
+                : activeTab === "agents"
+                  ? "Agent Settings"
+                  : activeTab}
             </h3>
             <button
               onClick={onClose}
@@ -345,6 +363,8 @@ export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogPr
                 </div>
               </div>
             )}
+
+            {activeTab === "agents" && <AgentSettings />}
 
             {activeTab === "ai" && (
               <div className="space-y-6">


### PR DESCRIPTION
## Summary
This PR implements a dedicated settings page for configuring AI agent CLI options (Claude, Gemini, Codex). Users can now customize agent behavior through a UI in the Settings dialog, including approval modes, models, sandbox policies, and advanced options like custom CLI flags.

Closes #201

## Changes Made
- Add AgentSettings types with Claude/Gemini/Codex configuration
- Add CLI flag generation functions for each agent
- Implement IPC handlers for get/set/reset operations
- Add persistence layer with defaults in electron-store
- Create AgentSettings UI component with tabbed interface
- Add Agents tab to SettingsDialog with approval modes and sandbox policies
- Update useAgentLauncher to apply settings when spawning terminals
- Add agentSettingsClient wrapper for type-safe IPC calls

## Testing
- TypeScript type checking passes
- ESLint passes (0 errors, existing warnings only)
- Prettier formatting passes
- All changes follow existing codebase patterns

## Follow-up Items (from Codex review)
The following enhancements should be addressed in future PRs:
1. Update Claude/Gemini CLI flag mappings to match latest CLI versions
2. Add IPC validation to prevent prototype pollution (use zod/yup schemas)
3. Implement settings reload on change (avoid stale settings in launcher)
4. Add debouncing to settings input to prevent race conditions
5. Make showAdvanced state per-tab instead of shared
6. Add error state handling if settings fail to load