### PR TITLE
Add clickable URL support in terminal windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/diff": "^7.0.2",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/headless": "^5.5.0",
     "@xterm/xterm": "^5.5.0",


### PR DESCRIPTION
## Summary
Adds clickable URL support to terminal windows using @xterm/addon-web-links with security hardening to protect against protocol injection and improve user experience.

Closes #506

## Changes Made
- Installed @xterm/addon-web-links dependency
- Integrated WebLinksAddon in TerminalInstanceService with security features:
  - URL normalization for scheme-less URLs (www.example.com → https://www.example.com)
  - Protocol validation to restrict to http/https only (prevents file:// and other protocol handlers)
  - Error handling for failed URL opens with console logging
  - Proper addon disposal in destroy() method to prevent memory leaks
- URLs in terminal output are now underlined on hover and clickable
- Clicking URLs opens them in the system default browser via Electron's shell.openExternal()

## Security
- Custom regex restricts URL detection to http/https protocols only
- event.preventDefault() prevents in-app navigation
- URL validation blocks file:// and other potentially dangerous protocols
- All URLs are normalized to include https:// scheme when missing

## Testing
- All existing tests pass (npm run check)
- TypeScript compilation succeeds
- Linting passes with no new warnings