### PR TITLE
Add session history and transcript search to Diagnostics dock

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -158,6 +158,11 @@ export const CHANNELS = {
   WORKTREE_CONFIG_SET_PATTERN: "worktree-config:set-pattern",
 
   WINDOW_FULLSCREEN_CHANGE: "window:fullscreen-change",
+
+  HISTORY_GET_ALL: "history:get-all",
+  HISTORY_GET_SESSION: "history:get-session",
+  HISTORY_DELETE: "history:delete",
+  HISTORY_EXPORT: "history:export",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -18,6 +18,7 @@ import { registerHibernationHandlers } from "./handlers/hibernation.js";
 import { registerSystemSleepHandlers } from "./handlers/systemSleep.js";
 import { registerKeybindingHandlers } from "./handlers/keybinding.js";
 import { registerWorktreeConfigHandlers } from "./handlers/worktreeConfig.js";
+import { registerHistoryHandlers } from "./handlers/history.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
 export { typedHandle, typedSend, sendToRenderer };
@@ -55,6 +56,7 @@ export function registerIpcHandlers(
     registerSystemSleepHandlers(deps),
     registerKeybindingHandlers(deps),
     registerWorktreeConfigHandlers(deps),
+    registerHistoryHandlers(deps),
   ];
 
   return () => {

--- a/electron/ipc/handlers/history.ts
+++ b/electron/ipc/handlers/history.ts
@@ -1,0 +1,70 @@
+import { ipcMain, dialog } from "electron";
+import { CHANNELS } from "../channels.js";
+import { getTranscriptService } from "../../services/TranscriptService.js";
+import type { HandlerDependencies } from "../types.js";
+import type { AgentSession } from "../../../shared/types/ipc.js";
+
+export function registerHistoryHandlers(_deps: HandlerDependencies): () => void {
+  const handlers: Array<() => void> = [];
+  const transcriptService = getTranscriptService();
+
+  const handleGetAll = async (): Promise<AgentSession[]> => {
+    return transcriptService.getAllSessions();
+  };
+  ipcMain.handle(CHANNELS.HISTORY_GET_ALL, handleGetAll);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.HISTORY_GET_ALL));
+
+  const handleGetSession = async (
+    _event: Electron.IpcMainInvokeEvent,
+    id: string
+  ): Promise<AgentSession | null> => {
+    if (typeof id !== "string") {
+      throw new Error("Session ID must be a string");
+    }
+    return transcriptService.getSession(id);
+  };
+  ipcMain.handle(CHANNELS.HISTORY_GET_SESSION, handleGetSession);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.HISTORY_GET_SESSION));
+
+  const handleDelete = async (_event: Electron.IpcMainInvokeEvent, id: string): Promise<void> => {
+    if (typeof id !== "string") {
+      throw new Error("Session ID must be a string");
+    }
+    return transcriptService.deleteSession(id);
+  };
+  ipcMain.handle(CHANNELS.HISTORY_DELETE, handleDelete);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.HISTORY_DELETE));
+
+  const handleExport = async (
+    _event: Electron.IpcMainInvokeEvent,
+    id: string
+  ): Promise<string | null> => {
+    if (typeof id !== "string") {
+      throw new Error("Session ID must be a string");
+    }
+
+    const session = await transcriptService.getSession(id);
+    if (!session) {
+      throw new Error("Session not found");
+    }
+
+    const result = await dialog.showSaveDialog({
+      title: "Export Session",
+      defaultPath: `session-${session.agentType}-${new Date(session.startTime).toISOString().split("T")[0]}.md`,
+      filters: [{ name: "Markdown", extensions: ["md"] }],
+    });
+
+    if (result.canceled || !result.filePath) {
+      return null;
+    }
+
+    await transcriptService.exportSession(id, result.filePath);
+    return result.filePath;
+  };
+  ipcMain.handle(CHANNELS.HISTORY_EXPORT, handleExport);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.HISTORY_EXPORT));
+
+  return () => {
+    handlers.forEach((cleanup) => cleanup());
+  };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -28,6 +28,7 @@ import {
   initializeSystemSleepService,
   getSystemSleepService,
 } from "./services/SystemSleepService.js";
+import { getTranscriptService, disposeTranscriptService } from "./services/TranscriptService.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -266,6 +267,11 @@ async function createWindow(): Promise<void> {
   initializeSystemSleepService();
   console.log("[MAIN] SystemSleepService initialized successfully");
 
+  console.log("[MAIN] Initializing TranscriptService...");
+  const transcriptService = getTranscriptService();
+  await transcriptService.initialize();
+  console.log("[MAIN] TranscriptService initialized successfully");
+
   console.log("[MAIN] Initializing EventBuffer...");
   eventBuffer = new EventBuffer(1000);
   eventBuffer.start();
@@ -448,6 +454,9 @@ async function createWindow(): Promise<void> {
     // Dispose SystemSleepService
     const sleepService = getSystemSleepService();
     sleepService.dispose();
+
+    // Dispose TranscriptService
+    disposeTranscriptService();
 
     setLoggerWindow(null);
     mainWindow = null;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -250,6 +250,12 @@ const CHANNELS = {
 
   // Window channels
   WINDOW_FULLSCREEN_CHANGE: "window:fullscreen-change",
+
+  // History channels
+  HISTORY_GET_ALL: "history:get-all",
+  HISTORY_GET_SESSION: "history:get-session",
+  HISTORY_DELETE: "history:delete",
+  HISTORY_EXPORT: "history:export",
 } as const;
 
 const api: ElectronAPI = {
@@ -710,6 +716,17 @@ const api: ElectronAPI = {
       ipcRenderer.on(CHANNELS.WINDOW_FULLSCREEN_CHANGE, handler);
       return () => ipcRenderer.removeListener(CHANNELS.WINDOW_FULLSCREEN_CHANGE, handler);
     },
+  },
+
+  // History API
+  history: {
+    getAll: () => ipcRenderer.invoke(CHANNELS.HISTORY_GET_ALL),
+
+    getSession: (id: string) => ipcRenderer.invoke(CHANNELS.HISTORY_GET_SESSION, id),
+
+    deleteSession: (id: string) => ipcRenderer.invoke(CHANNELS.HISTORY_DELETE, id),
+
+    exportSession: (id: string) => ipcRenderer.invoke(CHANNELS.HISTORY_EXPORT, id),
   },
 };
 

