### PR TITLE
Extract TerminalPane header and logic into subcomponents

### DIFF
--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -70,7 +70,6 @@ export function TerminalSettingsTab() {
   
   // Performance Mode Store
   const performanceMode = usePerformanceModeStore((state) => state.performanceMode);
-  const setPerformanceMode = usePerformanceModeStore((state) => state.setPerformanceMode); // Kept for consistency if needed, but enable/disable are better
   const autoEnabled = usePerformanceModeStore((state) => state.autoEnabled);
   const autoEnableThreshold = usePerformanceModeStore((state) => state.autoEnableThreshold);
   const enablePerformanceMode = usePerformanceModeStore((state) => state.enablePerformanceMode);

--- a/src/hooks/useTerminalLogic.ts
+++ b/src/hooks/useTerminalLogic.ts
@@ -1,0 +1,186 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { RetryAction } from "@/store";
+import { useContextInjection } from "@/hooks/useContextInjection";
+import { errorsClient } from "@/clients";
+
+interface UseTerminalLogicOptions {
+  id: string;
+  title: string;
+  onTitleChange?: (newTitle: string) => void;
+  removeError: (errorId: string) => void;
+}
+
+export interface UseTerminalLogicReturn {
+  // Title editing
+  isEditingTitle: boolean;
+  editingValue: string;
+  titleInputRef: React.RefObject<HTMLInputElement | null>;
+  setEditingValue: (value: string) => void;
+  handleTitleDoubleClick: (e: React.MouseEvent) => void;
+  handleTitleKeyDown: (e: React.KeyboardEvent) => void;
+  handleTitleInputKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  handleTitleSave: () => void;
+  handleTitleCancel: () => void;
+
+  // Error handling
+  handleErrorRetry: (
+    errorId: string,
+    action: RetryAction,
+    args?: Record<string, unknown>
+  ) => Promise<void>;
+
+  // Exit handling
+  isExited: boolean;
+  exitCode: number | null;
+  handleExit: (code: number) => void;
+
+  // Context injection
+  inject: ReturnType<typeof useContextInjection>["inject"];
+  isInjecting: boolean;
+  injectionProgress: ReturnType<typeof useContextInjection>["progress"];
+}
+
+export function useTerminalLogic({
+  id,
+  title,
+  onTitleChange,
+  removeError,
+}: UseTerminalLogicOptions): UseTerminalLogicReturn {
+  const [isExited, setIsExited] = useState(false);
+  const [exitCode, setExitCode] = useState<number | null>(null);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [editingValue, setEditingValue] = useState(title);
+  const titleInputRef = useRef<HTMLInputElement | null>(null);
+  const cancelledRef = useRef(false);
+
+  const { inject, isInjecting, progress: injectionProgress } = useContextInjection(id);
+
+  // Reset exit state when terminal ID changes
+  useEffect(() => {
+    setIsExited(false);
+    setExitCode(null);
+  }, [id]);
+
+  // Sync editing value when title changes externally (and not editing)
+  useEffect(() => {
+    if (!isEditingTitle) {
+      setEditingValue(title);
+    }
+  }, [title, isEditingTitle]);
+
+  // Focus and select input when editing starts
+  useEffect(() => {
+    if (isEditingTitle && titleInputRef.current) {
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [isEditingTitle]);
+
+  const handleTitleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onTitleChange) {
+        setIsEditingTitle(true);
+      }
+    },
+    [onTitleChange]
+  );
+
+  const handleTitleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (onTitleChange && (e.key === "Enter" || e.key === "F2")) {
+        e.preventDefault();
+        e.stopPropagation();
+        setIsEditingTitle(true);
+      }
+    },
+    [onTitleChange]
+  );
+
+  const handleTitleSave = useCallback(() => {
+    if (!isEditingTitle || cancelledRef.current) {
+      cancelledRef.current = false;
+      return;
+    }
+    setIsEditingTitle(false);
+    if (onTitleChange) {
+      onTitleChange(editingValue);
+    }
+  }, [isEditingTitle, editingValue, onTitleChange]);
+
+  const handleTitleCancel = useCallback(() => {
+    cancelledRef.current = true;
+    setIsEditingTitle(false);
+    setEditingValue(title);
+  }, [title]);
+
+  const handleTitleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleTitleSave();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleTitleCancel();
+      }
+    },
+    [handleTitleSave, handleTitleCancel]
+  );
+
+  const handleExit = useCallback((code: number) => {
+    setIsExited(true);
+    setExitCode(code);
+  }, []);
+
+  const handleErrorRetry = useCallback(
+    async (errorId: string, action: RetryAction, args?: Record<string, unknown>) => {
+      try {
+        if (action === "injectContext") {
+          const worktreeIdArg = args?.worktreeId as string | undefined;
+          const terminalIdArg = args?.terminalId as string | undefined;
+          const selectedPaths = args?.selectedPaths as string[] | undefined;
+
+          if (!worktreeIdArg || !terminalIdArg) {
+            console.error("Missing worktreeId or terminalId for injectContext retry");
+            return;
+          }
+
+          await inject(worktreeIdArg, terminalIdArg, selectedPaths);
+          removeError(errorId);
+        } else {
+          await errorsClient.retry(errorId, action, args);
+          removeError(errorId);
+        }
+      } catch (error) {
+        console.error("Error retry failed:", error);
+      }
+    },
+    [inject, removeError]
+  );
+
+  return {
+    // Title editing
+    isEditingTitle,
+    editingValue,
+    titleInputRef,
+    setEditingValue,
+    handleTitleDoubleClick,
+    handleTitleKeyDown,
+    handleTitleInputKeyDown,
+    handleTitleSave,
+    handleTitleCancel,
+
+    // Error handling
+    handleErrorRetry,
+
+    // Exit handling
+    isExited,
+    exitCode,
+    handleExit,
+
+    // Context injection
+    inject,
+    isInjecting,
+    injectionProgress,
+  };
+}


### PR DESCRIPTION
## Summary

Refactors the large TerminalPane component (660 lines) into focused, maintainable subcomponents. This improves code organization, testability, and readability by separating UI rendering from business logic.

Closes #562

## Changes Made

- Create TerminalHeader component (350 lines) for header UI rendering
- Create useTerminalLogic hook (186 lines) for state and event handlers  
- Refactor TerminalPane (660→310 lines) to use extracted components
- Fix Escape key cancellation in title editing (properly reverts changes)
- Fix double-click on input text triggering unwanted maximize
- Add Cancel button to context injection progress UI
- Remove unused setPerformanceMode in TerminalSettingsTab

## Technical Details

**TerminalHeader.tsx:**
- Handles all header rendering (icon, title, badges, buttons)
- Properly guards double-click handler to avoid interfering with input text selection
- Memoized for performance

**useTerminalLogic.ts:**
- Manages title editing state with proper cancel/save handling
- Handles error retry logic for terminal errors
- Tracks exit state and codes
- Integrates context injection via useContextInjection hook
- Uses ref-based cancellation flag to prevent save-on-blur after Escape

**TerminalPane.tsx:**
- Reduced from 660 to 310 lines
- Focuses on layout and xterm integration
- Delegates header rendering and logic to extracted components
- All functionality preserved with no regressions

## Testing

- ✅ TypeScript compilation passes
- ✅ Codex code review completed with fixes applied
- ✅ All original functionality preserved