### PR TITLE
Add in-app toggle for verbose logging

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -91,6 +91,8 @@ export const CHANNELS = {
   LOGS_CLEAR: "logs:clear",
   LOGS_ENTRY: "logs:entry",
   LOGS_OPEN_FILE: "logs:open-file",
+  LOGS_SET_VERBOSE: "logs:set-verbose",
+  LOGS_GET_VERBOSE: "logs:get-verbose",
 
   ERROR_NOTIFY: "error:notify",
   ERROR_RETRY: "error:retry",

--- a/electron/ipc/handlers/app.ts
+++ b/electron/ipc/handlers/app.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { logBuffer } from "../../services/LogBuffer.js";
+import { setVerboseLogging, isVerboseLogging, logInfo } from "../../utils/logger.js";
 import type { HandlerDependencies } from "../types.js";
 import type { FilterOptions as LogFilterOptions } from "../../services/LogBuffer.js";
 import type { FilterOptions as EventFilterOptions } from "../../services/EventBuffer.js";
@@ -195,6 +196,24 @@ export function registerAppHandlers(deps: HandlerDependencies): () => void {
   };
   ipcMain.handle(CHANNELS.LOGS_OPEN_FILE, handleLogsOpenFile);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_OPEN_FILE));
+
+  const handleLogsSetVerbose = async (_event: Electron.IpcMainInvokeEvent, enabled: boolean) => {
+    if (typeof enabled !== "boolean") {
+      console.error("Invalid verbose logging payload:", enabled);
+      return { success: false };
+    }
+    setVerboseLogging(enabled);
+    logInfo(`Verbose logging ${enabled ? "enabled" : "disabled"} by user`);
+    return { success: true };
+  };
+  ipcMain.handle(CHANNELS.LOGS_SET_VERBOSE, handleLogsSetVerbose);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_SET_VERBOSE));
+
+  const handleLogsGetVerbose = async () => {
+    return isVerboseLogging();
+  };
+  ipcMain.handle(CHANNELS.LOGS_GET_VERBOSE, handleLogsGetVerbose);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_GET_VERBOSE));
 
   const handleEventInspectorGetEvents = async () => {
     if (!eventBuffer) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -170,6 +170,8 @@ const CHANNELS = {
   LOGS_CLEAR: "logs:clear",
   LOGS_ENTRY: "logs:entry",
   LOGS_OPEN_FILE: "logs:open-file",
+  LOGS_SET_VERBOSE: "logs:set-verbose",
+  LOGS_GET_VERBOSE: "logs:get-verbose",
 
   // Directory channels (legacy - migrated to Projects system)
 
@@ -479,6 +481,10 @@ const api: ElectronAPI = {
     clear: () => _typedInvoke(CHANNELS.LOGS_CLEAR),
 
     openFile: () => _typedInvoke(CHANNELS.LOGS_OPEN_FILE),
+
+    setVerbose: (enabled: boolean) => _typedInvoke(CHANNELS.LOGS_SET_VERBOSE, enabled),
+
+    getVerbose: () => _typedInvoke(CHANNELS.LOGS_GET_VERBOSE),
 
     onEntry: (callback: (entry: LogEntry) => void) => _typedOn(CHANNELS.LOGS_ENTRY, callback),
   },

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -28,14 +28,24 @@ const ENABLE_FILE_LOGGING = process.env.NODE_ENV === "development";
 const SENSITIVE_KEYS = new Set([
   "token",
   "password",
-  "apiKey",
+  "apikey",
   "secret",
-  "accessToken",
-  "refreshToken",
+  "accesstoken",
+  "refreshtoken",
 ]);
 
-const IS_DEBUG = process.env.NODE_ENV === "development" || process.env.CANOPY_DEBUG;
+const IS_DEBUG_BOOT = process.env.NODE_ENV === "development" || Boolean(process.env.CANOPY_DEBUG);
 const IS_TEST = process.env.NODE_ENV === "test";
+
+let verboseLogging = IS_DEBUG_BOOT;
+
+export function setVerboseLogging(enabled: boolean): void {
+  verboseLogging = enabled;
+}
+
+export function isVerboseLogging(): boolean {
+  return verboseLogging;
+}
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -160,8 +170,9 @@ function writeToLogFile(level: string, message: string, context?: LogContext): v
 }
 
 function log(level: LogLevel, message: string, context?: LogContext): LogEntry {
-  // Only capture source in development or for errors/warnings
-  const source = IS_DEBUG || level === "warn" || level === "error" ? getCallerSource() : undefined;
+  // Only capture source in verbose mode or for errors/warnings
+  const source =
+    isVerboseLogging() || level === "warn" || level === "error" ? getCallerSource() : undefined;
 
   const safeContext = context ? redactSensitiveData(context) : undefined;
 
@@ -202,7 +213,7 @@ function redactSensitiveData(obj: Record<string, unknown>): Record<string, unkno
 export function logDebug(message: string, context?: LogContext): void {
   log("debug", message, context);
   writeToLogFile("DEBUG", message, context);
-  if (IS_DEBUG && !IS_TEST) {
+  if (isVerboseLogging() && !IS_TEST) {
     console.log(`[DEBUG] ${message}`, context ? safeStringify(context) : "");
   }
 }
@@ -210,7 +221,7 @@ export function logDebug(message: string, context?: LogContext): void {
 export function logInfo(message: string, context?: LogContext): void {
   log("info", message, context);
   writeToLogFile("INFO", message, context);
-  if (IS_DEBUG && !IS_TEST) {
+  if (isVerboseLogging() && !IS_TEST) {
     console.log(`[INFO] ${message}`, context ? safeStringify(context) : "");
   }
 }
@@ -218,7 +229,7 @@ export function logInfo(message: string, context?: LogContext): void {
 export function logWarn(message: string, context?: LogContext): void {
   log("warn", message, context);
   writeToLogFile("WARN", message, context);
-  if (IS_DEBUG && !IS_TEST) {
+  if (isVerboseLogging() && !IS_TEST) {
     console.warn(`[WARN] ${message}`, context ? safeStringify(context) : "");
   }
 }

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1095,6 +1095,14 @@ export interface IpcInvokeMap {
     args: [];
     result: void;
   };
+  "logs:set-verbose": {
+    args: [enabled: boolean];
+    result: { success: boolean };
+  };
+  "logs:get-verbose": {
+    args: [];
+    result: boolean;
+  };
 
   // Error channels
   "error:retry": {
@@ -1540,6 +1548,8 @@ export interface ElectronAPI {
     getSources(): Promise<string[]>;
     clear(): Promise<void>;
     openFile(): Promise<void>;
+    setVerbose(enabled: boolean): Promise<{ success: boolean }>;
+    getVerbose(): Promise<boolean>;
     onEntry(callback: (entry: LogEntry) => void): () => void;
   };
   // Directory API has been removed - use project API instead

--- a/src/clients/logsClient.ts
+++ b/src/clients/logsClient.ts
@@ -7,6 +7,7 @@ import type { LogEntry, LogFilterOptions } from "@shared/types";
  *
  * const logs = await logsClient.getAll({ levels: ["error", "warn"] });
  * const cleanup = logsClient.onEntry((entry) => console.log(entry));
+ * await logsClient.setVerbose(true); // Enable verbose logging
  * ```
  */
 export const logsClient = {
@@ -24,6 +25,14 @@ export const logsClient = {
 
   openFile: (): Promise<void> => {
     return window.electron.logs.openFile();
+  },
+
+  setVerbose: (enabled: boolean): Promise<{ success: boolean }> => {
+    return window.electron.logs.setVerbose(enabled);
+  },
+
+  getVerbose: (): Promise<boolean> => {
+    return window.electron.logs.getVerbose();
   },
 
   onEntry: (callback: (entry: LogEntry) => void): (() => void) => {


### PR DESCRIPTION
## Summary
Adds a runtime toggle in Troubleshooting settings to enable verbose logging without requiring app restart, making it easier for beta users to capture detailed logs for bug reports.

Closes #720

## Changes Made
- Add runtime toggle to enable/disable verbose logging without restart
- Implement setVerboseLogging/isVerboseLogging functions in logger.ts
- Add IPC handlers for logs:set-verbose and logs:get-verbose
- Create UI toggle in TroubleshootingTab with session-only indicator
- Add input validation and error handling for IPC handlers
- Fix sensitive key matching to use lowercase normalization
- Add accessibility attributes (role=switch, aria-checked) to toggle
- Include pending state and success checking for robust state management
- Display performance warning when verbose logging is enabled

## Technical Details
- **Session-only**: Verbose logging resets on app restart (not persisted)
- **Security**: Input validation prevents malformed payloads from enabling verbose mode
- **Accessibility**: Toggle uses proper ARIA attributes for screen readers
- **UX**: Clear "this session only" indicator and performance warning when enabled