### PR TITLE
Add tooltips and improve dev server UX affordances

### DIFF
--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -263,21 +263,30 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                       !devServerEnabled && "opacity-50 pointer-events-none"
                     )}
                   >
-                    <label className="flex items-center gap-3 cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={devServerAutoStart}
-                        onChange={(e) => setDevServerAutoStart(e.target.checked)}
-                        disabled={!devServerEnabled}
-                        className="w-4 h-4 rounded border-canopy-border bg-canopy-sidebar text-canopy-accent focus:ring-canopy-accent/50 disabled:opacity-50"
-                      />
-                      <div>
-                        <span className="text-sm text-canopy-text">Auto-start on project load</span>
-                        <p className="text-xs text-canopy-text/60">
-                          Automatically start the dev server when switching to this project
+                    <div className="space-y-2">
+                      <label className="flex items-center gap-3 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={devServerAutoStart}
+                          onChange={(e) => setDevServerAutoStart(e.target.checked)}
+                          disabled={!devServerEnabled}
+                          className="w-4 h-4 rounded border-canopy-border bg-canopy-sidebar text-canopy-accent focus:ring-canopy-accent/50 disabled:opacity-50"
+                        />
+                        <div>
+                          <span className="text-sm text-canopy-text">
+                            Auto-start on project load
+                          </span>
+                          <p className="text-xs text-canopy-text/60">
+                            Automatically start the dev server when switching to this project
+                          </p>
+                        </div>
+                      </label>
+                      {devServerAutoStart && devServerEnabled && (
+                        <p className="text-xs text-[var(--color-status-success)] ml-7">
+                          Dev server will start automatically when you open this project
                         </p>
-                      </div>
-                    </label>
+                      )}
+                    </div>
 
                     <div className="space-y-2">
                       <label

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -62,6 +62,21 @@ function getServerLabel(serverState: DevServerState | null): string | null {
   return "Dev Server";
 }
 
+function getServerStatusTooltip(serverState: DevServerState | null): string {
+  if (!serverState) return "Dev server status unknown";
+  switch (serverState.status) {
+    case "running":
+      return serverState.url ? `Dev server running at ${serverState.url}` : "Dev server is running";
+    case "starting":
+      return "Dev server is starting...";
+    case "error":
+      return "Dev server failed to start";
+    case "stopped":
+    default:
+      return "Dev server is stopped";
+  }
+}
+
 export function WorktreeDetails({
   worktree,
   homeDir,
@@ -176,7 +191,10 @@ export function WorktreeDetails({
 
           {showDevServer && serverState && (
             <div className="flex items-center justify-between text-xs">
-              <div className="flex items-center gap-2 text-canopy-text/60 font-mono">
+              <div
+                className="flex items-center gap-2 text-canopy-text/60 font-mono"
+                title={getServerStatusTooltip(serverState)}
+              >
                 <Globe className="w-3.5 h-3.5" />
                 <div className="flex items-center gap-1.5">
                   {getServerStatusIndicator(serverState)}
@@ -191,6 +209,24 @@ export function WorktreeDetails({
                   }
                 }}
                 disabled={serverLoading || serverState.status === "starting"}
+                title={
+                  serverState.status === "running"
+                    ? "Stop dev server"
+                    : serverState.status === "starting"
+                      ? "Server is starting..."
+                      : serverState.status === "error"
+                        ? "Retry dev server (last start failed)"
+                        : "Start dev server"
+                }
+                aria-label={
+                  serverState.status === "running"
+                    ? "Stop dev server"
+                    : serverState.status === "starting"
+                      ? "Dev server is starting"
+                      : serverState.status === "error"
+                        ? "Retry dev server"
+                        : "Start dev server"
+                }
                 className={cn(
                   "px-2 py-1 rounded text-xs font-medium transition-colors",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",


### PR DESCRIPTION
## Summary
Adds tooltips and explanatory text to dev server controls, making the feature more discoverable and easier to understand. Includes state-aware messaging for all server states and improved accessibility.

Closes #648

## Changes Made
- Add state-aware tooltips to dev server toggle button (start/stop/retry)
- Add tooltip to dev server status indicator with current state
- Add explanatory text for auto-start checkbox when enabled
- Improve accessibility with proper aria-labels for all server states
- Add distinct error state messaging for retry action