### PR TITLE
Simplify toolbar agent button logic with dedicated component

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,0 +1,105 @@
+import { Button } from "@/components/ui/button";
+import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
+import { cn } from "@/lib/utils";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import type { ComponentType } from "react";
+
+type AgentType = "claude" | "gemini" | "codex";
+
+interface IconProps {
+  className?: string;
+  brandColor?: string;
+}
+
+interface AgentMeta {
+  name: string;
+  Icon: ComponentType<IconProps>;
+  shortcut: string | null;
+  tooltip: string;
+}
+
+const AGENT_META: Record<AgentType, AgentMeta> = {
+  claude: {
+    name: "Claude",
+    Icon: ClaudeIcon,
+    shortcut: "Cmd/Ctrl+Alt+C",
+    tooltip: "deep, focused work",
+  },
+  gemini: {
+    name: "Gemini",
+    Icon: GeminiIcon,
+    shortcut: "Cmd/Ctrl+Alt+G",
+    tooltip: "quick exploration",
+  },
+  codex: {
+    name: "Codex",
+    Icon: CodexIcon,
+    shortcut: "Cmd/Ctrl+Alt+X",
+    tooltip: "careful, methodical runs",
+  },
+};
+
+interface AgentButtonProps {
+  type: AgentType;
+  availability?: boolean;
+  isEnabled: boolean;
+  onLaunch: () => void;
+  onOpenSettings: () => void;
+}
+
+export function AgentButton({
+  type,
+  availability,
+  isEnabled,
+  onLaunch,
+  onOpenSettings,
+}: AgentButtonProps) {
+  if (!isEnabled) return null;
+
+  const meta = AGENT_META[type];
+  const isLoading = availability === undefined;
+  const isAvailable = availability ?? false;
+
+  const tooltip = isLoading
+    ? `Checking ${meta.name} CLI availability...`
+    : isAvailable
+      ? `Start ${meta.name} — ${meta.tooltip}${meta.shortcut ? ` (${meta.shortcut})` : ""}`
+      : `${meta.name} CLI not found. Click to install.`;
+
+  const ariaLabel = isLoading
+    ? `Checking ${meta.name} availability`
+    : isAvailable
+      ? `Start ${meta.name} Agent`
+      : `${meta.name} CLI not installed`;
+
+  const handleClick = () => {
+    if (isAvailable) {
+      onLaunch();
+    } else {
+      onOpenSettings();
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleClick}
+      disabled={isLoading}
+      className={cn(
+        "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
+        isAvailable && "hover:text-canopy-accent focus-visible:text-canopy-accent",
+        !isAvailable && !isLoading && "opacity-60"
+      )}
+      title={tooltip}
+      aria-label={ariaLabel}
+    >
+      <div className="relative">
+        <meta.Icon className="h-4 w-4" brandColor={getBrandColorHex(type)} />
+        {!isAvailable && !isLoading && (
+          <div className="absolute -top-1 -right-1 w-2 h-2 bg-amber-500 rounded-full" />
+        )}
+      </div>
+    </Button>
+  );
+}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -14,11 +14,11 @@ import {
   PanelLeft,
   PanelLeftClose,
 } from "lucide-react";
-import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
-import { getProjectGradient, getBrandColorHex } from "@/lib/colorUtils";
+import { getProjectGradient } from "@/lib/colorUtils";
 import { BulkActionsMenu } from "@/components/Terminal";
 import { GitHubResourceList } from "@/components/GitHub";
+import { AgentButton } from "./AgentButton";
 import { useProjectStore } from "@/store/projectStore";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useSidecarStore } from "@/store";
@@ -66,33 +66,7 @@ export function Toolbar({
   }, []);
 
   const showBulkActions = terminals.length > 0;
