### PR TITLE
fix(ui): increase toaster z-index to prevent sidecar occlusion

### DIFF
--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -71,7 +71,7 @@ export function Toaster() {
   if (!mounted) return null;
 
   return createPortal(
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-full max-w-sm pointer-events-none">
+    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2 w-full max-w-sm pointer-events-none">
       {notifications.map((notification) => (
         <Toast key={notification.id} notification={notification} />
       ))}


### PR DESCRIPTION
## Summary
Fixes z-index stacking conflict that prevented toast notifications from appearing above the sidecar when in overlay mode. Users can now see context injection success/error notifications regardless of sidecar state.

Closes #548

## Changes Made
- Change toast notification z-index from z-50 to z-[100]
- Ensures toasts appear above sidecar overlay in overlay mode
- Aligns with existing z-index hierarchy (dropdowns/popovers use z-[100])
- Fixes issue where context injection notifications were hidden