### PR TITLE
Add Context Sidecar with WebContentsView browser dock

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -122,6 +122,17 @@ export const CHANNELS = {
   TERMINAL_CONFIG_SET_PERFORMANCE_MODE: "terminal-config:set-performance-mode",
 
   GIT_GET_FILE_DIFF: "git:get-file-diff",
+
+  SIDECAR_CREATE: "sidecar:create",
+  SIDECAR_SHOW: "sidecar:show",
+  SIDECAR_HIDE: "sidecar:hide",
+  SIDECAR_RESIZE: "sidecar:resize",
+  SIDECAR_CLOSE_TAB: "sidecar:close-tab",
+  SIDECAR_NAVIGATE: "sidecar:navigate",
+  SIDECAR_GO_BACK: "sidecar:go-back",
+  SIDECAR_GO_FORWARD: "sidecar:go-forward",
+  SIDECAR_RELOAD: "sidecar:reload",
+  SIDECAR_NAV_EVENT: "sidecar:nav-event",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -3,6 +3,7 @@ import type { DevServerManager } from "../services/DevServerManager.js";
 import type { WorktreeService } from "../services/WorktreeService.js";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import type { EventBuffer } from "../services/EventBuffer.js";
+import type { SidecarManager } from "../services/SidecarManager.js";
 import { HandlerDependencies, TerminalManager } from "./types.js";
 import { registerWorktreeHandlers } from "./handlers/worktree.js";
 import { registerTerminalHandlers } from "./handlers/terminal.js";
@@ -12,6 +13,7 @@ import { registerAiHandlers } from "./handlers/ai.js";
 import { registerProjectHandlers } from "./handlers/project.js";
 import { registerGithubHandlers } from "./handlers/github.js";
 import { registerAppHandlers } from "./handlers/app.js";
+import { registerSidecarHandlers } from "./handlers/sidecar.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
 export { typedHandle, typedSend, sendToRenderer };
@@ -22,7 +24,8 @@ export function registerIpcHandlers(
   devServerManager?: DevServerManager,
   worktreeService?: WorktreeService,
   eventBuffer?: EventBuffer,
-  cliAvailabilityService?: CliAvailabilityService
+  cliAvailabilityService?: CliAvailabilityService,
+  sidecarManager?: SidecarManager
 ): () => void {
   const deps: HandlerDependencies = {
     mainWindow,
@@ -31,6 +34,7 @@ export function registerIpcHandlers(
     worktreeService,
     eventBuffer,
     cliAvailabilityService,
+    sidecarManager,
   };
 
   const cleanupFunctions = [
@@ -42,6 +46,7 @@ export function registerIpcHandlers(
     registerProjectHandlers(deps),
     registerGithubHandlers(deps),
     registerAppHandlers(deps),
+    registerSidecarHandlers(deps),
   ];
 
   return () => {

--- a/electron/ipc/handlers/sidecar.ts
+++ b/electron/ipc/handlers/sidecar.ts
@@ -1,0 +1,131 @@
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import type { HandlerDependencies } from "../types.js";
+import type {
+  SidecarCreatePayload,
+  SidecarShowPayload,
+  SidecarCloseTabPayload,
+  SidecarNavigatePayload,
+  SidecarBounds,
+} from "../../../shared/types/sidecar.js";
+
+export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
+  const { sidecarManager } = deps;
+  const handlers: Array<() => void> = [];
+
+  const handleSidecarCreate = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: SidecarCreatePayload
+  ) => {
+    try {
+      if (!sidecarManager) return;
+      if (!payload?.tabId || typeof payload.tabId !== "string") {
+        throw new Error("Invalid tabId");
+      }
+      if (!payload?.url || typeof payload.url !== "string") {
+        throw new Error("Invalid url");
+      }
+      sidecarManager.createTab(payload.tabId, payload.url);
+    } catch (error) {
+      console.error("[SidecarHandler] Error in create:", error);
+      throw error;
+    }
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_CREATE, handleSidecarCreate);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_CREATE));
+
+  const handleSidecarShow = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: SidecarShowPayload
+  ) => {
+    try {
+      if (!sidecarManager) return;
+      if (!payload?.tabId || typeof payload.tabId !== "string") {
+        throw new Error("Invalid tabId");
+      }
+      if (!payload?.bounds || typeof payload.bounds !== "object") {
+        throw new Error("Invalid bounds");
+      }
+      sidecarManager.showTab(payload.tabId, payload.bounds);
+    } catch (error) {
+      console.error("[SidecarHandler] Error in show:", error);
+      throw error;
+    }
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_SHOW, handleSidecarShow);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_SHOW));
+
+  const handleSidecarHide = async () => {
+    if (!sidecarManager) return;
+    sidecarManager.hideAll();
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_HIDE, handleSidecarHide);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_HIDE));
+
+  const handleSidecarResize = async (
+    _event: Electron.IpcMainInvokeEvent,
+    bounds: SidecarBounds
+  ) => {
+    try {
+      if (!sidecarManager) return;
+      if (!bounds || typeof bounds !== "object") {
+        throw new Error("Invalid bounds");
+      }
+      sidecarManager.updateBounds(bounds);
+    } catch (error) {
+      console.error("[SidecarHandler] Error in resize:", error);
+      throw error;
+    }
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_RESIZE, handleSidecarResize);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_RESIZE));
+
+  const handleSidecarCloseTab = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: SidecarCloseTabPayload
+  ) => {
+    if (!sidecarManager) return;
+    sidecarManager.closeTab(payload.tabId);
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_CLOSE_TAB, handleSidecarCloseTab);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_CLOSE_TAB));
+
+  const handleSidecarNavigate = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: SidecarNavigatePayload
+  ) => {
+    if (!sidecarManager) return;
+    sidecarManager.navigate(payload.tabId, payload.url);
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_NAVIGATE, handleSidecarNavigate);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_NAVIGATE));
+
+  const handleSidecarGoBack = async (
+    _event: Electron.IpcMainInvokeEvent,
+    tabId: string
+  ): Promise<boolean> => {
+    if (!sidecarManager) return false;
+    return sidecarManager.goBack(tabId);
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_GO_BACK, handleSidecarGoBack);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_GO_BACK));
+
+  const handleSidecarGoForward = async (
+    _event: Electron.IpcMainInvokeEvent,
+    tabId: string
+  ): Promise<boolean> => {
+    if (!sidecarManager) return false;
+    return sidecarManager.goForward(tabId);
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_GO_FORWARD, handleSidecarGoForward);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_GO_FORWARD));
+
+  const handleSidecarReload = async (_event: Electron.IpcMainInvokeEvent, tabId: string) => {
+    if (!sidecarManager) return;
+    sidecarManager.reload(tabId);
+  };
+  ipcMain.handle(CHANNELS.SIDECAR_RELOAD, handleSidecarReload);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_RELOAD));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -5,6 +5,7 @@ import type { DevServerManager } from "../services/DevServerManager.js";
 import type { WorktreeService } from "../services/WorktreeService.js";
 import type { EventBuffer } from "../services/EventBuffer.js";
 import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
