### PR TITLE
Add Alt-click modifier for instant terminal close

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -82,6 +82,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const [isRestoring, setIsRestoring] = useState(false);
   const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
   const trashTerminal = useTerminalStore((s) => s.trashTerminal);
+  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
 
   const { inject, cancel } = useContextInjection();
 
@@ -130,10 +131,17 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     setIsOpen(false);
   }, [setIsOpen]);
 
-  const handleClose = useCallback(() => {
-    trashTerminal(terminal.id);
-    setIsOpen(false);
-  }, [trashTerminal, terminal.id, setIsOpen]);
+  const handleClose = useCallback(
+    (force?: boolean) => {
+      if (force) {
+        removeTerminal(terminal.id);
+      } else {
+        trashTerminal(terminal.id);
+      }
+      setIsOpen(false);
+    },
+    [trashTerminal, removeTerminal, terminal.id, setIsOpen]
+  );
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -145,6 +145,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
 
   const addTerminal = useTerminalStore((state) => state.addTerminal);
   const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+  const removeTerminal = useTerminalStore((state) => state.removeTerminal);
   const updateTitle = useTerminalStore((state) => state.updateTitle);
   const setFocused = useTerminalStore((state) => state.setFocused);
   const toggleMaximize = useTerminalStore((state) => state.toggleMaximize);
@@ -314,7 +315,9 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
               }
               location="grid"
               onFocus={() => setFocused(terminal.id)}
-              onClose={() => trashTerminal(terminal.id)}
+              onClose={(force) =>
+                force ? removeTerminal(terminal.id) : trashTerminal(terminal.id)
+              }
               onInjectContext={
                 terminal.worktreeId
                   ? () => handleInjectContext(terminal.id, terminal.worktreeId)
@@ -402,7 +405,9 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
                       }
                       location="grid"
                       onFocus={() => setFocused(terminal.id)}
-                      onClose={() => trashTerminal(terminal.id)}
+                      onClose={(force) =>
+                        force ? removeTerminal(terminal.id) : trashTerminal(terminal.id)
+                      }
                       onInjectContext={
                         terminal.worktreeId
                           ? () => handleInjectContext(terminal.id, terminal.worktreeId)

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -51,7 +51,7 @@ export interface TerminalPaneProps {
   agentState?: AgentState;
   activity?: ActivityState | null;
   onFocus: () => void;
-  onClose: () => void;
+  onClose: (force?: boolean) => void;
   onInjectContext?: () => void;
   onCancelInjection?: () => void;
   onToggleMaximize?: () => void;
@@ -493,11 +493,18 @@ function TerminalPaneComponent({
           <button
             onClick={(e) => {
               e.stopPropagation();
-              onClose();
+              onClose(e.altKey);
+            }}
+            onKeyDown={(e) => {
+              if ((e.key === "Enter" || e.key === " ") && e.altKey) {
+                e.preventDefault();
+                e.stopPropagation();
+                onClose(true);
+              }
             }}
             className="p-1.5 hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-status-error)] text-canopy-text/60 hover:text-[var(--color-status-error)] transition-colors"
-            title="Close Session (Ctrl+Shift+W)"
-            aria-label="Close session"
+            title="Close Session (Alt+Click to force close)"
+            aria-label="Close session. Hold Alt and click to force close without recovery."
           >
             <X className="w-3 h-3" aria-hidden="true" />
           </button>


### PR DESCRIPTION
## Summary
Adds support for Alt-click (Option-click on macOS) on terminal close buttons to immediately remove terminals without the trash recovery system. Regular clicks continue to move terminals to trash with 30-second recovery.

Closes #452

## Changes Made
- Updated TerminalPane onClose prop to accept optional force parameter
- Pass Alt key state from click event to onClose handler
- Route to removeTerminal when force is true, trashTerminal otherwise
- Added keyboard accessibility with Alt+Enter/Space support for force close
- Enhanced aria-label to describe Alt-click force close behavior
- Applied changes consistently across grid, maximized, and docked terminal views

## Accessibility
- Keyboard users can now use Alt+Enter or Alt+Space when focused on close button
- Screen reader users are informed about the Alt-click modifier via aria-label