### PR TITLE
Improve trash terminal UX with consolidated dock item and location memory

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -171,8 +171,8 @@ export class PtyManager extends EventEmitter {
   private trashTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private ptyPool: PtyPool | null = null;
 
-  /** TTL for trashed terminals before auto-kill (60 seconds) */
-  private readonly TRASH_TTL_MS = 60 * 1000;
+  /** TTL for trashed terminals before auto-kill (2 minutes) */
+  private readonly TRASH_TTL_MS = 120 * 1000;
 
   constructor() {
     super();

--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -14,11 +14,10 @@
 
 import { useState, useCallback, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTerminalStore } from "@/store";
 import { DockedTerminalItem } from "./DockedTerminalItem";
-import { TrashedTerminalItem } from "./TrashedTerminalItem";
+import { TrashContainer } from "./TrashContainer";
 import {
   getTerminalDragData,
   isTerminalDrag,
@@ -187,19 +186,8 @@ export function TerminalDock() {
         <div className="w-px h-5 bg-canopy-border mx-2 shrink-0" />
       )}
 
-      {/* Trashed terminals section */}
-      {trashedItems.length > 0 && (
-        <>
-          <span className="text-xs text-red-400/80 mr-2 shrink-0 flex items-center gap-1">
-            <Trash2 className="w-3 h-3" />
-            Trash ({trashedItems.length})
-          </span>
-
-          {trashedItems.map(({ terminal, trashedInfo }) => (
-            <TrashedTerminalItem key={terminal.id} terminal={terminal} trashedInfo={trashedInfo} />
-          ))}
-        </>
-      )}
+      {/* Consolidated trash container */}
+      <TrashContainer trashedTerminals={trashedItems} />
     </div>
   );
 }

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -1,0 +1,84 @@
+/**
+ * TrashContainer Component
+ *
+ * A consolidated container for trashed terminals in the dock.
+ * Shows a collapsed "Trash (N)" indicator that can be expanded to show
+ * individual trashed terminals with restore/delete actions.
+ *
+ * Features:
+ * - Collapsed by default, showing count of trashed terminals
+ * - Click to expand and show list of trashed terminals
+ * - Auto-collapses when trash becomes empty
+ * - More subtle visual design than individual trash items
+ */
+
+import { useState, useEffect } from "react";
+import { ChevronDown, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TerminalInstance } from "@/store";
+import type { TrashedTerminal } from "@/store/slices";
+import { TrashedTerminalItem } from "./TrashedTerminalItem";
+
+interface TrashContainerProps {
+  trashedTerminals: Array<{
+    terminal: TerminalInstance;
+    trashedInfo: TrashedTerminal;
+  }>;
+}
+
+export function TrashContainer({ trashedTerminals }: TrashContainerProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Auto-collapse when trash becomes empty
+  useEffect(() => {
+    if (trashedTerminals.length === 0) {
+      setIsExpanded(false);
+    }
+  }, [trashedTerminals.length]);
+
+  // Don't render if no trashed terminals
+  if (trashedTerminals.length === 0) return null;
+
+  return (
+    <div className="flex flex-col shrink-0">
+      {/* Collapsed view - always visible when there are items */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className={cn(
+          "flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs transition-all",
+          "hover:bg-orange-500/10 text-orange-400/80 hover:text-orange-400",
+          isExpanded && "bg-orange-500/10"
+        )}
+        aria-expanded={isExpanded}
+        aria-controls="trash-list"
+        aria-label={`Trash: ${trashedTerminals.length} terminal${trashedTerminals.length === 1 ? "" : "s"}. Click to ${isExpanded ? "collapse" : "expand"}`}
+      >
+        <Trash2 className="w-3 h-3" aria-hidden="true" />
+        <span className="font-mono tabular-nums">
+          Trash ({trashedTerminals.length})
+        </span>
+        <ChevronDown
+          className={cn(
+            "w-3 h-3 transition-transform duration-200",
+            isExpanded && "rotate-180"
+          )}
+          aria-hidden="true"
+        />
+      </button>
+
+      {/* Expanded view - shows individual trashed terminals */}
+      {isExpanded && (
+        <div id="trash-list" className="flex items-center gap-1.5 mt-1.5 pl-1" role="list">
+          {trashedTerminals.map(({ terminal, trashedInfo }) => (
+            <TrashedTerminalItem
+              key={terminal.id}
+              terminal={terminal}
+              trashedInfo={trashedInfo}
+              compact
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Layout/TrashedTerminalItem.tsx
+++ b/src/components/Layout/TrashedTerminalItem.tsx
@@ -3,6 +3,10 @@
  *
  * Displays a terminal that's pending deletion with a countdown timer.
  * Shows a restore button and countdown progress bar.
+ *
+ * Supports two display modes:
+ * - Default: Full display with progress bar background (legacy, for backwards compatibility)
+ * - Compact: Subtle display for use in TrashContainer (muted colors, smaller)
  */
 
 import { useState, useEffect, useCallback } from "react";
@@ -24,6 +28,8 @@ import type { TerminalType } from "@/types";
 interface TrashedTerminalItemProps {
   terminal: TerminalInstance;
   trashedInfo: TrashedTerminal;
+  /** Use compact styling for TrashContainer (muted colors, no progress bar) */
+  compact?: boolean;
 }
 
 /**
@@ -57,7 +63,11 @@ function getTerminalIcon(type: TerminalType, className?: string) {
   }
 }
 
-export function TrashedTerminalItem({ terminal, trashedInfo }: TrashedTerminalItemProps) {
+export function TrashedTerminalItem({
+  terminal,
+  trashedInfo,
+  compact = false,
+}: TrashedTerminalItemProps) {
   const restoreTerminal = useTerminalStore((s) => s.restoreTerminal);
   const removeTerminal = useTerminalStore((s) => s.removeTerminal);
 
@@ -107,49 +117,78 @@ export function TrashedTerminalItem({ terminal, trashedInfo }: TrashedTerminalIt
   return (
     <div
       className={cn(
-        "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all relative overflow-hidden",
-        "bg-red-500/10 border-red-500/30 text-red-200"
+        "flex items-center gap-2 rounded text-xs border transition-all relative overflow-hidden",
+        compact
+          ? // Compact mode: muted orange tones, no progress bar
+            "px-2 py-1 bg-orange-500/5 border-orange-500/20 text-orange-300/80"
+          : // Default mode: more prominent orange styling with progress bar
+            "px-3 py-1.5 bg-orange-500/10 border-orange-500/30 text-orange-200"
       )}
       role="status"
       aria-live="polite"
       aria-label={`${terminal.title} will be deleted in ${secondsRemaining} seconds`}
     >
-      {/* Progress bar background */}
-      <div
-        className="absolute inset-0 bg-red-500/20 transition-all duration-100"
-        style={{ width: `${progress * 100}%` }}
-        aria-hidden="true"
-      />
+      {/* Progress bar background - only in non-compact mode */}
+      {!compact && (
+        <div
+          className="absolute inset-0 bg-orange-500/15 transition-all duration-100"
+          style={{ width: `${progress * 100}%` }}
+          aria-hidden="true"
+        />
+      )}
 
       {/* Content layer */}
-      <div className="flex items-center gap-2 relative z-10">
+      <div className="flex items-center gap-1.5 relative z-10">
         {/* Terminal type icon */}
-        {getTerminalIcon(terminal.type, "text-red-300")}
+        {getTerminalIcon(terminal.type, compact ? "text-orange-400/70" : "text-orange-300")}
 
         {/* Countdown */}
-        <span className="font-mono text-red-300 tabular-nums w-5 text-center" aria-hidden="true">
+        <span
+          className={cn(
+            "font-mono tabular-nums text-center",
+            compact ? "text-orange-400/70 w-4" : "text-orange-300 w-5"
+          )}
+          aria-hidden="true"
+        >
           {secondsRemaining}s
         </span>
 
-        {/* Terminal title */}
-        <span className="truncate max-w-[80px] font-mono opacity-70">{terminal.title}</span>
+        {/* Terminal title - narrower in compact mode */}
+        <span
+          className={cn(
+            "truncate font-mono",
+            compact ? "max-w-[60px] opacity-60" : "max-w-[80px] opacity-70"
+          )}
+        >
+          {terminal.title}
+        </span>
 
         {/* Restore button */}
         <button
           onClick={handleRestore}
-          className="p-1 hover:bg-green-500/20 rounded transition-colors text-green-300 hover:text-green-200"
+          className={cn(
+            "rounded transition-colors",
+            compact
+              ? "p-0.5 hover:bg-emerald-500/20 text-emerald-400/70 hover:text-emerald-400"
+              : "p-1 hover:bg-emerald-500/20 text-emerald-400 hover:text-emerald-300"
+          )}
           aria-label={`Restore ${terminal.title}`}
         >
-          <Undo2 className="w-3 h-3" aria-hidden="true" />
+          <Undo2 className={compact ? "w-2.5 h-2.5" : "w-3 h-3"} aria-hidden="true" />
         </button>
 
-        {/* Immediate close button */}
+        {/* Immediate close button - red for destructive action */}
         <button
           onClick={handleImmediateClose}
-          className="p-1 hover:bg-red-500/30 rounded transition-colors text-red-300 hover:text-red-200"
+          className={cn(
+            "rounded transition-colors",
+            compact
+              ? "p-0.5 hover:bg-red-500/20 text-red-400/70 hover:text-red-400"
+              : "p-1 hover:bg-red-500/30 text-red-400 hover:text-red-300"
+          )}
           aria-label={`Delete ${terminal.title} immediately`}
         >
-          <X className="w-3 h-3" aria-hidden="true" />
+          <X className={compact ? "w-2.5 h-2.5" : "w-3 h-3"} aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -239,7 +239,12 @@ if (typeof window !== "undefined") {
   trashedUnsubscribe = terminalClient.onTrashed((data) => {
     const { id, expiresAt } = data;
     const state = useTerminalStore.getState();
-    state.markAsTrashed(id, expiresAt);
+    // Fallback to 'grid' if terminal wasn't trashed via trashTerminal (edge case)
+    // The terminal's original location is captured by trashTerminal before this event
+    const terminal = state.terminals.find((t) => t.id === id);
+    const originalLocation: "dock" | "grid" =
+      terminal?.location === "dock" ? "dock" : "grid";
+    state.markAsTrashed(id, expiresAt, originalLocation);
 
     // Clear focus/maximize if the trashed terminal was active (same as trashTerminal override)
     const updates: Partial<TerminalGridState> = {};


### PR DESCRIPTION
## Summary
This PR improves the trash terminal user experience by consolidating trashed terminals into a single dock item, increasing the trash TTL, and preserving terminal location (dock vs grid) during restoration.

Closes #288

## Changes Made
- Increase trash TTL from 60 seconds to 2 minutes for better user experience
- Add `originalLocation` field to `TrashedTerminal` interface to preserve dock/grid state
- Create `TrashContainer` component with collapsed/expanded states
- Implement compact mode for `TrashedTerminalItem` with subtle orange styling
- Fix race conditions in `markAsTrashed`/`markAsRestored` IPC handlers
- Add accessibility improvements (`aria-controls`, `role` attributes)
- Update color palette from red to orange/amber tones for less visual prominence

## Implementation Details

### Location Memory
- Terminals now remember whether they were in the dock or grid before being trashed
- On restore, terminals return to their original location instead of always going to the grid
- Handles edge cases like rapid trash/restore and IPC event ordering

### Consolidated Trash UI
- All trashed terminals appear as a single "Trash (N)" item in the dock
- Click to expand and see individual terminals with restore/delete actions
- Auto-collapses when trash becomes empty
- More subtle visual design with muted orange tones

### Fixes
- Fixed race condition where `markAsRestored` could override location set by `restoreTerminal`
- Added guard in `markAsTrashed` to ignore stale IPC events after fast restore
- Improved accessibility with proper ARIA attributes for screen readers