### PR TITLE
Consolidate duplicate terminal icon rendering logic

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,16 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useDndMonitor } from "@dnd-kit/core";
-import { Loader2, Terminal, Command } from "lucide-react";
-import {
-  ClaudeIcon,
-  GeminiIcon,
-  CodexIcon,
-  NpmIcon,
-  YarnIcon,
-  PnpmIcon,
-  BunIcon,
-} from "@/components/icons";
+import { Loader2 } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
@@ -18,39 +9,14 @@ import { getTerminalAnimationDuration } from "@/lib/animationUtils";
 import { useTerminalStore, useSidecarStore, type TerminalInstance } from "@/store";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
-import type { AgentState, TerminalType } from "@/types";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import type { AgentState } from "@/types";
 import { TerminalRefreshTier } from "@/types";
 import { terminalClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 interface DockedTerminalItemProps {
   terminal: TerminalInstance;
-}
-
-function getTerminalIcon(type: TerminalType, className?: string) {
-  const brandColor = getBrandColorHex(type);
-  const props = { className: cn("w-3 h-3", className), "aria-hidden": "true" as const };
-  switch (type) {
-    case "claude":
-      return <ClaudeIcon {...props} brandColor={brandColor} />;
-    case "gemini":
-      return <GeminiIcon {...props} brandColor={brandColor} />;
-    case "codex":
-      return <CodexIcon {...props} brandColor={brandColor} />;
-    case "npm":
-      return <NpmIcon {...props} />;
-    case "yarn":
-      return <YarnIcon {...props} />;
-    case "pnpm":
-      return <PnpmIcon {...props} />;
-    case "bun":
-      return <BunIcon {...props} />;
-    case "custom":
-      return <Command {...props} />;
-    case "shell":
-    default:
-      return <Terminal {...props} />;
-  }
 }
 
 function getStateIndicator(state?: AgentState) {
@@ -202,7 +168,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                 aria-hidden="true"
               />
             ) : (
-              getTerminalIcon(terminal.type)
+              <TerminalIcon type={terminal.type} className="w-3 h-3" brandColor={brandColor} />
             )}
             {getStateIndicator(terminal.agentState)}
             <span className="truncate max-w-[120px] font-mono">{terminal.title}</span>

