### PR TITLE
Fix infinite render loop in ProblemsActions component

### DIFF
--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -31,7 +31,7 @@ function ActionButton({ onClick, disabled, children, className, title }: ActionB
 }
 
 export function ProblemsActions() {
-  const activeErrors = useErrorStore((state) => state.errors.filter((e) => !e.dismissed));
+  const hasActiveErrors = useErrorStore((state) => state.errors.some((e) => !e.dismissed));
   const clearAll = useErrorStore((state) => state.clearAll);
 
   const handleOpenLogs = useCallback(() => {
@@ -45,7 +45,7 @@ export function ProblemsActions() {
       </ActionButton>
       <ActionButton
         onClick={clearAll}
-        disabled={activeErrors.length === 0}
+        disabled={!hasActiveErrors}
         title="Clear all errors"
       >
         Clear All


### PR DESCRIPTION
## Summary
Resolves the infinite render loop in the ProblemsActions component that caused "Maximum update depth exceeded" error and crashed the Diagnostics panel.

Closes #415

## Changes Made
- Replace `.filter()` with `.some()` in useErrorStore selector to return primitive boolean instead of array reference
- Change from `activeErrors.length === 0` to `!hasActiveErrors` for button disabled logic
- Prevents React's `useSyncExternalStore` from detecting false state changes on every render
- Eliminates unnecessary re-renders and stabilizes component behavior

## Technical Details
The root cause was that `state.errors.filter((e) => !e.dismissed)` returned a new array reference on every selector invocation, triggering React's `useSyncExternalStore` to believe state changed every render. Using `.some()` returns a primitive boolean value, which is compared by value rather than reference, ensuring stable render cycles.