### PR TITLE
Add visual ping animation to terminal headers

### DIFF
--- a/src/components/Terminal/TerminalHeader.tsx
+++ b/src/components/Terminal/TerminalHeader.tsx
@@ -53,6 +53,7 @@ export interface TerminalHeaderProps {
 
   isMaximized?: boolean;
   location?: "grid" | "dock";
+  isPinged?: boolean;
 }
 
 function TerminalHeaderComponent({
@@ -83,6 +84,7 @@ function TerminalHeaderComponent({
   onRestart,
   isMaximized,
   location = "grid",
+  isPinged,
 }: TerminalHeaderProps) {
   // Get background activity stats for Zen Mode header (optimized single-pass)
   // Only count grid terminals - docked terminals are visually separate
@@ -116,7 +118,9 @@ function TerminalHeaderComponent({
           "flex items-center justify-between px-3 shrink-0 font-mono text-xs transition-colors relative overflow-hidden",
           isMaximized ? "h-10 bg-canopy-sidebar border-b border-canopy-border" : "h-8",
           !isMaximized &&
-            (isFocused ? "bg-[var(--color-surface-highlight)]" : "bg-[var(--color-surface)]")
+            !isPinged &&
+            (isFocused ? "bg-[var(--color-surface-highlight)]" : "bg-[var(--color-surface)]"),
+          isPinged && !isMaximized && "animate-ping-header bg-[var(--color-surface-highlight)]"
         )}
         onDoubleClick={handleHeaderDoubleClick}
       >

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import type { TerminalType } from "@/types";
 import { cn } from "@/lib/utils";
@@ -80,6 +80,12 @@ function TerminalPaneComponent({
   const queueCount = useTerminalStore(
     useShallow((state) => state.commandQueue.filter((c) => c.terminalId === id).length)
   );
+
+  const pingedIdSelector = useMemo(
+    () => (state: ReturnType<typeof useTerminalStore.getState>) => state.pingedId === id,
+    [id]
+  );
+  const isPinged = useTerminalStore(pingedIdSelector);
 
   const terminalErrors = useErrorStore(
     useShallow((state) => state.errors.filter((e) => e.context?.terminalId === id && !e.dismissed))
@@ -261,6 +267,7 @@ function TerminalPaneComponent({
         onRestart={handleRestart}
         isMaximized={isMaximized}
         location={location}
+        isPinged={isPinged}
       />
 
       {terminalErrors.length > 0 && (
@@ -298,29 +305,6 @@ function TerminalPaneComponent({
   );
 }
 
-export const TerminalPane = React.memo(TerminalPaneComponent, (prev, next) => {
-  return (
-    prev.id === next.id &&
-    prev.title === next.title &&
-    prev.type === next.type &&
-    prev.worktreeId === next.worktreeId &&
-    prev.cwd === next.cwd &&
-    prev.isFocused === next.isFocused &&
-    prev.isMaximized === next.isMaximized &&
-    prev.agentState === next.agentState &&
-    prev.activity?.headline === next.activity?.headline &&
-    prev.activity?.status === next.activity?.status &&
-    prev.activity?.type === next.activity?.type &&
-    prev.location === next.location &&
-    prev.restartKey === next.restartKey &&
-    prev.onFocus === next.onFocus &&
-    prev.onClose === next.onClose &&
-    prev.onToggleMaximize === next.onToggleMaximize &&
-    prev.onTitleChange === next.onTitleChange &&
-    prev.onMinimize === next.onMinimize &&
-    prev.onRestore === next.onRestore &&
-    prev.isTrashing === next.isTrashing
-  );
-});
+export const TerminalPane = React.memo(TerminalPaneComponent);
 
 export default TerminalPane;

--- a/src/index.css
+++ b/src/index.css
@@ -442,6 +442,26 @@ body,
   }
 }
 
+/* Terminal Header Ping Animation - brief brightness flash for visual feedback */
+@keyframes ping-highlight {
+  0% {
+    background-color: rgba(255, 255, 255, 0.25);
+  }
+  100% {
+    background-color: var(--color-surface-highlight);
+  }
+}
+
+.animate-ping-header {
+  animation: ping-highlight 600ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-ping-header {
+    animation: none;
+  }
+}
+
 /* Section header pattern - for organizing content hierarchically */
 .section-header {
   @apply text-xs font-bold tracking-widest text-muted-foreground uppercase;


### PR DESCRIPTION
## Summary
Implements a visual feedback system that provides a brief brightness flash on terminal headers when terminals are programmatically focused. This helps users quickly identify which terminal became active in dense grid layouts (16+ terminals).

Closes #762

## Changes Made
- Add CSS keyframes for 600ms brightness flash animation
- Extend terminalFocusSlice with pingedId state and pingTerminal action
- Implement timeout cleanup to prevent memory leaks and race conditions
- Pass isPinged prop from TerminalPane to TerminalHeader
- Apply animate-ping-header class conditionally (suppressed when maximized)
- Fix animation fill mode to preserve background color after flash

## Implementation Details
- Animation uses GPU-accelerated CSS for performance
- Timeout automatically clears ping state after 600ms
- Consecutive pings on different terminals work correctly
- Animation respects prefers-reduced-motion user preference
- Ping suppressed in maximized (Zen Mode) view to avoid distraction

## API
```typescript
// Option 1: Ping while focusing
useTerminalStore.getState().setFocused("terminal-123", true);

// Option 2: Ping without changing focus
useTerminalStore.getState().pingTerminal("terminal-123");
```