### PR TITLE
Fix: Terminal palette shows trashed terminals

### DIFF
--- a/src/hooks/useTerminalPalette.ts
+++ b/src/hooks/useTerminalPalette.ts
@@ -72,14 +72,16 @@ export function useTerminalPalette(): UseTerminalPaletteReturn {
   }, [query]);
 
   const searchableTerminals = useMemo<SearchableTerminal[]>(() => {
-    return terminals.map((t) => ({
-      id: t.id,
-      title: t.title,
-      type: t.type,
-      worktreeId: t.worktreeId,
-      worktreeName: t.worktreeId ? worktreeMap.get(t.worktreeId)?.name : undefined,
-      cwd: t.cwd,
-    }));
+    return terminals
+      .filter((t) => t.location !== "trash")
+      .map((t) => ({
+        id: t.id,
+        title: t.title,
+        type: t.type,
+        worktreeId: t.worktreeId,
+        worktreeName: t.worktreeId ? worktreeMap.get(t.worktreeId)?.name : undefined,
+        cwd: t.cwd,
+      }));
   }, [terminals, worktreeMap]);
 
   const fuse = useMemo(() => {


### PR DESCRIPTION
## Summary
The terminal palette (⌘T) now correctly excludes trashed terminals from the quick-switch interface, ensuring users only see active terminals in grid or dock locations.

Closes #444

## Changes Made
- Add filter to searchableTerminals memo to exclude location === "trash"
- Ensures Command+T palette only shows active grid/dock terminals
- Trashed terminals now immediately disappear from quick-switch results
- Restored terminals automatically reappear in palette due to reactive dependencies