### PR TITLE
fix(sidecar): initialize link discovery on app startup

### DIFF
--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -120,7 +120,10 @@ export class HibernationService {
     }
     if (config.inactiveThresholdHours !== undefined) {
       // Clamp to valid range (1-168 hours)
-      current.inactiveThresholdHours = Math.max(1, Math.min(168, Math.round(config.inactiveThresholdHours)));
+      current.inactiveThresholdHours = Math.max(
+        1,
+        Math.min(168, Math.round(config.inactiveThresholdHours))
+      );
     }
 
     store.set("hibernation", current);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   useTerminalConfig,
   useKeybinding,
   useProjectSettings,
+  useLinkDiscovery,
 } from "./hooks";
 import { AppLayout } from "./components/Layout";
 import { TerminalGrid } from "./components/Terminal";
@@ -342,6 +343,7 @@ function App() {
   const { inject, isInjecting } = useContextInjection();
   const loadRecipes = useRecipeStore((state) => state.loadRecipes);
   useTerminalConfig();
+  useLinkDiscovery();
 
   const terminalPalette = useTerminalPalette();
 

--- a/src/hooks/useLinkDiscovery.ts
+++ b/src/hooks/useLinkDiscovery.ts
@@ -9,6 +9,7 @@ export function useLinkDiscovery() {
 
   useEffect(() => {
     if (discoveryComplete) return;
+    if (typeof window === "undefined" || !window.electron) return;
 
     const runDiscovery = async () => {
       try {
@@ -25,6 +26,7 @@ export function useLinkDiscovery() {
   }, [discoveryComplete, setDiscoveredLinks, markDiscoveryComplete]);
 
   const rescan = useCallback(async () => {
+    if (typeof window === "undefined" || !window.electron) return;
     setIsScanning(true);
     try {
       const availability = await window.electron.system.refreshCliAvailability();


### PR DESCRIPTION
## Summary
Fixes the lazy initialization bug where Sidecar link discovery only ran when the Settings > Sidecar tab was opened. The fix adds the `useLinkDiscovery()` hook to the App component so discovery runs immediately at application startup.

Closes #491

## Changes Made
- Add `useLinkDiscovery` hook to `App` component initialization (src/App.tsx:346)
- Add Electron availability guards in `useLinkDiscovery` hook to prevent errors in non-Electron environments
- Ensures discovered CLI tools (Claude, Gemini, Codex) appear immediately in Sidecar panel without requiring user to visit Settings first

## Technical Details
- Hook uses existing `discoveryComplete` flag to prevent duplicate runs
- Preserves user-customized link settings through intelligent merge logic in `setDiscoveredLinks`
- No performance impact - discovery already ran on Settings tab mount, now just happens earlier
- Error handling remains robust with try-catch and completion marking on failure