### PR TITLE
Fix: Enable agent CLI spawning and brand colors in empty state launcher

### DIFF
--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -8,6 +8,7 @@ import { TerminalPane } from "./TerminalPane";
 import { FilePickerModal } from "@/components/ContextInjection";
 import { Terminal } from "lucide-react";
 import { CanopyIcon, CodexIcon, ClaudeIcon, GeminiIcon } from "@/components/icons";
+import { getBrandColorHex } from "@/lib/colorUtils";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
@@ -89,14 +90,14 @@ function EmptyState({
             title="Claude Code"
             description="Best for sustained, autonomous refactoring sessions."
             shortcut="Ctrl+Shift+C"
-            icon={<ClaudeIcon className="h-5 w-5" />}
+            icon={<ClaudeIcon className="h-5 w-5" brandColor={getBrandColorHex("claude")} />}
             onClick={() => onLaunchAgent("claude")}
             primary
           />
           <LauncherCard
             title="Codex CLI"
             description="Top-tier reasoning depth with context compaction."
-            icon={<CodexIcon className="h-5 w-5" />}
+            icon={<CodexIcon className="h-5 w-5" brandColor={getBrandColorHex("codex")} />}
             onClick={() => onLaunchAgent("codex")}
             primary
           />
@@ -104,7 +105,7 @@ function EmptyState({
             title="Gemini CLI"
             description="Fast auto-routing and multi-modal image input."
             shortcut="Ctrl+Shift+G"
-            icon={<GeminiIcon className="h-5 w-5" />}
+            icon={<GeminiIcon className="h-5 w-5" brandColor={getBrandColorHex("gemini")} />}
             onClick={() => onLaunchAgent("gemini")}
             primary
           />
@@ -180,10 +181,10 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
     async (type: "claude" | "gemini" | "codex" | "shell") => {
       try {
         const cwd = defaultCwd || "";
-        await addTerminal({ type, cwd });
+        const command = type !== "shell" ? type : undefined;
+        await addTerminal({ type, cwd, command });
       } catch (error) {
         console.error(`Failed to launch ${type}:`, error);
-        // Error will be displayed via the error banner system
       }
     },
     [addTerminal, defaultCwd]

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -133,7 +133,7 @@ export const createTerminalRegistrySlice =
           worktreeId: options.worktreeId,
         });
 
-        const isAgentTerminal = type === "claude" || type === "gemini";
+        const isAgentTerminal = type === "claude" || type === "gemini" || type === "codex";
         const terminal: TerminalInstance = {
           id,
           type,


### PR DESCRIPTION
## Summary
Fixes agent launcher buttons in the terminal grid empty state to properly spawn agent CLI processes and display brand colors.

Closes #320

## Changes Made
- Added command parameter to handleLaunchAgent to explicitly spawn agent CLI processes ("claude", "gemini", "codex")
- Applied brand colors to Claude, Gemini, and Codex launcher icons using getBrandColorHex utility
- Included Codex in agent terminal detection for proper state tracking and lifecycle management

## Technical Details
The root cause was that handleLaunchAgent only passed the `type` parameter to `addTerminal`, but didn't specify the `command` parameter. Without an explicit command, terminals would spawn as plain shells instead of launching the agent CLI.

The fix maps each agent type to its corresponding CLI command string, while keeping shell-type terminals as undefined to preserve default shell behavior.

Additionally, the terminal registry slice now properly identifies Codex as an agent terminal, enabling state tracking, transcripts, and agent lifecycle management features.