### PR TITLE
Extract GridFullOverlay component for better code organization

### DIFF
--- a/src/components/Terminal/GridFullOverlay.tsx
+++ b/src/components/Terminal/GridFullOverlay.tsx
@@ -1,0 +1,28 @@
+import { Ban } from "lucide-react";
+
+export interface GridFullOverlayProps {
+  maxTerminals: number;
+  show: boolean;
+}
+
+/**
+ * Overlay displayed when attempting to drag a terminal to a full grid.
+ * Uses pointer-events-none to allow drag operations underneath.
+ */
+export function GridFullOverlay({ maxTerminals, show }: GridFullOverlayProps) {
+  if (!show) return null;
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm pointer-events-none">
+      <div className="flex flex-col items-center gap-3 text-center px-6 py-4 rounded-xl bg-canopy-bg/90 border border-canopy-border/40 shadow-xl">
+        <Ban className="h-8 w-8 text-amber-400" />
+        <div>
+          <p className="text-sm font-medium text-canopy-text">Grid is full</p>
+          <p className="text-xs text-canopy-text/60 mt-1">
+            Maximum {maxTerminals} terminals. Close one to add more.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/store";
 import { TerminalPane } from "./TerminalPane";
 import { TerminalCountWarning } from "./TerminalCountWarning";
+import { GridFullOverlay } from "./GridFullOverlay";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   SortableTerminal,
@@ -20,7 +21,7 @@ import {
   GRID_PLACEHOLDER_ID,
   GridPlaceholder,
 } from "@/components/DragDrop";
-import { Terminal, AlertTriangle, Ban } from "lucide-react";
+import { Terminal, AlertTriangle } from "lucide-react";
 import { CanopyIcon, CodexIcon, ClaudeIcon, GeminiIcon } from "@/components/icons";
 import { Kbd } from "@/components/ui/Kbd";
 import { getBrandColorHex } from "@/lib/colorUtils";
@@ -516,19 +517,7 @@ export function TerminalGrid({ className, defaultCwd, onLaunchAgent }: TerminalG
           </div>
         </SortableContext>
 
-        {showGridFullOverlay && (
-          <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm pointer-events-none">
-            <div className="flex flex-col items-center gap-3 text-center px-6 py-4 rounded-xl bg-canopy-bg/90 border border-canopy-border/40 shadow-xl">
-              <Ban className="h-8 w-8 text-amber-400" />
-              <div>
-                <p className="text-sm font-medium text-canopy-text">Grid is full</p>
-                <p className="text-xs text-canopy-text/60 mt-1">
-                  Maximum {MAX_GRID_TERMINALS} terminals. Close one to add more.
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
+        <GridFullOverlay maxTerminals={MAX_GRID_TERMINALS} show={showGridFullOverlay} />
       </div>
     </div>
   );

--- a/src/components/Terminal/index.ts
+++ b/src/components/Terminal/index.ts
@@ -12,3 +12,5 @@ export { StateBadge } from "./StateBadge";
 export { ActivityBadge } from "./ActivityBadge";
 export type { ActivityStatus, ActivityType } from "./ActivityBadge";
 export { TerminalCountWarning, SOFT_TERMINAL_LIMIT } from "./TerminalCountWarning";
+export { GridFullOverlay } from "./GridFullOverlay";
+export type { GridFullOverlayProps } from "./GridFullOverlay";


### PR DESCRIPTION
## Summary
Extracts the inline GridFullOverlay JSX from TerminalGrid into a dedicated reusable component to improve code readability and maintainability.

Closes #741

## Changes Made
- Create dedicated GridFullOverlay component in Terminal directory
- Remove inline JSX from TerminalGrid (lines 519-531)
- Export component and props interface from Terminal index
- Remove unused Ban icon import from TerminalGrid