### PR TITLE
Add right-click context menus to terminal components

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@octokit/graphql": "^9.0.3",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { useTerminalStore, useSidecarStore, type TerminalInstance } from "@/store";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
+import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { useContextInjection } from "@/hooks/useContextInjection";
 import type { AgentState, TerminalType } from "@/types";
 import { TerminalRefreshTier } from "@/types";
@@ -178,30 +179,32 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
 
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <button
-          className={cn(
-            "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
-            "hover:bg-canopy-accent/10 border-canopy-border hover:border-canopy-accent/50",
-            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
-            "cursor-grab active:cursor-grabbing",
-            isOpen && "bg-canopy-accent/20 border-canopy-accent"
-          )}
-          title={`${terminal.title} - Click to preview, drag to reorder`}
-        >
-          {isWorking ? (
-            <Loader2
-              className="w-3 h-3 animate-spin"
-              style={{ color: brandColor }}
-              aria-hidden="true"
-            />
-          ) : (
-            getTerminalIcon(terminal.type)
-          )}
-          {getStateIndicator(terminal.agentState)}
-          <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>
-        </button>
-      </PopoverTrigger>
+      <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
+        <PopoverTrigger asChild>
+          <button
+            className={cn(
+              "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
+              "hover:bg-canopy-accent/10 border-canopy-border hover:border-canopy-accent/50",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
+              "cursor-grab active:cursor-grabbing",
+              isOpen && "bg-canopy-accent/20 border-canopy-accent"
+            )}
+            title={`${terminal.title} - Click to preview, drag to reorder`}
+          >
+            {isWorking ? (
+              <Loader2
+                className="w-3 h-3 animate-spin"
+                style={{ color: brandColor }}
+                aria-hidden="true"
+              />
+            ) : (
+              getTerminalIcon(terminal.type)
+            )}
+            {getStateIndicator(terminal.agentState)}
+            <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>
+          </button>
+        </PopoverTrigger>
+      </TerminalContextMenu>
 
       <PopoverContent
         className="w-[700px] h-[500px] p-0 border-canopy-border bg-canopy-bg shadow-2xl"

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -1,0 +1,142 @@
+import { useCallback } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
+  ContextMenuCheckboxItem,
+} from "@/components/ui/context-menu";
+import { Maximize2, Minimize2, Trash2, ArrowUp, Copy, Settings2, Skull } from "lucide-react";
+import { useTerminalStore } from "@/store";
+import { useContextInjection } from "@/hooks/useContextInjection";
+import type { TerminalLocation } from "@/types";
+
+interface TerminalContextMenuProps {
+  terminalId: string;
+  children: React.ReactNode;
+  forceLocation?: TerminalLocation;
+}
+
+/**
+ * Right-click context menu for terminal components.
+ * Integrates with terminal store for actions and context injection.
+ * Used by both DockedTerminalItem and TerminalHeader.
+ */
+export function TerminalContextMenu({
+  terminalId,
+  children,
+  forceLocation,
+}: TerminalContextMenuProps) {
+  const terminal = useTerminalStore((state) => state.terminals.find((t) => t.id === terminalId));
+
+  const moveTerminalToDock = useTerminalStore((s) => s.moveTerminalToDock);
+  const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
+  const trashTerminal = useTerminalStore((s) => s.trashTerminal);
+  const removeTerminal = useTerminalStore((s) => s.removeTerminal);
+  const toggleMaximize = useTerminalStore((s) => s.toggleMaximize);
+  const updateTerminalSettings = useTerminalStore((s) => s.updateTerminalSettings);
+  const isMaximized = useTerminalStore((s) => s.maximizedId === terminalId);
+
+  const { inject } = useContextInjection();
+
+  const handleInjectContext = useCallback(() => {
+    if (terminal?.worktreeId) {
+      inject(terminal.worktreeId, terminalId);
+    }
+  }, [terminal, terminalId, inject]);
+
+  if (!terminal) return <>{children}</>;
+
+  const currentLocation: TerminalLocation = forceLocation ?? terminal.location ?? "grid";
+  const isAgent = ["claude", "gemini", "codex"].includes(terminal.type);
+  const canInjectContext = terminal.worktreeId && isAgent;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        {/* Layout Actions */}
+        {currentLocation === "grid" ? (
+          <ContextMenuItem onClick={() => moveTerminalToDock(terminalId)}>
+            <Minimize2 className="w-4 h-4 mr-2" aria-hidden="true" />
+            Minimize to Dock
+          </ContextMenuItem>
+        ) : (
+          <ContextMenuItem onClick={() => moveTerminalToGrid(terminalId)}>
+            <ArrowUp className="w-4 h-4 mr-2" aria-hidden="true" />
+            Restore to Grid
+          </ContextMenuItem>
+        )}
+
+        {currentLocation === "grid" && (
+          <ContextMenuItem onClick={() => toggleMaximize(terminalId)}>
+            {isMaximized ? (
+              <>
+                <Minimize2 className="w-4 h-4 mr-2" aria-hidden="true" />
+                Restore Size
+                <ContextMenuShortcut>^⇧F</ContextMenuShortcut>
+              </>
+            ) : (
+              <>
+                <Maximize2 className="w-4 h-4 mr-2" aria-hidden="true" />
+                Maximize
+                <ContextMenuShortcut>^⇧F</ContextMenuShortcut>
+              </>
+            )}
+          </ContextMenuItem>
+        )}
+
+        <ContextMenuSeparator />
+
+        {/* Functionality Actions */}
+        {terminal.worktreeId && (
+          <ContextMenuItem onClick={handleInjectContext} disabled={!canInjectContext}>
+            <Copy className="w-4 h-4 mr-2" aria-hidden="true" />
+            Inject Context
+            <ContextMenuShortcut>^⇧I</ContextMenuShortcut>
+          </ContextMenuItem>
+        )}
+
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>
+            <Settings2 className="w-4 h-4 mr-2" aria-hidden="true" />
+            Settings
+          </ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            <ContextMenuCheckboxItem
+              checked={terminal.settings?.autoRestart ?? isAgent}
+              onCheckedChange={(checked) =>
+                updateTerminalSettings(terminalId, { autoRestart: checked === true })
+              }
+            >
+              Auto-restart on open
+            </ContextMenuCheckboxItem>
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+
+        <ContextMenuSeparator />
+
+        <ContextMenuItem
+          onClick={() => trashTerminal(terminalId)}
+          className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
+        >
+          <Trash2 className="w-4 h-4 mr-2" aria-hidden="true" />
+          Close Terminal
+        </ContextMenuItem>
+
+        <ContextMenuItem
+          onClick={() => removeTerminal(terminalId)}
+          className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
+        >
+          <Skull className="w-4 h-4 mr-2" aria-hidden="true" />
+          Force Kill
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/src/components/Terminal/TerminalHeader.tsx
+++ b/src/components/Terminal/TerminalHeader.tsx
@@ -32,6 +32,7 @@ import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { StateBadge } from "./StateBadge";
 import { ActivityBadge } from "./ActivityBadge";
+import { TerminalContextMenu } from "./TerminalContextMenu";
 import type { ActivityState } from "./TerminalPane";
 
 interface TerminalIconProps {
@@ -111,7 +112,7 @@ export interface TerminalHeaderProps {
 }
 
 function TerminalHeaderComponent({
-  id: _id,
+  id,
   title,
   type,
   worktreeId,
@@ -153,7 +154,8 @@ function TerminalHeaderComponent({
   };
 
   return (
-    <div
+    <TerminalContextMenu terminalId={id} forceLocation={location}>
+      <div
       className={cn(
         "flex items-center justify-between px-3 h-8 shrink-0 font-mono text-xs transition-colors relative overflow-hidden",
         isFocused ? "bg-[var(--color-surface-highlight)]" : "bg-[var(--color-surface)]"
@@ -361,7 +363,8 @@ function TerminalHeaderComponent({
           <X className="w-3 h-3" aria-hidden="true" />
         </button>
       </div>
-    </div>
+      </div>
+    </TerminalContextMenu>
   );
 }
 

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,187 @@
+import * as React from "react";
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ContextMenu = ContextMenuPrimitive.Root;
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-canopy-border data-[state=open]:bg-canopy-border",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" aria-hidden="true" />
+  </ContextMenuPrimitive.SubTrigger>
+));
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-[100] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+      className
+    )}
+    {...props}
+  />
+));
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-[100] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+));
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+));
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" aria-hidden="true" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+));
+ContextMenuCheckboxItem.displayName = ContextMenuPrimitive.CheckboxItem.displayName;
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" aria-hidden="true" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+));
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold text-canopy-text/70", inset && "pl-8", className)}
+    {...props}
+  />
+));
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-canopy-border", className)}
+    {...props}
+  />
+));
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+
+const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn("ml-auto text-xs tracking-widest text-canopy-text/50", className)}
+      {...props}
+    />
+  );
+};
+ContextMenuShortcut.displayName = "ContextMenuShortcut";
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};


### PR DESCRIPTION
## Summary
Implements right-click context menus for both docked terminals and terminal grid headers using Radix UI components, providing quick access to common terminal operations.

Closes #583

## Changes Made
- Add @radix-ui/react-context-menu dependency
- Create context-menu.tsx UI component following ShadCN pattern
- Implement TerminalContextMenu logic component with store integration
- Wrap DockedTerminalItem button with context menu (coexists with Popover)
- Wrap TerminalHeader with context menu for grid terminals
- Support location-specific menu items (dock vs grid)
- Include keyboard shortcut hints (^⇧F for maximize, ^⇧I for inject context)
- Properly type TerminalLocation to prevent type erosion
- Menu items: minimize/restore, maximize, inject context, settings, close, force kill

## Testing
- Type checking passes
- Codex review completed and fixes applied
- No new lint errors introduced