### PR TITLE
fix(sidecar): hide WebContentsView when UI collapses

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -182,6 +182,13 @@ export function AppLayout({
     return () => window.removeEventListener("resize", handleResize);
   }, [sidebarWidth, isFocusMode, updateSidecarLayoutMode]);
 
+  // Hide sidecar WebContentsView when closed (React unmount doesn't trigger IPC)
+  useEffect(() => {
+    if (!sidecarOpen) {
+      window.electron.sidecar.hide();
+    }
+  }, [sidecarOpen]);
+
   const handleSidebarResize = useCallback((newWidth: number) => {
     const clampedWidth = Math.min(Math.max(newWidth, MIN_SIDEBAR_WIDTH), MAX_SIDEBAR_WIDTH);
     setSidebarWidth(clampedWidth);


### PR DESCRIPTION
## Summary
Fixes ghost browser view that persists when sidecar UI collapses by explicitly hiding the native WebContentsView via IPC.

Closes #490

## Changes Made
- Add useEffect hook in AppLayout to hide sidecar view when sidecarOpen becomes false
- Explicitly call window.electron.sidecar.hide() via IPC to remove native view
- Fixes issue where React unmount doesn't trigger cleanup of Electron's WebContentsView