### PR TITLE
Auto-close docked terminal popover on drag start

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
+import { useDndMonitor } from "@dnd-kit/core";
 import { Loader2, Terminal, Command } from "lucide-react";
 import {
   ClaudeIcon,
@@ -120,6 +121,15 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
       cancelled = true;
     };
   }, [isOpen, terminal.id, isRestoring]);
+
+  // Auto-close popover when drag starts for this terminal
+  useDndMonitor({
+    onDragStart: ({ active }) => {
+      if (active.id === terminal.id && isOpen) {
+        setIsOpen(false);
+      }
+    },
+  });
 
   const handleRestore = useCallback(() => {
     setIsRestoring(true);


### PR DESCRIPTION
## Summary
Implements automatic closing of docked terminal popovers when a drag operation begins, providing cleaner visual feedback during drag-and-drop operations.

Closes #500

## Changes Made
- Add `useDndMonitor` hook to detect drag start events
- Close popover immediately when drag operation begins
- Prevent visual clutter during drag-and-drop operations
- Use event-based monitoring to avoid unnecessary re-renders

## Implementation Details
The solution uses `@dnd-kit/core`'s `useDndMonitor` hook with an `onDragStart` callback that checks if the active drag ID matches the current terminal's ID. When a match is found and the popover is open, it immediately closes the popover by setting `isOpen` to `false`.

This approach is more performant than using `useDndContext` because it only triggers on drag start events rather than subscribing to all drag state changes, avoiding unnecessary re-renders on every drag movement.