### PR TITLE
feat: add explicit close project lifecycle with resource cleanup

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -110,6 +110,8 @@ export const CHANNELS = {
   PROJECT_SAVE_SETTINGS: "project:save-settings",
   PROJECT_DETECT_RUNNERS: "project:detect-runners",
   PROJECT_REGENERATE_IDENTITY: "project:regenerate-identity",
+  PROJECT_CLOSE: "project:close",
+  PROJECT_GET_STATS: "project:get-stats",
 
   HISTORY_GET_SESSIONS: "history:get-sessions",
   HISTORY_GET_SESSION: "history:get-session",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -193,6 +193,8 @@ const CHANNELS = {
   PROJECT_SAVE_SETTINGS: "project:save-settings",
   PROJECT_DETECT_RUNNERS: "project:detect-runners",
   PROJECT_REGENERATE_IDENTITY: "project:regenerate-identity",
+  PROJECT_CLOSE: "project:close",
+  PROJECT_GET_STATS: "project:get-stats",
 
   // History channels (agent transcripts & artifacts)
   HISTORY_GET_SESSIONS: "history:get-sessions",
@@ -491,6 +493,10 @@ const api: ElectronAPI = {
       _typedInvoke(CHANNELS.PROJECT_SAVE_SETTINGS, { projectId, settings }),
 
     detectRunners: (projectId: string) => _typedInvoke(CHANNELS.PROJECT_DETECT_RUNNERS, projectId),
+
+    close: (projectId: string) => ipcRenderer.invoke(CHANNELS.PROJECT_CLOSE, projectId),
+
+    getStats: (projectId: string) => ipcRenderer.invoke(CHANNELS.PROJECT_GET_STATS, projectId),
   },
 
   // History API (Agent Transcripts & Artifacts)

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -297,6 +297,34 @@ export class ProjectStore {
       throw error;
     }
   }
+
+  /**
+   * Clear persisted state for a project.
+   * Deletes the state.json file, forcing fresh state on next load.
+   * Used when explicitly closing a project to free resources.
+   * @param projectId - Project ID to clear state for
+   */
+  async clearProjectState(projectId: string): Promise<void> {
+    const stateFilePath = this.getStateFilePath(projectId);
+
+    if (!stateFilePath) {
+      console.warn(`[ProjectStore] Invalid project ID: ${projectId}`);
+      return;
+    }
+
+    if (!existsSync(stateFilePath)) {
+      console.log(`[ProjectStore] No state file to clear for project ${projectId}`);
+      return;
+    }
+
+    try {
+      await fs.unlink(stateFilePath);
+      console.log(`[ProjectStore] Cleared state for project ${projectId}`);
+    } catch (error) {
+      console.error(`[ProjectStore] Failed to clear state for ${projectId}:`, error);
+      throw error;
+    }
+  }
 }
 
 export const projectStore = new ProjectStore();

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -98,6 +98,9 @@ export type {
   // PR detection IPC types
   PRDetectedPayload,
   PRClearedPayload,
+  // Project close IPC types
+  ProjectCloseResult,
+  ProjectStats,
   // GitHub IPC types
   RepositoryStats,
   GitHubCliStatus,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -300,6 +300,38 @@ export interface PRClearedPayload {
   worktreeId: string;
 }
 
+// Project Close IPC Types
+
+/** Result from project:close operation */
+export interface ProjectCloseResult {
+  /** Whether the operation succeeded */
+  success: boolean;
+  /** Total number of processes killed */
+  processesKilled: number;
+  /** Number of terminals killed */
+  terminalsKilled: number;
+  /** Number of dev servers stopped */
+  serversStopped: number;
+  /** Error message if operation failed */
+  error?: string;
+}
+
+/** Project resource statistics */
+export interface ProjectStats {
+  /** Total number of running processes */
+  processCount: number;
+  /** Number of terminal processes */
+  terminalCount: number;
+  /** Number of dev server processes */
+  serverCount: number;
+  /** Estimated memory usage in MB */
+  estimatedMemoryMB: number;
+  /** Terminal types breakdown */
+  terminalTypes: Record<string, number>;
+  /** Process IDs of running terminals */
+  processIds: number[];
+}
+
 // GitHub IPC Types
 
 /** Repository stats from GitHub API */
@@ -1449,6 +1481,8 @@ export interface ElectronAPI {
     getSettings(projectId: string): Promise<ProjectSettings>;
     saveSettings(projectId: string, settings: ProjectSettings): Promise<void>;
     detectRunners(projectId: string): Promise<RunCommand[]>;
+    close(projectId: string): Promise<ProjectCloseResult>;
+    getStats(projectId: string): Promise<ProjectStats>;
   };
   history: {
     getSessions(filters?: HistoryGetSessionsPayload): Promise<AgentSession[]>;

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -1,4 +1,10 @@
-import type { Project, ProjectSettings, RunCommand } from "@shared/types";
+import type {
+  Project,
+  ProjectSettings,
+  RunCommand,
+  ProjectCloseResult,
+  ProjectStats,
+} from "@shared/types";
 
 /**
  * @example
@@ -52,5 +58,13 @@ export const projectClient = {
 
   detectRunners: (projectId: string): Promise<RunCommand[]> => {
     return window.electron.project.detectRunners(projectId);
+  },
+
+  close: (projectId: string): Promise<ProjectCloseResult> => {
+    return window.electron.project.close(projectId);
+  },
+
+  getStats: (projectId: string): Promise<ProjectStats> => {
+    return window.electron.project.getStats(projectId);
   },
 } as const;


### PR DESCRIPTION
## Summary
Implements Phase 4 of the multi-tenant process management epic: adds explicit "Close Project" action to kill terminals, stop dev servers, and clear persisted state for background projects.

Closes #469

## Changes Made

### Backend (electron/services)
- Add `killByProject()` and `getProjectStats()` to PtyManager for terminal lifecycle management
- Add `stopByProject()` and `getProjectServerCount()` to DevServerManager
- Add `clearProjectState()` to ProjectStore for state cleanup

### IPC Layer
- Add `project:close` handler with dual-source active project protection (checks both PtyManager and ProjectStore)
- Add `project:get-stats` handler to retrieve process counts and resource usage
- Add new IPC channel constants in channels.ts
- Add `ProjectCloseResult` and `ProjectStats` TypeScript types

### Frontend (src)
- Add `close()` and `getStats()` methods to projectClient
- Add `closeProject()` action to projectStore with active project validation
- Update ProjectSwitcher UI with:
  - Green dot indicator for projects with running processes
  - Process stats tooltips showing terminal/server counts and memory estimates
  - Close button (X icon) for non-active projects with running processes
  - Stats polling (5s interval) when project dropdown is open
  - User confirmation dialog with process breakdown before closing

### Code Review Fixes (Applied from Codex)
- Changed sequential stats fetching to `Promise.allSettled()` for parallel execution
- Added fallback path for missing stats (allows close with generic confirmation)
- Enhanced active project protection to check both ptyManager and projectStore

## Test Plan
- Verify close button only appears for non-active projects with running processes
- Verify active project cannot be closed (error message shown)
- Verify stats polling updates every 5s when dropdown is open
- Verify confirmation dialog shows accurate process counts
- Verify all terminals and dev servers are killed when closing a project
- Verify persisted state is cleared after close