--- a/electron/services/TranscriptService.ts
+++ b/electron/services/TranscriptService.ts
@@ -1,0 +1,341 @@
+import { app } from "electron";
+import path from "path";
+import fs from "fs/promises";
+import { events } from "./events.js";
+import type { AgentSession } from "../../shared/types/ipc.js";
+import type { TerminalType } from "../types/index.js";
+
+const MAX_RETAINED_SESSIONS = 500;
+const EVICTION_BATCH_SIZE = 50;
+
+class TranscriptService {
+  private storageDir: string;
+  private activeSessions = new Map<string, AgentSession>();
+  private initialized = false;
+  private eventCleanups: Array<() => void> = [];
+
+  constructor() {
+    this.storageDir = path.join(app.getPath("userData"), "transcripts");
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    try {
+      await fs.mkdir(this.storageDir, { recursive: true });
+      this.bindEvents();
+      this.initialized = true;
+      void this.pruneOldSessions();
+    } catch (err) {
+      console.error("[TranscriptService] Failed to create transcripts directory:", err);
+    }
+  }
+
+  private bindEvents(): void {
+    const spawnedHandler = (payload: {
+      terminalId: string;
+      type: TerminalType;
+      worktreeId?: string;
+      timestamp?: number;
+    }) => {
+      const agentType = this.mapTerminalTypeToAgentType(payload.type);
+      this.activeSessions.set(payload.terminalId, {
+        id: payload.terminalId,
+        agentType,
+        worktreeId: payload.worktreeId,
+        startTime: payload.timestamp ?? Date.now(),
+        state: "active",
+        transcript: [],
+        artifacts: [],
+        metadata: {
+          terminalId: payload.terminalId,
+          cwd: "",
+        },
+      });
+    };
+    events.on("agent:spawned", spawnedHandler);
+    this.eventCleanups.push(() => events.off("agent:spawned", spawnedHandler));
+
+    const outputHandler = (payload: {
+      terminalId?: string;
+      agentId?: string;
+      data: string;
+      timestamp?: number;
+    }) => {
+      const sessionId = payload.terminalId ?? payload.agentId;
+      if (!sessionId) return;
+
+      const session = this.activeSessions.get(sessionId);
+      if (session) {
+        session.transcript.push({
+          timestamp: payload.timestamp ?? Date.now(),
+          type: "agent",
+          content: payload.data,
+        });
+      }
+    };
+    events.on("agent:output", outputHandler);
+    this.eventCleanups.push(() => events.off("agent:output", outputHandler));
+
+    const artifactHandler = (payload: { terminalId: string; artifacts: unknown[] }) => {
+      const session = this.activeSessions.get(payload.terminalId);
+      if (session) {
+        session.artifacts.push(...(payload.artifacts as never[]));
+      }
+    };
+    events.on("artifact:detected", artifactHandler);
+    this.eventCleanups.push(() => events.off("artifact:detected", artifactHandler));
+
+    const completedHandler = (payload: {
+      terminalId?: string;
+      agentId?: string;
+      exitCode?: number;
+    }) => {
+      const sessionId = payload.terminalId ?? payload.agentId;
+      if (sessionId) {
+        this.finalizeSession(sessionId, "completed", payload.exitCode);
+      }
+    };
+    events.on("agent:completed", completedHandler);
+    this.eventCleanups.push(() => events.off("agent:completed", completedHandler));
+
+    const failedHandler = (payload: { terminalId?: string; agentId?: string }) => {
+      const sessionId = payload.terminalId ?? payload.agentId;
+      if (sessionId) {
+        this.finalizeSession(sessionId, "failed");
+      }
+    };
+    events.on("agent:failed", failedHandler);
+    this.eventCleanups.push(() => events.off("agent:failed", failedHandler));
+
+    const killedHandler = (payload: { terminalId?: string; agentId?: string }) => {
+      const sessionId = payload.terminalId ?? payload.agentId;
+      if (sessionId) {
+        this.finalizeSession(sessionId, "failed");
+      }
+    };
+    events.on("agent:killed", killedHandler);
+    this.eventCleanups.push(() => events.off("agent:killed", killedHandler));
+  }
+
+  private mapTerminalTypeToAgentType(type: TerminalType): AgentSession["agentType"] {
+    switch (type) {
+      case "claude":
+        return "claude";
+      case "gemini":
+        return "gemini";
+      case "codex":
+        return "codex";
+      default:
+        return "custom";
+    }
+  }
+
+  private async finalizeSession(
+    id: string,
+    state: "completed" | "failed",
+    exitCode?: number
+  ): Promise<void> {
+    const session = this.activeSessions.get(id);
+    if (!session) return;
+
+    session.state = state;
+    session.endTime = Date.now();
+    if (exitCode !== undefined) {
+      session.metadata.exitCode = exitCode;
+    }
+
+    const lastEntry = session.transcript.slice(-1)[0];
+    if (lastEntry) {
+      const ansiRegex = /\x1b\[[0-9;]*m/g; // eslint-disable-line no-control-regex
+      const summary = lastEntry.content.replace(ansiRegex, "").slice(0, 100).trim();
+      (session as AgentSession & { summary?: string }).summary = summary;
+    }
+
+    const filePath = path.join(this.storageDir, `${id}.json`);
+    try {
+      await fs.writeFile(filePath, JSON.stringify(session, null, 2));
+      void this.pruneOldSessions();
+    } catch (err) {
+      console.error(`[TranscriptService] Failed to save session ${id}:`, err);
+    }
+
+    this.activeSessions.delete(id);
+  }
+
+  private async pruneOldSessions(): Promise<void> {
+    try {
+      const files = await fs.readdir(this.storageDir);
+      const jsonFiles = files.filter((f) => f.endsWith(".json"));
+
+      if (jsonFiles.length <= MAX_RETAINED_SESSIONS) return;
+
+      console.log(
+        `[TranscriptService] Pruning sessions. Current: ${jsonFiles.length}, Max: ${MAX_RETAINED_SESSIONS}`
+      );
+
+      const allSessions = await this.getAllSessions();
+      const sessionsToDelete = allSessions.slice(MAX_RETAINED_SESSIONS);
+      const batch = sessionsToDelete.slice(0, EVICTION_BATCH_SIZE);
+
+      await Promise.all(
+        batch.map(async (session) => {
+          try {
+            await fs.unlink(path.join(this.storageDir, `${session.id}.json`));
+          } catch {
+            // Ignore if file already gone
+          }
+        })
+      );
+
+      console.log(`[TranscriptService] Evicted ${batch.length} old sessions.`);
+    } catch (err) {
+      console.error("[TranscriptService] Eviction error:", err);
+    }
+  }
+
+  async getAllSessions(): Promise<AgentSession[]> {
+    try {
+      const files = await fs.readdir(this.storageDir);
+      const sessions = await Promise.all(
+        files
+          .filter((f) => f.endsWith(".json"))
+          .map(async (f) => {
+            try {
+              const content = await fs.readFile(path.join(this.storageDir, f), "utf-8");
+              return JSON.parse(content) as AgentSession;
+            } catch {
+              return null;
+            }
+          })
+      );
+      return sessions
+        .filter((s): s is AgentSession => s !== null)
+        .sort((a, b) => b.startTime - a.startTime);
+    } catch (err) {
+      console.error("[TranscriptService] Failed to read sessions:", err);
+      return [];
+    }
+  }
+
+  private validateSessionId(id: string): boolean {
+    const basename = path.basename(id);
+    return basename === id && /^[a-zA-Z0-9_-]+$/.test(id);
+  }
+
+  async getSession(id: string): Promise<AgentSession | null> {
+    if (!this.validateSessionId(id)) {
+      console.error(`[TranscriptService] Invalid session ID: ${id}`);
+      return null;
+    }
+
+    try {
+      const filePath = path.join(this.storageDir, `${id}.json`);
+      const resolvedPath = path.resolve(filePath);
+      const resolvedStorageDir = path.resolve(this.storageDir);
+
+      if (!resolvedPath.startsWith(resolvedStorageDir)) {
+        console.error(`[TranscriptService] Path traversal attempt: ${id}`);
+        return null;
+      }
+
+      const content = await fs.readFile(filePath, "utf-8");
+      return JSON.parse(content) as AgentSession;
+    } catch {
+      return null;
+    }
+  }
+
+  async deleteSession(id: string): Promise<void> {
+    if (!this.validateSessionId(id)) {
+      console.error(`[TranscriptService] Invalid session ID: ${id}`);
+      return;
+    }
+
+    try {
+      const filePath = path.join(this.storageDir, `${id}.json`);
+      const resolvedPath = path.resolve(filePath);
+      const resolvedStorageDir = path.resolve(this.storageDir);
+
+      if (!resolvedPath.startsWith(resolvedStorageDir)) {
+        console.error(`[TranscriptService] Path traversal attempt: ${id}`);
+        return;
+      }
+
+      await fs.unlink(filePath);
+    } catch (err) {
+      console.error(`[TranscriptService] Failed to delete session ${id}:`, err);
+    }
+  }
+
+  async exportSession(id: string, targetPath: string): Promise<void> {
+    const session = await this.getSession(id);
+    if (!session) throw new Error("Session not found");
+
+    const markdown = this.sessionToMarkdown(session);
+    await fs.writeFile(targetPath, markdown);
+  }
+
+  private sessionToMarkdown(session: AgentSession): string {
+    const lines: string[] = [];
+    lines.push(`# Agent Session: ${session.id}`);
+    lines.push("");
+    lines.push(`**Agent Type**: ${session.agentType}`);
+    lines.push(`**Started**: ${new Date(session.startTime).toLocaleString()}`);
+    if (session.endTime) {
+      lines.push(`**Ended**: ${new Date(session.endTime).toLocaleString()}`);
+    }
+    lines.push(`**State**: ${session.state}`);
+    lines.push("");
+    lines.push("## Transcript");
+    lines.push("");
+
+    const ansiStripRegex = /\x1b\[[0-9;]*m/g; // eslint-disable-line no-control-regex
+    for (const entry of session.transcript) {
+      const time = new Date(entry.timestamp).toLocaleTimeString();
+      lines.push(`**[${time}] ${entry.type}**`);
+      const cleanContent = entry.content.replace(ansiStripRegex, "");
+      lines.push(cleanContent);
+      lines.push("");
+    }
+
+    if (session.artifacts.length > 0) {
+      lines.push("## Artifacts");
+      lines.push("");
+      session.artifacts.forEach((artifact, i) => {
+        lines.push(`### Artifact ${i + 1}: ${artifact.type}`);
+        if (artifact.filename) lines.push(`**File**: ${artifact.filename}`);
+        lines.push("```" + (artifact.language || ""));
+        lines.push(artifact.content);
+        lines.push("```");
+        lines.push("");
+      });
+    }
+
+    return lines.join("\n");
+  }
+
+  dispose(): void {
+    this.eventCleanups.forEach((cleanup) => cleanup());
+    this.eventCleanups = [];
+    this.activeSessions.clear();
+  }
+}
+
+let transcriptServiceInstance: TranscriptService | null = null;
+
+export function getTranscriptService(): TranscriptService {
+  if (!transcriptServiceInstance) {
+    transcriptServiceInstance = new TranscriptService();
+  }
+  return transcriptServiceInstance;
+}
+
+export function disposeTranscriptService(): void {
+  if (transcriptServiceInstance) {
+    transcriptServiceInstance.dispose();
+    transcriptServiceInstance = null;
+  }
+}
+
+export { TranscriptService };

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1346,6 +1346,24 @@ export interface IpcInvokeMap {
     args: [payload: { pattern: string }];
     result: WorktreeConfig;
   };
+
+  // History channels
+  "history:get-all": {
+    args: [];
+    result: AgentSession[];
+  };
+  "history:get-session": {
+    args: [id: string];
+    result: AgentSession | null;
+  };
+  "history:delete": {
+    args: [id: string];
+    result: void;
+  };
+  "history:export": {
+    args: [id: string];
+    result: string | null;
+  };
 }
 
 /**
@@ -1661,5 +1679,15 @@ export interface ElectronAPI {
   window: {
     /** Subscribe to fullscreen state changes */
     onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void;
+  };
+  history: {
+    /** Get all saved agent sessions */
+    getAll(): Promise<AgentSession[]>;
+    /** Get a specific session by ID */
+    getSession(id: string): Promise<AgentSession | null>;
+    /** Delete a session by ID */
+    deleteSession(id: string): Promise<void>;
+    /** Export a session to markdown file, returns the file path or null if cancelled */
+    exportSession(id: string): Promise<string | null>;
   };
 }

