### PR TITLE
Add warm-up handshake to verify pty-host responsiveness after system wake

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -60,6 +60,8 @@ export class PtyClient extends EventEmitter {
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private restartAttempts = 0;
   private isHealthCheckPaused = false;
+  private isWaitingForHandshake = false;
+  private handshakeTimeout: NodeJS.Timeout | null = null;
   private pendingSpawns: Map<string, PtyHostSpawnOptions> = new Map();
   private snapshotCallbacks: Map<string, (snapshot: TerminalSnapshot | null) => void> = new Map();
   private allSnapshotsCallback: ((snapshots: TerminalSnapshot[]) => void) | null = null;
@@ -296,7 +298,16 @@ export class PtyClient extends EventEmitter {
       }
 
       case "pong":
-        // Health check passed
+        // If waiting for handshake, this pong confirms host is responsive
+        if (this.isWaitingForHandshake) {
+          this.isWaitingForHandshake = false;
+          if (this.handshakeTimeout) {
+            clearTimeout(this.handshakeTimeout);
+            this.handshakeTimeout = null;
+          }
+          console.log("[PtyClient] Handshake successful - resuming health checks");
+          this.startHealthCheckInterval();
+        }
         break;
 
       case "terminals-for-project": {
@@ -537,10 +548,16 @@ export class PtyClient extends EventEmitter {
       clearInterval(this.healthCheckInterval);
       this.healthCheckInterval = null;
     }
+    // Clear any pending handshake from rapid suspend/resume cycles
+    if (this.handshakeTimeout) {
+      clearTimeout(this.handshakeTimeout);
+      this.handshakeTimeout = null;
+    }
+    this.isWaitingForHandshake = false;
     console.log("[PtyClient] Health check paused");
   }
 
-  /** Resume health check after system wake with reset timestamp */
+  /** Resume health check after system wake with handshake verification */
   resumeHealthCheck(): void {
     if (!this.isHealthCheckPaused) return;
     if (!this.isInitialized || !this.child) {
@@ -551,20 +568,49 @@ export class PtyClient extends EventEmitter {
 
     this.isHealthCheckPaused = false;
 
-    // Clear any existing interval before starting new one
+    // Clear any existing interval before starting handshake
     if (this.healthCheckInterval) {
       clearInterval(this.healthCheckInterval);
       this.healthCheckInterval = null;
     }
 
-    // Restart health check interval
+    // Clear any existing handshake timeout from rapid suspend/resume
+    if (this.handshakeTimeout) {
+      clearTimeout(this.handshakeTimeout);
+      this.handshakeTimeout = null;
+    }
+
+    // Send handshake ping before resuming normal health checks
+    console.log("[PtyClient] System resumed. Initiating handshake...");
+    this.isWaitingForHandshake = true;
+    this.send({ type: "health-check" });
+
+    // Timeout if no response within 5 seconds - fall back to immediate start
+    this.handshakeTimeout = setTimeout(() => {
+      if (this.isWaitingForHandshake) {
+        console.warn("[PtyClient] Handshake timeout - forcing health check resume");
+        this.isWaitingForHandshake = false;
+        this.handshakeTimeout = null;
+        this.startHealthCheckInterval();
+      }
+    }, 5000);
+  }
+
+  /** Start the health check interval (called after handshake or timeout) */
+  private startHealthCheckInterval(): void {
+    // Clear any existing interval
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
+    }
+
     this.healthCheckInterval = setInterval(() => {
       if (this.isInitialized && this.child && !this.isHealthCheckPaused) {
         this.send({ type: "health-check" });
       }
     }, this.config.healthCheckIntervalMs);
 
-    console.log("[PtyClient] Health check resumed");
+    console.log("[PtyClient] Health check interval started");
   }
 
   /** Handle project switch - forward to host */
@@ -590,6 +636,12 @@ export class PtyClient extends EventEmitter {
       clearInterval(this.healthCheckInterval);
       this.healthCheckInterval = null;
     }
+
+    if (this.handshakeTimeout) {
+      clearTimeout(this.handshakeTimeout);
+      this.handshakeTimeout = null;
+    }
+    this.isWaitingForHandshake = false;
 
     if (this.child) {
       this.send({ type: "dispose" });

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { EventEmitter } from "events";
+
+// Mock Electron modules before importing PtyClient
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: vi.fn(),
+  },
+  dialog: {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+  },
+}));
+
+import { utilityProcess } from "electron";
+import type { PtyClientConfig } from "../PtyClient.js";
+
+interface MockUtilityProcess extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+}
+
+describe("PtyClient Handshake Protocol", () => {
+  let mockChild: MockUtilityProcess;
+  let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+
+    // Create mock utility process
+    mockChild = Object.assign(new EventEmitter(), {
+      postMessage: vi.fn(),
+      kill: vi.fn(),
+    });
+
+    (utilityProcess.fork as Mock).mockReturnValue(mockChild);
+
+    // Re-import to get fresh module with mocks
+    vi.resetModules();
+    vi.doMock("electron", () => ({
+      utilityProcess: {
+        fork: vi.fn().mockReturnValue(mockChild),
+      },
+      dialog: {
+        showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+      },
+      app: {
+        getPath: vi.fn().mockReturnValue("/mock/user/data"),
+      },
+    }));
+
+    const module = await import("../PtyClient.js");
+    PtyClientClass = module.PtyClient;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const createClient = (config?: PtyClientConfig) => {
+    const client = new PtyClientClass(config);
+    // Simulate ready event from host
+    mockChild.emit("message", { type: "ready" });
+    return client;
+  };
+
+  describe("resumeHealthCheck", () => {
+    it("should send health-check ping when resuming after pause", () => {
+      const client = createClient();
+
+      // Pause and resume
+      client.pauseHealthCheck();
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Should send health-check immediately for handshake
+      expect(mockChild.postMessage).toHaveBeenCalledWith({ type: "health-check" });
+    });
+
+    it("should wait for pong before starting interval", () => {
+      const client = createClient({ healthCheckIntervalMs: 1000 });
+
+      client.pauseHealthCheck();
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Clear the initial handshake ping call
+      const initialCalls = mockChild.postMessage.mock.calls.length;
+
+      // Advance time but don't send pong - interval should not have started
+      vi.advanceTimersByTime(2000);
+
+      // Should NOT have additional health-check calls (interval not started)
+      // Only the initial handshake ping should exist
+      expect(
+        mockChild.postMessage.mock.calls.filter((c) => c[0]?.type === "health-check").length
+      ).toBe(initialCalls);
+    });
+
+    it("should start interval after receiving pong", () => {
+      const client = createClient({ healthCheckIntervalMs: 1000 });
+
+      client.pauseHealthCheck();
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Send pong response
+      mockChild.emit("message", { type: "pong" });
+
+      // Now interval should be running
+      vi.advanceTimersByTime(1000);
+      expect(mockChild.postMessage).toHaveBeenCalledTimes(2); // handshake + first interval
+
+      vi.advanceTimersByTime(1000);
+      expect(mockChild.postMessage).toHaveBeenCalledTimes(3); // + second interval
+    });
+
+    it("should fall back to immediate start after 5 second timeout", () => {
+      const client = createClient({ healthCheckIntervalMs: 1000 });
+
+      client.pauseHealthCheck();
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Advance past the 5 second timeout without pong
+      vi.advanceTimersByTime(5000);
+
+      // Now interval should be running (fallback)
+      vi.advanceTimersByTime(1000);
+      expect(
+        mockChild.postMessage.mock.calls.filter((c) => c[0]?.type === "health-check").length
+      ).toBe(2); // handshake + first interval
+    });
+
+    it("should ignore late pong after timeout", () => {
+      const client = createClient({ healthCheckIntervalMs: 1000 });
+
+      client.pauseHealthCheck();
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Advance past timeout
+      vi.advanceTimersByTime(5000);
+
+      // Late pong should not cause issues (interval already started)
+      expect(() => mockChild.emit("message", { type: "pong" })).not.toThrow();
+
+      // Interval should still be running normally
+      vi.advanceTimersByTime(1000);
+      expect(
+        mockChild.postMessage.mock.calls.filter((c) => c[0]?.type === "health-check").length
+      ).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("rapid suspend/resume cycles", () => {
+    it("should clear handshake timeout on re-pause", () => {
+      const client = createClient();
+
+      // First cycle
+      client.pauseHealthCheck();
+      client.resumeHealthCheck();
+
+      // Re-pause before timeout
+      vi.advanceTimersByTime(2000);
+      client.pauseHealthCheck();
+
+      // Resume again
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Should start fresh handshake
+      expect(mockChild.postMessage).toHaveBeenCalledWith({ type: "health-check" });
+    });
+
+    it("should handle multiple rapid cycles without timeout accumulation", () => {
+      const client = createClient({ healthCheckIntervalMs: 1000 });
+
+      // Multiple rapid cycles
+      for (let i = 0; i < 5; i++) {
+        client.pauseHealthCheck();
+        client.resumeHealthCheck();
+        vi.advanceTimersByTime(1000); // Partial timeout
+      }
+
+      // Should not have multiple timeouts firing
+      mockChild.postMessage.mockClear();
+
+      // Send single pong
+      mockChild.emit("message", { type: "pong" });
+
+      // Verify interval is running correctly
+      vi.advanceTimersByTime(1000);
+      expect(mockChild.postMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should not resume if not paused", () => {
+      const client = createClient();
+
+      mockChild.postMessage.mockClear();
+      client.resumeHealthCheck();
+
+      // Should not send handshake if not paused
+      expect(mockChild.postMessage).not.toHaveBeenCalledWith({ type: "health-check" });
+    });
+
+    it("should handle resume when host not initialized", () => {
+      // Create client but don't emit ready
+      const client = new PtyClientClass();
+
+      client.pauseHealthCheck();
+
+      // Should warn but not throw
+      expect(() => client.resumeHealthCheck()).not.toThrow();
+    });
+
+    it("should clean up handshake state on dispose", () => {
+      const client = createClient();
+
+      client.pauseHealthCheck();
+      client.resumeHealthCheck();
+
+      // Dispose during handshake
+      expect(() => client.dispose()).not.toThrow();
+
+      // Advance past timeout - should not throw
+      vi.advanceTimersByTime(6000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements a handshake protocol to verify the pty-host UtilityProcess is responsive before resuming normal health checks after system wake. This prevents false timeout errors on slow-waking systems.

Closes #531

## Changes Made

- Add handshake verification before resuming health checks after system wake
- Implement 5-second timeout with fallback to immediate start (no worse than current behavior)
- Add cleanup for rapid suspend/resume cycles
- Extract health check interval start into dedicated method `startHealthCheckInterval()`
- Add comprehensive unit tests for handshake protocol (10 test cases)

## Technical Details

**Problem**: After system wake, the current 2-second delay before resuming health checks doesn't verify the pty-host is actually responsive. On slow-waking systems (especially with encryption or many background processes), the UtilityProcess can take 3-5 seconds to fully wake, causing false "host is dead" errors.

**Solution**: 
1. Send a `health-check` ping immediately after the 2-second stabilization delay
2. Wait for `pong` response before starting the normal health check interval
3. If no response within 5 seconds, fall back to immediate start (preserves current behavior)
4. Clean up handshake state on rapid suspend/resume cycles

## Test Coverage

- Basic handshake flow (pause → resume → ping → pong → interval starts)
- Timeout fallback (5 seconds without pong → force start)
- Rapid suspend/resume cycles (cleanup of stale timeouts)
- Edge cases (resume when not paused, host not initialized, dispose during handshake)

All 10 tests pass.