### PR TITLE
feat(terminal): add terminal dock with minimize/restore functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@octokit/graphql": "^9.0.3",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-webgl": "^0.18.0",

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -266,6 +266,9 @@ export interface RunRecord {
 /** Type of terminal instance */
 export type TerminalType = "shell" | "claude" | "gemini" | "codex" | "custom";
 
+/** Location of a terminal instance in the UI */
+export type TerminalLocation = "grid" | "dock";
+
 /** Valid triggers for agent state changes */
 export type AgentStateChangeTrigger =
   | "input"
@@ -311,6 +314,8 @@ export interface TerminalInstance {
   activityType?: "interactive" | "background" | "idle";
   /** Timestamp when activity was last updated */
   activityTimestamp?: number;
+  /** Location in the UI - grid (main view) or dock (minimized) */
+  location: TerminalLocation;
 }
 
 /** Options for spawning a new PTY process */
@@ -378,6 +383,8 @@ export interface TerminalSnapshot {
   cwd: string;
   /** Associated worktree ID */
   worktreeId?: string;
+  /** Location in the UI - grid or dock */
+  location: TerminalLocation;
 }
 
 /** Terminal layout metadata */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -35,6 +35,7 @@ export type {
   RunRecord,
   // Terminal types
   TerminalType,
+  TerminalLocation,
   AgentStateChangeTrigger,
   TerminalInstance,
   PtySpawnOptions,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -11,6 +11,7 @@
 
 import type {
   TerminalType,
+  TerminalLocation,
   DevServerState,
   WorktreeState,
   Project,
@@ -66,6 +67,8 @@ export interface TerminalState {
   cwd: string;
   /** Associated worktree ID */
   worktreeId?: string;
+  /** Location in the UI - grid or dock */
+  location?: TerminalLocation;
 }
 
 /** Terminal data payload for IPC */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -366,6 +366,7 @@ function App() {
                 title: terminal.title,
                 cwd,
                 worktreeId: terminal.worktreeId,
+                location: terminal.location || "grid", // Restore dock state, default to grid for legacy
               });
             } catch (error) {
               console.warn(`Failed to restore terminal ${terminal.id}:`, error);

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, type ReactNode } from "react";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
+import { TerminalDock } from "./TerminalDock";
 import { DiagnosticsDock } from "../Diagnostics";
 import { useFocusStore, useDiagnosticsStore, useErrorStore, type PanelState } from "@/store";
 import type { RetryAction } from "@/store";
@@ -246,10 +247,18 @@ export function AppLayout({
             </Sidebar>
           )}
           <main
-            className="flex-1 overflow-hidden bg-canopy-bg"
-            style={{ flex: 1, overflow: "hidden", backgroundColor: "#1a1b26" }}
+            className="flex-1 flex flex-col overflow-hidden bg-canopy-bg"
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              backgroundColor: "#1a1b26",
+            }}
           >
