### PR TITLE
Add per-terminal settings with auto-restart control

### DIFF
--- a/electron/store.ts
+++ b/electron/store.ts
@@ -34,12 +34,15 @@ export interface StoreSchema {
     };
     terminals: Array<{
       id: string;
-      type: "shell" | "claude" | "gemini" | "codex" | "custom";
+      type: "shell" | "claude" | "gemini" | "codex" | "npm" | "yarn" | "pnpm" | "bun" | "custom";
       title: string;
       cwd: string;
       worktreeId?: string;
       location: "grid" | "dock";
       command?: string;
+      settings?: {
+        autoRestart?: boolean;
+      };
     }>;
     recipes?: Array<{
       id: string;

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -239,6 +239,12 @@ export enum TerminalRefreshTier {
   BACKGROUND = 1000, // 1fps
 }
 
+/** Per-terminal configuration settings */
+export interface TerminalSettings {
+  /** Whether to automatically re-execute the command on app restart */
+  autoRestart?: boolean;
+}
+
 /** Represents a terminal instance in the application */
 export interface TerminalInstance {
   /** Unique identifier for this terminal */
@@ -281,6 +287,8 @@ export interface TerminalInstance {
   command?: string;
   /** Whether the terminal pane is currently visible in the viewport */
   isVisible?: boolean;
+  /** Per-terminal configuration settings */
+  settings?: TerminalSettings;
 }
 
 /** Options for spawning a new PTY process */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -36,6 +36,7 @@ export type {
   TerminalType,
   TerminalLocation,
   AgentStateChangeTrigger,
+  TerminalSettings,
   TerminalInstance,
   PtySpawnOptions,
   TerminalDimensions,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1,6 +1,7 @@
 import type {
   TerminalType,
   TerminalLocation,
+  TerminalSettings,
   DevServerState,
   WorktreeState,
   Project,
@@ -59,6 +60,8 @@ export interface TerminalState {
   location?: TerminalLocation;
   /** Command to execute after shell starts (e.g., 'claude' for AI agents) */
   command?: string;
+  /** Per-terminal configuration settings */
+  settings?: TerminalSettings;
   /** Last detected agent type (for restoration hints) */
   lastDetectedAgent?: TerminalType;
   /** Last detected agent title (for restoration hints) */

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -9,7 +9,15 @@ import {
   Copy,
   ArrowDownToLine,
   Loader2,
+  Settings2,
 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuCheckboxItem,
+  DropdownMenuTrigger,
+  DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu";
 import {
   ClaudeIcon,
   GeminiIcon,
@@ -129,6 +137,8 @@ function TerminalPaneComponent({
 
   const updateVisibility = useTerminalStore((state) => state.updateVisibility);
   const getTerminal = useTerminalStore((state) => state.getTerminal);
+  const updateTerminalSettings = useTerminalStore((state) => state.updateTerminalSettings);
+  const terminal = useTerminalStore((state) => state.terminals.find((t) => t.id === id));
 
   const queueCount = useTerminalStore(
     useShallow((state) => state.commandQueue.filter((c) => c.terminalId === id).length)
@@ -429,6 +439,29 @@ function TerminalPaneComponent({
         </div>
 
         <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="p-1.5 hover:bg-canopy-text/10 focus-visible:bg-canopy-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent text-canopy-text/60 hover:text-canopy-text transition-colors rounded"
+                onClick={(e) => e.stopPropagation()}
+                title="Terminal Settings"
+                aria-label="Terminal settings"
+              >
+                <Settings2 className="w-3 h-3" aria-hidden="true" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56">
+              <DropdownMenuLabel>Terminal Settings</DropdownMenuLabel>
+              <DropdownMenuCheckboxItem
+                checked={terminal?.settings?.autoRestart ?? false}
+                onCheckedChange={(checked) =>
+                  updateTerminalSettings(id, { autoRestart: checked === true })
+                }
+              >
+                Auto-restart on open
+              </DropdownMenuCheckboxItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
           {worktreeId && onInjectContext && (
             <button
               onClick={(e) => {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -124,11 +125,35 @@ const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTML
 };
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" aria-hidden="true" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
   DropdownMenuSeparator,
   DropdownMenuLabel,
   DropdownMenuShortcut,

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -1,6 +1,6 @@
 import { appClient, projectClient, terminalConfigClient } from "@/clients";
 import { useLayoutConfigStore, useScrollbackStore, usePerformanceModeStore } from "@/store";
-import type { TerminalType } from "@/types";
+import type { TerminalType, TerminalSettings } from "@/types";
 
 export interface HydrationOptions {
   addTerminal: (options: {
@@ -10,6 +10,7 @@ export interface HydrationOptions {
     worktreeId?: string;
     location?: "grid" | "dock";
     command?: string;
+    settings?: TerminalSettings;
   }) => Promise<string>;
   setActiveWorktree: (id: string | null) => void;
   loadRecipes: () => Promise<void>;
@@ -72,13 +73,18 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
           const cwd = terminal.cwd || projectRoot || "";
 
+          // Only pass command if autoRestart is explicitly true
+          const autoRestart = terminal.settings?.autoRestart ?? false;
+          const commandToRun = autoRestart ? terminal.command : undefined;
+
           await addTerminal({
             type: terminal.type,
             title: terminal.title,
             cwd,
             worktreeId: terminal.worktreeId,
-            location: "grid",
-            command: terminal.command,
+            location: terminal.location === "dock" ? "dock" : "grid",
+            command: commandToRun,
+            settings: terminal.settings,
           });
         } catch (error) {
           console.warn(`Failed to restore terminal ${terminal.id}:`, error);


### PR DESCRIPTION
## Summary

Implements a per-terminal settings system with an `autoRestart` flag to control whether terminals automatically re-execute their saved commands on app restart. This prevents heavy operations like builds and migrations from running unintentionally while allowing dev servers to auto-start.

Closes #450

## Changes Made

**Type Definitions:**
- Added `TerminalSettings` interface with `autoRestart` field
- Updated `TerminalInstance` to include optional `settings` property
- Added settings to `TerminalState` for persistence
- Exported `TerminalSettings` from shared types index

**Persistence & State Management:**
- Updated electron store schema to persist terminal settings
- Added `updateTerminalSettings` action to terminal registry slice
- Enhanced persistence logic to save/restore settings object
- Fixed store schema to include all TerminalType variants (npm, yarn, pnpm, bun)

**Hydration Logic:**
- Modified state hydration to check `autoRestart` before executing commands
- Commands only execute on restart when `autoRestart` is explicitly `true`
- Default behavior: `autoRestart: false` (safe by default)
- Preserve terminal location (dock/grid) correctly on app restart
- Use `TerminalSettings` type for type safety

**UI Implementation:**
- Added `DropdownMenuCheckboxItem` component to dropdown-menu.tsx
- Added settings dropdown to terminal header with gear icon
- Settings menu displays "Auto-restart on open" checkbox
- Menu is accessible on hover/focus with keyboard support
- Added proper accessibility attributes (aria-hidden on icons)

**Code Quality:**
- Fixed type safety issues throughout the data flow
- Added null guards for undefined settings in updateTerminalSettings
- Ensured backward compatibility with existing terminals
- All type checks pass with no errors