### PR TITLE
Add DevServerManager health check and recovery after system wake

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -305,7 +305,7 @@ async function createWindow(): Promise<void> {
     }
 
     // 2-second delay allows OS network/disk subsystems to stabilize
-    resumeTimeout = setTimeout(() => {
+    resumeTimeout = setTimeout(async () => {
       resumeTimeout = null;
       try {
         if (ptyClient) {
@@ -313,6 +313,11 @@ async function createWindow(): Promise<void> {
         }
         worktreeService.setPollingEnabled(true);
         void worktreeService.refresh();
+
+        // Check and recover dev servers that died during sleep
+        if (devServerManager) {
+          await devServerManager.onSystemResume();
+        }
       } catch (error) {
         console.error("[MAIN] Error during resume:", error);
       }


### PR DESCRIPTION
## Summary

Implements health checking and recovery for dev servers that die during system sleep. When the system wakes, `DevServerManager.onSystemResume()` checks if tracked dev server processes are still alive and marks dead ones as errored. Servers can optionally be auto-restarted if the project has `devServer.autoStart` enabled.

Closes #534

## Changes Made

- Add `DevServerManager.onSystemResume()` to detect dead servers after sleep
- Implement robust process liveness check using `kill(pid, 0)` with EPERM vs ESRCH handling
- Add PID reuse detection by cross-checking with tracked process promises
- Implement auto-restart for projects with `devServer.autoStart` enabled
- Add 60-second cooldown mechanism to prevent restart loops
- Cache worktree paths for restart and clean up on stop/stopAll
- Add `resumeInProgress` guard to prevent overlapping resume operations
- Handle stale promise resolution when servers are restarted (prevent state clobbering)
- Integrate with main.ts power monitor resume handler (2s delay after wake)
- Check both "running" and "starting" states for comprehensive recovery
- Re-read state before marking dead to avoid racing with manual stop operations