### PR TITLE
Add micro-animations for terminal trash and restore

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -14,6 +14,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
+import { getTerminalAnimationDuration } from "@/lib/animationUtils";
 import { useTerminalStore, useSidecarStore, type TerminalInstance } from "@/store";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
@@ -75,6 +76,7 @@ function getStateIndicator(state?: AgentState) {
 export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
+  const [isTrashing, setIsTrashing] = useState(false);
   const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
   const trashTerminal = useTerminalStore((s) => s.trashTerminal);
   const removeTerminal = useTerminalStore((s) => s.removeTerminal);
@@ -152,10 +154,15 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     (force?: boolean) => {
       if (force) {
         removeTerminal(terminal.id);
+        setIsOpen(false);
       } else {
-        trashTerminal(terminal.id);
+        const duration = getTerminalAnimationDuration();
+        setIsTrashing(true);
+        setTimeout(() => {
+          trashTerminal(terminal.id);
+          setIsOpen(false);
+        }, duration);
       }
-      setIsOpen(false);
     },
     [trashTerminal, removeTerminal, terminal.id, setIsOpen]
   );
@@ -233,6 +240,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           onClose={handleClose}
           onRestore={handleRestore}
           onMinimize={handleMinimize}
+          isTrashing={isTrashing}
         />
       </PopoverContent>
     </Popover>

--- a/src/index.css
+++ b/src/index.css
@@ -101,6 +101,7 @@
 
   --animation-duration: 150ms;
   --transition-duration: 150ms;
+  --terminal-animation-duration: 150ms;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -344,6 +345,44 @@ body,
   [type="reset"] {
     transform: none !important;
     transition: none !important;
+  }
+}
+
+/* Terminal trash/restore animations */
+@keyframes terminal-restore {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes terminal-trash {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+}
+
+.terminal-restoring {
+  animation: terminal-restore var(--terminal-animation-duration) ease-out;
+}
+
+.terminal-trashing {
+  animation: terminal-trash var(--terminal-animation-duration) ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .terminal-restoring,
+  .terminal-trashing {
+    animation: none;
   }
 }
 

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -1,0 +1,8 @@
+export const TERMINAL_ANIMATION_DURATION = 150;
+
+export function getTerminalAnimationDuration(): number {
+  if (typeof window === "undefined") return TERMINAL_ANIMATION_DURATION;
+
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  return reducedMotion ? 0 : TERMINAL_ANIMATION_DURATION;
+}


### PR DESCRIPTION
## Summary

Implements subtle 150ms fade and translate animations for terminal trash and restore operations to provide visual feedback and improve spatial awareness when terminals change state.

Closes #717

## Changes Made

- Added CSS keyframes for terminal-restore (fade in + translate up 4px) and terminal-trash (fade out + translate down 4px)
- Implemented animation classes with 150ms ease-out timing using CSS variable `--terminal-animation-duration`
- Added full prefers-reduced-motion support with zero-delay for accessibility users
- Created `getTerminalAnimationDuration()` utility that returns 0ms for reduced-motion users, eliminating unnecessary delays
- Updated TerminalPane to apply restore animation on mount
- Added `isTrashing` prop to TerminalPane for coordinated exit animations
- Modified TerminalGrid and DockedTerminalItem to delay trash operation for animation playback
- Centralized animation duration constant across all components to prevent drift

## Accessibility

The implementation respects `prefers-reduced-motion: reduce` in two ways:
1. CSS animations are disabled via media query
2. JavaScript delays are skipped (returns 0ms) so reduced-motion users experience instant operations without lag

## Technical Details

**Animation Specs:**
- Duration: 150ms (configurable via CSS variable)
- Easing: ease-out
- Effects: Fade (opacity) + subtle translate (4px)
- Direction: Restore (0→1 opacity, 4px→0 translate), Trash (inverse)

**Performance:**
- Uses GPU-accelerated properties only (opacity, transform)
- No layout thrashing or jank
- Animations skipped entirely for reduced-motion users