### PR TITLE
Fix: Trashed terminals not removed from UI when expired

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import {
 } from "./store";
 import { useShallow } from "zustand/react/shallow";
 import { useRecipeStore } from "./store/recipeStore";
-import { cleanupTerminalStoreListeners } from "./store/terminalStore";
+import { setupTerminalStoreListeners } from "./store/terminalStore";
 import type { WorktreeState } from "./types";
 import {
   systemClient,
@@ -532,10 +532,10 @@ function App() {
   useKeybinding("panel.diagnostics", () => toggleDiagnosticsDock(), { enabled: electronAvailable });
 
   useEffect(() => {
-    return () => {
-      cleanupTerminalStoreListeners();
-    };
-  }, []);
+    if (!electronAvailable) return;
+    const cleanup = setupTerminalStoreListeners();
+    return cleanup;
+  }, [electronAvailable]);
 
   useEffect(() => {
     if (!electronAvailable) return;

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -179,7 +179,37 @@ let trashedUnsubscribe: (() => void) | null = null;
 let restoredUnsubscribe: (() => void) | null = null;
 let exitUnsubscribe: (() => void) | null = null;
 
-if (typeof window !== "undefined") {
+export function cleanupTerminalStoreListeners() {
+  if (agentStateUnsubscribe) {
+    agentStateUnsubscribe();
+    agentStateUnsubscribe = null;
+  }
+  if (activityUnsubscribe) {
+    activityUnsubscribe();
+    activityUnsubscribe = null;
+  }
+  if (trashedUnsubscribe) {
+    trashedUnsubscribe();
+    trashedUnsubscribe = null;
+  }
+  if (restoredUnsubscribe) {
+    restoredUnsubscribe();
+    restoredUnsubscribe = null;
+  }
+  if (exitUnsubscribe) {
+    exitUnsubscribe();
+    exitUnsubscribe = null;
+  }
+}
+
+export function setupTerminalStoreListeners() {
+  if (typeof window === "undefined") return () => {};
+
+  // Idempotent: return early if already setup to prevent event loss window and overlapping cleanup
+  if (exitUnsubscribe !== null) {
+    return cleanupTerminalStoreListeners;
+  }
+
   agentStateUnsubscribe = terminalClient.onAgentStateChanged((data) => {
     const { agentId, state, timestamp, trigger, confidence } = data;
 
@@ -235,27 +265,6 @@ if (typeof window !== "undefined") {
       state.removeTerminal(id);
     }
   });
-}
 
-export function cleanupTerminalStoreListeners() {
-  if (agentStateUnsubscribe) {
-    agentStateUnsubscribe();
-    agentStateUnsubscribe = null;
-  }
-  if (activityUnsubscribe) {
-    activityUnsubscribe();
-    activityUnsubscribe = null;
-  }
-  if (trashedUnsubscribe) {
-    trashedUnsubscribe();
-    trashedUnsubscribe = null;
-  }
-  if (restoredUnsubscribe) {
-    restoredUnsubscribe();
-    restoredUnsubscribe = null;
-  }
-  if (exitUnsubscribe) {
-    exitUnsubscribe();
-    exitUnsubscribe = null;
-  }
+  return cleanupTerminalStoreListeners;
 }


### PR DESCRIPTION
## Summary
Fixes the bug where trashed terminals remain visible in the UI even after the backend expires and kills them after 2 minutes. The root cause was event listeners being registered at module-load time, which were lost during React Strict Mode unmounts or HMR reloads.

Closes #355

## Changes Made
- Move listener registration from module-level to `setupTerminalStoreListeners()` function
- Call setup in `App.tsx` useEffect with proper cleanup on unmount
- Make setup idempotent to prevent event loss during HMR/Strict Mode remounts
- Use computed `electronAvailable` value with dependency tracking
- Fixes the critical `onExit` listener that removes expired terminals from UI state