### PR TITLE
Close all chat tabs when sidecar close button is pressed

### DIFF
--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -15,6 +15,7 @@ export function SidecarDock() {
     setOpen,
     createBlankTab,
     closeTab,
+    closeAllTabs,
     markTabCreated,
     updateTabUrl,
     updateTabTitle,
@@ -207,9 +208,10 @@ export function SidecarDock() {
   );
 
   const handleClose = useCallback(async () => {
+    closeAllTabs();
     await window.electron.sidecar.hide();
     setOpen(false);
-  }, [setOpen]);
+  }, [closeAllTabs, setOpen]);
 
   const handleGoBack = useCallback(async () => {
     if (activeTabId) {

--- a/src/store/sidecarStore.ts
+++ b/src/store/sidecarStore.ts
@@ -29,6 +29,7 @@ interface SidecarActions {
   createTab: (url: string, title: string) => string;
   createBlankTab: () => string;
   closeTab: (id: string) => void;
+  closeAllTabs: () => void;
   updateTabTitle: (id: string, title: string) => void;
   updateTabUrl: (id: string, url: string) => void;
   updateLayoutMode: (windowWidth: number, sidebarWidth: number) => void;
@@ -153,6 +154,14 @@ const createSidecarStore: StateCreator<SidecarState & SidecarActions> = (set, ge
     } else {
       window.electron.sidecar.hide();
     }
+  },
+
+  closeAllTabs: () => {
+    const state = get();
+    for (const tab of state.tabs) {
+      window.electron.sidecar.closeTab({ tabId: tab.id });
+    }
+    set({ tabs: [], activeTabId: null, createdTabs: new Set<string>() });
   },
 
   updateTabTitle: (id, title) =>


### PR DESCRIPTION
## Summary
When clicking the close button (X) in the sidecar, all chat tabs are now properly closed and cleaned up before the sidecar is hidden. When the sidecar is reopened, it shows the empty launchpad state.

Closes #616

## Changes Made
- Add closeAllTabs action to sidecarStore that iterates through all tabs
- Call IPC closeTab for each tab to properly clean up webviews in the main process
- Reset tabs array, activeTabId, and createdTabs set to empty state
- Update handleClose callback to call closeAllTabs before hiding the sidecar