### PR TITLE
Fix system sleep/wake terminal crashes and output flooding

### DIFF
--- a/electron/services/WorktreeMonitor.ts
+++ b/electron/services/WorktreeMonitor.ts
@@ -503,6 +503,24 @@ export class WorktreeMonitor {
     }
   }
 
+  /** Pause polling (used during system sleep) */
+  public pause(): void {
+    if (!this.pollingEnabled) return;
+    this.pollingEnabled = false;
+    this.stopPolling();
+    logDebug("WorktreeMonitor paused", { id: this.id });
+  }
+
+  /** Resume polling (used after system wake) */
+  public resume(): void {
+    if (this.pollingEnabled) return;
+    this.pollingEnabled = true;
+    if (this.isRunning && !this.pollingStrategy.isCircuitBreakerTripped()) {
+      this.scheduleNextPoll();
+    }
+    logDebug("WorktreeMonitor resumed", { id: this.id });
+  }
+
   private stopPolling(): void {
     if (this.pollingTimer) {
       clearTimeout(this.pollingTimer);


### PR DESCRIPTION
## Summary
Implements comprehensive sleep/wake handling to prevent terminal crashes and output flooding when the system suspends/resumes.

Closes #511

## Changes Made
- Add powerMonitor handlers in main.ts to pause/resume services during system sleep
- Implement health check pause/resume in PtyClient to prevent time-drift false positives
- Add output circuit breaker in PtyManager to prevent IPC flooding (5MB/s threshold)
- Add polling enable/disable to WorktreeService/WorktreeMonitor for sleep cycles
- Enhance WebGL context recovery with disposal checks and retry limits (max 3 attempts)
- Add debouncing for rapid suspend/resume cycles
- Add cooldown period to circuit breaker to prevent oscillation

## Technical Details

### Power Management
- `powerMonitor.on('suspend')`: Pauses health checks and worktree polling
- `powerMonitor.on('resume')`: Resumes services after 2-second stabilization delay
- Debounces rapid suspend/resume cycles to prevent stale resume operations

### Circuit Breaker
- Monitors output rate per terminal (5MB/s threshold)
- Automatically pauses PTY when threshold exceeded
- Requires 2 seconds of low output before auto-resuming
- Prevents rapid pause/resume oscillation

### WebGL Recovery
- Detects context loss during sleep/wake
- Falls back to canvas renderer immediately
- Attempts recovery up to 3 times to prevent infinite loops
- Checks terminal disposal before recovery attempts

## Testing
- All type checks pass
- Lint and format checks pass
- Code reviewed by Codex MCP with 7 issues identified and fixed