### PR TITLE
fix(terminal): auto-restart agent terminals on app reload

### DIFF
--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -169,7 +169,9 @@ async function spawnNewTerminal(
   cwd: string,
   addTerminal: HydrationOptions["addTerminal"]
 ): Promise<void> {
-  const autoRestart = terminal.settings?.autoRestart ?? false;
+  // Agent terminals default to auto-restart to preserve session context/flags
+  const isAgent = ["claude", "gemini", "codex"].includes(terminal.type);
+  const autoRestart = terminal.settings?.autoRestart ?? isAgent;
   const commandToRun = autoRestart ? terminal.command : undefined;
 
   await addTerminal({


### PR DESCRIPTION
## Summary

Fixes agent terminals (Claude, Gemini, Codex) not re-executing their commands on application restart. Previously, these terminals would restore as empty shells, losing their session context and command-line flags like `--dangerously-skip-permissions`.

Closes #496

## Changes Made

- Modified `spawnNewTerminal` in `src/utils/stateHydration.ts` to detect agent terminal types
- Default `autoRestart` to `true` for agent terminals to preserve command context
- Shell terminals continue to open empty unless `autoRestart` explicitly enabled
- Respects user's explicit `autoRestart` setting when configured