### PR TITLE
Fix terminal cursor invisible when selecting backgrounded terminal

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -39,6 +39,7 @@ import { useErrorStore, useTerminalStore, getTerminalRefreshTier, type RetryActi
 import { useContextInjection } from "@/hooks/useContextInjection";
 import type { AgentState } from "@/types";
 import { errorsClient } from "@/clients";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 export type { TerminalType };
 
@@ -292,6 +293,12 @@ function TerminalPaneComponent({
     return getTerminalRefreshTier(terminal, isFocused);
   }, [id, isFocused, getTerminal]);
 
+  // Handler for container clicks - calls focus and boosts refresh rate
+  const handleClick = useCallback(() => {
+    onFocus();
+    terminalInstanceService.boostRefreshRate(id);
+  }, [onFocus, id]);
+
   const isWorking = agentState === "working";
 
   return (
@@ -312,7 +319,7 @@ function TerminalPaneComponent({
 
         isExited && "opacity-75 grayscale"
       )}
-      onClick={onFocus}
+      onClick={handleClick}
       onFocus={onFocus}
       onKeyDown={handleKeyDown}
       tabIndex={0}


### PR DESCRIPTION
## Summary
Implements a boost mechanism to fix the invisible cursor issue when focusing backgrounded terminals. When a terminal is running in the background (BACKGROUND refresh tier at 1000ms), and the user clicks to focus it, cursor position updates are now rendered immediately instead of waiting for the slow background timer to expire.

Closes #503

## Changes Made
- Add boost() method to throttledWriter to force immediate flush when terminal receives focus
- Add boostRefreshRate() to TerminalInstanceService for external triggers
- Call boost when terminal tier changes to FOCUSED or BURST in XtermAdapter
- Call boost on terminal container click to ensure cursor visibility
- Track tier value with useMemo to properly trigger effect on all tier changes (not just function reference changes)

## Technical Details
The boost mechanism works by:
1. Activating burst mode (setting lastInputTime) so subsequent writes use fast timers
2. Canceling any pending background timer and rescheduling an immediate flush (8ms)
3. Ensuring WebGL renderer is acquired for high-performance rendering

This ensures cursor updates that arrived during background state are flushed within ~16ms of focus, instead of waiting up to 1 second for the background timer to expire.