-            {children}
+            <div className="flex-1 overflow-hidden min-h-0">{children}</div>
+            {/* Terminal Dock - appears at bottom only when terminals are docked */}
+            <TerminalDock />
           </main>
         </div>
         {/* Unified diagnostics dock replaces LogsPanel, EventInspectorPanel, and ProblemsPanel */}

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,0 +1,156 @@
+/**
+ * DockedTerminalItem Component
+ *
+ * A compact chip representing a docked terminal in the TerminalDock.
+ * Shows terminal title and agent state indicator.
+ * Clicking opens a popover with an interactive terminal preview.
+ */
+
+import { useState, useCallback } from "react";
+import { Maximize2, X, Loader2, Terminal, Command } from "lucide-react";
+import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
+import type { AgentState, TerminalType } from "@/types";
+
+interface DockedTerminalItemProps {
+  terminal: TerminalInstance;
+}
+
+/**
+ * Get terminal icon based on type
+ */
+function getTerminalIcon(type: TerminalType, className?: string) {
+  const props = { className: cn("w-3 h-3", className), "aria-hidden": "true" as const };
+  switch (type) {
+    case "claude":
+      return <ClaudeIcon {...props} />;
+    case "gemini":
+      return <GeminiIcon {...props} />;
+    case "codex":
+      return <CodexIcon {...props} />;
+    case "custom":
+      return <Command {...props} />;
+    case "shell":
+      return <Terminal {...props} />;
+  }
+}
+
+/**
+ * Get compact status indicator based on agent state
+ */
+function getStateIndicator(state?: AgentState) {
+  if (!state || state === "idle") return null;
+
+  switch (state) {
+    case "working":
+      return <Loader2 className="h-3 w-3 animate-spin text-blue-400" aria-hidden="true" />;
+    case "waiting":
+      return (
+        <span className="w-2 h-2 rounded-full bg-yellow-400 animate-pulse" aria-hidden="true" />
+      );
+    case "completed":
+      return <span className="w-2 h-2 rounded-full bg-green-400" aria-hidden="true" />;
+    case "failed":
+      return <span className="w-2 h-2 rounded-full bg-red-400" aria-hidden="true" />;
+    default:
+      return null;
+  }
+}
+
+export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
+  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
+
+  const handleRestore = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      moveTerminalToGrid(terminal.id);
+      setIsOpen(false);
+    },
+    [moveTerminalToGrid, terminal.id]
+  );
+
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      removeTerminal(terminal.id);
+      setIsOpen(false);
+    },
+    [removeTerminal, terminal.id]
+  );
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    setIsOpen(open);
+  }, []);
+
+  return (
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
+            "hover:bg-canopy-accent/10 border-canopy-border hover:border-canopy-accent/50",
+            isOpen && "bg-canopy-accent/20 border-canopy-accent"
+          )}
+          title={`${terminal.title} - Click to preview`}
+        >
+          {/* Terminal type icon */}
+          {getTerminalIcon(terminal.type)}
+
+          {/* Status indicator */}
+          {getStateIndicator(terminal.agentState)}
+
+          {/* Terminal title */}
+          <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-[700px] h-[500px] p-0 border-canopy-border bg-[#1a1b26] shadow-2xl"
+        side="top"
+        align="start"
+        sideOffset={8}
+      >
+        <div className="flex flex-col h-full">
+          {/* Mini Header */}
+          <div className="h-9 flex items-center justify-between px-3 border-b border-canopy-border bg-[#1a1b26] shrink-0">
+            <div className="flex items-center gap-2">
+              {getTerminalIcon(terminal.type, "text-canopy-text/70")}
+              {getStateIndicator(terminal.agentState)}
+              <span className="font-mono text-xs text-canopy-text">{terminal.title}</span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              {/* Restore to Grid Button */}
+              <button
+                onClick={handleRestore}
+                className="p-1 hover:bg-canopy-accent/20 rounded transition-colors text-canopy-text/60 hover:text-canopy-text"
+                title="Restore to grid"
+              >
+                <Maximize2 className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+
+              {/* Close (Kill) Button */}
+              <button
+                onClick={handleClose}
+                className="p-1 hover:bg-red-500/20 rounded transition-colors text-canopy-text/60 hover:text-red-400"
+                title="Close terminal"
+              >
+                <X className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          </div>
+
+          {/* The Actual Terminal */}
+          <div className="flex-1 relative overflow-hidden min-h-0">
+            <XtermAdapter terminalId={terminal.id} className="absolute inset-0" />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -1,0 +1,40 @@
+/**
+ * TerminalDock Component
+ *
+ * A dock bar at the bottom of the application that displays minimized terminals.
+ * Terminals can be docked to free up grid space while keeping them accessible.
+ * The dock only renders when there are docked terminals.
+ */
+
+import { useShallow } from "zustand/react/shallow";
+import { cn } from "@/lib/utils";
+import { useTerminalStore } from "@/store";
+import { DockedTerminalItem } from "./DockedTerminalItem";
+
+export function TerminalDock() {
+  // Filter terminals in dock location using shallow comparison
+  const dockTerminals = useTerminalStore(
+    useShallow((state) => state.terminals.filter((t) => t.location === "dock"))
+  );
+
+  // Don't render if no docked terminals
+  if (dockTerminals.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "h-10 bg-[#1a1b26] border-t border-canopy-border",
+        "flex items-center px-4 gap-2 overflow-x-auto",
+        "z-40 shrink-0"
+      )}
+    >
+      <span className="text-xs text-canopy-text/60 mr-2 shrink-0">
+        Background ({dockTerminals.length})
+      </span>
+
+      {dockTerminals.map((terminal) => (
+        <DockedTerminalItem key={terminal.id} terminal={terminal} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -17,7 +17,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { Terminal, Command, X, Maximize2, Minimize2, Copy } from "lucide-react";
+import { Terminal, Command, X, Maximize2, Minimize2, Copy, ArrowDownToLine } from "lucide-react";
 import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { XtermAdapter } from "./XtermAdapter";
@@ -83,6 +83,8 @@ export interface TerminalPaneProps {
   onToggleMaximize?: () => void;
   /** Called when user edits the terminal title */
   onTitleChange?: (newTitle: string) => void;
+  /** Called when minimize to dock button is clicked */
+  onMinimize?: () => void;
 }
 
 /**
@@ -123,6 +125,7 @@ export function TerminalPane({
   onCancelInjection: _onCancelInjection, // Unused with minimal progress bar
   onToggleMaximize,
   onTitleChange,
+  onMinimize,
 }: TerminalPaneProps) {
   const [isExited, setIsExited] = useState(false);
   const [exitCode, setExitCode] = useState<number | null>(null);
@@ -409,6 +412,19 @@ export function TerminalPane({
               disabled={isExited || isInjecting}
             >
               <Copy className="w-3 h-3" aria-hidden="true" />
+            </button>
+          )}
+          {onMinimize && !isMaximized && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onMinimize();
+              }}
+              className="p-1.5 hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent text-canopy-text/60 hover:text-canopy-text transition-colors"
+              title="Minimize to dock"
+              aria-label="Minimize terminal to dock"
+            >
+              <ArrowDownToLine className="w-3 h-3" aria-hidden="true" />
             </button>
           )}
           {onToggleMaximize && (

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,37 @@
+/**
+ * Popover Component
+ *
+ * Based on Radix UI Popover primitive with Canopy styling.
+ */
+
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar text-canopy-text shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/src/hooks/__tests__/useWorktreeTerminals.test.ts
+++ b/src/hooks/__tests__/useWorktreeTerminals.test.ts
@@ -61,6 +61,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
       },
       {
         id: "term-2",
@@ -70,6 +71,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/2",
         cols: 80,
         rows: 24,
+        location: "grid",
       },
       {
         id: "term-3",
@@ -79,6 +81,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
       },
     ];
 
@@ -99,6 +102,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         // No agentState
       },
       {
@@ -109,6 +113,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         // No agentState
       },
     ];
