### PR TITLE
Add minimize button to docked terminal popover

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -126,14 +126,21 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     moveTerminalToGrid(terminal.id);
   }, [moveTerminalToGrid, terminal.id]);
 
+  const handleMinimize = useCallback(() => {
+    setIsOpen(false);
+  }, [setIsOpen]);
+
   const handleClose = useCallback(() => {
     trashTerminal(terminal.id);
     setIsOpen(false);
-  }, [trashTerminal, terminal.id]);
+  }, [trashTerminal, terminal.id, setIsOpen]);
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    setIsOpen(open);
-  }, []);
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setIsOpen(open);
+    },
+    [setIsOpen]
+  );
 
   const handleInjectContext = useCallback(async () => {
     if (!terminal.worktreeId) return;
@@ -186,6 +193,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           onFocus={() => {}}
           onClose={handleClose}
           onRestore={handleRestore}
+          onMinimize={handleMinimize}
           onInjectContext={terminal.worktreeId ? handleInjectContext : undefined}
           onCancelInjection={cancel}
         />

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -446,15 +446,15 @@ function TerminalPaneComponent({
               <Copy className="w-3 h-3" aria-hidden="true" />
             </button>
           )}
-          {location === "grid" && onMinimize && !isMaximized && (
+          {onMinimize && !isMaximized && (
             <button
               onClick={(e) => {
                 e.stopPropagation();
                 onMinimize();
               }}
               className="p-1.5 hover:bg-canopy-text/10 focus-visible:bg-canopy-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent text-canopy-text/60 hover:text-canopy-text transition-colors"
-              title="Minimize to dock"
-              aria-label="Minimize to dock"
+              title={location === "dock" ? "Minimize" : "Minimize to dock"}
+              aria-label={location === "dock" ? "Minimize" : "Minimize to dock"}
             >
               <ArrowDownToLine className="w-3 h-3" aria-hidden="true" />
             </button>


### PR DESCRIPTION
## Summary
Adds an explicit minimize button to the docked terminal popover header for better UX and consistency with grid terminals.

Closes #417

## Changes Made
- Remove location === "grid" check from minimize button condition in TerminalPane
- Add context-aware tooltips (Minimize vs Minimize to dock) based on location
- Add handleMinimize callback in DockedTerminalItem that closes the popover
- Wire onMinimize prop to TerminalPane in dock context
- Fix useCallback dependencies for exhaustive-deps compliance

## Details
Users can already minimize docked terminals by clicking outside the popover, but the explicit minimize button (ArrowDownToLine icon) provides clearer affordance and consistency with grid terminals. The button uses context-aware tooltips to distinguish between dock context (Minimize) and grid context (Minimize to dock).