### PR TITLE
Add consistent focus-visible styles for keyboard navigation

### DIFF
--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -20,6 +20,7 @@ function ActionButton({ onClick, disabled, children, className, title }: ActionB
       className={cn(
         "px-2 py-0.5 text-xs rounded transition-colors",
         "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canopy-bg",
         disabled && "opacity-50 cursor-not-allowed",
         className
       )}
@@ -43,7 +44,12 @@ export function ProblemsActions() {
       <ActionButton onClick={handleOpenLogs} title="Open log file">
         Open Logs
       </ActionButton>
-      <ActionButton onClick={clearAll} disabled={!hasActiveErrors} title="Clear all errors">
+      <ActionButton
+        onClick={clearAll}
+        disabled={!hasActiveErrors}
+        title="Clear all errors"
+        className="focus-visible:ring-[var(--color-status-error)] focus-visible:ring-offset-canopy-bg"
+      >
         Clear All
       </ActionButton>
     </div>
@@ -70,6 +76,7 @@ export function LogsActions() {
         onClick={() => setAutoScroll(!autoScroll)}
         className={cn(
           "px-2 py-0.5 text-xs rounded transition-colors",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canopy-bg",
           autoScroll
             ? "bg-blue-600 text-white"
             : "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border"
@@ -81,7 +88,11 @@ export function LogsActions() {
       <ActionButton onClick={handleOpenFile} title="Open log file">
         Open File
       </ActionButton>
-      <ActionButton onClick={handleClearLogs} title="Clear logs">
+      <ActionButton
+        onClick={handleClearLogs}
+        title="Clear logs"
+        className="focus-visible:ring-[var(--color-status-error)] focus-visible:ring-offset-canopy-bg"
+      >
         Clear
       </ActionButton>
     </div>
@@ -102,7 +113,11 @@ export function EventsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <ActionButton onClick={handleClearEvents} title="Clear all events">
+      <ActionButton
+        onClick={handleClearEvents}
+        title="Clear all events"
+        className="focus-visible:ring-[var(--color-status-error)] focus-visible:ring-offset-canopy-bg"
+      >
         Clear
       </ActionButton>
     </div>

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -35,8 +35,9 @@ const TabButton = memo(function TabButton({
       id={`diagnostics-${tab}-tab`}
       onClick={onClick}
       className={cn(
-        "px-3 py-1.5 text-sm font-medium transition-colors relative",
+        "px-3 py-1.5 text-sm font-medium transition-colors relative rounded",
         "hover:text-canopy-text",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-sidebar",
         isActive ? "text-canopy-text" : "text-canopy-text/60"
       )}
       role="tab"
@@ -179,7 +180,7 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
       <div
         className={cn(
           "group h-1.5 cursor-ns-resize transition-colors flex items-center justify-center",
-          "hover:bg-canopy-accent/30 focus:outline-none focus:bg-canopy-accent/50",
+          "hover:bg-canopy-accent/30 focus-visible:outline-none focus-visible:bg-canopy-accent/50",
           isResizing && "bg-canopy-accent/50"
         )}
         onMouseDown={handleResizeStart}
@@ -223,7 +224,7 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
 
           <button
             onClick={closeDock}
-            className="p-1.5 hover:bg-canopy-border rounded transition-colors text-canopy-text/60 hover:text-canopy-text"
+            className="p-1.5 hover:bg-canopy-border rounded transition-colors text-canopy-text/60 hover:text-canopy-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
             title="Close diagnostics dock"
             aria-label="Close diagnostics dock"
           >

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -90,7 +90,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
             {currentProject && (
               <button
                 onClick={() => setIsSettingsOpen(true)}
-                className="p-2 mr-1 text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/50 rounded transition-colors"
+                className="p-2 mr-1 text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/50 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                 title="Project Settings"
               >
                 <Settings className="h-4 w-4" />
@@ -109,10 +109,12 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           aria-label="Resize sidebar"
           aria-orientation="vertical"
           aria-valuenow={width}
+          aria-valuemin={200}
+          aria-valuemax={600}
           tabIndex={0}
           className={cn(
             "group absolute top-0 right-0 w-1.5 h-full cursor-col-resize flex items-center justify-center",
-            "hover:bg-canopy-accent/30 transition-colors focus:outline-none focus:bg-canopy-accent/50",
+            "hover:bg-canopy-accent/30 transition-colors focus-visible:outline-none focus-visible:bg-canopy-accent/50",
             isResizing && "bg-canopy-accent/50"
           )}
           onMouseDown={startResizing}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -91,6 +91,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("general")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "general"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -102,6 +103,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("keyboard")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "keyboard"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -114,6 +116,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("terminal")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "terminal"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -126,6 +129,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("agents")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "agents"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -138,6 +142,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("github")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "github"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -150,6 +155,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("sidecar")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors flex items-center gap-2",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "sidecar"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -162,6 +168,7 @@ export function SettingsDialog({
             onClick={() => setActiveTab("troubleshooting")}
             className={cn(
               "text-left px-3 py-2 rounded-[var(--radius-md)] text-sm transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2 focus-visible:ring-offset-canopy-bg",
               activeTab === "troubleshooting"
                 ? "bg-canopy-accent/10 text-canopy-accent"
                 : "text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text"
@@ -188,7 +195,7 @@ export function SettingsDialog({
             </h3>
             <button
               onClick={onClose}
-              className="text-canopy-text/60 hover:text-canopy-text transition-colors"
+              className="text-canopy-text/60 hover:text-canopy-text transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
               aria-label="Close settings"
             >
               <X className="h-5 w-5" />

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -338,7 +338,8 @@ export function WorktreeCard({
         isActive ? "bg-white/[0.03]" : "hover:bg-white/[0.02] bg-transparent",
         isFocused && "bg-white/[0.04]",
         // Current worktree accent: persistent left border indicating "you are here"
-        worktree.isCurrent && "border-l-2 border-l-teal-500/50"
+        worktree.isCurrent && "border-l-2 border-l-teal-500/50",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
       )}
       onClick={onSelect}
       onKeyDown={(e) => {
@@ -366,7 +367,7 @@ export function WorktreeCard({
             {hasExpandableContent && (
               <button
                 onClick={handleToggleExpand}
-                className="p-0.5 text-canopy-text/60 hover:text-canopy-text transition-colors"
+                className="p-0.5 text-canopy-text/60 hover:text-canopy-text transition-colors rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                 aria-label={isExpanded ? "Collapse details" : "Expand details"}
                 aria-expanded={isExpanded}
                 aria-controls={detailsId}
@@ -422,7 +423,7 @@ export function WorktreeCard({
                   e.currentTarget.blur();
                   onCopyTree();
                 }}
-                className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/10 rounded transition-colors"
+                className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/10 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                 title="Copy Context"
                 aria-label="Copy Context"
               >
@@ -433,7 +434,7 @@ export function WorktreeCard({
                 <DropdownMenuTrigger asChild>
                   <button
                     onClick={(e) => e.stopPropagation()}
-                    className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/10 rounded transition-colors"
+                    className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/10 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                     aria-label="More actions"
                   >
                     <MoreHorizontal className="w-3.5 h-3.5" />
@@ -658,7 +659,8 @@ export function WorktreeCard({
                       className={cn(
                         "flex items-center gap-1 text-[10px] text-[var(--color-status-info)]",
                         "bg-blue-500/10 px-1.5 py-0.5 rounded border border-blue-500/20",
-                        "hover:bg-blue-500/20 transition-colors cursor-pointer"
+                        "hover:bg-blue-500/20 transition-colors cursor-pointer",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                       )}
                       title="Open Issue on GitHub"
                     >
@@ -676,6 +678,7 @@ export function WorktreeCard({
                         "flex items-center gap-1 text-[10px]",
                         "px-1.5 py-0.5 rounded border",
                         "hover:brightness-125 transition-colors cursor-pointer",
+                        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
                         // Color based on PR state (open=green, merged=purple, closed=red)
                         worktree.prState === "merged"
                           ? "text-purple-400 bg-purple-500/10 border-purple-500/20"

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -147,7 +147,7 @@ export function WorktreeDetails({
                   href={segment.content}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-[var(--color-status-info)] underline hover:text-blue-300"
+                  className="text-[var(--color-status-info)] underline hover:text-blue-300 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
                   onClick={(e) => handleLinkClick(e, segment.content)}
                 >
                   {segment.content}
@@ -193,6 +193,7 @@ export function WorktreeDetails({
                 disabled={serverLoading || serverState.status === "starting"}
                 className={cn(
                   "px-2 py-1 rounded text-xs font-medium transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
                   serverState.status === "running"
                     ? "bg-red-500/10 text-red-400 hover:bg-red-500/20"
                     : "bg-green-500/10 text-green-400 hover:bg-green-500/20",
@@ -275,7 +276,8 @@ export function WorktreeDetails({
               onPathClick();
             }}
             className={cn(
-              "text-[0.7rem] text-canopy-text/60 hover:text-canopy-text/80 hover:underline text-left font-mono truncate flex-1 min-w-0 flex items-center gap-1.5",
+              "text-[0.7rem] text-canopy-text/60 hover:text-canopy-text/80 hover:underline text-left font-mono truncate flex-1 min-w-0 flex items-center gap-1.5 rounded",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
               isFocused && "underline"
             )}
             title={`Open folder: ${worktree.path}`}
@@ -287,7 +289,7 @@ export function WorktreeDetails({
           <button
             type="button"
             onClick={handleCopyPath}
-            className="shrink-0 p-1 text-canopy-text/60 hover:text-canopy-text/80 hover:bg-white/5 rounded transition-colors"
+            className="shrink-0 p-1 text-canopy-text/60 hover:text-canopy-text/80 hover:bg-white/5 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
             title={pathCopied ? "Copied!" : "Copy full path"}
             aria-label={pathCopied ? "Path copied to clipboard" : "Copy path to clipboard"}
           >


### PR DESCRIPTION
## Summary
Implements comprehensive keyboard focus indicators across interactive elements to improve accessibility and meet WCAG 2.4.7 (Level AA) standards. All interactive elements now have clear, visible focus indicators that only appear with keyboard navigation (using focus-visible).

Closes #638

## Changes Made
- Added focus-visible rings to Settings dialog tab navigation buttons with proper offset
- Added focus indicators to Diagnostics dock tabs and close button
- Added focus outline to Sidebar project settings button
- Added focus styles to all Worktree card interactive elements (expand, copy, more actions, issue/PR badges)
- Added focus outline to WorktreeDetails note links, path controls, and server toggle
- Added focus styles to DiagnosticsActions buttons with error-red focus for destructive clear actions
- Added aria-valuemin/max attributes to Sidebar resize handle for complete screen reader support
- Ensured consistent use of focus-visible (not focus) to avoid mouse-click outlines
- Applied error-red focus indicators to destructive actions for better visual distinction