### PR TITLE
Fix bottom text clipping in docked terminals

### DIFF
--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -72,10 +72,9 @@ export function TerminalDock() {
     <div
       ref={setNodeRef}
       className={cn(
-        "min-h-[40px] bg-canopy-bg/95 backdrop-blur-sm border-t-2 border-canopy-border/60 shadow-[0_-4px_12px_rgba(0,0,0,0.3)]",
-        "flex items-center px-4 gap-2",
+        "bg-canopy-bg/95 backdrop-blur-sm border-t-2 border-canopy-border/60 shadow-[0_-4px_12px_rgba(0,0,0,0.3)]",
+        "flex items-center px-4 py-2 gap-2",
         "z-40 shrink-0",
-        isEmpty && !isOver && "h-10",
         isOver && "bg-white/[0.03] ring-2 ring-canopy-accent/30 ring-inset"
       )}
       role="list"

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -247,9 +247,9 @@ function XtermAdapterComponent({
     <div
       ref={containerRef}
       className={cn(
-        // pl-2 pt-2 provides 8px padding that FitAddon can measure correctly
+        // pl-2 pt-2 pb-2 provides 8px padding that FitAddon can measure correctly
         // (previously was on .xterm-screen in CSS which caused measurement mismatches)
-        "w-full h-full bg-[#18181b] text-white overflow-hidden rounded-b-lg pl-2 pt-2",
+        "w-full h-full bg-[#18181b] text-white overflow-hidden rounded-b-lg pl-2 pt-2 pb-2",
         className
       )}
     />


### PR DESCRIPTION
## Summary
Fixes text clipping at the bottom of docked terminals by adding appropriate vertical padding to the dock container and terminal canvas.

Closes #497

## Changes Made
- Add py-2 vertical padding to TerminalDock container
- Remove fixed height constraints (min-h-[40px] and h-10)
- Add pb-2 bottom padding to XtermAdapter container
- Ensures text descenders and terminal output fully visible