### PR TITLE
Add terminal trash and restore functionality

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -34,6 +34,10 @@ export const CHANNELS = {
   TERMINAL_KILL: "terminal:kill",
   TERMINAL_EXIT: "terminal:exit",
   TERMINAL_ERROR: "terminal:error",
+  TERMINAL_TRASH: "terminal:trash",
+  TERMINAL_RESTORE: "terminal:restore",
+  TERMINAL_TRASHED: "terminal:trashed",
+  TERMINAL_RESTORED: "terminal:restored",
 
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -148,6 +148,10 @@ const CHANNELS = {
   TERMINAL_KILL: "terminal:kill",
   TERMINAL_EXIT: "terminal:exit",
   TERMINAL_ERROR: "terminal:error",
+  TERMINAL_TRASH: "terminal:trash",
+  TERMINAL_RESTORE: "terminal:restore",
+  TERMINAL_TRASHED: "terminal:trashed",
+  TERMINAL_RESTORED: "terminal:restored",
 
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",
@@ -444,6 +448,25 @@ const api: ElectronAPI = {
       };
       ipcRenderer.on(CHANNELS.TERMINAL_ACTIVITY, handler);
       return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_ACTIVITY, handler);
+    },
+
+    trash: (id: string): Promise<void> => ipcRenderer.invoke(CHANNELS.TERMINAL_TRASH, id),
+
+    restore: (id: string): Promise<boolean> => ipcRenderer.invoke(CHANNELS.TERMINAL_RESTORE, id),
+
+    onTrashed: (callback: (data: { id: string; expiresAt: number }) => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { id: string; expiresAt: number }
+      ) => callback(data);
+      ipcRenderer.on(CHANNELS.TERMINAL_TRASHED, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_TRASHED, handler);
+    },
+
+    onRestored: (callback: (data: { id: string }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: { id: string }) => callback(data);
+      ipcRenderer.on(CHANNELS.TERMINAL_RESTORED, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_RESTORED, handler);
     },
   },
 

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -238,6 +238,20 @@ export const EVENT_META: Record<keyof CanopyEventMap, EventMetadata> = {
     description: "Code artifacts extracted from agent output",
   },
 
