### PR TITLE
Replace raw blue-600 CTAs with semantic info token

### DIFF
--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -71,7 +71,7 @@ export function LogsActions() {
         className={cn(
           "px-2 py-0.5 text-xs rounded transition-colors",
           autoScroll
-            ? "bg-blue-600 text-white"
+            ? "bg-[var(--color-status-info)] text-white hover:brightness-110"
             : "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border"
         )}
         title={autoScroll ? "Auto-scroll enabled" : "Auto-scroll disabled"}

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -158,8 +158,8 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
           }}
           className={cn(
             "absolute bottom-4 right-4 px-3 py-1.5 text-xs rounded-full",
-            "bg-blue-600 text-white shadow-lg",
-            "hover:bg-blue-500 transition-colors"
+            "bg-[var(--color-status-info)] text-white shadow-lg",
+            "hover:brightness-110 transition-all"
           )}
         >
           Scroll to bottom


### PR DESCRIPTION
## Summary
Migrates diagnostics and logs components from raw Tailwind `blue-600`/`blue-500` colors to the semantic `--color-status-info` design token for visual consistency across the app.

Closes #682

## Changes Made
- Replace bg-blue-600 with bg-[var(--color-status-info)] in LogsContent scroll-to-bottom button
- Replace bg-blue-600 with bg-[var(--color-status-info)] in DiagnosticsActions auto-scroll toggle
- Use hover:brightness-110 instead of opacity for consistency with other info-colored buttons
- Maintains visual consistency with app's semantic color system