### PR TITLE
Add customizable keyboard shortcuts

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -151,6 +151,11 @@ export const CHANNELS = {
   SYSTEM_SLEEP_GET_AWAKE_TIME: "system-sleep:get-awake-time",
   SYSTEM_SLEEP_RESET: "system-sleep:reset",
   SYSTEM_SLEEP_ON_WAKE: "system-sleep:on-wake",
+
+  KEYBINDING_GET_OVERRIDES: "keybinding:get-overrides",
+  KEYBINDING_SET_OVERRIDE: "keybinding:set-override",
+  KEYBINDING_REMOVE_OVERRIDE: "keybinding:remove-override",
+  KEYBINDING_RESET_ALL: "keybinding:reset-all",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -16,6 +16,7 @@ import { registerAppHandlers } from "./handlers/app.js";
 import { registerSidecarHandlers } from "./handlers/sidecar.js";
 import { registerHibernationHandlers } from "./handlers/hibernation.js";
 import { registerSystemSleepHandlers } from "./handlers/systemSleep.js";
+import { registerKeybindingHandlers } from "./handlers/keybinding.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
 export { typedHandle, typedSend, sendToRenderer };
@@ -51,6 +52,7 @@ export function registerIpcHandlers(
     registerSidecarHandlers(deps),
     registerHibernationHandlers(deps),
     registerSystemSleepHandlers(deps),
+    registerKeybindingHandlers(deps),
   ];
 
   return () => {

--- a/electron/ipc/handlers/keybinding.ts
+++ b/electron/ipc/handlers/keybinding.ts
@@ -1,0 +1,78 @@
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import { store } from "../../store.js";
+import type { HandlerDependencies } from "../types.js";
+import type { KeyAction } from "../../../shared/types/keymap.js";
+
+function getValidatedOverrides(): Record<string, string[]> {
+  const raw = store.get("keybindingOverrides.overrides");
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const validated: Record<string, string[]> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (Array.isArray(value) && value.every((c) => typeof c === "string" && c.trim() !== "")) {
+      validated[key] = value;
+    }
+  }
+  return validated;
+}
+
+export function registerKeybindingHandlers(_deps: HandlerDependencies): () => void {
+  const handlers: Array<() => void> = [];
+
+  const handleGetOverrides = async () => {
+    return getValidatedOverrides();
+  };
+  ipcMain.handle(CHANNELS.KEYBINDING_GET_OVERRIDES, handleGetOverrides);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_GET_OVERRIDES));
+
+  const handleSetOverride = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: { actionId: KeyAction; combo: string[] }
+  ) => {
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid keybinding override payload");
+    }
+
+    const { actionId, combo } = payload;
+
+    if (typeof actionId !== "string" || actionId.trim() === "") {
+      throw new Error("Invalid actionId: must be non-empty string");
+    }
+
+    if (!Array.isArray(combo)) {
+      throw new Error("Invalid combo: must be an array");
+    }
+
+    if (combo.length > 0 && combo.some((c) => typeof c !== "string" || c.trim() === "")) {
+      throw new Error("Invalid combo: array contains non-string or empty values");
+    }
+
+    const overrides = getValidatedOverrides();
+    overrides[actionId] = combo;
+    store.set("keybindingOverrides.overrides", overrides);
+  };
+  ipcMain.handle(CHANNELS.KEYBINDING_SET_OVERRIDE, handleSetOverride);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_SET_OVERRIDE));
+
+  const handleRemoveOverride = async (_event: Electron.IpcMainInvokeEvent, actionId: KeyAction) => {
+    if (typeof actionId !== "string" || actionId.trim() === "") {
+      throw new Error("Invalid actionId for remove");
+    }
+
+    const overrides = getValidatedOverrides();
+    delete overrides[actionId];
+    store.set("keybindingOverrides.overrides", overrides);
+  };
+  ipcMain.handle(CHANNELS.KEYBINDING_REMOVE_OVERRIDE, handleRemoveOverride);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_REMOVE_OVERRIDE));
+
+  const handleResetAll = async () => {
+    store.set("keybindingOverrides.overrides", {});
+  };
+  ipcMain.handle(CHANNELS.KEYBINDING_RESET_ALL, handleResetAll);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_RESET_ALL));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -241,6 +241,12 @@ const CHANNELS = {
   SYSTEM_SLEEP_GET_AWAKE_TIME: "system-sleep:get-awake-time",
   SYSTEM_SLEEP_RESET: "system-sleep:reset",
   SYSTEM_SLEEP_ON_WAKE: "system-sleep:on-wake",
+
+  // Keybinding channels
+  KEYBINDING_GET_OVERRIDES: "keybinding:get-overrides",
+  KEYBINDING_SET_OVERRIDE: "keybinding:set-override",
+  KEYBINDING_REMOVE_OVERRIDE: "keybinding:remove-override",
+  KEYBINDING_RESET_ALL: "keybinding:reset-all",
 } as const;
 
 const api: ElectronAPI = {
@@ -683,6 +689,19 @@ const api: ElectronAPI = {
 
     onWake: (callback: (sleepDurationMs: number) => void) =>
       _typedOn(CHANNELS.SYSTEM_SLEEP_ON_WAKE, callback),
+  },
+
+  // Keybinding API
+  keybinding: {
+    getOverrides: () => _typedInvoke(CHANNELS.KEYBINDING_GET_OVERRIDES),
+
+    setOverride: (actionId: string, combo: string[]) =>
+      _typedInvoke(CHANNELS.KEYBINDING_SET_OVERRIDE, { actionId, combo }),
+
+    removeOverride: (actionId: string) =>
+      _typedInvoke(CHANNELS.KEYBINDING_REMOVE_OVERRIDE, actionId),
+
+    resetAll: () => _typedInvoke(CHANNELS.KEYBINDING_RESET_ALL),
   },
 };
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -71,6 +71,9 @@ export interface StoreSchema {
     githubToken?: string;
   };
   agentSettings: AgentSettings;
