### PR TITLE
Remove waiting state indicator from worktree cards

### DIFF
--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -51,7 +51,7 @@ const STATE_CONFIG: Record<
 };
 
 export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorProps) {
-  if (!state || state === "idle") {
+  if (!state || state === "idle" || state === "waiting") {
     return null;
   }
 
@@ -63,8 +63,7 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
   return (
     <span
       className={cn(
-        "inline-flex items-center justify-center w-5 h-5 text-xs font-bold",
-        state === "waiting" ? "rounded-sm px-2" : "rounded-full",
+        "inline-flex items-center justify-center w-5 h-5 text-xs font-bold rounded-full",
         config.color,
         config.bgColor,
         config.borderColor && "border",
@@ -82,10 +81,10 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
 }
 
 const STATE_PRIORITY: Record<AgentState, number> = {
-  waiting: 5,
+  failed: 5,
   working: 4,
-  failed: 3,
-  completed: 2,
+  completed: 3,
+  waiting: 2,
   idle: 1,
 };
 

--- a/src/components/Worktree/TerminalCountBadge.tsx
+++ b/src/components/Worktree/TerminalCountBadge.tsx
@@ -17,7 +17,7 @@ const STATE_LABELS: Record<AgentState, string> = {
 function formatStateCounts(byState: Record<AgentState, number>): string {
   const parts: string[] = [];
 
-  const priorityOrder: AgentState[] = ["working", "waiting", "failed", "idle", "completed"];
+  const priorityOrder: AgentState[] = ["working", "failed", "idle", "completed"];
 
   for (const state of priorityOrder) {
     const count = byState[state];
@@ -36,7 +36,6 @@ export function TerminalCountBadge({ counts }: TerminalCountBadgeProps) {
 
   const hasNonIdleStates =
     counts.byState.working > 0 ||
-    counts.byState.waiting > 0 ||
     counts.byState.completed > 0 ||
     counts.byState.failed > 0;
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -529,7 +529,7 @@ export function WorktreeCard({
             <div className="flex items-center gap-1">
               <Terminal className="w-2.5 h-2.5" />
               <span>{terminalCounts.total}</span>
-              {(terminalCounts.byState.working > 0 || terminalCounts.byState.waiting > 0) && (
+              {terminalCounts.byState.working > 0 && (
                 <div className="w-1 h-1 rounded-full bg-[var(--color-status-success)] animate-pulse" />
               )}
             </div>


### PR DESCRIPTION
## Summary
Removes the yellow question mark indicator representing the agent's `waiting` state from the Worktree Dashboard UI. The `waiting` state continues to be tracked internally by the `AgentStateMachine`, but no longer renders any visual indicators.

Closes #416

## Changes Made
- Suppress waiting state in AgentStatusIndicator component (returns null for waiting)
- Adjust state priority so `failed` takes precedence over `waiting` to prevent masking critical states
- Remove waiting from WorktreeCard pulsing activity dot condition
- Remove waiting from TerminalCountBadge display and priority ordering
- Preserve waiting in STATE_CONFIG for potential future use

## Impact
- Worktree cards no longer show the yellow ? indicator when agents are idle
- The activity light and other state indicators (working, completed, failed) remain functional
- Backend state tracking unchanged - waiting state still tracked internally