+import type { SidecarManager } from "../services/SidecarManager.js";
 
 /** Terminal manager - either PtyManager (direct) or PtyClient (via UtilityProcess) */
 export type TerminalManager = PtyManager | PtyClient;
@@ -16,4 +17,5 @@ export interface HandlerDependencies {
   worktreeService?: WorktreeService;
   eventBuffer?: EventBuffer;
   cliAvailabilityService?: CliAvailabilityService;
+  sidecarManager?: SidecarManager;
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -209,6 +209,18 @@ const CHANNELS = {
 
   // Git channels
   GIT_GET_FILE_DIFF: "git:get-file-diff",
+
+  // Sidecar channels
+  SIDECAR_CREATE: "sidecar:create",
+  SIDECAR_SHOW: "sidecar:show",
+  SIDECAR_HIDE: "sidecar:hide",
+  SIDECAR_RESIZE: "sidecar:resize",
+  SIDECAR_CLOSE_TAB: "sidecar:close-tab",
+  SIDECAR_NAVIGATE: "sidecar:navigate",
+  SIDECAR_GO_BACK: "sidecar:go-back",
+  SIDECAR_GO_FORWARD: "sidecar:go-forward",
+  SIDECAR_RELOAD: "sidecar:reload",
+  SIDECAR_NAV_EVENT: "sidecar:nav-event",
 } as const;
 
 const api: ElectronAPI = {
@@ -558,6 +570,37 @@ const api: ElectronAPI = {
 
     setPerformanceMode: (performanceMode: boolean) =>
       _typedInvoke(CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE, performanceMode),
+  },
+
+  // Sidecar API
+  sidecar: {
+    create: (payload: { tabId: string; url: string }) =>
+      ipcRenderer.invoke(CHANNELS.SIDECAR_CREATE, payload),
+
+    show: (payload: {
+      tabId: string;
+      bounds: { x: number; y: number; width: number; height: number };
+    }) => ipcRenderer.invoke(CHANNELS.SIDECAR_SHOW, payload),
+
+    hide: () => ipcRenderer.invoke(CHANNELS.SIDECAR_HIDE),
+
+    resize: (bounds: { x: number; y: number; width: number; height: number }) =>
+      ipcRenderer.invoke(CHANNELS.SIDECAR_RESIZE, bounds),
+
+    closeTab: (payload: { tabId: string }) =>
+      ipcRenderer.invoke(CHANNELS.SIDECAR_CLOSE_TAB, payload),
+
+    navigate: (payload: { tabId: string; url: string }) =>
+      ipcRenderer.invoke(CHANNELS.SIDECAR_NAVIGATE, payload),
+
+    goBack: (tabId: string) => ipcRenderer.invoke(CHANNELS.SIDECAR_GO_BACK, tabId),
+
+    goForward: (tabId: string) => ipcRenderer.invoke(CHANNELS.SIDECAR_GO_FORWARD, tabId),
+
+    reload: (tabId: string) => ipcRenderer.invoke(CHANNELS.SIDECAR_RELOAD, tabId),
+
+    onNavEvent: (callback: (data: { tabId: string; title: string; url: string }) => void) =>
+      _typedOn(CHANNELS.SIDECAR_NAV_EVENT, callback),
   },
 };
 

--- a/electron/services/SidecarManager.ts
+++ b/electron/services/SidecarManager.ts
@@ -1,0 +1,205 @@
+import { BrowserWindow, WebContentsView } from "electron";
+import type { SidecarBounds, SidecarNavEvent } from "../../shared/types/sidecar.js";
+import { CHANNELS } from "../ipc/channels.js";
+
+export class SidecarManager {
+  private window: BrowserWindow;
+  private viewMap = new Map<string, WebContentsView>();
+  private activeView: WebContentsView | null = null;
+  private activeTabId: string | null = null;
+
+  constructor(window: BrowserWindow) {
+    this.window = window;
+  }
+
+  createTab(tabId: string, url: string): void {
+    if (this.viewMap.has(tabId)) return;
+
+    try {
+      const parsedUrl = new URL(url);
+      if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+        throw new Error(`Invalid URL protocol: ${parsedUrl.protocol}`);
+      }
+    } catch (error) {
+      console.error(`[SidecarManager] Invalid URL for tab ${tabId}:`, error);
+      return;
+    }
+
+    const view = new WebContentsView({
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+        partition: "persist:sidecar",
+      },
+    });
+
+    view.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+    const sendNavEvent = (navEvent: SidecarNavEvent) => {
+      if (!this.window?.isDestroyed()) {
+        this.window.webContents.send(CHANNELS.SIDECAR_NAV_EVENT, navEvent);
+      }
+    };
+
+    view.webContents.on("page-title-updated", (_, title) => {
+      sendNavEvent({
+        tabId,
+        title,
+        url: view.webContents.getURL(),
+      });
+    });
+
+    view.webContents.on("did-navigate", (_, url) => {
+      sendNavEvent({
+        tabId,
+        title: view.webContents.getTitle(),
+        url,
+      });
+    });
+
+    view.webContents.on("did-navigate-in-page", (_, url) => {
+      sendNavEvent({
+        tabId,
+        title: view.webContents.getTitle(),
+        url,
+      });
+    });
+
+    view.webContents.once("destroyed", () => {
+      this.viewMap.delete(tabId);
+      if (this.activeTabId === tabId) {
+        this.activeView = null;
+        this.activeTabId = null;
+      }
+    });
+
+    view.webContents.loadURL(url);
+    this.viewMap.set(tabId, view);
+  }
+
+  showTab(tabId: string, bounds: SidecarBounds): void {
+    const view = this.viewMap.get(tabId);
+    if (!view) return;
+
+    if (this.activeView && this.activeView !== view) {
+      this.window.contentView.removeChildView(this.activeView);
+    }
+
+    if (this.activeView !== view) {
+      this.window.contentView.addChildView(view);
+    }
+
+    const validatedBounds = this.validateBounds(bounds);
+    view.setBounds(validatedBounds);
+    this.activeView = view;
+    this.activeTabId = tabId;
+  }
+
+  private validateBounds(bounds: SidecarBounds): {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } {
+    const x = Number.isFinite(bounds.x) ? Math.max(0, Math.round(bounds.x)) : 0;
+    const y = Number.isFinite(bounds.y) ? Math.max(0, Math.round(bounds.y)) : 0;
+    const width = Number.isFinite(bounds.width) ? Math.max(100, Math.round(bounds.width)) : 800;
+    const height = Number.isFinite(bounds.height) ? Math.max(100, Math.round(bounds.height)) : 600;
+
+    return { x, y, width, height };
+  }
+
+  hideAll(): void {
+    if (this.activeView) {
+      this.window.contentView.removeChildView(this.activeView);
+      this.activeView = null;
+      this.activeTabId = null;
+    }
+  }
+
+  updateBounds(bounds: SidecarBounds): void {
+    if (this.activeView) {
+      const validatedBounds = this.validateBounds(bounds);
+      this.activeView.setBounds(validatedBounds);
+    }
+  }
+
+  closeTab(tabId: string): void {
+    const view = this.viewMap.get(tabId);
+    if (!view) return;
+
+    if (this.activeView === view) {
+      this.window.contentView.removeChildView(view);
+      this.activeView = null;
+      this.activeTabId = null;
+    }
+
+    try {
+      view.webContents.close();
+    } catch (error) {
+      console.error(`[SidecarManager] Error closing tab ${tabId}:`, error);
+    }
+
+    this.viewMap.delete(tabId);
+  }
+
+  navigate(tabId: string, url: string): void {
+    const view = this.viewMap.get(tabId);
+    if (!view) return;
+
+    try {
+      const parsedUrl = new URL(url);
+      if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+        throw new Error(`Invalid URL protocol: ${parsedUrl.protocol}`);
+      }
+      view.webContents.loadURL(url);
+    } catch (error) {
+      console.error(`[SidecarManager] Invalid navigation URL for tab ${tabId}:`, error);
+    }
+  }
+
+  goBack(tabId: string): boolean {
+    const view = this.viewMap.get(tabId);
+    if (!view || !view.webContents.canGoBack()) return false;
+    view.webContents.goBack();
+    return true;
+  }
+
+  goForward(tabId: string): boolean {
+    const view = this.viewMap.get(tabId);
+    if (!view || !view.webContents.canGoForward()) return false;
+    view.webContents.goForward();
+    return true;
+  }
+
+  reload(tabId: string): void {
+    const view = this.viewMap.get(tabId);
+    if (!view) return;
+    view.webContents.reload();
+  }
+
+  getActiveTabId(): string | null {
+    return this.activeTabId;
+  }
+
+  hasTab(tabId: string): boolean {
+    return this.viewMap.has(tabId);
+  }
+
+  destroy(): void {
+    this.viewMap.forEach((view) => {
+      try {
+        if (this.activeView === view) {
+          this.window.contentView.removeChildView(view);
+        }
+        view.webContents.close();
+      } catch (error) {
+        console.error("[SidecarManager] Error destroying view:", error);
+      }
+    });
+    this.viewMap.clear();
+    this.activeView = null;
+    this.activeTabId = null;
+  }
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -235,3 +235,23 @@ export type {
   AgentFailedPayload,
   AgentKilledPayload,
 } from "./pty-host.js";