+  keybindingOverrides: {
+    overrides: Record<string, string[]>;
+  };
 }
 
 export const store = new Store<StoreSchema>({
@@ -106,6 +109,9 @@ export const store = new Store<StoreSchema>({
     },
     userConfig: {},
     agentSettings: DEFAULT_AGENT_SETTINGS,
+    keybindingOverrides: {
+      overrides: {},
+    },
   },
   cwd: process.env.CANOPY_USER_DATA,
 });

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -16,6 +16,7 @@ import type {
   CodexSettings,
 } from "./agentSettings.js";
 import type { TerminalGridConfig } from "./config.js";
+import type { KeyAction } from "./keymap.js";
 
 // Terminal IPC Types
 
@@ -1327,6 +1328,24 @@ export interface IpcInvokeMap {
     args: [];
     result: void;
   };
+
+  // Keybinding channels
+  "keybinding:get-overrides": {
+    args: [];
+    result: Record<KeyAction, string[]>;
+  };
+  "keybinding:set-override": {
+    args: [payload: { actionId: KeyAction; combo: string[] }];
+    result: void;
+  };
+  "keybinding:remove-override": {
+    args: [actionId: KeyAction];
+    result: void;
+  };
+  "keybinding:reset-all": {
+    args: [];
+    result: void;
+  };
 }
 
 /**
@@ -1627,5 +1646,15 @@ export interface ElectronAPI {
     reset(): Promise<void>;
     /** Subscribe to wake events with sleep duration */
     onWake(callback: (sleepDurationMs: number) => void): () => void;
