### PR TITLE
Fix: Standardize docked terminal spinner with grid view

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -52,16 +52,9 @@ function getTerminalIcon(type: TerminalType, className?: string) {
 }
 
 function getStateIndicator(state?: AgentState) {
-  if (!state || state === "idle") return null;
+  if (!state || state === "idle" || state === "working") return null;
 
   switch (state) {
-    case "working":
-      return (
-        <Loader2
-          className="h-3 w-3 animate-spin text-[var(--color-state-working)]"
-          aria-hidden="true"
-        />
-      );
     case "completed":
       return (
         <span
@@ -165,6 +158,9 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     await inject(terminal.worktreeId, terminal.id);
   }, [inject, terminal.id, terminal.worktreeId]);
 
+  const isWorking = terminal.agentState === "working";
+  const brandColor = getBrandColorHex(terminal.type);
+
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
@@ -178,7 +174,15 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           )}
           title={`${terminal.title} - Click to preview, drag to reorder`}
         >
-          {getTerminalIcon(terminal.type)}
+          {isWorking ? (
+            <Loader2
+              className="w-3 h-3 animate-spin"
+              style={{ color: brandColor }}
+              aria-hidden="true"
+            />
+          ) : (
+            getTerminalIcon(terminal.type)
+          )}
           {getStateIndicator(terminal.agentState)}
           <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>
         </button>

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -610,8 +610,7 @@ export const createTerminalRegistrySlice =
           if (t.id !== id) return t;
 
           // Default autoRestart based on terminal type (matches addTerminal logic)
-          const isAgentTerminal =
-            t.type === "claude" || t.type === "gemini" || t.type === "codex";
+          const isAgentTerminal = t.type === "claude" || t.type === "gemini" || t.type === "codex";
           const defaultSettings: TerminalSettings = {
             autoRestart: isAgentTerminal,
           };


### PR DESCRIPTION
## Summary
Standardizes the agent busy indicator across terminal locations by replacing the terminal icon with a brand-colored spinner in the dock view, matching the existing grid view behavior.

Closes #576

## Changes Made
- Replace icon with brand-colored spinner when agent is working in docked terminals
- Remove working state from getStateIndicator helper function
- Match TerminalHeader behavior for visual consistency
- Use correct dock icon dimensions (w-3 h-3) for spinner size

## Visual Consistency
- When agent is working: icon → brand-colored spinner
- When agent is idle/completed/failed: shows original icon
- Spinner color matches agent brand (Claude orange, Gemini blue, Codex gray)
- No duplicate spinners visible at any time