### PR TITLE
Improve terminal feature discoverability with keyboard shortcut hints

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -79,7 +79,7 @@ export function Toolbar({
             size="icon"
             onClick={() => onLaunchAgent("claude")}
             className="text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors hover:text-canopy-accent focus-visible:text-canopy-accent"
-            title="Start Claude (Opus 4.5 for deep work)"
+            title="Start Claude — Opus 4.5 for deep work (Ctrl+Shift+C)"
             aria-label="Start Claude Agent"
           >
             <ClaudeIcon className="h-4 w-4" brandColor={getBrandColorHex("claude")} />
@@ -91,7 +91,7 @@ export function Toolbar({
             size="icon"
             onClick={() => onLaunchAgent("gemini")}
             className="text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors hover:text-canopy-accent focus-visible:text-canopy-accent"
-            title="Start Gemini (Auto-routing enabled)"
+            title="Start Gemini — Auto-routing enabled (Ctrl+Shift+G)"
             aria-label="Start Gemini Agent"
           >
             <GeminiIcon className="h-4 w-4" brandColor={getBrandColorHex("gemini")} />
@@ -103,7 +103,7 @@ export function Toolbar({
             size="icon"
             onClick={() => onLaunchAgent("codex")}
             className="text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors hover:text-canopy-accent focus-visible:text-canopy-accent"
-            title="Start Codex (GPT-5.1 Max)"
+            title="Start Codex — GPT-5.1 Max (Ctrl+Shift+X)"
             aria-label="Start Codex Agent"
           >
             <CodexIcon className="h-4 w-4" brandColor={getBrandColorHex("codex")} />
@@ -114,7 +114,7 @@ export function Toolbar({
           size="icon"
           onClick={() => onLaunchAgent("shell")}
           className="text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors hover:text-canopy-accent focus-visible:text-canopy-accent"
-          title="Open Shell"
+          title="Open Shell (⌘T for palette)"
           aria-label="Open Shell"
         >
           <Terminal className="h-4 w-4" />

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -8,6 +8,7 @@ import { TerminalPane } from "./TerminalPane";
 import { FilePickerModal } from "@/components/ContextInjection";
 import { Terminal } from "lucide-react";
 import { CanopyIcon, CodexIcon, ClaudeIcon, GeminiIcon } from "@/components/icons";
+import { Kbd } from "@/components/ui/Kbd";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { terminalClient } from "@/clients";
@@ -85,7 +86,7 @@ function EmptyState({
           </p>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-3xl mb-12">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-3xl mb-8">
           <LauncherCard
             title="Claude Code"
             description="Best for sustained, autonomous refactoring sessions."
@@ -116,6 +117,10 @@ function EmptyState({
             onClick={() => onLaunchAgent("shell")}
           />
         </div>
+
+        <p className="text-xs text-canopy-text/40 text-center">
+          Tip: Press <Kbd>⌘T</Kbd> to open the terminal palette anytime
+        </p>
       </div>
     </div>
   );

--- a/src/components/TerminalPalette/TerminalPalette.tsx
+++ b/src/components/TerminalPalette/TerminalPalette.tsx
@@ -108,7 +108,11 @@ export function TerminalPalette({
         )}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-3 border-b border-canopy-border">
+        <div className="px-3 pt-2 pb-1 border-b border-canopy-border">
+          <div className="flex justify-between items-center mb-1.5 text-[11px] text-canopy-text/40">
+            <span>Quick switch</span>
+            <span className="font-mono">⌘T</span>
+          </div>
           <input
             ref={inputRef}
             type="text"

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -1,0 +1,21 @@
+import { cn } from "@/lib/utils";
+
+export interface KbdProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Kbd({ children, className }: KbdProps) {
+  return (
+    <kbd
+      className={cn(
+        "px-1.5 py-0.5 rounded text-xs font-mono",
+        "bg-canopy-border text-canopy-text/70",
+        "border border-canopy-border/60",
+        className
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}


### PR DESCRIPTION
## Summary
Adds contextual keyboard shortcut hints throughout the UI to help users discover powerful features like the terminal palette (⌘T) and agent launcher shortcuts.

Closes #249

## Changes Made
- Create reusable Kbd component for consistent keyboard shortcut styling
- Add terminal palette hint (⌘T) to empty state display
- Display keyboard shortcut in TerminalPalette header
- Update agent launcher tooltips to include keyboard shortcuts
- Add terminal palette reference to Shell button tooltip