### PR TITLE
Enhance Sidecar with configurable AI URLs, brand colors, and sortable pill tabs

### DIFF
--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -41,17 +41,6 @@ export const LINK_TEMPLATES: Record<string, LinkTemplate> = {
     icon: "gemini",
     cliDetector: "gemini",
   },
-  localhost: {
-    title: "Localhost",
-    url: "http://localhost:3000",
-    icon: "globe",
-    alwaysEnabled: true,
-  },
-  google: {
-    title: "Google",
-    url: "https://www.google.com",
-    icon: "search",
-  },
 };
 
 export interface SidecarTab {

--- a/src/components/Sidecar/SidecarLaunchpad.tsx
+++ b/src/components/Sidecar/SidecarLaunchpad.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Globe, Search } from "lucide-react";
 import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
 import type { SidecarLink } from "@shared/types";
+import { getBrandColorHex } from "@/lib/colorUtils";
 
 function LinkIcon({ link, size = 32 }: { link: SidecarLink; size?: number }) {
   const [showFallback, setShowFallback] = useState(false);
@@ -13,11 +14,11 @@ function LinkIcon({ link, size = 32 }: { link: SidecarLink; size?: number }) {
 
   switch (link.icon) {
     case "claude":
-      return <ClaudeIcon className={iconClass} />;
+      return <ClaudeIcon className={iconClass} brandColor={getBrandColorHex("claude")} />;
     case "gemini":
-      return <GeminiIcon className={iconClass} />;
+      return <GeminiIcon className={iconClass} brandColor={getBrandColorHex("gemini")} />;
     case "openai":
-      return <CodexIcon className={iconClass} />;
+      return <CodexIcon className={iconClass} brandColor={getBrandColorHex("codex")} />;
     case "search":
       return <Search className={iconClass} />;
     default:


### PR DESCRIPTION
## Summary
This PR enhances the Sidecar panel with highly requested features: customizable AI service URLs, distinctive brand colors, and an improved pill-based tab design with drag-and-drop reordering.

Closes #482

## Changes Made
- Remove localhost/Google from default system links
- Add URL editing for AI services with validation feedback
- Implement sortable pill tabs using @dnd-kit with multi-line wrapping support
- Apply brand colors to AI service icons in settings and launchpad
- Add bounds checking to reorderTabs/reorderLinks actions
- Improve tab accessibility with proper button semantics and ARIA attributes
- Preserve user-edited URLs and titles during CLI re-scans

## Technical Details
- Uses `@dnd-kit/core` and `@dnd-kit/sortable` for drag-and-drop functionality with `closestCorners` collision detection for better multi-line wrapping
- Implements proper accessibility with `role="tab"`, `aria-selected`, and `aria-label` attributes
- Adds URL validation with user feedback for invalid entries
- Integrates `getBrandColorHex()` utility for consistent brand coloring across components