### PR TITLE
Add visual drop placeholders for terminal drag and drop

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -25,7 +25,6 @@ interface DockedTerminalItemProps {
   terminal: TerminalInstance;
   index: number;
   isDragging?: boolean;
-  isDropTarget?: boolean;
   onDragStart?: (id: string, index: number) => void;
   onDragEnd?: () => void;
 }
@@ -87,7 +86,6 @@ export function DockedTerminalItem({
   terminal,
   index,
   isDragging,
-  isDropTarget,
   onDragStart,
   onDragEnd,
 }: DockedTerminalItemProps) {
@@ -224,65 +222,61 @@ export function DockedTerminalItem({
   }, [onDragEnd]);
 
   return (
-    <div className="relative flex items-center">
-      {isDropTarget && <div className="absolute -left-1.5 w-0.5 h-6 bg-canopy-accent rounded" />}
-
-      <Popover open={isOpen} onOpenChange={handleOpenChange}>
-        <PopoverTrigger asChild>
-          <button
-            data-docked-terminal-id={terminal.id}
-            className={cn(
-              "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
-              "hover:bg-canopy-accent/10 border-canopy-border hover:border-canopy-accent/50",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
-              "cursor-grab active:cursor-grabbing",
-              isOpen && "bg-canopy-accent/20 border-canopy-accent",
-              isDragging && "opacity-50 ring-2 ring-canopy-accent"
-            )}
-            title={`${terminal.title} - Click to preview, drag to reorder`}
-            draggable={!isOpen}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-            aria-grabbed={isDragging}
-          >
-            {getTerminalIcon(terminal.type)}
-            {getStateIndicator(terminal.agentState)}
-            <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>
-          </button>
-        </PopoverTrigger>
-
-        <PopoverContent
-          className="w-[700px] h-[500px] p-0 border-canopy-border bg-canopy-bg shadow-2xl"
-          side="top"
-          align="start"
-          sideOffset={8}
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          data-docked-terminal-id={terminal.id}
+          className={cn(
+            "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
+            "hover:bg-canopy-accent/10 border-canopy-border hover:border-canopy-accent/50",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
+            "cursor-grab active:cursor-grabbing",
+            isOpen && "bg-canopy-accent/20 border-canopy-accent",
+            isDragging && "opacity-50 ring-2 ring-canopy-accent"
+          )}
+          title={`${terminal.title} - Click to preview, drag to reorder`}
+          draggable={!isOpen}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          aria-grabbed={isDragging}
         >
-          <TerminalPane
-            id={terminal.id}
-            title={terminal.title}
-            type={terminal.type}
-            worktreeId={terminal.worktreeId}
-            cwd={terminal.cwd}
-            isFocused={true}
-            agentState={terminal.agentState}
-            activity={
-              terminal.activityHeadline
-                ? {
-                    headline: terminal.activityHeadline,
-                    status: terminal.activityStatus ?? "working",
-                    type: terminal.activityType ?? "interactive",
-                  }
-                : null
-            }
-            location="dock"
-            onFocus={() => {}}
-            onClose={handleClose}
-            onRestore={handleRestore}
-            onInjectContext={terminal.worktreeId ? handleInjectContext : undefined}
-            onCancelInjection={cancel}
-          />
-        </PopoverContent>
-      </Popover>
-    </div>
+          {getTerminalIcon(terminal.type)}
+          {getStateIndicator(terminal.agentState)}
+          <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-[700px] h-[500px] p-0 border-canopy-border bg-canopy-bg shadow-2xl"
+        side="top"
+        align="start"
+        sideOffset={8}
+      >
+        <TerminalPane
+          id={terminal.id}
+          title={terminal.title}
+          type={terminal.type}
+          worktreeId={terminal.worktreeId}
+          cwd={terminal.cwd}
+          isFocused={true}
+          agentState={terminal.agentState}
+          activity={
+            terminal.activityHeadline
+              ? {
+                  headline: terminal.activityHeadline,
+                  status: terminal.activityStatus ?? "working",
+                  type: terminal.activityType ?? "interactive",
+                }
+              : null
+          }
+          location="dock"
+          onFocus={() => {}}
+          onClose={handleClose}
+          onRestore={handleRestore}
+          onInjectContext={terminal.worktreeId ? handleInjectContext : undefined}
+          onCancelInjection={cancel}
+        />
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/Terminal/DropPlaceholder.tsx
+++ b/src/components/Terminal/DropPlaceholder.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@/lib/utils";
+
+interface DropPlaceholderProps {
+  className?: string;
+  label?: string;
+}
+
+export function DropPlaceholder({ className, label }: DropPlaceholderProps) {
+  return (
+    <div
+      className={cn(
+        "h-full w-full rounded-lg border-2 border-dashed border-canopy-accent/30 bg-canopy-accent/5",
+        "flex items-center justify-center p-4",
+        "animate-in fade-in duration-200",
+        className
+      )}
+    >
+      <span className="text-sm font-medium text-canopy-accent/50 select-none">
+        {label || "Drop here"}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Enhances the terminal drag-and-drop experience by adding visual placeholder elements that appear during drag operations, showing users exactly where terminals will land when dropped in the grid or dock.

Closes #375

## Changes Made
- Created DropPlaceholder component with dashed border and fade-in animation
- Added placeholder injection in TerminalGrid for dock-to-grid drops
- Added horizontal placeholder support in TerminalDock
- Fixed empty grid drop target support by restructuring render logic
- Synchronized placeholder count with dropIndex to prevent column drift
- Removed isDropTarget prop from DockedTerminalItem

## Implementation Details
- Placeholders appear only when dragging from dock to grid (grid-to-grid reordering uses ring indicators)
- Grid dynamically expands columns to accommodate placeholder
- Placeholder is spliced into renderItems array at dropIndex position
- Empty grid now accepts drops by always rendering grid container with drag handlers
- All changes validated with TypeScript type checking and Codex code review