### PR TITLE
fix(build): implement environment-aware CSP transformation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- CSP: Allow Vite dev server in development -->
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self' http://localhost:5173 ws://localhost:5173; script-src 'self' http://localhost:5173; style-src 'self' http://localhost:5173 'unsafe-inline'; font-src 'self' data:; connect-src 'self' http://localhost:5173 ws://localhost:5173; img-src 'self' http://localhost:5173 https://avatars.githubusercontent.com; frame-src 'self' https://www.youtube.com;"
-    />
+    <!-- CSP: Transformed by vite.config.ts cspTransformPlugin (dev/prod aware) -->
+    <meta http-equiv="Content-Security-Policy" content="" />
     <title>Canopy</title>
   </head>
   <body>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -245,14 +245,6 @@ export function DockedTerminalItem({
             isInjecting={isInjecting}
             injectionProgress={progress}
             agentState={terminal.agentState}
-            stateDebugInfo={
-              terminal.stateChangeTrigger
-                ? {
-                    trigger: terminal.stateChangeTrigger,
-                    confidence: terminal.stateChangeConfidence ?? 0,
-                  }
-                : null
-            }
             activity={
               terminal.activityHeadline
                 ? {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,53 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
 
+// CSP definitions for development and production
+const DEV_CSP = [
+  "default-src 'self' http://localhost:5173 ws://localhost:5173",
+  "script-src 'self' http://localhost:5173",
+  "style-src 'self' http://localhost:5173 'unsafe-inline'",
+  "font-src 'self' data:",
+  "connect-src 'self' http://localhost:5173 ws://localhost:5173",
+  "img-src 'self' http://localhost:5173 https://avatars.githubusercontent.com",
+  "frame-src 'self' https://www.youtube.com",
+].join("; ");
+
+const PROD_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  "connect-src 'self'",
+  "img-src 'self' https://avatars.githubusercontent.com",
+  "frame-src 'self' https://www.youtube.com",
+].join("; ");
+
+// Plugin to transform CSP meta tag based on build mode
+function cspTransformPlugin(): Plugin {
+  return {
+    name: "csp-transform",
+    transformIndexHtml(html, ctx) {
+      const csp = ctx.server ? DEV_CSP : PROD_CSP;
+      const cspRegex = /<meta\s+[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/i;
+
+      if (!cspRegex.test(html)) {
+        throw new Error(
+          "CSP meta tag not found in index.html. Expected: <meta http-equiv=\"Content-Security-Policy\" ...>"
+        );
+      }
+
+      return html.replace(
+        cspRegex,
+        `<meta http-equiv="Content-Security-Policy" content="${csp}" />`
+      );
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), cspTransformPlugin()],
   base: "./",
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary
Implements Vite plugin to transform Content Security Policy (CSP) based on build environment, ensuring production builds do not contain development server references.

Closes #363

## Changes Made
- Add Vite plugin to inject development or production CSP based on build mode
- Production CSP removes all localhost references
- Development CSP allows Vite dev server (localhost:5173, ws://localhost:5173)
- Plugin validates CSP meta tag presence and fails build if missing
- Fix TypeScript error in DockedTerminalItem (remove obsolete stateDebugInfo prop)

## Verification
- ✅ Production build confirmed to have clean CSP without localhost references
- ✅ Plugin includes error handling to fail build if CSP meta tag is missing
- ✅ Regex pattern handles both single and double quotes for attribute matching
- ✅ All typecheck and build validation passes