### PR TITLE
Add "Waiting for You" strip for quick agent navigation

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, type ReactNode } from "react";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
+import { WaitingForYouStrip } from "./WaitingForYouStrip";
 import { TerminalDock } from "./TerminalDock";
 import { DiagnosticsDock } from "../Diagnostics";
 import { useFocusStore, useDiagnosticsStore, useErrorStore, type PanelState } from "@/store";
@@ -229,6 +230,7 @@ export function AppLayout({
         onToggleFocusMode={handleToggleFocusMode}
         isRefreshing={isRefreshing}
       />
+      <WaitingForYouStrip />
       <div
         className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}

--- a/src/components/Layout/WaitingAgentChip.tsx
+++ b/src/components/Layout/WaitingAgentChip.tsx
@@ -1,0 +1,94 @@
+/**
+ * WaitingAgentChip Component
+ *
+ * Individual chip displayed in the WaitingForYouStrip for an agent
+ * that is currently in "waiting" state (needs user input).
+ *
+ * Features:
+ * - Yellow color scheme indicates attention needed
+ * - Pulsing dot reinforces "needs input" status
+ * - Click to focus and scroll to the terminal
+ * - Shows issue number (preferred) or terminal title
+ */
+
+import { useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { useTerminalStore } from "@/store/terminalStore";
+import type { TerminalInstance } from "@/store/terminalStore";
+
+interface WaitingAgentChipProps {
+  /** The terminal instance that is waiting */
+  terminal: TerminalInstance;
+}
+
+export function WaitingAgentChip({ terminal }: WaitingAgentChipProps) {
+  const setFocused = useTerminalStore((state) => state.setFocused);
+  const moveTerminalToGrid = useTerminalStore((state) => state.moveTerminalToGrid);
+  const getTerminal = useTerminalStore((state) => state.getTerminal);
+  const isInTrash = useTerminalStore((state) => state.isInTrash);
+
+  const handleClick = useCallback(() => {
+    // Fetch the latest terminal state to ensure it still exists and isn't trashed
+    const currentTerminal = getTerminal(terminal.id);
+    if (!currentTerminal || isInTrash(terminal.id)) {
+      // Terminal was removed or trashed, skip action
+      return;
+    }
+
+    // If terminal is docked, restore it to grid first
+    if (currentTerminal.location === "dock") {
+      moveTerminalToGrid(terminal.id);
+    }
+
+    // Focus the terminal
+    setFocused(terminal.id);
+
+    // Scroll terminal into view with retries
+    // Use requestAnimationFrame to wait for DOM updates after state changes
+    const scrollToTerminal = () => {
+      const terminalEl = document.querySelector(`[data-terminal-id="${terminal.id}"]`);
+      if (terminalEl) {
+        terminalEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      } else {
+        // Retry once more if element not found (may still be mounting)
+        requestAnimationFrame(() => {
+          const retryEl = document.querySelector(`[data-terminal-id="${terminal.id}"]`);
+          if (retryEl) {
+            retryEl.scrollIntoView({ behavior: "smooth", block: "nearest" });
+          }
+        });
+      }
+    };
+
+    requestAnimationFrame(scrollToTerminal);
+  }, [terminal.id, setFocused, moveTerminalToGrid, getTerminal, isInTrash]);
+
+  // Prefer issue number display, fall back to terminal title
+  // Match various patterns: "issue-123", "issue/123", "issues-123", "123-fix-login"
+  const issueMatch = terminal.worktreeId?.match(/(?:^|[\W])(?:issue|issues)[-_/]?(\d+)|^(\d+)-/i);
+  const issueNumber = issueMatch ? parseInt(issueMatch[1] || issueMatch[2], 10) : null;
+
+  const displayName = issueNumber ? `Issue #${issueNumber}` : terminal.title;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "px-3 py-1 rounded-full",
+        "bg-yellow-500/20 border border-yellow-500/50",
+        "hover:bg-yellow-500/30 hover:border-yellow-500/70",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
+        "text-sm font-medium text-yellow-500",
+        "transition-colors",
+        "flex items-center gap-2",
+        "shrink-0"
+      )}
+      title={`Click to focus ${terminal.title}`}
+      aria-label={`${displayName} needs input - click to focus`}
+    >
+      <span className="w-2 h-2 rounded-full bg-yellow-500 animate-pulse" aria-hidden="true" />
+      <span className="truncate max-w-[150px]">{displayName}</span>
+    </button>
+  );
+}

