### PR TITLE
Fix docked terminal popover overlapping sidecar

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,4 +1,5 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useDndMonitor } from "@dnd-kit/core";
 import { Loader2, Terminal, Command } from "lucide-react";
 import {
@@ -13,7 +14,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
-import { useTerminalStore, type TerminalInstance } from "@/store";
+import { useTerminalStore, useSidecarStore, type TerminalInstance } from "@/store";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { useContextInjection } from "@/hooks/useContextInjection";
 import type { AgentState, TerminalType } from "@/types";
@@ -85,7 +86,21 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const trashTerminal = useTerminalStore((s) => s.trashTerminal);
   const removeTerminal = useTerminalStore((s) => s.removeTerminal);
 
+  const { isOpen: sidecarOpen, width: sidecarWidth } = useSidecarStore(
+    useShallow((s) => ({ isOpen: s.isOpen, width: s.width }))
+  );
+
   const { inject, cancel } = useContextInjection();
+
+  const collisionPadding = useMemo(() => {
+    const basePadding = 16;
+    return {
+      top: basePadding,
+      left: basePadding,
+      bottom: basePadding,
+      right: sidecarOpen ? sidecarWidth + basePadding : basePadding,
+    };
+  }, [sidecarOpen, sidecarWidth]);
 
   // Toggle buffering based on popover open state
   useEffect(() => {
@@ -189,6 +204,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         side="top"
         align="start"
         sideOffset={8}
+        collisionPadding={collisionPadding}
       >
         <TerminalPane
           id={terminal.id}

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -610,8 +610,7 @@ export const createTerminalRegistrySlice =
           if (t.id !== id) return t;
 
           // Default autoRestart based on terminal type (matches addTerminal logic)
-          const isAgentTerminal =
-            t.type === "claude" || t.type === "gemini" || t.type === "codex";
+          const isAgentTerminal = t.type === "claude" || t.type === "gemini" || t.type === "codex";
           const defaultSettings: TerminalSettings = {
             autoRestart: isAgentTerminal,
           };


### PR DESCRIPTION
## Summary
Prevents docked terminal popovers from overlapping the sidecar panel when positioned at the right edge. Implements dynamic collision padding that adjusts based on sidecar state.

Closes #580

## Changes Made
- Add dynamic collision padding to PopoverContent based on sidecar state
- Use useShallow for optimized Zustand selector to prevent double renders
- Import useSidecarStore to access sidecar width and open state
- Calculate right padding as sidecarWidth + 16px when sidecar is open
- Radix UI collision detection now respects sidecar as boundary

## Implementation
The fix uses Radix UI's `collisionPadding` prop to define a safe zone on the right edge equal to the sidecar width plus a 16px margin. When the sidecar is open, popovers automatically shift left to avoid overlap.

## Technical Notes
- Optimized with `useShallow` to prevent unnecessary re-renders when both sidecar state values change
- Uses `useMemo` for the padding object to avoid recreating on every render
- TypeScript types are correctly satisfied for Radix UI props