### PR TITLE
Refactor Focus Mode into standard sidebar toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -354,8 +354,6 @@ function App() {
   const [isStateLoaded, setIsStateLoaded] = useState(false);
 
   const hasRestoredState = useRef(false);
-  const isCtrlKPressed = useRef(false);
-  const chordTimeout = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (!isElectronAvailable() || hasRestoredState.current) {
@@ -528,48 +526,18 @@ function App() {
     enabled: electronAvailable,
   });
   useKeybinding("panel.diagnostics", () => toggleDiagnosticsDock(), { enabled: electronAvailable });
+  useKeybinding(
+    "nav.toggleSidebar",
+    () => {
+      window.dispatchEvent(new CustomEvent("canopy:toggle-focus-mode"));
+    },
+    { enabled: electronAvailable }
+  );
 
   useEffect(() => {
     if (!electronAvailable) return;
     const cleanup = setupTerminalStoreListeners();
     return cleanup;
-  }, [electronAvailable]);
-
-  useEffect(() => {
-    if (!electronAvailable) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k" && !e.shiftKey) {
-        e.preventDefault();
-        isCtrlKPressed.current = true;
-        if (chordTimeout.current) {
-          clearTimeout(chordTimeout.current);
-        }
-        chordTimeout.current = setTimeout(() => {
-          isCtrlKPressed.current = false;
-        }, 1000);
-        return;
-      }
-
-      if (isCtrlKPressed.current && (e.key === "z" || e.key === "Z") && !e.metaKey && !e.ctrlKey) {
-        e.preventDefault();
-        isCtrlKPressed.current = false;
-        if (chordTimeout.current) {
-          clearTimeout(chordTimeout.current);
-          chordTimeout.current = null;
-        }
-        window.dispatchEvent(new CustomEvent("canopy:toggle-focus-mode"));
-        return;
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      if (chordTimeout.current) {
-        clearTimeout(chordTimeout.current);
-      }
-    };
   }, [electronAvailable]);
 
   if (!isElectronAvailable()) {

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -140,9 +140,9 @@ export function AppLayout({
 
   const handleToggleFocusMode = useCallback(async () => {
     if (isFocusMode) {
+      // Expanding sidebar - restore saved width only, not diagnostics state
       if (savedPanelState) {
         setSidebarWidth((savedPanelState as PanelState).sidebarWidth);
-        setDiagnosticsOpen((savedPanelState as PanelState).diagnosticsOpen);
       }
       toggleFocusMode({ sidebarWidth, diagnosticsOpen } as PanelState);
       try {
@@ -151,24 +151,16 @@ export function AppLayout({
         console.error("Failed to clear focus panel state:", error);
       }
     } else {
+      // Collapsing sidebar - only affect sidebar, not diagnostics
       const currentPanelState: PanelState = { sidebarWidth, diagnosticsOpen };
       toggleFocusMode(currentPanelState);
-      setDiagnosticsOpen(false);
-      // Persist panel state for restoration after restart
       try {
         await appClient.setState({ focusPanelState: currentPanelState });
       } catch (error) {
         console.error("Failed to persist focus panel state:", error);
       }
     }
-  }, [
-    isFocusMode,
-    savedPanelState,
-    sidebarWidth,
-    diagnosticsOpen,
-    toggleFocusMode,
-    setDiagnosticsOpen,
-  ]);
+  }, [isFocusMode, savedPanelState, sidebarWidth, diagnosticsOpen, toggleFocusMode]);
 
   useEffect(() => {
     const handleFocusModeToggle = () => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -6,13 +6,13 @@ import {
   Settings,
   Terminal,
   AlertCircle,
-  Maximize2,
-  Minimize2,
   GitCommit,
   GitPullRequest,
   AlertTriangle,
   PanelRightOpen,
   PanelRightClose,
+  PanelLeft,
+  PanelLeftClose,
 } from "lucide-react";
 import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -71,6 +71,19 @@ export function Toolbar({
       <div className="w-20 shrink-0" />
 
       <div className="flex items-center gap-1 app-no-drag">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onToggleFocusMode}
+          className={cn(
+            "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors mr-2",
+            isFocusMode && "text-canopy-text/50"
+          )}
+          title={isFocusMode ? "Show Sidebar (Cmd+B)" : "Hide Sidebar (Cmd+B)"}
+          aria-label="Toggle Sidebar"
+        >
+          {isFocusMode ? <PanelLeft className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
+        </Button>
         {shouldShowAgent("claude") && (
           <Button
             variant="ghost"
@@ -234,38 +247,6 @@ export function Toolbar({
         )}
 
         <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onToggleFocusMode}
-            className={cn(
-              "text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-8 w-8",
-              isFocusMode && "bg-canopy-accent/20 text-canopy-accent"
-            )}
-            title={
-              isFocusMode ? "Exit Focus Mode (Cmd/Ctrl+K, Z)" : "Toggle Focus Mode (Cmd/Ctrl+K, Z)"
-            }
-            aria-label={isFocusMode ? "Exit focus mode" : "Enter focus mode"}
-            aria-pressed={isFocusMode}
-          >
-            {isFocusMode ? (
-              <Minimize2 className="h-4 w-4" aria-hidden="true" />
-            ) : (
-              <Maximize2 className="h-4 w-4" aria-hidden="true" />
-            )}
-          </Button>
-          <span
-            role="status"
-            aria-live="polite"
-            className={cn(
-              "px-2 py-0.5 rounded-full text-[10px] font-medium transition-opacity",
-              isFocusMode
-                ? "bg-canopy-accent/15 text-canopy-accent border border-canopy-accent/40 opacity-100"
-                : "opacity-0 pointer-events-none invisible"
-            )}
-          >
-            Focus
-          </span>
           <Button
             variant="ghost"
             size="icon"

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -108,6 +108,13 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     description: "Toggle diagnostics dock",
   },
   {
+    actionId: "nav.toggleSidebar",
+    combo: "Cmd+B",
+    scope: "global",
+    priority: 0,
+    description: "Toggle sidebar",
+  },
+  {
     actionId: "modal.close",
     combo: "Escape",
     scope: "modal",


### PR DESCRIPTION
## Summary

Converts the Focus Mode functionality into a standard sidebar toggle that aligns with conventional IDE patterns (like VS Code). This change relocates the toggle button from the right side of the toolbar to the left, removes the visual "Focus" pill indicator, and decouples sidebar visibility from the diagnostics dock behavior.

Closes #478

## Changes Made

- Move sidebar toggle from right to left toolbar (grouped with agent launchers)
- Replace Maximize2/Minimize2 icons with PanelLeft/PanelLeftClose icons
- Remove "Focus" pill indicator from toolbar
- Decouple diagnostics dock from sidebar toggle (dock state now independent)
- Change keyboard shortcut from Cmd+K Z chord to Cmd+B (industry-standard)
- Add nav.toggleSidebar keybinding to KeybindingService
- Replace custom keyboard event handler with useKeybinding hook
- Remove unused refs (isCtrlKPressed, chordTimeout)

## Technical Details

**Files Modified:**
- `src/components/Layout/Toolbar.tsx` - Moved button to left, updated icons and tooltips
- `src/components/Layout/AppLayout.tsx` - Removed diagnostics dock coupling from toggle logic
- `src/services/KeybindingService.ts` - Added nav.toggleSidebar action with Cmd+B
- `src/App.tsx` - Replaced chord handler with standard useKeybinding hook

**Net Result:** 52 lines removed, code is simpler and more maintainable.