### PR TITLE
Fix toolbar dropdowns rendering behind Sidecar in push mode

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -52,11 +52,11 @@ export function Toolbar({
 
   const sidecarOpen = useSidecarStore((state) => state.isOpen);
   const sidecarWidth = useSidecarStore((state) => state.width);
-  const layoutMode = useSidecarStore((state) => state.layoutMode);
   const toggleSidecar = useSidecarStore((state) => state.toggle);
 
-  // Collision padding for dropdowns - only apply in overlay mode where sidecar occludes content
-  const rightCollisionPadding = sidecarOpen && layoutMode === "overlay" ? sidecarWidth + 20 : 10;
+  // Sidecar uses a native WebContentsView, which sits above all DOM elements.
+  // Apply collision padding whenever sidecar is open, regardless of layout mode.
+  const rightCollisionPadding = sidecarOpen ? sidecarWidth + 20 : 10;
 
   const [issuesOpen, setIssuesOpen] = useState(false);
   const [prsOpen, setPrsOpen] = useState(false);


### PR DESCRIPTION
## Summary
Fixes toolbar dropdown positioning when the Sidecar is open. Dropdowns now shift left to remain visible in both overlay and push layout modes.

Closes #611

## Changes Made
- Remove layoutMode condition from collision padding calculation
- Apply padding whenever sidecar is open, not just in overlay mode
- Update comment to explain WebContentsView z-index behavior

## Technical Details
The Sidecar uses an Electron `WebContentsView`, which is a native window layer that sits above all DOM elements regardless of CSS z-index. The previous implementation only applied collision detection in overlay mode, but the issue occurs in push mode as well because the Toolbar is full-width and dropdowns extend downward into the Sidecar's native view space.

This fix ensures Radix UI's collision detection system accounts for the Sidecar width whenever it's open, forcing dropdowns to position left of the native view boundary.