+  // Terminal trash events
+  "terminal:trashed": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: false,
+    description: "Terminal moved to trash pending deletion",
+  },
+  "terminal:restored": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: false,
+    description: "Terminal restored from trash",
+  },
+
   // Task events
   "task:created": {
     category: "task",
@@ -599,6 +613,25 @@ export type CanopyEventMap = {
   }>;
 
   // ============================================================================
+  // Terminal Trash Events
+  // ============================================================================
+
+  /**
+   * Emitted when a terminal is moved to trash (pending deletion).
+   */
+  "terminal:trashed": {
+    id: string;
+    expiresAt: number;
+  };
+
+  /**
+   * Emitted when a terminal is restored from trash.
+   */
+  "terminal:restored": {
+    id: string;
+  };
+
+  // ============================================================================
   // Task Lifecycle Events (Future-proof for task management)
   // ============================================================================
 
@@ -738,6 +771,8 @@ export const ALL_EVENT_TYPES: Array<keyof CanopyEventMap> = [
   "agent:failed",
   "agent:killed",
   "artifact:detected",
+  "terminal:trashed",
+  "terminal:restored",
   "task:created",
   "task:assigned",
   "task:state-changed",

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -908,6 +908,14 @@ export interface IpcInvokeMap {
     args: [id: string];
     result: void;
   };
+  "terminal:trash": {
+    args: [id: string];
+    result: void;
+  };
+  "terminal:restore": {
+    args: [id: string];
+    result: boolean;
+  };
 
   // ============================================
   // Agent channels
@@ -1312,6 +1320,8 @@ export interface IpcEventMap {
   "terminal:data": [id: string, data: string];
   "terminal:exit": [id: string, exitCode: number];
   "terminal:error": [id: string, error: string];
+  "terminal:trashed": { id: string; expiresAt: number };
+  "terminal:restored": { id: string };
 
   // ============================================
   // Agent events
@@ -1418,10 +1428,14 @@ export interface ElectronAPI {
     write(id: string, data: string): void;
     resize(id: string, cols: number, rows: number): void;
     kill(id: string): Promise<void>;
+    trash(id: string): Promise<void>;
+    restore(id: string): Promise<boolean>;
     onData(id: string, callback: (data: string) => void): () => void;
     onExit(callback: (id: string, exitCode: number) => void): () => void;
     onAgentStateChanged(callback: (data: AgentStateChangePayload) => void): () => void;
     onActivity(callback: (data: TerminalActivityPayload) => void): () => void;
+    onTrashed(callback: (data: { id: string; expiresAt: number }) => void): () => void;
+    onRestored(callback: (data: { id: string }) => void): () => void;
   };
   artifact: {
     onDetected(callback: (data: ArtifactDetectedPayload) => void): () => void;

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -43,6 +43,16 @@ export const terminalClient = {
     return window.electron.terminal.kill(id);
   },
 
+  /** Move terminal to trash (pending deletion with countdown) */
+  trash: (id: string): Promise<void> => {
+    return window.electron.terminal.trash(id);
+  },
+
+  /** Restore terminal from trash, cancelling countdown */
+  restore: (id: string): Promise<boolean> => {
+    return window.electron.terminal.restore(id);
+  },
+
   /** Subscribe to terminal data for a specific terminal. Returns cleanup function. */
   onData: (id: string, callback: (data: string) => void): (() => void) => {
     return window.electron.terminal.onData(id, callback);
@@ -61,5 +71,15 @@ export const terminalClient = {
   /** Subscribe to terminal activity events. Returns cleanup function. */
   onActivity: (callback: (data: TerminalActivityPayload) => void): (() => void) => {
     return window.electron.terminal.onActivity(callback);
+  },
+
+  /** Subscribe to terminal trashed events. Returns cleanup function. */
+  onTrashed: (callback: (data: { id: string; expiresAt: number }) => void): (() => void) => {
+    return window.electron.terminal.onTrashed(callback);
+  },
+
+  /** Subscribe to terminal restored events. Returns cleanup function. */
+  onRestored: (callback: (data: { id: string }) => void): (() => void) => {
+    return window.electron.terminal.onRestored(callback);
   },
 } as const;

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -63,7 +63,7 @@ function getStateIndicator(state?: AgentState) {
 export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
-  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
+  const trashTerminal = useTerminalStore((s) => s.trashTerminal);
 
   const handleRestore = useCallback(
     (e: React.MouseEvent) => {
@@ -77,10 +77,10 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      removeTerminal(terminal.id);
+      trashTerminal(terminal.id);
       setIsOpen(false);
     },
-    [removeTerminal, terminal.id]
+    [trashTerminal, terminal.id]
   );
 
   const handleOpenChange = useCallback((open: boolean) => {

--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -3,13 +3,16 @@
  *
  * A dock bar at the bottom of the application that displays minimized terminals.
  * Terminals can be docked to free up grid space while keeping them accessible.
- * The dock only renders when there are docked terminals.
+ * Also shows terminals pending deletion (in trash) with countdown timers.
+ * The dock only renders when there are docked or trashed terminals.
  */
 
 import { useShallow } from "zustand/react/shallow";
+import { Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTerminalStore } from "@/store";
 import { DockedTerminalItem } from "./DockedTerminalItem";
+import { TrashedTerminalItem } from "./TrashedTerminalItem";
 
 export function TerminalDock() {
   // Filter terminals in dock location using shallow comparison
@@ -17,8 +20,26 @@ export function TerminalDock() {
     useShallow((state) => state.terminals.filter((t) => t.location === "dock"))
   );
 
-  // Don't render if no docked terminals
-  if (dockTerminals.length === 0) return null;
+  // Get trashed terminals Map and convert to array for rendering
+  const trashedTerminals = useTerminalStore(useShallow((state) => state.trashedTerminals));
+  const terminals = useTerminalStore((state) => state.terminals);
+
+  // Get trashed terminal info paired with terminal instances
+  const trashedItems = Array.from(trashedTerminals.values())
+    .map((trashed) => ({
+      terminal: terminals.find((t) => t.id === trashed.id),
+      trashedInfo: trashed,
+    }))
+    .filter((item) => item.terminal !== undefined) as {
+    terminal: (typeof terminals)[0];
+    trashedInfo: typeof trashedTerminals extends Map<string, infer V> ? V : never;
+  }[];
+
+  // Filter out trashed terminals from docked terminals list
+  const activeDockTerminals = dockTerminals.filter((t) => !trashedTerminals.has(t.id));
+
+  // Don't render if no docked or trashed terminals
+  if (activeDockTerminals.length === 0 && trashedItems.length === 0) return null;
 
   return (
     <div
@@ -28,13 +49,37 @@ export function TerminalDock() {
         "z-40 shrink-0"
       )}
     >
-      <span className="text-xs text-canopy-text/60 mr-2 shrink-0">
-        Background ({dockTerminals.length})
-      </span>
+      {/* Active docked terminals section */}
+      {activeDockTerminals.length > 0 && (
+        <>
+          <span className="text-xs text-canopy-text/60 mr-2 shrink-0">
+            Background ({activeDockTerminals.length})
+          </span>
 
-      {dockTerminals.map((terminal) => (
-        <DockedTerminalItem key={terminal.id} terminal={terminal} />
-      ))}
+          {activeDockTerminals.map((terminal) => (
+            <DockedTerminalItem key={terminal.id} terminal={terminal} />
+          ))}
+        </>
+      )}
+
+      {/* Separator between sections */}
+      {activeDockTerminals.length > 0 && trashedItems.length > 0 && (
+        <div className="w-px h-5 bg-canopy-border mx-2 shrink-0" />
+      )}
+
+      {/* Trashed terminals section */}
+      {trashedItems.length > 0 && (
+        <>
+          <span className="text-xs text-red-400/80 mr-2 shrink-0 flex items-center gap-1">
+            <Trash2 className="w-3 h-3" />
+            Trash ({trashedItems.length})
+          </span>
+
+          {trashedItems.map(({ terminal, trashedInfo }) => (
+            <TrashedTerminalItem key={terminal.id} terminal={terminal} trashedInfo={trashedInfo} />
+          ))}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/Layout/TrashedTerminalItem.tsx
+++ b/src/components/Layout/TrashedTerminalItem.tsx
@@ -1,0 +1,137 @@
+/**
+ * TrashedTerminalItem Component
+ *
+ * Displays a terminal that's pending deletion with a countdown timer.
+ * Shows a restore button and countdown progress bar.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { Undo2, X, Terminal, Command } from "lucide-react";
+import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
+import { cn } from "@/lib/utils";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import type { TrashedTerminal } from "@/store/slices";
+import type { TerminalType } from "@/types";
+
+interface TrashedTerminalItemProps {
+  terminal: TerminalInstance;
+  trashedInfo: TrashedTerminal;
+}
+
+/**
+ * Get terminal icon based on type
+ */
+function getTerminalIcon(type: TerminalType, className?: string) {
+  const props = { className: cn("w-3 h-3", className), "aria-hidden": "true" as const };
+  switch (type) {
+    case "claude":
+      return <ClaudeIcon {...props} />;
+    case "gemini":
+      return <GeminiIcon {...props} />;
+    case "codex":
+      return <CodexIcon {...props} />;
+    case "custom":
+      return <Command {...props} />;
+    case "shell":
+      return <Terminal {...props} />;
+  }
+}
+
+export function TrashedTerminalItem({ terminal, trashedInfo }: TrashedTerminalItemProps) {
+  const restoreTerminal = useTerminalStore((s) => s.restoreTerminal);
+  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
+
+  // Calculate actual TTL duration from when component mounts
+  const [totalDuration] = useState(() => Math.max(1000, trashedInfo.expiresAt - Date.now()));
+
+  // Calculate remaining time and progress
+  const [timeRemaining, setTimeRemaining] = useState(() => {
+    const remaining = Math.max(0, trashedInfo.expiresAt - Date.now());
+    return remaining;
+  });
+
+  // Update countdown every 100ms for smooth animation
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const remaining = Math.max(0, trashedInfo.expiresAt - Date.now());
+      setTimeRemaining(remaining);
+
+      if (remaining <= 0) {
+        clearInterval(interval);
+      }
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, [trashedInfo.expiresAt]);
+
+  // Calculate progress based on actual duration
+  const progress = Math.max(0, Math.min(1, timeRemaining / totalDuration));
+  const secondsRemaining = Math.ceil(timeRemaining / 1000);
+
+  const handleRestore = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      restoreTerminal(terminal.id);
+    },
+    [restoreTerminal, terminal.id]
+  );
+
+  const handleImmediateClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      removeTerminal(terminal.id);
+    },
+    [removeTerminal, terminal.id]
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all relative overflow-hidden",
+        "bg-red-500/10 border-red-500/30 text-red-200"
+      )}
+      role="status"
+      aria-live="polite"
+      aria-label={`${terminal.title} will be deleted in ${secondsRemaining} seconds`}
+    >
+      {/* Progress bar background */}
+      <div
+        className="absolute inset-0 bg-red-500/20 transition-all duration-100"
+        style={{ width: `${progress * 100}%` }}
+        aria-hidden="true"
+      />
+
+      {/* Content layer */}
+      <div className="flex items-center gap-2 relative z-10">
+        {/* Terminal type icon */}
+        {getTerminalIcon(terminal.type, "text-red-300")}
+
+        {/* Countdown */}
+        <span className="font-mono text-red-300 tabular-nums w-5 text-center" aria-hidden="true">
+          {secondsRemaining}s
+        </span>
+
+        {/* Terminal title */}
+        <span className="truncate max-w-[80px] font-mono opacity-70">{terminal.title}</span>
+
+        {/* Restore button */}
+        <button
+          onClick={handleRestore}
+          className="p-1 hover:bg-green-500/20 rounded transition-colors text-green-300 hover:text-green-200"
+          aria-label={`Restore ${terminal.title}`}
+        >
+          <Undo2 className="w-3 h-3" aria-hidden="true" />
+        </button>
+
+        {/* Immediate close button */}
+        <button
+          onClick={handleImmediateClose}
+          className="p-1 hover:bg-red-500/30 rounded transition-colors text-red-300 hover:text-red-200"
+          aria-label={`Delete ${terminal.title} immediately`}
+        >
+          <X className="w-3 h-3" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -111,7 +111,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
 
   // Get actions separately - these are stable references
   const addTerminal = useTerminalStore((state) => state.addTerminal);
-  const removeTerminal = useTerminalStore((state) => state.removeTerminal);
+  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
   const updateTitle = useTerminalStore((state) => state.updateTitle);
   const setFocused = useTerminalStore((state) => state.setFocused);
   const toggleMaximize = useTerminalStore((state) => state.toggleMaximize);
@@ -230,7 +230,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
                 : null
             }
             onFocus={() => setFocused(terminal.id)}
-            onClose={() => removeTerminal(terminal.id)}
+            onClose={() => trashTerminal(terminal.id)}
             onInjectContext={
               terminal.worktreeId
                 ? () => handleInjectContext(terminal.id, terminal.worktreeId)
@@ -300,7 +300,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
               : null
           }
           onFocus={() => setFocused(terminal.id)}
-          onClose={() => removeTerminal(terminal.id)}
+          onClose={() => trashTerminal(terminal.id)}
           onInjectContext={
             terminal.worktreeId
               ? () => handleInjectContext(terminal.id, terminal.worktreeId)

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -314,14 +314,19 @@ export function TerminalPane({
           // DESIGN CHANGE: Header logic
           // Active: Tinted background (accent/10) + solid bottom border
           // Inactive: Dark background + subtle bottom border
-          isFocused 
-            ? "bg-canopy-accent/10 border-b border-canopy-accent/20" 
+          isFocused
+            ? "bg-canopy-accent/10 border-b border-canopy-accent/20"
             : "bg-[#16171f] border-b border-canopy-border/30"
         )}
         onDoubleClick={onToggleMaximize}
       >
         <div className="flex items-center gap-2 min-w-0">
-          <span className={cn("shrink-0 transition-colors", isFocused ? "text-canopy-accent" : "text-canopy-text/50")}>
+          <span
+            className={cn(
+              "shrink-0 transition-colors",
+              isFocused ? "text-canopy-accent" : "text-canopy-text/50"
+            )}
+          >
             {getTerminalIcon(type)}
           </span>
 

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -11,6 +11,7 @@ export {
   type TerminalInstance,
   type AddTerminalOptions,
   type TerminalRegistryMiddleware,
+  type TrashedTerminal,
 } from "./terminalRegistrySlice";
 
 export { createTerminalFocusSlice, type TerminalFocusSlice } from "./terminalFocusSlice";

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -123,6 +123,8 @@ export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
 // This runs once at module load and the cleanup function should be called on app shutdown
 let agentStateUnsubscribe: (() => void) | null = null;
 let activityUnsubscribe: (() => void) | null = null;
+let trashedUnsubscribe: (() => void) | null = null;
+let restoredUnsubscribe: (() => void) | null = null;
 
 if (typeof window !== "undefined") {
   agentStateUnsubscribe = terminalClient.onAgentStateChanged((data) => {
@@ -154,6 +156,18 @@ if (typeof window !== "undefined") {
     // Update the terminal's activity state
     useTerminalStore.getState().updateActivity(terminalId, headline, status, type, timestamp);
   });
+
+  // Subscribe to terminal trashed events from the main process
+  trashedUnsubscribe = terminalClient.onTrashed((data) => {
+    const { id, expiresAt } = data;
+    useTerminalStore.getState().markAsTrashed(id, expiresAt);
+  });
+
+  // Subscribe to terminal restored events from the main process
+  restoredUnsubscribe = terminalClient.onRestored((data) => {
+    const { id } = data;
+    useTerminalStore.getState().markAsRestored(id);
+  });
 }
 
 // Export cleanup function for app shutdown
@@ -165,5 +179,13 @@ export function cleanupTerminalStoreListeners() {
   if (activityUnsubscribe) {
     activityUnsubscribe();
     activityUnsubscribe = null;
+  }
+  if (trashedUnsubscribe) {
+    trashedUnsubscribe();
+    trashedUnsubscribe = null;
+  }
+  if (restoredUnsubscribe) {
+    restoredUnsubscribe();
+    restoredUnsubscribe = null;
   }
 }


### PR DESCRIPTION
## Summary
Implements soft-delete functionality for terminals with a 60-second TTL countdown, allowing users to undo terminal closure and preventing accidental data loss.

Closes #267

## Changes Made
- Add trash/restore methods to PtyManager with 60s TTL auto-deletion
- Implement IPC channels and handlers for trash/restore operations
- Create TrashedTerminalItem component with countdown timer and progress bar
- Update TerminalDock to display trash section with visual separation
- Add Zustand state management for trashedTerminals Map
- Fix memory leaks: clear trash timeouts on terminal exit and removal
- Improve restore() semantics: only return true when actually restoring
- Add accessibility: aria-label and aria-live for countdown UI
- Use actual TTL duration for progress calculation instead of hardcoded 60s