### PR TITLE
Fix agent terminal restoration with command persistence

### DIFF
--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -467,11 +467,15 @@ export function registerIpcHandlers(
 
       // If a command is specified (e.g., 'claude' or 'gemini'), execute it after shell initializes
       if (validatedOptions.command) {
-        // Whitelist allowed commands to prevent command injection
-        // Allow any non-empty command for recipe flexibility
         const trimmedCommand = validatedOptions.command.trim();
+
+        // Security: Validate command to prevent injection attacks
         if (trimmedCommand.length === 0) {
           console.warn("Empty command provided, ignoring");
+        } else if (trimmedCommand.includes("\n") || trimmedCommand.includes("\r")) {
+          console.error("Multi-line commands not allowed for security, ignoring");
+        } else if (trimmedCommand.includes(";") || trimmedCommand.includes("&&") || trimmedCommand.includes("||")) {
+          console.error("Command chaining not allowed for security, ignoring");
         } else {
           // Small delay to allow shell to initialize before sending command
           setTimeout(() => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -97,17 +97,11 @@ if (!gotTheLock) {
 
     console.log("[MAIN] Starting graceful shutdown...");
 
-    // Save terminal state before cleanup
-    if (ptyManager) {
-      const terminals = ptyManager.getAll().map((t) => ({
-        id: t.id,
-        type: t.type || "shell",
-        title: t.title || "Terminal",
-        cwd: t.cwd,
-        worktreeId: t.worktreeId,
-      }));
-      store.set("appState.terminals", terminals);
-    }
+    // NOTE: Terminal state is persisted by the renderer via appClient.setState()
+    // in terminalRegistrySlice.ts. We don't overwrite it here because:
+    // 1. Renderer state includes command/location fields needed for restoration
+    // 2. PtyManager only has runtime state (id/type/title/cwd), missing persistence fields
+    // 3. Overwriting would strip command field, breaking agent terminal restoration
 
     // Perform cleanup
     Promise.all([

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -29,10 +29,12 @@ export interface StoreSchema {
     diagnosticsHeight?: number;
     terminals: Array<{
       id: string;
-      type: "shell" | "claude" | "gemini" | "custom";
+      type: "shell" | "claude" | "gemini" | "codex" | "custom";
       title: string;
       cwd: string;
       worktreeId?: string;
+      location?: "grid" | "dock";
+      command?: string;
     }>;
     recipes?: Array<{
       id: string;

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -316,6 +316,8 @@ export interface TerminalInstance {
   activityTimestamp?: number;
   /** Location in the UI - grid (main view) or dock (minimized) */
   location: TerminalLocation;
+  /** Command to execute after shell starts (e.g., 'claude --model sonnet-4' for AI agents) */
+  command?: string;
 }
 
 /** Options for spawning a new PTY process */
@@ -385,6 +387,8 @@ export interface TerminalSnapshot {
   worktreeId?: string;
   /** Location in the UI - grid or dock */
   location: TerminalLocation;
+  /** Command to execute after shell starts (e.g., 'claude --model sonnet-4' for AI agents) */
+  command?: string;
 }
 
 /** Terminal layout metadata */

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -69,6 +69,8 @@ export interface TerminalState {
   worktreeId?: string;
   /** Location in the UI - grid or dock */
   location?: TerminalLocation;
+  /** Command to execute after shell starts (e.g., 'claude' for AI agents) */
+  command?: string;
 }
 
 /** Terminal data payload for IPC */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -367,6 +367,7 @@ function App() {
                 cwd,
                 worktreeId: terminal.worktreeId,
                 location: terminal.location || "grid", // Restore dock state, default to grid for legacy
+                command: terminal.command, // Restore agent command for re-launching CLI
               });
             } catch (error) {
               console.warn(`Failed to restore terminal ${terminal.id}:`, error);

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -87,6 +87,8 @@ function persistTerminals(terminals: TerminalInstance[]): void {
         cwd: t.cwd,
         worktreeId: t.worktreeId,
         location: t.location,
+        // Only persist command if non-empty (trim whitespace)
+        command: t.command?.trim() || undefined,
       })),
     })
     .catch((error) => {
@@ -140,6 +142,7 @@ export const createTerminalRegistrySlice =
           agentState: isAgentTerminal ? "idle" : undefined,
           lastStateChange: isAgentTerminal ? Date.now() : undefined,
           location,
+          command: options.command, // Store command for persistence
         };
 
         set((state) => {


### PR DESCRIPTION
## Summary
Fixes agent terminals not re-launching their CLI on app restart by persisting and restoring the command field.

Closes #241

## Changes Made
- Add `command` field to TerminalState, TerminalInstance, and TerminalSnapshot types
- Store command when creating terminals in terminalRegistrySlice
- Persist command to electron-store with trim validation
- Restore command during app launch in App.tsx
- Update electron-store schema to include command, location, and codex type
- Remove duplicate terminal persistence in main.ts shutdown handler that was stripping fields
- Add security validation to prevent command injection (multi-line, chaining)

## Technical Details
The issue was that agent terminals (Claude, Gemini, Codex) were restored as plain shell sessions instead of re-launching their respective CLIs. The command parameter (e.g., `"claude --model sonnet-4"`) was being passed during initial spawn but not persisted to storage.

**Root causes fixed:**
1. Command field was missing from type definitions and persistence logic
2. Main process was overwriting renderer-persisted state on shutdown, stripping command/location fields
3. No security validation on persisted commands

**Security improvements:**
- Command injection prevention: reject multi-line commands and command chaining (`;`, `&&`, `||`)
- Trim empty/whitespace commands before persisting to avoid noisy state

## Testing
- TypeScript compilation passes
- Backward compatible with old persisted state (terminals without command field fall back to plain shell)
- Security: Commands with injection patterns are rejected and logged