### PR TITLE
Consolidate duplicate utility functions (formatBytes, SimpleCache)

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -14,6 +14,7 @@
 import { graphql, type GraphQlQueryResponseData } from "@octokit/graphql";
 import { simpleGit } from "simple-git";
 import { store } from "../store.js";
+import { Cache } from "../utils/cache.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -72,56 +73,13 @@ export interface BatchPRCheckResult {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Cache
-// ─────────────────────────────────────────────────────────────────────────────
-
-interface CacheEntry<T> {
-  value: T;
-  expiresAt: number;
-}
-
-class SimpleCache<T> {
-  private cache = new Map<string, CacheEntry<T>>();
-  private defaultTTL: number;
-
-  constructor(defaultTTL: number = 60000) {
-    this.defaultTTL = defaultTTL;
-  }
-
-  get(key: string): T | undefined {
-    const entry = this.cache.get(key);
-    if (!entry) return undefined;
-    if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
-      return undefined;
-    }
-    return entry.value;
-  }
-
-  set(key: string, value: T, ttl?: number): void {
-    this.cache.set(key, {
-      value,
-      expiresAt: Date.now() + (ttl ?? this.defaultTTL),
-    });
-  }
-
-  clear(): void {
-    this.cache.clear();
-  }
-
-  delete(key: string): void {
-    this.cache.delete(key);
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // GitHub Service
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Cache instances
-const repoContextCache = new SimpleCache<RepoContext>(300000); // 5 minutes
-const repoStatsCache = new SimpleCache<RepoStats>(60000); // 1 minute
-const prCheckCache = new SimpleCache<PRCheckResult>(60000); // 1 minute
+const repoContextCache = new Cache<string, RepoContext>({ defaultTTL: 300000 }); // 5 minutes
+const repoStatsCache = new Cache<string, RepoStats>({ defaultTTL: 60000 }); // 1 minute
+const prCheckCache = new Cache<string, PRCheckResult>({ defaultTTL: 60000 }); // 1 minute
 
 /**
  * Get the GitHub token from storage.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,18 +40,10 @@ import {
   errorsClient,
   devServerClient,
 } from "@/clients";
+import { formatBytes } from "@/lib/formatBytes";
 
 interface SidebarContentProps {
   onOpenSettings: (tab?: "ai" | "general" | "troubleshooting") => void;
-}
-
-function formatBytes(bytes: number, decimals = 2) {
-  if (!+bytes) return "0 Bytes";
-  const k = 1024;
-  const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
 function SidebarContent({ onOpenSettings }: SidebarContentProps) {

--- a/src/components/ContextInjection/FilePickerModal.tsx
+++ b/src/components/ContextInjection/FilePickerModal.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { formatBytes } from "@/lib/formatBytes";
 import { useFileTree } from "@/hooks/useFileTree";
 import type { FileTreeNode } from "@shared/types";
 
@@ -329,10 +330,3 @@ function FileTreeNode({
 }
 
 // Utility to format bytes
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return "0 B";
-  const k = 1024;
-  const sizes = ["B", "KB", "MB", "GB"];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(1))} ${sizes[i]}`;
-}

--- a/src/lib/__tests__/formatBytes.test.ts
+++ b/src/lib/__tests__/formatBytes.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { formatBytes } from "../formatBytes";
+
+describe("formatBytes", () => {
+  it("should format zero bytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+  });
+
+  it("should format bytes", () => {
+    expect(formatBytes(1)).toBe("1 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+  });
+
+  it("should format kilobytes", () => {
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(10240)).toBe("10 KB");
+  });
+
+  it("should format megabytes", () => {
+    expect(formatBytes(1048576)).toBe("1 MB");
+    expect(formatBytes(5242880)).toBe("5 MB");
+    expect(formatBytes(1572864)).toBe("1.5 MB");
+  });
+
+  it("should format gigabytes", () => {
+    expect(formatBytes(1073741824)).toBe("1 GB");
+    expect(formatBytes(5368709120)).toBe("5 GB");
+    expect(formatBytes(1610612736)).toBe("1.5 GB");
+  });
+
+  it("should format terabytes", () => {
+    expect(formatBytes(1099511627776)).toBe("1 TB");
+    expect(formatBytes(5497558138880)).toBe("5 TB");
+  });
+
+  it("should round to 1 decimal place", () => {
+    expect(formatBytes(1234)).toBe("1.2 KB");
+    expect(formatBytes(1567)).toBe("1.5 KB");
+    expect(formatBytes(1890)).toBe("1.8 KB");
+  });
+
+  it("should handle boundary values correctly", () => {
+    // Just below 1 KB (should stay in bytes)
+    expect(formatBytes(1023)).toBe("1023 B");
+
+    // Just below 1 MB (should stay in KB, not round up to 1024 KB)
+    expect(formatBytes(1048575)).toBe("1 MB"); // 1024^2 - 1 rounds to 1 MB
+
+    // Just below 1 GB
+    expect(formatBytes(1073741823)).toBe("1 GB"); // 1024^3 - 1 rounds to 1 GB
+  });
+
+  it("should handle negative and sub-byte values", () => {
+    expect(formatBytes(-1)).toBe("0 B");
+    expect(formatBytes(-1000)).toBe("0 B");
+    expect(formatBytes(0.5)).toBe("0.5 B"); // Fractional bytes are shown as-is
+  });
+
+  it("should handle very large values (petabytes and above)", () => {
+    // 1 PB (beyond TB range) - should clamp to TB
+    expect(formatBytes(1125899906842624)).toBe("1024 TB");
+
+    // 10 PB
+    expect(formatBytes(11258999068426240)).toBe("10240 TB");
+  });
+});

--- a/src/lib/formatBytes.ts
+++ b/src/lib/formatBytes.ts
@@ -1,0 +1,27 @@
+/**
+ * Format bytes to human-readable size string
+ * @param bytes - Number of bytes to format
+ * @returns Formatted string (e.g., "1.5 MB")
+ */
+export function formatBytes(bytes: number): string {
+  // Handle non-positive values
+  if (bytes <= 0) return "0 B";
+
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+
+  // Calculate unit index and clamp to valid range
+  let i = Math.floor(Math.log(bytes) / Math.log(k));
+  i = Math.max(0, Math.min(i, sizes.length - 1));
+
+  // Calculate the value in the selected unit
+  const value = bytes / Math.pow(k, i);
+  const rounded = parseFloat(value.toFixed(1));
+
+  // Handle rounding up to next unit (e.g., 1023.95 KB → 1 MB)
+  if (rounded >= k && i < sizes.length - 1) {
+    return `${parseFloat((rounded / k).toFixed(1))} ${sizes[i + 1]}`;
+  }
+
+  return `${rounded} ${sizes[i]}`;
+}


### PR DESCRIPTION
## Summary
Consolidates duplicate utility implementations to reduce code duplication and improve maintainability.

Closes #316

## Changes Made
- Created shared `formatBytes` utility in `src/lib/formatBytes.ts` with robust edge case handling (negative values, boundary rounding, petabyte overflow)
- Removed duplicate `formatBytes` implementations from `App.tsx` and `FilePickerModal.tsx`
- Migrated `GitHubService` from custom `SimpleCache<T>` to canonical `Cache<K,V>` from `utils/cache.ts`
- Added comprehensive test coverage for `formatBytes` including edge cases and boundary values
- Fixed formatBytes boundary rounding issue (e.g., 1048575 bytes now correctly displays as "1 MB" instead of "1024 KB")

## Testing
- All existing tests pass
- Added 10 new test cases for `formatBytes` covering zero, bytes, KB, MB, GB, TB, boundaries, negatives, and overflow
- TypeScript compilation and linting pass without new warnings