### PR TITLE
Wire up terminal activity monitoring and waiting state UI

### DIFF
--- a/electron/ipc/handlers/terminal.ts
+++ b/electron/ipc/handlers/terminal.ts
@@ -5,7 +5,7 @@ import path from "path";
 import { CHANNELS } from "../channels.js";
 import { sendToRenderer } from "../utils.js";
 import { projectStore } from "../../services/ProjectStore.js";
-import { events } from "../../services/events.js";
+import { events, type CanopyEventMap } from "../../services/events.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalSpawnOptions, TerminalResizePayload } from "../../types/index.js";
 import type { ActivityTier } from "../../../shared/types/pty-host.js";
@@ -52,6 +52,14 @@ export function registerTerminalHandlers(deps: HandlerDependencies): () => void 
     sendToRenderer(mainWindow, CHANNELS.ARTIFACT_DETECTED, payload);
   });
   handlers.push(unsubArtifactDetected);
+
+  const unsubTerminalActivity = events.on(
+    "terminal:activity",
+    (payload: CanopyEventMap["terminal:activity"]) => {
+      sendToRenderer(mainWindow, CHANNELS.TERMINAL_ACTIVITY, payload);
+    }
+  );
+  handlers.push(unsubTerminalActivity);
 
   const handleTerminalSpawn = async (
     _event: Electron.IpcMainInvokeEvent,

--- a/electron/services/ActivityHeadlineGenerator.ts
+++ b/electron/services/ActivityHeadlineGenerator.ts
@@ -1,0 +1,142 @@
+import type { TerminalActivityStatus, TerminalTaskType } from "../../shared/types/terminal.js";
+import type { AgentState, TerminalType } from "../../shared/types/domain.js";
+
+export interface ActivityContext {
+  terminalId: string;
+  terminalType?: TerminalType;
+  agentId?: string;
+  agentState?: AgentState;
+  lastCommand?: string;
+  activity?: "busy" | "idle";
+}
+
+export interface GeneratedActivity {
+  headline: string;
+  status: TerminalActivityStatus;
+  type: TerminalTaskType;
+}
+
+const COMMAND_PATTERNS: Array<{ pattern: RegExp; headline: string }> = [
+  {
+    pattern: /^npm\s+install|^npm\s+i\b|^yarn\s+install|^yarn\s*$|^pnpm\s+install|^bun\s+install/i,
+    headline: "Installing dependencies",
+  },
+  {
+    pattern: /^npm\s+test|^yarn\s+test|^pnpm\s+test|^jest|^vitest|^mocha/i,
+    headline: "Running tests",
+  },
+  {
+    pattern: /^npm\s+run\s+build|^yarn\s+build|^pnpm\s+build|^vite\s+build|^webpack/i,
+    headline: "Building project",
+  },
+  { pattern: /^npm\s+run\s+dev|^yarn\s+dev|^pnpm\s+dev|^vite/i, headline: "Starting dev server" },
+  { pattern: /^npm\s+run\s+lint|^eslint|^prettier/i, headline: "Running linter" },
+  { pattern: /^git\s+clone/i, headline: "Cloning repository" },
+  { pattern: /^git\s+push/i, headline: "Pushing changes" },
+  { pattern: /^git\s+pull/i, headline: "Pulling changes" },
+  { pattern: /^git\s+fetch/i, headline: "Fetching updates" },
+  { pattern: /^git\s+checkout|^git\s+switch/i, headline: "Switching branch" },
+  { pattern: /^git\s+merge/i, headline: "Merging changes" },
+  { pattern: /^git\s+rebase/i, headline: "Rebasing branch" },
+  { pattern: /^docker\s+build/i, headline: "Building image" },
+  { pattern: /^docker\s+pull/i, headline: "Pulling image" },
+  { pattern: /^docker\s+run|^docker-compose\s+up/i, headline: "Running container" },
+  { pattern: /^cargo\s+build/i, headline: "Compiling Rust" },
+  { pattern: /^cargo\s+test/i, headline: "Running Rust tests" },
+  { pattern: /^go\s+build/i, headline: "Building Go" },
+  { pattern: /^go\s+test/i, headline: "Running Go tests" },
+  { pattern: /^pip\s+install|^poetry\s+install/i, headline: "Installing packages" },
+  { pattern: /^python|^python3/i, headline: "Running Python" },
+  { pattern: /^node\s+/i, headline: "Running Node.js" },
+  { pattern: /^tsc\b/i, headline: "Type checking" },
+  { pattern: /^make\b/i, headline: "Running make" },
+  { pattern: /^curl\s+|^wget\s+/i, headline: "Downloading" },
+];
+
+export class ActivityHeadlineGenerator {
+  generate(context: ActivityContext): GeneratedActivity {
+    // Agent terminals use agent state
+    if (context.agentId) {
+      return this.generateFromAgentState(context.agentState);
+    }
+
+    // Shell terminals use activity + command detection
+    return this.generateFromShellActivity(context);
+  }
+
+  private generateFromAgentState(agentState?: AgentState): GeneratedActivity {
+    switch (agentState) {
+      case "working":
+        return {
+          headline: "Agent working",
+          status: "working",
+          type: "interactive",
+        };
+      case "waiting":
+        return {
+          headline: "Waiting for input",
+          status: "waiting",
+          type: "interactive",
+        };
+      case "completed":
+        return {
+          headline: "Completed",
+          status: "success",
+          type: "idle",
+        };
+      case "failed":
+        return {
+          headline: "Failed",
+          status: "failure",
+          type: "idle",
+        };
+      case "idle":
+      default:
+        return {
+          headline: "Idle",
+          status: "success",
+          type: "idle",
+        };
+    }
+  }
+
+  private generateFromShellActivity(context: ActivityContext): GeneratedActivity {
+    const { activity, lastCommand } = context;
+
+    if (activity === "busy") {
+      const headline = lastCommand ? this.getCommandHeadline(lastCommand) : "Command running";
+
+      return {
+        headline,
+        status: "working",
+        type: "background",
+      };
+    }
+
+    // Idle state
+    return {
+      headline: "Idle",
+      status: "success",
+      type: "idle",
+    };
+  }
+
+  private getCommandHeadline(command: string): string {
+    const trimmedCommand = command.trim();
+
+    for (const { pattern, headline } of COMMAND_PATTERNS) {
+      if (pattern.test(trimmedCommand)) {
+        return headline;
+      }
+    }
+
+    // Generic fallback: extract the base command
+    const parts = trimmedCommand.split(/\s+/);
+    const baseCommand = parts[0]?.replace(/^\.\//, "") || "command";
+
+    // Capitalize first letter
+    const capitalizedCommand = baseCommand.charAt(0).toUpperCase() + baseCommand.slice(1);
+
+    return `Running ${capitalizedCommand}`;
+  }
+}

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -250,8 +250,8 @@ export const EVENT_META: Record<keyof CanopyEventMap, EventMetadata> = {
   "terminal:activity": {
     category: "agent",
     requiresContext: false,
-    requiresTimestamp: false,
-    description: "Terminal activity state changed (busy/idle via process tree)",
+    requiresTimestamp: true,
+    description: "Terminal activity state changed with human-readable headlines",
   },
   "terminal:backgrounded": {
     category: "agent",
@@ -581,11 +581,16 @@ export type CanopyEventMap = {
   /**
    * Emitted when a terminal's activity state changes (busy/idle).
    * For shell terminals, this uses process tree inspection for accuracy.
+   * For agent terminals, this includes human-readable status headlines.
    */
   "terminal:activity": {
     terminalId: string;
-    activity: "busy" | "idle";
-    source: "process-tree" | "data-flow";
+    headline: string;
+    status: "working" | "waiting" | "success" | "failure";
+    type: "interactive" | "background" | "idle";
+    confidence: number;
+    timestamp: number;
+    worktreeId?: string;
   };
 
   /**

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, type ReactNode } from "react";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
+import { WaitingStrip } from "./WaitingStrip";
 import { TerminalDock } from "./TerminalDock";
 import { DiagnosticsDock } from "../Diagnostics";
 import { ErrorBoundary } from "../ErrorBoundary";
@@ -274,6 +275,9 @@ export function AppLayout({
         agentAvailability={agentAvailability}
         agentSettings={agentSettings}
       />
+      <ErrorBoundary variant="section" componentName="WaitingStrip">
+        <WaitingStrip />
+      </ErrorBoundary>
       <div
         className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}

--- a/src/components/Layout/WaitingStrip.tsx
+++ b/src/components/Layout/WaitingStrip.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from "react";
+import { AlertCircle, ChevronRight } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { cn } from "@/lib/utils";
+import { useWaitingTerminalIds } from "@/hooks/useTerminalSelectors";
+import { useTerminalStore } from "@/store/terminalStore";
+import { useWorktrees } from "@/hooks/useWorktrees";
+import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import type { TerminalType } from "@/types";
+
+function getTerminalIcon(type: TerminalType) {
+  const iconProps = { className: "h-3.5 w-3.5 shrink-0" };
+
+  switch (type) {
+    case "claude":
+      return <ClaudeIcon {...iconProps} brandColor={getBrandColorHex("claude")} />;
+    case "gemini":
+      return <GeminiIcon {...iconProps} brandColor={getBrandColorHex("gemini")} />;
+    case "codex":
+      return <CodexIcon {...iconProps} brandColor={getBrandColorHex("codex")} />;
+    default:
+      return <AlertCircle {...iconProps} />;
+  }
+}
+
+export function WaitingStrip() {
+  const waitingIds = useWaitingTerminalIds();
+  const terminals = useTerminalStore(
+    useShallow((state) =>
+      waitingIds.map((id) => state.terminals.find((t) => t.id === id)).filter(Boolean)
+    )
+  );
+  const setFocused = useTerminalStore((state) => state.setFocused);
+  const { worktreeMap } = useWorktrees();
+
+  const waitingTerminals = useMemo(() => {
+    return terminals.filter((t): t is NonNullable<typeof t> => t !== undefined);
+  }, [terminals]);
+
+  if (waitingTerminals.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "shrink-0 flex items-center gap-2 px-3 py-1.5",
+        "bg-[color-mix(in_oklab,var(--color-status-warning)_8%,transparent)]",
+        "border-b border-[color-mix(in_oklab,var(--color-status-warning)_20%,transparent)]"
+      )}
+      role="status"
+      aria-live="polite"
+      aria-label={`${waitingTerminals.length} agent${waitingTerminals.length !== 1 ? "s" : ""} waiting for input`}
+    >
+      <div className="flex items-center gap-1.5 text-[var(--color-status-warning)] shrink-0">
+        <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+        <span className="text-xs font-semibold whitespace-nowrap">
+          {waitingTerminals.length} waiting
+        </span>
+      </div>
+
+      <div className="h-4 w-px bg-[color-mix(in_oklab,var(--color-status-warning)_30%,transparent)]" />
+
+      <div className="flex items-center gap-1.5 overflow-x-auto">
+        {waitingTerminals.map((terminal) => {
+          const worktree = terminal.worktreeId ? worktreeMap.get(terminal.worktreeId) : null;
+
+          return (
+            <button
+              key={terminal.id}
+              type="button"
+              onClick={() => setFocused(terminal.id)}
+              className={cn(
+                "flex items-center gap-1.5 px-2 py-1 rounded",
+                "bg-canopy-sidebar/60 hover:bg-canopy-sidebar",
+                "border border-canopy-border/40 hover:border-canopy-border",
+                "text-xs text-canopy-text/90 hover:text-canopy-text",
+                "transition-colors cursor-pointer",
+                "whitespace-nowrap"
+              )}
+              title={`${terminal.title}${worktree ? ` (${worktree.name})` : ""} - Click to focus`}
+              aria-label={`Focus ${terminal.title}${worktree ? ` in ${worktree.name}` : ""}`}
+            >
+              {getTerminalIcon(terminal.type)}
+              <span className="font-medium truncate max-w-[100px]">{terminal.title}</span>
+              {worktree && (
+                <>
+                  <ChevronRight className="h-3 w-3 text-canopy-text/40" aria-hidden="true" />
+                  <span className="text-canopy-text/60 truncate max-w-[80px]">{worktree.name}</span>
+                </>
+              )}
+              {terminal.activityHeadline && (
+                <span className="text-canopy-text/50 italic truncate max-w-[100px]">
+                  {terminal.activityHeadline}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,3 +1,4 @@
 export { AppLayout } from "./AppLayout";
 export { Toolbar } from "./Toolbar";
 export { Sidebar } from "./Sidebar";
+export { WaitingStrip } from "./WaitingStrip";


### PR DESCRIPTION
## Summary
Implements terminal activity monitoring with human-readable status headlines and adds a WaitingStrip UI component to display terminals that are waiting for user input.

Closes #733

## Changes Made
- Added ActivityHeadlineGenerator service for semantic status updates
- Emitting terminal:activity events with headline/status/type/confidence fields
- Updated AgentStateService to emit activity events on state changes
- Improved TerminalProcess command detection with intelligent prompt stripping
- Added WaitingStrip component to show waiting terminals in the UI
- Wired up type-safe IPC relay for terminal:activity events
- Fixed idle agent status mapping (success instead of working)
- Added ErrorBoundary wrapper for WaitingStrip component
- Optimized WaitingStrip selector to prevent unnecessary re-renders