### PR TITLE
Fix sidecar obstructing toolbar dropdowns and settings dialog

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -52,10 +52,12 @@ export function Toolbar({
 
   const sidecarOpen = useSidecarStore((state) => state.isOpen);
   const sidecarWidth = useSidecarStore((state) => state.width);
+  const layoutMode = useSidecarStore((state) => state.layoutMode);
   const toggleSidecar = useSidecarStore((state) => state.toggle);
 
-  // Collision padding for dropdowns near sidecar boundary
-  const rightCollisionPadding = sidecarOpen ? sidecarWidth + 10 : 10;
+  // Collision padding for dropdowns - only apply in overlay mode where sidecar occludes content
+  const rightCollisionPadding =
+    sidecarOpen && layoutMode === "overlay" ? sidecarWidth + 20 : 10;
 
   const [issuesOpen, setIssuesOpen] = useState(false);
   const [prsOpen, setPrsOpen] = useState(false);

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useErrors, useOverlayState } from "@/hooks";
-import { useLogsStore } from "@/store";
+import { useLogsStore, useSidecarStore } from "@/store";
 import { X, Bot, Github, LayoutGrid, PanelRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { appClient } from "@/clients";
@@ -29,6 +29,14 @@ export function SettingsDialog({
   useOverlayState(isOpen);
 
   const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab ?? "general");
+  const setSidecarOpen = useSidecarStore((state) => state.setOpen);
+
+  // Close sidecar when settings opens to prevent z-index conflicts
+  useEffect(() => {
+    if (isOpen) {
+      setSidecarOpen(false);
+    }
+  }, [isOpen, setSidecarOpen]);
   const { openLogs } = useErrors();
   const clearLogs = useLogsStore((state) => state.clearLogs);
 

--- a/src/components/Terminal/BulkActionsMenu.tsx
+++ b/src/components/Terminal/BulkActionsMenu.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ChevronDown, CheckCircle, XCircle, Clock, Trash2, RefreshCw } from "lucide-react";
 import { useTerminalStore } from "@/store/terminalStore";
+import { useSidecarStore } from "@/store/sidecarStore";
 import { ConfirmDialog } from "./ConfirmDialog";
 
 export interface BulkActionsMenuProps {
@@ -24,6 +25,15 @@ export function BulkActionsMenu({ worktreeId, trigger, className }: BulkActionsM
   const bulkCloseByWorktree = useTerminalStore((state) => state.bulkCloseByWorktree);
   const bulkCloseAll = useTerminalStore((state) => state.bulkCloseAll);
   const restartFailedAgents = useTerminalStore((state) => state.restartFailedAgents);
+
+  const sidecarOpen = useSidecarStore((state) => state.isOpen);
+  const sidecarWidth = useSidecarStore((state) => state.width);
+  const layoutMode = useSidecarStore((state) => state.layoutMode);
+
+  // Collision padding to prevent dropdown from being hidden behind sidecar in overlay mode
+  const collisionPadding = {
+    right: sidecarOpen && layoutMode === "overlay" ? sidecarWidth + 20 : 10,
+  };
 
   const [confirmDialog, setConfirmDialog] = useState<{
     isOpen: boolean;
@@ -134,7 +144,7 @@ export function BulkActionsMenu({ worktreeId, trigger, className }: BulkActionsM
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>{trigger || defaultTrigger}</DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-56">
+        <DropdownMenuContent align="start" className="w-56" collisionPadding={collisionPadding}>
           <DropdownMenuItem
             onClick={handleCloseCompleted}
             disabled={completedCount === 0}


### PR DESCRIPTION
## Summary
Fixes sidecar overlay obstruction issues by implementing two strategies:
- **Settings Dialog**: Auto-closes sidecar when opened to prevent z-index conflicts
- **Toolbar & Bulk Actions Dropdowns**: Uses Radix UI collision padding to intelligently position dropdowns away from sidecar in overlay mode

Closes #579

## Changes Made
- Add auto-close sidecar when Settings dialog opens to prevent z-index conflicts
- Fix collision padding in Toolbar to only apply in overlay mode (not push mode)
- Add collision padding to BulkActionsMenu dropdown to prevent sidecar obstruction
- Ensure dropdowns remain visible by avoiding sidecar area in overlay layout mode

## Technical Details
- **SettingsDialog**: Added `useEffect` hook that calls `setSidecarOpen(false)` when dialog opens
- **Toolbar**: Updated `rightCollisionPadding` calculation to check `layoutMode === "overlay"` before applying padding
- **BulkActionsMenu**: Added sidecar state hooks and collision padding logic matching Toolbar pattern
- Collision padding uses `sidecarWidth + 20` when sidecar is open in overlay mode, falls back to `10` otherwise

## Testing
- ✅ TypeScript type checking passes
- ✅ ESLint passes (no new warnings)
- ✅ Codex code review completed (no issues found)
- Manual testing required:
  - Open sidecar in overlay mode → click Issues/PRs buttons → verify dropdowns appear to left of sidecar
  - Open sidecar → open Settings → verify sidecar automatically closes
  - Test both overlay and push layout modes