### PR TITLE
Standardize custom buttons to use shared Button component

### DIFF
--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -1,35 +1,8 @@
 import { useCallback } from "react";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { useLogsStore, useErrorStore } from "@/store";
 import { useEventStore } from "@/store/eventStore";
 import { logsClient, eventInspectorClient, errorsClient } from "@/clients";
-
-interface ActionButtonProps {
-  onClick: () => void;
-  disabled?: boolean;
-  children: React.ReactNode;
-  className?: string;
-  title?: string;
-}
-
-function ActionButton({ onClick, disabled, children, className, title }: ActionButtonProps) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "px-2 py-0.5 text-xs rounded transition-colors",
-        "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canopy-bg",
-        disabled && "opacity-50 cursor-not-allowed",
-        className
-      )}
-      title={title}
-    >
-      {children}
-    </button>
-  );
-}
 
 export function ProblemsActions() {
   const hasActiveErrors = useErrorStore((state) => state.errors.some((e) => !e.dismissed));
@@ -41,17 +14,18 @@ export function ProblemsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <ActionButton onClick={handleOpenLogs} title="Open log file">
+      <Button variant="subtle" size="xs" onClick={handleOpenLogs} title="Open log file">
         Open Logs
-      </ActionButton>
-      <ActionButton
+      </Button>
+      <Button
+        variant="subtle"
+        size="xs"
         onClick={clearAll}
         disabled={!hasActiveErrors}
         title="Clear all errors"
-        className="focus-visible:ring-[var(--color-status-error)] focus-visible:ring-offset-canopy-bg"
       >
         Clear All
-      </ActionButton>
+      </Button>
     </div>
   );
 }
@@ -72,29 +46,20 @@ export function LogsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <button
+      <Button
+        variant={autoScroll ? "info" : "subtle"}
+        size="xs"
         onClick={() => setAutoScroll(!autoScroll)}
-        className={cn(
-          "px-2 py-0.5 text-xs rounded transition-colors",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-1 focus-visible:ring-offset-canopy-bg",
-          autoScroll
-            ? "bg-[var(--color-status-info)] text-white hover:brightness-110"
-            : "bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border"
-        )}
         title={autoScroll ? "Auto-scroll enabled" : "Auto-scroll disabled"}
       >
         Auto-scroll
-      </button>
-      <ActionButton onClick={handleOpenFile} title="Open log file">
+      </Button>
+      <Button variant="subtle" size="xs" onClick={handleOpenFile} title="Open log file">
         Open File
-      </ActionButton>
-      <ActionButton
-        onClick={handleClearLogs}
-        title="Clear logs"
-        className="focus-visible:ring-[var(--color-status-error)] focus-visible:ring-offset-canopy-bg"
-      >
+      </Button>
+      <Button variant="subtle" size="xs" onClick={handleClearLogs} title="Clear logs">
         Clear
-      </ActionButton>
+      </Button>
     </div>
   );
 }
@@ -113,13 +78,9 @@ export function EventsActions() {
 
   return (
     <div className="flex items-center gap-2">
-      <ActionButton
-        onClick={handleClearEvents}
-        title="Clear all events"
-        className="focus-visible:ring-[var(--color-status-error)] focus-visible:ring-offset-canopy-bg"
-      >
+      <Button variant="subtle" size="xs" onClick={handleClearEvents} title="Clear all events">
         Clear
-      </ActionButton>
+      </Button>
     </div>
   );
 }

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { useLogsStore, filterLogs } from "@/store";
 import { LogEntry } from "../Logs/LogEntry";
 import { LogFilters } from "../Logs/LogFilters";
@@ -123,11 +124,12 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
         availableSources={sourcesRef.current}
       />
 
-      <div
-        ref={containerRef}
-        onScroll={handleScroll}
-        className="flex-1 overflow-y-auto overflow-x-hidden font-mono relative"
-      >
+      <div className="flex-1 relative">
+        <div
+          ref={containerRef}
+          onScroll={handleScroll}
+          className="absolute inset-0 overflow-y-auto overflow-x-hidden font-mono"
+        >
         {filteredLogs.length === 0 ? (
           <div className="flex items-center justify-center h-full text-canopy-text/60 text-sm">
             {logs.length === 0 ? "No logs yet" : "No logs match filters"}
@@ -142,10 +144,13 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
             />
           ))
         )}
