### PR TITLE
Enhance visual separation for bottom docks

### DIFF
--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -163,7 +163,7 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
   return (
     <div
       className={cn(
-        "flex flex-col border-t border-canopy-border bg-canopy-bg",
+        "flex flex-col border-t-2 border-canopy-border/60 bg-canopy-bg/95 backdrop-blur-sm shadow-[0_-4px_12px_rgba(0,0,0,0.3)]",
         "transition-[height] duration-200 ease-out",
         isResizing && "select-none",
         className

--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -45,7 +45,7 @@ export function TerminalDock() {
   return (
     <div
       className={cn(
-        "h-10 bg-canopy-bg border-t border-canopy-border",
+        "h-10 bg-canopy-bg/95 backdrop-blur-sm border-t-2 border-canopy-border/60 shadow-[0_-4px_12px_rgba(0,0,0,0.3)]",
         "flex items-center px-4 gap-2 overflow-x-auto",
         "z-40 shrink-0"
       )}


### PR DESCRIPTION
## Summary
Improves visual separation of the TerminalDock and DiagnosticsDock from the main application background through enhanced styling. The docks now have clear depth and boundaries while maintaining the existing Digital Ecology design system aesthetic.

Closes #298

## Changes Made
- Add shadow-lg effect (0 -4px 12px rgba(0,0,0,0.3)) to create depth
- Strengthen border from 1px to 2px with reduced opacity (60%)
- Apply semi-transparent background (95%) with backdrop blur
- Apply consistent styling to both TerminalDock and DiagnosticsDock for visual harmony