### PR TITLE
Add clickable context filters to Event Inspector

### DIFF
--- a/src/components/EventInspector/EventDetail.tsx
+++ b/src/components/EventInspector/EventDetail.tsx
@@ -1,25 +1,71 @@
 import { useState, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
-import type { EventRecord } from "@/store/eventStore";
-import { Copy, Check, ChevronDown, ChevronRight } from "lucide-react";
+import { useEventStore, type EventRecord, type EventFilterOptions } from "@/store/eventStore";
+import { Copy, Check, ChevronDown, ChevronRight, Filter, X } from "lucide-react";
 
 interface EventDetailProps {
   event: EventRecord | null;
   className?: string;
 }
 
+interface ContextPillProps {
+  label: string;
+  value: string | number;
+  filterKey: keyof EventFilterOptions;
+  currentFilters: EventFilterOptions;
+  onToggle: (key: keyof EventFilterOptions, value: string | number) => void;
+}
+
+function ContextPill({ label, value, filterKey, currentFilters, onToggle }: ContextPillProps) {
+  const strValue = String(value);
+  const isActive = currentFilters[filterKey] === value;
+
+  return (
+    <div className="grid grid-cols-[100px_1fr] gap-2 items-center">
+      <span className="text-muted-foreground">{label}:</span>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle(filterKey, value);
+        }}
+        className={cn(
+          "group flex items-center gap-2 px-2 py-1 rounded text-xs font-mono text-left w-fit transition-all max-w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          isActive
+            ? "bg-primary/15 text-primary border border-primary/30 hover:bg-primary/25"
+            : "hover:bg-muted border border-transparent hover:border-border text-foreground"
+        )}
+        title={isActive ? "Click to clear filter" : `Filter by ${label}`}
+        aria-pressed={isActive}
+      >
+        <span className="truncate">{strValue}</span>
+        {isActive ? (
+          <X className="w-3 h-3 flex-shrink-0 opacity-70" />
+        ) : (
+          <Filter className="w-3 h-3 flex-shrink-0 opacity-0 group-hover:opacity-30" />
+        )}
+      </button>
+    </div>
+  );
+}
+
 export function EventDetail({ event, className }: EventDetailProps) {
+  const filters = useEventStore((state) => state.filters);
+  const setFilters = useEventStore((state) => state.setFilters);
   const [copied, setCopied] = useState(false);
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(["payload"]));
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  const handleContextToggle = (key: keyof EventFilterOptions, value: string | number) => {
+    const newValue = filters[key] === value ? undefined : value;
+    setFilters({ [key]: newValue });
+  };
+
   useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-        copyTimeoutRef.current = null;
