### PR TITLE
Use centralized CLI availability service in renderer

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -363,11 +363,11 @@ export class PtyManager extends EventEmitter {
     const args = options.args || this.getDefaultShellArgs(shell);
 
     const spawnedAt = Date.now();
-        const isAgentTerminal =
-          options.type === "claude" ||
-          options.type === "gemini" ||
-          options.type === "codex" ||
-          options.type === "custom";
+    const isAgentTerminal =
+      options.type === "claude" ||
+      options.type === "gemini" ||
+      options.type === "codex" ||
+      options.type === "custom";
     // For agent terminals, use terminal ID as agent ID
     const agentId = isAgentTerminal ? id : undefined;
 

--- a/src/clients/cliAvailabilityClient.ts
+++ b/src/clients/cliAvailabilityClient.ts
@@ -1,0 +1,48 @@
+/**
+ * CLI Availability Client
+ *
+ * Provides access to the centralized CLI availability detection service.
+ * Use this client to get cached CLI availability status for AI agents
+ * instead of making individual checkCommand calls.
+ *
+ * The service checks availability of: claude, gemini, codex
+ */
+
+import type { CliAvailability } from "@shared/types";
+
+/**
+ * Client for CLI availability operations.
+ *
+ * @example
+ * ```typescript
+ * import { cliAvailabilityClient } from "@/clients";
+ *
+ * // Get cached CLI availability (fast, uses cache)
+ * const availability = await cliAvailabilityClient.get();
+ * if (availability.claude) {
+ *   // Claude CLI is available
+ * }
+ *
+ * // Force refresh (re-checks all CLIs)
+ * const updated = await cliAvailabilityClient.refresh();
+ * ```
+ */
+export const cliAvailabilityClient = {
+  /**
+   * Get cached CLI availability status.
+   * Uses cached results from the main process for optimal performance.
+   * @returns CLI availability status for all supported AI agents
+   */
+  get: (): Promise<CliAvailability> => {
+    return window.electron.system.getCliAvailability();
+  },
+
+  /**
+   * Refresh CLI availability by re-checking all CLIs.
+   * Use sparingly - typically only on user action or settings change.
+   * @returns Updated CLI availability status
+   */
+  refresh: (): Promise<CliAvailability> => {
+    return window.electron.system.refreshCliAvailability();
+  },
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -37,6 +37,7 @@
 
 export { agentSettingsClient } from "./agentSettingsClient";
 export { aiClient } from "./aiClient";
+export { cliAvailabilityClient } from "./cliAvailabilityClient";
 export { appClient } from "./appClient";
 export { artifactClient } from "./artifactClient";
 export { copyTreeClient } from "./copyTreeClient";

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -314,14 +314,19 @@ export function TerminalPane({
           // DESIGN CHANGE: Header logic
           // Active: Tinted background (accent/10) + solid bottom border
           // Inactive: Dark background + subtle bottom border
-          isFocused 
-            ? "bg-canopy-accent/10 border-b border-canopy-accent/20" 
+          isFocused
+            ? "bg-canopy-accent/10 border-b border-canopy-accent/20"
             : "bg-[#16171f] border-b border-canopy-border/30"
         )}
         onDoubleClick={onToggleMaximize}
       >
         <div className="flex items-center gap-2 min-w-0">
-          <span className={cn("shrink-0 transition-colors", isFocused ? "text-canopy-accent" : "text-canopy-text/50")}>
+          <span
+            className={cn(
+              "shrink-0 transition-colors",
+              isFocused ? "text-canopy-accent" : "text-canopy-text/50"
+            )}
+          >
             {getTerminalIcon(type)}
           </span>
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,7 +12,7 @@ export { useDevServer, useDevServerStates } from "./useDevServer";
 export { useElectron, isElectronAvailable } from "./useElectron";
 
 export { useAgentLauncher } from "./useAgentLauncher";
-export type { AgentType, AgentAvailability, UseAgentLauncherReturn } from "./useAgentLauncher";
+export type { AgentType, UseAgentLauncherReturn } from "./useAgentLauncher";
 
 export { useContextInjection } from "./useContextInjection";
 export type { UseContextInjectionReturn } from "./useContextInjection";


### PR DESCRIPTION
## Summary
Refactors `useAgentLauncher` hook to use the centralized `CliAvailabilityService` instead of making three separate `checkCommand` IPC calls, improving performance and maintaining a single source of truth.

Closes #257

## Changes Made
- Add `cliAvailabilityClient` wrapping `getCliAvailability`/`refreshCliAvailability` IPC calls
- Update `useAgentLauncher` to use `cliAvailabilityClient.refresh()` on mount for fresh data
- Remove duplicate `AgentAvailability` type, use shared `CliAvailability` type from shared types
- Change initial availability defaults from optimistic `true` to safe `false` values
- Fix error handling to maintain safe defaults instead of optimistic values
- Remove `AgentAvailability` re-export from hooks index

## Performance Improvement
- **Before**: 3 separate IPC calls on every hook mount
- **After**: 1 IPC call returning cached result with refresh on mount
- Estimated improvement: 60-70% reduction in IPC overhead