### PR TITLE
Add React Error Boundaries to prevent renderer crashes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { RecipeEditor } from "./components/TerminalRecipe/RecipeEditor";
 import { SettingsDialog } from "./components/Settings";
 import { HistoryPanel } from "./components/History";
 import { Toaster } from "./components/ui/toaster";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import {
   useTerminalStore,
   useWorktreeSelectionStore,
@@ -589,7 +590,7 @@ function App() {
   }
 
   return (
-    <>
+    <ErrorBoundary variant="fullscreen" componentName="App">
       <AppLayout
         sidebarContent={<SidebarContent onOpenSettings={handleOpenSettings} />}
         historyContent={<HistoryPanel />}
@@ -629,7 +630,7 @@ function App() {
       />
 
       <Toaster />
-    </>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,168 @@
+import React, { Component, type ReactNode } from "react";
+import { ErrorFallback, type ErrorFallbackProps } from "./ErrorFallback";
+import { useErrorStore } from "@/store/errorStore";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: React.ComponentType<ErrorFallbackProps>;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  resetKeys?: Array<string | number>;
+  variant?: "fullscreen" | "section" | "component";
+  componentName?: string;
+  context?: {
+    worktreeId?: string;
+    terminalId?: string;
+  };
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    const { onError, context, componentName } = this.props;
+
+    this.setState({
+      errorInfo,
+    });
+
+    try {
+      useErrorStore.getState().addError({
+        type: "unknown",
+        message: error.message || "Component rendering error",
+        details: `${error.stack || ""}\n\nComponent Stack:${errorInfo.componentStack || ""}`,
+        source: componentName || "ErrorBoundary",
+        context,
+        isTransient: false,
+      });
+    } catch (storeError) {
+      console.error("Failed to add error to store:", storeError);
+    }
+
+    if (onError) {
+      try {
+        onError(error, errorInfo);
+      } catch (handlerError) {
+        console.error("Error in onError handler:", handlerError);
+      }
+    }
+
+    console.error("ErrorBoundary caught error:", error, errorInfo);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    const { resetKeys } = this.props;
+    const { hasError } = this.state;
+
+    if (hasError && resetKeys) {
+      const prevResetKeys = prevProps.resetKeys || [];
+      const hasResetKeyChanged =
+        resetKeys.length !== prevResetKeys.length ||
+        resetKeys.some((key, index) => key !== prevResetKeys[index]);
+
+      if (hasResetKeyChanged) {
+        this.resetError();
+      }
+    }
+  }
+
+  resetError = (): void => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    });
+  };
+
+  handleReport = (): void => {
+    const { error, errorInfo } = this.state;
+    const { componentName, context } = this.props;
+
+    const issueBody = encodeURIComponent(
+      `## Error Report\n\n` +
+        `**Component:** ${componentName || "Unknown"}\n` +
+        `**Message:** ${error?.message || "Unknown error"}\n\n` +
+        `**Context:**\n` +
+        `${context ? JSON.stringify(context, null, 2) : "None"}\n\n` +
+        `**Stack Trace:**\n\`\`\`\n${error?.stack || "No stack trace"}\n\`\`\`\n\n` +
+        `**Component Stack:**\n\`\`\`\n${errorInfo?.componentStack || "No component stack"}\n\`\`\``
+    );
+
+    const issueUrl = `https://github.com/gregpriday/canopy-electron/issues/new?title=${encodeURIComponent(`Component Error: ${error?.message || "Unknown"}`)}&body=${issueBody}`;
+
+    if (window.electron?.system?.openExternal) {
+      window.electron.system.openExternal(issueUrl);
+    }
+  };
+
+  render(): ReactNode {
+    const { hasError, error, errorInfo } = this.state;
+    const { children, fallback: FallbackComponent, variant, componentName } = this.props;
+
+    if (hasError && error) {
+      const Fallback = FallbackComponent || ErrorFallback;
+
+      return (
+        <Fallback
+          error={error}
+          errorInfo={errorInfo || undefined}
+          resetError={this.resetError}
+          variant={variant}
+          componentName={componentName}
+          onReport={variant === "fullscreen" ? this.handleReport : undefined}
+        />
+      );
+    }
+
+    return children;
+  }
+}
+
+export interface WithErrorBoundaryOptions {
+  variant?: "fullscreen" | "section" | "component";
+  componentName?: string;
+  context?: {
+    worktreeId?: string;
+    terminalId?: string;
+  };
+  resetKeys?: Array<string | number>;
+}
+
+export function withErrorBoundary<P extends object>(
+  Component: React.ComponentType<P>,
+  options: WithErrorBoundaryOptions = {}
+): React.ComponentType<P> {
+  const WrappedComponent = (props: P) => (
+    <ErrorBoundary
+      variant={options.variant || "component"}
+      componentName={options.componentName || Component.displayName || Component.name}
+      context={options.context}
+      resetKeys={options.resetKeys}
+    >
+      <Component {...props} />
+    </ErrorBoundary>
+  );
+
+  WrappedComponent.displayName = `withErrorBoundary(${Component.displayName || Component.name || "Component"})`;
+
+  return WrappedComponent;
+}

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,0 +1,129 @@
+import { cn } from "@/lib/utils";
+
+export interface ErrorFallbackProps {
+  error: Error;
+  errorInfo?: React.ErrorInfo;
+  resetError: () => void;
+  variant?: "fullscreen" | "section" | "component";
+  componentName?: string;
+  onReport?: () => void;
+}
+
+const VARIANT_STYLES = {
+  fullscreen: "h-screen w-screen flex items-center justify-center bg-canopy-bg",
+  section: "h-full w-full flex items-center justify-center p-8",
+  component: "p-4 rounded-lg bg-red-900/20 border border-red-700/50",
+} as const;
+
+const VARIANT_SIZES = {
+  fullscreen: {
+    icon: "text-6xl",
+    title: "text-2xl",
+    message: "text-base",
+    button: "px-6 py-3 text-base",
+  },
+  section: {
+    icon: "text-4xl",
+    title: "text-xl",
+    message: "text-sm",
+    button: "px-4 py-2 text-sm",
+  },
+  component: {
+    icon: "text-2xl",
+    title: "text-base",
+    message: "text-xs",
+    button: "px-3 py-1.5 text-xs",
+  },
+} as const;
+
+export function ErrorFallback({
+  error,
+  errorInfo,
+  resetError,
+  variant = "component",
+  componentName,
+  onReport,
+}: ErrorFallbackProps) {
+  const sizes = VARIANT_SIZES[variant];
+
+  const handleOpenLogs = () => {
+    if (window.electron?.errors?.openLogs) {
+      window.electron.errors.openLogs();
+    }
+  };
+
+  return (
+    <div className={cn(VARIANT_STYLES[variant])}>
+      <div className="flex flex-col items-center gap-4 max-w-2xl">
+        <div className={cn("text-red-500", sizes.icon)}>⚠️</div>
+
+        <div className="text-center space-y-2">
+          <h2 className={cn("font-semibold text-red-400", sizes.title)}>
+            {variant === "fullscreen" && "Application Error"}
+            {variant === "section" && "Section Error"}
+            {variant === "component" && `${componentName || "Component"} Error`}
+          </h2>
+
+          <p className={cn("text-canopy-text/80", sizes.message)}>{error.message}</p>
+
+          {variant === "fullscreen" && (
+            <p className={cn("text-canopy-text/60", sizes.message)}>
+              The application encountered an unexpected error. You can try restarting or check the logs
+              for more details.
+            </p>
+          )}
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={resetError}
+            className={cn(
+              "bg-red-600 hover:bg-red-700 text-white rounded transition-colors",
+              sizes.button
+            )}
+          >
+            {variant === "fullscreen" ? "Restart Application" : "Try Again"}
+          </button>
+
+          {variant === "fullscreen" && onReport && (
+            <button
+              type="button"
+              onClick={onReport}
+              className={cn(
+                "bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors",
+                sizes.button
+              )}
+            >
+              Report Issue
+            </button>
+          )}
+
+          <button
+            type="button"
+            onClick={handleOpenLogs}
+            className={cn(
+              "bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors",
+              sizes.button
+            )}
+          >
+            View Logs
+          </button>
+        </div>
+
+        {errorInfo?.componentStack && variant !== "component" && (
+          <details className="w-full mt-4">
+            <summary className="cursor-pointer text-xs text-canopy-text/60 hover:text-canopy-text/80">
+              Technical Details
+            </summary>
+            <pre className="mt-2 p-3 bg-black/30 rounded text-xs text-red-300/80 overflow-auto max-h-48">
+              {error.stack || "No stack trace available"}
+              {"\n\nComponent Stack:\n"}
+              {errorInfo.componentStack}
+            </pre>
+          </details>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ErrorBoundary/index.ts
+++ b/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,4 @@
+export { ErrorBoundary, withErrorBoundary } from "./ErrorBoundary";
+export { ErrorFallback } from "./ErrorFallback";
+export type { ErrorFallbackProps } from "./ErrorFallback";
+export type { WithErrorBoundaryOptions } from "./ErrorBoundary";

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
 import { TerminalDock } from "./TerminalDock";
 import { DiagnosticsDock } from "../Diagnostics";
+import { ErrorBoundary } from "../ErrorBoundary";
 import { useFocusStore, useDiagnosticsStore, useErrorStore, type PanelState } from "@/store";
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
@@ -231,31 +232,39 @@ export function AppLayout({
           style={{ flex: 1, display: "flex", overflow: "hidden" }}
         >
           {!isFocusMode && (
-            <Sidebar
-              width={effectiveSidebarWidth}
-              onResize={handleSidebarResize}
-              historyContent={historyContent}
-            >
-              {sidebarContent}
-            </Sidebar>
+            <ErrorBoundary variant="section" componentName="Sidebar">
+              <Sidebar
+                width={effectiveSidebarWidth}
+                onResize={handleSidebarResize}
+                historyContent={historyContent}
+              >
+                {sidebarContent}
+              </Sidebar>
+            </ErrorBoundary>
           )}
-          <main
-            className="flex-1 flex flex-col overflow-hidden bg-canopy-bg"
-            style={{
-              flex: 1,
-              display: "flex",
-              flexDirection: "column",
-              overflow: "hidden",
-              backgroundColor: "#18181b", // Zinc-950
-            }}
-          >
-            <div className="flex-1 overflow-hidden min-h-0">{children}</div>
-            {/* Terminal Dock - appears at bottom only when terminals are docked */}
-            <TerminalDock />
-          </main>
+          <ErrorBoundary variant="section" componentName="MainContent">
+            <main
+              className="flex-1 flex flex-col overflow-hidden bg-canopy-bg"
+              style={{
+                flex: 1,
+                display: "flex",
+                flexDirection: "column",
+                overflow: "hidden",
+                backgroundColor: "#18181b", // Zinc-950
+              }}
+            >
+              <div className="flex-1 overflow-hidden min-h-0">{children}</div>
+              {/* Terminal Dock - appears at bottom only when terminals are docked */}
+              <ErrorBoundary variant="section" componentName="TerminalDock">
+                <TerminalDock />
+              </ErrorBoundary>
+            </main>
+          </ErrorBoundary>
         </div>
         {/* Unified diagnostics dock replaces LogsPanel, EventInspectorPanel, and ProblemsPanel */}
-        <DiagnosticsDock onRetry={onRetry} />
+        <ErrorBoundary variant="section" componentName="DiagnosticsDock">
+          <DiagnosticsDock onRetry={onRetry} />
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -7,6 +7,7 @@ import { useTerminalDragAndDrop } from "@/hooks/useDragAndDrop";
 import { TerminalPane } from "./TerminalPane";
 import { DropPlaceholder } from "./DropPlaceholder";
 import { FilePickerModal } from "@/components/ContextInjection";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Terminal } from "lucide-react";
 import { CanopyIcon, CodexIcon, ClaudeIcon, GeminiIcon } from "@/components/icons";
 import { Kbd } from "@/components/ui/Kbd";
@@ -295,43 +296,52 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
 
       return (
         <div key={terminal.id} className="relative h-full">
-          <TerminalPane
-            id={terminal.id}
-            title={terminal.title}
-            type={terminal.type}
-            worktreeId={terminal.worktreeId}
-            cwd={terminal.cwd}
-            isFocused={terminal.id === focusedId}
-            isMaximized={false}
-            agentState={terminal.agentState}
-            activity={
-              terminal.activityHeadline
-                ? {
-                    headline: terminal.activityHeadline,
-                    status: terminal.activityStatus ?? "working",
-                    type: terminal.activityType ?? "interactive",
-                  }
-                : null
-            }
-            location="grid"
-            onFocus={() => setFocused(terminal.id)}
-            onClose={() => trashTerminal(terminal.id)}
-            onInjectContext={
-              terminal.worktreeId
-                ? () => handleInjectContext(terminal.id, terminal.worktreeId)
-                : undefined
-            }
-            onCancelInjection={cancel}
-            onToggleMaximize={() => toggleMaximize(terminal.id)}
-            onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
-            onMinimize={() => moveTerminalToDock(terminal.id)}
-            isDragging={false}
-            onDragStart={
-              !isTerminalInTrash
-                ? createDragStartHandler(terminal.id, "grid", originalIndex)
-                : undefined
-            }
-          />
+          <ErrorBoundary
+            variant="component"
+            componentName="TerminalPane"
+            resetKeys={[terminal.id, terminal.worktreeId, terminal.agentState].filter(
+              (key): key is string => key !== undefined
+            )}
+            context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
+          >
+            <TerminalPane
+              id={terminal.id}
+              title={terminal.title}
+              type={terminal.type}
+              worktreeId={terminal.worktreeId}
+              cwd={terminal.cwd}
+              isFocused={terminal.id === focusedId}
+              isMaximized={false}
+              agentState={terminal.agentState}
+              activity={
+                terminal.activityHeadline
+                  ? {
+                      headline: terminal.activityHeadline,
+                      status: terminal.activityStatus ?? "working",
+                      type: terminal.activityType ?? "interactive",
+                    }
+                  : null
+              }
+              location="grid"
+              onFocus={() => setFocused(terminal.id)}
+              onClose={() => trashTerminal(terminal.id)}
+              onInjectContext={
+                terminal.worktreeId
+                  ? () => handleInjectContext(terminal.id, terminal.worktreeId)
+                  : undefined
+              }
+              onCancelInjection={cancel}
+              onToggleMaximize={() => toggleMaximize(terminal.id)}
+              onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
+              onMinimize={() => moveTerminalToDock(terminal.id)}
+              isDragging={false}
+              onDragStart={
+                !isTerminalInTrash
+                  ? createDragStartHandler(terminal.id, "grid", originalIndex)
+                  : undefined
+              }
+            />
+          </ErrorBoundary>
         </div>
       );
     });
@@ -374,36 +384,45 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
     if (terminal) {
       return (
         <div className={cn("h-full", className)}>
-          <TerminalPane
-            id={terminal.id}
-            title={terminal.title}
-            type={terminal.type}
-            worktreeId={terminal.worktreeId}
-            cwd={terminal.cwd}
-            isFocused={true}
-            isMaximized={true}
-            agentState={terminal.agentState}
-            activity={
-              terminal.activityHeadline
-                ? {
-                    headline: terminal.activityHeadline,
-                    status: terminal.activityStatus ?? "working",
-                    type: terminal.activityType ?? "interactive",
-                  }
-                : null
-            }
-            location="grid"
-            onFocus={() => setFocused(terminal.id)}
-            onClose={() => trashTerminal(terminal.id)}
-            onInjectContext={
-              terminal.worktreeId
-                ? () => handleInjectContext(terminal.id, terminal.worktreeId)
-                : undefined
-            }
-            onCancelInjection={cancel}
-            onToggleMaximize={() => toggleMaximize(terminal.id)}
-            onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
-          />
+          <ErrorBoundary
+            variant="component"
+            componentName="TerminalPane"
+            resetKeys={[terminal.id, terminal.worktreeId, terminal.agentState].filter(
+              (key): key is string => key !== undefined
+            )}
+            context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
+          >
+            <TerminalPane
+              id={terminal.id}
+              title={terminal.title}
+              type={terminal.type}
+              worktreeId={terminal.worktreeId}
+              cwd={terminal.cwd}
+              isFocused={true}
+              isMaximized={true}
+              agentState={terminal.agentState}
+              activity={
+                terminal.activityHeadline
+                  ? {
+                      headline: terminal.activityHeadline,
+                      status: terminal.activityStatus ?? "working",
+                      type: terminal.activityType ?? "interactive",
+                    }
+                  : null
+              }
+              location="grid"
+              onFocus={() => setFocused(terminal.id)}
+              onClose={() => trashTerminal(terminal.id)}
+              onInjectContext={
+                terminal.worktreeId
+                  ? () => handleInjectContext(terminal.id, terminal.worktreeId)
+                  : undefined
+              }
+              onCancelInjection={cancel}
+              onToggleMaximize={() => toggleMaximize(terminal.id)}
+              onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
+            />
+          </ErrorBoundary>
         </div>
       );
     }

--- a/src/components/Worktree/WorktreeList.tsx
+++ b/src/components/Worktree/WorktreeList.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WorktreeState } from "../../types";
 import { WorktreeCard } from "./WorktreeCard";
 import { WorktreeCardSkeleton } from "./WorktreeCardSkeleton";
+import { ErrorBoundary } from "../ErrorBoundary";
 
 export interface WorktreeListProps {
   worktrees: WorktreeState[];
@@ -320,25 +321,32 @@ export function WorktreeList({
             aria-current={worktree.id === activeId ? "true" : undefined}
             id={worktree.id}
           >
-            <WorktreeCard
-              worktree={worktree}
-              isActive={worktree.id === activeId}
-              isFocused={index === focusIndex && hasFocus}
-              onSelect={() => onSelect(worktree.id)}
-              onCopyTree={() => onCopyTree(worktree.id)}
-              onOpenEditor={() => onOpenEditor(worktree.id)}
-              onToggleServer={() => onToggleServer(worktree.id)}
-              onOpenIssue={
-                worktree.issueNumber && onOpenIssue
-                  ? () => onOpenIssue(worktree.id, worktree.issueNumber!)
-                  : undefined
-              }
-              onOpenPR={
-                worktree.prUrl && worktree.prNumber && onOpenPR
-                  ? () => onOpenPR(worktree.id, worktree.prUrl!)
-                  : undefined
-              }
-            />
+            <ErrorBoundary
+              variant="component"
+              componentName="WorktreeCard"
+              resetKeys={[worktree.id]}
+              context={{ worktreeId: worktree.id }}
+            >
+              <WorktreeCard
+                worktree={worktree}
+                isActive={worktree.id === activeId}
+                isFocused={index === focusIndex && hasFocus}
+                onSelect={() => onSelect(worktree.id)}
+                onCopyTree={() => onCopyTree(worktree.id)}
+                onOpenEditor={() => onOpenEditor(worktree.id)}
+                onToggleServer={() => onToggleServer(worktree.id)}
+                onOpenIssue={
+                  worktree.issueNumber && onOpenIssue
+                    ? () => onOpenIssue(worktree.id, worktree.issueNumber!)
+                    : undefined
+                }
+                onOpenPR={
+                  worktree.prUrl && worktree.prNumber && onOpenPR
+                    ? () => onOpenPR(worktree.id, worktree.prUrl!)
+                    : undefined
+                }
+              />
+            </ErrorBoundary>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
Implements comprehensive React Error Boundaries at three granularity levels to prevent white screen crashes in the renderer process. Errors are now caught and isolated at app, section, and component levels, with graceful fallback UIs and recovery options.

Closes #397

## Changes Made
- Create ErrorBoundary component with error catching and reset logic
- Create ErrorFallback component with variant support (fullscreen/section/component)
- Add top-level boundary in App.tsx for catastrophic errors
- Add section boundaries in AppLayout for sidebar/main/dock isolation
- Add component boundaries around TerminalPane and WorktreeCard
- Integrate error logging with existing error store
- Support automatic reset on prop changes via resetKeys
- Include context tracking for terminal and worktree IDs

## Implementation Details

**Error Boundary Architecture:**
- Class component implementing getDerivedStateFromError and componentDidCatch
- Logs errors to Zustand error store with full context and stack traces
- Supports resetKeys for automatic recovery when props change
- Prevents error loops with proper lifecycle management

**Fallback UI Variants:**
- Fullscreen: App-level failures with restart and report options
- Section: Sidebar/main area failures with reload section
- Component: Individual terminal/worktree failures with retry

**Integration Points:**
- App.tsx: Wraps entire application
- AppLayout.tsx: Wraps sidebar, main content, terminal dock, diagnostics dock
- TerminalGrid.tsx: Wraps each TerminalPane with context
- WorktreeList.tsx: Wraps each WorktreeCard with context

**Codex Review Applied:**
- Fixed resetKeys length comparison to detect array changes
- Added type="button" to prevent unintended form submissions
- Enhanced terminal resetKeys with worktreeId and agentState for better auto-recovery
- Improved error stack formatting with separators
- Wrapped previously unwrapped docks for better isolation