### PR TITLE
Phase 3: Frontend State Swapping

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -31,6 +31,9 @@ export const CHANNELS = {
   TERMINAL_RESTORED: "terminal:restored",
   TERMINAL_SET_BUFFERING: "terminal:set-buffering",
   TERMINAL_FLUSH: "terminal:flush",
+  TERMINAL_GET_FOR_PROJECT: "terminal:get-for-project",
+  TERMINAL_RECONNECT: "terminal:reconnect",
+  TERMINAL_REPLAY_HISTORY: "terminal:replay-history",
 
   AGENT_STATE_CHANGED: "agent:state-changed",
   AGENT_GET_STATE: "agent:get-state",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -100,6 +100,9 @@ const CHANNELS = {
   TERMINAL_RESTORED: "terminal:restored",
   TERMINAL_SET_BUFFERING: "terminal:set-buffering",
   TERMINAL_FLUSH: "terminal:flush",
+  TERMINAL_GET_FOR_PROJECT: "terminal:get-for-project",
+  TERMINAL_RECONNECT: "terminal:reconnect",
+  TERMINAL_REPLAY_HISTORY: "terminal:replay-history",
 
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",
@@ -346,6 +349,14 @@ const api: ElectronAPI = {
       _typedInvoke(CHANNELS.TERMINAL_SET_BUFFERING, { id, enabled }),
 
     flush: (id: string) => _typedInvoke(CHANNELS.TERMINAL_FLUSH, id),
+
+    getForProject: (projectId: string) =>
+      ipcRenderer.invoke(CHANNELS.TERMINAL_GET_FOR_PROJECT, projectId),
+
+    reconnect: (terminalId: string) => ipcRenderer.invoke(CHANNELS.TERMINAL_RECONNECT, terminalId),
+
+    replayHistory: (terminalId: string, maxLines?: number) =>
+      ipcRenderer.invoke(CHANNELS.TERMINAL_REPLAY_HISTORY, { terminalId, maxLines }),
   },
 
   // Artifact API

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -297,6 +297,45 @@ port.on("message", (rawMsg: any) => {
         sendEvent({ type: "pong" });
         break;
 
+      case "get-terminals-for-project":
+        sendEvent({
+          type: "terminals-for-project",
+          requestId: msg.requestId,
+          terminalIds: ptyManager.getTerminalsForProject(msg.projectId),
+        });
+        break;
+
+      case "get-terminal": {
+        const terminal = ptyManager.getTerminal(msg.id);
+        sendEvent({
+          type: "terminal-info",
+          requestId: msg.requestId,
+          terminal: terminal
+            ? {
+                id: terminal.id,
+                projectId: terminal.projectId,
+                type: terminal.type,
+                title: terminal.title,
+                cwd: terminal.cwd,
+                worktreeId: terminal.worktreeId,
+                agentState: terminal.agentState,
+                spawnedAt: terminal.spawnedAt,
+              }
+            : null,
+        });
+        break;
+      }
+
+      case "replay-history": {
+        const replayed = ptyManager.replayHistory(msg.id, msg.maxLines);
+        sendEvent({
+          type: "replay-history-result",
+          requestId: msg.requestId,
+          replayed,
+        });
+        break;
+      }
+
       case "dispose":
         cleanup();
         break;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -72,6 +72,8 @@ export type {
   TerminalKillPayload,
   TerminalExitPayload,
   TerminalErrorPayload,
+  BackendTerminalInfo,
+  TerminalReconnectResult,
   // CopyTree IPC types
   CopyTreeOptions,
   CopyTreeGeneratePayload,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -98,6 +98,28 @@ export interface TerminalErrorPayload {
   error: string;
 }
 
+/** Terminal info from backend for reconnection */
+export interface BackendTerminalInfo {
+  id: string;
+  projectId?: string;
+  type?: TerminalType;
+  title?: string;
+  cwd: string;
+  worktreeId?: string;
+  agentState?: string;
+  spawnedAt: number;
+}
+
+/** Result from terminal reconnect operation */
+export interface TerminalReconnectResult {
+  exists: boolean;
+  id?: string;
+  type?: TerminalType;
+  cwd?: string;
+  agentState?: string;
+  error?: string;
+}
+
 // CopyTree IPC Types
 
 /** CopyTree generation options */
@@ -876,6 +898,18 @@ export interface IpcInvokeMap {
     args: [id: string];
     result: void;
   };
+  "terminal:get-for-project": {
+    args: [projectId: string];
+    result: BackendTerminalInfo[];
+  };
+  "terminal:reconnect": {
+    args: [terminalId: string];
+    result: TerminalReconnectResult;
+  };
+  "terminal:replay-history": {
+    args: [payload: { terminalId: string; maxLines?: number }];
+    result: { replayed: number };
+  };
 
   // Agent channels
   "agent:get-state": {
@@ -1338,6 +1372,9 @@ export interface ElectronAPI {
     restore(id: string): Promise<boolean>;
     setBuffering(id: string, enabled: boolean): Promise<void>;
     flush(id: string): Promise<void>;
+    getForProject(projectId: string): Promise<BackendTerminalInfo[]>;
+    reconnect(terminalId: string): Promise<TerminalReconnectResult>;
+    replayHistory(terminalId: string, maxLines?: number): Promise<{ replayed: number }>;
     onData(id: string, callback: (data: string) => void): () => void;
     onExit(callback: (id: string, exitCode: number) => void): () => void;
     onAgentStateChanged(callback: (data: AgentStateChangePayload) => void): () => void;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -20,6 +20,7 @@ export interface PtyHostSpawnOptions {
   type?: TerminalType;
   title?: string;
   worktreeId?: string;
+  projectId?: string;
 }
 
 /**
@@ -48,7 +49,10 @@ export type PtyHostRequest =
       spawnedAt?: number;
     }
   | { type: "health-check" }
-  | { type: "dispose" };
+  | { type: "dispose" }
+  | { type: "get-terminals-for-project"; projectId: string; requestId: string }
+  | { type: "get-terminal"; id: string; requestId: string }
+  | { type: "replay-history"; id: string; maxLines: number; requestId: string };
 
 /**
  * Terminal snapshot data sent from Host → Main for state queries.
@@ -111,7 +115,22 @@ export type PtyHostEvent =
   | { type: "all-snapshots"; snapshots: PtyHostTerminalSnapshot[] }
   | { type: "transition-result"; id: string; requestId: string; success: boolean }
   | { type: "pong" }
-  | { type: "ready" };
+  | { type: "ready" }
+  | { type: "terminals-for-project"; requestId: string; terminalIds: string[] }
+  | { type: "terminal-info"; requestId: string; terminal: PtyHostTerminalInfo | null }
+  | { type: "replay-history-result"; requestId: string; replayed: number };
+
+/** Terminal info sent from Host → Main for getTerminal queries */
+export interface PtyHostTerminalInfo {
+  id: string;
+  projectId?: string;
+  type?: TerminalType;
+  title?: string;
+  cwd: string;
+  worktreeId?: string;
+  agentState?: AgentState;
+  spawnedAt: number;
+}
 
 /** Payload for agent:spawned event */
 export interface AgentSpawnedPayload {

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -2,6 +2,8 @@ import type {
   TerminalSpawnOptions,
   AgentStateChangePayload,
   TerminalActivityPayload,
+  BackendTerminalInfo,
+  TerminalReconnectResult,
 } from "@shared/types";
 
 export const terminalClient = {
@@ -63,5 +65,29 @@ export const terminalClient = {
 
   flush: (id: string): Promise<void> => {
     return window.electron.terminal.flush(id);
+  },
+
+  /**
+   * Query backend for terminals belonging to a specific project.
+   * Used during state hydration to reconcile UI with backend processes.
+   */
+  getForProject: (projectId: string): Promise<BackendTerminalInfo[]> => {
+    return window.electron.terminal.getForProject(projectId);
+  },
+
+  /**
+   * Reconnect to an existing terminal process in the backend.
+   * Returns the terminal info if it exists, error otherwise.
+   */
+  reconnect: (terminalId: string): Promise<TerminalReconnectResult> => {
+    return window.electron.terminal.reconnect(terminalId);
+  },
+
+  /**
+   * Replay terminal history from backend semantic buffer.
+   * Used after reconnecting to restore terminal output.
+   */
+  replayHistory: (terminalId: string, maxLines?: number): Promise<{ replayed: number }> => {
+    return window.electron.terminal.replayHistory(terminalId, maxLines);
   },
 } as const;

--- a/src/store/resetStores.ts
+++ b/src/store/resetStores.ts
@@ -8,7 +8,9 @@ import { useErrorStore } from "./errorStore";
 import { useNotificationStore } from "./notificationStore";
 
 export async function resetAllStoresForProjectSwitch(): Promise<void> {
-  await useTerminalStore.getState().reset();
+  // Use resetWithoutKilling instead of reset
+  // This preserves backend processes while clearing UI state
+  await useTerminalStore.getState().resetWithoutKilling();
 
   useWorktreeSelectionStore.getState().reset();
   useLogsStore.getState().reset();


### PR DESCRIPTION
## Summary

Implements Phase 3 of multi-project terminal state management: frontend state swapping with process reconciliation. This enables seamless project switching by preserving terminal state in the frontend while keeping backend processes alive from Phase 1.

Closes #468

## Changes Made

- Add IPC handlers for terminal query and reconnection operations
- Implement PtyClient async methods with proper callback cleanup
- Add `resetWithoutKilling()` to preserve backend processes during UI reset  
- Implement state hydration with process reconciliation logic
- Preserve agent state during terminal reconnection
- Add debounced persistence flushing before project switch
- Handle reconnection errors with fallback to spawning new terminals
- Add type contracts for new IPC channels and pty-host messages
- Support `projectId` in PtyHostSpawnOptions for better tracking

## Technical Details

**Backend (IPC & Process Communication):**
- New IPC channels: `terminal:get-for-project`, `terminal:reconnect`, `terminal:replay-history`
- PtyClient async methods with proper callback resolution on dispose
- Pty-host message handlers for terminal queries

**Frontend (State Management):**
- `resetWithoutKilling()` clears UI state without killing backend processes
- State hydration queries backend for existing terminals and reconnects
- Agent state preservation during reconnection (no forced reset to "idle")
- Debounced persistence flushing prevents race conditions during project switch

**Error Handling:**
- Reconnection failures fall back to spawning new terminals
- Callback cleanup prevents hanging promises on PtyClient disposal
- Consistent fallback logic using `lastKnownProjectId` for legacy terminals