-
-  const getAgentStatus = (type: "claude" | "gemini" | "codex") => {
-    const isAvailable = agentAvailability?.[type];
-    const isEnabled = agentSettings?.[type]?.enabled ?? true;
-    const agentNames = { claude: "Claude", gemini: "Gemini", codex: "Codex" };
-    const isLoading = isAvailable === undefined;
-
-    return {
-      show: isEnabled,
-      available: isAvailable ?? false,
-      isLoading,
-      tooltip: isLoading
-        ? `Checking ${agentNames[type]} CLI availability...`
-        : isAvailable
-          ? type === "claude"
-            ? "Start Claude — deep, focused work (Cmd/Ctrl+Alt+C)"
-            : type === "gemini"
-              ? "Start Gemini — quick exploration (Cmd/Ctrl+Alt+G)"
-              : "Start Codex — careful, methodical runs (Cmd/Ctrl+Alt+X)"
-          : `${agentNames[type]} CLI not found. Click to install.`,
-      ariaLabel: isLoading
-        ? `Checking ${agentNames[type]} availability`
-        : isAvailable
-          ? `Start ${agentNames[type]} Agent`
-          : `${agentNames[type]} CLI not installed`,
-    };
-  };
+  const openAgentSettings = onOpenAgentSettings ?? onSettings;
 
   return (
     <header className="relative h-12 flex items-center px-4 shrink-0 app-drag-region bg-canopy-sidebar/95 backdrop-blur-sm border-b border-canopy-border shadow-sm">
@@ -116,90 +90,27 @@ export function Toolbar({
         >
           {isFocusMode ? <PanelLeft className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
         </Button>
-        {(() => {
-          const status = getAgentStatus("claude");
-          if (!status.show) return null;
-          return (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() =>
-                status.available ? onLaunchAgent("claude") : (onOpenAgentSettings ?? onSettings)()
-              }
-              disabled={status.isLoading}
-              className={cn(
-                "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
-                status.available && "hover:text-canopy-accent focus-visible:text-canopy-accent",
-                !status.available && !status.isLoading && "opacity-60"
-              )}
-              title={status.tooltip}
-              aria-label={status.ariaLabel}
-            >
-              <div className="relative">
-                <ClaudeIcon className="h-4 w-4" brandColor={getBrandColorHex("claude")} />
-                {!status.available && !status.isLoading && (
-                  <div className="absolute -top-1 -right-1 w-2 h-2 bg-amber-500 rounded-full" />
-                )}
-              </div>
-            </Button>
-          );
-        })()}
-        {(() => {
-          const status = getAgentStatus("gemini");
-          if (!status.show) return null;
-          return (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() =>
-                status.available ? onLaunchAgent("gemini") : (onOpenAgentSettings ?? onSettings)()
-              }
-              disabled={status.isLoading}
-              className={cn(
-                "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
-                status.available && "hover:text-canopy-accent focus-visible:text-canopy-accent",
-                !status.available && !status.isLoading && "opacity-60"
-              )}
-              title={status.tooltip}
-              aria-label={status.ariaLabel}
-            >
-              <div className="relative">
-                <GeminiIcon className="h-4 w-4" brandColor={getBrandColorHex("gemini")} />
-                {!status.available && !status.isLoading && (
-                  <div className="absolute -top-1 -right-1 w-2 h-2 bg-amber-500 rounded-full" />
-                )}
-              </div>
-            </Button>
-          );
-        })()}
-        {(() => {
-          const status = getAgentStatus("codex");
-          if (!status.show) return null;
-          return (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() =>
-                status.available ? onLaunchAgent("codex") : (onOpenAgentSettings ?? onSettings)()
-              }
-              disabled={status.isLoading}
-              className={cn(
-                "text-canopy-text hover:bg-canopy-border h-8 w-8 transition-colors",
-                status.available && "hover:text-canopy-accent focus-visible:text-canopy-accent",
-                !status.available && !status.isLoading && "opacity-60"
-              )}
-              title={status.tooltip}
-              aria-label={status.ariaLabel}
-            >
-              <div className="relative">
-                <CodexIcon className="h-4 w-4" brandColor={getBrandColorHex("codex")} />
-                {!status.available && !status.isLoading && (
-                  <div className="absolute -top-1 -right-1 w-2 h-2 bg-amber-500 rounded-full" />
-                )}
-              </div>
-            </Button>
-          );
-        })()}
+        <AgentButton
+          type="claude"
+          availability={agentAvailability?.claude}
+          isEnabled={agentSettings?.claude?.enabled ?? true}
+          onLaunch={() => onLaunchAgent("claude")}
+          onOpenSettings={openAgentSettings}
+        />
+        <AgentButton
+          type="gemini"
+          availability={agentAvailability?.gemini}
+          isEnabled={agentSettings?.gemini?.enabled ?? true}
+          onLaunch={() => onLaunchAgent("gemini")}
+          onOpenSettings={openAgentSettings}
+        />
+        <AgentButton
+          type="codex"
+          availability={agentAvailability?.codex}
+          isEnabled={agentSettings?.codex?.enabled ?? true}
+          onLaunch={() => onLaunchAgent("codex")}
+          onOpenSettings={openAgentSettings}
+        />
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -2,3 +2,4 @@ export { AppLayout } from "./AppLayout";
 export { Toolbar } from "./Toolbar";
 export { Sidebar } from "./Sidebar";
 export { WaitingStrip } from "./WaitingStrip";
+export { AgentButton } from "./AgentButton";


### PR DESCRIPTION
## Summary
Refactors the Toolbar component to use a dedicated AgentButton component, eliminating ~100 lines of duplicated agent button rendering logic.

Closes #739

## Changes Made
- Created AgentButton component with consolidated agent metadata (icons, tooltips, shortcuts)
- Removed duplicate button rendering from Toolbar (reduced from ~400 to 311 lines)
- Added AGENT_META constant for centralized agent configuration
- Exported AgentButton from Layout index
- All three agents (Claude, Gemini, Codex) now use the same component
- Maintains identical UI/UX behavior with improved maintainability