--- a/src/components/Layout/WaitingForYouStrip.tsx
+++ b/src/components/Layout/WaitingForYouStrip.tsx
@@ -1,0 +1,49 @@
+/**
+ * WaitingForYouStrip Component
+ *
+ * A persistent horizontal strip at the top of the terminal grid that shows
+ * all agents currently in "waiting" state, providing one-click navigation
+ * to agents that need user input.
+ *
+ * This is a key UX primitive from the "8+ Agents at Once" guide for reducing
+ * context-switching cost when orchestrating multiple agents.
+ *
+ * Features:
+ * - Auto-hides when no agents are waiting
+ * - Yellow color scheme indicates attention needed
+ * - Horizontal scroll support for many chips
+ * - Real-time updates as agents transition in/out of waiting state
+ */
+
+import { WaitingAgentChip } from "./WaitingAgentChip";
+import { useTerminalStore } from "@/store/terminalStore";
+import { useShallow } from "zustand/react/shallow";
+
+export function WaitingForYouStrip() {
+  // Use shallow selector to only re-render when the waiting terminals actually change
+  const waitingTerminals = useTerminalStore(
+    useShallow((state) =>
+      state.terminals.filter((t) => t.agentState === "waiting" && !state.isInTrash(t.id))
+    )
+  );
+
+  // Hide strip when no agents waiting
+  if (waitingTerminals.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="h-10 border-b border-canopy-border bg-canopy-sidebar/50 px-4 flex items-center gap-3 shrink-0"
+      role="region"
+      aria-label="Agents waiting for input"
+    >
+      <span className="text-sm font-medium text-canopy-text/70 shrink-0">Waiting for you:</span>
+      <div className="flex items-center gap-2 overflow-x-auto scrollbar-thin scrollbar-thumb-canopy-border scrollbar-track-transparent">
+        {waitingTerminals.map((terminal) => (
+          <WaitingAgentChip key={terminal.id} terminal={terminal} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -2,3 +2,5 @@ export { AppLayout } from "./AppLayout";
 export { Toolbar } from "./Toolbar";
 export { Sidebar } from "./Sidebar";
 export type { SidebarTab } from "./Sidebar";
+export { WaitingForYouStrip } from "./WaitingForYouStrip";
+export { WaitingAgentChip } from "./WaitingAgentChip";

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -321,6 +321,7 @@ export function TerminalPane({
   return (
     <div
       ref={containerRef}
+      data-terminal-id={id}
       className={cn(
         "flex flex-col h-full border border-canopy-border/50 group", // Tiling style - full border for all edges
         isFocused ? "border-canopy-accent/20" : "border-canopy-border/30",


### PR DESCRIPTION
## Summary

Add a persistent horizontal strip at the top of the terminal grid that displays all agents currently in "waiting" state, providing one-click navigation to terminals that need user input. This is a key UX primitive from the "8+ Agents at Once" guide for reducing context-switching cost when orchestrating multiple agents.

Closes #197

## Changes Made

- Add WaitingForYouStrip component with shallow selector optimization
- Add WaitingAgentChip with robust click handling and focus restoration
- Implement issue number extraction from worktree IDs (supports multiple patterns)
- Filter trashed terminals from waiting list
- Add data-terminal-id attribute to TerminalPane for scroll targeting
- Add keyboard focus styles and ARIA labels for accessibility
- Use requestAnimationFrame for reliable scroll-to-terminal behavior

## Features

- **Auto-hide**: Strip only appears when at least one agent is waiting
- **One-click navigation**: Click chip to restore docked terminals and focus them
- **Issue-centric labels**: Shows "Issue #123" when available, falls back to terminal title
- **Performance optimized**: Uses shallow selector to avoid unnecessary re-renders
- **Accessible**: Full keyboard support with focus-visible styles and ARIA labels
- **Robust**: Handles edge cases like removed terminals, trashed terminals, and rapid clicks