-      </div>
+        </div>
 
-      {!autoScroll && filteredLogs.length > 0 && (
-        <button
+        {!autoScroll && filteredLogs.length > 0 && (
+        <Button
+          variant="info"
+          size="sm"
+          className="absolute bottom-4 right-4 rounded-full shadow-lg"
           onClick={() => {
             setAutoScroll(true);
             if (containerRef.current) {
@@ -156,15 +161,11 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
               }, 50);
             }
           }}
-          className={cn(
-            "absolute bottom-4 right-4 px-3 py-1.5 text-xs rounded-full",
-            "bg-[var(--color-status-info)] text-white shadow-lg",
-            "hover:brightness-110 transition-all"
-          )}
         >
           Scroll to bottom
-        </button>
-      )}
+        </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import type { AppError, RetryAction } from "@/store/errorStore";
 
 export interface ErrorBannerProps {
@@ -72,24 +73,24 @@ export function ErrorBanner({
         <span className="shrink-0">{typeIcon}</span>
         <span className="text-[var(--color-status-error)] truncate flex-1">{error.message}</span>
         {canRetry && (
-          <button
+          <Button
+            variant="outline"
+            size="xs"
             onClick={handleRetry}
             disabled={isRetrying}
-            className={cn(
-              "px-1.5 py-0.5 text-xs text-[var(--color-status-success)] hover:text-[var(--color-status-success)]/80 border border-[var(--color-status-success)]/50 rounded",
-              isRetrying && "opacity-50 cursor-not-allowed"
-            )}
+            className="border-[var(--color-status-success)]/50 text-[var(--color-status-success)] hover:text-[var(--color-status-success)]/80"
           >
             {isRetrying ? "..." : "Retry"}
-          </button>
+          </Button>
         )}
-        <button
+        <Button
+          variant="ghost-danger"
+          size="icon-sm"
           onClick={handleDismiss}
-          className="text-[var(--color-status-error)] hover:text-[var(--color-status-error)]/80"
           aria-label="Dismiss error"
         >
           ×
-        </button>
+        </Button>
       </div>
     );
   }
@@ -117,37 +118,43 @@ export function ErrorBanner({
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {error.details && (
-            <button
+            <Button
+              variant="ghost-danger"
+              size="xs"
               onClick={toggleExpanded}
-              className="px-2 py-1 text-xs text-[var(--color-status-error)] hover:text-[var(--color-status-error)]/80 hover:bg-[var(--color-status-error)]/10 rounded"
+              aria-expanded={isExpanded}
+              aria-controls={`error-details-${error.id}`}
             >
               {isExpanded ? "Hide" : "Details"}
-            </button>
+            </Button>
           )}
           {canRetry && (
-            <button
+            <Button
+              variant="outline"
+              size="xs"
               onClick={handleRetry}
               disabled={isRetrying}
-              className={cn(
-                "px-2 py-1 text-xs text-[var(--color-status-success)] hover:text-[var(--color-status-success)]/80 border border-[var(--color-status-success)]/50 hover:bg-[var(--color-status-success)]/10 rounded",
-                isRetrying && "opacity-50 cursor-not-allowed"
-              )}
+              className="border-[var(--color-status-success)]/50 text-[var(--color-status-success)] hover:text-[var(--color-status-success)]/80 hover:bg-[var(--color-status-success)]/10"
             >
               {isRetrying ? "Retrying..." : "Retry"}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
+            variant="ghost-danger"
+            size="icon-sm"
             onClick={handleDismiss}
-            className="p-1 text-[var(--color-status-error)] hover:text-[var(--color-status-error)]/80 hover:bg-[var(--color-status-error)]/10 rounded"
             aria-label="Dismiss error"
           >
             ×
-          </button>
+          </Button>
         </div>
       </div>
 
       {isExpanded && error.details && (
-        <div className="px-3 py-2 border-t border-[var(--color-status-error)]/30 bg-[color-mix(in_oklab,var(--color-status-error)_12%,transparent)]">
+        <div
+          id={`error-details-${error.id}`}
+          className="px-3 py-2 border-t border-[var(--color-status-error)]/30 bg-[color-mix(in_oklab,var(--color-status-error)_12%,transparent)]"
+        >
           <pre className="text-xs text-[var(--color-status-error)]/80 whitespace-pre-wrap break-all font-mono overflow-x-auto">
             {error.details}
           </pre>

--- a/src/components/EventInspector/EventFilters.tsx
+++ b/src/components/EventInspector/EventFilters.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { Search, X, Filter, Tag } from "lucide-react";
 import type { EventRecord, EventFilterOptions, EventCategory } from "@/store/eventStore";
 
@@ -175,12 +176,14 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
             )}
           />
           {searchInput && (
-            <button
+            <Button
+              variant="ghost"
+              size="icon-sm"
               onClick={clearSearch}
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
             >
               <X className="w-4 h-4" />
-            </button>
+            </Button>
           )}
         </div>
 
@@ -202,12 +205,14 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
               )}
             />
             {traceIdInput && (
-              <button
+              <Button
+                variant="ghost"
+                size="icon-sm"
                 onClick={clearTraceId}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
               >
                 <X className="w-4 h-4" />
-              </button>
+              </Button>
             )}
           </div>
         </div>
@@ -219,12 +224,9 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
               <span>Categories</span>
             </div>
             {filters.categories && filters.categories.length > 0 && (
-              <button
-                onClick={clearCategoryFilters}
-                className="text-xs text-muted-foreground hover:text-foreground"
-              >
+              <Button variant="ghost" size="xs" onClick={clearCategoryFilters} className="h-auto p-0">
                 Clear
-              </button>
+              </Button>
             )}
           </div>
           <div className="flex flex-wrap gap-1.5">
@@ -234,11 +236,12 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
               const config = CATEGORY_CONFIG[category];
 
               return (
-                <button
+                <Button
                   key={category}
+                  variant="outline"
+                  size="xs"
                   onClick={() => toggleCategoryFilter(category)}
                   className={cn(
-                    "inline-flex items-center gap-1.5 px-2 py-1 text-xs rounded-md border transition-colors",
                     isActive
                       ? config.color
                       : "bg-muted/30 text-muted-foreground border-transparent hover:bg-muted/50"
@@ -250,20 +253,18 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
                       {count}
                     </span>
                   )}
-                </button>
+                </Button>
               );
             })}
           </div>
         </div>
 
         <div className="flex items-center justify-between">
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => setShowTypeFilters(!showTypeFilters)}
-            className={cn(
-              "flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition-colors",
-              "hover:bg-muted/50",
-              showTypeFilters && "bg-muted"
-            )}
+            className={cn(showTypeFilters && "bg-muted")}
           >
             <Filter className="w-3.5 h-3.5" />
             <span>Event Types</span>