+  };
+  keybinding: {
+    /** Get current keybinding overrides */
+    getOverrides(): Promise<Record<KeyAction, string[]>>;
+    /** Set override for a specific action */
+    setOverride(actionId: KeyAction, combo: string[]): Promise<void>;
+    /** Remove override for a specific action (revert to default) */
+    removeOverride(actionId: KeyAction): Promise<void>;
+    /** Reset all overrides to defaults */
+    resetAll(): Promise<void>;
   };
 }

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -1,0 +1,347 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Search, RotateCcw, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { keybindingService, KeybindingConfig } from "@/services/KeybindingService";
+
+interface ShortcutBinding extends KeybindingConfig {
+  effectiveCombo: string;
+  isOverridden: boolean;
+}
+
+interface KeyRecorderProps {
+  onCapture: (combo: string) => void;
+  onCancel: () => void;
+  conflicts: KeybindingConfig[];
+}
+
+function KeyRecorder({ onCapture, onCancel, conflicts }: KeyRecorderProps) {
+  const [recording, setRecording] = useState(false);
+  const [capturedCombo, setCapturedCombo] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!recording) return;
+
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const parts: string[] = [];
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+
+      if (isMac && e.metaKey) parts.push("Cmd");
+      if (!isMac && e.ctrlKey) parts.push("Cmd");
+      if (e.shiftKey) parts.push("Shift");
+      if (e.altKey) parts.push("Alt");
+
+      const key = normalizeKey(e.key);
+      if (!["Meta", "Control", "Alt", "Shift"].includes(key)) {
+        parts.push(key);
+        const combo = parts.join("+");
+        setCapturedCombo(combo);
+        setRecording(false);
+      }
+    };
+
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
+  }, [recording]);
+
+  const handleStartRecording = () => {
+    setCapturedCombo(null);
+    setRecording(true);
+  };
+
+  const handleSave = () => {
+    if (capturedCombo) {
+      onCapture(capturedCombo);
+    }
+  };
+
+  const handleClear = () => {
+    onCapture("");
+  };
+
+  return (
+    <div className="bg-canopy-bg/50 border border-canopy-border rounded-lg p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        {recording ? (
+          <div className="flex-1 px-4 py-2 border border-canopy-accent rounded bg-canopy-accent/10 text-canopy-accent animate-pulse text-center">
+            Press key combination...
+          </div>
+        ) : capturedCombo ? (
+          <div className="flex-1 px-4 py-2 border border-canopy-border rounded bg-canopy-bg text-canopy-text text-center font-mono">
+            {keybindingService.formatComboForDisplay(capturedCombo)}
+          </div>
+        ) : (
+          <button
+            onClick={handleStartRecording}
+            className="flex-1 px-4 py-2 border border-canopy-border rounded bg-canopy-bg text-gray-400 hover:text-canopy-text hover:border-canopy-accent transition-colors"
+          >
+            Click to record shortcut
+          </button>
+        )}
+      </div>
+
+      {conflicts.length > 0 && (
+        <div className="flex items-start gap-2 text-amber-400 text-sm">
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>
+            Conflicts with: {conflicts.map((c) => c.description || c.actionId).join(", ")}
+          </span>
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleClear}
+          className="px-3 py-1.5 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+        >
+          Clear
+        </button>
+        {capturedCombo && (
+          <button
+            onClick={handleSave}
+            className="px-3 py-1.5 text-sm bg-canopy-accent text-white rounded hover:bg-canopy-accent/90 transition-colors"
+          >
+            Save
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function normalizeKey(key: string): string {
+  const keyMap: Record<string, string> = {
+    " ": "Space",
+    arrowup: "ArrowUp",
+    arrowdown: "ArrowDown",
+    arrowleft: "ArrowLeft",
+    arrowright: "ArrowRight",
+    escape: "Escape",
+    enter: "Enter",
+    return: "Enter",
+    tab: "Tab",
+    home: "Home",
+    end: "End",
+    pageup: "PageUp",
+    pagedown: "PageDown",
+    backspace: "Backspace",
+    delete: "Delete",
+  };
+  return keyMap[key.toLowerCase()] || key;
+}
+
+interface ShortcutRowProps {
+  binding: ShortcutBinding;
+  isEditing: boolean;
+  onEdit: () => void;
+  onSave: (combo: string) => void;
+  onCancel: () => void;
+  onReset: () => void;
+}
+
+function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: ShortcutRowProps) {
+  const [pendingCombo, setPendingCombo] = useState<string | null>(null);
+
+  const conflicts = useMemo(() => {
+    if (!pendingCombo) return [];
+    return keybindingService.findConflicts(pendingCombo, binding.actionId);
+  }, [pendingCombo, binding.actionId]);
+
+  const handleCapture = (combo: string) => {
+    if (combo === "") {
+      onSave("");
+    } else {
+      setPendingCombo(combo);
+      onSave(combo);
+    }
+    setPendingCombo(null);
+  };
+
+  if (isEditing) {
+    return (
+      <div className="py-2 border-b border-canopy-border/50">
+        <div className="flex items-center justify-between mb-2">
+          <span className="text-sm text-canopy-text">
+            {binding.description || binding.actionId}
+          </span>
+        </div>
+        <KeyRecorder onCapture={handleCapture} onCancel={onCancel} conflicts={conflicts} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-canopy-border/50 group">
+      <span className="text-sm text-canopy-text">{binding.description || binding.actionId}</span>
+      <div className="flex items-center gap-2">
+        {binding.effectiveCombo ? (
+          <span
+            className={cn(
+              "px-2 py-0.5 text-xs font-mono rounded",
+              binding.isOverridden
+                ? "bg-canopy-accent/20 text-canopy-accent"
+                : "bg-canopy-border text-gray-300"
+            )}
+          >
+            {keybindingService.formatComboForDisplay(binding.effectiveCombo)}
+          </span>
+        ) : (
+          <span className="text-xs text-gray-500 italic">unbound</span>
+        )}
+        <button
+          onClick={onEdit}
+          className="px-2 py-0.5 text-xs text-gray-400 hover:text-canopy-text opacity-0 group-hover:opacity-100 transition-opacity"
+        >
+          Edit
+        </button>
+        {binding.isOverridden && (
+          <button
+            onClick={onReset}
+            className="p-0.5 text-gray-400 hover:text-canopy-text opacity-0 group-hover:opacity-100 transition-opacity"
+            title="Reset to default"
+          >
+            <RotateCcw className="w-3 h-3" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function KeyboardShortcutsTab() {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [editingActionId, setEditingActionId] = useState<string | null>(null);
+  const [bindings, setBindings] = useState<ShortcutBinding[]>([]);
+  const [, setUpdateKey] = useState(0);
+
+  const loadBindings = useCallback(() => {
+    const allBindings = keybindingService.getAllBindingsWithEffectiveCombos();
+    setBindings(
+      allBindings.map((b) => ({
+        ...b,
+        isOverridden: keybindingService.hasOverride(b.actionId),
+      }))
+    );
+  }, []);
+
+  useEffect(() => {
+    keybindingService.loadOverrides().then(loadBindings);
+
+    const unsubscribe = keybindingService.subscribe(() => {
+      loadBindings();
+      setUpdateKey((k) => k + 1);
+    });
+
+    return unsubscribe;
+  }, [loadBindings]);
+
+  const filteredBindings = useMemo(() => {
+    if (!searchQuery.trim()) return bindings;
+
+    const query = searchQuery.toLowerCase();
+    return bindings.filter(
+      (b) =>
+        (b.description?.toLowerCase().includes(query) ?? false) ||
+        b.actionId.toLowerCase().includes(query) ||
+        b.effectiveCombo.toLowerCase().includes(query) ||
+        (b.category?.toLowerCase().includes(query) ?? false)
+    );
+  }, [bindings, searchQuery]);
+
+  const groupedBindings = useMemo(() => {
+    const groups = new Map<string, ShortcutBinding[]>();
+    filteredBindings.forEach((binding) => {
+      const category = binding.category || "Other";
+      if (!groups.has(category)) {
+        groups.set(category, []);
+      }
+      groups.get(category)!.push(binding);
+    });
+    return groups;
+  }, [filteredBindings]);
+
+  const handleSaveShortcut = async (actionId: string, combo: string) => {
+    if (combo === "") {
+      await keybindingService.setOverride(actionId, []);
+    } else {
+      await keybindingService.setOverride(actionId, [combo]);
+    }
+    setEditingActionId(null);
+    loadBindings();
+  };
+
+  const handleResetShortcut = async (actionId: string) => {
+    await keybindingService.removeOverride(actionId);
+    loadBindings();
+  };
+
+  const handleResetAll = async () => {
+    await keybindingService.resetAllOverrides();
+    loadBindings();
+  };
+
+  const hasOverrides = bindings.some((b) => b.isOverridden);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            placeholder="Search shortcuts..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-9 pr-3 py-2 bg-canopy-bg border border-canopy-border rounded text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:border-canopy-accent"
+          />
+        </div>
+        {hasOverrides && (
+          <button
+            onClick={handleResetAll}
+            className="flex items-center gap-1.5 px-3 py-2 text-sm text-gray-400 hover:text-canopy-text border border-canopy-border rounded hover:border-canopy-accent transition-colors"
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+            Reset All
+          </button>
+        )}
+      </div>
+
+      <div className="space-y-4 max-h-[380px] overflow-y-auto pr-1">
+        {Array.from(groupedBindings.entries()).map(([category, categoryBindings]) => (
+          <div key={category}>
+            <h4 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+              {category}
+            </h4>
+            <div className="space-y-0">
+              {categoryBindings.map((binding) => (
+                <ShortcutRow
+                  key={binding.actionId}
+                  binding={binding}
+                  isEditing={editingActionId === binding.actionId}
+                  onEdit={() => setEditingActionId(binding.actionId)}
+                  onSave={(combo) => handleSaveShortcut(binding.actionId, combo)}
+                  onCancel={() => setEditingActionId(null)}
+                  onReset={() => handleResetShortcut(binding.actionId)}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {filteredBindings.length === 0 && (
+          <div className="text-center py-8 text-gray-400">
+            No shortcuts found matching "{searchQuery}"
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useErrors, useOverlayState } from "@/hooks";
 import { useLogsStore, useSidecarStore } from "@/store";
-import { X, Bot, Github, LayoutGrid, PanelRight } from "lucide-react";
+import { X, Bot, Github, LayoutGrid, PanelRight, Keyboard } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { appClient } from "@/clients";
 import { AgentSettings } from "./AgentSettings";
@@ -10,6 +10,7 @@ import { TerminalSettingsTab } from "./TerminalSettingsTab";
 import { GitHubSettingsTab } from "./GitHubSettingsTab";
 import { TroubleshootingTab } from "./TroubleshootingTab";
 import { SidecarSettingsTab } from "./SidecarSettingsTab";
+import { KeyboardShortcutsTab } from "./KeyboardShortcutsTab";
 
 interface SettingsDialogProps {
   isOpen: boolean;
@@ -18,7 +19,14 @@ interface SettingsDialogProps {
   onSettingsChange?: () => void;
 }
 
-type SettingsTab = "general" | "terminal" | "agents" | "github" | "sidecar" | "troubleshooting";
+type SettingsTab =
+  | "general"
+  | "keyboard"
+  | "terminal"
+  | "agents"
+  | "github"
+  | "sidecar"
+  | "troubleshooting";
 
 export function SettingsDialog({
   isOpen,
@@ -89,6 +97,18 @@ export function SettingsDialog({
             )}
           >
             General
+          </button>
+          <button
+            onClick={() => setActiveTab("keyboard")}
+            className={cn(
+              "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
+              activeTab === "keyboard"
+                ? "bg-canopy-accent/10 text-canopy-accent"
+                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+            )}
+          >
+            <Keyboard className="w-4 h-4" />
+            Keyboard
           </button>
           <button
             onClick={() => setActiveTab("terminal")}
@@ -162,7 +182,9 @@ export function SettingsDialog({
                     ? "Terminal Grid"
                     : activeTab === "sidecar"
                       ? "Sidecar Links"
-                      : activeTab}
+                      : activeTab === "keyboard"
+                        ? "Keyboard Shortcuts"
+                        : activeTab}
             </h3>
             <button
               onClick={onClose}
@@ -176,6 +198,10 @@ export function SettingsDialog({
           <div className="p-6 overflow-y-auto flex-1">
             <div className={activeTab === "general" ? "" : "hidden"}>
               <GeneralTab appVersion={appVersion} />
+            </div>
+
+            <div className={activeTab === "keyboard" ? "" : "hidden"}>
+              <KeyboardShortcutsTab />
             </div>
 
             <div className={activeTab === "terminal" ? "" : "hidden"}>


### PR DESCRIPTION
## Summary
This PR adds a dedicated settings page for customizing keyboard shortcuts, allowing users to rebind any shortcut to their preferred key combinations with conflict detection and reset functionality.

Closes #626

## Changes Made
- Add keyboard shortcuts settings tab with search and filtering
- Implement keybinding override system with persistence via Electron store
- Add conflict detection for duplicate key combinations
- Create IPC handlers for get/set/remove/reset keybinding overrides
- Add KeyRecorder component for capturing keyboard input
- Enhance KeybindingService with override loading and merging
- Add data validation and error handling for IPC operations
- Integrate keyboard shortcuts tab into settings dialog