### PR TITLE
Add interactive terminal dropdown to worktree cards

### DIFF
--- a/src/components/Worktree/TerminalCountBadge.tsx
+++ b/src/components/Worktree/TerminalCountBadge.tsx
@@ -1,9 +1,22 @@
-import { TerminalSquare } from "lucide-react";
+import { TerminalSquare, LayoutGrid, PanelBottom } from "lucide-react";
 import type { WorktreeTerminalCounts } from "@/hooks/useWorktreeTerminals";
-import type { AgentState } from "@/types";
+import type { AgentState, TerminalInstance, TerminalType } from "@/types";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+import { ClaudeIcon, GeminiIcon, CodexIcon, NpmIcon, YarnIcon, PnpmIcon, BunIcon } from "@/components/icons";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import { cn } from "@/lib/utils";
 
 interface TerminalCountBadgeProps {
   counts: WorktreeTerminalCounts;
+  terminals: TerminalInstance[];
+  onSelectTerminal: (terminal: TerminalInstance) => void;
 }
 
 const STATE_LABELS: Record<AgentState, string> = {
@@ -17,7 +30,7 @@ const STATE_LABELS: Record<AgentState, string> = {
 function formatStateCounts(byState: Record<AgentState, number>): string {
   const parts: string[] = [];
 
-  const priorityOrder: AgentState[] = ["working", "failed", "idle", "completed"];
+  const priorityOrder: AgentState[] = ["working", "waiting", "failed", "idle", "completed"];
 
   for (const state of priorityOrder) {
     const count = byState[state];
@@ -29,24 +42,110 @@ function formatStateCounts(byState: Record<AgentState, number>): string {
   return parts.join(" · ");
 }
 
-export function TerminalCountBadge({ counts }: TerminalCountBadgeProps) {
+function getTerminalIcon(type: TerminalType) {
+  const brandColor = getBrandColorHex(type);
+  const className = "w-3.5 h-3.5";
+
+  switch (type) {
+    case "claude":
+      return <ClaudeIcon className={className} brandColor={brandColor} />;
+    case "gemini":
+      return <GeminiIcon className={className} brandColor={brandColor} />;
+    case "codex":
+      return <CodexIcon className={className} brandColor={brandColor} />;
+    case "npm":
+      return <NpmIcon className={className} />;
+    case "yarn":
+      return <YarnIcon className={className} />;
+    case "pnpm":
+      return <PnpmIcon className={className} />;
+    case "bun":
+      return <BunIcon className={className} />;
+    default:
+      return <TerminalSquare className={className} />;
+  }
+}
+
+export function TerminalCountBadge({ counts, terminals, onSelectTerminal }: TerminalCountBadgeProps) {
   if (counts.total === 0) {
     return null;
   }
 
   const hasNonIdleStates =
-    counts.byState.working > 0 || counts.byState.completed > 0 || counts.byState.failed > 0;
+    counts.byState.working > 0 ||
+    counts.byState.completed > 0 ||
+    counts.byState.failed > 0 ||
+    counts.byState.waiting > 0;
 
   return (
-    <div className="flex items-center gap-1.5 px-2 py-1 text-xs text-canopy-text/50 bg-black/20 rounded-sm">
-      <TerminalSquare className="w-3 h-3 opacity-70" aria-hidden="true" />
-      {hasNonIdleStates ? (
-        <span className="font-mono">{formatStateCounts(counts.byState)}</span>
-      ) : (
-        <span className="font-mono">
-          {counts.total} {counts.total === 1 ? "terminal" : "terminals"}
-        </span>
-      )}
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "flex items-center gap-1.5 px-2 py-1 text-xs text-canopy-text/60 bg-black/20 rounded-sm",
+            "hover:bg-black/40 hover:text-canopy-text transition-colors cursor-pointer border border-transparent hover:border-white/10"
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <TerminalSquare className="w-3 h-3 opacity-70" aria-hidden="true" />
+          {hasNonIdleStates ? (
+            <span className="font-mono">{formatStateCounts(counts.byState)}</span>
+          ) : (
+            <span className="font-mono">
+              {counts.total} {counts.total === 1 ? "terminal" : "terminals"}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64" onClick={(e) => e.stopPropagation()}>
+        <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
+          Active Sessions ({terminals.length})
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <div className="max-h-[300px] overflow-y-auto">
+          {terminals.map((term) => (
+            <DropdownMenuItem
+              key={term.id}
+              onSelect={(e) => {
+                e.preventDefault();
+                onSelectTerminal(term);
+              }}
+              className="flex items-center gap-3 py-2 cursor-pointer"
+            >
+              <div className="shrink-0 opacity-80">{getTerminalIcon(term.type)}</div>
+              <div className="flex-1 min-w-0 flex flex-col">
+                <span className="text-sm font-medium truncate">{term.title}</span>
+                <span className="text-[10px] text-muted-foreground truncate flex items-center gap-1.5">
+                  {term.location === "dock" ? (
+                    <>
+                      <PanelBottom className="w-3 h-3" /> Docked
+                    </>
+                  ) : (
+                    <>
+                      <LayoutGrid className="w-3 h-3" /> Grid
+                    </>
+                  )}
+                  {term.agentState && term.agentState !== "idle" && (
+                    <>
+                      <span>•</span>
+                      <span
+                        className={cn(
+                          term.agentState === "working" && "text-[var(--color-state-working)]",
+                          term.agentState === "failed" && "text-[var(--color-status-error)]",
+                          term.agentState === "completed" && "text-[var(--color-status-success)]",
+                          term.agentState === "waiting" && "text-[var(--color-state-waiting)]"
+                        )}
+                      >
+                        {term.agentState}
+                      </span>
+                    </>
+                  )}
+                </span>
+              </div>
+            </DropdownMenuItem>
+          ))}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -10,7 +10,7 @@ import { TerminalCountBadge } from "./TerminalCountBadge";
 import { WorktreeDetails } from "./WorktreeDetails";
 import { useDevServer } from "../../hooks/useDevServer";
 import { useWorktreeTerminals } from "../../hooks/useWorktreeTerminals";
-import { useErrorStore, useTerminalStore, type RetryAction } from "../../store";
+import { useErrorStore, useTerminalStore, type RetryAction, type TerminalInstance } from "../../store";
 import { useRecipeStore } from "../../store/recipeStore";
 import { useWorktreeSelectionStore } from "../../store/worktreeStore";
 import { systemClient, errorsClient } from "@/clients";
@@ -98,7 +98,13 @@ export function WorktreeCard({
   const recipes = getRecipesForWorktree(worktree.id);
   const [runningRecipeId, setRunningRecipeId] = useState<string | null>(null);
 
-  const { counts: terminalCounts, dominantAgentState } = useWorktreeTerminals(worktree.id);
+  const {
+    counts: terminalCounts,
+    dominantAgentState,
+    terminals: worktreeTerminals,
+  } = useWorktreeTerminals(worktree.id);
+
+  const setFocused = useTerminalStore((state) => state.setFocused);
 
   const bulkCloseByWorktree = useTerminalStore((state) => state.bulkCloseByWorktree);
   const completedCount = terminalCounts.byState.completed;
@@ -246,6 +252,13 @@ export function WorktreeCard({
       onLaunchAgent?.(type);
     },
     [onLaunchAgent]
+  );
+
+  const handleTerminalSelect = useCallback(
+    (terminal: TerminalInstance) => {
+      setFocused(terminal.id);
+    },
+    [setFocused]
   );
 
   const branchLabel = worktree.branch ?? worktree.name;
@@ -621,7 +634,11 @@ export function WorktreeCard({
               <div className="flex items-center justify-between mt-2 pt-2 border-t border-white/5 text-[10px] font-mono">
                 <div className="flex flex-wrap items-center gap-1.5">
                   <AgentStatusIndicator state={dominantAgentState} />
-                  <TerminalCountBadge counts={terminalCounts} />
+                  <TerminalCountBadge
+                    counts={terminalCounts}
+                    terminals={worktreeTerminals}
+                    onSelectTerminal={handleTerminalSelect}
+                  />
                 </div>
                 <div className="flex items-center gap-1.5">
                   {worktree.issueNumber && (

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -20,7 +20,9 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
   // Without this, .filter() returns a new reference every render,
   // breaking React's useSyncExternalStore contract.
   const terminals = useTerminalStore(
-    useShallow((state) => state.terminals.filter((t) => t.worktreeId === worktreeId))
+    useShallow((state) =>
+      state.terminals.filter((t) => t.worktreeId === worktreeId && t.location !== "trash")
+    )
   );
 
   return useMemo(() => {


### PR DESCRIPTION
## Summary

Converts the static terminal count badge in worktree cards into an interactive dropdown that allows users to view and select terminals associated with each worktree. Clicking any terminal in the dropdown focuses it (whether in grid or dock).

Closes #634

## Changes Made

- Convert static terminal count badge into clickable dropdown menu
- Display terminal list with icons, titles, locations (Grid/Dock), and agent states
- Filter trashed terminals from counts and dropdown list
- Add keyboard accessibility with onSelect handler for dropdown items
- Include waiting state in badge summary and priority order
- Wire up terminal selection to focus terminals in grid or dock via setFocused