### PR TITLE
Improve resize handle visibility and accessibility

### DIFF
--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -76,6 +76,8 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
   const resizeStartY = useRef(0);
   const resizeStartHeight = useRef(0);
 
+  const RESIZE_STEP = 10;
+
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
@@ -84,6 +86,22 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
       resizeStartHeight.current = height;
     },
     [height]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        const maxHeight = window.innerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO;
+        const newHeight = Math.min(height + RESIZE_STEP, maxHeight);
+        setHeight(newHeight);
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        const newHeight = Math.max(height - RESIZE_STEP, DIAGNOSTICS_MIN_HEIGHT);
+        setHeight(newHeight);
+      }
+    },
+    [height, setHeight]
   );
 
   useEffect(() => {
@@ -160,15 +178,29 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
     >
       <div
         className={cn(
-          "h-1 cursor-ns-resize transition-colors",
-          "hover:bg-canopy-accent/50",
-          isResizing && "bg-canopy-accent"
+          "group h-1.5 cursor-ns-resize transition-colors flex items-center justify-center",
+          "hover:bg-canopy-accent/30 focus:outline-none focus:bg-canopy-accent/50",
+          isResizing && "bg-canopy-accent/50"
         )}
         onMouseDown={handleResizeStart}
+        onKeyDown={handleKeyDown}
         role="separator"
         aria-orientation="horizontal"
         aria-label="Resize diagnostics dock"
-      />
+        aria-valuenow={Math.round(height)}
+        aria-valuemin={DIAGNOSTICS_MIN_HEIGHT}
+        aria-valuemax={Math.round(window.innerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO)}
+        tabIndex={0}
+      >
+        <div
+          className={cn(
+            "w-8 h-0.5 rounded-full transition-colors",
+            "bg-canopy-text/20",
+            "group-hover:bg-canopy-accent/70 group-focus:bg-canopy-accent",
+            isResizing && "bg-canopy-accent"
+          )}
+        />
+      </div>
 
       <div className="flex items-center justify-between px-4 h-10 border-b border-canopy-border bg-canopy-sidebar shrink-0">
         <div className="flex items-center gap-2" role="tablist" aria-label="Diagnostics tabs">

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -111,13 +111,22 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           aria-valuenow={width}
           tabIndex={0}
           className={cn(
-            "absolute top-0 right-0 w-1 h-full cursor-col-resize",
-            "hover:bg-canopy-accent/50 transition-colors focus:outline-none focus:bg-canopy-accent",
-            isResizing && "bg-canopy-accent"
+            "group absolute top-0 right-0 w-1.5 h-full cursor-col-resize flex items-center justify-center",
+            "hover:bg-canopy-accent/30 transition-colors focus:outline-none focus:bg-canopy-accent/50",
+            isResizing && "bg-canopy-accent/50"
           )}
           onMouseDown={startResizing}
           onKeyDown={handleKeyDown}
-        />
+        >
+          <div
+            className={cn(
+              "w-0.5 h-8 rounded-full transition-colors",
+              "bg-canopy-text/20",
+              "group-hover:bg-canopy-accent/70",
+              isResizing && "bg-canopy-accent"
+            )}
+          />
+        </div>
       </aside>
 
       {/* Project Settings Dialog - Only mount when open to avoid duplicate hook calls */}

--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback, useState, useMemo } from "react";
 import { useSidecarStore } from "@/store";
+import { cn } from "@/lib/utils";
 import { SidecarToolbar } from "./SidecarToolbar";
 import { SidecarLaunchpad } from "./SidecarLaunchpad";
 import { SIDECAR_MIN_WIDTH, SIDECAR_MAX_WIDTH } from "@shared/types";
@@ -231,6 +232,8 @@ export function SidecarDock() {
     }
   }, [activeTabId]);
 
+  const RESIZE_STEP = 10;
+
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
@@ -264,6 +267,21 @@ export function SidecarDock() {
     [width, setWidth]
   );
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        const newWidth = Math.min(width + RESIZE_STEP, SIDECAR_MAX_WIDTH);
+        setWidth(newWidth);
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        const newWidth = Math.max(width - RESIZE_STEP, SIDECAR_MIN_WIDTH);
+        setWidth(newWidth);
+      }
+    },
+    [width, setWidth]
+  );
+
   useEffect(() => {
     return () => {
       setIsResizing(false);
@@ -273,9 +291,30 @@ export function SidecarDock() {
   return (
     <div className="flex flex-col h-full bg-zinc-900 relative" style={{ width }}>
       <div
-        className={`absolute left-0 top-0 bottom-0 w-1 cursor-ew-resize hover:bg-blue-500/50 transition-colors ${isResizing ? "bg-blue-500" : ""}`}
+        role="separator"
+        aria-label="Resize sidecar panel"
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(width)}
+        aria-valuemin={SIDECAR_MIN_WIDTH}
+        aria-valuemax={SIDECAR_MAX_WIDTH}
+        tabIndex={0}
+        className={cn(
+          "group absolute left-0 top-0 bottom-0 w-1.5 cursor-ew-resize flex items-center justify-center",
+          "hover:bg-canopy-accent/30 transition-colors focus:outline-none focus:bg-canopy-accent/50",
+          isResizing && "bg-canopy-accent/50"
+        )}
         onMouseDown={handleResizeStart}
-      />
+        onKeyDown={handleKeyDown}
+      >
+        <div
+          className={cn(
+            "w-0.5 h-8 rounded-full transition-colors",
+            "bg-canopy-text/20",
+            "group-hover:bg-canopy-accent/70 group-focus:bg-canopy-accent",
+            isResizing && "bg-canopy-accent"
+          )}
+        />
+      </div>
       <SidecarToolbar
         tabs={tabs}
         activeTabId={activeTabId}


### PR DESCRIPTION
## Summary
Enhances resize handles across the application with improved visual affordances, keyboard accessibility, and consistent design patterns.

Closes #639

## Changes Made
- Increase resize handle thickness from 1px to 6px (h-1.5/w-1.5) for better discoverability
- Add visible grip pattern (centered line) to signal interactivity
- Implement keyboard resize support using arrow keys for all panels
- Add ARIA attributes (valuenow, valuemin, valuemax) for screen readers
- Enhance focus states with accent color highlighting
- Apply consistent design tokens (canopy-accent, canopy-text) across all resize handles
- Update DiagnosticsDock, Sidebar, and SidecarDock for visual and functional uniformity

## Technical Details
- **DiagnosticsDock**: Horizontal resize (Arrow Up/Down)
- **Sidebar**: Vertical resize (Arrow Left/Right) 
- **SidecarDock**: Vertical resize (Arrow Left/Right)

All resize handles now feature:
- 6px thickness (previously 1-4px)
- Centered grip line for visual affordance
- Keyboard navigation support
- ARIA attributes for accessibility
- Consistent hover/focus/active states