### PR TITLE
Implement activity indicator with 90-second fade transition

### DIFF
--- a/src/components/Worktree/ActivityLight.tsx
+++ b/src/components/Worktree/ActivityLight.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { getActivityColor } from "@/utils/colorInterpolation";
+
+interface ActivityLightProps {
+  lastActivityTimestamp?: number | null;
+  className?: string;
+}
+
+/**
+ * Activity indicator that fades from green to gray over 90 seconds.
+ * Updates every second to create smooth fade effect.
+ */
+export function ActivityLight({ lastActivityTimestamp, className }: ActivityLightProps) {
+  const [color, setColor] = useState(() => getActivityColor(lastActivityTimestamp));
+
+  useEffect(() => {
+    setColor(getActivityColor(lastActivityTimestamp));
+
+    if (lastActivityTimestamp == null) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      const newColor = getActivityColor(lastActivityTimestamp);
+      setColor(newColor);
+
+      if (newColor === "#52525b") {
+        clearInterval(interval);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [lastActivityTimestamp]);
+
+  const hasActivity = lastActivityTimestamp != null;
+  const label = hasActivity ? "Recent file activity" : "No recent activity";
+
+  return (
+    <div
+      className={cn(
+        "w-2.5 h-2.5 rounded-full transition-colors duration-1000 ease-linear",
+        className
+      )}
+      style={{ backgroundColor: color }}
+      title={label}
+      role="status"
+      aria-label={label}
+    />
+  );
+}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { WorktreeState } from "../../types";
+import { ActivityLight } from "./ActivityLight";
 import { AgentStatusIndicator } from "./AgentStatusIndicator";
 import { FileChangeList } from "./FileChangeList";
 import { ErrorBanner } from "../Errors/ErrorBanner";
@@ -102,8 +103,6 @@ export function WorktreeCard({
   onOpenSettings,
   homeDir,
 }: WorktreeCardProps) {
-  const mood = worktree.mood || "stable";
-
   const isExpanded = useWorktreeSelectionStore(
     useCallback((state) => state.expandedWorktrees.has(worktree.id), [worktree.id])
   );
@@ -396,23 +395,9 @@ export function WorktreeCard({
                   )}
                 </button>
               )}
+              <ActivityLight lastActivityTimestamp={worktree.lastActivityTimestamp} />
               <AgentStatusIndicator state={dominantAgentState} />
-              {isActive && (
-                <span
-                  className="text-[var(--color-state-active)] text-[0.6rem]"
-                  aria-label="Active worktree"
-                >
-                  ●
-                </span>
-              )}
-              <span
-                className={cn(
-                  "truncate font-semibold",
-                  mood === "active" ? "text-[var(--color-status-warning)]" : "text-gray-200"
-                )}
-              >
-                {branchLabel}
-              </span>
+              <span className="truncate font-semibold text-gray-200">{branchLabel}</span>
               {!worktree.branch && (
                 <span className="text-[var(--color-status-warning)] text-[0.65rem]">
                   (detached)

--- a/src/utils/colorInterpolation.ts
+++ b/src/utils/colorInterpolation.ts
@@ -49,3 +49,21 @@ export function getHeatColor(lastActivity: number | undefined | null): string {
   // Phase 4: Idle/Dormant
   return "#52525b"; // Zinc-600
 }
+
+/**
+ * Linear decay from Emerald-500 to Zinc-600 over 90 seconds.
+ * 0s → #10b981, 90s+ → #52525b
+ */
+export function getActivityColor(lastActivityTimestamp: number | null | undefined): string {
+  if (lastActivityTimestamp == null) return "#52525b";
+
+  const DECAY_DURATION = 90 * 1000;
+  const elapsed = Date.now() - lastActivityTimestamp;
+
+  if (elapsed >= DECAY_DURATION) {
+    return "#52525b";
+  }
+
+  const factor = elapsed / DECAY_DURATION;
+  return interpolateColor("#10b981", "#52525b", factor);
+}


### PR DESCRIPTION
## Summary
This PR implements a dedicated activity indicator for worktree cards that visualizes recent Git activity through a color transition from green to gray over 90 seconds. This decouples the "Active/Selected" state from the activity indicator, restoring the original "traffic light" visual feedback system.

Closes #422

## Changes Made
- Add ActivityLight component that fades from green to gray over 90 seconds
- Add getActivityColor function for linear decay calculation
- Replace active state green dot with activity indicator in WorktreeCard
- Implement strict null checking to avoid falsy number issues
- Optimize interval cleanup to stop ticking after decay completes
- Add accessibility support with role="status" and aria-label
- Selected worktree now indicated solely through border styling

## Technical Details
- Linear color interpolation from Emerald-500 (#10b981) to Zinc-600 (#52525b)
- 1-second update interval with automatic cleanup when dormant color reached
- Null-safe implementation with strict equality checks
- Performance-optimized to avoid unnecessary intervals for inactive worktrees
- Full accessibility support with ARIA attributes