### PR TITLE
Fix: Resolve docked terminal input freeze and unify terminal components

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -15,10 +15,7 @@ import { TerminalObserver } from "./services/TerminalObserver.js";
 import { PtyPool, getPtyPool } from "./services/PtyPool.js";
 import { events } from "./services/events.js";
 import type { AgentEvent } from "./services/AgentStateMachine.js";
-import type {
-  PtyHostEvent,
-  PtyHostTerminalSnapshot,
-} from "../shared/types/pty-host.js";
+import type { PtyHostEvent, PtyHostTerminalSnapshot } from "../shared/types/pty-host.js";
 
 // Validate we're running in UtilityProcess context
 if (!process.parentPort) {

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -280,6 +280,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
                   }
                 : null
             }
+            location="grid"
             onFocus={() => setFocused(terminal.id)}
             onClose={() => trashTerminal(terminal.id)}
             onInjectContext={
@@ -376,6 +377,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
                     }
                   : null
               }
+              location="grid"
               onFocus={() => setFocused(terminal.id)}
               onClose={() => trashTerminal(terminal.id)}
               onInjectContext={

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -57,6 +57,8 @@ export interface TerminalPaneProps {
   onToggleMaximize?: () => void;
   onTitleChange?: (newTitle: string) => void;
   onMinimize?: () => void;
+  onRestore?: () => void;
+  location?: "grid" | "dock";
   isDragging?: boolean;
   onDragStart?: (e: React.DragEvent) => void;
 }
@@ -117,6 +119,8 @@ export function TerminalPane({
   onToggleMaximize,
   onTitleChange,
   onMinimize,
+  onRestore,
+  location = "grid",
   isDragging,
   onDragStart,
 }: TerminalPaneProps) {
@@ -294,9 +298,7 @@ export function TerminalPane({
         "flex flex-col h-full rounded overflow-hidden border transition-all duration-200 group",
         "bg-[var(--color-surface)] shadow-md",
         // Subtle focus indicator - neutral glow
-        isFocused
-          ? "terminal-focused border-zinc-600"
-          : "border-zinc-800 hover:border-zinc-700",
+        isFocused ? "terminal-focused border-zinc-600" : "border-zinc-800 hover:border-zinc-700",
         isExited && "opacity-75 grayscale",
         isDragging && "opacity-50 ring-2 ring-canopy-accent"
       )}
@@ -453,7 +455,7 @@ export function TerminalPane({
               <Copy className="w-3 h-3" aria-hidden="true" />
             </button>
           )}
-          {onMinimize && !isMaximized && (
+          {location === "grid" && onMinimize && !isMaximized && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -464,6 +466,19 @@ export function TerminalPane({
               aria-label="Minimize to dock"
             >
               <ArrowDownToLine className="w-3 h-3" aria-hidden="true" />
+            </button>
+          )}
+          {location === "dock" && onRestore && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onRestore();
+              }}
+              className="p-1.5 hover:bg-white/10 focus-visible:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent text-canopy-text/60 hover:text-canopy-text transition-colors"
+              title="Restore to grid"
+              aria-label="Restore to grid"
+            >
+              <Maximize2 className="w-3 h-3" aria-hidden="true" />
             </button>
           )}
           {onToggleMaximize && (


### PR DESCRIPTION
## Summary
Fixes docked terminals freezing user input when the popover is opened by implementing proper buffering control and unifying the terminal component architecture.

Closes #351

## Changes Made
- Added `location` prop (`"grid" | "dock"`) to TerminalPane for context-aware rendering
- Replaced raw XtermAdapter in DockedTerminalItem with full TerminalPane component
- Implemented buffering toggle in useEffect that:
  - Disables buffering and flushes queue when popover opens
  - Enables buffering when popover closes for resource optimization
- Added race condition guards:
  - `isRestoring` flag prevents buffering conflicts during grid restore
  - Cancellation token prevents stale async operations
- Added error handling for terminal trash/exit scenarios
- All TerminalPane features now available in dock: artifact overlay, context injection, state badges, error banners

## Technical Details
**Root cause:** Buffering was enabled when terminal moved to dock but never disabled when popover opened, causing all output to queue instead of streaming.

**Solution:** Dynamic buffering control via useEffect watching `isOpen` state:
- Open: `setBuffering(false)` + `flush()` + `TerminalRefreshTier.VISIBLE`
- Close: `setBuffering(true)` + `TerminalRefreshTier.BACKGROUND`

**Race conditions fixed:**
1. Restore path: Set `isRestoring` flag before calling `moveTerminalToGrid` to skip buffering effect
2. Async operations: Sequential awaits with cancellation token prevent stale operations

## Testing
- ✅ Type checking passes
- ✅ ESLint passes (no new warnings)
- ✅ Code formatting applied
- ✅ Codex review completed - 3 critical issues fixed