### PR TITLE
Fix WebGL terminal rendering artifacts after drag operations

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -315,11 +315,12 @@ export function DndProvider({ children }: DndProviderProps) {
         }
       }
 
-      // Refresh all terminals after drag to fix WebGL canvas rendering artifacts
-      // Use setTimeout instead of requestAnimationFrame to ensure CSS Grid layout has fully settled
+      // Reset WebGL renderers after drag to fix rendering artifacts
+      // Use setTimeout with longer delay to ensure CSS Grid layout has fully settled
+      // before measuring container dimensions for fit()
       setTimeout(() => {
-        terminalInstanceService.refreshAll();
-      }, 50);
+        terminalInstanceService.resetAllRenderers();
+      }, 100);
     },
     [activeData, overContainer, terminals, reorderTerminals, moveTerminalToPosition, setFocused]
   );
@@ -330,11 +331,11 @@ export function DndProvider({ children }: DndProviderProps) {
     setOverContainer(null);
     setPlaceholderIndex(null);
 
-    // Refresh all terminals after drag cancel to fix WebGL canvas rendering artifacts
-    // Use setTimeout instead of requestAnimationFrame to ensure CSS Grid layout has fully settled
+    // Reset WebGL renderers after drag cancel to fix rendering artifacts
+    // Use setTimeout with longer delay to ensure CSS Grid layout has fully settled
     setTimeout(() => {
-      terminalInstanceService.refreshAll();
-    }, 50);
+      terminalInstanceService.resetAllRenderers();
+    }, 100);
   }, []);
 
   // Use rectIntersection for grid (better for 2D layouts), closestCenter for dock (1D horizontal)

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -252,6 +252,11 @@ function XtermAdapterComponent({
         "w-full h-full bg-[#18181b] text-white overflow-hidden rounded-b-lg pl-2 pt-2 pb-2",
         className
       )}
+      style={{
+        // Force GPU layer promotion to prevent WebGL canvas snapshot DPI issues during drag
+        willChange: "transform",
+        transform: "translateZ(0)",
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Fixes WebGL terminal rendering artifacts that persisted after drag-and-drop operations. Terminals previously showed incorrect padding and font rendering after being dragged, requiring a click to trigger a repaint. This PR implements a complete WebGL context reset mechanism with visibility checks and GPU layer promotion.

Closes #418

## Changes Made

- Add `resetRenderer` and `resetAllRenderers` methods to TerminalInstanceService with WebGL context disposal and recreation
- Implement GPU layer promotion in XtermAdapter with `will-change` and `translateZ(0)` to prevent DPI issues during CSS transforms
- Replace simple `refreshAll` with `resetAllRenderers` in DndProvider after drag end/cancel
- Add visibility and size checks to prevent resetting detached or zero-sized terminals
- Reset `webglRecoveryAttempts` counter on successful WebGL acquisition to prevent stuck canvas fallback
- Optimize `resetAllRenderers` to only target terminals with active WebGL addons
- Increase post-drag timeout from 50ms to 100ms for CSS Grid layout stabilization

## Technical Details

The fix addresses three key issues identified in the original report:

1. **WebGL Context State**: Disposes and recreates the WebGL addon to force a clean context after layout changes
2. **GPU Layer Snapshotting**: Applies CSS hints to maintain proper DPI during @dnd-kit transforms
3. **Layout Timing**: Increased delay ensures CSS Grid has fully settled before measuring container dimensions

## Testing

- TypeScript compilation passes
- All existing functionality preserved
- Memory leaks prevented through proper WebGL disposal and LRU tracking