### PR TITLE
Implement backend multi-tenancy for process preservation during project switching

### DIFF
--- a/electron/ipc/handlers/devServer.ts
+++ b/electron/ipc/handlers/devServer.ts
@@ -2,6 +2,7 @@ import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { sendToRenderer } from "../utils.js";
 import { events } from "../../services/events.js";
+import { projectStore } from "../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../types.js";
 import {
   DevServerStartPayloadSchema,
@@ -35,7 +36,17 @@ export function registerDevServerHandlers(deps: HandlerDependencies): () => void
     }
 
     const validated = parseResult.data;
-    await devServerManager.start(validated.worktreeId, validated.worktreePath, validated.command);
+
+    // Get current project ID for multi-tenancy
+    const currentProject = projectStore.getCurrentProject();
+    const projectId = currentProject?.id;
+
+    await devServerManager.start(
+      validated.worktreeId,
+      validated.worktreePath,
+      validated.command,
+      projectId // Pass project ID for multi-tenancy
+    );
     return devServerManager.getState(validated.worktreeId);
   };
   ipcMain.handle(CHANNELS.DEVSERVER_START, handleDevServerStart);
@@ -71,7 +82,17 @@ export function registerDevServerHandlers(deps: HandlerDependencies): () => void
     }
 
     const validated = parseResult.data;
-    await devServerManager.toggle(validated.worktreeId, validated.worktreePath, validated.command);
+
+    // Get current project ID for multi-tenancy
+    const currentProject = projectStore.getCurrentProject();
+    const projectId = currentProject?.id;
+
+    await devServerManager.toggle(
+      validated.worktreeId,
+      validated.worktreePath,
+      validated.command,
+      projectId // Pass project ID for multi-tenancy
+    );
     return devServerManager.getState(validated.worktreeId);
   };
   ipcMain.handle(CHANNELS.DEVSERVER_TOGGLE, handleDevServerToggle);

--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -192,10 +192,12 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
 
     console.log("[ProjectSwitch] Cleaning up previous project state...");
 
+    // Pass projectId to PtyManager and DevServerManager for multi-tenancy
+    // (they background instead of kill processes from other projects)
     const cleanupResults = await Promise.allSettled([
       deps.worktreeService?.onProjectSwitch() ?? Promise.resolve(),
-      deps.devServerManager?.onProjectSwitch() ?? Promise.resolve(),
-      Promise.resolve(ptyManager.onProjectSwitch()),
+      deps.devServerManager?.onProjectSwitch(projectId) ?? Promise.resolve(),
+      Promise.resolve(ptyManager.onProjectSwitch(projectId)),
       Promise.resolve(logBuffer.onProjectSwitch()),
       Promise.resolve(deps.eventBuffer?.onProjectSwitch()),
     ]);

--- a/electron/ipc/handlers/terminal.ts
+++ b/electron/ipc/handlers/terminal.ts
@@ -105,6 +105,10 @@ export function registerTerminalHandlers(deps: HandlerDependencies): () => void 
       cwd = await getValidatedFallback();
     }
 
