### PR TITLE
Fix docked terminal border overlap with loader

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -245,14 +245,6 @@ export function DockedTerminalItem({
             isInjecting={isInjecting}
             injectionProgress={progress}
             agentState={terminal.agentState}
-            stateDebugInfo={
-              terminal.stateChangeTrigger
-                ? {
-                    trigger: terminal.stateChangeTrigger,
-                    confidence: terminal.stateChangeConfidence ?? 0,
-                  }
-                : null
-            }
             activity={
               terminal.activityHeadline
                 ? {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -297,10 +297,18 @@ export function TerminalPane({
       ref={containerRef}
       data-terminal-id={id}
       className={cn(
-        "flex flex-col h-full rounded overflow-hidden border transition-all duration-200 group",
-        "bg-[var(--color-surface)] shadow-md",
-        // Subtle focus indicator - neutral glow
-        isFocused ? "terminal-focused border-zinc-600" : "border-zinc-800 hover:border-zinc-700",
+        "flex flex-col h-full overflow-hidden transition-all duration-200 group",
+        "bg-[var(--color-surface)]",
+
+        // Only apply border, rounding, and shadow if NOT in the dock (prevents double-border glitch)
+        location !== "dock" && "rounded border shadow-md",
+
+        // Apply focus styles only if NOT docked
+        location !== "dock" &&
+          (isFocused
+            ? "terminal-focused border-zinc-600"
+            : "border-zinc-800 hover:border-zinc-700"),
+
         isExited && "opacity-75 grayscale",
         isDragging && "opacity-50 ring-2 ring-canopy-accent"
       )}


### PR DESCRIPTION
## Summary
Fixes the double-border glitch where docked terminals' borders stacked with the Popover container's borders, causing visual crowding and pushing the active loader/spinner against the top edge.

Closes #364

## Changes Made
- Conditionally apply border, rounding, and shadow styles only when location !== "dock"
- Conditionally apply focus styles only when location !== "dock"
- Remove obsolete stateDebugInfo prop from DockedTerminalItem