### PR TITLE
Fix terminal flash when dragging terminals in grid

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -302,7 +302,7 @@ export function DndProvider({ children }: DndProviderProps) {
       if (sourceLocation === "dock" && targetContainer === "grid" && isGridFull) {
         // Grid is full, cancel the drop
         setTimeout(() => {
-          terminalInstanceService.resetAllRenderers();
+          terminalInstanceService.refreshAll();
         }, 100);
         return;
       }
@@ -328,11 +328,11 @@ export function DndProvider({ children }: DndProviderProps) {
         }
       }
 
-      // Reset WebGL renderers after drag to fix rendering artifacts
+      // Refresh terminals after drag to ensure correct rendering
       // Use setTimeout with longer delay to ensure CSS Grid layout has fully settled
       // before measuring container dimensions for fit()
       setTimeout(() => {
-        terminalInstanceService.resetAllRenderers();
+        terminalInstanceService.refreshAll();
       }, 100);
     },
     [activeData, overContainer, terminals, reorderTerminals, moveTerminalToPosition, setFocused]
@@ -344,10 +344,10 @@ export function DndProvider({ children }: DndProviderProps) {
     setOverContainer(null);
     setPlaceholderIndex(null);
 
-    // Reset WebGL renderers after drag cancel to fix rendering artifacts
+    // Refresh terminals after drag cancel to ensure correct rendering
     // Use setTimeout with longer delay to ensure CSS Grid layout has fully settled
     setTimeout(() => {
-      terminalInstanceService.resetAllRenderers();
+      terminalInstanceService.refreshAll();
     }, 100);
   }, []);
 


### PR DESCRIPTION
## Summary
Eliminates the visual flash that occurs when dragging terminals within the terminal grid by replacing `resetAllRenderers()` with `refreshAll()` in drag-and-drop handlers.

Closes #766

## Changes Made
- Replace `resetAllRenderers()` with `refreshAll()` in `DndProvider.tsx` at three call sites (drag end, drag cancel, and grid-full cancel)
- Maintain WebGL contexts throughout drag operations instead of destroying and recreating them
- Update comments to reflect the new refresh approach instead of reset approach

## Technical Details
The previous implementation called `resetAllRenderers()` which explicitly disposed WebGL contexts and recreated them, causing a visible flash as terminals temporarily fell back to Canvas/DOM rendering. The new `refreshAll()` method provides the same geometry recalculation and screen repaint without destroying WebGL contexts.

Terminal resizing after drag operations is already handled by the existing `ResizeObserver` mechanism in `XtermAdapter`, which automatically detects container dimension changes and syncs the PTY.