### PR TITLE
Add customizable links system with CLI auto-detection for Sidecar

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -239,6 +239,9 @@ export type {
 // Sidecar types - browser dock
 export type {
   SidecarLayoutMode,
+  SidecarLinkType,
+  SidecarLink,
+  LinkTemplate,
   SidecarTab,
   SidecarBounds,
   SidecarNavEvent,
@@ -249,6 +252,7 @@ export type {
 } from "./sidecar.js";
 
 export {
+  LINK_TEMPLATES,
   DEFAULT_SIDECAR_TABS,
   SIDECAR_MIN_WIDTH,
   SIDECAR_MAX_WIDTH,

--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -1,5 +1,59 @@
 export type SidecarLayoutMode = "push" | "overlay";
 
+export type SidecarLinkType = "system" | "discovered" | "user";
+
+export interface SidecarLink {
+  id: string;
+  title: string;
+  url: string;
+  icon: string;
+  type: SidecarLinkType;
+  enabled: boolean;
+  order: number;
+  cliDetector?: string;
+  alwaysEnabled?: boolean;
+}
+
+export interface LinkTemplate {
+  title: string;
+  url: string;
+  icon: string;
+  cliDetector?: string;
+  alwaysEnabled?: boolean;
+}
+
+export const LINK_TEMPLATES: Record<string, LinkTemplate> = {
+  claude: {
+    title: "Claude",
+    url: "https://claude.ai/new",
+    icon: "claude",
+    cliDetector: "claude",
+  },
+  chatgpt: {
+    title: "ChatGPT",
+    url: "https://chatgpt.com/",
+    icon: "openai",
+    cliDetector: "openai",
+  },
+  gemini: {
+    title: "Gemini",
+    url: "https://gemini.google.com/app",
+    icon: "gemini",
+    cliDetector: "gemini",
+  },
+  localhost: {
+    title: "Localhost",
+    url: "http://localhost:3000",
+    icon: "globe",
+    alwaysEnabled: true,
+  },
+  google: {
+    title: "Google",
+    url: "https://www.google.com",
+    icon: "search",
+  },
+};
+
 export interface SidecarTab {
   id: string;
   url: string;

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useErrors } from "@/hooks";
 import { useLogsStore } from "@/store";
-import { X, Bot, Github, LayoutGrid } from "lucide-react";
+import { X, Bot, Github, LayoutGrid, PanelRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { appClient } from "@/clients";
 import { AgentSettings } from "./AgentSettings";
@@ -9,6 +9,7 @@ import { GeneralTab } from "./GeneralTab";
 import { TerminalSettingsTab } from "./TerminalSettingsTab";
 import { GitHubSettingsTab } from "./GitHubSettingsTab";
 import { TroubleshootingTab } from "./TroubleshootingTab";
+import { SidecarSettingsTab } from "./SidecarSettingsTab";
 
 interface SettingsDialogProps {
   isOpen: boolean;
@@ -17,7 +18,7 @@ interface SettingsDialogProps {
   onSettingsChange?: () => void;
 }
 
-type SettingsTab = "general" | "terminal" | "agents" | "github" | "troubleshooting";
+type SettingsTab = "general" | "terminal" | "agents" | "github" | "sidecar" | "troubleshooting";
 
 export function SettingsDialog({
   isOpen,
@@ -116,6 +117,18 @@ export function SettingsDialog({
             GitHub
           </button>
           <button
+            onClick={() => setActiveTab("sidecar")}
+            className={cn(
+              "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
+              activeTab === "sidecar"
+                ? "bg-canopy-accent/10 text-canopy-accent"
+                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+            )}
+          >
+            <PanelRight className="w-4 h-4" />
+            Sidecar
+          </button>
+          <button
             onClick={() => setActiveTab("troubleshooting")}
             className={cn(
               "text-left px-3 py-2 rounded-md text-sm transition-colors",
@@ -137,7 +150,9 @@ export function SettingsDialog({
                   ? "GitHub Integration"
                   : activeTab === "terminal"
                     ? "Terminal Grid"
-                    : activeTab}
+                    : activeTab === "sidecar"
+                      ? "Sidecar Links"
+                      : activeTab}
             </h3>
             <button
               onClick={onClose}
@@ -163,6 +178,10 @@ export function SettingsDialog({
 
             <div className={activeTab === "github" ? "" : "hidden"}>
               <GitHubSettingsTab />
+            </div>
+
+            <div className={activeTab === "sidecar" ? "" : "hidden"}>
+              <SidecarSettingsTab />
             </div>
 
             <div className={activeTab === "troubleshooting" ? "" : "hidden"}>

--- a/src/components/Settings/SidecarSettingsTab.tsx
+++ b/src/components/Settings/SidecarSettingsTab.tsx
@@ -1,0 +1,346 @@
+import { useState } from "react";
+import { RefreshCw, Plus, Trash2, Globe, Check, X, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useSidecarStore } from "@/store/sidecarStore";
+import { useLinkDiscovery } from "@/hooks/useLinkDiscovery";
+import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
+import { LINK_TEMPLATES } from "@shared/types";
+
+function ServiceIcon({ name, size = 16 }: { name: string; size?: number }) {
+  const className = size === 16 ? "w-4 h-4" : size === 32 ? "w-8 h-8" : "w-4 h-4";
+
+  switch (name) {
+    case "claude":
+      return <ClaudeIcon className={className} />;
+    case "gemini":
+      return <GeminiIcon className={className} />;
+    case "openai":
+      return <CodexIcon className={className} />;
+    case "globe":
+      return <Globe className={className} />;
+    case "search":
+      return <Search className={className} />;
+    default:
+      return <Globe className={className} />;
+  }
+}
+
+function FaviconIcon({ url }: { url: string }) {
+  const [hasError, setHasError] = useState(false);
+
+  try {
+    const domain = new URL(url).hostname;
+    const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
+
+    if (hasError) {
+      return <Globe className="w-4 h-4" />;
+    }
+
+    return (
+      <img
+        src={faviconUrl}
+        alt=""
+        className="w-4 h-4"
+        onError={() => setHasError(true)}
+      />
+    );
+  } catch {
+    return <Globe className="w-4 h-4" />;
+  }
+}
+
+export function SidecarSettingsTab() {
+  const links = useSidecarStore((s) => s.links);
+  const toggleLink = useSidecarStore((s) => s.toggleLink);
+  const addLink = useSidecarStore((s) => s.addLink);
+  const removeLink = useSidecarStore((s) => s.removeLink);
+  const updateLink = useSidecarStore((s) => s.updateLink);
+  const { rescan, isScanning } = useLinkDiscovery();
+
+  const [newLinkName, setNewLinkName] = useState("");
+  const [newLinkUrl, setNewLinkUrl] = useState("");
+  const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editUrl, setEditUrl] = useState("");
+
+  const discoveredLinks = links.filter((l) => l.type === "discovered");
+  const userLinks = links.filter((l) => l.type === "user");
+  const systemLinks = links.filter((l) => l.type === "system");
+
+  const handleAddLink = () => {
+    if (!newLinkName.trim() || !newLinkUrl.trim()) return;
+
+    try {
+      const url = new URL(newLinkUrl);
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    addLink({
+      title: newLinkName,
+      url: newLinkUrl,
+      icon: "globe",
+      type: "user",
+      enabled: true,
+    });
+
+    setNewLinkName("");
+    setNewLinkUrl("");
+  };
+
+  const handleStartEdit = (id: string, title: string, url: string) => {
+    setEditingLinkId(id);
+    setEditName(title);
+    setEditUrl(url);
+  };
+
+  const handleSaveEdit = () => {
+    if (!editingLinkId || !editName.trim() || !editUrl.trim()) return;
+
+    try {
+      const url = new URL(editUrl);
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        return;
+      }
+    } catch {
+      return;
+    }
+
+    updateLink(editingLinkId, { title: editName, url: editUrl });
+    setEditingLinkId(null);
+    setEditName("");
+    setEditUrl("");
+  };
+
+  const handleCancelEdit = () => {
+    setEditingLinkId(null);
+    setEditName("");
+    setEditUrl("");
+  };
+
+  const knownServices = Object.entries(LINK_TEMPLATES).filter(
+    ([_, template]) => template.cliDetector
+  );
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h4 className="text-sm font-medium text-canopy-text mb-3">AI Services</h4>
+        <div className="space-y-2">
+          {knownServices.map(([key, template]) => {
+            const link = discoveredLinks.find(
+              (l) => l.id === `discovered-${key === "chatgpt" ? "chatgpt" : key}`
+            );
+            const isDetected = !!link;
+
+            return (
+              <div
+                key={key}
+                className="flex items-center justify-between p-3 rounded-lg bg-canopy-bg border border-canopy-border"
+              >
+                <div className="flex items-center gap-3">
+                  <ServiceIcon name={template.icon} />
+                  <span className="text-sm text-canopy-text">{template.title}</span>
+                  <span
+                    className={cn(
+                      "text-xs flex items-center gap-1",
+                      isDetected ? "text-green-500" : "text-zinc-500"
+                    )}
+                  >
+                    {isDetected ? (
+                      <>
+                        <Check className="w-3 h-3" /> CLI detected
+                      </>
+                    ) : (
+                      <>
+                        <X className="w-3 h-3" /> Not detected
+                      </>
+                    )}
+                  </span>
+                </div>
+                <button
+                  onClick={() => link && toggleLink(link.id)}
+                  disabled={!isDetected}
+                  className={cn(
+                    "w-10 h-5 rounded-full relative transition-colors",
+                    !isDetected && "opacity-50 cursor-not-allowed",
+                    link?.enabled ? "bg-canopy-accent" : "bg-canopy-border"
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform",
+                      link?.enabled ? "translate-x-5" : "translate-x-0.5"
+                    )}
+                  />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <button
+          onClick={rescan}
+          disabled={isScanning}
+          className="mt-3 flex items-center gap-2 px-3 py-1.5 text-xs rounded-md border border-canopy-border hover:bg-canopy-border/50 transition-colors text-canopy-text/70"
+        >
+          <RefreshCw className={cn("w-3 h-3", isScanning && "animate-spin")} />
+          {isScanning ? "Scanning..." : "Re-scan for tools"}
+        </button>
+      </section>
+
+      <section className="pt-4 border-t border-canopy-border">
+        <h4 className="text-sm font-medium text-canopy-text mb-3">System Links</h4>
+        <div className="space-y-2">
+          {systemLinks.map((link) => (
+            <div
+              key={link.id}
+              className="flex items-center justify-between p-3 rounded-lg bg-canopy-bg border border-canopy-border"
+            >
+              <div className="flex items-center gap-3">
+                <ServiceIcon name={link.icon} />
+                <span className="text-sm text-canopy-text">{link.title}</span>
+                <span className="text-xs text-zinc-500">{link.url}</span>
+              </div>
+              <button
+                onClick={() => toggleLink(link.id)}
+                className={cn(
+                  "w-10 h-5 rounded-full relative transition-colors",
+                  link.enabled ? "bg-canopy-accent" : "bg-canopy-border"
+                )}
+              >
+                <div
+                  className={cn(
+                    "absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform",
+                    link.enabled ? "translate-x-5" : "translate-x-0.5"
+                  )}
+                />
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="pt-4 border-t border-canopy-border">
+        <h4 className="text-sm font-medium text-canopy-text mb-3">Custom Links</h4>
+        <div className="space-y-2">
+          {userLinks.map((link) => (
+            <div
+              key={link.id}
+              className="flex items-center justify-between p-3 rounded-lg bg-canopy-bg border border-canopy-border"
+            >
+              {editingLinkId === link.id ? (
+                <div className="flex items-center gap-2 flex-1">
+                  <input
+                    type="text"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className="bg-canopy-bg border border-canopy-border rounded px-2 py-1 text-sm text-canopy-text w-32 focus:border-canopy-accent focus:outline-none"
+                    placeholder="Name"
+                  />
+                  <input
+                    type="text"
+                    value={editUrl}
+                    onChange={(e) => setEditUrl(e.target.value)}
+                    className="bg-canopy-bg border border-canopy-border rounded px-2 py-1 text-sm text-canopy-text flex-1 focus:border-canopy-accent focus:outline-none"
+                    placeholder="URL"
+                  />
+                  <button
+                    onClick={handleSaveEdit}
+                    className="p-1.5 rounded hover:bg-canopy-border text-green-500"
+                  >
+                    <Check className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    className="p-1.5 rounded hover:bg-canopy-border text-zinc-500"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center gap-3">
+                    <FaviconIcon url={link.url} />
+                    <span className="text-sm text-canopy-text">{link.title}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => handleStartEdit(link.id, link.title, link.url)}
+                      className="text-xs text-zinc-500 hover:text-canopy-text px-2 py-1 rounded hover:bg-canopy-border"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => toggleLink(link.id)}
+                      disabled={link.alwaysEnabled}
+                      className={cn(
+                        "w-10 h-5 rounded-full relative transition-colors",
+                        link.alwaysEnabled && "opacity-50 cursor-not-allowed",
+                        link.enabled ? "bg-canopy-accent" : "bg-canopy-border"
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          "absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform",
+                          link.enabled ? "translate-x-5" : "translate-x-0.5"
+                        )}
+                      />
+                    </button>
+                    <button
+                      onClick={() => removeLink(link.id)}
+                      disabled={link.alwaysEnabled}
+                      className={cn(
+                        "p-1.5 rounded hover:bg-canopy-border text-zinc-500 hover:text-red-500",
+                        link.alwaysEnabled && "opacity-50 cursor-not-allowed"
+                      )}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="flex gap-2 mt-3">
+          <input
+            type="text"
+            placeholder="Name"
+            value={newLinkName}
+            onChange={(e) => setNewLinkName(e.target.value)}
+            className="bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text w-32 focus:border-canopy-accent focus:outline-none"
+          />
+          <input
+            type="text"
+            placeholder="https://..."
+            value={newLinkUrl}
+            onChange={(e) => setNewLinkUrl(e.target.value)}
+            className="bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text flex-1 focus:border-canopy-accent focus:outline-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleAddLink();
+            }}
+          />
+          <button
+            onClick={handleAddLink}
+            disabled={!newLinkName.trim() || !newLinkUrl.trim()}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-md bg-canopy-accent text-white text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed hover:bg-canopy-accent/90 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Add
+          </button>
+        </div>
+      </section>
+
+      <section className="pt-4 border-t border-canopy-border">
+        <p className="text-xs text-canopy-text/50">
+          Enabled links appear as tabs in the Sidecar browser panel. AI service links are
+          auto-detected based on installed CLI tools.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/src/components/Sidecar/SidecarLaunchpad.tsx
+++ b/src/components/Sidecar/SidecarLaunchpad.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Globe, Search, Settings } from "lucide-react";
+import { useSidecarStore } from "@/store/sidecarStore";
+import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
+import type { SidecarLink } from "@shared/types";
+
+function LinkIcon({ link, size = 32 }: { link: SidecarLink; size?: number }) {
+  const [showFallback, setShowFallback] = useState(false);
+  const iconClass = size === 32 ? "w-8 h-8" : "w-4 h-4";
+
+  if (showFallback || link.icon === "globe") {
+    return <Globe className={iconClass} />;
+  }
+
+  switch (link.icon) {
+    case "claude":
+      return <ClaudeIcon className={iconClass} />;
+    case "gemini":
+      return <GeminiIcon className={iconClass} />;
+    case "openai":
+      return <CodexIcon className={iconClass} />;
+    case "search":
+      return <Search className={iconClass} />;
+    default:
+      if (link.type === "user") {
+        try {
+          const domain = new URL(link.url).hostname;
+          const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
+          return (
+            <img
+              src={faviconUrl}
+              alt=""
+              className={iconClass}
+              onError={() => setShowFallback(true)}
+            />
+          );
+        } catch {
+          return <Globe className={iconClass} />;
+        }
+      }
+      return <Globe className={iconClass} />;
+  }
+}
+
+interface SidecarLaunchpadProps {
+  onSelectLink: (linkId: string) => void;
+  onOpenSettings?: () => void;
+}
+
+export function SidecarLaunchpad({ onSelectLink, onOpenSettings }: SidecarLaunchpadProps) {
+  const links = useSidecarStore((s) => s.links);
+  const enabledLinks = links.filter((l) => l.enabled).sort((a, b) => a.order - b.order);
+
+  if (enabledLinks.length === 0) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center text-zinc-500 p-6">
+        <Globe className="w-12 h-12 mb-4 opacity-50" />
+        <p className="text-sm mb-4">No links configured</p>
+        {onOpenSettings && (
+          <button
+            onClick={onOpenSettings}
+            className="flex items-center gap-2 px-4 py-2 rounded-md bg-zinc-800 hover:bg-zinc-700 transition-colors text-zinc-300 text-sm"
+          >
+            <Settings className="w-4 h-4" />
+            Add links in Settings
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 p-6 overflow-y-auto">
+      <h2 className="text-sm font-medium mb-4 text-zinc-400">Quick Links</h2>
+      <div className="grid grid-cols-2 gap-3">
+        {enabledLinks.map((link) => (
+          <button
+            key={link.id}
+            onClick={() => onSelectLink(link.id)}
+            className="flex flex-col items-center gap-2 p-4 rounded-lg bg-zinc-800/50 hover:bg-zinc-800 border border-zinc-700/50 hover:border-zinc-600 transition-all group"
+          >
+            <div className="w-8 h-8 flex items-center justify-center text-zinc-300 group-hover:text-white transition-colors">
+              <LinkIcon link={link} size={32} />
+            </div>
+            <span className="text-sm text-zinc-400 group-hover:text-zinc-200 transition-colors truncate max-w-full">
+              {link.title}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -39,3 +39,5 @@ export {
   useFocusedTerminal,
   useWaitingTerminalIds,
 } from "./useTerminalSelectors";
+
+export { useLinkDiscovery } from "./useLinkDiscovery";

--- a/src/hooks/useLinkDiscovery.ts
+++ b/src/hooks/useLinkDiscovery.ts
@@ -1,0 +1,40 @@
+import { useEffect, useCallback, useState } from "react";
+import { useSidecarStore } from "@/store/sidecarStore";
+
+export function useLinkDiscovery() {
+  const discoveryComplete = useSidecarStore((s) => s.discoveryComplete);
+  const setDiscoveredLinks = useSidecarStore((s) => s.setDiscoveredLinks);
+  const markDiscoveryComplete = useSidecarStore((s) => s.markDiscoveryComplete);
+  const [isScanning, setIsScanning] = useState(false);
+
+  useEffect(() => {
+    if (discoveryComplete) return;
+
+    const runDiscovery = async () => {
+      try {
+        const availability = await window.electron.system.getCliAvailability();
+        setDiscoveredLinks(availability);
+        markDiscoveryComplete();
+      } catch (error) {
+        console.error("Link discovery failed:", error);
+        markDiscoveryComplete();
+      }
+    };
+
+    runDiscovery();
+  }, [discoveryComplete, setDiscoveredLinks, markDiscoveryComplete]);
+
+  const rescan = useCallback(async () => {
+    setIsScanning(true);
+    try {
+      const availability = await window.electron.system.refreshCliAvailability();
+      setDiscoveredLinks(availability);
+    } catch (error) {
+      console.error("Link rescan failed:", error);
+    } finally {
+      setIsScanning(false);
+    }
+  }, [setDiscoveredLinks]);
+
+  return { rescan, isScanning };
+}

--- a/src/store/sidecarStore.ts
+++ b/src/store/sidecarStore.ts
@@ -1,11 +1,18 @@
 import { create, type StateCreator } from "zustand";
-import type { SidecarLayoutMode, SidecarTab } from "@shared/types";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type {
+  SidecarLayoutMode,
+  SidecarTab,
+  SidecarLink,
+  CliAvailability,
+} from "@shared/types";
 import {
   DEFAULT_SIDECAR_TABS,
   SIDECAR_MIN_WIDTH,
   SIDECAR_MAX_WIDTH,
   SIDECAR_DEFAULT_WIDTH,
   MIN_GRID_WIDTH,
+  LINK_TEMPLATES,
 } from "@shared/types";
 
 interface SidecarState {
@@ -15,6 +22,8 @@ interface SidecarState {
   activeTabId: string | null;
   tabs: SidecarTab[];
   createdTabs: Set<string>;
+  links: SidecarLink[];
+  discoveryComplete: boolean;
 }
 
 interface SidecarActions {
@@ -28,6 +37,37 @@ interface SidecarActions {
   markTabCreated: (id: string) => void;
   isTabCreated: (id: string) => boolean;
   reset: () => void;
+  addLink: (link: Omit<SidecarLink, "id" | "order">) => void;
+  removeLink: (id: string) => void;
+  updateLink: (id: string, updates: Partial<SidecarLink>) => void;
+  toggleLink: (id: string) => void;
+  reorderLinks: (fromIndex: number, toIndex: number) => void;
+  setDiscoveredLinks: (cliAvailability: CliAvailability) => void;
+  markDiscoveryComplete: () => void;
+  initializeDefaultLinks: () => void;
+}
+
+function createDefaultLinks(): SidecarLink[] {
+  let order = 0;
+  const links: SidecarLink[] = [];
+
+  links.push({
+    id: "system-localhost",
+    ...LINK_TEMPLATES.localhost,
+    type: "system",
+    enabled: true,
+    order: order++,
+  });
+
+  links.push({
+    id: "system-google",
+    ...LINK_TEMPLATES.google,
+    type: "system",
+    enabled: true,
+    order: order++,
+  });
+
+  return links;
 }
 
 const initialState: SidecarState = {
@@ -37,6 +77,8 @@ const initialState: SidecarState = {
   activeTabId: null,
   tabs: DEFAULT_SIDECAR_TABS,
   createdTabs: new Set<string>(),
+  links: createDefaultLinks(),
+  discoveryComplete: false,
 };
 
 const createSidecarStore: StateCreator<SidecarState & SidecarActions> = (set, get) => ({
@@ -113,6 +155,122 @@ const createSidecarStore: StateCreator<SidecarState & SidecarActions> = (set, ge
       ...initialState,
       createdTabs: new Set<string>(),
     }),
+
+  addLink: (link) =>
+    set((s) => {
+      const maxOrder = s.links.reduce((max, l) => Math.max(max, l.order), -1);
+      return {
+        links: [
+          ...s.links,
+          {
+            ...link,
+            id: `user-${Date.now()}`,
+            type: "user",
+            enabled: true,
+            order: maxOrder + 1,
+          },
+        ],
+      };
+    }),
+
+  removeLink: (id) =>
+    set((s) => {
+      const filtered = s.links.filter((l) => l.id !== id);
+      return {
+        links: filtered.map((l, i) => ({ ...l, order: i })),
+      };
+    }),
+
+  updateLink: (id, updates) =>
+    set((s) => ({
+      links: s.links.map((l) => (l.id === id ? { ...l, ...updates } : l)),
+    })),
+
+  toggleLink: (id) =>
+    set((s) => ({
+      links: s.links.map((l) =>
+        l.id === id && !l.alwaysEnabled ? { ...l, enabled: !l.enabled } : l
+      ),
+    })),
+
+  reorderLinks: (fromIndex, toIndex) =>
+    set((s) => {
+      const links = [...s.links];
+      const [moved] = links.splice(fromIndex, 1);
+      links.splice(toIndex, 0, moved);
+      return { links: links.map((l, i) => ({ ...l, order: i })) };
+    }),
+
+  setDiscoveredLinks: (availability) =>
+    set((s) => {
+      const existingUserLinks = s.links.filter((l) => l.type === "user").sort((a, b) => a.order - b.order);
+      const existingSystemLinks = s.links.filter((l) => l.type === "system").sort((a, b) => a.order - b.order);
+      const existingDiscoveredLinks = s.links.filter((l) => l.type === "discovered");
+
+      const newLinks: SidecarLink[] = [];
+      let order = 0;
+
+      if (availability.claude) {
+        const existing = existingDiscoveredLinks.find((l) => l.id === "discovered-claude");
+        newLinks.push({
+          id: "discovered-claude",
+          ...LINK_TEMPLATES.claude,
+          type: "discovered",
+          enabled: existing?.enabled ?? true,
+          order: order++,
+        });
+      }
+
+      if (availability.gemini) {
+        const existing = existingDiscoveredLinks.find((l) => l.id === "discovered-gemini");
+        newLinks.push({
+          id: "discovered-gemini",
+          ...LINK_TEMPLATES.gemini,
+          type: "discovered",
+          enabled: existing?.enabled ?? true,
+          order: order++,
+        });
+      }
+
+      if (availability.codex) {
+        const existing = existingDiscoveredLinks.find((l) => l.id === "discovered-chatgpt");
+        newLinks.push({
+          id: "discovered-chatgpt",
+          ...LINK_TEMPLATES.chatgpt,
+          type: "discovered",
+          enabled: existing?.enabled ?? true,
+          order: order++,
+        });
+      }
+
+      const systemLinks = existingSystemLinks.map((l) => ({ ...l, order: order++ }));
+      const userLinks = existingUserLinks.map((l) => ({ ...l, order: order++ }));
+
+      return { links: [...newLinks, ...systemLinks, ...userLinks] };
+    }),
+
+  markDiscoveryComplete: () => set({ discoveryComplete: true }),
+
+  initializeDefaultLinks: () =>
+    set((s) => {
+      if (s.links.length === 0) {
+        return { links: createDefaultLinks() };
+      }
+      return s;
+    }),
 });
 
-export const useSidecarStore = create<SidecarState & SidecarActions>(createSidecarStore);
+const sidecarStoreCreator: StateCreator<
+  SidecarState & SidecarActions,
+  [],
+  [["zustand/persist", Partial<SidecarState>]]
+> = persist(createSidecarStore, {
+  name: "sidecar-storage",
+  storage: createJSONStorage(() => (typeof window !== "undefined" ? localStorage : undefined as any)),
+  partialize: (state) => ({
+    links: state.links,
+    width: state.width,
+  }),
+});
+
+export const useSidecarStore = create<SidecarState & SidecarActions>()(sidecarStoreCreator);


### PR DESCRIPTION
## Summary

Transforms the Sidecar browser panel from static hardcoded tabs into a personalized AI Launchpad with customizable links and intelligent CLI-based service detection. Users can now configure which web chat interfaces appear as tabs, with automatic detection of installed CLI tools (Claude, Gemini, Codex) to populate smart defaults.

Closes #460

## Changes Made

- **Type System**: Added `SidecarLink`, `LinkTemplate`, and `SidecarLinkType` with `alwaysEnabled` protection
- **Store Management**: Implemented link CRUD operations in `sidecarStore` with localStorage persistence
- **CLI Discovery**: Created `useLinkDiscovery` hook that auto-detects installed AI CLI tools
- **Settings UI**: Built `SidecarSettingsTab` with three sections (AI Services, System Links, Custom Links)
- **Launchpad View**: Added `SidecarLaunchpad` component showing enabled links in a grid with favicon support
- **Integration**: Updated `SidecarDock` to use links system with launchpad toggle
- **Security**: Added http/https protocol validation for custom URLs
- **UX Improvements**: Stateful favicon fallbacks, ordering fixes, and alwaysEnabled protection

## Technical Details

**Link Types:**
- **Discovered**: Auto-detected from CLI tools (claude, gemini, codex)
- **System**: Always-available links (localhost, Google)
- **User**: Custom links added by users

**Key Features:**
- Automatic CLI detection on first launch with manual re-scan option
- Persistent link configuration across app restarts
- URL validation to prevent navigation injection (http/https only)
- Protected system links that cannot be toggled or deleted
- Proper link ordering with reindexing on removal
- Stateful favicon loading with fallback icons