### PR TITLE
Split GitHubService into query and auth modules

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -375,8 +375,7 @@ export class PtyManager extends EventEmitter {
     this.ptyPool = pool;
   }
 
-  private emitActivityState(terminalId: string, activity: "busy" | "idle"):
-    void {
+  private emitActivityState(terminalId: string, activity: "busy" | "idle"): void {
     const terminal = this.terminals.get(terminalId);
     if (!terminal || !terminal.agentId) {
       return;
@@ -830,13 +829,16 @@ export class PtyManager extends EventEmitter {
     const now = Date.now();
     if (now - terminal.lastTierChangeAt < 100) {
       // Schedule this tier change to apply after debounce period
-      setTimeout(() => {
-        // Only apply if terminal still exists and tier hasn't changed again
-        const t = this.terminals.get(id);
-        if (t && t.activityTier === previousTier) {
-          this.setActivityTier(id, tier);
-        }
-      }, 100 - (now - terminal.lastTierChangeAt));
+      setTimeout(
+        () => {
+          // Only apply if terminal still exists and tier hasn't changed again
+          const t = this.terminals.get(id);
+          if (t && t.activityTier === previousTier) {
+            this.setActivityTier(id, tier);
+          }
+        },
+        100 - (now - terminal.lastTierChangeAt)
+      );
       return;
     }
 
@@ -1977,9 +1979,7 @@ export class PtyManager extends EventEmitter {
    * @param projectId - Project ID to get stats for
    * @returns Stats object with counts and terminal types
    */
-  getProjectStats(
-    projectId: string
-  ): {
+  getProjectStats(projectId: string): {
     terminalCount: number;
     processIds: number[];
     terminalTypes: Record<string, number>;

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -1,0 +1,105 @@
+import { graphql } from "@octokit/graphql";
+import { secureStorage } from "../SecureStorage.js";
+
+export interface GitHubTokenConfig {
+  hasToken: boolean;
+  scopes?: string[];
+  username?: string;
+}
+
+export interface GitHubTokenValidation {
+  valid: boolean;
+  scopes: string[];
+  username?: string;
+  error?: string;
+}
+
+export class GitHubAuth {
+  static getToken(): string | undefined {
+    return secureStorage.get("userConfig.githubToken");
+  }
+
+  static hasToken(): boolean {
+    return !!GitHubAuth.getToken();
+  }
+
+  static setToken(token: string): void {
+    secureStorage.set("userConfig.githubToken", token.trim());
+  }
+
+  static clearToken(): void {
+    secureStorage.delete("userConfig.githubToken");
+  }
+
+  static getConfig(): GitHubTokenConfig {
+    return {
+      hasToken: GitHubAuth.hasToken(),
+    };
+  }
+
+  static createClient(): typeof graphql | null {
+    const token = GitHubAuth.getToken();
+    if (!token) return null;
+
+    return graphql.defaults({
+      headers: {
+        authorization: `token ${token}`,
+      },
+    });
+  }
+
+  static async validate(token: string): Promise<GitHubTokenValidation> {
+    if (!token || token.trim() === "") {
+      return { valid: false, scopes: [], error: "Token is empty" };
+    }
+
+    if (
+      !token.startsWith("ghp_") &&
+      !token.startsWith("github_pat_") &&
+      !token.startsWith("gho_")
+    ) {
+      if (token.length < 40) {
+        return { valid: false, scopes: [], error: "Invalid token format" };
+      }
+    }
+
+    try {
+      const response = await fetch("https://api.github.com/user", {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: "application/vnd.github.v3+json",
+        },
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          return { valid: false, scopes: [], error: "Invalid or expired token" };
+        }
+        if (response.status === 403) {
+          return { valid: false, scopes: [], error: "Token lacks required permissions" };
+        }
+        return { valid: false, scopes: [], error: `GitHub API error: ${response.statusText}` };
+      }
+
+      const userData = (await response.json()) as { login?: string };
+      const scopesHeader = response.headers.get("x-oauth-scopes");
+      const scopes = scopesHeader ? scopesHeader.split(",").map((s) => s.trim()) : [];
+
+      return {
+        valid: true,
+        scopes,
+        username: userData.login,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes("ENOTFOUND") || message.includes("ETIMEDOUT")) {
+        return {
+          valid: false,
+          scopes: [],
+          error: "Cannot reach GitHub. Check your internet connection.",
+        };
+      }
+      return { valid: false, scopes: [], error: message };
+    }
+  }
+}

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -1,0 +1,20 @@
+export { GitHubAuth } from "./GitHubAuth.js";
+export type { GitHubTokenConfig, GitHubTokenValidation } from "./GitHubAuth.js";
+
+export {
+  REPO_STATS_QUERY,
+  LIST_ISSUES_QUERY,
+  LIST_PRS_QUERY,
+  SEARCH_QUERY,
+  buildBatchPRQuery,
+} from "./GitHubQueries.js";
+
+export type {
+  RepoContext,
+  RepoStats,
+  RepoStatsResult,
+  LinkedPR,
+  PRCheckResult,
+  PRCheckCandidate,
+  BatchPRCheckResult,
+} from "./types.js";

--- a/electron/services/github/types.ts
+++ b/electron/services/github/types.ts
@@ -1,0 +1,38 @@
+export interface RepoContext {
+  owner: string;
+  repo: string;
+}
+
+export interface RepoStats {
+  issueCount: number;
+  prCount: number;
+}
+
+export interface RepoStatsResult {
+  stats: RepoStats | null;
+  error?: string;
+}
+
+export interface LinkedPR {
+  number: number;
+  url: string;
+  state: "open" | "merged" | "closed";
+  isDraft: boolean;
+}
+
+export interface PRCheckResult {
+  issueNumber?: number;
+  branchName?: string;
+  pr: LinkedPR | null;
+}
+
+export interface PRCheckCandidate {
+  worktreeId: string;
+  issueNumber?: number;
+  branchName?: string;
+}
+
+export interface BatchPRCheckResult {
+  results: Map<string, PRCheckResult>;
+  error?: string;
+}

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -16,10 +16,7 @@ import {
   useScrollbackStore,
   useTerminalStore,
 } from "@/store";
-import {
-  AUTO_ENABLE_THRESHOLD_MIN,
-  AUTO_ENABLE_THRESHOLD_MAX,
-} from "@/store/performanceModeStore";
+import { AUTO_ENABLE_THRESHOLD_MIN, AUTO_ENABLE_THRESHOLD_MAX } from "@/store/performanceModeStore";
 import { appClient, terminalConfigClient } from "@/clients";
 import type { TerminalLayoutStrategy, TerminalGridConfig, TerminalType } from "@/types";
 import { getScrollbackForType, estimateMemoryUsage, formatBytes } from "@/utils/scrollbackConfig";
@@ -67,7 +64,7 @@ const TYPICAL_TERMINAL_COUNTS: Partial<Record<TerminalType, number>> = {
 export function TerminalSettingsTab() {
   const layoutConfig = useLayoutConfigStore((state) => state.layoutConfig);
   const setLayoutConfig = useLayoutConfigStore((state) => state.setLayoutConfig);
-  
+
   // Performance Mode Store
   const performanceMode = usePerformanceModeStore((state) => state.performanceMode);
   const setPerformanceMode = usePerformanceModeStore((state) => state.setPerformanceMode); // Kept for consistency if needed, but enable/disable are better
@@ -76,14 +73,14 @@ export function TerminalSettingsTab() {
   const enablePerformanceMode = usePerformanceModeStore((state) => state.enablePerformanceMode);
   const disablePerformanceMode = usePerformanceModeStore((state) => state.disablePerformanceMode);
   const setAutoEnableThreshold = usePerformanceModeStore((state) => state.setAutoEnableThreshold);
-  
+
   // Terminal Store (for count)
   const terminalCount = useTerminalStore((state) => state.terminals.length);
 
   // Scrollback Store
   const scrollbackLines = useScrollbackStore((state) => state.scrollbackLines);
   const setScrollbackLines = useScrollbackStore((state) => state.setScrollbackLines);
-  
+
   const [showMemoryDetails, setShowMemoryDetails] = useState(false);
 
   const memoryEstimate = useMemo(() => {


### PR DESCRIPTION
## Summary

Split `electron/services/GitHubService.ts` into focused modules by extracting GraphQL queries and authentication logic. This improves maintainability and separates concerns between authentication, query management, and data fetching.

Closes #565

## Changes Made

- Created `electron/services/github/GitHubAuth.ts` - Authentication logic with class-based API
- Created `electron/services/github/GitHubQueries.ts` - GraphQL query strings and query builders
- Created `electron/services/github/types.ts` - Shared type definitions
- Created `electron/services/github/index.ts` - Centralized exports
- Refactored `electron/services/GitHubService.ts` to import from new modules
- Reduced GitHubService from 800 to 542 lines (32% reduction)
- Removed unused `prCheckCache` variable
- Added token normalization (trim before storage)
- Added guard for empty candidates in `buildBatchPRQuery`

## Module Structure

**GitHubAuth** (105 lines)
- Token storage and retrieval
- Token validation
- GraphQL client creation
- Class-based API: `GitHubAuth.getToken()`, `GitHubAuth.validate()`, etc.

**GitHubQueries** (184 lines)
- Static GraphQL query constants: `LIST_ISSUES_QUERY`, `LIST_PRS_QUERY`, `SEARCH_QUERY`, `REPO_STATS_QUERY`
- Query builder: `buildBatchPRQuery()` for dynamic PR checks

**GitHubService** (542 lines, down from 800)
- Imports from new modules
- Focuses on data fetching, caching, and transformation
- Maintains all existing API signatures

## Testing

- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ All imports and exports verified
- ✅ Codex review completed with fixes applied