-      }
-    };
+    setCopied(false);
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = null;
+    }
   }, [event]);
 
   if (!event) {
@@ -173,7 +219,10 @@ export function EventDetail({ event, className }: EventDetailProps) {
         (event.payload.worktreeId ||
           event.payload.agentId ||
           event.payload.taskId ||
-          event.payload.runId) && (
+          event.payload.runId ||
+          event.payload.terminalId ||
+          event.payload.issueNumber ||
+          event.payload.prNumber) && (
           <div className="flex-shrink-0">
             <button
               onClick={() => toggleSection("context")}
@@ -187,46 +236,69 @@ export function EventDetail({ event, className }: EventDetailProps) {
               <span className="text-sm font-medium">Context</span>
             </button>
             {expandedSections.has("context") && (
-              <div className="px-4 pb-3 space-y-2 text-sm">
-                {event.payload.worktreeId && (
-                  <div className="grid grid-cols-[100px_1fr] gap-2">
-                    <span className="text-muted-foreground">Worktree:</span>
-                    <span className="font-mono text-xs truncate">
-                      {String(event.payload.worktreeId)}
-                    </span>
-                  </div>
+              <div className="px-4 pb-3 space-y-1.5 text-sm">
+                {event.payload.worktreeId !== undefined && (
+                  <ContextPill
+                    label="Worktree"
+                    value={event.payload.worktreeId}
+                    filterKey="worktreeId"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
                 )}
-                {event.payload.agentId && (
-                  <div className="grid grid-cols-[100px_1fr] gap-2">
-                    <span className="text-muted-foreground">Agent:</span>
-                    <span className="font-mono text-xs truncate">
-                      {String(event.payload.agentId)}
-                    </span>
-                  </div>
+                {event.payload.agentId !== undefined && (
+                  <ContextPill
+                    label="Agent"
+                    value={event.payload.agentId}
+                    filterKey="agentId"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
                 )}
-                {event.payload.taskId && (
-                  <div className="grid grid-cols-[100px_1fr] gap-2">
-                    <span className="text-muted-foreground">Task:</span>
-                    <span className="font-mono text-xs truncate">
-                      {String(event.payload.taskId)}
-                    </span>
-                  </div>
+                {event.payload.taskId !== undefined && (
+                  <ContextPill
+                    label="Task"
+                    value={event.payload.taskId}
+                    filterKey="taskId"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
                 )}
-                {event.payload.runId && (
-                  <div className="grid grid-cols-[100px_1fr] gap-2">
-                    <span className="text-muted-foreground">Run:</span>
-                    <span className="font-mono text-xs truncate">
-                      {String(event.payload.runId)}
-                    </span>
-                  </div>
+                {event.payload.runId !== undefined && (
+                  <ContextPill
+                    label="Run"
+                    value={event.payload.runId}
+                    filterKey="runId"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
                 )}
-                {event.payload.terminalId && (
-                  <div className="grid grid-cols-[100px_1fr] gap-2">
-                    <span className="text-muted-foreground">Terminal:</span>
-                    <span className="font-mono text-xs truncate">
-                      {String(event.payload.terminalId)}
-                    </span>
-                  </div>
+                {event.payload.terminalId !== undefined && (
+                  <ContextPill
+                    label="Terminal"
+                    value={event.payload.terminalId}
+                    filterKey="terminalId"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
+                )}
+                {event.payload.issueNumber !== undefined && (
+                  <ContextPill
+                    label="Issue #"
+                    value={event.payload.issueNumber}
+                    filterKey="issueNumber"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
+                )}
+                {event.payload.prNumber !== undefined && (
+                  <ContextPill
+                    label="PR #"
+                    value={event.payload.prNumber}
+                    filterKey="prNumber"
+                    currentFilters={filters}
+                    onToggle={handleContextToggle}
+                  />
                 )}
               </div>
             )}

--- a/src/store/eventStore.ts
+++ b/src/store/eventStore.ts
@@ -141,6 +141,34 @@ const createEventsStore: StateCreator<EventsState> = (set, get) => ({
       });
     }
 
+    if (filters.runId) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.runId === filters.runId;
+      });
+    }
+
+    if (filters.terminalId) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.terminalId === filters.terminalId;
+      });
+    }
+
+    if (filters.issueNumber !== undefined) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.issueNumber === filters.issueNumber;
+      });
+    }
+
+    if (filters.prNumber !== undefined) {
+      filtered = filtered.filter((event) => {
+        const payload = event.payload;
+        return payload && payload.prNumber === filters.prNumber;
+      });
+    }
+
     if (filters.search) {
       const searchLower = filters.search.toLowerCase();
       filtered = filtered.filter((event) => {


### PR DESCRIPTION
## Summary
Transform Event Inspector context values (Worktree, Agent, Task, Run, Terminal, Issue #, PR #) from plain text into interactive filter pills. Clicking a context value instantly filters the event timeline to show only related events.

Closes #759

## Changes Made
- Add filter logic to eventStore for runId, terminalId, issueNumber, prNumber
- Create ContextPill component with toggle functionality and visual feedback
- Replace plain text context values with interactive filter pills
- Add accessibility support with aria-pressed and focus-visible rings
- Handle falsy values (0, empty strings) correctly with !== undefined checks
- Reset copy state when switching events to prevent stale UI

## Implementation Details
- **Store**: Added missing filter checks for runId, terminalId, issueNumber, prNumber following existing pattern
- **UI**: ContextPill component shows active state with highlighted background and X icon
- **Interaction**: Click to toggle filter on/off, supports multiple active filters (AND logic)
- **Accessibility**: Added aria-pressed attribute and focus-visible styling for keyboard navigation