@@ -272,14 +273,11 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
                 {activeFilterCount}
               </span>
             )}
-          </button>
+          </Button>
           {filters.types && filters.types.length > 0 && (
-            <button
-              onClick={clearTypeFilters}
-              className="text-xs text-muted-foreground hover:text-foreground"
-            >
+            <Button variant="ghost" size="xs" onClick={clearTypeFilters} className="h-auto p-0">
               Clear filters
-            </button>
+            </Button>
           )}
         </div>
       </div>

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -10,6 +10,7 @@ import {
   BunIcon,
 } from "@/components/icons";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { useTerminalStore, type TerminalInstance } from "@/store";
 import type { TrashedTerminal } from "@/store/slices";
 import type { TerminalType } from "@/types";
@@ -89,22 +90,24 @@ export function TrashBinItem({ terminal, trashedInfo }: TrashBinItemProps) {
       </div>
 
       <div className="flex gap-1">
-        <button
+        <Button
+          variant="ghost-success"
+          size="icon-sm"
           onClick={handleRestore}
-          className="p-1.5 rounded hover:bg-green-500/20 text-green-400 transition-colors"
           aria-label={`Restore ${terminalName}`}
           title={`Restore ${terminalName}`}
         >
-          <RotateCcw className="w-3.5 h-3.5" aria-hidden="true" />
-        </button>
-        <button
+          <RotateCcw aria-hidden="true" />
+        </Button>
+        <Button
+          variant="ghost-danger"
+          size="icon-sm"
           onClick={handleKill}
-          className="p-1.5 rounded hover:bg-red-500/20 text-red-400 transition-colors"
           aria-label={`Remove ${terminalName} permanently`}
           title={`Remove ${terminalName} permanently`}
         >
-          <X className="w-3.5 h-3.5" aria-hidden="true" />
-        </button>
+          <X aria-hidden="true" />
+        </Button>
       </div>
     </div>
   );

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Trash2 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { TerminalInstance } from "@/store";
 import type { TrashedTerminal } from "@/store/slices";
