### PR TITLE
Auto-trash terminals on clean exit

### DIFF
--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -267,9 +267,18 @@ export function setupTerminalStoreListeners() {
 
   exitUnsubscribe = terminalClient.onExit((id) => {
     const state = useTerminalStore.getState();
-    if (state.terminals.some((t) => t.id === id)) {
+    const terminal = state.terminals.find((t) => t.id === id);
+
+    if (!terminal) return;
+
+    // If already trashed, this is TTL expiry cleanup - permanently remove
+    if (terminal.location === "trash") {
       state.removeTerminal(id);
+      return;
     }
+
+    // Auto-trash on exit preserves history for review (consistent with manual close)
+    state.trashTerminal(id);
   });
 
   // Flush pending terminal persistence on window close to prevent data loss


### PR DESCRIPTION
## Summary
Implements automatic terminal trashing on process exit instead of immediate removal. When a user types "exit" in a terminal or a process terminates, the terminal now moves to the trash location with a 30-second recovery window, making the behavior consistent with manual close operations.

Closes #453

## Changes Made
- Move terminals to trash on process exit instead of immediate removal
- Preserve terminal history for 30-second recovery window
- Detect TTL expiry and permanently remove already-trashed terminals
- Make exit behavior consistent with manual close

## Implementation Details
- Modified the `exitUnsubscribe` listener in `terminalStore.ts`
- Added location check to differentiate between normal exits and TTL expiry cleanup
- Normal exit: calls `trashTerminal(id)` to preserve history
- TTL expiry: calls `removeTerminal(id)` to permanently remove after timeout