### PR TITLE
Add focus mode indicator pill to toolbar

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -256,6 +256,18 @@ export function Toolbar({
               <Maximize2 className="h-4 w-4" aria-hidden="true" />
             )}
           </Button>
+          <span
+            role="status"
+            aria-live="polite"
+            className={cn(
+              "px-2 py-0.5 rounded-full text-[10px] font-medium transition-opacity",
+              isFocusMode
+                ? "bg-canopy-accent/15 text-canopy-accent border border-canopy-accent/40 opacity-100"
+                : "opacity-0 pointer-events-none invisible"
+            )}
+          >
+            Focus
+          </span>
           <Button
             variant="ghost"
             size="icon"


### PR DESCRIPTION
## Summary
Adds a visual pill indicator to the toolbar that displays "Focus" when focus mode is active, making it clear that the sidebar is intentionally hidden rather than missing or broken.

Closes #253

## Changes Made
- Add "Focus" pill that appears when focus mode is active
- Reserve layout space to prevent horizontal shift on toggle
- Add aria-live region for screen reader announcements when focus mode state changes
- Use visible text instead of aria-label for better accessibility compliance