### PR TITLE
Redesign sidebar with flat list layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -245,15 +245,16 @@ function SidebarContent() {
     worktrees.length > 0 && worktrees[0].path ? worktrees[0].path.split("/.git/")[0] : "";
 
   return (
-    <div className="p-4">
-      <div className="flex items-center justify-between mb-4">
+    <div className="flex flex-col h-full">
+      {/* Header Section */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 bg-[#18181b] shrink-0">
         <div className="flex items-center gap-2">
-          <h2 className="text-canopy-text font-semibold text-sm">Worktrees</h2>
+          <h2 className="text-gray-200 font-semibold text-sm tracking-wide">Worktrees</h2>
           <button
             onClick={handleRefresh}
             className={cn(
-              "p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-white/5 rounded transition-colors",
-              isRefreshing && "animate-spin text-canopy-text"
+              "p-1.5 text-gray-500 hover:text-gray-300 hover:bg-white/5 rounded-md transition-all",
+              isRefreshing && "animate-spin text-gray-300"
             )}
             title="Refresh worktrees"
             disabled={isRefreshing}
@@ -263,28 +264,32 @@ function SidebarContent() {
         </div>
         <button
           onClick={() => setIsNewWorktreeDialogOpen(true)}
-          className="text-xs px-2 py-1 bg-canopy-accent/10 hover:bg-canopy-accent/20 text-canopy-accent rounded transition-colors"
+          className="flex items-center gap-1.5 text-xs font-medium px-3 py-1.5 bg-[#10b981] hover:bg-[#059669] text-white rounded-md transition-colors shadow-sm"
           title="Create new worktree"
         >
-          + New
+          <span className="text-[10px]">+</span> New
         </button>
       </div>
-      <div className="space-y-2">
-        {worktrees.map((worktree) => (
-          <WorktreeCard
-            key={worktree.id}
-            worktree={worktree}
-            isActive={worktree.id === activeWorktreeId}
-            isFocused={worktree.id === focusedWorktreeId}
-            onSelect={() => selectWorktree(worktree.id)}
-            onCopyTree={() => handleCopyTree(worktree)}
-            onOpenEditor={() => handleOpenEditor(worktree)}
-            onToggleServer={() => handleToggleServer(worktree)}
-            onCreateRecipe={() => handleCreateRecipe(worktree.id)}
-            homeDir={homeDir}
-            devServerSettings={projectSettings?.devServer}
-          />
-        ))}
+
+      {/* List Section - Flat list with borders */}
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex flex-col">
+          {worktrees.map((worktree) => (
+            <WorktreeCard
+              key={worktree.id}
+              worktree={worktree}
+              isActive={worktree.id === activeWorktreeId}
+              isFocused={worktree.id === focusedWorktreeId}
+              onSelect={() => selectWorktree(worktree.id)}
+              onCopyTree={() => handleCopyTree(worktree)}
+              onOpenEditor={() => handleOpenEditor(worktree)}
+              onToggleServer={() => handleToggleServer(worktree)}
+              onCreateRecipe={() => handleCreateRecipe(worktree.id)}
+              homeDir={homeDir}
+              devServerSettings={projectSettings?.devServer}
+            />
+          ))}
+        </div>
       </div>
 
       <RecipeEditor

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -282,11 +282,9 @@ export function WorktreeCard({
   return (
     <div
       className={cn(
-        "group relative overflow-hidden rounded-xl bg-card/30 border border-border/60 p-4 mb-3 cursor-pointer transition-all duration-200",
-        isActive
-          ? "border-canopy-accent/50 bg-canopy-accent/3"
-          : "hover:border-canopy-accent/60 hover:bg-card/60",
-        isFocused && "ring-1 ring-canopy-accent"
+        "group relative border-b border-white/5 transition-colors duration-200",
+        isActive ? "bg-white/[0.04]" : "hover:bg-white/[0.02] bg-transparent",
+        isFocused && "ring-1 ring-inset ring-[#10b981]/50"
       )}
       onClick={onSelect}
       onKeyDown={(e) => {
@@ -299,272 +297,289 @@ export function WorktreeCard({
       role="button"
       aria-label={`Worktree: ${branchLabel}`}
     >
-      <div className="flex flex-col gap-1">
-        {/* Header Row: Expand, Activity, Agent Status, Branch, Menu */}
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex flex-col min-w-0 flex-1">
-            <div className="flex items-center gap-2 text-xs font-mono leading-none">
-              {hasExpandableContent && (
+      <div className="px-4 py-3">
+        <div className="flex flex-col gap-1">
+          {/* Header Row: Expand, Activity, Agent Status, Branch, Menu */}
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-start gap-2 min-w-0 flex-1">
+              {/* Left-aligned Expand Chevron */}
+              {hasExpandableContent ? (
                 <button
                   onClick={handleToggleExpand}
-                  className="p-0.5 -ml-0.5 rounded hover:bg-white/10 text-gray-400 hover:text-gray-200 transition-colors"
+                  className="mt-0.5 p-0.5 text-gray-500 hover:text-gray-300 transition-colors"
                   aria-label={isExpanded ? "Collapse details" : "Expand details"}
                   aria-expanded={isExpanded}
                   aria-controls={detailsId}
                 >
                   {isExpanded ? (
-                    <ChevronDown className="w-3 h-3" />
+                    <ChevronDown className="w-4 h-4" />
                   ) : (
-                    <ChevronRight className="w-3 h-3" />
+                    <ChevronRight className="w-4 h-4" />
                   )}
                 </button>
+              ) : (
+                <div className="w-5" />
               )}
-              <ActivityLight lastActivityTimestamp={worktree.lastActivityTimestamp} />
-              <AgentStatusIndicator state={dominantAgentState} />
-              <span className="truncate font-semibold text-gray-200">{branchLabel}</span>
-              {!worktree.branch && (
-                <span className="text-[var(--color-status-warning)] text-[0.65rem]">
-                  (detached)
-                </span>
-              )}
+
+              <div className="flex flex-col min-w-0">
+                <div className="flex items-center gap-2 text-xs font-mono leading-none">
+                  <ActivityLight lastActivityTimestamp={worktree.lastActivityTimestamp} />
+                  <AgentStatusIndicator state={dominantAgentState} />
+                  <span
+                    className={cn(
+                      "truncate font-semibold text-[13px]",
+                      isActive ? "text-white" : "text-gray-300"
+                    )}
+                  >
+                    {branchLabel}
+                  </span>
+                  {!worktree.branch && (
+                    <span className="text-amber-500 text-[10px]">(detached)</span>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCopyTree();
+                }}
+                className="p-1.5 text-gray-500 hover:text-gray-200 transition-colors"
+                title="Copy Context"
+                aria-label="Copy Context"
+              >
+                <Copy className="w-3.5 h-3.5" />
+              </button>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    onClick={(e) => e.stopPropagation()}
+                    className="p-1.5 text-gray-500 hover:text-gray-200"
+                    aria-label="More actions"
+                  >
+                    <MoreHorizontal className="w-3.5 h-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  sideOffset={4}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <DropdownMenuItem onClick={() => onCopyTree()}>
+                    <Copy className="w-3 h-3 mr-2" />
+                    Copy Context
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => onOpenEditor()}>
+                    <Code className="w-3 h-3 mr-2" />
+                    Open in Editor
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => handlePathClick()}>
+                    <Folder className="w-3 h-3 mr-2" />
+                    Reveal in Finder
+                  </DropdownMenuItem>
+
+                  {(worktree.issueNumber || worktree.prNumber) && <DropdownMenuSeparator />}
+
+                  {worktree.issueNumber && onOpenIssue && (
+                    <DropdownMenuItem onClick={() => handleOpenIssue()}>
+                      <CircleDot className="w-3 h-3 mr-2" />
+                      Open Issue #{worktree.issueNumber}
+                    </DropdownMenuItem>
+                  )}
+                  {worktree.prNumber && onOpenPR && (
+                    <DropdownMenuItem onClick={() => handleOpenPR()}>
+                      <GitPullRequest className="w-3 h-3 mr-2" />
+                      Open PR #{worktree.prNumber}
+                    </DropdownMenuItem>
+                  )}
+
+                  {(recipes.length > 0 || onCreateRecipe) && <DropdownMenuSeparator />}
+
+                  {recipes.length > 0 && (
+                    <>
+                      <DropdownMenuLabel>Recipes</DropdownMenuLabel>
+                      {recipes.map((recipe) => (
+                        <DropdownMenuItem
+                          key={recipe.id}
+                          onClick={() => handleRunRecipe(recipe.id)}
+                          disabled={runningRecipeId !== null}
+                        >
+                          <Play className="w-3 h-3 mr-2" />
+                          {recipe.name}
+                        </DropdownMenuItem>
+                      ))}
+                    </>
+                  )}
+                  {onCreateRecipe && (
+                    <DropdownMenuItem onClick={onCreateRecipe}>
+                      <Plus className="w-3 h-3 mr-2" />
+                      Create Recipe...
+                    </DropdownMenuItem>
+                  )}
+
+                  {totalTerminalCount > 0 && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuLabel>Sessions</DropdownMenuLabel>
+                      <DropdownMenuItem
+                        onClick={handleCloseCompleted}
+                        disabled={completedCount === 0}
+                      >
+                        Close Completed ({completedCount})
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={handleCloseFailed} disabled={failedCount === 0}>
+                        Close Failed ({failedCount})
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={handleCloseAllTerminals}
+                        className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
+                      >
+                        Close All...
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
 
-          <div className="flex items-center gap-0.5 -mt-0.5">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onCopyTree();
-              }}
-              className="p-1.5 rounded hover:bg-white/10 text-gray-400 hover:text-canopy-accent transition-colors mr-1"
-              title="Copy Context"
-              aria-label="Copy Context"
-            >
-              <Copy className="w-3.5 h-3.5" />
-            </button>
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
+          {/* PR/Issue Badges Row - Dedicated second row */}
+          {(worktree.prNumber || worktree.issueNumber) && (
+            <div className="flex items-center gap-2 mt-1 ml-7">
+              {worktree.prNumber && (
                 <button
-                  onClick={(e) => e.stopPropagation()}
-                  className="p-1.5 rounded hover:bg-white/10 text-gray-400 hover:text-canopy-accent"
-                  aria-label="More actions"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpenPR?.();
+                  }}
+                  className={cn(
+                    "flex items-center gap-1.5 text-xs text-[var(--color-status-success)]",
+                    "bg-green-500/10 px-2 py-0.5 rounded border border-green-500/20",
+                    "hover:bg-green-500/20 transition-colors cursor-pointer"
+                  )}
+                  title="Open Pull Request on GitHub"
                 >
-                  <MoreHorizontal className="w-3.5 h-3.5" />
+                  <GitPullRequest className="w-3 h-3" />
+                  <span className="font-mono">#{worktree.prNumber}</span>
                 </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" sideOffset={4} onClick={(e) => e.stopPropagation()}>
-                <DropdownMenuItem onClick={() => onCopyTree()}>
-                  <Copy className="w-3 h-3 mr-2" />
-                  Copy Context
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onOpenEditor()}>
-                  <Code className="w-3 h-3 mr-2" />
-                  Open in Editor
-                </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => handlePathClick()}>
-                  <Folder className="w-3 h-3 mr-2" />
-                  Reveal in Finder
-                </DropdownMenuItem>
-
-                {(worktree.issueNumber || worktree.prNumber) && <DropdownMenuSeparator />}
-
-                {worktree.issueNumber && onOpenIssue && (
-                  <DropdownMenuItem onClick={() => handleOpenIssue()}>
-                    <CircleDot className="w-3 h-3 mr-2" />
-                    Open Issue #{worktree.issueNumber}
-                  </DropdownMenuItem>
-                )}
-                {worktree.prNumber && onOpenPR && (
-                  <DropdownMenuItem onClick={() => handleOpenPR()}>
-                    <GitPullRequest className="w-3 h-3 mr-2" />
-                    Open PR #{worktree.prNumber}
-                  </DropdownMenuItem>
-                )}
-
-                {(recipes.length > 0 || onCreateRecipe) && <DropdownMenuSeparator />}
-
-                {recipes.length > 0 && (
-                  <>
-                    <DropdownMenuLabel>Recipes</DropdownMenuLabel>
-                    {recipes.map((recipe) => (
-                      <DropdownMenuItem
-                        key={recipe.id}
-                        onClick={() => handleRunRecipe(recipe.id)}
-                        disabled={runningRecipeId !== null}
-                      >
-                        <Play className="w-3 h-3 mr-2" />
-                        {recipe.name}
-                      </DropdownMenuItem>
-                    ))}
-                  </>
-                )}
-                {onCreateRecipe && (
-                  <DropdownMenuItem onClick={onCreateRecipe}>
-                    <Plus className="w-3 h-3 mr-2" />
-                    Create Recipe...
-                  </DropdownMenuItem>
-                )}
-
-                {totalTerminalCount > 0 && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuLabel>Sessions</DropdownMenuLabel>
-                    <DropdownMenuItem
-                      onClick={handleCloseCompleted}
-                      disabled={completedCount === 0}
-                    >
-                      Close Completed ({completedCount})
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={handleCloseFailed} disabled={failedCount === 0}>
-                      Close Failed ({failedCount})
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={handleCloseAllTerminals}
-                      className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
-                    >
-                      Close All...
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-
-        {/* PR/Issue Badges Row - Dedicated second row */}
-        {(worktree.prNumber || worktree.issueNumber) && (
-          <div className="flex items-center gap-2 mt-2">
-            {worktree.prNumber && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenPR?.();
-                }}
-                className={cn(
-                  "flex items-center gap-1.5 text-xs text-[var(--color-status-success)]",
-                  "bg-green-500/10 px-2 py-0.5 rounded border border-green-500/20",
-                  "hover:bg-green-500/20 transition-colors cursor-pointer"
-                )}
-                title="Open Pull Request on GitHub"
-              >
-                <GitPullRequest className="w-3 h-3" />
-                <span className="font-mono">#{worktree.prNumber}</span>
-              </button>
-            )}
-            {worktree.issueNumber && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onOpenIssue?.();
-                }}
-                className={cn(
-                  "flex items-center gap-1.5 text-xs text-[var(--color-status-info)]",
-                  "bg-blue-500/10 px-2 py-0.5 rounded border border-blue-500/20",
-                  "hover:bg-blue-500/20 transition-colors cursor-pointer"
-                )}
-                title="Open Issue on GitHub"
-              >
-                <CircleDot className="w-3 h-3" />
-                <span className="font-mono">#{worktree.issueNumber}</span>
-              </button>
-            )}
-          </div>
-        )}
-
-        {/* File Changes Preview - Only show if we have changes OR if expanded */}
-        {worktree.worktreeChanges && (hasChanges || isExpanded) && (
-          <div className="mt-2">
-            {hasChanges ? (
-              <FileChangeList
-                changes={worktree.worktreeChanges.changes}
-                rootPath={worktree.worktreeChanges.rootPath}
-                maxVisible={isExpanded ? 8 : 2}
-              />
-            ) : (
-              <div className="text-xs text-gray-500 italic">No file changes</div>
-            )}
-          </div>
-        )}
-
-        {/* Footer Row: Stats - Only render when there's content to show */}
-        {showFooter && (
-          <div className="flex items-center gap-4 mt-2 text-xs text-gray-400 font-mono">
-            {terminalCounts.total > 0 && (
-              <div className="flex items-center gap-1">
-                <Terminal className="w-2.5 h-2.5" />
-                <span>{terminalCounts.total}</span>
-                {terminalCounts.byState.working > 0 && (
-                  <div className="w-1 h-1 rounded-full bg-[var(--color-status-success)] animate-pulse" />
-                )}
-              </div>
-            )}
-
-            {hasChanges && worktree.worktreeChanges && (
-              <div className="flex items-center gap-1">
-                <GitCommitHorizontal className="w-2.5 h-2.5" />
-                <span className="text-[var(--color-status-success)]">
-                  +{worktree.worktreeChanges.insertions ?? 0}
-                </span>
-                <span className="text-gray-600">/</span>
-                <span className="text-[var(--color-status-error)]">
-                  -{worktree.worktreeChanges.deletions ?? 0}
-                </span>
-              </div>
-            )}
-
-            {showDevServer && serverState && serverState.status !== "stopped" && (
-              <div className="flex items-center gap-1">
-                <Globe className="w-2.5 h-2.5" />
-                {getServerStatusIndicator()}
-              </div>
-            )}
-
-            {worktreeErrors.length > 0 && (
-              <div className="flex items-center gap-1 text-[var(--color-status-error)]">
-                <AlertCircle className="w-2.5 h-2.5" />
-                <span>{worktreeErrors.length}</span>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Expanded Details Section */}
-        <div
-          id={detailsId}
-          aria-hidden={!isExpanded}
-          inert={!isExpanded}
-          className={cn(
-            "overflow-hidden transition-[max-height,opacity] duration-300 ease-out",
-            isExpanded ? "max-h-[800px] opacity-100" : "max-h-0 opacity-0"
+              )}
+              {worktree.issueNumber && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpenIssue?.();
+                  }}
+                  className={cn(
+                    "flex items-center gap-1.5 text-xs text-[var(--color-status-info)]",
+                    "bg-blue-500/10 px-2 py-0.5 rounded border border-blue-500/20",
+                    "hover:bg-blue-500/20 transition-colors cursor-pointer"
+                  )}
+                  title="Open Issue on GitHub"
+                >
+                  <CircleDot className="w-3 h-3" />
+                  <span className="font-mono">#{worktree.issueNumber}</span>
+                </button>
+              )}
+            </div>
           )}
-        >
-          <WorktreeDetails
-            worktree={worktree}
-            homeDir={homeDir}
-            effectiveNote={effectiveNote}
-            showDevServer={showDevServer}
-            serverState={serverState}
-            serverLoading={serverLoading}
-            worktreeErrors={worktreeErrors}
-            hasChanges={hasChanges}
-            showFooter={showFooter}
-            isFocused={isFocused}
-            onPathClick={handlePathClick}
-            onToggleServer={onToggleServer}
-            onDismissError={dismissError}
-            onRetryError={handleErrorRetry}
-            renderSummary={renderSummary}
+
+          {/* File Changes Preview - Only show if we have changes OR if expanded */}
+          {worktree.worktreeChanges && (hasChanges || isExpanded) && (
+            <div className="mt-2 ml-7">
+              {hasChanges ? (
+                <FileChangeList
+                  changes={worktree.worktreeChanges.changes}
+                  rootPath={worktree.worktreeChanges.rootPath}
+                  maxVisible={isExpanded ? 8 : 2}
+                />
+              ) : (
+                <div className="text-xs text-gray-500 italic">No file changes</div>
+              )}
+            </div>
+          )}
+
+          {/* Footer Row: Stats - Only render when there's content to show */}
+          {showFooter && (
+            <div className="flex items-center gap-4 mt-2 ml-7 text-xs text-gray-400 font-mono">
+              {terminalCounts.total > 0 && (
+                <div className="flex items-center gap-1">
+                  <Terminal className="w-2.5 h-2.5" />
+                  <span>{terminalCounts.total}</span>
+                  {terminalCounts.byState.working > 0 && (
+                    <div className="w-1 h-1 rounded-full bg-[var(--color-status-success)] animate-pulse" />
+                  )}
+                </div>
+              )}
+
+              {hasChanges && worktree.worktreeChanges && (
+                <div className="flex items-center gap-1">
+                  <GitCommitHorizontal className="w-2.5 h-2.5" />
+                  <span className="text-[var(--color-status-success)]">
+                    +{worktree.worktreeChanges.insertions ?? 0}
+                  </span>
+                  <span className="text-gray-600">/</span>
+                  <span className="text-[var(--color-status-error)]">
+                    -{worktree.worktreeChanges.deletions ?? 0}
+                  </span>
+                </div>
+              )}
+
+              {showDevServer && serverState && serverState.status !== "stopped" && (
+                <div className="flex items-center gap-1">
+                  <Globe className="w-2.5 h-2.5" />
+                  {getServerStatusIndicator()}
+                </div>
+              )}
+
+              {worktreeErrors.length > 0 && (
+                <div className="flex items-center gap-1 text-[var(--color-status-error)]">
+                  <AlertCircle className="w-2.5 h-2.5" />
+                  <span>{worktreeErrors.length}</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Expanded Details Section */}
+          <div
+            id={detailsId}
+            aria-hidden={!isExpanded}
+            inert={!isExpanded}
+            className={cn(
+              "overflow-hidden transition-[max-height,opacity] duration-300 ease-out ml-7",
+              isExpanded ? "max-h-[800px] opacity-100" : "max-h-0 opacity-0"
+            )}
+          >
+            <WorktreeDetails
+              worktree={worktree}
+              homeDir={homeDir}
+              effectiveNote={effectiveNote}
+              showDevServer={showDevServer}
+              serverState={serverState}
+              serverLoading={serverLoading}
+              worktreeErrors={worktreeErrors}
+              hasChanges={hasChanges}
+              showFooter={showFooter}
+              isFocused={isFocused}
+              onPathClick={handlePathClick}
+              onToggleServer={onToggleServer}
+              onDismissError={dismissError}
+              onRetryError={handleErrorRetry}
+              renderSummary={renderSummary}
+            />
+          </div>
+
+          <ConfirmDialog
+            isOpen={confirmDialog.isOpen}
+            title={confirmDialog.title}
+            description={confirmDialog.description}
+            onConfirm={confirmDialog.onConfirm}
+            onCancel={closeConfirmDialog}
           />
         </div>
-
-        <ConfirmDialog
-          isOpen={confirmDialog.isOpen}
-          title={confirmDialog.title}
-          description={confirmDialog.description}
-          onConfirm={confirmDialog.onConfirm}
-          onCancel={closeConfirmDialog}
-        />
       </div>
     </div>
   );

--- a/src/components/Worktree/WorktreeList.tsx
+++ b/src/components/Worktree/WorktreeList.tsx
@@ -214,7 +214,7 @@ export function WorktreeList({
     return (
       <div className="relative h-full">
         <div
-          className="flex flex-col gap-2 p-2 h-full overflow-y-auto"
+          className="flex flex-col h-full overflow-y-auto"
           tabIndex={0}
           role="list"
           aria-label="Worktree list"
@@ -308,7 +308,7 @@ export function WorktreeList({
       <div
         ref={listRef}
         onScroll={handleScroll}
-        className="flex flex-col gap-1 p-1 h-full overflow-y-auto"
+        className="flex flex-col h-full overflow-y-auto"
         tabIndex={0}
         role="list"
         aria-label="Worktree list"


### PR DESCRIPTION
## Summary
Redesigns the worktree sidebar from a card-based layout to a flat list design, creating a cleaner interface that emphasizes content over UI chrome. This implementation follows the detailed specifications in issue #622.

Closes #622

## Changes Made
- Updated App.tsx sidebar header with dark background (#18181b) and solid green "New" button
- Flattened WorktreeCard from rounded card to flat list item with subtle bottom borders
- Moved expansion chevron to left side following tree UI conventions
- Restyled FileChangeList with monospace font and single-letter colored status indicators (M/A/D/R)
- Removed gap and padding from WorktreeList container for seamless flat appearance
- Updated all hover states (subtle white/[0.02]) and active states (white/[0.04])
- Added left-margin indentation (ml-7) for tree structure hierarchy
- Updated focus rings to use green accent color (#10b981/50)

## Visual Changes
- Header: Dark background with prominent green "New" button
- Items: No cards - each worktree is a bordered row with full-width hover
- Hierarchy: Left-aligned chevron with indented file lists (tree structure)
- Files: Clean monospace display with color-coded status letters and +/- stats