### PR TITLE
Fix UI overlays hidden behind Sidecar webview

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+      "z-[100] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
       className
     )}
     {...props}
@@ -57,7 +57,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+        "z-[100] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -18,7 +18,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar text-canopy-text shadow-lg",
+        "z-[100] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar text-canopy-text shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}


### PR DESCRIPTION
## Summary
Fixes z-index stacking conflict where toolbar popovers and dropdown menus were rendering behind the Sidecar webview, making them inaccessible when the Sidecar was open.

Closes #495

## Changes Made
- Update PopoverContent z-index from z-50 to z-[100]
- Update DropdownMenuSubContent z-index from z-50 to z-[100]
- Update DropdownMenuContent z-index from z-50 to z-[100]

## Technical Details
The Sidecar and UI overlay components were both using z-50, creating a stacking context conflict. This PR creates a dedicated z-[100] tier for transient UI elements (dropdowns, popovers, tooltips) that must always float on top, separate from the persistent overlay tier (z-50) used by the Sidecar.

## Affected Components
- GitHub Issues popover in toolbar
- GitHub Pull Requests popover in toolbar
- Settings dropdown menu
- Agent launcher dropdowns
- Bulk Actions menu