### PR TITLE
Fix padding for docked terminals

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -253,7 +253,7 @@ function TerminalPaneComponent({
           terminalType={type}
           onReady={handleReady}
           onExit={handleExit}
-          className="absolute inset-2"
+          className={cn("absolute", location === "dock" ? "inset-0" : "inset-2")}
           getRefreshTier={getRefreshTierCallback}
         />
         <ArtifactOverlay terminalId={id} worktreeId={worktreeId} cwd={cwd} />

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -315,9 +315,8 @@ function XtermAdapterComponent({
     <div
       ref={containerRef}
       className={cn(
-        // pl-2 pt-2 pb-2 provides 8px padding that FitAddon can measure correctly
-        // (previously was on .xterm-screen in CSS which caused measurement mismatches)
-        "w-full h-full bg-[#18181b] text-white overflow-hidden rounded-b-lg pl-2 pt-2 pb-2",
+        // pl-2 pt-2 pb-4: left/top padding for FitAddon measurement; pb-4 prevents text from touching bottom edge
+        "w-full h-full bg-[#18181b] text-white overflow-hidden rounded-b-lg pl-2 pt-2 pb-4",
         className
       )}
       style={{


### PR DESCRIPTION
## Summary
This PR improves terminal padding by removing excessive outer margin for docked terminals and increasing bottom padding to prevent text from touching the terminal's bottom edge.

Closes #615

## Changes Made
- Remove outer margin (inset-0) for docked terminals to maximize usable space in popovers
- Increase bottom padding from pb-2 (8px) to pb-4 (16px) to prevent text with descenders from touching bottom edge
- Maintain existing inset-2 margin for grid terminals
- Update inline comment to reflect new padding purpose

## Testing
- Verified TypeScript type checking passes
- Verified all linting and formatting checks pass
- Changes are purely CSS/styling - no logic modifications