### PR TITLE
Fix welcome screen agent launchers to respect configuration settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -568,7 +568,7 @@ function App() {
           agentAvailability={availability}
           agentSettings={agentSettings}
         >
-          <TerminalGrid className="h-full w-full" />
+          <TerminalGrid className="h-full w-full" onLaunchAgent={handleLaunchAgent} />
         </AppLayout>
       </DndProvider>
 

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -25,6 +25,7 @@ import { TerminalRefreshTier } from "@/types";
 export interface TerminalGridProps {
   className?: string;
   defaultCwd?: string;
+  onLaunchAgent?: (type: "claude" | "gemini" | "codex" | "shell") => Promise<void> | void;
 }
 
 interface LauncherCardProps {
@@ -150,7 +151,7 @@ function EmptyState({
   );
 }
 
-export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
+export function TerminalGrid({ className, defaultCwd, onLaunchAgent }: TerminalGridProps) {
   const { terminals, focusedId, maximizedId } = useTerminalStore(
     useShallow((state) => ({
       terminals: state.terminals,
@@ -218,6 +219,15 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
 
   const handleLaunchAgent = useCallback(
     async (type: "claude" | "gemini" | "codex" | "shell") => {
+      if (onLaunchAgent) {
+        try {
+          await onLaunchAgent(type);
+        } catch (error) {
+          console.error(`Failed to launch ${type}:`, error);
+        }
+        return;
+      }
+
       try {
         const cwd = defaultCwd || "";
         const command = type !== "shell" ? type : undefined;
@@ -226,7 +236,7 @@ export function TerminalGrid({ className, defaultCwd }: TerminalGridProps) {
         console.error(`Failed to launch ${type}:`, error);
       }
     },
-    [addTerminal, defaultCwd]
+    [addTerminal, defaultCwd, onLaunchAgent]
   );
 
   const handleInjectContext = useCallback((terminalId: string, worktreeId?: string) => {


### PR DESCRIPTION
## Summary

Fixes a bug where agent launchers on the welcome screen (empty state) bypassed configured settings and spawned terminals with default arguments instead of respecting user-configured models, flags, and system prompts.

Closes #515

## Changes Made

- Add onLaunchAgent prop to TerminalGridProps interface to accept settings-aware launcher
- Pass handleLaunchAgent from App.tsx to TerminalGrid component (connects settings logic)
- Update handleLaunchAgent callback to delegate to prop when provided
- Add proper async/await handling with error catching for prop handler
- Maintain fallback behavior for standalone TerminalGrid usage (preserves component reusability)

## Testing

- Type checking passes (no errors)
- Linting passes (no new warnings)
- Agents launched from welcome screen now use same settings-aware path as toolbar launches