### PR TITLE
Fix terminal header padding on various displays

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -343,7 +343,7 @@ function TerminalPaneComponent({
       {/* Header - Uniform background for all terminal types */}
       <div
         className={cn(
-          "flex items-center justify-between px-3 h-7 shrink-0 font-mono text-xs transition-colors relative overflow-hidden",
+          "flex items-center justify-between px-3 h-8 shrink-0 font-mono text-xs transition-colors relative overflow-hidden",
           // Base background - uniform for all types
           isFocused ? "bg-[var(--color-surface-highlight)]" : "bg-[var(--color-surface)]"
         )}


### PR DESCRIPTION
## Summary
Increases the terminal header height from 28px to 32px to ensure consistent padding on all displays and zoom levels. This prevents buttons and text from appearing cramped or touching the header edges.

Closes #499

## Changes Made
- Changed header height from h-7 (28px) to h-8 (32px) in TerminalPane.tsx
- Provides 4px top/bottom padding instead of fragile 2px
- Prevents buttons from touching header edges on various displays
- Fixes intermittent padding loss due to sub-pixel rendering

## Technical Details
- **Old:** 28px container - 24px button = 4px total space (2px top/bottom)
- **New:** 32px container - 24px button = 8px total space (4px top/bottom)
- The 4px buffer is resilient to sub-pixel rendering variations across different displays and zoom levels