### PR TITLE
Fix worktree path suggestion on Windows

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -7,6 +7,7 @@ export const CHANNELS = {
   WORKTREE_CREATE: "worktree:create",
   WORKTREE_LIST_BRANCHES: "worktree:list-branches",
   WORKTREE_PR_REFRESH: "worktree:pr-refresh",
+  WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
 
   DEVSERVER_START: "devserver:start",
   DEVSERVER_STOP: "devserver:stop",

--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -77,6 +77,20 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
   ipcMain.handle(CHANNELS.WORKTREE_LIST_BRANCHES, handleWorktreeListBranches);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_LIST_BRANCHES));
 
+  const handleWorktreeGetDefaultPath = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: { rootPath: string; branchName: string }
+  ): Promise<string> => {
+    const { rootPath, branchName } = payload;
+    const repoName = path.basename(rootPath);
+    const sanitizedBranch = branchName.replace(/[^a-zA-Z0-9-_]/g, "-");
+    const worktreesDir = path.join(path.dirname(rootPath), `${repoName}-worktrees`);
+    const worktreePath = path.join(worktreesDir, sanitizedBranch);
+    return path.normalize(worktreePath);
+  };
+  ipcMain.handle(CHANNELS.WORKTREE_GET_DEFAULT_PATH, handleWorktreeGetDefaultPath);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_DEFAULT_PATH));
+
   const handleGitGetFileDiff = async (
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; filePath: string; status: string }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -71,6 +71,7 @@ const CHANNELS = {
   WORKTREE_CREATE: "worktree:create",
   WORKTREE_LIST_BRANCHES: "worktree:list-branches",
   WORKTREE_PR_REFRESH: "worktree:pr-refresh",
+  WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
   WORKTREE_SET_ADAPTIVE_BACKOFF_CONFIG: "worktree:set-adaptive-backoff-config",
   WORKTREE_IS_CIRCUIT_BREAKER_TRIPPED: "worktree:is-circuit-breaker-tripped",
   WORKTREE_GET_ADAPTIVE_BACKOFF_METRICS: "worktree:get-adaptive-backoff-metrics",
@@ -229,6 +230,9 @@ const api: ElectronAPI = {
       _typedInvoke(CHANNELS.WORKTREE_CREATE, { rootPath, options }),
 
     listBranches: (rootPath: string) => _typedInvoke(CHANNELS.WORKTREE_LIST_BRANCHES, { rootPath }),
+
+    getDefaultPath: (rootPath: string, branchName: string): Promise<string> =>
+      _typedInvoke(CHANNELS.WORKTREE_GET_DEFAULT_PATH, { rootPath, branchName }),
 
     setAdaptiveBackoffConfig: (enabled: boolean, maxInterval?: number, threshold?: number) =>
       _typedInvoke(CHANNELS.WORKTREE_SET_ADAPTIVE_BACKOFF_CONFIG, {

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -821,6 +821,10 @@ export interface IpcInvokeMap {
     args: [payload: { rootPath: string }];
     result: BranchInfo[];
   };
+  "worktree:get-default-path": {
+    args: [payload: { rootPath: string; branchName: string }];
+    result: string;
+  };
   "worktree:set-adaptive-backoff-config": {
     args: [payload: { enabled: boolean; maxInterval?: number; threshold?: number }];
     result: void;
@@ -1292,6 +1296,7 @@ export interface ElectronAPI {
     setActive(worktreeId: string): Promise<void>;
     create(options: CreateWorktreeOptions, rootPath: string): Promise<void>;
     listBranches(rootPath: string): Promise<BranchInfo[]>;
+    getDefaultPath(rootPath: string, branchName: string): Promise<string>;
     setAdaptiveBackoffConfig(
       enabled: boolean,
       maxInterval?: number,

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -39,6 +39,10 @@ export const worktreeClient = {
     return window.electron.worktree.listBranches(rootPath);
   },
 
+  getDefaultPath: (rootPath: string, branchName: string): Promise<string> => {
+    return window.electron.worktree.getDefaultPath(rootPath, branchName);
+  },
+
   setAdaptiveBackoffConfig: (
     enabled: boolean,
     maxInterval?: number,

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -245,14 +245,6 @@ export function DockedTerminalItem({
             isInjecting={isInjecting}
             injectionProgress={progress}
             agentState={terminal.agentState}
-            stateDebugInfo={
-              terminal.stateChangeTrigger
-                ? {
-                    trigger: terminal.stateChangeTrigger,
-                    confidence: terminal.stateChangeConfidence ?? 0,
-                  }
-                : null
-            }
             activity={
               terminal.activityHeadline
                 ? {

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -52,10 +52,21 @@ export function NewWorktreeDialog({
 
   useEffect(() => {
     if (newBranch && rootPath) {
-      const repoName = rootPath.split("/").pop() || "repo";
-      const sanitizedBranch = newBranch.replace(/[^a-zA-Z0-9-_]/g, "-");
-      const suggestedPath = `${rootPath}/../${repoName}-worktrees/${sanitizedBranch}`;
-      setWorktreePath(suggestedPath);
+      const trimmedBranch = newBranch.trim();
+      worktreeClient
+        .getDefaultPath(rootPath, trimmedBranch)
+        .then((suggestedPath) => {
+          setWorktreePath(suggestedPath);
+        })
+        .catch((err) => {
+          console.error("Failed to get default path:", err);
+          const sanitizedBranch = trimmedBranch.replace(/[^a-zA-Z0-9-_]/g, "-");
+          const separator = rootPath.includes("\\") ? "\\" : "/";
+          const repoName = rootPath.split(/[/\\]/).pop() || "repo";
+          setWorktreePath(
+            `${rootPath}${separator}..${separator}${repoName}-worktrees${separator}${sanitizedBranch}`
+          );
+        });
     }
   }, [newBranch, rootPath]);
 


### PR DESCRIPTION
## Summary
Fixes the worktree path suggestion feature on Windows by using Node.js path utilities instead of hardcoded forward slash string splitting. The dialog now calls an IPC handler in the main process that properly uses `path.basename()`, `path.dirname()`, `path.join()`, and `path.normalize()` for cross-platform compatibility.

Closes #362

## Changes Made
- Add IPC handler to generate default worktree paths using Node.js path utilities
- Replace hardcoded forward slash string splitting with path.basename/dirname/join
- Update NewWorktreeDialog to call IPC instead of computing paths in renderer
- Trim branch name before path generation to match creation behavior
- Implement cross-platform fallback with proper path separator detection
- Remove unused stateDebugInfo prop from DockedTerminalItem
- Fixes path generation on Windows where backslashes are used

## Testing
- TypeScript type checking passes
- ESLint passes (all warnings pre-existing)
- Prettier formatting passes
- Code reviewed with Codex