### PR TITLE
Optimize terminal grid render performance during context injection

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -96,7 +96,8 @@ export function DockedTerminalItem({
   const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
   const trashTerminal = useTerminalStore((s) => s.trashTerminal);
 
-  const { inject, cancel, isInjecting, progress } = useContextInjection();
+  // Only need inject/cancel actions - TerminalPane subscribes to its own progress
+  const { inject, cancel } = useContextInjection();
 
   // Toggle buffering based on popover open state
   useEffect(() => {
@@ -263,8 +264,6 @@ export function DockedTerminalItem({
             worktreeId={terminal.worktreeId}
             cwd={terminal.cwd}
             isFocused={true}
-            isInjecting={isInjecting}
-            injectionProgress={progress}
             agentState={terminal.agentState}
             activity={
               terminal.activityHeadline

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -157,7 +157,8 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
     getDropIndicator,
   } = useTerminalDragAndDrop();
 
-  const { inject, cancel, isInjecting, progress } = useContextInjection();
+  // Only need inject/cancel actions - each TerminalPane subscribes to its own progress
+  const { inject, cancel } = useContextInjection();
 
   const [filePickerState, setFilePickerState] = useState<{
     isOpen: boolean;
@@ -274,8 +275,6 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
             cwd={terminal.cwd}
             isFocused={true}
             isMaximized={true}
-            isInjecting={isInjecting}
-            injectionProgress={progress}
             agentState={terminal.agentState}
             activity={
               terminal.activityHeadline
@@ -370,8 +369,6 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
               cwd={terminal.cwd}
               isFocused={terminal.id === focusedId}
               isMaximized={false}
-              isInjecting={isInjecting}
-              injectionProgress={progress}
               agentState={terminal.agentState}
               activity={
                 terminal.activityHeadline

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import React, { useState, useCallback, useEffect, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import {
   Terminal,
@@ -28,7 +28,7 @@ import { StateBadge } from "./StateBadge";
 import { ActivityBadge } from "./ActivityBadge";
 import { ErrorBanner } from "../Errors/ErrorBanner";
 import { useErrorStore, useTerminalStore, getTerminalRefreshTier, type RetryAction } from "@/store";
-import { useContextInjection, type CopyTreeProgress } from "@/hooks/useContextInjection";
+import { useContextInjection } from "@/hooks/useContextInjection";
 import type { AgentState } from "@/types";
 import { errorsClient } from "@/clients";
 
@@ -48,8 +48,6 @@ export interface TerminalPaneProps {
   cwd: string;
   isFocused: boolean;
   isMaximized?: boolean;
-  isInjecting?: boolean;
-  injectionProgress?: CopyTreeProgress | null;
   agentState?: AgentState;
   activity?: ActivityState | null;
   onFocus: () => void;
@@ -101,7 +99,7 @@ function getTerminalIcon(type: TerminalType, props: TerminalIconProps) {
   }
 }
 
-export function TerminalPane({
+function TerminalPaneComponent({
   id,
   title,
   type,
@@ -109,8 +107,6 @@ export function TerminalPane({
   cwd,
   isFocused,
   isMaximized,
-  isInjecting,
-  injectionProgress,
   agentState,
   activity,
   onFocus,
@@ -132,7 +128,8 @@ export function TerminalPane({
   const titleInputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { inject } = useContextInjection();
+  // Subscribe to injection progress for this terminal only
+  const { inject, isInjecting, progress: injectionProgress } = useContextInjection(id);
 
   const updateVisibility = useTerminalStore((state) => state.updateVisibility);
   const getTerminal = useTerminalStore((state) => state.getTerminal);
@@ -599,5 +596,32 @@ export function TerminalPane({
     </div>
   );
 }
+
+export const TerminalPane = React.memo(TerminalPaneComponent, (prev, next) => {
+  return (
+    prev.id === next.id &&
+    prev.title === next.title &&
+    prev.type === next.type &&
+    prev.worktreeId === next.worktreeId &&
+    prev.cwd === next.cwd &&
+    prev.isFocused === next.isFocused &&
+    prev.isMaximized === next.isMaximized &&
+    prev.agentState === next.agentState &&
+    prev.activity?.headline === next.activity?.headline &&
+    prev.activity?.status === next.activity?.status &&
+    prev.activity?.type === next.activity?.type &&
+    prev.location === next.location &&
+    prev.isDragging === next.isDragging &&
+    prev.onFocus === next.onFocus &&
+    prev.onClose === next.onClose &&
+    prev.onInjectContext === next.onInjectContext &&
+    prev.onCancelInjection === next.onCancelInjection &&
+    prev.onToggleMaximize === next.onToggleMaximize &&
+    prev.onTitleChange === next.onTitleChange &&
+    prev.onMinimize === next.onMinimize &&
+    prev.onRestore === next.onRestore &&
+    prev.onDragStart === next.onDragStart
+  );
+});
 
 export default TerminalPane;

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo, useRef } from "react";
+import React, { useCallback, useLayoutEffect, useMemo, useRef } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { cn } from "@/lib/utils";
 import { terminalClient } from "@/clients";
@@ -43,7 +43,7 @@ const MAX_ZERO_RETRIES = 10;
 const FIT_SETTLE_DELAY_MS = 120;
 const PERFORMANCE_MODE_SCROLLBACK = 2000;
 
-export function XtermAdapter({
+function XtermAdapterComponent({
   terminalId,
   onReady,
   onExit,
@@ -237,3 +237,5 @@ export function XtermAdapter({
     />
   );
 }
+
+export const XtermAdapter = React.memo(XtermAdapterComponent);


### PR DESCRIPTION
## Summary
This PR eliminates unnecessary re-renders in the terminal grid during context injection by isolating progress subscriptions to individual terminals. Previously, all terminals re-rendered at 10Hz during context injection, causing typing lag and UI stuttering. Now only the target terminal updates its progress UI.

Closes #372

## Changes Made
- Move injection progress subscription from TerminalGrid to individual TerminalPane instances
- Implement global state with useSyncExternalStore for efficient cross-component sync
- Add injection ID tracking to prevent race conditions between concurrent injections
- Memoize TerminalPane and XtermAdapter to prevent unnecessary re-renders
- Remove isInjecting/progress props from TerminalPane interface
- Replace polling-based state sync with event-driven notification system

## Performance Impact
- **Before**: All N terminals re-render at 10Hz during injection (e.g., 4 terminals = 40 renders/second)
- **After**: Only 1 terminal re-renders at 10Hz during injection (10 renders/second)
- **Result**: 75% reduction in renders for a 4-terminal grid, scaling with terminal count