### PR TITLE
Add performance mode toggle for multi-terminal optimization

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -127,6 +127,7 @@ export const CHANNELS = {
 
   TERMINAL_CONFIG_GET: "terminal-config:get",
   TERMINAL_CONFIG_SET_SCROLLBACK: "terminal-config:set-scrollback",
+  TERMINAL_CONFIG_SET_PERFORMANCE_MODE: "terminal-config:set-performance-mode",
 
   GIT_GET_FILE_DIFF: "git:get-file-diff",
 } as const;

--- a/electron/ipc/handlers/app.ts
+++ b/electron/ipc/handlers/app.ts
@@ -247,5 +247,18 @@ export function registerAppHandlers(deps: HandlerDependencies): () => void {
   ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK, handleTerminalConfigSetScrollback);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK));
 
+  const handleTerminalConfigSetPerformanceMode = async (
+    _event: Electron.IpcMainInvokeEvent,
+    performanceMode: boolean
+  ) => {
+    const currentConfig = store.get("terminalConfig");
+    store.set("terminalConfig", { ...currentConfig, performanceMode: Boolean(performanceMode) });
+  };
+  ipcMain.handle(
+    CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE,
+    handleTerminalConfigSetPerformanceMode
+  );
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE));
+
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -214,6 +214,7 @@ const CHANNELS = {
   // Terminal config channels
   TERMINAL_CONFIG_GET: "terminal-config:get",
   TERMINAL_CONFIG_SET_SCROLLBACK: "terminal-config:set-scrollback",
+  TERMINAL_CONFIG_SET_PERFORMANCE_MODE: "terminal-config:set-performance-mode",
 
   // Git channels
   GIT_GET_FILE_DIFF: "git:get-file-diff",
@@ -584,6 +585,9 @@ const api: ElectronAPI = {
 
     setScrollback: (scrollbackLines: number) =>
       _typedInvoke(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK, scrollbackLines),
+
+    setPerformanceMode: (performanceMode: boolean) =>
+      _typedInvoke(CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE, performanceMode),
   },
 };
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -13,6 +13,7 @@ export interface StoreSchema {
   };
   terminalConfig: {
     scrollbackLines: number; // -1 for unlimited, otherwise 100-100000
+    performanceMode: boolean;
   };
   appState: {
     activeWorktreeId?: string;
@@ -77,6 +78,7 @@ export const store = new Store<StoreSchema>({
     },
     terminalConfig: {
       scrollbackLines: 5000,
+      performanceMode: false,
     },
     appState: {
       sidebarWidth: 350,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -795,6 +795,7 @@ export interface AdaptiveBackoffMetrics {
 /** Terminal configuration for scrollback, etc. */
 export interface TerminalConfig {
   scrollbackLines: number; // -1 for unlimited, otherwise 100-100000
+  performanceMode: boolean;
 }
 
 // IPC Contract Maps
@@ -1201,6 +1202,10 @@ export interface IpcInvokeMap {
     args: [scrollbackLines: number];
     result: void;
   };
+  "terminal-config:set-performance-mode": {
+    args: [performanceMode: boolean];
+    result: void;
+  };
 
   // Git channels
   "git:get-file-diff": {
@@ -1471,5 +1476,6 @@ export interface ElectronAPI {
   terminalConfig: {
     get(): Promise<TerminalConfig>;
     setScrollback(scrollbackLines: number): Promise<void>;
+    setPerformanceMode(performanceMode: boolean): Promise<void>;
   };
 }

--- a/src/clients/terminalConfigClient.ts
+++ b/src/clients/terminalConfigClient.ts
@@ -8,4 +8,8 @@ export const terminalConfigClient = {
   setScrollback: (scrollbackLines: number): Promise<void> => {
     return window.electron.terminalConfig.setScrollback(scrollbackLines);
   },
+
+  setPerformanceMode: (performanceMode: boolean): Promise<void> => {
+    return window.electron.terminalConfig.setPerformanceMode(performanceMode);
+  },
 } as const;

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,8 @@
 }
 
 :root {
+  --animation-duration: 150ms;
+  --transition-duration: 150ms;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -600,4 +602,20 @@ body,
 
 .diff-viewer table.diff td {
   vertical-align: top;
+}
+
+/* ============================================================================
+ * Performance Mode Overrides
+ *
+ * When data-performance-mode="true" is set on the body element, these styles
+ * disable all animations and transitions for improved performance with many
+ * concurrent terminals.
+ * ============================================================================ */
+
+body[data-performance-mode="true"] *,
+body[data-performance-mode="true"] *::before,
+body[data-performance-mode="true"] *::after {
+  animation: none !important;
+  animation-play-state: paused !important;
+  transition: none !important;
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,3 +29,5 @@ export {
 export { useLayoutConfigStore } from "./layoutConfigStore";
 
 export { useScrollbackStore } from "./scrollbackStore";
+
+export { usePerformanceModeStore } from "./performanceModeStore";

--- a/src/store/performanceModeStore.ts
+++ b/src/store/performanceModeStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface PerformanceModeState {
+  performanceMode: boolean;
+  setPerformanceMode: (enabled: boolean) => void;
+}
+
+export const usePerformanceModeStore = create<PerformanceModeState>()((set) => ({
+  performanceMode: false,
+  setPerformanceMode: (enabled) => set({ performanceMode: enabled }),
+}));


### PR DESCRIPTION
## Summary
Implements a performance mode toggle in Terminal Settings that optimizes Canopy for running many concurrent terminals. When enabled, scrollback is reduced to 2,000 lines and all CSS animations/transitions are disabled.

Closes #263

## Changes Made
- Add performance mode toggle UI in Terminal Settings tab with visual feedback
- Create performanceModeStore for Zustand state management
- Implement complete IPC chain (channels, handlers, types) for performance mode persistence
- Add performance mode field to electron-store with default false
- Modify XtermAdapter to dynamically set scrollback based on performance mode (2k when enabled)
- Add CSS rules to disable all animations/transitions via body[data-performance-mode="true"] attribute
- Hydrate performance mode during app initialization before terminal restoration
- Fix hydration order to apply terminal config even if appState is missing
- Fix toggle handler to persist setting before updating UI state to prevent state drift
- Simplify CSS animation disabling rules for comprehensive coverage

## Testing Notes
- Performance mode persists across app restarts
- Existing terminals unchanged when toggling (by design)
- New terminals spawn with 2k scrollback when performance mode enabled
- All UI animations disabled when performance mode active
- Settings UI shows current state with appropriate visual feedback