### PR TITLE
Fix: Zen Mode background count excludes docked terminals

### DIFF
--- a/src/components/Terminal/TerminalHeader.tsx
+++ b/src/components/Terminal/TerminalHeader.tsx
@@ -85,12 +85,14 @@ function TerminalHeaderComponent({
   location = "grid",
 }: TerminalHeaderProps) {
   // Get background activity stats for Zen Mode header (optimized single-pass)
+  // Only count grid terminals - docked terminals are visually separate
+  // Treat undefined location as grid for compatibility with persisted data
   const { activeCount, workingCount } = useTerminalStore(
     useShallow((state) => {
       let active = 0;
       let working = 0;
       for (const t of state.terminals) {
-        if (t.id !== id && t.location !== "trash") {
+        if (t.id !== id && (t.location === "grid" || t.location === undefined)) {
           active++;
           if (t.agentState === "working") working++;
         }


### PR DESCRIPTION
## Summary
Fixes the Zen Mode background terminal count to only include grid terminals, excluding docked terminals that are visually separated in the dock area.

Closes #755

## Changes Made
- Changed background count filter from `location !== "trash"` to `location === "grid"`
- Added undefined location handling for compatibility with persisted data
- Prevented docked terminals from inflating the background indicator count

## Technical Details
The fix updates the terminal counting logic in `TerminalHeader.tsx` to align with the existing codebase pattern of treating undefined locations as grid terminals while explicitly excluding dock terminals from the Zen Mode background count.