### PR TITLE
Extract WorktreeCard expanded details and note parsing

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -375,8 +375,7 @@ export class PtyManager extends EventEmitter {
     this.ptyPool = pool;
   }
 
-  private emitActivityState(terminalId: string, activity: "busy" | "idle"):
-    void {
+  private emitActivityState(terminalId: string, activity: "busy" | "idle"): void {
     const terminal = this.terminals.get(terminalId);
     if (!terminal || !terminal.agentId) {
       return;
@@ -830,13 +829,16 @@ export class PtyManager extends EventEmitter {
     const now = Date.now();
     if (now - terminal.lastTierChangeAt < 100) {
       // Schedule this tier change to apply after debounce period
-      setTimeout(() => {
-        // Only apply if terminal still exists and tier hasn't changed again
-        const t = this.terminals.get(id);
-        if (t && t.activityTier === previousTier) {
-          this.setActivityTier(id, tier);
-        }
-      }, 100 - (now - terminal.lastTierChangeAt));
+      setTimeout(
+        () => {
+          // Only apply if terminal still exists and tier hasn't changed again
+          const t = this.terminals.get(id);
+          if (t && t.activityTier === previousTier) {
+            this.setActivityTier(id, tier);
+          }
+        },
+        100 - (now - terminal.lastTierChangeAt)
+      );
       return;
     }
 
@@ -1977,9 +1979,7 @@ export class PtyManager extends EventEmitter {
    * @param projectId - Project ID to get stats for
    * @returns Stats object with counts and terminal types
    */
-  getProjectStats(
-    projectId: string
-  ): {
+  getProjectStats(projectId: string): {
     terminalCount: number;
     processIds: number[];
     terminalTypes: Record<string, number>;

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -16,10 +16,7 @@ import {
   useScrollbackStore,
   useTerminalStore,
 } from "@/store";
-import {
-  AUTO_ENABLE_THRESHOLD_MIN,
-  AUTO_ENABLE_THRESHOLD_MAX,
-} from "@/store/performanceModeStore";
+import { AUTO_ENABLE_THRESHOLD_MIN, AUTO_ENABLE_THRESHOLD_MAX } from "@/store/performanceModeStore";
 import { appClient, terminalConfigClient } from "@/clients";
 import type { TerminalLayoutStrategy, TerminalGridConfig, TerminalType } from "@/types";
 import { getScrollbackForType, estimateMemoryUsage, formatBytes } from "@/utils/scrollbackConfig";
@@ -67,23 +64,22 @@ const TYPICAL_TERMINAL_COUNTS: Partial<Record<TerminalType, number>> = {
 export function TerminalSettingsTab() {
   const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
   const setLayoutConfig = useLayoutConfigStore((state) => state.setLayoutConfig);
-  
+
   // Performance Mode Store
   const performanceMode = usePerformanceModeStore((state) => state.performanceMode);
-  const setPerformanceMode = usePerformanceModeStore((state) => state.setPerformanceMode); // Kept for consistency if needed, but enable/disable are better
   const autoEnabled = usePerformanceModeStore((state) => state.autoEnabled);
   const autoEnableThreshold = usePerformanceModeStore((state) => state.autoEnableThreshold);
   const enablePerformanceMode = usePerformanceModeStore((state) => state.enablePerformanceMode);
   const disablePerformanceMode = usePerformanceModeStore((state) => state.disablePerformanceMode);
   const setAutoEnableThreshold = usePerformanceModeStore((state) => state.setAutoEnableThreshold);
-  
+
   // Terminal Store (for count)
   const terminalCount = useTerminalStore((state) => state.terminals.length);
 
   // Scrollback Store
   const scrollbackLines = useScrollbackStore((state) => state.scrollbackLines);
   const setScrollbackLines = useScrollbackStore((state) => state.setScrollbackLines);
-  
+
   const [showMemoryDetails, setShowMemoryDetails] = useState(false);
 
   const memoryEstimate = useMemo(() => {

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -1,0 +1,182 @@
+import { useMemo } from "react";
+import type { WorktreeState, DevServerState } from "../../types";
+import type { AppError, RetryAction } from "../../store/errorStore";
+import { ErrorBanner } from "../Errors/ErrorBanner";
+import { cn } from "../../lib/utils";
+import { systemClient } from "@/clients";
+import { Globe, Play } from "lucide-react";
+import { parseNoteWithLinks, formatPath, type TextSegment } from "../../utils/textParsing";
+
+export interface WorktreeDetailsProps {
+  worktree: WorktreeState;
+  homeDir?: string;
+  effectiveNote?: string;
+  showDevServer: boolean;
+  serverState: DevServerState | null;
+  serverLoading: boolean;
+  worktreeErrors: AppError[];
+  hasChanges: boolean;
+  showFooter: boolean;
+  isFocused: boolean;
+
+  onPathClick: () => void;
+  onToggleServer: () => void;
+  onDismissError: (id: string) => void;
+  onRetryError: (id: string, action: RetryAction, args?: Record<string, unknown>) => Promise<void>;
+  renderSummary: () => React.ReactNode;
+}
+
+function getServerStatusIndicator(serverState: DevServerState | null): React.ReactNode {
+  if (!serverState) return null;
+  switch (serverState.status) {
+    case "stopped":
+      return <span className="text-gray-600">○</span>;
+    case "starting":
+      return <span className="text-[var(--color-server-starting)]">◐</span>;
+    case "running":
+      return <span className="text-[var(--color-server-running)]">●</span>;
+    case "error":
+      return <span className="text-[var(--color-server-error)]">●</span>;
+    default:
+      return <span className="text-gray-600">○</span>;
+  }
+}
+
+function getServerLabel(serverState: DevServerState | null): string | null {
+  if (!serverState) return null;
+  if (serverState.status === "running" && serverState.url) {
+    return serverState.url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+  }
+  if (serverState.status === "error") return "Error";
+  if (serverState.status === "starting") return "Starting";
+  return "Dev Server";
+}
+
+export function WorktreeDetails({
+  worktree,
+  homeDir,
+  effectiveNote,
+  showDevServer,
+  serverState,
+  serverLoading,
+  worktreeErrors,
+  hasChanges,
+  showFooter,
+  isFocused,
+  onPathClick,
+  onToggleServer,
+  onDismissError,
+  onRetryError,
+  renderSummary,
+}: WorktreeDetailsProps) {
+  const displayPath = formatPath(worktree.path, homeDir);
+
+  const parsedNoteSegments: TextSegment[] = useMemo(() => {
+    return effectiveNote ? parseNoteWithLinks(effectiveNote) : [];
+  }, [effectiveNote]);
+
+  const handleLinkClick = (e: React.MouseEvent, url: string) => {
+    e.stopPropagation();
+    e.preventDefault();
+    systemClient.openExternal(url);
+  };
+
+  return (
+    <div
+      className={cn(
+        "pt-2 mt-2 space-y-2",
+        (hasChanges || showFooter) && "border-t border-border/40"
+      )}
+    >
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onPathClick();
+        }}
+        className={cn(
+          "text-[0.7rem] text-gray-500 hover:text-gray-400 hover:underline text-left font-mono truncate block",
+          isFocused && "underline"
+        )}
+      >
+        {displayPath}
+      </button>
+
+      <div className="text-xs leading-relaxed break-words">{renderSummary()}</div>
+
+      {effectiveNote && (
+        <div
+          className={cn(
+            "text-xs text-gray-400 bg-black/20 p-1.5 rounded border-l-2 border-gray-700 font-mono",
+            "line-clamp-none whitespace-pre-wrap"
+          )}
+        >
+          {parsedNoteSegments.map((segment, index) =>
+            segment.type === "link" ? (
+              <a
+                key={index}
+                href={segment.content}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[var(--color-status-info)] underline hover:text-blue-300"
+                onClick={(e) => handleLinkClick(e, segment.content)}
+              >
+                {segment.content}
+              </a>
+            ) : (
+              <span key={index}>{segment.content}</span>
+            )
+          )}
+        </div>
+      )}
+
+      {showDevServer && serverState && (
+        <div className="flex items-center gap-2 text-xs text-gray-400 font-mono">
+          <Globe className="w-3 h-3" />
+          <div className="flex items-center gap-1">
+            {getServerStatusIndicator(serverState)}
+            <span className="truncate max-w-[120px]">{getServerLabel(serverState)}</span>
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!serverLoading && serverState.status !== "starting") {
+                onToggleServer();
+              }
+            }}
+            disabled={serverLoading || serverState.status === "starting"}
+            className={cn(
+              "ml-1 p-0.5 rounded hover:bg-gray-700 transition-colors",
+              serverLoading ? "opacity-50" : ""
+            )}
+            title={serverState.status === "running" ? "Stop Server" : "Start Server"}
+          >
+            {serverState.status === "running" ? (
+              <div className="w-1.5 h-1.5 bg-[var(--color-status-error)] rounded-sm" />
+            ) : (
+              <Play className="w-2 h-2 fill-current" />
+            )}
+          </button>
+        </div>
+      )}
+
+      {worktreeErrors.length > 0 && (
+        <div className="space-y-1">
+          {worktreeErrors.slice(0, 3).map((error) => (
+            <ErrorBanner
+              key={error.id}
+              error={error}
+              onDismiss={onDismissError}
+              onRetry={onRetryError}
+              compact
+            />
+          ))}
+          {worktreeErrors.length > 3 && (
+            <div className="text-[0.65rem] text-gray-500 text-center">
+              +{worktreeErrors.length - 3} more errors
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/utils/textParsing.ts
+++ b/src/utils/textParsing.ts
@@ -1,0 +1,35 @@
+export interface TextSegment {
+  type: "text" | "link";
+  content: string;
+}
+
+const URL_REGEX = /(https?:\/\/[^\s]+)/g;
+
+export function parseNoteWithLinks(text: string): TextSegment[] {
+  const segments: TextSegment[] = [];
+  let lastIndex = 0;
+  const regex = new RegExp(URL_REGEX.source, "g");
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: "text", content: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: "link", content: match[1] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", content: text.slice(lastIndex) });
+  }
+
+  return segments;
+}
+
+export function formatPath(targetPath: string, homeDir?: string): string {
+  const home = homeDir || "";
+  if (home && targetPath.startsWith(home)) {
+    return targetPath.replace(home, "~");
+  }
+  return targetPath;
+}


### PR DESCRIPTION
## Summary

Refactors WorktreeCard component by extracting the expanded details section and text parsing logic into separate files, improving code organization and reducing component size from 702 to 573 lines.

Closes #564

## Changes Made

- **Created `src/utils/textParsing.ts`** with `parseNoteWithLinks()` and `formatPath()` utilities for reusable text processing
- **Created `src/components/Worktree/WorktreeDetails.tsx`** component to render expanded details section (path, summary, AI notes, dev server controls, errors)
- **Refactored WorktreeCard.tsx** to use WorktreeDetails component instead of inline rendering (reduced from 702 to 573 lines)
- **Fixed whitespace handling** in AI notes by adding `whitespace-pre-wrap` for proper multi-line rendering
- **Fixed footer logic** to gate server indicator on `showDevServer` to prevent empty footer rows when dev server management is disabled
- **Code cleanup** removed unused `setPerformanceMode` from TerminalSettingsTab and formatted PtyManager.ts with Prettier

## Technical Details

**WorktreeDetails Component API:**
- Props: worktree state, display settings, server state, errors, event handlers
- Handles path display with home directory substitution
- Parses AI notes for clickable links
- Renders dev server controls conditionally
- Displays error banners with retry/dismiss actions

**Text Parsing Utilities:**
- `parseNoteWithLinks()`: Extracts URLs from text and returns typed segments for rendering
- `formatPath()`: Substitutes home directory with `~` for cleaner display

## Testing

- ✅ TypeScript type checking passes
- ✅ All lint and format checks pass
- ✅ Codex review completed with fixes applied