### PR TITLE
Shift UI language to agent-centric mental model

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -138,7 +138,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
               <button
                 onClick={handleClose}
                 className="p-1 hover:bg-red-500/20 rounded transition-colors text-canopy-text/60 hover:text-red-400"
-                title="Close terminal"
+                title="Close session"
               >
                 <X className="w-3.5 h-3.5" aria-hidden="true" />
               </button>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -93,8 +93,8 @@ export function Toolbar({
           size="icon"
           onClick={() => onLaunchAgent("claude")}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
-          title="Launch Claude Agent (Ctrl+Shift+C)"
-          aria-label="Launch Claude Agent"
+          title="Start Claude Agent (Ctrl+Shift+C)"
+          aria-label="Start Claude Agent"
         >
           <ClaudeIcon className="h-4 w-4" />
         </Button>
@@ -103,8 +103,8 @@ export function Toolbar({
           size="icon"
           onClick={() => onLaunchAgent("gemini")}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
-          title="Launch Gemini Agent (Ctrl+Shift+G)"
-          aria-label="Launch Gemini Agent"
+          title="Start Gemini Agent (Ctrl+Shift+G)"
+          aria-label="Start Gemini Agent"
         >
           <GeminiIcon className="h-4 w-4" />
         </Button>
@@ -113,8 +113,8 @@ export function Toolbar({
           size="icon"
           onClick={() => onLaunchAgent("codex")}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
-          title="Launch Codex Agent"
-          aria-label="Launch Codex Agent"
+          title="Start Codex Agent"
+          aria-label="Start Codex Agent"
         >
           <CodexIcon className="h-4 w-4" />
         </Button>
@@ -123,8 +123,8 @@ export function Toolbar({
           size="icon"
           onClick={() => onLaunchAgent("shell")}
           className="text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8"
-          title="Open Shell Terminal"
-          aria-label="Open Shell Terminal"
+          title="Open Shell"
+          aria-label="Open Shell"
         >
           <Terminal className="h-4 w-4" />
         </Button>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -40,20 +40,20 @@ type SettingsTab = "general" | "agents" | "ai" | "troubleshooting";
 // Keyboard shortcuts organized by category
 const KEYBOARD_SHORTCUTS = [
   {
-    category: "Terminal",
+    category: "Agents",
     shortcuts: [
-      { key: "Cmd+T", description: "Open terminal palette" },
-      { key: "Ctrl+Tab", description: "Focus next terminal" },
-      { key: "Ctrl+Shift+Tab", description: "Focus previous terminal" },
-      { key: "Ctrl+Shift+F", description: "Toggle maximize terminal" },
+      { key: "Ctrl+Shift+C", description: "Start Claude agent" },
+      { key: "Ctrl+Shift+G", description: "Start Gemini agent" },
+      { key: "Ctrl+Shift+I", description: "Inject context to agent" },
+      { key: "Cmd+T", description: "Open agent palette" },
     ],
   },
   {
-    category: "Agents",
+    category: "Navigation",
     shortcuts: [
-      { key: "Ctrl+Shift+C", description: "Launch Claude agent" },
-      { key: "Ctrl+Shift+G", description: "Launch Gemini agent" },
-      { key: "Ctrl+Shift+I", description: "Inject context to terminal" },
+      { key: "Ctrl+Tab", description: "Focus next agent or shell" },
+      { key: "Ctrl+Shift+Tab", description: "Focus previous agent or shell" },
+      { key: "Ctrl+Shift+F", description: "Toggle maximize focused tile" },
     ],
   },
   {
@@ -343,8 +343,8 @@ export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogPr
                 <div className="space-y-2">
                   <h4 className="text-sm font-medium text-canopy-text">Description</h4>
                   <p className="text-sm text-gray-400">
-                    A mini IDE for orchestrating AI coding agents. Monitor worktrees, manage
-                    terminals, and inject context into Claude, Gemini, and other AI agents.
+                    An orchestration board for AI coding agents. Start agents on worktrees, monitor
+                    their progress, and inject context to help them understand your codebase.
                   </p>
                 </div>
 
@@ -467,8 +467,8 @@ export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogPr
                   )}
 
                   <p className="text-xs text-gray-500">
-                    Required for AI-powered summaries, project naming, and context analysis. Your
-                    key is stored locally and never sent to our servers.
+                    Used for worktree summaries and project identity. Helps agents understand your
+                    codebase context. Stored locally and never sent to our servers.
                   </p>
                 </div>
 
@@ -538,8 +538,8 @@ export function SettingsDialog({ isOpen, onClose, defaultTab }: SettingsDialogPr
                     </span>
                   </label>
                   <p className="text-xs text-gray-500">
-                    When enabled, Canopy will use AI to generate worktree summaries and project
-                    identities.
+                    When enabled, Canopy generates worktree summaries and project identities to help
+                    agents understand your work.
                   </p>
                 </div>
               </div>

--- a/src/components/Terminal/BulkActionsMenu.tsx
+++ b/src/components/Terminal/BulkActionsMenu.tsx
@@ -94,8 +94,8 @@ export function BulkActionsMenu({ worktreeId, trigger, className }: BulkActionsM
     const count = worktreeId ? totalCount : terminals.length;
     setConfirmDialog({
       isOpen: true,
-      title: "Close All Terminals",
-      description: `This will close ${count} terminal${count !== 1 ? "s" : ""}. This action cannot be undone.`,
+      title: "Close All Sessions",
+      description: `This will close ${count} session${count !== 1 ? "s" : ""} (including agents and shells). This action cannot be undone.`,
       onConfirm: () => {
         if (worktreeId) {
           bulkCloseByWorktree(worktreeId);
@@ -117,8 +117,8 @@ export function BulkActionsMenu({ worktreeId, trigger, className }: BulkActionsM
   const handleRestartFailed = useCallback(() => {
     // Note: This restarts ALL failed agents globally, not just for this worktree
     const globalRestartMessage = worktreeId
-      ? `This will restart ${restartableCount} failed agent${restartableCount !== 1 ? "s" : ""} across ALL worktrees (not just this one). The terminals will be closed and new ones will be spawned with the same configuration.`
-      : `This will restart ${restartableCount} failed agent${restartableCount !== 1 ? "s" : ""}. The terminals will be closed and new ones will be spawned with the same configuration.`;
+      ? `This will restart ${restartableCount} failed agent${restartableCount !== 1 ? "s" : ""} across ALL worktrees (not just this one). Sessions will be closed and new ones spawned with the same configuration.`
+      : `This will restart ${restartableCount} failed agent${restartableCount !== 1 ? "s" : ""}. Sessions will be closed and new ones spawned with the same configuration.`;
 
     setConfirmDialog({
       isOpen: true,
@@ -191,7 +191,7 @@ export function BulkActionsMenu({ worktreeId, trigger, className }: BulkActionsM
             className="flex items-center gap-2 text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
           >
             <Trash2 className="h-4 w-4" />
-            <span>Close All Terminals...</span>
+            <span>Close All Sessions...</span>
             <span className="ml-auto text-xs text-canopy-text/50">({totalCount})</span>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -295,7 +295,17 @@ export function TerminalPane({
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="group"
-      aria-label={`${type} terminal: ${title}`}
+      aria-label={
+        type === "shell"
+          ? `Shell terminal: ${title}`
+          : type === "claude"
+            ? `Claude agent: ${title}`
+            : type === "gemini"
+              ? `Gemini agent: ${title}`
+              : type === "codex"
+                ? `Codex agent: ${title}`
+                : `${type} session: ${title}`
+      }
     >
       {/* Header - Status bar style */}
       <div
@@ -321,7 +331,7 @@ export function TerminalPane({
               onKeyDown={handleTitleInputKeyDown}
               onBlur={handleTitleSave}
               className="text-sm font-medium bg-black/40 border border-canopy-accent/50 px-1 h-5 min-w-32 outline-none text-canopy-text select-text"
-              aria-label="Edit terminal title"
+              aria-label={type === "shell" ? "Edit shell title" : "Edit agent title"}
             />
           ) : (
             <span
@@ -335,7 +345,11 @@ export function TerminalPane({
               role={onTitleChange ? "button" : undefined}
               title={onTitleChange ? `${title} — Double-click or press Enter to edit` : title}
               aria-label={
-                onTitleChange ? `Terminal title: ${title}. Press Enter or F2 to edit` : undefined
+                onTitleChange
+                  ? type === "shell"
+                    ? `Shell title: ${title}. Press Enter or F2 to edit`
+                    : `Agent title: ${title}. Press Enter or F2 to edit`
+                  : undefined
               }
             >
               {title}
@@ -422,7 +436,7 @@ export function TerminalPane({
               }}
               className="p-1.5 hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent text-canopy-text/60 hover:text-canopy-text transition-colors"
               title="Minimize to dock"
-              aria-label="Minimize terminal to dock"
+              aria-label="Minimize to dock"
             >
               <ArrowDownToLine className="w-3 h-3" aria-hidden="true" />
             </button>
@@ -436,7 +450,7 @@ export function TerminalPane({
               }}
               className="p-1.5 hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent text-canopy-text/60 hover:text-canopy-text transition-colors"
               title={isMaximized ? "Restore (Ctrl+Shift+F)" : "Maximize (Ctrl+Shift+F)"}
-              aria-label={isMaximized ? "Restore terminal" : "Maximize terminal"}
+              aria-label={isMaximized ? "Restore" : "Maximize"}
             >
               {isMaximized ? (
                 <Minimize2 className="w-3 h-3" aria-hidden="true" />
@@ -451,8 +465,8 @@ export function TerminalPane({
               onClose();
             }}
             className="p-1.5 hover:bg-red-500/20 focus-visible:bg-red-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-status-error)] text-canopy-text/60 hover:text-[var(--color-status-error)] transition-colors"
-            title="Close Terminal (Ctrl+Shift+W)"
-            aria-label="Close terminal"
+            title="Close Session (Ctrl+Shift+W)"
+            aria-label="Close session"
           >
             <X className="w-3 h-3" aria-hidden="true" />
           </button>

--- a/src/components/TerminalPalette/TerminalPalette.tsx
+++ b/src/components/TerminalPalette/TerminalPalette.tsx
@@ -128,7 +128,7 @@ export function TerminalPalette({
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"
-      aria-label="Terminal palette"
+      aria-label="Agent palette"
     >
       <div
         className={cn(
@@ -145,7 +145,7 @@ export function TerminalPalette({
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search terminals by name, type, or worktree..."
+            placeholder="Search agents and shells..."
             className={cn(
               "w-full px-3 py-2 text-sm",
               "bg-canopy-sidebar border border-canopy-border rounded-md",
@@ -155,7 +155,7 @@ export function TerminalPalette({
             role="combobox"
             aria-expanded={isOpen}
             aria-haspopup="listbox"
-            aria-label="Search terminals"
+            aria-label="Search agents and shells"
             aria-controls="terminal-list"
             aria-activedescendant={
               results.length > 0 && selectedIndex >= 0
@@ -170,12 +170,16 @@ export function TerminalPalette({
           ref={listRef}
           id="terminal-list"
           role="listbox"
-          aria-label="Terminals"
+          aria-label="Agents and shells"
           className="max-h-[50vh] overflow-y-auto p-2 space-y-1"
         >
           {results.length === 0 ? (
             <div className="px-3 py-8 text-center text-canopy-text/50 text-sm">
-              {query.trim() ? <>No terminals match "{query}"</> : <>No terminals open</>}
+              {query.trim() ? (
+                <>No agents or shells match "{query}"</>
+              ) : (
+                <>No agents or shells running</>
+              )}
             </div>
           ) : (
             results.map((terminal, index) => (

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -272,8 +272,8 @@ export function WorktreeCard({
   const handleCloseAllTerminals = useCallback(() => {
     setConfirmDialog({
       isOpen: true,
-      title: "Close All Terminals",
-      description: `This will close ${totalTerminalCount} terminal${totalTerminalCount !== 1 ? "s" : ""} for this worktree. This action cannot be undone.`,
+      title: "Close All Sessions",
+      description: `This will close ${totalTerminalCount} session${totalTerminalCount !== 1 ? "s" : ""} (including agents and shells) for this worktree. This action cannot be undone.`,
       onConfirm: () => {
         bulkCloseByWorktree(worktree.id);
         closeConfirmDialog();
@@ -533,7 +533,7 @@ export function WorktreeCard({
                 {totalTerminalCount > 0 && (
                   <>
                     <DropdownMenuSeparator />
-                    <DropdownMenuLabel>Terminals</DropdownMenuLabel>
+                    <DropdownMenuLabel>Sessions</DropdownMenuLabel>
                     <DropdownMenuItem
                       onClick={handleCloseCompleted}
                       disabled={completedCount === 0}


### PR DESCRIPTION
## Summary
This PR updates all user-facing language throughout Canopy to use agent-centric terminology instead of terminal-centric language. The changes better communicate that Canopy is an AI orchestration tool, not a terminal emulator.

Closes #202

## Changes Made
- Update empty state to feature agent launcher buttons with clear messaging about what each agent does
- Change toolbar tooltips from 'Launch' to 'Start' for consistency across the UI
- Reorganize keyboard shortcuts by agent-focused categories (Agents, Navigation, Panels)
- Clarify navigation shortcuts apply to both agents and shells to avoid confusion
- Update Settings description to emphasize orchestration over terminal management
- Fix bulk close dialogs to explicitly mention agents and shells in confirmation messages
- Add error handling for agent launch failures in empty state for better UX
- Update aria-labels to distinguish agent sessions from shell terminals for accessibility
- Improve accessibility by aligning screen reader text with visual language throughout