### PR TITLE
feat(dragdrop): add ghost placeholder with terminal icon and title

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -27,11 +27,13 @@ export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
 interface DndPlaceholderContextValue {
   placeholderIndex: number | null;
   sourceContainer: "grid" | "dock" | null;
+  activeTerminal: TerminalInstance | null;
 }
 
 const DndPlaceholderContext = createContext<DndPlaceholderContextValue>({
   placeholderIndex: null,
   sourceContainer: null,
+  activeTerminal: null,
 });
 
 export function useDndPlaceholder() {
@@ -197,8 +199,8 @@ export function DndProvider({ children }: DndProviderProps) {
       // Handle placeholder for cross-container drag (dock -> grid)
       const sourceContainer = activeDataCurrent?.sourceLocation;
       if (sourceContainer === "dock" && detectedContainer === "grid") {
-        // Find grid terminals to calculate insertion index
-        const gridTerminals = terminals.filter((t) => t.location !== "dock");
+        // Find grid terminals to calculate insertion index (match TerminalGrid filter)
+        const gridTerminals = terminals.filter((t) => t.location === "grid" || t.location === undefined);
         const overId = over.id as string;
         const overIndex = gridTerminals.findIndex((t) => t.id === overId);
 
@@ -274,7 +276,9 @@ export function DndProvider({ children }: DndProviderProps) {
       // Get target index
       let targetIndex = 0;
       const containerTerminals = terminals.filter((t) =>
-        targetContainer === "dock" ? t.location === "dock" : t.location !== "dock"
+        targetContainer === "dock"
+          ? t.location === "dock"
+          : t.location === "grid" || t.location === undefined
       );
 
       // Find index of item we're dropping on
@@ -353,8 +357,9 @@ export function DndProvider({ children }: DndProviderProps) {
     () => ({
       placeholderIndex,
       sourceContainer: activeData?.sourceLocation ?? null,
+      activeTerminal,
     }),
-    [placeholderIndex, activeData?.sourceLocation]
+    [placeholderIndex, activeData?.sourceLocation, activeTerminal]
   );
 
   return (

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -1,20 +1,88 @@
+import { Terminal, Command } from "lucide-react";
+import {
+  ClaudeIcon,
+  GeminiIcon,
+  CodexIcon,
+  NpmIcon,
+  YarnIcon,
+  PnpmIcon,
+  BunIcon,
+} from "@/components/icons";
 import { cn } from "@/lib/utils";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import { useDndPlaceholder } from "./DndProvider";
+import type { TerminalType } from "@/types";
 
 interface GridPlaceholderProps {
   className?: string;
 }
 
+function getPlaceholderIcon(type: TerminalType) {
+  const brandColor = getBrandColorHex(type);
+  const props = {
+    className: "w-3.5 h-3.5",
+    "aria-hidden": "true" as const,
+  };
+  const customProps = { ...props, brandColor };
+
+  switch (type) {
+    case "claude":
+      return <ClaudeIcon {...customProps} />;
+    case "gemini":
+      return <GeminiIcon {...customProps} />;
+    case "codex":
+      return <CodexIcon {...customProps} />;
+    case "npm":
+      return <NpmIcon {...props} />;
+    case "yarn":
+      return <YarnIcon {...props} />;
+    case "pnpm":
+      return <PnpmIcon {...props} />;
+    case "bun":
+      return <BunIcon {...props} />;
+    case "custom":
+      return <Command {...props} />;
+    case "shell":
+    default:
+      return <Terminal {...props} />;
+  }
+}
+
 export function GridPlaceholder({ className }: GridPlaceholderProps) {
+  const { activeTerminal } = useDndPlaceholder();
+
+  // Fallback: render simple background if terminal data unavailable
+  if (!activeTerminal) {
+    return <div className={cn("h-full rounded-lg bg-white/5", className)} />;
+  }
+
+  const { title, type } = activeTerminal;
+
   return (
     <div
       className={cn(
-        "h-full min-h-[200px] rounded-lg",
-        "border-2 border-dashed border-canopy-accent/40",
-        "bg-canopy-accent/5",
-        "animate-pulse",
+        "h-full w-full rounded flex flex-col overflow-hidden",
+        "border border-canopy-accent/40 bg-canopy-accent/5",
+        "animate-in fade-in duration-200",
         className
       )}
       aria-hidden="true"
-    />
+    >
+      {/* Ghost Handle / Header */}
+      <div
+        className={cn(
+          "flex items-center gap-2 px-3 h-7 shrink-0 font-mono text-xs",
+          "bg-canopy-accent/10 border-b border-canopy-accent/10"
+        )}
+      >
+        <span className="shrink-0 flex items-center justify-center text-canopy-accent/80">
+          {getPlaceholderIcon(type)}
+        </span>
+        <span className="font-medium text-canopy-accent/80 truncate opacity-80">{title}</span>
+      </div>
+
+      {/* Empty Body */}
+      <div className="flex-1 w-full bg-transparent" />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
Replaces the generic dotted border placeholder with a transparent "ghost" version of the terminal handle that displays the icon and title of the terminal being dragged from the dock to the grid.

Closes #426

## Changes Made
- Extend DndPlaceholderContextValue to include activeTerminal
- Redesign GridPlaceholder to show terminal icon and title in header
- Add icon mapping for all terminal types (Claude, Gemini, Codex, Shell, npm, etc.)
- Apply transparent ghost styling with fade-in animation
- Fix location filter to match TerminalGrid (exclude trashed terminals)

## Visual Changes
**Before:** Generic dotted border box with pulse animation
**After:** Ghost terminal header showing icon and title with transparent preview styling

## Technical Details
- Context now passes activeTerminal through DndPlaceholderContext
- GridPlaceholder renders a 28px (h-7) header matching actual terminal headers
- Icon colors use brand colors via getBrandColorHex utility
- Fallback to simple background if terminal data unavailable
- Fixed bug where trashed terminals affected placeholder index calculation