### PR TITLE
Hide terminal dock when empty to reclaim screen space

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -23,7 +23,10 @@ import { store } from "./store.js";
 import { MigrationRunner } from "./services/StoreMigrations.js";
 import { migrations } from "./services/migrations/index.js";
 import { initializeHibernationService } from "./services/HibernationService.js";
-import { initializeSystemSleepService, getSystemSleepService } from "./services/SystemSleepService.js";
+import {
+  initializeSystemSleepService,
+  getSystemSleepService,
+} from "./services/SystemSleepService.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -420,8 +420,10 @@ const api: ElectronAPI = {
     refreshCliAvailability: () => _typedInvoke(CHANNELS.SYSTEM_REFRESH_CLI_AVAILABILITY),
 
     onWake: (callback: (data: { sleepDuration: number; timestamp: number }) => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, data: { sleepDuration: number; timestamp: number }) =>
-        callback(data);
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { sleepDuration: number; timestamp: number }
+      ) => callback(data);
       ipcRenderer.on(CHANNELS.SYSTEM_WAKE, handler);
       return () => ipcRenderer.removeListener(CHANNELS.SYSTEM_WAKE, handler);
     },

--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -68,6 +68,10 @@ export function TerminalDock() {
   // Terminal IDs for SortableContext
   const terminalIds = useMemo(() => activeDockTerminals.map((t) => t.id), [activeDockTerminals]);
 
+  if (isEmpty) {
+    return null;
+  }
+
   return (
     <div
       ref={setNodeRef}
@@ -80,46 +84,37 @@ export function TerminalDock() {
       role="list"
     >
       <div className="flex items-center gap-2 overflow-x-auto flex-1 no-scrollbar">
-        {(!isEmpty || isOver) && (
-          <>
-            {!isEmpty && (
-              <button
-                onClick={handleToggleCollapse}
-                className={cn(
-                  "flex items-center gap-1 text-xs text-canopy-text/60 mr-2 shrink-0 select-none",
-                  "hover:text-canopy-text transition-colors rounded px-1 py-0.5",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent"
-                )}
-                title={isCollapsed ? "Show background terminals" : "Hide background terminals"}
-                aria-expanded={!isCollapsed}
-              >
-                <ChevronDown
-                  className={cn(
-                    "h-3 w-3 transition-transform duration-200",
-                    isCollapsed && "-rotate-90"
-                  )}
-                  aria-hidden="true"
-                />
-                <span>Background ({activeDockTerminals.length})</span>
-              </button>
-            )}
+        <button
+          onClick={handleToggleCollapse}
+          className={cn(
+            "flex items-center gap-1 text-xs text-canopy-text/60 mr-2 shrink-0 select-none",
+            "hover:text-canopy-text transition-colors rounded px-1 py-0.5",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent"
+          )}
+          title={isCollapsed ? "Show background terminals" : "Hide background terminals"}
+          aria-expanded={!isCollapsed}
+        >
+          <ChevronDown
+            className={cn("h-3 w-3 transition-transform duration-200", isCollapsed && "-rotate-90")}
+            aria-hidden="true"
+          />
+          <span>Background ({activeDockTerminals.length})</span>
+        </button>
 
-            {!isCollapsed && (
-              <SortableContext
-                id="dock-container"
-                items={terminalIds}
-                strategy={horizontalListSortingStrategy}
-              >
-                <div className="flex items-center gap-2">
-                  {activeDockTerminals.map((terminal, index) => (
-                    <SortableDockItem key={terminal.id} terminal={terminal} sourceIndex={index}>
-                      <DockedTerminalItem terminal={terminal} />
-                    </SortableDockItem>
-                  ))}
-                </div>
-              </SortableContext>
-            )}
-          </>
+        {!isCollapsed && (
+          <SortableContext
+            id="dock-container"
+            items={terminalIds}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className="flex items-center gap-2">
+              {activeDockTerminals.map((terminal, index) => (
+                <SortableDockItem key={terminal.id} terminal={terminal} sourceIndex={index}>
+                  <DockedTerminalItem terminal={terminal} />
+                </SortableDockItem>
+              ))}
+            </div>
+          </SortableContext>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
Implements automatic hiding of the terminal dock when it contains no docked terminals or trashed items, maximizing available screen space for active terminals and the worktree dashboard.

Closes #549

## Changes Made
- Add early return when dock has no terminals or trashed items
- Remove redundant isEmpty conditionals in render logic
- Simplify component structure while maintaining functionality
- Dock now appears only when terminals are docked or trashed

## Implementation Details
- The `TerminalDock` component now returns `null` when `isEmpty` is true
- Removed nested conditional logic since `isEmpty` is guaranteed false after the early return
- Primary docking mechanism (minimize button on terminal headers) remains fully functional
- Drag-to-empty-dock is intentionally disabled as documented in the issue (accepted trade-off for screen space)

## Testing
- ✅ TypeScript type checks pass
- ✅ ESLint passes (pre-existing warnings unrelated to changes)
- ✅ Prettier formatting applied
- ✅ Codex code review completed