### PR TITLE
Refactor terminal Actions menu to remove non-functional options

### DIFF
--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -610,8 +610,7 @@ export const createTerminalRegistrySlice =
           if (t.id !== id) return t;
 
           // Default autoRestart based on terminal type (matches addTerminal logic)
-          const isAgentTerminal =
-            t.type === "claude" || t.type === "gemini" || t.type === "codex";
+          const isAgentTerminal = t.type === "claude" || t.type === "gemini" || t.type === "codex";
           const defaultSettings: TerminalSettings = {
             autoRestart: isAgentTerminal,
           };

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -75,7 +75,7 @@ export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
   const bulkActionsSlice = createTerminalBulkActionsSlice(
     getTerminals,
     (id) => get().removeTerminal(id),
-    (options) => get().addTerminal(options)
+    (id) => get().restartTerminal(id)
   )(set, get, api);
 
   return {

--- a/src/store/utils/terminalTypeGuards.ts
+++ b/src/store/utils/terminalTypeGuards.ts
@@ -1,0 +1,9 @@
+import type { TerminalType } from "@/types";
+
+export function isAgentTerminal(type: TerminalType): boolean {
+  return type === "claude" || type === "gemini" || type === "codex" || type === "custom";
+}
+
+export function hasAgentDefaults(type: TerminalType): boolean {
+  return type === "claude" || type === "gemini" || type === "codex";
+}


### PR DESCRIPTION
## Summary
This PR refactors the terminal Actions menu to remove non-functional options and improve agent type handling. It streamlines the UI by removing "Close Failed" and "Close Idle" menu items that provided unclear value, adds a new "Restart Idle Agents" feature, and ensures all agent types (Claude, Gemini, Codex, Custom) are properly handled.

Closes #585

## Changes Made
- Remove non-functional "Close Failed" and "Close Idle" menu items
- Add "Restart Idle Agents" functionality for all agent types
- Update "Restart Failed Agents" to support all agent types (claude, gemini, codex, custom)
- Centralize agent type detection in shared utility module (`terminalTypeGuards.ts`)
- Use `restartTerminal` method to preserve terminal location and trash state during restarts
- Eliminate duplicate agent type helpers between store slice and UI component

## Technical Improvements
- Created `src/store/utils/terminalTypeGuards.ts` for centralized agent type detection
- Refactored restart logic to use existing `restartTerminal` method, ensuring location/trash state preservation
- Reduced code duplication and improved maintainability