### PR TITLE
Standardize grey scale and typography using design tokens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -203,7 +203,7 @@ function SidebarContent() {
         <div className="text-[var(--color-status-error)] text-sm mb-2">{error}</div>
         <button
           onClick={refresh}
-          className="text-xs px-2 py-1 border border-gray-600 rounded hover:bg-gray-800 text-gray-300"
+          className="text-xs px-2 py-1 border border-canopy-border rounded hover:bg-canopy-border text-canopy-text"
         >
           Retry
         </button>
@@ -217,16 +217,16 @@ function SidebarContent() {
         <h2 className="text-canopy-text font-semibold text-sm mb-4">Worktrees</h2>
 
         <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-          <FolderOpen className="w-12 h-12 text-gray-500 mb-3" aria-hidden="true" />
+          <FolderOpen className="w-12 h-12 text-canopy-text/60 mb-3" aria-hidden="true" />
 
           <h3 className="text-canopy-text font-medium mb-2">No Worktrees Found</h3>
 
-          <p className="text-sm text-gray-400 mb-4 max-w-xs">
+          <p className="text-sm text-canopy-text/60 mb-4 max-w-xs">
             Open a Git repository with worktrees to get started. Use{" "}
-            <kbd className="px-1.5 py-0.5 bg-gray-700 rounded text-xs">File → Open Directory</kbd>
+            <kbd className="px-1.5 py-0.5 bg-canopy-border rounded text-xs">File → Open Directory</kbd>
           </p>
 
-          <div className="text-xs text-gray-500 text-left w-full max-w-xs">
+          <div className="text-xs text-canopy-text/60 text-left w-full max-w-xs">
             <div className="font-medium mb-1">Quick Start:</div>
             <ol className="space-y-1 list-decimal list-inside">
               <li>Open a repository</li>
@@ -246,10 +246,10 @@ function SidebarContent() {
     <div className="flex flex-col h-full">
       {/* Header Section */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 bg-[#18181b] shrink-0">
-        <h2 className="text-gray-200 font-semibold text-sm tracking-wide">Worktrees</h2>
+        <h2 className="text-canopy-text font-semibold text-sm tracking-wide">Worktrees</h2>
         <button
           onClick={() => setIsNewWorktreeDialogOpen(true)}
-          className="flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 text-gray-400 hover:text-gray-200 hover:bg-white/5 rounded transition-colors"
+          className="flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 text-canopy-text/60 hover:text-canopy-text hover:bg-white/5 rounded transition-colors"
           title="Create new worktree"
         >
           <span className="text-[10px]">+</span> New

--- a/src/components/ContextInjection/ProgressBar.tsx
+++ b/src/components/ContextInjection/ProgressBar.tsx
@@ -50,7 +50,7 @@ export function ProgressBar({ progress, onCancel, compact = false, className }: 
               e.stopPropagation();
               onCancel();
             }}
-            className="p-0.5 hover:bg-red-900/50 rounded text-gray-400 hover:text-[var(--color-status-error)] transition-colors shrink-0"
+            className="p-0.5 hover:bg-red-900/50 rounded text-canopy-text/60 hover:text-[var(--color-status-error)] transition-colors shrink-0"
             title="Cancel"
             aria-label="Cancel context generation"
           >

--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -19,7 +19,7 @@ function ActionButton({ onClick, disabled, children, className, title }: ActionB
       disabled={disabled}
       className={cn(
         "px-2 py-0.5 text-xs rounded transition-colors",
-        "bg-gray-800 text-gray-400 hover:text-gray-200 hover:bg-gray-700",
+        "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border",
         disabled && "opacity-50 cursor-not-allowed",
         className
       )}
@@ -72,7 +72,7 @@ export function LogsActions() {
           "px-2 py-0.5 text-xs rounded transition-colors",
           autoScroll
             ? "bg-blue-600 text-white"
-            : "bg-gray-800 text-gray-400 hover:text-gray-200 hover:bg-gray-700"
+            : "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border"
         )}
         title={autoScroll ? "Auto-scroll enabled" : "Auto-scroll disabled"}
       >

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -37,7 +37,7 @@ const TabButton = memo(function TabButton({
       className={cn(
         "px-3 py-1.5 text-sm font-medium transition-colors relative",
         "hover:text-canopy-text",
-        isActive ? "text-canopy-text" : "text-gray-400"
+        isActive ? "text-canopy-text" : "text-canopy-text/60"
       )}
       role="tab"
       aria-selected={isActive}
@@ -191,7 +191,7 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
 
           <button
             onClick={closeDock}
-            className="p-1.5 hover:bg-gray-800 rounded transition-colors text-gray-400 hover:text-gray-200"
+            className="p-1.5 hover:bg-canopy-border rounded transition-colors text-canopy-text/60 hover:text-canopy-text"
             title="Close diagnostics dock"
             aria-label="Close diagnostics dock"
           >

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -129,7 +129,7 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
         className="flex-1 overflow-y-auto overflow-x-hidden font-mono relative"
       >
         {filteredLogs.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+          <div className="flex items-center justify-center h-full text-canopy-text/60 text-sm">
             {logs.length === 0 ? "No logs yet" : "No logs match filters"}
           </div>
         ) : (

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -45,14 +45,14 @@ function ErrorRow({ error, isExpanded, onToggleExpand, onDismiss, onRetry }: Err
 
   return (
     <>
-      <tr className={cn("hover:bg-gray-800/50 transition-colors", isExpanded && "bg-gray-800/30")}>
-        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">
+      <tr className={cn("hover:bg-canopy-border/50 transition-colors", isExpanded && "bg-canopy-border/30")}>
+        <td className="px-3 py-2 text-xs text-canopy-text/60 whitespace-nowrap">
           {formatTimestamp(error.timestamp)}
         </td>
         <td className={cn("px-3 py-2 text-xs whitespace-nowrap font-medium", typeColor)}>
           {typeLabel}
         </td>
-        <td className="px-3 py-2 text-sm text-gray-300 max-w-md">
+        <td className="px-3 py-2 text-sm text-canopy-text max-w-md">
           <button
             onClick={onToggleExpand}
             className="text-left w-full hover:text-white transition-colors"
@@ -62,7 +62,7 @@ function ErrorRow({ error, isExpanded, onToggleExpand, onDismiss, onRetry }: Err
             <span className="truncate block">{error.message}</span>
           </button>
         </td>
-        <td className="px-3 py-2 text-xs text-gray-500 whitespace-nowrap">{error.source || "-"}</td>
+        <td className="px-3 py-2 text-xs text-canopy-text/60 whitespace-nowrap">{error.source || "-"}</td>
         <td className="px-3 py-2 whitespace-nowrap">
           <div className="flex items-center gap-1">
             {canRetry && (
@@ -81,7 +81,7 @@ function ErrorRow({ error, isExpanded, onToggleExpand, onDismiss, onRetry }: Err
                 e.stopPropagation();
                 onDismiss();
               }}
-              className="p-1 text-gray-500 hover:text-gray-300"
+              className="p-1 text-canopy-text/60 hover:text-canopy-text"
               aria-label="Dismiss error"
             >
               ×
@@ -90,13 +90,13 @@ function ErrorRow({ error, isExpanded, onToggleExpand, onDismiss, onRetry }: Err
         </td>
       </tr>
       {isExpanded && error.details && (
-        <tr className="bg-gray-900/50" id={`error-details-${error.id}`}>
+        <tr className="bg-canopy-sidebar/50" id={`error-details-${error.id}`}>
           <td colSpan={5} className="px-3 py-2">
-            <pre className="text-xs text-gray-400 whitespace-pre-wrap break-all font-mono max-h-40 overflow-y-auto">
+            <pre className="text-xs text-canopy-text/60 whitespace-pre-wrap break-all font-mono max-h-40 overflow-y-auto">
               {error.details}
             </pre>
             {error.context && Object.keys(error.context).length > 0 && (
-              <div className="mt-2 text-xs text-gray-500">
+              <div className="mt-2 text-xs text-canopy-text/60">
                 <span className="font-medium">Context: </span>
                 {Object.entries(error.context)
                   .filter(([, v]) => v !== undefined)
@@ -141,18 +141,18 @@ export function ProblemsContent({ onRetry, className }: ProblemsContentProps) {
   return (
     <div className={cn("h-full overflow-auto", className)}>
       {activeErrors.length === 0 ? (
-        <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+        <div className="flex items-center justify-center h-full text-canopy-text/60 text-sm">
           No problems detected
         </div>
       ) : (
         <table className="w-full">
           <thead className="sticky top-0 bg-canopy-sidebar border-b border-canopy-border">
             <tr>
-              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-24">Time</th>
-              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-20">Type</th>
-              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400">Message</th>
-              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-28">Source</th>
-              <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 w-24">
+              <th className="px-3 py-2 text-left text-xs font-medium text-canopy-text/60 w-24">Time</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-canopy-text/60 w-20">Type</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-canopy-text/60">Message</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-canopy-text/60 w-28">Source</th>
+              <th className="px-3 py-2 text-left text-xs font-medium text-canopy-text/60 w-24">
                 Actions
               </th>
             </tr>

--- a/src/components/EventInspector/EventTimeline.tsx
+++ b/src/components/EventInspector/EventTimeline.tsx
@@ -39,7 +39,7 @@ export function EventTimeline({
     return (
       CATEGORY_STYLES[category] || {
         label: "???",
-        color: "bg-gray-500/20 text-gray-400 border-gray-500/30",
+        color: "bg-canopy-border/20 text-canopy-text/60 border-canopy-border/30",
       }
     );
   };

--- a/src/components/History/ArtifactList.tsx
+++ b/src/components/History/ArtifactList.tsx
@@ -18,7 +18,7 @@ const ARTIFACT_TYPE_COLORS: Record<string, string> = {
   patch: "border-green-500 text-[var(--color-status-success)]",
   file: "border-purple-500 text-purple-400",
   summary: "border-yellow-500 text-[var(--color-status-warning)]",
-  other: "border-gray-500 text-gray-400",
+  other: "border-canopy-border text-canopy-text/60",
 };
 
 const ARTIFACT_TYPE_ICONS: Record<string, string> = {
@@ -53,8 +53,8 @@ function ArtifactCard({ artifact, isExpanded, onToggle }: ArtifactCardProps) {
       <button
         onClick={onToggle}
         className={cn(
-          "w-full flex items-center justify-between px-3 py-2 bg-gray-800/50 text-left",
-          "hover:bg-gray-800 transition-colors",
+          "w-full flex items-center justify-between px-3 py-2 bg-canopy-bg/50 text-left",
+          "hover:bg-canopy-border transition-colors",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-inset"
         )}
         aria-expanded={isExpanded}
@@ -62,14 +62,14 @@ function ArtifactCard({ artifact, isExpanded, onToggle }: ArtifactCardProps) {
       >
         <div className="flex items-center gap-2">
           <span className={cn("font-mono text-xs", colorClass.split(" ")[1])}>{icon}</span>
-          <span className="text-sm text-gray-200 font-medium">{title}</span>
+          <span className="text-sm text-canopy-text font-medium">{title}</span>
           {artifact.language && artifact.language !== artifact.type && (
-            <span className="text-xs text-gray-500">{artifact.language}</span>
+            <span className="text-xs text-canopy-text/60">{artifact.language}</span>
           )}
         </div>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-500">{artifact.content.split("\n").length} lines</span>
-          <span className="text-gray-500">{isExpanded ? "−" : "+"}</span>
+          <span className="text-xs text-canopy-text/60">{artifact.content.split("\n").length} lines</span>
+          <span className="text-canopy-text/60">{isExpanded ? "−" : "+"}</span>
         </div>
       </button>
 
@@ -80,9 +80,9 @@ function ArtifactCard({ artifact, isExpanded, onToggle }: ArtifactCardProps) {
             !isExpanded && "max-h-20 overflow-hidden"
           )}
         >
-          <code className="text-gray-300">
+          <code className="text-canopy-text">
             {isExpanded ? artifact.content : previewLines.join("\n")}
-            {!isExpanded && hasMore && <span className="text-gray-500">{"\n"}...</span>}
+            {!isExpanded && hasMore && <span className="text-canopy-text/60">{"\n"}...</span>}
           </code>
         </pre>
 
@@ -93,9 +93,9 @@ function ArtifactCard({ artifact, isExpanded, onToggle }: ArtifactCardProps) {
           }}
           className={cn(
             "absolute top-2 right-2 px-2 py-1 text-xs rounded",
-            "bg-gray-800 hover:bg-gray-700 transition-colors",
+            "bg-canopy-border hover:bg-canopy-border/80 transition-colors",
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent",
-            copied ? "text-[var(--color-status-success)]" : "text-gray-400"
+            copied ? "text-[var(--color-status-success)]" : "text-canopy-text/60"
           )}
           aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
         >
@@ -123,7 +123,7 @@ export function ArtifactList({ artifacts, className }: ArtifactListProps) {
 
   if (artifacts.length === 0) {
     return (
-      <div className={cn("text-center py-8 text-gray-500 text-sm", className)}>
+      <div className={cn("text-center py-8 text-canopy-text/60 text-sm", className)}>
         No artifacts extracted from this session
       </div>
     );

--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -108,17 +108,17 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
         role="dialog"
         aria-modal="true"
         aria-labelledby="shortcuts-dialog-title"
-        className="bg-gray-900 rounded-lg shadow-2xl w-full max-w-4xl max-h-[80vh] flex flex-col border border-gray-700"
+        className="bg-canopy-sidebar rounded-lg shadow-2xl w-full max-w-4xl max-h-[80vh] flex flex-col border border-canopy-border"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-6 border-b border-gray-700">
+        <div className="p-6 border-b border-canopy-border">
           <div className="flex items-center justify-between mb-4">
-            <h2 id="shortcuts-dialog-title" className="text-2xl font-semibold text-gray-100">
+            <h2 id="shortcuts-dialog-title" className="text-2xl font-semibold text-canopy-text">
               Keyboard Shortcuts
             </h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-200 text-2xl leading-none"
+              className="text-canopy-text/60 hover:text-canopy-text text-2xl leading-none"
               aria-label="Close"
             >
               ×
@@ -130,36 +130,36 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
             placeholder="Search shortcuts..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full px-4 py-2 bg-gray-800 border border-gray-600 rounded-md text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full px-4 py-2 bg-canopy-bg border border-canopy-border rounded-md text-canopy-text placeholder-canopy-text/40 focus:outline-none focus:ring-2 focus:ring-canopy-accent"
           />
         </div>
 
         <div className="flex-1 overflow-y-auto p-6">
           {sortedCategories.length === 0 ? (
-            <div className="text-center text-gray-500 py-8">
+            <div className="text-center text-canopy-text/60 py-8">
               No shortcuts found matching "{searchQuery}"
             </div>
           ) : (
             <div className="space-y-8">
               {sortedCategories.map((category) => (
                 <div key={category}>
-                  <h3 className="text-lg font-semibold text-gray-300 mb-3 pb-2 border-b border-gray-700">
+                  <h3 className="text-lg font-semibold text-canopy-text mb-3 pb-2 border-b border-canopy-border">
                     {category}
                   </h3>
                   <div className="space-y-2">
                     {filteredGroups[category].map((binding) => (
                       <div
                         key={binding.actionId}
-                        className="flex items-center justify-between py-2 px-3 rounded hover:bg-gray-800/50"
+                        className="flex items-center justify-between py-2 px-3 rounded hover:bg-canopy-border/50"
                       >
                         <div className="flex-1">
-                          <div className="text-gray-200 font-medium">{binding.description}</div>
+                          <div className="text-canopy-text font-medium">{binding.description}</div>
                           {binding.scope !== "global" && (
-                            <div className="text-xs text-gray-500 mt-1">Scope: {binding.scope}</div>
+                            <div className="text-xs text-canopy-text/60 mt-1">Scope: {binding.scope}</div>
                           )}
                         </div>
                         <div className="ml-4">
-                          <kbd className="px-3 py-1.5 bg-gray-800 border border-gray-600 rounded text-sm font-mono text-gray-300 shadow-sm">
+                          <kbd className="px-3 py-1.5 bg-canopy-bg border border-canopy-border rounded text-sm font-mono text-canopy-text shadow-sm">
                             {keybindingService.getDisplayCombo(binding.actionId)}
                           </kbd>
                         </div>
@@ -172,9 +172,9 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
           )}
         </div>
 
-        <div className="p-4 border-t border-gray-700 bg-gray-800/50">
-          <div className="text-sm text-gray-400 text-center">
-            Press <kbd className="px-2 py-1 bg-gray-700 rounded text-xs">Esc</kbd> to close
+        <div className="p-4 border-t border-canopy-border bg-canopy-bg/50">
+          <div className="text-sm text-canopy-text/60 text-center">
+            Press <kbd className="px-2 py-1 bg-canopy-border rounded text-xs">Esc</kbd> to close
           </div>
         </div>
       </div>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -90,7 +90,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
             {currentProject && (
               <button
                 onClick={() => setIsSettingsOpen(true)}
-                className="p-2 mr-1 text-gray-400 hover:text-canopy-text hover:bg-canopy-border/50 rounded transition-colors"
+                className="p-2 mr-1 text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/50 rounded transition-colors"
                 title="Project Settings"
               >
                 <Settings className="h-4 w-4" />

--- a/src/components/Logs/LogEntry.tsx
+++ b/src/components/Logs/LogEntry.tsx
@@ -10,9 +10,9 @@ interface LogEntryProps {
 
 const LEVEL_COLORS: Record<LogLevel, { bg: string; text: string; border: string }> = {
   debug: {
-    bg: "bg-gray-500/20",
-    text: "text-gray-400",
-    border: "border-gray-500/30",
+    bg: "bg-canopy-border/20",
+    text: "text-canopy-text/60",
+    border: "border-canopy-border/30",
   },
   info: {
     bg: "bg-blue-500/20",
@@ -69,9 +69,9 @@ function LogEntryComponent({ entry, isExpanded, onToggle }: LogEntryProps) {
   return (
     <div
       className={cn(
-        "border-b border-gray-800/50 py-1.5 px-2",
-        hasContext && "cursor-pointer hover:bg-gray-800/30",
-        isExpanded && "bg-gray-800/20"
+        "border-b border-canopy-border/50 py-1.5 px-2",
+        hasContext && "cursor-pointer hover:bg-canopy-border/30",
+        isExpanded && "bg-canopy-border/20"
       )}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -87,7 +87,7 @@ function LogEntryComponent({ entry, isExpanded, onToggle }: LogEntryProps) {
     >
       <div className="flex items-start gap-2 min-w-0">
         <span
-          className="text-gray-500 text-xs font-mono shrink-0"
+          className="text-canopy-text/60 text-xs font-mono shrink-0"
           title={new Date(entry.timestamp).toISOString()}
         >
           {formatTimestamp(entry.timestamp)}
@@ -107,12 +107,12 @@ function LogEntryComponent({ entry, isExpanded, onToggle }: LogEntryProps) {
           <span className="text-purple-400 text-xs font-mono shrink-0">[{entry.source}]</span>
         )}
 
-        <span className="text-gray-200 text-xs font-mono break-words min-w-0 flex-1">
+        <span className="text-canopy-text text-xs font-mono break-words min-w-0 flex-1">
           {entry.message}
         </span>
 
         {hasContext && (
-          <span className="text-gray-500 text-xs shrink-0">{isExpanded ? "[-]" : "[+]"}</span>
+          <span className="text-canopy-text/60 text-xs shrink-0">{isExpanded ? "[-]" : "[+]"}</span>
         )}
       </div>
 
@@ -122,12 +122,12 @@ function LogEntryComponent({ entry, isExpanded, onToggle }: LogEntryProps) {
           className={cn(
             "mt-2 ml-[72px] p-2 rounded border text-xs font-mono overflow-x-auto",
             colors.border,
-            "bg-gray-900/50"
+            "bg-canopy-sidebar/50"
           )}
           role="region"
           aria-label="Log entry context"
         >
-          <pre className="text-gray-300 whitespace-pre-wrap">{formatContext(entry.context!)}</pre>
+          <pre className="text-canopy-text whitespace-pre-wrap">{formatContext(entry.context!)}</pre>
         </div>
       )}
     </div>

--- a/src/components/Logs/LogFilters.tsx
+++ b/src/components/Logs/LogFilters.tsx
@@ -10,7 +10,7 @@ interface LogFiltersProps {
 }
 
 const LOG_LEVELS: { level: LogLevel; label: string; color: string }[] = [
-  { level: "debug", label: "Debug", color: "text-gray-400 hover:bg-gray-700" },
+  { level: "debug", label: "Debug", color: "text-canopy-text/60 hover:bg-canopy-border" },
   { level: "info", label: "Info", color: "text-[var(--color-status-info)] hover:bg-blue-900/30" },
   {
     level: "warn",
@@ -70,7 +70,7 @@ export function LogFilters({
     filters.search;
 
   return (
-    <div className="flex flex-wrap items-center gap-2 p-2 border-b border-gray-800 bg-gray-900/50">
+    <div className="flex flex-wrap items-center gap-2 p-2 border-b border-canopy-border bg-canopy-sidebar/50">
       <div className="relative flex-1 min-w-[150px] max-w-[250px]">
         <input
           type="text"
@@ -79,15 +79,15 @@ export function LogFilters({
           placeholder="Search logs..."
           className={cn(
             "w-full px-2 py-1 text-xs rounded",
-            "bg-gray-800 border border-gray-700",
-            "text-gray-200 placeholder-gray-500",
+            "bg-canopy-bg border border-canopy-border",
+            "text-canopy-text placeholder-canopy-text/40",
             "focus:outline-none focus:border-blue-500"
           )}
         />
         {searchValue && (
           <button
             onClick={() => setSearchValue("")}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-canopy-text/60 hover:text-canopy-text"
           >
             x
           </button>
@@ -95,7 +95,7 @@ export function LogFilters({
       </div>
 
       <div className="flex items-center gap-1">
-        <span className="text-gray-500 text-xs mr-1">Level:</span>
+        <span className="text-canopy-text/60 text-xs mr-1">Level:</span>
         {LOG_LEVELS.map(({ level, label, color }) => {
           const isActive = filters.levels?.includes(level);
           return (
@@ -104,7 +104,7 @@ export function LogFilters({
               onClick={() => handleLevelToggle(level)}
               className={cn(
                 "px-2 py-0.5 text-xs rounded transition-colors",
-                isActive ? "bg-gray-700 font-medium" : "bg-gray-800/50",
+                isActive ? "bg-canopy-border font-medium" : "bg-canopy-bg/50",
                 color
               )}
             >
@@ -119,8 +119,8 @@ export function LogFilters({
           <button
             className={cn(
               "px-2 py-0.5 text-xs rounded transition-colors",
-              "bg-gray-800 border border-gray-700 text-gray-300",
-              "hover:bg-gray-700"
+              "bg-canopy-bg border border-canopy-border text-canopy-text",
+              "hover:bg-canopy-border"
             )}
           >
             Sources {filters.sources?.length ? `(${filters.sources.length})` : ""}
@@ -128,7 +128,7 @@ export function LogFilters({
           <div
             className={cn(
               "absolute left-0 top-full mt-1 z-50",
-              "bg-gray-800 border border-gray-700 rounded shadow-lg",
+              "bg-canopy-bg border border-canopy-border rounded shadow-lg",
               "min-w-[150px] max-h-[200px] overflow-y-auto",
               "hidden group-hover:block"
             )}
@@ -141,8 +141,8 @@ export function LogFilters({
                   onClick={() => handleSourceToggle(source)}
                   className={cn(
                     "w-full px-3 py-1.5 text-xs text-left",
-                    "hover:bg-gray-700 transition-colors",
-                    isActive ? "text-[var(--color-status-info)] bg-blue-900/20" : "text-gray-300"
+                    "hover:bg-canopy-border transition-colors",
+                    isActive ? "text-[var(--color-status-info)] bg-blue-900/20" : "text-canopy-text"
                   )}
                 >
                   {isActive && "* "}
@@ -157,7 +157,7 @@ export function LogFilters({
       {hasActiveFilters && (
         <button
           onClick={handleClearAll}
-          className="px-2 py-0.5 text-xs rounded bg-gray-800 text-gray-400 hover:text-gray-200 hover:bg-gray-700"
+          className="px-2 py-0.5 text-xs rounded bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border"
         >
           Clear
         </button>

--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -154,7 +154,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-canopy-text transition-colors"
+            className="text-canopy-text/60 hover:text-canopy-text transition-colors"
             aria-label="Close settings"
           >
             <X className="h-5 w-5" />
@@ -163,7 +163,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
 
         <div className="p-4 overflow-y-auto flex-1">
           {isLoading && (
-            <div className="text-sm text-gray-400 text-center py-8">Loading settings...</div>
+            <div className="text-sm text-canopy-text/60 text-center py-8">Loading settings...</div>
           )}
           {error && (
             <div className="text-sm text-[var(--color-status-error)] bg-red-900/20 border border-red-900/30 rounded p-3 mb-4">
@@ -182,7 +182,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                   <h3 className="text-sm font-semibold text-canopy-text/80 mb-2">
                     Project Identity
                   </h3>
-                  <p className="text-xs text-gray-500 mb-4">
+                  <p className="text-xs text-canopy-text/60 mb-4">
                     Customize how your project appears in the sidebar and dashboard.
                   </p>
 
@@ -215,7 +215,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                     <div className="flex-1 min-w-0 flex flex-col justify-center h-14">
                       <label
                         htmlFor="project-name-input"
-                        className="text-xs font-medium text-gray-500 mb-1.5 ml-1"
+                        className="text-xs font-medium text-canopy-text/60 mb-1.5 ml-1"
                       >
                         Project Name
                       </label>
@@ -224,7 +224,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                         type="text"
                         value={name}
                         onChange={(e) => setName(e.target.value)}
-                        className="w-full bg-transparent border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-gray-600"
+                        className="w-full bg-transparent border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-canopy-text/40"
                         placeholder="My Awesome Project"
                       />
                     </div>
@@ -237,7 +237,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                   <Server className="h-4 w-4" />
                   Dev Server
                 </h3>
-                <p className="text-xs text-gray-500 mb-4">
+                <p className="text-xs text-canopy-text/60 mb-4">
                   Configure how the development server is managed for this project.
                 </p>
 
@@ -251,7 +251,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                     />
                     <div>
                       <span className="text-sm text-canopy-text">Enable dev server management</span>
-                      <p className="text-xs text-gray-500">
+                      <p className="text-xs text-canopy-text/60">
                         Show dev server controls on worktree cards
                       </p>
                     </div>
@@ -273,7 +273,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                       />
                       <div>
                         <span className="text-sm text-canopy-text">Auto-start on project load</span>
-                        <p className="text-xs text-gray-500">
+                        <p className="text-xs text-canopy-text/60">
                           Automatically start the dev server when switching to this project
                         </p>
                       </div>
@@ -295,11 +295,11 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                         className={cn(
                           "w-full bg-canopy-sidebar border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono",
                           "focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all",
-                          "placeholder:text-gray-600 disabled:opacity-50"
+                          "placeholder:text-canopy-text/40 disabled:opacity-50"
                         )}
                         placeholder={detectedCommand || "npm run dev"}
                       />
-                      <div className="flex items-start gap-2 text-xs text-gray-500">
+                      <div className="flex items-start gap-2 text-xs text-canopy-text/60">
                         <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
                         <span>
                           Leave blank to use auto-detection. Supports any command: npm, yarn, pnpm,
@@ -323,7 +323,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
           <Button
             onClick={onClose}
             variant="ghost"
-            className="text-gray-400 hover:text-canopy-text"
+            className="text-canopy-text/60 hover:text-canopy-text"
           >
             Cancel
           </Button>

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -118,7 +118,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-32">
-        <div className="text-gray-400 text-sm">Loading settings...</div>
+        <div className="text-canopy-text/60 text-sm">Loading settings...</div>
       </div>
     );
   }
@@ -161,7 +161,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
         <div className="space-y-4">
           <div className="space-y-2">
             <h3 className="text-sm font-medium text-canopy-text">Enabled Agents</h3>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-canopy-text/60">
               Choose which agents appear in your toolbar. Agents must also be installed on your
               system to appear.
             </p>
@@ -173,14 +173,14 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 <ClaudeIcon size={18} className="text-canopy-text" />
                 <div>
                   <div className="text-sm font-medium text-canopy-text">Claude</div>
-                  <div className="text-xs text-gray-500">Anthropic's Claude CLI</div>
+                  <div className="text-xs text-canopy-text/60">Anthropic's Claude CLI</div>
                 </div>
               </div>
               <button
                 onClick={() => handleToggleEnabled("claude")}
                 className={cn(
                   "relative w-11 h-6 rounded-full transition-colors",
-                  (settings.claude.enabled ?? true) ? "bg-canopy-accent" : "bg-gray-600"
+                  (settings.claude.enabled ?? true) ? "bg-canopy-accent" : "bg-canopy-border"
                 )}
               >
                 <span
@@ -197,14 +197,14 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 <GeminiIcon size={18} className="text-canopy-text" />
                 <div>
                   <div className="text-sm font-medium text-canopy-text">Gemini</div>
-                  <div className="text-xs text-gray-500">Google's Gemini CLI</div>
+                  <div className="text-xs text-canopy-text/60">Google's Gemini CLI</div>
                 </div>
               </div>
               <button
                 onClick={() => handleToggleEnabled("gemini")}
                 className={cn(
                   "relative w-11 h-6 rounded-full transition-colors",
-                  (settings.gemini.enabled ?? true) ? "bg-canopy-accent" : "bg-gray-600"
+                  (settings.gemini.enabled ?? true) ? "bg-canopy-accent" : "bg-canopy-border"
                 )}
               >
                 <span
@@ -221,14 +221,14 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 <CodexIcon size={18} className="text-canopy-text" />
                 <div>
                   <div className="text-sm font-medium text-canopy-text">Codex</div>
-                  <div className="text-xs text-gray-500">OpenAI's Codex CLI</div>
+                  <div className="text-xs text-canopy-text/60">OpenAI's Codex CLI</div>
                 </div>
               </div>
               <button
                 onClick={() => handleToggleEnabled("codex")}
                 className={cn(
                   "relative w-11 h-6 rounded-full transition-colors",
-                  (settings.codex.enabled ?? true) ? "bg-canopy-accent" : "bg-gray-600"
+                  (settings.codex.enabled ?? true) ? "bg-canopy-accent" : "bg-canopy-border"
                 )}
               >
                 <span
@@ -241,7 +241,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
             </div>
           </div>
 
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-canopy-text/60">
             Note: The Shell button is always available and cannot be disabled.
           </p>
         </div>
@@ -256,9 +256,9 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               value={settings.claude.model || ""}
               onChange={(e) => handleClaudeChange({ model: e.target.value })}
               placeholder="e.g., opus-4.5, sonnet-4.5"
-              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
             />
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-canopy-text/60">
               Opus 4.5 recommended for long-horizon autonomous tasks. Leave empty to use Claude CLI
               default.
             </p>
@@ -296,7 +296,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
                     settings.claude.approvalMode === option.value
                       ? "border-canopy-accent bg-canopy-accent/10"
-                      : "border-canopy-border hover:border-gray-500"
+                      : "border-canopy-border hover:border-canopy-border"
                   )}
                 >
                   <input
@@ -314,7 +314,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       "w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5",
                       settings.claude.approvalMode === option.value
                         ? "border-canopy-accent"
-                        : "border-gray-500"
+                        : "border-canopy-border"
                     )}
                   >
                     {settings.claude.approvalMode === option.value && (
@@ -329,7 +329,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                         <AlertTriangle className="w-3.5 h-3.5 text-yellow-500" />
                       )}
                     </div>
-                    <div className="text-xs text-gray-500">{option.desc}</div>
+                    <div className="text-xs text-canopy-text/60">{option.desc}</div>
                   </div>
                 </label>
               ))}
@@ -339,7 +339,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
           <div className="border-t border-canopy-border pt-4">
             <button
               onClick={() => setShowAdvanced(!showAdvanced)}
-              className="flex items-center gap-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+              className="flex items-center gap-2 text-sm text-canopy-text/60 hover:text-canopy-text transition-colors"
             >
               {showAdvanced ? (
                 <ChevronUp className="w-4 h-4" />
@@ -358,7 +358,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     onChange={(e) => handleClaudeChange({ systemPrompt: e.target.value })}
                     placeholder="Custom system instructions..."
                     rows={3}
-                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent resize-none"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent resize-none"
                   />
                 </div>
 
@@ -369,9 +369,9 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     value={settings.claude.customFlags || ""}
                     onChange={(e) => handleClaudeChange({ customFlags: e.target.value })}
                     placeholder="e.g., --verbose --no-color"
-                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
                   />
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-canopy-text/60">
                     Additional CLI flags to pass to Claude (space-separated)
                   </p>
                 </div>
@@ -384,7 +384,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               variant="outline"
               size="sm"
               onClick={() => handleReset("claude")}
-              className="text-gray-400 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+              className="text-canopy-text/60 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
             >
               <RotateCcw className="w-4 h-4 mr-2" />
               Reset to Defaults
@@ -402,9 +402,9 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               value={settings.gemini.model || ""}
               onChange={(e) => handleGeminiChange({ model: e.target.value })}
               placeholder="e.g., gemini-3-pro"
-              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
             />
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-canopy-text/60">
               Leave empty to use 'Auto' routing (switches between Pro/Flash based on complexity).
             </p>
           </div>
@@ -438,7 +438,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
                     settings.gemini.approvalMode === option.value
                       ? "border-canopy-accent bg-canopy-accent/10"
-                      : "border-canopy-border hover:border-gray-500"
+                      : "border-canopy-border hover:border-canopy-border"
                   )}
                 >
                   <input
@@ -456,7 +456,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       "w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5",
                       settings.gemini.approvalMode === option.value
                         ? "border-canopy-accent"
-                        : "border-gray-500"
+                        : "border-canopy-border"
                     )}
                   >
                     {settings.gemini.approvalMode === option.value && (
@@ -468,7 +468,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       {option.label}
                       {option.warning && <AlertTriangle className="w-3.5 h-3.5 text-yellow-500" />}
                     </div>
-                    <div className="text-xs text-gray-500">{option.desc}</div>
+                    <div className="text-xs text-canopy-text/60">{option.desc}</div>
                   </div>
                 </label>
               ))}
@@ -478,7 +478,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
           <div className="border-t border-canopy-border pt-4">
             <button
               onClick={() => setShowAdvanced(!showAdvanced)}
-              className="flex items-center gap-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+              className="flex items-center gap-2 text-sm text-canopy-text/60 hover:text-canopy-text transition-colors"
             >
               {showAdvanced ? (
                 <ChevronUp className="w-4 h-4" />
@@ -495,7 +495,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     onClick={() => handleGeminiChange({ sandbox: !settings.gemini.sandbox })}
                     className={cn(
                       "relative w-11 h-6 rounded-full transition-colors",
-                      settings.gemini.sandbox ? "bg-canopy-accent" : "bg-gray-600"
+                      settings.gemini.sandbox ? "bg-canopy-accent" : "bg-canopy-border"
                     )}
                   >
                     <span
@@ -507,7 +507,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                   </button>
                   <div>
                     <span className="text-sm text-canopy-text">Enable Sandbox Mode</span>
-                    <p className="text-xs text-gray-500">Run Gemini in a sandboxed environment</p>
+                    <p className="text-xs text-canopy-text/60">Run Gemini in a sandboxed environment</p>
                   </div>
                 </label>
 
@@ -518,9 +518,9 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     value={settings.gemini.customFlags || ""}
                     onChange={(e) => handleGeminiChange({ customFlags: e.target.value })}
                     placeholder="e.g., --verbose"
-                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
                   />
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-canopy-text/60">
                     Additional CLI flags to pass to Gemini (space-separated)
                   </p>
                 </div>
@@ -533,7 +533,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               variant="outline"
               size="sm"
               onClick={() => handleReset("gemini")}
-              className="text-gray-400 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+              className="text-canopy-text/60 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
             >
               <RotateCcw className="w-4 h-4 mr-2" />
               Reset to Defaults
@@ -551,9 +551,9 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               value={settings.codex.model || ""}
               onChange={(e) => handleCodexChange({ model: e.target.value })}
               placeholder="e.g., gpt-5.1-codex-max"
-              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+              className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
             />
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-canopy-text/60">
               Tip: Set effort to 'xhigh' for complex architecture decisions. Leave empty to use
               Codex CLI default.
             </p>
@@ -588,7 +588,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     "flex items-start gap-3 p-3 rounded-md border cursor-pointer transition-colors",
                     settings.codex.sandbox === option.value
                       ? "border-canopy-accent bg-canopy-accent/10"
-                      : "border-canopy-border hover:border-gray-500"
+                      : "border-canopy-border hover:border-canopy-border"
                   )}
                 >
                   <input
@@ -606,7 +606,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       "w-4 h-4 rounded-full border-2 flex items-center justify-center mt-0.5",
                       settings.codex.sandbox === option.value
                         ? "border-canopy-accent"
-                        : "border-gray-500"
+                        : "border-canopy-border"
                     )}
                   >
                     {settings.codex.sandbox === option.value && (
@@ -618,7 +618,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       {option.label}
                       {option.warning && <AlertTriangle className="w-3.5 h-3.5 text-yellow-500" />}
                     </div>
-                    <div className="text-xs text-gray-500">{option.desc}</div>
+                    <div className="text-xs text-canopy-text/60">{option.desc}</div>
                   </div>
                 </label>
               ))}
@@ -639,7 +639,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               <option value="on-request">On Request (approve when asked)</option>
               <option value="never">Never Ask</option>
             </select>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-canopy-text/60">
               When to ask for approval before executing shell commands
             </p>
           </div>
@@ -647,7 +647,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
           <div className="border-t border-canopy-border pt-4">
             <button
               onClick={() => setShowAdvanced(!showAdvanced)}
-              className="flex items-center gap-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+              className="flex items-center gap-2 text-sm text-canopy-text/60 hover:text-canopy-text transition-colors"
             >
               {showAdvanced ? (
                 <ChevronUp className="w-4 h-4" />
@@ -664,7 +664,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     onClick={() => handleCodexChange({ fullAuto: !settings.codex.fullAuto })}
                     className={cn(
                       "relative w-11 h-6 rounded-full transition-colors",
-                      settings.codex.fullAuto ? "bg-canopy-accent" : "bg-gray-600"
+                      settings.codex.fullAuto ? "bg-canopy-accent" : "bg-canopy-border"
                     )}
                   >
                     <span
@@ -676,7 +676,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                   </button>
                   <div>
                     <span className="text-sm text-canopy-text">Full Auto Mode</span>
-                    <p className="text-xs text-gray-500">Low-friction sandboxed execution</p>
+                    <p className="text-xs text-canopy-text/60">Low-friction sandboxed execution</p>
                   </div>
                 </label>
 
@@ -685,7 +685,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     onClick={() => handleCodexChange({ search: !settings.codex.search })}
                     className={cn(
                       "relative w-11 h-6 rounded-full transition-colors",
-                      settings.codex.search ? "bg-canopy-accent" : "bg-gray-600"
+                      settings.codex.search ? "bg-canopy-accent" : "bg-canopy-border"
                     )}
                   >
                     <span
@@ -697,7 +697,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                   </button>
                   <div>
                     <span className="text-sm text-canopy-text">Enable Web Search</span>
-                    <p className="text-xs text-gray-500">Allow Codex to search the web</p>
+                    <p className="text-xs text-canopy-text/60">Allow Codex to search the web</p>
                   </div>
                 </label>
 
@@ -728,7 +728,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       Bypass All Checks
                       <AlertTriangle className="w-3.5 h-3.5 text-red-500" />
                     </span>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-canopy-text/60">
                       Skip sandbox and approval checks (EXTREMELY DANGEROUS)
                     </p>
                   </div>
@@ -741,9 +741,9 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     value={settings.codex.customFlags || ""}
                     onChange={(e) => handleCodexChange({ customFlags: e.target.value })}
                     placeholder="e.g., --verbose"
-                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
                   />
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-canopy-text/60">
                     Additional CLI flags to pass to Codex (space-separated)
                   </p>
                 </div>
@@ -756,7 +756,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               variant="outline"
               size="sm"
               onClick={() => handleReset("codex")}
-              className="text-gray-400 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+              className="text-canopy-text/60 border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
             >
               <RotateCcw className="w-4 h-4 mr-2" />
               Reset to Defaults

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -122,11 +122,11 @@ export function GeneralTab({ appVersion }: GeneralTabProps) {
             </div>
             <div>
               <div className="font-semibold text-canopy-text text-lg">Canopy</div>
-              <div className="text-sm text-gray-400">Command Center</div>
+              <div className="text-sm text-canopy-text/60">Command Center</div>
             </div>
           </div>
           <div className="space-y-2 text-sm">
-            <div className="flex justify-between text-gray-400">
+            <div className="flex justify-between text-canopy-text/60">
               <span>Version</span>
               <span className="font-mono text-canopy-text">{appVersion}</span>
             </div>
@@ -136,7 +136,7 @@ export function GeneralTab({ appVersion }: GeneralTabProps) {
 
       <div className="space-y-2">
         <h4 className="text-sm font-medium text-canopy-text">Description</h4>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-canopy-text/60">
           An orchestration board for AI coding agents. Start agents on worktrees, monitor their
           progress, and inject context to help them understand your codebase.
         </p>
@@ -238,7 +238,7 @@ export function GeneralTab({ appVersion }: GeneralTabProps) {
           onClick={() => setIsShortcutsOpen(!isShortcutsOpen)}
           aria-expanded={isShortcutsOpen}
           aria-controls="keyboard-shortcuts-content"
-          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-canopy-text/60 hover:text-canopy-text transition-colors"
         >
           {isShortcutsOpen ? (
             <ChevronDown className="w-4 h-4" />
@@ -255,7 +255,7 @@ export function GeneralTab({ appVersion }: GeneralTabProps) {
           >
             {KEYBOARD_SHORTCUTS.map((category) => (
               <div key={category.category} className="space-y-2">
-                <h5 className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+                <h5 className="text-xs font-medium text-canopy-text/60 uppercase tracking-wide">
                   {category.category}
                 </h5>
                 <dl className="space-y-1">
@@ -264,7 +264,7 @@ export function GeneralTab({ appVersion }: GeneralTabProps) {
                       key={shortcut.key}
                       className="flex items-center justify-between text-sm py-1"
                     >
-                      <dt className="text-gray-300">{shortcut.description}</dt>
+                      <dt className="text-canopy-text">{shortcut.description}</dt>
                       <dd>
                         <kbd className="px-2 py-1 bg-canopy-bg border border-canopy-border rounded text-xs font-mono text-canopy-text">
                           {formatKey(shortcut.key)}

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -124,7 +124,7 @@ export function GitHubSettingsTab() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-32">
-        <div className="text-gray-400 text-sm">Loading GitHub settings...</div>
+        <div className="text-canopy-text/60 text-sm">Loading GitHub settings...</div>
       </div>
     );
   }
@@ -169,7 +169,7 @@ export function GitHubSettingsTab() {
             placeholder={
               githubConfig?.hasToken ? "Enter new token to replace" : "ghp_... or github_pat_..."
             }
-            className="flex-1 bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+            className="flex-1 bg-canopy-bg border border-canopy-border rounded-md px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:ring-1 focus:ring-canopy-accent"
             disabled={isValidating || isTesting}
           />
           <Button
@@ -233,7 +233,7 @@ export function GitHubSettingsTab() {
           </p>
         )}
 
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-canopy-text/60">
           Used for repository statistics, issue/PR detection, and linking worktrees to GitHub.
           Eliminates the need for the gh CLI.
         </p>
@@ -241,7 +241,7 @@ export function GitHubSettingsTab() {
 
       <div className="space-y-3 border border-canopy-border rounded-md p-4">
         <h4 className="text-sm font-medium text-canopy-text">Create a New Token</h4>
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-canopy-text/60">
           To create a personal access token with the required scopes (repo, read:org), click the
           button below. This will open GitHub in your browser.
         </p>
@@ -255,8 +255,8 @@ export function GitHubSettingsTab() {
           Create Token on GitHub
         </Button>
         <div className="mt-2 space-y-1">
-          <p className="text-xs text-gray-500">Required scopes:</p>
-          <ul className="text-xs text-gray-500 list-disc list-inside">
+          <p className="text-xs text-canopy-text/60">Required scopes:</p>
+          <ul className="text-xs text-canopy-text/60 list-disc list-inside">
             <li>
               <code className="text-canopy-text bg-canopy-bg px-1 rounded">repo</code> - Access
               repository data

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -75,7 +75,7 @@ function KeyRecorder({ onCapture, onCancel, conflicts }: KeyRecorderProps) {
         ) : (
           <button
             onClick={handleStartRecording}
-            className="flex-1 px-4 py-2 border border-canopy-border rounded bg-canopy-bg text-gray-400 hover:text-canopy-text hover:border-canopy-accent transition-colors"
+            className="flex-1 px-4 py-2 border border-canopy-border rounded bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:border-canopy-accent transition-colors"
           >
             Click to record shortcut
           </button>
@@ -94,13 +94,13 @@ function KeyRecorder({ onCapture, onCancel, conflicts }: KeyRecorderProps) {
       <div className="flex gap-2 justify-end">
         <button
           onClick={onCancel}
-          className="px-3 py-1.5 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+          className="px-3 py-1.5 text-sm text-canopy-text/60 hover:text-canopy-text transition-colors"
         >
           Cancel
         </button>
         <button
           onClick={handleClear}
-          className="px-3 py-1.5 text-sm text-gray-400 hover:text-canopy-text transition-colors"
+          className="px-3 py-1.5 text-sm text-canopy-text/60 hover:text-canopy-text transition-colors"
         >
           Clear
         </button>
@@ -188,24 +188,24 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
               "px-2 py-0.5 text-xs font-mono rounded",
               binding.isOverridden
                 ? "bg-canopy-accent/20 text-canopy-accent"
-                : "bg-canopy-border text-gray-300"
+                : "bg-canopy-border text-canopy-text"
             )}
           >
             {keybindingService.formatComboForDisplay(binding.effectiveCombo)}
           </span>
         ) : (
-          <span className="text-xs text-gray-500 italic">unbound</span>
+          <span className="text-xs text-canopy-text/60 italic">unbound</span>
         )}
         <button
           onClick={onEdit}
-          className="px-2 py-0.5 text-xs text-gray-400 hover:text-canopy-text opacity-0 group-hover:opacity-100 transition-opacity"
+          className="px-2 py-0.5 text-xs text-canopy-text/60 hover:text-canopy-text opacity-0 group-hover:opacity-100 transition-opacity"
         >
           Edit
         </button>
         {binding.isOverridden && (
           <button
             onClick={onReset}
-            className="p-0.5 text-gray-400 hover:text-canopy-text opacity-0 group-hover:opacity-100 transition-opacity"
+            className="p-0.5 text-canopy-text/60 hover:text-canopy-text opacity-0 group-hover:opacity-100 transition-opacity"
             title="Reset to default"
           >
             <RotateCcw className="w-3 h-3" />
@@ -294,19 +294,19 @@ export function KeyboardShortcutsTab() {
     <div className="space-y-4">
       <div className="flex items-center gap-3">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-canopy-text/60" />
           <input
             type="text"
             placeholder="Search shortcuts..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 bg-canopy-bg border border-canopy-border rounded text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:border-canopy-accent"
+            className="w-full pl-9 pr-3 py-2 bg-canopy-bg border border-canopy-border rounded text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:border-canopy-accent"
           />
         </div>
         {hasOverrides && (
           <button
             onClick={handleResetAll}
-            className="flex items-center gap-1.5 px-3 py-2 text-sm text-gray-400 hover:text-canopy-text border border-canopy-border rounded hover:border-canopy-accent transition-colors"
+            className="flex items-center gap-1.5 px-3 py-2 text-sm text-canopy-text/60 hover:text-canopy-text border border-canopy-border rounded hover:border-canopy-accent transition-colors"
           >
             <RotateCcw className="w-3.5 h-3.5" />
             Reset All
@@ -317,7 +317,7 @@ export function KeyboardShortcutsTab() {
       <div className="space-y-4 max-h-[380px] overflow-y-auto pr-1">
         {Array.from(groupedBindings.entries()).map(([category, categoryBindings]) => (
           <div key={category}>
-            <h4 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+            <h4 className="text-xs font-semibold text-canopy-text/60 uppercase tracking-wider mb-2">
               {category}
             </h4>
             <div className="space-y-0">
@@ -337,7 +337,7 @@ export function KeyboardShortcutsTab() {
         ))}
 
         {filteredBindings.length === 0 && (
-          <div className="text-center py-8 text-gray-400">
+          <div className="text-center py-8 text-canopy-text/60">
             No shortcuts found matching "{searchQuery}"
           </div>
         )}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -93,7 +93,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors",
               activeTab === "general"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             General
@@ -104,7 +104,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
               activeTab === "keyboard"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             <Keyboard className="w-4 h-4" />
@@ -116,7 +116,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
               activeTab === "terminal"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             <LayoutGrid className="w-4 h-4" />
@@ -128,7 +128,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
               activeTab === "agents"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             <Bot className="w-4 h-4" />
@@ -140,7 +140,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
               activeTab === "github"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             <Github className="w-4 h-4" />
@@ -152,7 +152,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors flex items-center gap-2",
               activeTab === "sidecar"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             <PanelRight className="w-4 h-4" />
@@ -164,7 +164,7 @@ export function SettingsDialog({
               "text-left px-3 py-2 rounded-md text-sm transition-colors",
               activeTab === "troubleshooting"
                 ? "bg-canopy-accent/10 text-canopy-accent"
-                : "text-gray-400 hover:bg-canopy-border hover:text-canopy-text"
+                : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
             )}
           >
             Troubleshooting
@@ -188,7 +188,7 @@ export function SettingsDialog({
             </h3>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-canopy-text transition-colors"
+              className="text-canopy-text/60 hover:text-canopy-text transition-colors"
               aria-label="Close settings"
             >
               <X className="h-5 w-5" />

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -110,7 +110,7 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
       <div className="space-y-4">
         <div>
           <h4 className="text-sm font-medium text-canopy-text mb-1">Application Logs</h4>
-          <p className="text-xs text-gray-400 mb-3">
+          <p className="text-xs text-canopy-text/60 mb-3">
             View internal application logs for debugging purposes.
           </p>
           <div className="flex gap-3">
@@ -142,7 +142,7 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
             <Bug className="w-4 h-4" />
             Developer Mode
           </h4>
-          <p className="text-xs text-gray-400 mb-3">
+          <p className="text-xs text-canopy-text/60 mb-3">
             Enable enhanced debugging features for development and troubleshooting.
           </p>
 
@@ -151,7 +151,7 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
               onClick={handleToggleDeveloperMode}
               className={cn(
                 "relative w-11 h-6 rounded-full transition-colors shrink-0",
-                developerMode ? "bg-canopy-accent" : "bg-gray-600"
+                developerMode ? "bg-canopy-accent" : "bg-canopy-border"
               )}
             >
               <span
@@ -163,7 +163,7 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
             </button>
             <div>
               <span className="text-sm text-canopy-text font-medium">Enable Developer Mode</span>
-              <p className="text-xs text-gray-400">Activates all debugging features below</p>
+              <p className="text-xs text-canopy-text/60">Activates all debugging features below</p>
             </div>
           </label>
 
@@ -179,11 +179,11 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
                 checked={autoOpenDiagnostics}
                 onChange={handleToggleAutoOpenDiagnostics}
                 disabled={!developerMode}
-                className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-canopy-accent focus:ring-canopy-accent focus:ring-offset-0 disabled:opacity-50"
+                className="w-4 h-4 rounded border-canopy-border bg-canopy-bg text-canopy-accent focus:ring-canopy-accent focus:ring-offset-0 disabled:opacity-50"
               />
               <div>
                 <span className="text-sm text-canopy-text">Auto-Open Diagnostics Dock</span>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-canopy-text/60">
                   Automatically open diagnostics panel on app startup
                 </p>
               </div>
@@ -200,11 +200,11 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
                 checked={focusEventsTab}
                 onChange={handleToggleFocusEventsTab}
                 disabled={!developerMode || !autoOpenDiagnostics}
-                className="w-4 h-4 rounded border-gray-600 bg-gray-700 text-canopy-accent focus:ring-canopy-accent focus:ring-offset-0 disabled:opacity-50"
+                className="w-4 h-4 rounded border-canopy-border bg-canopy-bg text-canopy-accent focus:ring-canopy-accent focus:ring-offset-0 disabled:opacity-50"
               />
               <div>
                 <span className="text-sm text-canopy-text">Focus Events Tab</span>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-canopy-text/60">
                   Default to Events tab when diagnostics opens
                 </p>
               </div>
@@ -215,18 +215,18 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
             <h5 className="text-xs font-medium text-canopy-text mb-2">
               Advanced: Main Process Logging
             </h5>
-            <p className="text-xs text-gray-400 mb-2">
+            <p className="text-xs text-canopy-text/60 mb-2">
               For verbose main process logs, restart the app with environment variables:
             </p>
             <code className="block text-xs bg-canopy-bg p-2 rounded border border-canopy-border font-mono text-canopy-text">
               CANOPY_DEBUG=1 CANOPY_VERBOSE=1 npm run dev
             </code>
             <div className="mt-2 space-y-1">
-              <p className="text-xs text-gray-400">
+              <p className="text-xs text-canopy-text/60">
                 <span className="font-medium text-canopy-text">CANOPY_DEBUG</span> — General logger
                 verbosity
               </p>
-              <p className="text-xs text-gray-400">
+              <p className="text-xs text-canopy-text/60">
                 <span className="font-medium text-canopy-text">CANOPY_VERBOSE</span> — Service-level
                 debug output
               </p>
@@ -238,7 +238,7 @@ export function TroubleshootingTab({ openLogs, clearLogs }: TroubleshootingTabPr
       <div className="space-y-4">
         <div>
           <h4 className="text-sm font-medium text-canopy-text mb-1">Keyboard Shortcuts</h4>
-          <p className="text-xs text-gray-400 mb-3">
+          <p className="text-xs text-canopy-text/60 mb-3">
             Use Cmd+Option+I (Mac) or Ctrl+Shift+I (Windows/Linux) to open DevTools.
           </p>
         </div>

--- a/src/components/Worktree/BranchLabel.tsx
+++ b/src/components/Worktree/BranchLabel.tsx
@@ -13,7 +13,7 @@ interface BranchLabelProps {
 const COLORS = {
   teal: { bg: "bg-teal-500/10", border: "border-teal-500/30", text: "text-teal-400" },
   red: { bg: "bg-red-500/10", border: "border-red-500/30", text: "text-red-400" },
-  gray: { bg: "bg-gray-500/10", border: "border-gray-500/30", text: "text-gray-400" },
+  gray: { bg: "bg-canopy-border/20", border: "border-canopy-border", text: "text-canopy-text/60" },
   blue: { bg: "bg-blue-500/10", border: "border-blue-500/30", text: "text-blue-400" },
   purple: { bg: "bg-purple-500/10", border: "border-purple-500/30", text: "text-purple-400" },
   yellow: { bg: "bg-yellow-500/10", border: "border-yellow-500/30", text: "text-yellow-400" },
@@ -111,7 +111,7 @@ export function BranchLabel({ label, isActive, isMainWorktree, className }: Bran
       <span
         className={cn(
           "truncate font-semibold text-[13px]",
-          isActive ? "text-white" : "text-gray-300",
+          isActive ? "text-white" : "text-canopy-text",
           isMainWorktree && "font-bold tracking-wide"
         )}
       >

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -33,7 +33,7 @@ const STATUS_CONFIG: Record<GitStatus, { label: string; color: string }> = {
   untracked: { label: "?", color: "text-green-400" },
   renamed: { label: "R", color: "text-blue-400" },
   copied: { label: "C", color: "text-blue-400" },
-  ignored: { label: "I", color: "text-gray-600" },
+  ignored: { label: "I", color: "text-canopy-text/40" },
 };
 
 const STATUS_PRIORITY: Record<GitStatus, number> = {
@@ -144,11 +144,11 @@ export function FileChangeList({ changes, maxVisible = 4, rootPath }: FileChange
               {/* File Path - directory truncates, filename is protected */}
               <div className="flex-1 min-w-0 flex items-center mr-2">
                 {displayDir && (
-                  <span className="truncate text-gray-400 opacity-60 group-hover:opacity-80">
+                  <span className="truncate text-canopy-text/60 opacity-60 group-hover:opacity-80">
                     {displayDir}/
                   </span>
                 )}
-                <span className="text-gray-300 group-hover:text-white font-medium shrink-0">
+                <span className="text-canopy-text group-hover:text-white font-medium shrink-0">
                   {base}
                 </span>
               </div>
@@ -167,7 +167,7 @@ export function FileChangeList({ changes, maxVisible = 4, rootPath }: FileChange
         })}
 
         {remainingCount > 0 && (
-          <div className="text-[10px] text-gray-500 pl-5 pt-1">
+          <div className="text-[10px] text-canopy-text/60 pl-5 pt-1">
             ...and {remainingCount} more
             {remainingFiles.length > 0 && (
               <span className="ml-1 opacity-75">

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -289,20 +289,20 @@ function getStatusInfo(status: GitStatus): {
     case "untracked":
       return {
         label: "?",
-        bgColor: "bg-gray-500/20",
-        textColor: "text-gray-400",
+        bgColor: "bg-canopy-border/20",
+        textColor: "text-canopy-text/60",
       };
     case "ignored":
       return {
         label: "I",
-        bgColor: "bg-gray-600/20",
-        textColor: "text-gray-500",
+        bgColor: "bg-canopy-border/30",
+        textColor: "text-canopy-text/60",
       };
     default:
       return {
         label: "?",
-        bgColor: "bg-gray-500/20",
-        textColor: "text-gray-400",
+        bgColor: "bg-canopy-border/20",
+        textColor: "text-canopy-text/60",
       };
   }
 }

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -137,7 +137,7 @@ export function NewWorktreeDialog({
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-canopy-text transition-colors"
+            className="text-canopy-text/60 hover:text-canopy-text transition-colors"
             disabled={creating}
           >
             <X className="h-5 w-5" />
@@ -148,7 +148,7 @@ export function NewWorktreeDialog({
           {loading ? (
             <div className="flex items-center justify-center py-12">
               <Loader2 className="w-6 h-6 animate-spin text-canopy-accent" />
-              <span className="ml-2 text-sm text-gray-400">Loading branches...</span>
+              <span className="ml-2 text-sm text-canopy-text/60">Loading branches...</span>
             </div>
           ) : (
             <>
@@ -171,7 +171,7 @@ export function NewWorktreeDialog({
                     </option>
                   ))}
                 </select>
-                <p className="text-xs text-gray-400">The branch to create the new worktree from</p>
+                <p className="text-xs text-canopy-text/60">The branch to create the new worktree from</p>
               </div>
 
               <div className="space-y-2">
@@ -187,7 +187,7 @@ export function NewWorktreeDialog({
                   className="w-full px-3 py-2 bg-canopy-bg border border-canopy-border rounded-md text-canopy-text focus:outline-none focus:ring-2 focus:ring-canopy-accent"
                   disabled={creating}
                 />
-                <p className="text-xs text-gray-400">Name for the new branch</p>
+                <p className="text-xs text-canopy-text/60">Name for the new branch</p>
               </div>
 
               <div className="space-y-2">
@@ -229,7 +229,7 @@ export function NewWorktreeDialog({
                     <FolderOpen className="w-4 h-4" />
                   </Button>
                 </div>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-canopy-text/60">
                   Directory where the worktree will be created
                 </p>
               </div>

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -348,7 +348,7 @@ export function WorktreeCard({
             {hasExpandableContent && (
               <button
                 onClick={handleToggleExpand}
-                className="p-0.5 text-gray-500 hover:text-gray-300 transition-colors"
+                className="p-0.5 text-canopy-text/60 hover:text-canopy-text transition-colors"
                 aria-label={isExpanded ? "Collapse details" : "Expand details"}
                 aria-expanded={isExpanded}
                 aria-controls={detailsId}
@@ -364,7 +364,7 @@ export function WorktreeCard({
           <div className="group/identity min-w-0 flex items-center justify-between gap-2 min-h-[22px] relative">
             <div className="flex items-baseline gap-1.5 min-w-0 pr-16">
               {isMainWorktree && (
-                <Shield className="w-3.5 h-3.5 text-gray-600 opacity-30 shrink-0 self-center" />
+                <Shield className="w-3.5 h-3.5 text-canopy-text/40 opacity-30 shrink-0 self-center" />
               )}
               <BranchLabel
                 label={branchLabel}
@@ -381,8 +381,8 @@ export function WorktreeCard({
               className={cn(
                 "flex items-center gap-1.5 shrink-0 text-[10px] px-2 py-0.5 rounded-full",
                 worktree.lastActivityTimestamp
-                  ? "bg-white/[0.03] text-gray-400"
-                  : "bg-transparent text-gray-600"
+                  ? "bg-white/[0.03] text-canopy-text/60"
+                  : "bg-transparent text-canopy-text/40"
               )}
               title={
                 worktree.lastActivityTimestamp
@@ -403,7 +403,7 @@ export function WorktreeCard({
                   e.stopPropagation();
                   onCopyTree();
                 }}
-                className="p-1 text-gray-400 hover:text-white hover:bg-white/10 rounded transition-colors"
+                className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/10 rounded transition-colors"
                 title="Copy Context"
                 aria-label="Copy Context"
               >
@@ -414,7 +414,7 @@ export function WorktreeCard({
                 <DropdownMenuTrigger asChild>
                   <button
                     onClick={(e) => e.stopPropagation()}
-                    className="p-1 text-gray-400 hover:text-white hover:bg-white/10 rounded transition-colors"
+                    className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/10 rounded transition-colors"
                     aria-label="More actions"
                   >
                     <MoreHorizontal className="w-3.5 h-3.5" />
@@ -510,7 +510,7 @@ export function WorktreeCard({
               <>
                 {/* Diff summary pill */}
                 {worktree.worktreeChanges && (
-                  <div className="inline-flex items-center gap-2 text-[11px] font-mono text-gray-400 bg-white/[0.02] border border-white/5 rounded px-2 py-0.5">
+                  <div className="inline-flex items-center gap-2 text-[11px] font-mono text-canopy-text/60 bg-white/[0.02] border border-white/5 rounded px-2 py-0.5">
                     <span>
                       {worktree.worktreeChanges.changedFileCount} file
                       {worktree.worktreeChanges.changedFileCount !== 1 ? "s" : ""}
@@ -518,7 +518,7 @@ export function WorktreeCard({
                     {((worktree.worktreeChanges.insertions ?? 0) > 0 ||
                       (worktree.worktreeChanges.deletions ?? 0) > 0) && (
                       <>
-                        <span className="text-gray-600">·</span>
+                        <span className="text-canopy-text/40">·</span>
                         {(worktree.worktreeChanges.insertions ?? 0) > 0 && (
                           <span className="text-[var(--color-status-success)]">
                             +{worktree.worktreeChanges.insertions}
@@ -526,7 +526,7 @@ export function WorktreeCard({
                         )}
                         {(worktree.worktreeChanges.insertions ?? 0) > 0 &&
                           (worktree.worktreeChanges.deletions ?? 0) > 0 && (
-                            <span className="text-gray-600">/</span>
+                            <span className="text-canopy-text/40">/</span>
                           )}
                         {(worktree.worktreeChanges.deletions ?? 0) > 0 && (
                           <span className="text-[var(--color-status-error)]">
@@ -545,15 +545,15 @@ export function WorktreeCard({
                   />
                 )}
                 {effectiveSummary && (
-                  <div className="text-xs text-gray-400 truncate mt-0.5">{effectiveSummary}</div>
+                  <div className="text-xs text-canopy-text/60 truncate mt-0.5">{effectiveSummary}</div>
                 )}
               </>
             ) : workspaceScenario === "clean-feature" ? (
               <>
                 {effectiveNote && !isExpanded ? (
-                  <div className="text-xs text-gray-300 truncate">{effectiveNote}</div>
+                  <div className="text-xs text-canopy-text truncate">{effectiveNote}</div>
                 ) : !isExpanded && firstLineLastCommitMessage ? (
-                  <div className="flex items-center gap-1.5 text-xs text-gray-400 opacity-80">
+                  <div className="flex items-center gap-1.5 text-xs text-canopy-text/60 opacity-80">
                     <GitCommit className="w-3 h-3 shrink-0" />
                     <span className="truncate">{firstLineLastCommitMessage}</span>
                   </div>
@@ -563,7 +563,7 @@ export function WorktreeCard({
               <>
                 {/* Last commit message - same as clean-feature */}
                 {firstLineLastCommitMessage ? (
-                  <div className="flex items-center gap-1.5 text-xs text-gray-400 opacity-80">
+                  <div className="flex items-center gap-1.5 text-xs text-canopy-text/60 opacity-80">
                     <GitCommit className="w-3 h-3 shrink-0" />
                     <span className="truncate">{firstLineLastCommitMessage}</span>
                     {/* Server indicator - only shown when running (terminal count is in footer) */}
@@ -578,7 +578,7 @@ export function WorktreeCard({
                     )}
                   </div>
                 ) : effectiveNote ? (
-                  <div className="text-xs text-gray-300 truncate">{effectiveNote}</div>
+                  <div className="text-xs text-canopy-text truncate">{effectiveNote}</div>
                 ) : null}
               </>
             ) : null}

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -40,7 +40,7 @@ function getServerStatusIndicator(serverState: DevServerState | null): React.Rea
   if (!serverState) return null;
   switch (serverState.status) {
     case "stopped":
-      return <span className="text-gray-600">○</span>;
+      return <span className="text-canopy-text/40">○</span>;
     case "starting":
       return <span className="text-[var(--color-server-starting)]">◐</span>;
     case "running":
@@ -48,7 +48,7 @@ function getServerStatusIndicator(serverState: DevServerState | null): React.Rea
     case "error":
       return <span className="text-[var(--color-server-error)]">●</span>;
     default:
-      return <span className="text-gray-600">○</span>;
+      return <span className="text-canopy-text/40">○</span>;
   }
 }
 
@@ -97,7 +97,7 @@ export function WorktreeDetails({
       {/* Zone 1: Context & Narrative */}
       {effectiveNote && (
         <div className="bg-yellow-500/5 p-2 rounded border-l-2 border-yellow-500/30">
-          <div className="text-xs text-gray-300 whitespace-pre-wrap font-mono">
+          <div className="text-xs text-canopy-text whitespace-pre-wrap font-mono">
             {parsedNoteSegments.map((segment, index) =>
               segment.type === "link" ? (
                 <a
@@ -119,7 +119,7 @@ export function WorktreeDetails({
       )}
 
       {showLastCommit && rawLastCommitMsg && (
-        <div className="text-xs text-gray-400 italic flex gap-2 p-2 bg-white/[0.02] rounded">
+        <div className="text-xs text-canopy-text/60 italic flex gap-2 p-2 bg-white/[0.02] rounded">
           <GitCommit className="w-3.5 h-3.5 mt-0.5 shrink-0 opacity-60" />
           <div className="whitespace-pre-wrap leading-relaxed min-w-0">{rawLastCommitMsg}</div>
         </div>
@@ -128,13 +128,13 @@ export function WorktreeDetails({
       {/* Zone 2: Operational Controls (The "Cockpit") */}
       {(showDevServer && serverState) || (terminalCounts && terminalCounts.total > 0) ? (
         <div className="space-y-2 p-2 bg-white/[0.02] rounded border border-white/5">
-          <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+          <div className="text-[10px] uppercase tracking-wider text-canopy-text/60 font-semibold">
             Controls
           </div>
 
           {showDevServer && serverState && (
             <div className="flex items-center justify-between text-xs">
-              <div className="flex items-center gap-2 text-gray-400 font-mono">
+              <div className="flex items-center gap-2 text-canopy-text/60 font-mono">
                 <Globe className="w-3.5 h-3.5" />
                 <div className="flex items-center gap-1.5">
                   {getServerStatusIndicator(serverState)}
@@ -174,7 +174,7 @@ export function WorktreeDetails({
           )}
 
           {terminalCounts && terminalCounts.total > 0 && (
-            <div className="flex items-center gap-2 text-xs text-gray-400 font-mono">
+            <div className="flex items-center gap-2 text-xs text-canopy-text/60 font-mono">
               <Terminal className="w-3.5 h-3.5" />
               <span>
                 {terminalCounts.total} terminal{terminalCounts.total !== 1 ? "s" : ""} active
@@ -202,7 +202,7 @@ export function WorktreeDetails({
             />
           ))}
           {worktreeErrors.length > 3 && (
-            <div className="text-[0.65rem] text-gray-500 text-center">
+            <div className="text-[0.65rem] text-canopy-text/60 text-center">
               +{worktreeErrors.length - 3} more errors
             </div>
           )}
@@ -212,7 +212,7 @@ export function WorktreeDetails({
       {/* Zone 3: The Work (Teleported File List) */}
       {hasChanges && worktree.worktreeChanges && (
         <div className="space-y-2">
-          <div className="text-[10px] uppercase tracking-wider text-gray-500 font-semibold">
+          <div className="text-[10px] uppercase tracking-wider text-canopy-text/60 font-semibold">
             Changed Files
           </div>
           <FileChangeList
@@ -231,7 +231,7 @@ export function WorktreeDetails({
             onPathClick();
           }}
           className={cn(
-            "text-[0.7rem] text-gray-500 hover:text-gray-400 hover:underline text-left font-mono truncate block w-full",
+            "text-[0.7rem] text-canopy-text/60 hover:text-canopy-text/80 hover:underline text-left font-mono truncate block w-full",
             isFocused && "underline"
           )}
           title={worktree.path}

--- a/src/components/Worktree/WorktreeList.tsx
+++ b/src/components/Worktree/WorktreeList.tsx
@@ -259,7 +259,7 @@ export function WorktreeList({
         {onRetry && (
           <button
             onClick={onRetry}
-            className="text-xs px-3 py-1 border border-gray-600 rounded hover:bg-gray-800 text-gray-300"
+            className="text-xs px-3 py-1 border border-canopy-border rounded hover:bg-canopy-border text-canopy-text"
           >
             Retry
           </button>
@@ -271,12 +271,12 @@ export function WorktreeList({
   if (sortedWorktrees.length === 0) {
     return (
       <div
-        className="flex flex-col items-center justify-center h-full p-4 text-gray-500"
+        className="flex flex-col items-center justify-center h-full p-4 text-canopy-text/60"
         role="status"
         aria-live="polite"
       >
         <svg
-          className="w-8 h-8 mb-2 text-gray-600"
+          className="w-8 h-8 mb-2 text-canopy-text/40"
           fill="none"
           viewBox="0 0 24 24"
           stroke="currentColor"
@@ -290,7 +290,7 @@ export function WorktreeList({
           />
         </svg>
         <span className="text-sm">No worktrees found</span>
-        <span className="text-xs text-gray-600 mt-1">
+        <span className="text-xs text-canopy-text/40 mt-1">
           Open a git repository with worktrees to get started
         </span>
       </div>
@@ -301,7 +301,7 @@ export function WorktreeList({
     <div className="relative h-full" onFocus={handleFocus} onBlur={handleBlur}>
       {showScrollUp && (
         <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-canopy-sidebar to-transparent pointer-events-none z-10 flex items-center justify-center">
-          <span className="text-xs text-gray-500">↑ more worktrees</span>
+          <span className="text-xs text-canopy-text/60">↑ more worktrees</span>
         </div>
       )}
 
@@ -353,7 +353,7 @@ export function WorktreeList({
 
       {showScrollDown && (
         <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-canopy-sidebar to-transparent pointer-events-none z-10 flex items-center justify-center">
-          <span className="text-xs text-gray-500">↓ more worktrees</span>
+          <span className="text-xs text-canopy-text/60">↓ more worktrees</span>
         </div>
       )}
     </div>

--- a/src/components/ui/SegmentedControl.tsx
+++ b/src/components/ui/SegmentedControl.tsx
@@ -90,7 +90,7 @@ export function SegmentedControl({
                 "flex-1 flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-all duration-200 ease-out",
                 isActive
                   ? "bg-canopy-accent/10 text-canopy-accent"
-                  : "text-gray-400 hover:text-gray-200 hover:bg-white/5"
+                  : "text-canopy-text/60 hover:text-canopy-text hover:bg-white/5"
               )}
             >
               {tab.icon && (

--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -112,7 +112,7 @@ export function Tabs({
               fullWidth && "flex-1",
               isActive
                 ? "text-canopy-accent border-b-2 border-canopy-accent -mb-px"
-                : "text-gray-400 hover:text-gray-200"
+                : "text-canopy-text/60 hover:text-canopy-text"
             )}
           >
             {option.icon && <span className="mr-2">{option.icon}</span>}

--- a/src/components/ui/emoji-picker.tsx
+++ b/src/components/ui/emoji-picker.tsx
@@ -14,14 +14,14 @@ export function EmojiPicker({ className, onEmojiSelect }: EmojiPickerProps) {
       emojibaseUrl="/emojibase"
     >
       <EmojiPickerPrimitive.Search
-        className="z-10 mx-2 mt-2 appearance-none rounded-md bg-canopy-bg border border-canopy-border px-3 py-2 text-sm text-canopy-text placeholder:text-gray-500 focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
+        className="z-10 mx-2 mt-2 appearance-none rounded-md bg-canopy-bg border border-canopy-border px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
         placeholder="Search emojis..."
       />
       <EmojiPickerPrimitive.Viewport className="relative flex-1 outline-hidden">
-        <EmojiPickerPrimitive.Loading className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
+        <EmojiPickerPrimitive.Loading className="absolute inset-0 flex items-center justify-center text-canopy-text/60 text-sm">
           Loading…
         </EmojiPickerPrimitive.Loading>
-        <EmojiPickerPrimitive.Empty className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
+        <EmojiPickerPrimitive.Empty className="absolute inset-0 flex items-center justify-center text-canopy-text/60 text-sm">
           No emoji found.
         </EmojiPickerPrimitive.Empty>
         <EmojiPickerPrimitive.List
@@ -29,7 +29,7 @@ export function EmojiPicker({ className, onEmojiSelect }: EmojiPickerProps) {
           components={{
             CategoryHeader: ({ category, ...props }) => (
               <div
-                className="bg-canopy-sidebar px-3 pt-3 pb-1.5 font-medium text-gray-400 text-xs"
+                className="bg-canopy-sidebar px-3 pt-3 pb-1.5 font-medium text-canopy-text/60 text-xs"
                 {...props}
               >
                 {category.label}
@@ -53,7 +53,7 @@ export function EmojiPicker({ className, onEmojiSelect }: EmojiPickerProps) {
       </EmojiPickerPrimitive.Viewport>
       <EmojiPickerPrimitive.ActiveEmoji>
         {({ emoji }) => (
-          <div className="flex items-center gap-2 px-3 py-2 border-t border-canopy-border text-sm text-gray-400 min-h-[40px]">
+          <div className="flex items-center gap-2 px-3 py-2 border-t border-canopy-border text-sm text-canopy-text/60 min-h-[40px]">
             {emoji ? (
               <>
                 <span className="text-xl">{emoji.emoji}</span>


### PR DESCRIPTION
## Summary
Replace hardcoded grey color classes with design tokens to ensure consistent styling across the application.

Closes #636

## Changes Made
- Replace `text-gray-*` classes with `text-canopy-text/60` for secondary text
- Replace `text-gray-*` classes with `text-canopy-text` for primary text
- Replace `text-gray-*` classes with `text-canopy-text/40` for subtle text
- Replace `placeholder:text-gray-*` with `placeholder:text-canopy-text/40`
- Replace `bg-gray-*` classes with `bg-canopy-bg` or `bg-canopy-border`
- Replace `border-gray-*` classes with `border-canopy-border`
- Replace `hover:text-gray-*` with `hover:text-canopy-text`
- Update 29 component files across the codebase