### PR TITLE
fix(terminal): change cursor style to block for TUI compatibility

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -71,8 +71,8 @@ function XtermAdapterComponent({
   const terminalOptions = useMemo(
     () => ({
       cursorBlink: true,
-      cursorStyle: "bar" as const,
-      cursorWidth: 2,
+      cursorStyle: "block" as const,
+      cursorInactiveStyle: "block" as const,
       fontSize: 13,
       lineHeight: 1.2,
       letterSpacing: 0,


### PR DESCRIPTION
## Summary
Fixes the double cursor issue when running TUI applications in Canopy terminals by changing the cursor style from bar to block.

Closes #502

## Changes Made
- Change cursorStyle from "bar" to "block" in XtermAdapter terminal options
- Remove cursorWidth property (not applicable to block cursors)
- Add cursorInactiveStyle to maintain block cursor when terminal loses focus

## Problem
TUI applications like Claude Code, vim, and htop draw their own cursor by inverting character blocks and expect the terminal to use a block cursor. When xterm was configured with a bar cursor, users saw both the TUI's inverted block AND xterm's bar cursor separately, creating a confusing double cursor effect.

## Solution
Block cursors are the standard terminal cursor style and visually merge with TUI application cursor rendering, providing a seamless single cursor experience.