### PR TITLE
Refactor OutputThrottler to use Uint8Array for reduced GC pressure

### DIFF
--- a/electron/ipc/handlers/terminal.ts
+++ b/electron/ipc/handlers/terminal.ts
@@ -15,7 +15,7 @@ export function registerTerminalHandlers(deps: HandlerDependencies): () => void 
   const { mainWindow, ptyManager, worktreeService } = deps;
   const handlers: Array<() => void> = [];
 
-  const handlePtyData = (id: string, data: string) => {
+  const handlePtyData = (id: string, data: string | Uint8Array) => {
     sendToRenderer(mainWindow, CHANNELS.TERMINAL_DATA, id, data);
   };
   ptyManager.on("data", handlePtyData);

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -72,8 +72,9 @@ export class PtyManager extends EventEmitter {
 
   /**
    * Emit terminal data with project-based filtering.
+   * Accepts both string and Uint8Array data for binary optimization.
    */
-  private emitData(id: string, data: string): void {
+  private emitData(id: string, data: string | Uint8Array): void {
     const terminalInfo = this.registry.get(id);
     if (!terminalInfo) {
       return;

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -59,7 +59,7 @@ function chunkInput(data: string): string[] {
 }
 
 export interface TerminalProcessCallbacks {
-  emitData: (id: string, data: string) => void;
+  emitData: (id: string, data: string | Uint8Array) => void;
   onExit: (id: string, exitCode: number) => void;
 }
 
@@ -660,7 +660,7 @@ export class TerminalProcess {
     });
   }
 
-  private emitData(data: string): void {
+  private emitData(data: string | Uint8Array): void {
     this.callbacks.emitData(this.id, data);
   }
 

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1480,7 +1480,7 @@ export interface ElectronAPI {
     getSerializedState(terminalId: string): Promise<string | null>;
     getSharedBuffer(): Promise<SharedArrayBuffer | null>;
     getAnalysisBuffer(): Promise<SharedArrayBuffer | null>;
-    onData(id: string, callback: (data: string) => void): () => void;
+    onData(id: string, callback: (data: string | Uint8Array) => void): () => void;
     onExit(callback: (id: string, exitCode: number) => void): () => void;
     onAgentStateChanged(callback: (data: AgentStateChangePayload) => void): () => void;
     onAgentDetected(callback: (data: AgentDetectedPayload) => void): () => void;

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -31,7 +31,7 @@ export const terminalClient = {
     return window.electron.terminal.restore(id);
   },
 
-  onData: (id: string, callback: (data: string) => void): (() => void) => {
+  onData: (id: string, callback: (data: string | Uint8Array) => void): (() => void) => {
     return window.electron.terminal.onData(id, callback);
   },
 

--- a/src/components/Layout/TerminalDock.tsx
+++ b/src/components/Layout/TerminalDock.tsx
@@ -162,7 +162,9 @@ export function TerminalDock() {
           >
             <Icon
               className="w-4 h-4"
-              style={type !== "shell" ? { color: getBrandColorHex(type as TerminalType) } : undefined}
+              style={
+                type !== "shell" ? { color: getBrandColorHex(type as TerminalType) } : undefined
+              }
             />
             <span>New {label}</span>
           </ContextMenuItem>

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -11,7 +11,17 @@ import {
   ContextMenuSubContent,
   ContextMenuCheckboxItem,
 } from "@/components/ui/context-menu";
-import { Maximize2, Minimize2, Trash2, ArrowUp, ArrowDownToLine, Copy, Settings2, Skull, RotateCcw } from "lucide-react";
+import {
+  Maximize2,
+  Minimize2,
+  Trash2,
+  ArrowUp,
+  ArrowDownToLine,
+  Copy,
+  Settings2,
+  Skull,
+  RotateCcw,
+} from "lucide-react";
 import { useTerminalStore } from "@/store";
 import { useContextInjection } from "@/hooks/useContextInjection";
 import type { TerminalLocation } from "@/types";


### PR DESCRIPTION
## Summary
Refactors the OutputThrottler and renderer-side terminal writer to use Uint8Array buffers instead of string concatenation, significantly reducing garbage collection pressure during high-throughput terminal output.

Closes #599

## Changes Made
- Replaced string concatenation with Uint8Array buffers in OutputThrottler (main process)
- Implemented efficient Buffer.concat() for Node.js environment with browser fallback
- Updated renderer-side throttled writer to handle binary chunks without concatenation
- Added TextEncoder for string-to-binary conversion (allocated once, reused)
- Fixed timer rescheduling to immediately flush when hard queue limit is reached
- Fixed false alarm logging when single chunk exceeds limit with no existing backlog
- Added Buffer.isBuffer() check in IPC preload for Node.js Buffer compatibility
- Updated type signatures throughout the data path (main, IPC, renderer) to support `string | Uint8Array`
- Fixed debug info calculation to use actual byte length for strings (UTF-8)

## Performance Impact
- Eliminates string concatenation GC pressure in both main and renderer processes
- Uses optimized C++ Buffer.concat() in Node.js (main process)
- Reduces memory allocations during burst output scenarios
- Maintains xterm.js compatibility (accepts both string and Uint8Array)

## Testing
- TypeScript compilation passes
- ESLint passes (no new warnings)
- Prettier formatting applied
- Code review completed via Codex MCP