### PR TITLE
Add keyboard shortcut to cycle through waiting agents

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -98,6 +98,7 @@ export type KeyAction =
   | "agent.gemini"
   | "agent.codex"
   | "agent.shell"
+  | "agent.focusNextWaiting"
 
   // Panel management
   | "panel.toggleDock"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -343,6 +343,7 @@ function App() {
     focusDirection,
     focusByIndex,
     focusDockDirection,
+    focusNextWaiting,
     toggleMaximize,
     focusedId,
     addTerminal,
@@ -355,6 +356,7 @@ function App() {
     bulkMoveToDock,
     bulkMoveToGrid,
     restoreLastTrashed,
+    isInTrash,
   } = useTerminalStore(
     useShallow((state) => ({
       focusNext: state.focusNext,
@@ -362,6 +364,7 @@ function App() {
       focusDirection: state.focusDirection,
       focusByIndex: state.focusByIndex,
       focusDockDirection: state.focusDockDirection,
+      focusNextWaiting: state.focusNextWaiting,
       toggleMaximize: state.toggleMaximize,
       focusedId: state.focusedId,
       addTerminal: state.addTerminal,
@@ -374,6 +377,7 @@ function App() {
       bulkMoveToDock: state.bulkMoveToDock,
       bulkMoveToGrid: state.bulkMoveToGrid,
       restoreLastTrashed: state.restoreLastTrashed,
+      isInTrash: state.isInTrash,
     }))
   );
   const terminals = useTerminalStore(useShallow((state) => state.terminals));
@@ -671,6 +675,9 @@ function App() {
   useKeybinding("agent.gemini", () => handleLaunchAgent("gemini"), { enabled: electronAvailable });
   useKeybinding("agent.codex", () => handleLaunchAgent("codex"), { enabled: electronAvailable });
   useKeybinding("agent.shell", () => handleLaunchAgent("shell"), { enabled: electronAvailable });
+  useKeybinding("agent.focusNextWaiting", () => focusNextWaiting(isInTrash), {
+    enabled: electronAvailable,
+  });
 
   useKeybinding(
     "terminal.moveLeft",

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -8,6 +8,7 @@ import { getBrandColorHex } from "@/lib/colorUtils";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useWaitingTerminalIds } from "@/hooks/useTerminalSelectors";
 import { useWorktrees } from "@/hooks/useWorktrees";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { ClaudeIcon, GeminiIcon, CodexIcon } from "@/components/icons";
 import type { TerminalType } from "@shared/types";
 
@@ -31,6 +32,7 @@ export function WaitingContainer() {
   const waitingIds = useWaitingTerminalIds();
   const activateTerminal = useTerminalStore((state) => state.activateTerminal);
   const { worktreeMap } = useWorktrees();
+  const shortcut = useKeybindingDisplay("agent.focusNextWaiting");
 
   const waitingTerminals = useTerminalStore(
     useShallow((state) =>
@@ -53,7 +55,7 @@ export function WaitingContainer() {
             "px-3",
             isOpen && "bg-canopy-border border-canopy-border ring-1 ring-canopy-accent/20"
           )}
-          title="View agents waiting for input"
+          title={`View agents waiting for input${shortcut ? ` (${shortcut})` : ""}`}
           aria-haspopup="dialog"
           aria-expanded={isOpen}
           aria-controls={contentId}

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -171,6 +171,14 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Agents",
   },
   {
+    actionId: "agent.focusNextWaiting",
+    combo: "Cmd+Alt+W",
+    scope: "global",
+    priority: 0,
+    description: "Jump to next waiting agent",
+    category: "Agents",
+  },
+  {
     actionId: "terminal.inject",
     combo: "Cmd+Shift+I",
     scope: "global",


### PR DESCRIPTION
## Summary
Implements a keyboard shortcut (Cmd+Alt+W) that cycles focus through terminals with agents in the "waiting" state, eliminating the need for visual scanning or mouse interaction when unblocking multiple agents.

Closes #760

## Changes Made
- Add "agent.focusNextWaiting" KeyAction type to keymap
- Register Cmd+Alt+W keybinding in KeybindingService  
- Implement focusNextWaiting() in terminalFocusSlice with ping animation integration
- Wire keyboard handler in App.tsx
- Add keyboard shortcut hint to WaitingContainer tooltip

## Implementation Details
- Cycles through waiting terminals in grid order with wrap-around
- Excludes trashed terminals from cycling
- Triggers visual ping animation when focusing for better visibility
- Handles edge cases: empty waiting list (no-op), single terminal (re-focuses same)
- Works with both grid and docked terminals via existing activateTerminal() logic

## Testing
- All existing tests pass
- TypeScript compilation successful
- No linting errors