+
+// Sidecar types - browser dock
+export type {
+  SidecarLayoutMode,
+  SidecarTab,
+  SidecarBounds,
+  SidecarNavEvent,
+  SidecarCreatePayload,
+  SidecarShowPayload,
+  SidecarCloseTabPayload,
+  SidecarNavigatePayload,
+} from "./sidecar.js";
+
+export {
+  DEFAULT_SIDECAR_TABS,
+  SIDECAR_MIN_WIDTH,
+  SIDECAR_MAX_WIDTH,
+  SIDECAR_DEFAULT_WIDTH,
+  MIN_GRID_WIDTH,
+} from "./sidecar.js";

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1159,6 +1159,44 @@ export interface IpcInvokeMap {
     args: [payload: GitGetFileDiffPayload];
     result: string;
   };
+
+  // Sidecar channels
+  "sidecar:create": {
+    args: [payload: import("./sidecar.js").SidecarCreatePayload];
+    result: void;
+  };
+  "sidecar:show": {
+    args: [payload: import("./sidecar.js").SidecarShowPayload];
+    result: void;
+  };
+  "sidecar:hide": {
+    args: [];
+    result: void;
+  };
+  "sidecar:resize": {
+    args: [bounds: import("./sidecar.js").SidecarBounds];
+    result: void;
+  };
+  "sidecar:close-tab": {
+    args: [payload: import("./sidecar.js").SidecarCloseTabPayload];
+    result: void;
+  };
+  "sidecar:navigate": {
+    args: [payload: import("./sidecar.js").SidecarNavigatePayload];
+    result: void;
+  };
+  "sidecar:go-back": {
+    args: [tabId: string];
+    result: boolean;
+  };
+  "sidecar:go-forward": {
+    args: [tabId: string];
+    result: boolean;
+  };
+  "sidecar:reload": {
+    args: [tabId: string];
+    result: void;
+  };
 }
 
 /**
@@ -1235,6 +1273,9 @@ export interface IpcEventMap {
 
   // Project events
   "project:on-switch": Project;
+
+  // Sidecar events
+  "sidecar:nav-event": import("./sidecar.js").SidecarNavEvent;
 }
 
 /**
@@ -1414,5 +1455,17 @@ export interface ElectronAPI {
     get(): Promise<TerminalConfig>;
     setScrollback(scrollbackLines: number): Promise<void>;
     setPerformanceMode(performanceMode: boolean): Promise<void>;
+  };
+  sidecar: {
+    create(payload: import("./sidecar.js").SidecarCreatePayload): Promise<void>;
+    show(payload: import("./sidecar.js").SidecarShowPayload): Promise<void>;
+    hide(): Promise<void>;
+    resize(bounds: import("./sidecar.js").SidecarBounds): Promise<void>;
+    closeTab(payload: import("./sidecar.js").SidecarCloseTabPayload): Promise<void>;
+    navigate(payload: import("./sidecar.js").SidecarNavigatePayload): Promise<void>;
+    goBack(tabId: string): Promise<boolean>;
+    goForward(tabId: string): Promise<boolean>;
+    reload(tabId: string): Promise<void>;
+    onNavEvent(callback: (data: import("./sidecar.js").SidecarNavEvent) => void): () => void;
   };
 }

--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -1,0 +1,52 @@
+export type SidecarLayoutMode = "push" | "overlay";
+
+export interface SidecarTab {
+  id: string;
+  url: string;
+  title: string;
+  favicon?: string;
+}
+
+export interface SidecarBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SidecarNavEvent {
+  tabId: string;
+  title: string;
+  url: string;
+}
+
+export interface SidecarCreatePayload {
+  tabId: string;
+  url: string;
+}
+
+export interface SidecarShowPayload {
+  tabId: string;
+  bounds: SidecarBounds;
+}
+
+export interface SidecarCloseTabPayload {
+  tabId: string;
+}
+
+export interface SidecarNavigatePayload {
+  tabId: string;
+  url: string;
+}
+
+export const DEFAULT_SIDECAR_TABS: SidecarTab[] = [
+  { id: "claude", url: "https://claude.ai/new", title: "Claude" },
+  { id: "chatgpt", url: "https://chatgpt.com/", title: "ChatGPT" },
+  { id: "localhost", url: "http://localhost:3000", title: "Localhost" },
+  { id: "google", url: "https://www.google.com", title: "Google" },
+];
+
+export const SIDECAR_MIN_WIDTH = 400;
+export const SIDECAR_MAX_WIDTH = 1200;
+export const SIDECAR_DEFAULT_WIDTH = 800;
+export const MIN_GRID_WIDTH = 600;

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -13,6 +13,8 @@ import {
   GitPullRequest,
   AlertTriangle,
   CircleHelp,
+  PanelRightOpen,
+  PanelRightClose,
 } from "lucide-react";
 import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -21,6 +23,7 @@ import { BulkActionsMenu } from "@/components/Terminal";
 import { GitHubResourceList } from "@/components/GitHub";
 import { useProjectStore } from "@/store/projectStore";
 import { useTerminalStore } from "@/store/terminalStore";
+import { useSidecarStore } from "@/store";
 import { useRepositoryStats } from "@/hooks/useRepositoryStats";
 import type { CliAvailability, AgentSettings } from "@shared/types";
 
@@ -54,6 +57,9 @@ export function Toolbar({
   const currentProject = useProjectStore((state) => state.currentProject);
   const terminals = useTerminalStore(useShallow((state) => state.terminals));
   const { stats, error: statsError, refresh: refreshStats } = useRepositoryStats();
+
+  const sidecarOpen = useSidecarStore((state) => state.isOpen);
+  const toggleSidecar = useSidecarStore((state) => state.toggle);
 
   const [issuesOpen, setIssuesOpen] = useState(false);
   const [prsOpen, setPrsOpen] = useState(false);
@@ -236,6 +242,24 @@ export function Toolbar({
         )}
 
         <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleSidecar}
+            className={cn(
+              "text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8",
+              sidecarOpen && "bg-canopy-accent/20 text-canopy-accent"
+            )}
+            title={sidecarOpen ? "Close Context Sidecar" : "Open Context Sidecar"}
+            aria-label={sidecarOpen ? "Close context sidecar" : "Open context sidecar"}
+            aria-pressed={sidecarOpen}
+          >
+            {sidecarOpen ? (
+              <PanelRightClose className="h-4 w-4" aria-hidden="true" />
+            ) : (
+              <PanelRightOpen className="h-4 w-4" aria-hidden="true" />
+            )}
+          </Button>
           <Button
             variant="ghost"
             size="icon"

--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -1,0 +1,176 @@
+import { useRef, useEffect, useCallback, useState } from "react";
+import { useSidecarStore } from "@/store";
+import { SidecarToolbar } from "./SidecarToolbar";
+import { SIDECAR_MIN_WIDTH, SIDECAR_MAX_WIDTH } from "@shared/types";
+
+export function SidecarDock() {
+  const {
+    width,
+    activeTabId,
+    tabs,
+    isTabCreated,
+    markTabCreated,
+    setActiveTab,
+    setWidth,
+    setOpen,
+  } = useSidecarStore();
+  const placeholderRef = useRef<HTMLDivElement>(null);
+  const [isResizing, setIsResizing] = useState(false);
+
+  const syncBounds = useCallback(() => {
+    if (!placeholderRef.current || !activeTabId) return;
+    const rect = placeholderRef.current.getBoundingClientRect();
+    window.electron.sidecar.resize({
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    });
+  }, [activeTabId]);
+
+  useEffect(() => {
+    if (!placeholderRef.current || !activeTabId) return;
+
+    const debouncedSync = debounce(syncBounds, 100);
+    const observer = new ResizeObserver(debouncedSync);
+    observer.observe(placeholderRef.current);
+
+    window.addEventListener("resize", debouncedSync);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", debouncedSync);
+    };
+  }, [activeTabId, syncBounds]);
+
+  useEffect(() => {
+    const cleanup = window.electron.sidecar.onNavEvent((data) => {
+      useSidecarStore.getState().updateTabTitle(data.tabId, data.title);
+      useSidecarStore.getState().updateTabUrl(data.tabId, data.url);
+    });
+    return cleanup;
+  }, []);
+
+  const handleTabClick = useCallback(
+    async (tabId: string) => {
+      const tab = tabs.find((t) => t.id === tabId);
+      if (!tab) return;
+
+      if (!isTabCreated(tabId)) {
+        await window.electron.sidecar.create({ tabId, url: tab.url });
+        markTabCreated(tabId);
+      }
+
+      setActiveTab(tabId);
+
+      if (placeholderRef.current) {
+        const rect = placeholderRef.current.getBoundingClientRect();
+        await window.electron.sidecar.show({
+          tabId,
+          bounds: {
+            x: Math.round(rect.x),
+            y: Math.round(rect.y),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          },
+        });
+      }
+    },
+    [tabs, isTabCreated, markTabCreated, setActiveTab]
+  );
+
+  const handleClose = useCallback(async () => {
+    await window.electron.sidecar.hide();
+    setOpen(false);
+  }, [setOpen]);
+
+  const handleGoBack = useCallback(async () => {
+    if (activeTabId) {
+      await window.electron.sidecar.goBack(activeTabId);
+    }
+  }, [activeTabId]);
+
+  const handleGoForward = useCallback(async () => {
+    if (activeTabId) {
+      await window.electron.sidecar.goForward(activeTabId);
+    }
+  }, [activeTabId]);
+
+  const handleReload = useCallback(async () => {
+    if (activeTabId) {
+      await window.electron.sidecar.reload(activeTabId);
+    }
+  }, [activeTabId]);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setIsResizing(true);
+      const startX = e.clientX;
+      const startWidth = width;
+
+      const handleMouseMove = (e: MouseEvent) => {
+        const delta = startX - e.clientX;
+        const newWidth = Math.min(
+          Math.max(startWidth + delta, SIDECAR_MIN_WIDTH),
+          SIDECAR_MAX_WIDTH
+        );
+        setWidth(newWidth);
+      };
+
+      const handleMouseUp = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+
+      return () => {
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+    },
+    [width, setWidth]
+  );
+
+  useEffect(() => {
+    return () => {
+      setIsResizing(false);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!activeTabId && tabs.length > 0) {
+      handleTabClick(tabs[0].id);
+    }
+  }, [activeTabId, tabs, handleTabClick]);
+
+  return (
+    <div className="flex flex-col h-full bg-zinc-900" style={{ width }}>
+      <div
+        className={`absolute left-0 top-0 bottom-0 w-1 cursor-ew-resize hover:bg-blue-500/50 transition-colors ${isResizing ? "bg-blue-500" : ""}`}
+        onMouseDown={handleResizeStart}
+      />
+      <SidecarToolbar
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onTabClick={handleTabClick}
+        onClose={handleClose}
+        onGoBack={handleGoBack}
+        onGoForward={handleGoForward}
+        onReload={handleReload}
+      />
+      <div ref={placeholderRef} className="flex-1 bg-zinc-950" id="sidecar-placeholder" />
+    </div>
+  );
+}
+
+function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): T {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  return ((...args: unknown[]) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), ms);
+  }) as T;
+}

--- a/src/components/Sidecar/SidecarToolbar.tsx
+++ b/src/components/Sidecar/SidecarToolbar.tsx
@@ -1,0 +1,77 @@
+import { ArrowLeft, ArrowRight, RotateCw, X } from "lucide-react";
+import type { SidecarTab } from "@shared/types";
+import { cn } from "@/lib/utils";
+
+interface SidecarToolbarProps {
+  tabs: SidecarTab[];
+  activeTabId: string | null;
+  onTabClick: (tabId: string) => void;
+  onClose: () => void;
+  onGoBack?: () => void;
+  onGoForward?: () => void;
+  onReload?: () => void;
+}
+
+export function SidecarToolbar({
+  tabs,
+  activeTabId,
+  onTabClick,
+  onClose,
+  onGoBack,
+  onGoForward,
+  onReload,
+}: SidecarToolbarProps) {
+  return (
+    <div className="flex items-center gap-1 px-2 py-1.5 bg-zinc-900 border-b border-zinc-800">
+      <div className="flex items-center gap-0.5 mr-2">
+        <button
+          onClick={onGoBack}
+          className="p-1 rounded hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors"
+          title="Go back"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+        </button>
+        <button
+          onClick={onGoForward}
+          className="p-1 rounded hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors"
+          title="Go forward"
+        >
+          <ArrowRight className="w-3.5 h-3.5" />
+        </button>
+        <button
+          onClick={onReload}
+          className="p-1 rounded hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors"
+          title="Reload"
+        >
+          <RotateCw className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div className="flex items-center gap-1 flex-1 overflow-x-auto">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => onTabClick(tab.id)}
+            className={cn(
+              "px-3 py-1 text-xs rounded transition-colors truncate max-w-[120px]",
+              activeTabId === tab.id
+                ? "bg-zinc-700 text-zinc-100"
+                : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+            )}
+            title={tab.title}
+          >
+            {tab.title}
+          </button>
+        ))}
+      </div>
+
+      <button
+        onClick={onClose}
+        className="p-1 rounded hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors ml-2"
+        title="Close sidecar"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Sidecar/index.ts
+++ b/src/components/Sidecar/index.ts
@@ -1,0 +1,2 @@
+export { SidecarDock } from "./SidecarDock";
+export { SidecarToolbar } from "./SidecarToolbar";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -31,3 +31,5 @@ export { useLayoutConfigStore } from "./layoutConfigStore";
 export { useScrollbackStore } from "./scrollbackStore";
 
 export { usePerformanceModeStore } from "./performanceModeStore";
+
+export { useSidecarStore } from "./sidecarStore";

--- a/src/store/sidecarStore.ts
+++ b/src/store/sidecarStore.ts
@@ -1,0 +1,118 @@
+import { create, type StateCreator } from "zustand";
+import type { SidecarLayoutMode, SidecarTab } from "@shared/types";
+import {
+  DEFAULT_SIDECAR_TABS,
+  SIDECAR_MIN_WIDTH,
+  SIDECAR_MAX_WIDTH,
+  SIDECAR_DEFAULT_WIDTH,
+  MIN_GRID_WIDTH,
+} from "@shared/types";
+
+interface SidecarState {
+  isOpen: boolean;
+  width: number;
+  layoutMode: SidecarLayoutMode;
+  activeTabId: string | null;
+  tabs: SidecarTab[];
+  createdTabs: Set<string>;
+}
+
+interface SidecarActions {
+  toggle: () => void;
+  setOpen: (open: boolean) => void;
+  setWidth: (width: number) => void;
+  setActiveTab: (id: string) => void;
+  updateTabTitle: (id: string, title: string) => void;
+  updateTabUrl: (id: string, url: string) => void;
+  updateLayoutMode: (windowWidth: number, sidebarWidth: number) => void;
+  markTabCreated: (id: string) => void;
+  isTabCreated: (id: string) => boolean;
+  reset: () => void;
+}
+
+const initialState: SidecarState = {
+  isOpen: false,
+  width: SIDECAR_DEFAULT_WIDTH,
+  layoutMode: "push",
+  activeTabId: null,
+  tabs: DEFAULT_SIDECAR_TABS,
+  createdTabs: new Set<string>(),
+};
+
+const createSidecarStore: StateCreator<SidecarState & SidecarActions> = (set, get) => ({
+  ...initialState,
+
+  toggle: () =>
+    set((s) => {
+      const newOpen = !s.isOpen;
+      if (newOpen && typeof window !== "undefined") {
+        setTimeout(() => {
+          const { updateLayoutMode } = get();
+          const sidebarWidth = 350;
+          updateLayoutMode(window.innerWidth, sidebarWidth);
+        }, 0);
+      }
+      return { isOpen: newOpen };
+    }),
+
+  setOpen: (open) => {
+    set({ isOpen: open });
+    if (open && typeof window !== "undefined") {
+      setTimeout(() => {
+        const { updateLayoutMode } = get();
+        const sidebarWidth = 350;
+        updateLayoutMode(window.innerWidth, sidebarWidth);
+      }, 0);
+    }
+  },
+
+  setWidth: (width) => {
+    const validWidth = Math.min(Math.max(width, SIDECAR_MIN_WIDTH), SIDECAR_MAX_WIDTH);
+    set({ width: validWidth });
+    if (typeof window !== "undefined") {
+      setTimeout(() => {
+        const { updateLayoutMode, isOpen } = get();
+        if (isOpen) {
+          const sidebarWidth = 350;
+          updateLayoutMode(window.innerWidth, sidebarWidth);
+        }
+      }, 0);
+    }
+  },
+
+  setActiveTab: (id) => set({ activeTabId: id }),
+
+  updateTabTitle: (id, title) =>
+    set((s) => ({
+      tabs: s.tabs.map((t) => (t.id === id ? { ...t, title } : t)),
+    })),
+
+  updateTabUrl: (id, url) =>
+    set((s) => ({
+      tabs: s.tabs.map((t) => (t.id === id ? { ...t, url } : t)),
+    })),
+
+  updateLayoutMode: (windowWidth, sidebarWidth) => {
+    const { width, isOpen } = get();
+    if (!isOpen) return;
+    const remainingSpace = windowWidth - sidebarWidth - width;
+    set({ layoutMode: remainingSpace < MIN_GRID_WIDTH ? "overlay" : "push" });
+  },
+
+  markTabCreated: (id) =>
+    set((s) => {
+      const newSet = new Set(s.createdTabs);
+      newSet.add(id);
+      return { createdTabs: newSet };
+    }),
+
+  isTabCreated: (id) => get().createdTabs.has(id),
+
+  reset: () =>
+    set({
+      ...initialState,
+      createdTabs: new Set<string>(),
+    }),
+});
+
+export const useSidecarStore = create<SidecarState & SidecarActions>(createSidecarStore);


### PR DESCRIPTION
## Summary

Implements Phase 1 of the Context Sidecar feature: a toggleable browser dock using Electron's WebContentsView API. This provides embedded web content alongside terminals without Alt-Tab context switching.

Closes #459

## Changes Made

- Add SidecarManager service for managing WebContentsView instances
- Implement IPC channels and handlers for sidecar operations
- Create sidecarStore with Zustand for state management
- Build SidecarDock component with resize, tab switching, and bounds sync
- Add SidecarToolbar with navigation controls and tab management
- Integrate sidecar into AppLayout with push/overlay layout modes
- Add toggle button to Toolbar for opening/closing sidecar
- Implement security hardening: URL validation, session partitioning, popup blocking
- Add bounds validation and error handling for WebContentsView operations

## Technical Details

**Layout Modes:**
- Push mode: Sidecar shrinks terminal grid (windows ≥ sidebar + 600px + sidecar)
- Overlay mode: Sidecar floats over terminals (narrow windows)

**IPC Architecture:**
- 7 new channels: create, show, hide, resize, close-tab, navigate, nav-event
- Dedicated handler file: `electron/ipc/handlers/sidecar.ts`

**Default Tabs (Phase 1):**
- Claude.ai
- ChatGPT
- Localhost:3000
- Google

**Files Changed:** 17 files, 972 lines added

## Next Phase

Phase 2 (#460) will add customizable links with CLI detection.
Phase 3 (#461) will implement Magic Paste for CopyTree injection.