--- a/src/clients/historyClient.ts
+++ b/src/clients/historyClient.ts
@@ -1,0 +1,19 @@
+import type { AgentSession } from "@shared/types";
+
+export const historyClient = {
+  getAll: (): Promise<AgentSession[]> => {
+    return window.electron.history.getAll();
+  },
+
+  getSession: (id: string): Promise<AgentSession | null> => {
+    return window.electron.history.getSession(id);
+  },
+
+  deleteSession: (id: string): Promise<void> => {
+    return window.electron.history.deleteSession(id);
+  },
+
+  exportSession: (id: string): Promise<string | null> => {
+    return window.electron.history.exportSession(id);
+  },
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -15,3 +15,4 @@ export { systemClient } from "./systemClient";
 export { terminalClient } from "./terminalClient";
 export { worktreeClient } from "./worktreeClient";
 export { worktreeConfigClient } from "./worktreeConfigClient";
+export { historyClient } from "./historyClient";

--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { useLogsStore, useErrorStore } from "@/store";
 import { useEventStore } from "@/store/eventStore";
+import { useSessionHistoryStore } from "@/store/sessionHistoryStore";
 import { logsClient, eventInspectorClient, errorsClient } from "@/clients";
 
 export function ProblemsActions() {
@@ -80,6 +81,26 @@ export function EventsActions() {
     <div className="flex items-center gap-2">
       <Button variant="subtle" size="xs" onClick={handleClearEvents} title="Clear all events">
         Clear
+      </Button>
+    </div>
+  );
+}
+
+export function HistoryActions() {
+  const loadSessions = useSessionHistoryStore((state) => state.loadSessions);
+  const clearFilters = useSessionHistoryStore((state) => state.clearFilters);
+
+  const handleRefresh = useCallback(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant="subtle" size="xs" onClick={handleRefresh} title="Refresh sessions">
+        Refresh
+      </Button>
+      <Button variant="subtle" size="xs" onClick={clearFilters} title="Clear filters">
+        Clear Filters
       </Button>
     </div>
   );

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -11,7 +11,8 @@ import { useErrorStore } from "@/store";
 import { ProblemsContent } from "./ProblemsContent";
 import { LogsContent } from "./LogsContent";
 import { EventsContent } from "./EventsContent";
-import { ProblemsActions, LogsActions, EventsActions } from "./DiagnosticsActions";
+import { HistoryContent } from "./HistoryContent";
+import { ProblemsActions, LogsActions, EventsActions, HistoryActions } from "./DiagnosticsActions";
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 
@@ -163,6 +164,7 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
     { id: "problems", label: "Problems", badge: errorCount },
     { id: "logs", label: "Logs" },
     { id: "events", label: "Events" },
+    { id: "history", label: "History" },
   ];
 
   return (
@@ -221,6 +223,7 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
           {activeTab === "problems" && <ProblemsActions />}
           {activeTab === "logs" && <LogsActions />}
           {activeTab === "events" && <EventsActions />}
+          {activeTab === "history" && <HistoryActions />}
 
           <button
             onClick={closeDock}
@@ -262,6 +265,16 @@ export function DiagnosticsDock({ onRetry, className }: DiagnosticsDockProps) {
             className="h-full"
           >
             <EventsContent />
+          </div>
+        )}
+        {activeTab === "history" && (
+          <div
+            id="diagnostics-history-panel"
+            role="tabpanel"
+            aria-labelledby="diagnostics-history-tab"
+            className="h-full"
+          >
+            <HistoryContent />
           </div>
         )}
       </div>

--- a/src/components/Diagnostics/HistoryContent.tsx
+++ b/src/components/Diagnostics/HistoryContent.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { cn } from "@/lib/utils";
+import { useSessionHistoryStore } from "@/store/sessionHistoryStore";
+import { SessionList, SessionDetail, SessionFilters } from "../SessionHistory";
+
+export interface HistoryContentProps {
+  className?: string;
+}
+
+export function HistoryContent({ className }: HistoryContentProps) {
+  const {
+    filteredSessions,
+    filters,
+    selectedSessionId,
+    isLoading,
+    error,
+    loadSessions,
+    setSearchQuery,
+    setFilters,
+    selectSession,
+    deleteSession,
+    exportSession,
+  } = useSessionHistoryStore(
+    useShallow((state) => ({
+      filteredSessions: state.filteredSessions,
+      filters: state.filters,
+      selectedSessionId: state.selectedSessionId,
+      isLoading: state.isLoading,
+      error: state.error,
+      loadSessions: state.loadSessions,
+      setSearchQuery: state.setSearchQuery,
+      setFilters: state.setFilters,
+      selectSession: state.selectSession,
+      deleteSession: state.deleteSession,
+      exportSession: state.exportSession,
+    }))
+  );
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  const selectedSession = useMemo(
+    () => filteredSessions.find((s) => s.id === selectedSessionId) || null,
+    [filteredSessions, selectedSessionId]
+  );
+
+  const handleDelete = async (id: string) => {
+    await deleteSession(id);
+  };
+
+  const handleExport = async (id: string) => {
+    await exportSession(id);
+  };
+
+  if (error) {
+    return (
+      <div
+        className={cn(
+          "flex flex-col items-center justify-center h-full text-muted-foreground gap-2",
+          className
+        )}
+      >
+        <p className="text-red-400">Failed to load session history</p>
+        <p className="text-xs">{error}</p>
+        <button
+          onClick={() => loadSessions()}
+          className="px-3 py-1 text-sm bg-muted hover:bg-muted/80 rounded"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (isLoading && filteredSessions.length === 0) {
+    return (
+      <div
+        className={cn("flex items-center justify-center h-full text-muted-foreground", className)}
+      >
+        Loading sessions...
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col h-full", className)}>
+      <SessionFilters
+        searchQuery={filters.searchQuery}
+        agentType={filters.agentType}
+        onSearchChange={setSearchQuery}
+        onAgentTypeChange={(type) => setFilters({ agentType: type })}
+      />
+
+      <div className="flex-1 flex min-h-0">
+        <div className="w-1/2 border-r overflow-y-auto">
+          <SessionList
+            sessions={filteredSessions}
+            selectedId={selectedSessionId}
+            onSelectSession={selectSession}
+          />
+        </div>
+
+        <div className="w-1/2 overflow-hidden">
+          <SessionDetail
+            session={selectedSession}
+            onDelete={handleDelete}
+            onExport={handleExport}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionHistory/SessionDetail.tsx
+++ b/src/components/SessionHistory/SessionDetail.tsx
@@ -1,0 +1,301 @@
+import { useState, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Download, Trash2, Copy, Check, ChevronDown, ChevronRight, Code } from "lucide-react";
+import type { AgentSession, Artifact } from "@shared/types";
+
+interface SessionDetailProps {
+  session: AgentSession | null;
+  onDelete: (id: string) => void;
+  onExport: (id: string) => void;
+  className?: string;
+}
+
+export function SessionDetail({ session, onDelete, onExport, className }: SessionDetailProps) {
+  const [copied, setCopied] = useState(false);
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(
+    new Set(["transcript", "artifacts"])
+  );
+  const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    setCopied(false);
+    return () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, [session?.id]);
+
+  if (!session) {
+    return (
+      <div
+        className={cn(
+          "flex items-center justify-center text-sm text-muted-foreground h-full",
+          className
+        )}
+      >
+        <p>Select a session to view details</p>
+      </div>
+    );
+  }
+
+  const toggleSection = (section: string) => {
+    setExpandedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(section)) {
+        next.delete(section);
+      } else {
+        next.add(section);
+      }
+      return next;
+    });
+  };
+
+  const copyTranscript = async () => {
+    try {
+      const text = session.transcript
+        .map((entry) => {
+          const time = new Date(entry.timestamp).toLocaleTimeString();
+          // eslint-disable-next-line no-control-regex
+          const clean = entry.content.replace(/\x1b\[[0-9;]*m/g, "");
+          return `[${time}] ${entry.type}: ${clean}`;
+        })
+        .join("\n\n");
+
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+      copyTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+      }, 2000);
+    } catch (err) {
+      console.error("Failed to copy transcript:", err);
+    }
+  };
+
+  const copyArtifact = async (artifact: Artifact) => {
+    try {
+      await navigator.clipboard.writeText(artifact.content);
+    } catch (err) {
+      console.error("Failed to copy artifact:", err);
+    }
+  };
+
+  const formatTimestamp = (timestamp: number) => {
+    return new Date(timestamp).toLocaleString();
+  };
+
+  const formatDuration = () => {
+    if (!session.endTime) return "In progress";
+    const duration = session.endTime - session.startTime;
+    const minutes = Math.floor(duration / 60000);
+    const seconds = Math.floor((duration % 60000) / 1000);
+    return `${minutes}m ${seconds}s`;
+  };
+
+  return (
+    <div className={cn("flex flex-col h-full bg-background", className)}>
+      <div className="flex-shrink-0 p-4 border-b">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0 space-y-1">
+            <h3 className="text-sm font-semibold capitalize">{session.agentType} Session</h3>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>{formatTimestamp(session.startTime)}</span>
+              <span>•</span>
+              <span>{formatDuration()}</span>
+              <span>•</span>
+              <span className={session.state === "failed" ? "text-red-400" : ""}>
+                {session.state}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onExport(session.id)}
+              title="Export as Markdown"
+            >
+              <Download className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onDelete(session.id)}
+              title="Delete session"
+              className="hover:text-red-400"
+            >
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="border-b">
+          <button
+            onClick={() => toggleSection("transcript")}
+            className="w-full px-4 py-2 flex items-center justify-between hover:bg-muted/50 transition-colors"
+          >
+            <div className="flex items-center gap-2">
+              {expandedSections.has("transcript") ? (
+                <ChevronDown className="w-4 h-4" />
+              ) : (
+                <ChevronRight className="w-4 h-4" />
+              )}
+              <span className="text-sm font-medium">Transcript</span>
+              <span className="text-xs text-muted-foreground">
+                ({session.transcript.length} entries)
+              </span>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                copyTranscript();
+              }}
+              title="Copy transcript"
+            >
+              {copied ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
+            </Button>
+          </button>
+          {expandedSections.has("transcript") && (
+            <div className="px-4 pb-4 space-y-3 max-h-96 overflow-y-auto">
+              {session.transcript.length === 0 ? (
+                <p className="text-xs text-muted-foreground italic">No output recorded</p>
+              ) : (
+                session.transcript.map((entry, i) => {
+                  const time = new Date(entry.timestamp).toLocaleTimeString();
+                  // eslint-disable-next-line no-control-regex
+                  const cleanContent = entry.content.replace(/\x1b\[[0-9;]*m/g, "");
+
+                  return (
+                    <div key={i} className="space-y-1">
+                      <div className="flex items-center gap-2 text-xs">
+                        <span className="text-muted-foreground font-mono">{time}</span>
+                        <span
+                          className={cn(
+                            "px-1.5 py-0.5 rounded text-[10px] font-medium",
+                            entry.type === "agent"
+                              ? "bg-purple-500/20 text-purple-400"
+                              : entry.type === "user"
+                                ? "bg-blue-500/20 text-blue-400"
+                                : "bg-gray-500/20 text-gray-400"
+                          )}
+                        >
+                          {entry.type}
+                        </span>
+                      </div>
+                      <pre className="text-xs font-mono bg-muted/50 p-2 rounded whitespace-pre-wrap break-words overflow-x-auto">
+                        {cleanContent || "(empty)"}
+                      </pre>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          )}
+        </div>
+
+        {session.artifacts.length > 0 && (
+          <div className="border-b">
+            <button
+              onClick={() => toggleSection("artifacts")}
+              className="w-full px-4 py-2 flex items-center gap-2 hover:bg-muted/50 transition-colors"
+            >
+              {expandedSections.has("artifacts") ? (
+                <ChevronDown className="w-4 h-4" />
+              ) : (
+                <ChevronRight className="w-4 h-4" />
+              )}
+              <Code className="w-4 h-4" />
+              <span className="text-sm font-medium">Artifacts</span>
+              <span className="text-xs text-muted-foreground">({session.artifacts.length})</span>
+            </button>
+            {expandedSections.has("artifacts") && (
+              <div className="px-4 pb-4 space-y-3">
+                {session.artifacts.map((artifact, i) => (
+                  <div key={artifact.id || i} className="space-y-1">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2 text-xs">
+                        <span
+                          className={cn(
+                            "px-1.5 py-0.5 rounded text-[10px] font-medium",
+                            artifact.type === "code"
+                              ? "bg-green-500/20 text-green-400"
+                              : artifact.type === "patch"
+                                ? "bg-orange-500/20 text-orange-400"
+                                : "bg-gray-500/20 text-gray-400"
+                          )}
+                        >
+                          {artifact.type}
+                        </span>
+                        {artifact.language && (
+                          <span className="text-muted-foreground">{artifact.language}</span>
+                        )}
+                        {artifact.filename && (
+                          <span className="font-mono text-muted-foreground">
+                            {artifact.filename}
+                          </span>
+                        )}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => copyArtifact(artifact)}
+                        title="Copy artifact"
+                      >
+                        <Copy className="w-3 h-3" />
+                      </Button>
+                    </div>
+                    <pre className="text-xs font-mono bg-muted/50 p-2 rounded overflow-x-auto max-h-48">
+                      {artifact.content.slice(0, 500)}
+                      {artifact.content.length > 500 && "..."}
+                    </pre>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="px-4 py-3">
+          <h4 className="text-xs font-medium text-muted-foreground mb-2">Session Info</h4>
+          <div className="grid grid-cols-[100px_1fr] gap-2 text-xs">
+            <span className="text-muted-foreground">ID:</span>
+            <span className="font-mono truncate" title={session.id}>
+              {session.id}
+            </span>
+            <span className="text-muted-foreground">Agent:</span>
+            <span className="capitalize">{session.agentType}</span>
+            {session.worktreeId && (
+              <>
+                <span className="text-muted-foreground">Worktree:</span>
+                <span className="font-mono truncate">{session.worktreeId}</span>
+              </>
+            )}
+            {session.metadata.cwd && (
+              <>
+                <span className="text-muted-foreground">Working Dir:</span>
+                <span className="font-mono truncate" title={session.metadata.cwd}>
+                  {session.metadata.cwd}
+                </span>
+              </>
+            )}
+            {session.metadata.exitCode !== undefined && (
+              <>
+                <span className="text-muted-foreground">Exit Code:</span>
+                <span>{session.metadata.exitCode}</span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionHistory/SessionFilters.tsx
+++ b/src/components/SessionHistory/SessionFilters.tsx
@@ -1,0 +1,130 @@
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Search, X, Bot, Sparkles, Terminal } from "lucide-react";
+import type { AgentSession } from "@shared/types";
+
+const AGENT_TYPE_OPTIONS: Array<{
+  type: AgentSession["agentType"];
+  label: string;
+  color: string;
+  icon: typeof Bot;
+}> = [
+  {
+    type: "claude",
+    label: "Claude",
+    color: "bg-orange-500/20 text-orange-400 border-orange-500/30",
+    icon: Bot,
+  },
+  {
+    type: "gemini",
+    label: "Gemini",
+    color: "bg-blue-500/20 text-blue-400 border-blue-500/30",
+    icon: Sparkles,
+  },
+  {
+    type: "codex",
+    label: "Codex",
+    color: "bg-green-500/20 text-green-400 border-green-500/30",
+    icon: Terminal,
+  },
+  {
+    type: "custom",
+    label: "Custom",
+    color: "bg-gray-500/20 text-gray-400 border-gray-500/30",
+    icon: Bot,
+  },
+];
+
+interface SessionFiltersProps {
+  searchQuery: string;
+  agentType?: AgentSession["agentType"];
+  onSearchChange: (query: string) => void;
+  onAgentTypeChange: (type: AgentSession["agentType"] | undefined) => void;
+  className?: string;
+}
+
+export function SessionFilters({
+  searchQuery,
+  agentType,
+  onSearchChange,
+  onAgentTypeChange,
+  className,
+}: SessionFiltersProps) {
+  const [searchInput, setSearchInput] = useState(searchQuery);
+
+  useEffect(() => {
+    setSearchInput(searchQuery);
+  }, [searchQuery]);
+
+  const handleSearchChange = (value: string) => {
+    setSearchInput(value);
+    onSearchChange(value);
+  };
+
+  const clearSearch = () => {
+    setSearchInput("");
+    onSearchChange("");
+  };
+
+  const toggleAgentType = (type: AgentSession["agentType"]) => {
+    onAgentTypeChange(agentType === type ? undefined : type);
+  };
+
+  return (
+    <div className={cn("flex-shrink-0 border-b bg-background", className)}>
+      <div className="p-3 space-y-2">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={searchInput}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            placeholder="Search transcripts..."
+            className={cn(
+              "w-full pl-9 pr-9 py-2 text-sm rounded-md",
+              "bg-muted/50 border border-transparent",
+              "focus:bg-background focus:border-primary focus:outline-none",
+              "placeholder:text-muted-foreground"
+            )}
+          />
+          {searchInput && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={clearSearch}
+              className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
+            >
+              <X className="w-4 h-4" />
+            </Button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {AGENT_TYPE_OPTIONS.map((option) => {
+            const isActive = agentType === option.type;
+            const Icon = option.icon;
+
+            return (
+              <Button
+                key={option.type}
+                variant="outline"
+                size="xs"
+                onClick={() => toggleAgentType(option.type)}
+                className={cn(
+                  "gap-1",
+                  isActive
+                    ? option.color
+                    : "bg-muted/30 text-muted-foreground border-transparent hover:bg-muted/50"
+                )}
+              >
+                <Icon className="w-3 h-3" />
+                <span>{option.label}</span>
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionHistory/SessionList.tsx
+++ b/src/components/SessionHistory/SessionList.tsx
@@ -1,0 +1,127 @@
+import { cn } from "@/lib/utils";
+import { History, Bot, Sparkles, Terminal } from "lucide-react";
+import type { AgentSession } from "@shared/types";
+
+const AGENT_TYPE_CONFIG: Record<
+  AgentSession["agentType"],
+  { label: string; color: string; icon: typeof Bot }
+> = {
+  claude: { label: "Claude", color: "text-orange-400", icon: Bot },
+  gemini: { label: "Gemini", color: "text-blue-400", icon: Sparkles },
+  codex: { label: "Codex", color: "text-green-400", icon: Terminal },
+  custom: { label: "Custom", color: "text-gray-400", icon: Bot },
+};
+
+interface SessionListProps {
+  sessions: AgentSession[];
+  selectedId: string | null;
+  onSelectSession: (id: string) => void;
+  className?: string;
+}
+
+export function SessionList({
+  sessions,
+  selectedId,
+  onSelectSession,
+  className,
+}: SessionListProps) {
+  const formatTimestamp = (timestamp: number) => {
+    const date = new Date(timestamp);
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const formatDuration = (session: AgentSession) => {
+    if (!session.endTime) return "In progress";
+    const duration = session.endTime - session.startTime;
+    if (duration < 60000) return `${Math.floor(duration / 1000)}s`;
+    if (duration < 3600000) return `${Math.floor(duration / 60000)}m`;
+    return `${Math.floor(duration / 3600000)}h ${Math.floor((duration % 3600000) / 60000)}m`;
+  };
+
+  const getSummary = (session: AgentSession & { summary?: string }) => {
+    if (session.summary) {
+      return session.summary.slice(0, 60) + (session.summary.length > 60 ? "..." : "");
+    }
+    if (session.transcript.length > 0) {
+      const lastEntry = session.transcript[session.transcript.length - 1];
+      // eslint-disable-next-line no-control-regex
+      const clean = lastEntry.content.replace(/\x1b\[[0-9;]*m/g, "").trim();
+      return clean.slice(0, 60) + (clean.length > 60 ? "..." : "");
+    }
+    return "No output";
+  };
+
+  if (sessions.length === 0) {
+    return (
+      <div
+        className={cn(
+          "flex-1 flex items-center justify-center text-sm text-muted-foreground",
+          className
+        )}
+      >
+        <div className="text-center space-y-2">
+          <History className="w-8 h-8 mx-auto opacity-30" />
+          <p>No sessions found</p>
+          <p className="text-xs">Agent sessions will appear here</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex-1 overflow-y-auto", className)}>
+      <div className="space-y-px">
+        {sessions.map((session) => {
+          const config = AGENT_TYPE_CONFIG[session.agentType];
+          const isSelected = session.id === selectedId;
+          const Icon = config.icon;
+
+          return (
+            <button
+              key={session.id}
+              onClick={() => onSelectSession(session.id)}
+              className={cn(
+                "w-full text-left px-3 py-2.5 hover:bg-muted/50 transition-colors",
+                "border-l-2 border-transparent",
+                isSelected && "bg-muted border-l-primary"
+              )}
+            >
+              <div className="flex items-start gap-2">
+                <Icon className={cn("w-4 h-4 mt-0.5 flex-shrink-0", config.color)} />
+                <div className="flex-1 min-w-0 space-y-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className={cn("text-xs font-medium", config.color)}>{config.label}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatTimestamp(session.startTime)}
+                    </span>
+                  </div>
+                  <p className="text-xs text-foreground/80 truncate">{getSummary(session)}</p>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{formatDuration(session)}</span>
+                    {session.artifacts.length > 0 && (
+                      <>
+                        <span>•</span>
+                        <span>{session.artifacts.length} artifact(s)</span>
+                      </>
+                    )}
+                    {session.state === "failed" && (
+                      <>
+                        <span>•</span>
+                        <span className="text-red-400">Failed</span>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SessionHistory/index.ts
+++ b/src/components/SessionHistory/index.ts
@@ -1,0 +1,3 @@
+export { SessionList } from "./SessionList";
+export { SessionDetail } from "./SessionDetail";
+export { SessionFilters } from "./SessionFilters";

--- a/src/store/diagnosticsStore.ts
+++ b/src/store/diagnosticsStore.ts
@@ -1,6 +1,6 @@
 import { create, type StateCreator } from "zustand";
 
-export type DiagnosticsTab = "problems" | "logs" | "events";
+export type DiagnosticsTab = "problems" | "logs" | "events" | "history";
 
 interface DiagnosticsState {
   isOpen: boolean;

--- a/src/store/sessionHistoryStore.ts
+++ b/src/store/sessionHistoryStore.ts
@@ -1,0 +1,167 @@
+import { create, type StateCreator } from "zustand";
+import Fuse from "fuse.js";
+import type { AgentSession } from "@shared/types";
+
+export interface SessionFilters {
+  searchQuery: string;
+  agentType?: AgentSession["agentType"];
+  worktreeId?: string;
+}
+
+interface SessionHistoryState {
+  sessions: AgentSession[];
+  filteredSessions: AgentSession[];
+  selectedSessionId: string | null;
+  filters: SessionFilters;
+  isLoading: boolean;
+  error: string | null;
+
+  loadSessions: () => Promise<void>;
+  setSearchQuery: (query: string) => void;
+  setFilters: (filters: Partial<SessionFilters>) => void;
+  clearFilters: () => void;
+  selectSession: (id: string | null) => void;
+  deleteSession: (id: string) => Promise<void>;
+  exportSession: (id: string) => Promise<string | null>;
+  reset: () => void;
+}
+
+const DEFAULT_FILTERS: SessionFilters = {
+  searchQuery: "",
+};
+
+const stripAnsi = (text: string) => text.replace(/\x1b\[[0-9;]*m/g, ""); // eslint-disable-line no-control-regex
+
+const applyFilters = (sessions: AgentSession[], filters: SessionFilters): AgentSession[] => {
+  let filtered = [...sessions];
+
+  if (filters.agentType) {
+    filtered = filtered.filter((s) => s.agentType === filters.agentType);
+  }
+
+  if (filters.worktreeId) {
+    filtered = filtered.filter((s) => s.worktreeId === filters.worktreeId);
+  }
+
+  if (filters.searchQuery.trim()) {
+    const sessionsWithCleanedContent = filtered.map((s) => ({
+      ...s,
+      transcript: s.transcript.map((t) => ({ ...t, content: stripAnsi(t.content) })),
+      artifacts: s.artifacts.map((a) => ({ ...a, content: stripAnsi(a.content) })),
+    }));
+
+    const fuse = new Fuse(sessionsWithCleanedContent, {
+      keys: [
+        { name: "transcript.content", weight: 0.5 },
+        { name: "artifacts.content", weight: 0.3 },
+        { name: "agentType", weight: 0.1 },
+        { name: "metadata.cwd", weight: 0.1 },
+      ],
+      threshold: 0.4,
+      ignoreLocation: true,
+      includeScore: true,
+    });
+
+    const results = fuse.search(filters.searchQuery);
+    return results.map((r) => filtered[sessionsWithCleanedContent.indexOf(r.item)]);
+  }
+
+  return filtered.sort((a, b) => b.startTime - a.startTime);
+};
+
+const createSessionHistoryStore: StateCreator<SessionHistoryState> = (set, get) => ({
+  sessions: [],
+  filteredSessions: [],
+  selectedSessionId: null,
+  filters: DEFAULT_FILTERS,
+  isLoading: false,
+  error: null,
+
+  loadSessions: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const sessions = await window.electron.history.getAll();
+      const filters = get().filters;
+      set({
+        sessions,
+        filteredSessions: applyFilters(sessions, filters),
+        isLoading: false,
+        error: null,
+      });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Failed to load sessions";
+      console.error("[SessionHistoryStore] Failed to load sessions:", err);
+      set({ isLoading: false, error: errorMessage });
+    }
+  },
+
+  setSearchQuery: (query) => {
+    const { sessions, filters, selectedSessionId } = get();
+    const newFilters = { ...filters, searchQuery: query };
+    const filteredSessions = applyFilters(sessions, newFilters);
+    const isSelectedVisible = filteredSessions.some((s) => s.id === selectedSessionId);
+    set({
+      filters: newFilters,
+      filteredSessions,
+      selectedSessionId: isSelectedVisible ? selectedSessionId : null,
+    });
+  },
+
+  setFilters: (newFilters) => {
+    const { sessions, filters, selectedSessionId } = get();
+    const merged = { ...filters, ...newFilters };
+    const filteredSessions = applyFilters(sessions, merged);
+    const isSelectedVisible = filteredSessions.some((s) => s.id === selectedSessionId);
+    set({
+      filters: merged,
+      filteredSessions,
+      selectedSessionId: isSelectedVisible ? selectedSessionId : null,
+    });
+  },
+
+  clearFilters: () => {
+    const { sessions } = get();
+    set({
+      filters: DEFAULT_FILTERS,
+      filteredSessions: applyFilters(sessions, DEFAULT_FILTERS),
+    });
+  },
+
+  selectSession: (id) => set({ selectedSessionId: id }),
+
+  deleteSession: async (id) => {
+    try {
+      await window.electron.history.deleteSession(id);
+      const { sessions, filters, selectedSessionId } = get();
+      const updated = sessions.filter((s) => s.id !== id);
+      set({
+        sessions: updated,
+        filteredSessions: applyFilters(updated, filters),
+        selectedSessionId: selectedSessionId === id ? null : selectedSessionId,
+      });
+    } catch (err) {
+      console.error("[SessionHistoryStore] Failed to delete session:", err);
+    }
+  },
+
+  exportSession: async (id) => {
+    try {
+      return await window.electron.history.exportSession(id);
+    } catch (err) {
+      console.error("[SessionHistoryStore] Failed to export session:", err);
+      return null;
+    }
+  },
+
+  reset: () =>
+    set({
+      sessions: [],
+      filteredSessions: [],
+      selectedSessionId: null,
+      filters: DEFAULT_FILTERS,
+      isLoading: false,
+      error: null,
+    }),
+});
+
+export const useSessionHistoryStore = create<SessionHistoryState>(createSessionHistoryStore);


### PR DESCRIPTION
## Summary
Adds a searchable session history and transcript viewer to the Diagnostics dock, enabling users to review past agent interactions, search transcripts, and export sessions.

Closes #761

## Changes Made
- Add TranscriptService backend with automatic session recording
- Implement session eviction (max 500 sessions) for long-term stability  
- Add path traversal protection and event cleanup to prevent security issues
- Create IPC handlers for session retrieval, deletion, and export
- Build searchable session history UI with Fuse.js full-text search
- Add ANSI code stripping for accurate search results
- Implement error states and filter reconciliation
- Integrate History tab into Diagnostics dock

## Security & Reliability
- Path traversal protection with strict session ID validation
- Event listener cleanup to prevent memory leaks
- Automatic eviction of old sessions (500 max) to maintain performance
- Error state handling with user-friendly retry mechanism

## Testing
- Typecheck: ✅ passes
- Lint: ✅ passes (0 errors, only pre-existing warnings)
- Format: ✅ passes
- Codex review: ✅ completed with all critical issues fixed