### PR TITLE
Fix terminal trash system race condition and UI

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -171,8 +171,8 @@ export class PtyManager extends EventEmitter {
   private trashTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private ptyPool: PtyPool | null = null;
 
-  /** TTL for trashed terminals before auto-kill (60 seconds) */
-  private readonly TRASH_TTL_MS = 60 * 1000;
+  /** TTL for trashed terminals before auto-kill (2 minutes) */
+  private readonly TRASH_TTL_MS = 120 * 1000;
 
   constructor() {
     super();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -298,7 +298,15 @@ function SidebarContent({ onOpenSettings }: SidebarContentProps) {
 type AppView = "grid" | "welcome";
 
 function App() {
-  const { focusNext, focusPrevious, toggleMaximize, focusedId, addTerminal, reorderTerminals, terminals } = useTerminalStore();
+  const {
+    focusNext,
+    focusPrevious,
+    toggleMaximize,
+    focusedId,
+    addTerminal,
+    reorderTerminals,
+    terminals,
+  } = useTerminalStore();
   const { launchAgent, availability, agentSettings, refreshSettings } = useAgentLauncher();
   const { activeWorktreeId, setActiveWorktree } = useWorktreeSelectionStore();
   const { inject, isInjecting } = useContextInjection();
@@ -537,7 +545,9 @@ function App() {
     () => {
       if (!focusedId) return;
       // Find grid terminals and current index
-      const gridTerminals = terminals.filter((t) => t.location === "grid" || t.location === undefined);
+      const gridTerminals = terminals.filter(
+        (t) => t.location === "grid" || t.location === undefined
+      );
       const currentIndex = gridTerminals.findIndex((t) => t.id === focusedId);
       if (currentIndex > 0) {
         reorderTerminals(currentIndex, currentIndex - 1, "grid");
@@ -550,7 +560,9 @@ function App() {
     () => {
       if (!focusedId) return;
       // Find grid terminals and current index
-      const gridTerminals = terminals.filter((t) => t.location === "grid" || t.location === undefined);
+      const gridTerminals = terminals.filter(
+        (t) => t.location === "grid" || t.location === undefined
+      );
       const currentIndex = gridTerminals.findIndex((t) => t.id === focusedId);
       if (currentIndex >= 0 && currentIndex < gridTerminals.length - 1) {
         reorderTerminals(currentIndex, currentIndex + 1, "grid");

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -156,9 +156,7 @@ export function DockedTerminalItem({
   return (
     <div className="relative flex items-center">
       {/* Drop indicator before this item */}
-      {isDropTarget && (
-        <div className="absolute -left-1.5 w-0.5 h-6 bg-canopy-accent rounded" />
-      )}
+      {isDropTarget && <div className="absolute -left-1.5 w-0.5 h-6 bg-canopy-accent rounded" />}
 
       <Popover open={isOpen} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
@@ -188,48 +186,48 @@ export function DockedTerminalItem({
           </button>
         </PopoverTrigger>
 
-      <PopoverContent
-        className="w-[700px] h-[500px] p-0 border-canopy-border bg-canopy-bg shadow-2xl"
-        side="top"
-        align="start"
-        sideOffset={8}
-      >
-        <div className="flex flex-col h-full">
-          {/* Mini Header */}
-          <div className="h-9 flex items-center justify-between px-3 border-b border-canopy-border bg-canopy-bg shrink-0">
-            <div className="flex items-center gap-2">
-              {getTerminalIcon(terminal.type, "text-canopy-text/70")}
-              {getStateIndicator(terminal.agentState)}
-              <span className="font-mono text-xs text-canopy-text">{terminal.title}</span>
+        <PopoverContent
+          className="w-[700px] h-[500px] p-0 border-canopy-border bg-canopy-bg shadow-2xl"
+          side="top"
+          align="start"
+          sideOffset={8}
+        >
+          <div className="flex flex-col h-full">
+            {/* Mini Header */}
+            <div className="h-9 flex items-center justify-between px-3 border-b border-canopy-border bg-canopy-bg shrink-0">
+              <div className="flex items-center gap-2">
+                {getTerminalIcon(terminal.type, "text-canopy-text/70")}
+                {getStateIndicator(terminal.agentState)}
+                <span className="font-mono text-xs text-canopy-text">{terminal.title}</span>
+              </div>
+
+              <div className="flex items-center gap-1">
+                {/* Restore to Grid Button */}
+                <button
+                  onClick={handleRestore}
+                  className="p-1 hover:bg-canopy-accent/20 rounded transition-colors text-canopy-text/60 hover:text-canopy-text"
+                  title="Restore to grid"
+                >
+                  <Maximize2 className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+
+                {/* Close (Kill) Button */}
+                <button
+                  onClick={handleClose}
+                  className="p-1 hover:bg-red-500/20 rounded transition-colors text-canopy-text/60 hover:text-red-400"
+                  title="Close session"
+                >
+                  <X className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              </div>
             </div>
 
-            <div className="flex items-center gap-1">
-              {/* Restore to Grid Button */}
-              <button
-                onClick={handleRestore}
-                className="p-1 hover:bg-canopy-accent/20 rounded transition-colors text-canopy-text/60 hover:text-canopy-text"
-                title="Restore to grid"
-              >
-                <Maximize2 className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
-
-              {/* Close (Kill) Button */}
-              <button
-                onClick={handleClose}
-                className="p-1 hover:bg-red-500/20 rounded transition-colors text-canopy-text/60 hover:text-red-400"
-                title="Close session"
-              >
-                <X className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
+            {/* The Actual Terminal */}
+            <div className="flex-1 relative overflow-hidden min-h-0">
+              <XtermAdapter terminalId={terminal.id} className="absolute inset-0" />
             </div>
           </div>
-
-          {/* The Actual Terminal */}
-          <div className="flex-1 relative overflow-hidden min-h-0">
-            <XtermAdapter terminalId={terminal.id} className="absolute inset-0" />
-          </div>
-        </div>
-      </PopoverContent>
+        </PopoverContent>
       </Popover>
     </div>
   );

--- a/src/components/Layout/TrashBin.tsx
+++ b/src/components/Layout/TrashBin.tsx
@@ -1,0 +1,86 @@
+/**
+ * TrashBin Component
+ *
+ * A grouped trash bin button that opens a popover with all trashed terminals.
+ * Replaces individual trash chips in the dock with a single interactive button.
+ */
+
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { TrashBinItem } from "./TrashBinItem";
+import type { TerminalInstance } from "@/store";
+import type { TrashedTerminal } from "@/store/slices";
+
+interface TrashBinProps {
+  items: Array<{
+    terminal: TerminalInstance;
+    trashedInfo: TrashedTerminal;
+  }>;
+}
+
+export function TrashBin({ items }: TrashBinProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const count = items.length;
+
+  if (count === 0) return null;
+
+  // Sort items by expiration time (soonest first)
+  const sortedItems = [...items].sort((a, b) => a.trashedInfo.expiresAt - b.trashedInfo.expiresAt);
+
+  // Calculate soonest expiration for header
+  const now = Date.now();
+  const soonestExpiry = sortedItems[0]?.trashedInfo.expiresAt ?? now;
+  const soonestSeconds = Math.max(0, Math.ceil((soonestExpiry - now) / 1000));
+  const headerNote =
+    soonestSeconds > 0 ? `Auto-clears in ${Math.ceil(soonestSeconds / 60)}m` : "Auto-clearing";
+
+  const contentId = "trash-bin-popover";
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          className={cn(
+            "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
+            "bg-red-500/10 border-red-500/30 text-red-200 hover:bg-red-500/20 hover:border-red-500/50",
+            isOpen && "bg-red-500/20 border-red-500/50 ring-1 ring-red-500/30"
+          )}
+          aria-haspopup="dialog"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          aria-label={`Open trash, ${count} ${count === 1 ? "item" : "items"}`}
+        >
+          <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+          <span className="font-medium">Trash ({count})</span>
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        id={contentId}
+        role="dialog"
+        aria-label="Recently closed terminals"
+        className="w-80 p-0 border-red-500/30 bg-[#1a1a1a] shadow-2xl"
+        side="top"
+        align="end"
+        sideOffset={8}
+      >
+        <div className="flex flex-col">
+          {/* Header */}
+          <div className="px-3 py-2 border-b border-white/10 bg-red-500/5 flex justify-between items-center">
+            <span className="text-xs font-medium text-red-200">Recently Closed</span>
+            <span className="text-[10px] text-white/40">{headerNote}</span>
+          </div>
+
+          {/* List */}
+          <div className="p-2 flex flex-col gap-2 max-h-[300px] overflow-y-auto">
+            {sortedItems.map(({ terminal, trashedInfo }) => (
+              <TrashBinItem key={terminal.id} terminal={terminal} trashedInfo={trashedInfo} />
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -1,0 +1,129 @@
+/**
+ * TrashBinItem Component
+ *
+ * A single item in the TrashBin popover showing a trashed terminal
+ * with restore and delete actions. Shows a countdown timer.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { RotateCcw, X, Terminal, Command } from "lucide-react";
+import {
+  ClaudeIcon,
+  GeminiIcon,
+  CodexIcon,
+  NpmIcon,
+  YarnIcon,
+  PnpmIcon,
+  BunIcon,
+} from "@/components/icons";
+import { cn } from "@/lib/utils";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import type { TrashedTerminal } from "@/store/slices";
+import type { TerminalType } from "@/types";
+
+interface TrashBinItemProps {
+  terminal: TerminalInstance;
+  trashedInfo: TrashedTerminal;
+}
+
+/**
+ * Get terminal icon based on type
+ */
+function getTerminalIcon(type: TerminalType, className?: string) {
+  const props = { className: cn("w-3.5 h-3.5", className), "aria-hidden": "true" as const };
+  switch (type) {
+    // AI Agents
+    case "claude":
+      return <ClaudeIcon {...props} />;
+    case "gemini":
+      return <GeminiIcon {...props} />;
+    case "codex":
+      return <CodexIcon {...props} />;
+    // Package Managers
+    case "npm":
+      return <NpmIcon {...props} />;
+    case "yarn":
+      return <YarnIcon {...props} />;
+    case "pnpm":
+      return <PnpmIcon {...props} />;
+    case "bun":
+      return <BunIcon {...props} />;
+    // Generic
+    case "custom":
+      return <Command {...props} />;
+    case "shell":
+    default:
+      return <Terminal {...props} />;
+  }
+}
+
+export function TrashBinItem({ terminal, trashedInfo }: TrashBinItemProps) {
+  const restoreTerminal = useTerminalStore((s) => s.restoreTerminal);
+  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
+
+  // Calculate remaining time
+  const [timeRemaining, setTimeRemaining] = useState(() => {
+    return Math.max(0, trashedInfo.expiresAt - Date.now());
+  });
+
+  // Update countdown every second
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const remaining = Math.max(0, trashedInfo.expiresAt - Date.now());
+      setTimeRemaining(remaining);
+
+      if (remaining <= 0) {
+        clearInterval(interval);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [trashedInfo.expiresAt]);
+
+  const seconds = Math.ceil(timeRemaining / 1000);
+
+  const handleRestore = useCallback(() => {
+    restoreTerminal(terminal.id);
+  }, [restoreTerminal, terminal.id]);
+
+  const handleKill = useCallback(() => {
+    removeTerminal(terminal.id);
+  }, [removeTerminal, terminal.id]);
+
+  const terminalName = terminal.title || terminal.type || "Terminal";
+
+  return (
+    <div className="flex items-center gap-2 p-2 rounded bg-white/5 hover:bg-white/10 transition-colors group">
+      {/* Icon */}
+      <div className="shrink-0 text-white/60">{getTerminalIcon(terminal.type)}</div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-medium text-white/90 truncate">{terminalName}</div>
+        <div className="text-[10px] text-white/40" aria-live="polite">
+          {seconds}s remaining
+        </div>
+      </div>
+
+      {/* Actions - always visible for quick access */}
+      <div className="flex gap-1">
+        <button
+          onClick={handleRestore}
+          className="p-1.5 rounded hover:bg-green-500/20 text-green-400 transition-colors"
+          aria-label={`Restore ${terminalName}`}
+          title={`Restore ${terminalName}`}
+        >
+          <RotateCcw className="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+        <button
+          onClick={handleKill}
+          className="p-1.5 rounded hover:bg-red-500/20 text-red-400 transition-colors"
+          aria-label={`Delete ${terminalName} permanently`}
+          title={`Delete ${terminalName} permanently`}
+        >
+          <X className="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -191,7 +191,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 onClick={() => handleToggleEnabled("claude")}
                 className={cn(
                   "relative w-11 h-6 rounded-full transition-colors",
-                  settings.claude.enabled ?? true ? "bg-canopy-accent" : "bg-gray-600"
+                  (settings.claude.enabled ?? true) ? "bg-canopy-accent" : "bg-gray-600"
                 )}
               >
                 <span
@@ -216,7 +216,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 onClick={() => handleToggleEnabled("gemini")}
                 className={cn(
                   "relative w-11 h-6 rounded-full transition-colors",
-                  settings.gemini.enabled ?? true ? "bg-canopy-accent" : "bg-gray-600"
+                  (settings.gemini.enabled ?? true) ? "bg-canopy-accent" : "bg-gray-600"
                 )}
               >
                 <span
@@ -241,7 +241,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 onClick={() => handleToggleEnabled("codex")}
                 className={cn(
                   "relative w-11 h-6 rounded-full transition-colors",
-                  settings.codex.enabled ?? true ? "bg-canopy-accent" : "bg-gray-600"
+                  (settings.codex.enabled ?? true) ? "bg-canopy-accent" : "bg-gray-600"
                 )}
               >
                 <span

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -330,7 +330,9 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
       ref={gridRef}
       className={cn(
         "h-full bg-canopy-border", // bg acts as divider lines
-        dragState.isDragging && dragState.dropZone === "grid" && "ring-2 ring-canopy-accent/30 ring-inset",
+        dragState.isDragging &&
+          dragState.dropZone === "grid" &&
+          "ring-2 ring-canopy-accent/30 ring-inset",
         className
       )}
       style={{
@@ -405,7 +407,9 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
               onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
               onMinimize={() => moveTerminalToDock(terminal.id)}
               isDragging={isDragging}
-              onDragStart={!isTerminalInTrash ? createDragStartHandler(terminal.id, "grid", index) : undefined}
+              onDragStart={
+                !isTerminalInTrash ? createDragStartHandler(terminal.id, "grid", index) : undefined
+              }
             />
           </div>
         );

--- a/src/utils/dragDrop.ts
+++ b/src/utils/dragDrop.ts
@@ -203,10 +203,7 @@ export interface TerminalDragData {
 /**
  * Set terminal drag data in a drag event.
  */
-export function setTerminalDragData(
-  dataTransfer: DataTransfer,
-  data: TerminalDragData
-): void {
+export function setTerminalDragData(dataTransfer: DataTransfer, data: TerminalDragData): void {
   dataTransfer.setData(TERMINAL_DRAG_MIME_TYPE, JSON.stringify(data));
   // Also set text/plain for debugging purposes
   dataTransfer.setData("text/plain", data.terminalId);


### PR DESCRIPTION
## Summary
Fixes critical race condition in terminal trash system where terminals would briefly "disappear" when closed, and replaces individual trash chips with a grouped trash bin UI with popover.

Closes #305

## Changes Made
- Increased trash TTL from 60s to 2 minutes for better recovery time
- Fixed race condition by optimistically updating trashedTerminals map immediately
- Added error handling and rollback for failed trash/restore IPC operations
- Replaced individual trash chips with grouped TrashBin popover component
- Sorted trashed items by expiration time (soonest first)
- Added comprehensive ARIA labels and accessibility features (keyboard navigation, screen readers)
- Improved type safety by removing type assertions and using flatMap

## Technical Details
**Backend (PtyManager):**
- Updated `TRASH_TTL_MS` constant from 60s to 120s

**Store (terminalRegistrySlice):**
- Optimistic update: immediately populate `trashedTerminals` map with calculated expiry
- Rollback mechanism if IPC trash operation fails
- Verify restore success before updating UI state

**UI Components:**
- `TrashBin.tsx`: Main button with popover showing all trashed terminals
- `TrashBinItem.tsx`: Individual item with restore/delete actions and countdown
- `TerminalDock.tsx`: Integration of TrashBin component with improved type safety

## Testing
- ✅ Type checking passes
- ✅ No new lint warnings
- ✅ Code formatted with Prettier
- ✅ Codex review completed (accessibility, error handling, type safety)