@@ -130,6 +135,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         agentState: "working",
       },
       {
@@ -140,6 +146,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         agentState: "working",
       },
       {
@@ -150,6 +157,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         agentState: "idle",
       },
       {
@@ -160,6 +168,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         agentState: "failed",
         error: "Test error",
       },
@@ -184,6 +193,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         // No worktreeId
       },
       {
@@ -194,6 +204,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
       },
     ];
 
@@ -214,6 +225,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         agentState: "waiting",
       },
       {
@@ -224,6 +236,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         // No agent state - should count as idle
       },
       {
@@ -234,6 +247,7 @@ describe("useWorktreeTerminals logic", () => {
         cwd: "/path/1",
         cols: 80,
         rows: 24,
+        location: "grid",
         agentState: "completed",
       },
     ];

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -53,27 +53,31 @@ export const createTerminalFocusSlice =
 
     focusNext: () => {
       const terminals = getTerminals();
-      if (terminals.length === 0) return;
+      // Only navigate through grid terminals (not docked ones)
+      const gridTerminals = terminals.filter((t) => t.location === "grid" || !t.location);
+      if (gridTerminals.length === 0) return;
 
       set((state) => {
         const currentIndex = state.focusedId
-          ? terminals.findIndex((t) => t.id === state.focusedId)
+          ? gridTerminals.findIndex((t) => t.id === state.focusedId)
           : -1;
-        const nextIndex = (currentIndex + 1) % terminals.length;
-        return { focusedId: terminals[nextIndex].id };
+        const nextIndex = (currentIndex + 1) % gridTerminals.length;
+        return { focusedId: gridTerminals[nextIndex].id };
       });
     },
 
     focusPrevious: () => {
       const terminals = getTerminals();
-      if (terminals.length === 0) return;
+      // Only navigate through grid terminals (not docked ones)
+      const gridTerminals = terminals.filter((t) => t.location === "grid" || !t.location);
+      if (gridTerminals.length === 0) return;
 
       set((state) => {
         const currentIndex = state.focusedId
-          ? terminals.findIndex((t) => t.id === state.focusedId)
+          ? gridTerminals.findIndex((t) => t.id === state.focusedId)
           : 0;
-        const prevIndex = currentIndex <= 0 ? terminals.length - 1 : currentIndex - 1;
-        return { focusedId: terminals[prevIndex].id };
+        const prevIndex = currentIndex <= 0 ? gridTerminals.length - 1 : currentIndex - 1;
+        return { focusedId: gridTerminals[prevIndex].id };
       });
     },
 
@@ -83,11 +87,17 @@ export const createTerminalFocusSlice =
 
         // Handle focus transfer if the removed terminal was focused
         if (state.focusedId === removedId) {
-          if (remainingTerminals.length > 0) {
-            // Focus the next terminal, or the previous if we removed the last one
-            const nextIndex = Math.min(removedIndex, remainingTerminals.length - 1);
-            updates.focusedId = remainingTerminals[nextIndex]?.id || null;
+          // Only focus grid terminals (not docked ones)
+          const gridTerminals = remainingTerminals.filter(
+            (t) => t.location === "grid" || !t.location
+          );
+
+          if (gridTerminals.length > 0) {
+            // Focus the next grid terminal, or the previous if we removed the last one
+            const nextIndex = Math.min(removedIndex, gridTerminals.length - 1);
+            updates.focusedId = gridTerminals[nextIndex]?.id || null;
           } else {
+            // No grid terminals left, clear focus
             updates.focusedId = null;
           }
         }


### PR DESCRIPTION
## Summary

This PR implements a terminal dock feature that allows users to minimize long-running terminals (agents, watchers, dev servers) to a bottom dock bar while keeping them accessible and running.

**Key Features:**
- Minimize terminals to a compact dock bar at the bottom of the window
- Interactive popover previews (700x500px) when clicking docked terminal chips
- Restore terminals back to the grid with a single click
- Persistent dock state across app restarts
- Proper focus management (grid vs docked terminals)
- Improved empty state messaging when all terminals are docked

**UI Components:**
- `TerminalDock`: Bottom dock bar with count badge
- `DockedTerminalItem`: Compact chip with popover preview
- Minimize button in `TerminalPane` header (arrow-down icon)
- Enhanced `EmptyState` for when all terminals are docked

**State Management:**
- New `TerminalLocation` type: 'grid' | 'dock'
- Added `location` field to `TerminalInstance` (required)
- New actions: `moveTerminalToDock`, `moveTerminalToGrid`, `toggleTerminalLocation`
- Focus navigation skips docked terminals (only navigates grid terminals)
- State restoration includes dock location

**Technical Details:**
- Used `@radix-ui/react-popover` for preview popovers
- Grid terminal filtering throughout (`location === 'grid'`)
- Backward compatible: legacy terminals default to 'grid'
- Type-safe with required location field

Fixes #188