### PR TITLE
Surface missing agent CLI warnings in toolbar and settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -357,7 +357,9 @@ function App() {
   const removeError = useErrorStore((state) => state.removeError);
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [settingsTab, setSettingsTab] = useState<"general" | "troubleshooting">("general");
+  const [settingsTab, setSettingsTab] = useState<"general" | "agents" | "troubleshooting">(
+    "general"
+  );
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
   const [isStateLoaded, setIsStateLoaded] = useState(false);
 
@@ -430,6 +432,11 @@ function App() {
 
   const handleSettings = useCallback(() => {
     setSettingsTab("general");
+    setIsSettingsOpen(true);
+  }, []);
+
+  const handleOpenAgentSettings = useCallback(() => {
+    setSettingsTab("agents");
     setIsSettingsOpen(true);
   }, []);
 
@@ -793,6 +800,7 @@ function App() {
           sidebarContent={<SidebarContent />}
           onLaunchAgent={handleLaunchAgent}
           onSettings={handleSettings}
+          onOpenAgentSettings={handleOpenAgentSettings}
           onRetry={handleErrorRetry}
           agentAvailability={availability}
           agentSettings={agentSettings}

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -22,6 +22,7 @@ interface AppLayoutProps {
   sidebarContent?: ReactNode;
   onLaunchAgent?: (type: "claude" | "gemini" | "codex" | "shell") => void;
   onSettings?: () => void;
+  onOpenAgentSettings?: () => void;
   onRetry?: (id: string, action: RetryAction, args?: Record<string, unknown>) => void;
   agentAvailability?: CliAvailability;
   agentSettings?: AgentSettings | null;
@@ -36,6 +37,7 @@ export function AppLayout({
   sidebarContent,
   onLaunchAgent,
   onSettings,
+  onOpenAgentSettings,
   onRetry,
   agentAvailability,
   agentSettings,
@@ -235,6 +237,7 @@ export function AppLayout({
       <Toolbar
         onLaunchAgent={handleLaunchAgent}
         onSettings={handleSettings}
+        onOpenAgentSettings={onOpenAgentSettings}
         errorCount={errorCount}
         onToggleProblems={handleToggleProblems}
         isFocusMode={isFocusMode}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -28,6 +28,7 @@ import type { CliAvailability, AgentSettings } from "@shared/types";
 interface ToolbarProps {
   onLaunchAgent: (type: "claude" | "gemini" | "codex" | "shell") => void;
   onSettings: () => void;
+  onOpenAgentSettings?: () => void;
   errorCount?: number;
   onToggleProblems?: () => void;
   isFocusMode?: boolean;
@@ -39,6 +40,7 @@ interface ToolbarProps {
 export function Toolbar({
   onLaunchAgent,
   onSettings,
+  onOpenAgentSettings,
   errorCount = 0,
   onToggleProblems,
   isFocusMode = false,
@@ -70,14 +72,20 @@ export function Toolbar({
       show: isEnabled,
       available: isAvailable ?? false,
       isLoading,
-      tooltip:
-        isLoading || isAvailable
+      tooltip: isLoading
+        ? `Checking ${agentNames[type]} CLI availability...`
+        : isAvailable
           ? type === "claude"
             ? "Start Claude — Opus 4.5 for deep work (Ctrl+Shift+C)"
             : type === "gemini"
               ? "Start Gemini — Auto-routing enabled (Ctrl+Shift+G)"
               : "Start Codex — GPT-5.1 Max (Ctrl+Shift+X)"
           : `${agentNames[type]} CLI not found. Click to install.`,
+      ariaLabel: isLoading
+        ? `Checking ${agentNames[type]} availability`
+        : isAvailable
+          ? `Start ${agentNames[type]} Agent`
+          : `${agentNames[type]} CLI not installed`,
     };
   };
 
@@ -108,14 +116,17 @@ export function Toolbar({
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => (status.available ? onLaunchAgent("claude") : onSettings())}
+              onClick={() =>
+                status.available ? onLaunchAgent("claude") : (onOpenAgentSettings ?? onSettings)()
+              }
+              disabled={status.isLoading}
               className={cn(
                 "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
                 status.available && "hover:text-canopy-accent focus-visible:text-canopy-accent",
                 !status.available && !status.isLoading && "opacity-60"
               )}
               title={status.tooltip}
-              aria-label={status.available ? "Start Claude Agent" : "Claude CLI not installed"}
+              aria-label={status.ariaLabel}
             >
               <div className="relative">
                 <ClaudeIcon className="h-4 w-4" brandColor={getBrandColorHex("claude")} />
@@ -133,14 +144,17 @@ export function Toolbar({
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => (status.available ? onLaunchAgent("gemini") : onSettings())}
+              onClick={() =>
+                status.available ? onLaunchAgent("gemini") : (onOpenAgentSettings ?? onSettings)()
+              }
+              disabled={status.isLoading}
               className={cn(
                 "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
                 status.available && "hover:text-canopy-accent focus-visible:text-canopy-accent",
                 !status.available && !status.isLoading && "opacity-60"
               )}
               title={status.tooltip}
-              aria-label={status.available ? "Start Gemini Agent" : "Gemini CLI not installed"}
+              aria-label={status.ariaLabel}
             >
               <div className="relative">
                 <GeminiIcon className="h-4 w-4" brandColor={getBrandColorHex("gemini")} />
@@ -158,14 +172,17 @@ export function Toolbar({
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => (status.available ? onLaunchAgent("codex") : onSettings())}
+              onClick={() =>
+                status.available ? onLaunchAgent("codex") : (onOpenAgentSettings ?? onSettings)()
+              }
+              disabled={status.isLoading}
               className={cn(
                 "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
                 status.available && "hover:text-canopy-accent focus-visible:text-canopy-accent",
                 !status.available && !status.isLoading && "opacity-60"
               )}
               title={status.tooltip}
-              aria-label={status.available ? "Start Codex Agent" : "Codex CLI not installed"}
+              aria-label={status.ariaLabel}
             >
               <div className="relative">
                 <CodexIcon className="h-4 w-4" brandColor={getBrandColorHex("codex")} />


### PR DESCRIPTION
## Summary
Implements direct navigation to the Agents settings tab when users click disabled agent buttons in the toolbar, improving discoverability of missing CLI installations.

Closes #645

## Changes Made
- Add `onOpenAgentSettings` callback to navigate directly to Agents tab
- Disable agent buttons during CLI availability check to prevent premature navigation
- Add loading state tooltips ("Checking ... CLI availability...")
- Fix ARIA labels to accurately reflect loading/unavailable/available states
- Clicking disabled agent buttons now opens Settings → Agents tab (not general Settings)

## Implementation Details
The toolbar already showed warning indicators (amber dots) for missing CLIs, but clicking them opened the General settings tab instead of the Agents tab where the installation instructions are located. This PR fixes that navigation flow and improves the loading state UX based on code review feedback.

**Files Modified:**
- `src/App.tsx`: Added `handleOpenAgentSettings` handler
- `src/components/Layout/AppLayout.tsx`: Thread through `onOpenAgentSettings` prop
- `src/components/Layout/Toolbar.tsx`: Use new callback + improved loading states