--- a/src/components/Terminal/TerminalHeader.tsx
+++ b/src/components/Terminal/TerminalHeader.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import {
-  Terminal,
-  Command,
   X,
   Maximize2,
   Minimize2,
@@ -11,60 +9,16 @@ import {
   Grid2X2,
   Activity,
 } from "lucide-react";
-import {
-  ClaudeIcon,
-  GeminiIcon,
-  CodexIcon,
-  NpmIcon,
-  YarnIcon,
-  PnpmIcon,
-  BunIcon,
-} from "@/components/icons";
 import type { TerminalType, AgentState } from "@/types";
 import { cn } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { StateBadge } from "./StateBadge";
 import { ActivityBadge } from "./ActivityBadge";
 import { TerminalContextMenu } from "./TerminalContextMenu";
+import { TerminalIcon } from "./TerminalIcon";
 import type { ActivityState } from "./TerminalPane";
 import { useTerminalStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
-
-interface TerminalIconProps {
-  className?: string;
-  brandColor?: string;
-}
-
-function getTerminalIcon(type: TerminalType, props: TerminalIconProps) {
-  const finalProps = {
-    className: cn("w-3.5 h-3.5", props.className),
-    "aria-hidden": "true" as const,
-  };
-
-  const customIconProps = { ...finalProps, brandColor: props.brandColor };
-
-  switch (type) {
-    case "claude":
-      return <ClaudeIcon {...customIconProps} />;
-    case "gemini":
-      return <GeminiIcon {...customIconProps} />;
-    case "codex":
-      return <CodexIcon {...customIconProps} />;
-    case "npm":
-      return <NpmIcon {...finalProps} />;
-    case "yarn":
-      return <YarnIcon {...finalProps} />;
-    case "pnpm":
-      return <PnpmIcon {...finalProps} />;
-    case "bun":
-      return <BunIcon {...finalProps} />;
-    case "custom":
-      return <Command {...finalProps} />;
-    case "shell":
-    default:
-      return <Terminal {...finalProps} />;
-  }
-}
 
 export interface TerminalHeaderProps {
   id: string;
@@ -173,7 +127,11 @@ function TerminalHeaderComponent({
                 aria-hidden="true"
               />
             ) : (
-              getTerminalIcon(type, { brandColor: getBrandColorHex(type) })
+              <TerminalIcon
+                type={type}
+                className="w-3.5 h-3.5"
+                brandColor={getBrandColorHex(type)}
+              />
             )}
           </span>
 

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -1,0 +1,47 @@
+import { Terminal, Command } from "lucide-react";
+import {
+  ClaudeIcon,
+  GeminiIcon,
+  CodexIcon,
+  NpmIcon,
+  YarnIcon,
+  PnpmIcon,
+  BunIcon,
+} from "@/components/icons";
+import { cn } from "@/lib/utils";
+import type { TerminalType } from "@/types";
+
+export interface TerminalIconProps {
+  type: TerminalType;
+  className?: string;
+  brandColor?: string;
+}
+
+export function TerminalIcon({ type, className, brandColor }: TerminalIconProps) {
+  const finalProps = {
+    className: cn("w-4 h-4", className),
+    "aria-hidden": "true" as const,
+  };
+
+  switch (type) {
+    case "claude":
+      return <ClaudeIcon {...finalProps} brandColor={brandColor} />;
+    case "gemini":
+      return <GeminiIcon {...finalProps} brandColor={brandColor} />;
+    case "codex":
+      return <CodexIcon {...finalProps} brandColor={brandColor} />;
+    case "npm":
+      return <NpmIcon {...finalProps} />;
+    case "yarn":
+      return <YarnIcon {...finalProps} />;
+    case "pnpm":
+      return <PnpmIcon {...finalProps} />;
+    case "bun":
+      return <BunIcon {...finalProps} />;
+    case "custom":
+      return <Command {...finalProps} />;
+    case "shell":
+    default:
+      return <Terminal {...finalProps} />;
+  }
+}

--- a/src/components/Terminal/index.ts
+++ b/src/components/Terminal/index.ts
@@ -12,3 +12,5 @@ export { StateBadge } from "./StateBadge";
 export { ActivityBadge } from "./ActivityBadge";
 export type { ActivityStatus, ActivityType } from "./ActivityBadge";
 export { TerminalCountWarning, SOFT_TERMINAL_LIMIT } from "./TerminalCountWarning";
+export { TerminalIcon } from "./TerminalIcon";
+export type { TerminalIconProps } from "./TerminalIcon";

--- a/src/components/TerminalPalette/TerminalListItem.tsx
+++ b/src/components/TerminalPalette/TerminalListItem.tsx
@@ -1,15 +1,7 @@
-import { Terminal, Command } from "lucide-react";
-import {
-  ClaudeIcon,
-  GeminiIcon,
-  CodexIcon,
-  NpmIcon,
-  YarnIcon,
-  PnpmIcon,
-  BunIcon,
-} from "@/components/icons";
 import { cn } from "@/lib/utils";
-import type { TerminalType } from "@/components/Terminal/TerminalPane";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import type { TerminalType } from "@/types";
 
 export interface TerminalListItemProps {
   id: string;
@@ -19,31 +11,6 @@ export interface TerminalListItemProps {
   cwd: string;
   isSelected: boolean;
   onClick: () => void;
-}
-
-function getIcon(type: TerminalType) {
-  const props = { className: "w-4 h-4", "aria-hidden": "true" as const };
-  switch (type) {
-    case "claude":
-      return <ClaudeIcon {...props} />;
-    case "gemini":
-      return <GeminiIcon {...props} />;
-    case "codex":
-      return <CodexIcon {...props} />;
-    case "npm":
-      return <NpmIcon {...props} />;
-    case "yarn":
-      return <YarnIcon {...props} />;
-    case "pnpm":
-      return <PnpmIcon {...props} />;
-    case "bun":
-      return <BunIcon {...props} />;
-    case "custom":
-      return <Command {...props} />;
-    case "shell":
-    default:
-      return <Terminal {...props} />;
-  }
 }
 
 function truncatePath(path: string, maxLength: number = 40): string {
@@ -84,7 +51,7 @@ export function TerminalListItem({
       role="option"
     >
       <span className="shrink-0 text-canopy-text/70" aria-hidden="true">
-        {getIcon(type)}
+        <TerminalIcon type={type} brandColor={getBrandColorHex(type)} />
       </span>
 
       <div className="flex-1 min-w-0 overflow-hidden">


### PR DESCRIPTION
## Summary
Eliminates ~70 lines of code duplication by consolidating three separate terminal icon rendering implementations into a single shared component.

Closes #738

## Changes Made
- Created shared `TerminalIcon` component in `src/components/Terminal/`
- Removed duplicate `getTerminalIcon`/`getIcon` functions from:
  - `DockedTerminalItem.tsx` (25 lines removed)
  - `TerminalHeader.tsx` (30 lines removed)
  - `TerminalListItem.tsx` (23 lines removed)
- Preserved original icon sizes via `className` overrides (w-3 h-3, w-3.5 h-3.5, w-4 h-4)
- Fixed missing `brandColor` propagation in `TerminalListItem` (improvement)
- Exported new component and types from Terminal index
- Net reduction: 60 lines of code

## Testing
- Type checking passes (`npm run typecheck`)
- Linting passes with no new warnings
- Formatting verified
- Codex review completed with no regressions found