@@ -28,10 +29,11 @@ export function TrashContainer({ trashedTerminals }: TrashContainerProps) {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <button
+        <Button
+          variant="pill"
+          size="sm"
           className={cn(
-            "flex items-center gap-2 px-3 py-1.5 rounded text-xs border transition-all",
-            "bg-canopy-bg/50 border-canopy-border text-canopy-text/60 hover:bg-canopy-border hover:border-canopy-border",
+            "px-3",
             isOpen && "bg-canopy-border border-canopy-border ring-1 ring-canopy-accent/20"
           )}
           title="View recently closed terminals"
@@ -42,7 +44,7 @@ export function TrashContainer({ trashedTerminals }: TrashContainerProps) {
         >
           <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
           <span className="font-medium">Trash ({count})</span>
-        </button>
+        </Button>
       </PopoverTrigger>
 
       <PopoverContent

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,12 +18,24 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 active:scale-95",
         ghost: "hover:bg-accent hover:text-accent-foreground active:scale-95",
         link: "text-primary underline-offset-4 hover:underline",
+        subtle:
+          "bg-canopy-bg text-canopy-text/60 hover:bg-canopy-border hover:text-canopy-text active:scale-95",
+        pill: "rounded-full bg-canopy-bg/50 border border-canopy-border text-canopy-text/60 hover:bg-canopy-border active:scale-95",
+        "ghost-danger":
+          "text-[var(--color-status-error)] hover:bg-[var(--color-status-error)]/10 active:scale-95",
+        "ghost-success":
+          "text-[var(--color-status-success)] hover:bg-[var(--color-status-success)]/10 active:scale-95",
+        "ghost-info":
+          "text-[var(--color-status-info)] hover:bg-[var(--color-status-info)]/10 active:scale-95",
+        info: "bg-[var(--color-status-info)] text-white hover:brightness-110 active:scale-95",
       },
       size: {
         default: "h-9 px-4 py-2",
         sm: "h-8 px-3 text-xs",
+        xs: "h-6 px-2 text-xs",
         lg: "h-10 px-8",
         icon: "h-9 w-9",
+        "icon-sm": "h-7 w-7 [&_svg]:size-3.5",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
Standardizes all custom button implementations across the application to use the shared Button component, improving consistency, accessibility, and maintainability.

Closes #681

## Changes Made
- Added new Button variants: subtle, pill, ghost-danger, ghost-success, ghost-info, info, and icon-sm size
- Migrated ErrorBanner retry/dismiss/details buttons with proper ARIA attributes (aria-expanded, aria-controls)
- Migrated TrashContainer pill-style trigger button
- Migrated TrashBinItem icon-only restore/delete buttons with semantic color variants
- Removed shadow ActionButton component from DiagnosticsActions and migrated all actions to shared Button
- Migrated LogsContent scroll-to-bottom button with fixed positioning context
- Migrated LogFilters with keyboard-accessible sources dropdown and standardized controls
- Migrated EventFilters category toggles and filter management buttons
- Improved button hit targets using icon-sm size for better accessibility
- Enhanced keyboard navigation and focus states across all migrated buttons