### PR TITLE
Distinguish empty grid spaces from active terminals

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -120,11 +120,7 @@ export async function validateGitHubToken(token: string): Promise<GitHubTokenVal
   }
 
   // Basic format validation
-  if (
-    !token.startsWith("ghp_") &&
-    !token.startsWith("github_pat_") &&
-    !token.startsWith("gho_")
-  ) {
+  if (!token.startsWith("ghp_") && !token.startsWith("github_pat_") && !token.startsWith("gho_")) {
     if (token.length < 40) {
       return { valid: false, scopes: [], error: "Invalid token format" };
     }
@@ -249,11 +245,7 @@ export async function getRepoInfo(cwd: string): Promise<RepoContext | null> {
 }
 
 /** Build batch PR query */
-function buildBatchPRQuery(
-  owner: string,
-  repo: string,
-  candidates: PRCheckCandidate[]
-): string {
+function buildBatchPRQuery(owner: string, repo: string, candidates: PRCheckCandidate[]): string {
   const issueQueries: string[] = [];
   const branchQueries: string[] = [];
 
@@ -323,7 +315,15 @@ function parseBatchPRResponse(
     )?.issue?.timelineItems?.nodes;
     if (issueData && Array.isArray(issueData)) {
       const prs: LinkedPR[] = [];
-      for (const node of issueData as Array<{ source?: { number?: number; url?: string; state?: string; isDraft?: boolean; merged?: boolean } }>) {
+      for (const node of issueData as Array<{
+        source?: {
+          number?: number;
+          url?: string;
+          state?: string;
+          isDraft?: boolean;
+          merged?: boolean;
+        };
+      }>) {
         const source = node?.source;
         if (source?.number && source?.url) {
           prs.push({
@@ -351,18 +351,21 @@ function parseBatchPRResponse(
     }
 
     if (!foundPR) {
-      const branchData = (
-        data?.[`${alias}_branch`] as { pullRequests?: { nodes?: unknown[] } }
-      )?.pullRequests?.nodes;
+      const branchData = (data?.[`${alias}_branch`] as { pullRequests?: { nodes?: unknown[] } })
+        ?.pullRequests?.nodes;
       if (branchData && Array.isArray(branchData) && branchData.length > 0) {
-        const pr = branchData[0] as { number?: number; url?: string; state?: string; isDraft?: boolean; merged?: boolean };
+        const pr = branchData[0] as {
+          number?: number;
+          url?: string;
+          state?: string;
+          isDraft?: boolean;
+          merged?: boolean;
+        };
         if (pr?.number && pr?.url) {
           foundPR = {
             number: pr.number,
             url: pr.url,
-            state: pr.merged
-              ? "merged"
-              : (pr.state?.toLowerCase() as "open" | "closed") || "open",
+            state: pr.merged ? "merged" : (pr.state?.toLowerCase() as "open" | "closed") || "open",
             isDraft: pr.isDraft ?? false,
           };
         }

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -151,7 +151,7 @@ export class GitService {
   > {
     try {
       const output = await this.git.raw(["worktree", "list", "--porcelain"]);
-      const worktrees: Array<{ 
+      const worktrees: Array<{
         path: string;
         branch: string;
         bare: boolean;

--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -149,7 +149,7 @@ export class ProcessDetector {
       }
 
       const { stdout } = await execAsync(
-        `wmic process where "ParentProcessId=${this.ptyPid}" get ProcessId,Name 2>nul || echo.`, 
+        `wmic process where "ParentProcessId=${this.ptyPid}" get ProcessId,Name 2>nul || echo.`,
         { timeout: 5000 }
       );
 
@@ -182,7 +182,7 @@ export class ProcessDetector {
       for (const childPid of childPids.slice(0, 10)) {
         try {
           const { stdout: childStdout } = await execAsync(
-            `wmic process where "ParentProcessId=${childPid}" get Name 2>nul || echo.`, 
+            `wmic process where "ParentProcessId=${childPid}" get Name 2>nul || echo.`,
             { timeout: 5000 }
           );
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -7,11 +7,7 @@ import type { WorktreeState } from "./WorktreeMonitor.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 60 * 1000;
 
-const ERROR_BACKOFF_INTERVALS = [
-  5 * 60 * 1000,
-  10 * 60 * 1000,
-  30 * 60 * 1000,
-];
+const ERROR_BACKOFF_INTERVALS = [5 * 60 * 1000, 10 * 60 * 1000, 30 * 60 * 1000];
 
 const MAX_CONSECUTIVE_ERRORS = 3;
 const UPDATE_DEBOUNCE_MS = 100;

--- a/electron/services/TranscriptManager.ts
+++ b/electron/services/TranscriptManager.ts
@@ -84,11 +84,7 @@ export class TranscriptManager {
   }
 
   /** Append output and extract artifacts */
-  private handleAgentOutput(payload: {
-    agentId: string;
-    data: string;
-    timestamp: number;
-  }): void {
+  private handleAgentOutput(payload: { agentId: string; data: string; timestamp: number }): void {
     if (this.disposed) return;
 
     const session = this.activeSessions.get(payload.agentId);

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -37,9 +37,7 @@ export function GitHubSettingsTab() {
       } catch (error) {
         console.error("Failed to load GitHub config:", error);
         if (!cancelled) {
-          setLoadError(
-            error instanceof Error ? error.message : "Failed to load GitHub settings"
-          );
+          setLoadError(error instanceof Error ? error.message : "Failed to load GitHub settings");
         }
       } finally {
         if (!cancelled) {

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -329,7 +329,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
     <div
       ref={gridRef}
       className={cn(
-        "h-full bg-canopy-border", // bg acts as divider lines
+        "h-full bg-black", // bg acts as divider lines
         dragState.isDragging &&
           dragState.dropZone === "grid" &&
           "ring-2 ring-canopy-accent/30 ring-inset",
@@ -339,7 +339,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
         display: "grid",
         gridTemplateColumns: `repeat(${gridCols}, 1fr)`,
         gridAutoRows: "1fr",
-        gap: "1px", // 1px gap reveals bg-canopy-border underneath = clean dividers
+        gap: "1px", // 1px gap reveals bg-black underneath = clean dividers
         padding: "0", // No outer padding
       }}
       role="grid"


### PR DESCRIPTION
## Summary
Changes the terminal grid background from light gray to pure black to visually distinguish empty grid cells from active terminal panes.

Closes #344

## Changes Made
- Change grid container background from `bg-canopy-border` to `bg-black`
- Update inline comment to reflect new background color
- Empty grid cells now render as pure black (#000000)
- Active terminals remain charcoal (#18181b) providing visual contrast
- Apply Prettier formatting to multiple service files