### PR TITLE
Add collapse/toggle affordance to terminal dock

### DIFF
--- a/electron/ipc/handlers/app.ts
+++ b/electron/ipc/handlers/app.ts
@@ -137,6 +137,10 @@ export function registerAppHandlers(deps: HandlerDependencies): () => void {
         }
       }
 
+      if ("dockCollapsed" in partialState) {
+        updates.dockCollapsed = Boolean(partialState.dockCollapsed);
+      }
+
       store.set("appState", { ...currentState, ...updates });
     } catch (error) {
       console.error("Failed to set app state:", error);

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -53,6 +53,7 @@ export interface StoreSchema {
       createdAt: number;
     }>;
     terminalGridConfig?: TerminalGridConfig;
+    dockCollapsed?: boolean;
   };
   projects: {
     list: Project[];
@@ -87,6 +88,7 @@ export const store = new Store<StoreSchema>({
       recipes: [],
       hasSeenWelcome: false,
       terminalGridConfig: { strategy: "automatic", value: 3 },
+      dockCollapsed: false,
     },
     projects: {
       list: [],

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -383,6 +383,8 @@ export interface AppState {
   };
   /** Terminal grid layout configuration */
   terminalGridConfig?: TerminalGridConfig;
+  /** Whether the terminal dock is collapsed */
+  dockCollapsed?: boolean;
 }
 
 // Log IPC Types


### PR DESCRIPTION
## Summary
Makes the terminal dock "Background (N)" label interactive, allowing users to quickly collapse and expand the dock to manage screen real estate.

Closes #258

## Changes Made
- Add clickable "Background (N)" label with chevron icon to collapse/expand dock
- Persist collapsed state across app restarts via electron-store
- Auto-expand dock when dragging terminals onto it while collapsed
- Add smooth CSS transitions for chevron rotation
- Include keyboard accessibility with focus styles and ARIA attributes

## Implementation Details
- Added `dockCollapsed` field to `AppState` interface and electron-store schema
- Implemented state persistence in IPC handler (`electron/ipc/handlers/app.ts`)
- Modified `TerminalDock` component with collapse toggle button and conditional rendering
- Auto-expands dock on drag-over to prevent confusing drop behavior when collapsed