+    // Get current project ID for multi-tenancy
+    const currentProject = projectStore.getCurrentProject();
+    const projectId = currentProject?.id;
+
     try {
       ptyManager.spawn(id, {
         cwd,
@@ -115,6 +119,7 @@ export function registerTerminalHandlers(deps: HandlerDependencies): () => void 
         type,
         title,
         worktreeId,
+        projectId, // Pass project ID for multi-tenancy
       });
 
       if (validatedOptions.command) {

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -253,6 +253,32 @@ export const EVENT_META: Record<keyof CanopyEventMap, EventMetadata> = {
     requiresTimestamp: false,
     description: "Terminal activity state changed (busy/idle via process tree)",
   },
+  "terminal:backgrounded": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Terminal backgrounded during project switch (kept alive but hidden)",
+  },
+  "terminal:foregrounded": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Terminal foregrounded during project switch (visible again)",
+  },
+
+  // Server multi-tenancy events
+  "server:backgrounded": {
+    category: "server",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Dev server backgrounded during project switch (kept running but hidden)",
+  },
+  "server:foregrounded": {
+    category: "server",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Dev server foregrounded during project switch (visible again)",
+  },
 
   // Task events
   "task:created": {
@@ -419,7 +445,7 @@ export type CanopyEventMap = {
   "watcher:change": WatcherChangePayload;
 
   "server:update": WithContext<DevServerState>;
-  "server:error": WithContext<{ error: string; errorMessage?: string }>;
+  "server:error": WithContext<{ error: string; errorMessage?: string; projectId?: string }>;
 
   "sys:pr:detected": {
     worktreeId: string;
@@ -562,6 +588,46 @@ export type CanopyEventMap = {
     source: "process-tree" | "data-flow";
   };
 
+  /**
+   * Emitted when a terminal is backgrounded during project switch.
+   * The process stays alive but is hidden from the UI.
+   */
+  "terminal:backgrounded": {
+    id: string;
+    projectId: string;
+    timestamp: number;
+  };
+
+  /**
+   * Emitted when a terminal is foregrounded during project switch.
+   * The terminal becomes visible again in the UI.
+   */
+  "terminal:foregrounded": {
+    id: string;
+    projectId: string;
+    timestamp: number;
+  };
+
+  /**
+   * Emitted when a dev server is backgrounded during project switch.
+   * The server stays running but is hidden from the UI.
+   */
+  "server:backgrounded": {
+    worktreeId: string;
+    projectId: string;
+    timestamp: number;
+  };
+
+  /**
+   * Emitted when a dev server is foregrounded during project switch.
+   * The server becomes visible again in the UI.
+   */
+  "server:foregrounded": {
+    worktreeId: string;
+    projectId: string;
+    timestamp: number;
+  };
+
   // Task Lifecycle Events (Future-proof for task management)
 
   /**
@@ -653,6 +719,10 @@ export const ALL_EVENT_TYPES: Array<keyof CanopyEventMap> = [
   "terminal:trashed",
   "terminal:restored",
   "terminal:activity",
+  "terminal:backgrounded",
+  "terminal:foregrounded",
+  "server:backgrounded",
+  "server:foregrounded",
   "task:created",
   "task:assigned",
   "task:state-changed",

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -136,6 +136,8 @@ export type DevServerStatus = "stopped" | "starting" | "running" | "error";
 export interface DevServerState {
   /** ID of the worktree this server belongs to */
   worktreeId: string;
+  /** ID of the project this server belongs to (for multi-tenancy) */
+  projectId?: string;
   /** Current server status */
   status: DevServerStatus;
   /** URL where the server is accessible */


### PR DESCRIPTION
## Summary

This PR implements backend multi-tenancy to prevent process killing during project switching. Instead of terminating all terminals and dev servers when switching projects, processes are now "backgrounded" (kept alive but hidden from UI) and can be "foregrounded" when switching back to their project.

Closes #466

## Changes Made

- Add projectId tracking to terminals and dev servers for multi-tenant isolation
- Refactor onProjectSwitch to background processes instead of killing them
- Use lastKnownProjectId fallback to prevent legacy process misclassification
- Stop detectors and monitors for backgrounded terminals to reduce overhead
- Add projectId to DevServerState change detection and error events
- Implement getTerminalsForProject and getServersForProject helper methods
- Add terminal:backgrounded/foregrounded and server:backgrounded/foregrounded events
- Pass projectId from IPC handlers when spawning terminals and starting dev servers

## Technical Details

### Architecture Changes

**PtyManager:**
- Added `lastKnownProjectId` to track the current project
- Modified `onProjectSwitch(newProjectId)` to filter terminals by projectId instead of disposing all
- Backgrounded terminals: enable buffering, stop ProcessDetector and ActivityMonitor
- Foregrounded terminals: disable buffering, restart detectors/monitors
- Legacy terminals (no projectId) use lastKnownProjectId as fallback

**DevServerManager:**
- Added `lastKnownProjectId` to track the current project
- Modified `onProjectSwitch(newProjectId)` to emit background/foreground events instead of stopAll()
- Legacy servers (no projectId) use lastKnownProjectId as fallback
- Updated change detection to include projectId changes
- Added projectId to error events for proper correlation

**Event System:**
- New events: `terminal:backgrounded`, `terminal:foregrounded`, `server:backgrounded`, `server:foregrounded`
- Updated `server:error` to include optional projectId field

**IPC Integration:**
- Terminal spawn handler passes projectId from current project
- DevServer start/toggle handlers pass projectId from current project
- Project switch handler passes newProjectId to services

## Testing

- ✅ Type checks pass
- ✅ Linting passes (warnings are pre-existing)
- ✅ Formatting passes

## Known Limitations

- Frontend work needed: UI doesn't yet filter terminals/servers by projectId or handle background/foreground events
- IPC forwarding needed: Background/foreground events are emitted internally but not yet forwarded to renderer