### PR TITLE
Fix terminal rendering issues during Codex MCP execution

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -186,7 +186,7 @@ function TerminalPaneComponent({
     <div
       ref={containerRef}
       className={cn(
-        "flex flex-col h-full overflow-hidden transition-all duration-200 group",
+        "flex flex-col h-full overflow-hidden group",
 
         // Background color: surface tint for cards, canvas for maximized
         location === "grid" && !isMaximized && "bg-[var(--color-surface)]",

--- a/src/services/TerminalInstanceService.ts
+++ b/src/services/TerminalInstanceService.ts
@@ -34,10 +34,18 @@ interface ManagedTerminal {
   // Geometry caching for resize optimization
   lastWidth: number;
   lastHeight: number;
+  // WebGL dispose grace period timer
+  webglDisposeTimer?: number;
+  // Renderer policy hysteresis state
+  lastAppliedTier?: TerminalRefreshTier; // The tier currently in effect
+  pendingTier?: TerminalRefreshTier; // Target tier for scheduled downgrade
+  tierChangeTimer?: number;
 }
 
 const BURST_MODE_WINDOW_MS = 500;
 const MAX_WEBGL_RECOVERY_ATTEMPTS = 3;
+const WEBGL_DISPOSE_GRACE_MS = 10000; // 10s grace period before releasing WebGL on hide
+const TIER_DOWNGRADE_HYSTERESIS_MS = 500; // Delay before applying tier downgrades to prevent flapping
 
 /**
  * Creates a throttled writer that batches terminal output for efficient rendering.
@@ -91,7 +99,8 @@ function createThrottledWriter(
       // Consider recent input OR output for burst mode to handle streaming agent output
       const timeSinceInput = Date.now() - lastInputTime;
       const timeSinceOutput = Date.now() - lastOutputTime;
-      const isBurstMode = timeSinceInput < BURST_MODE_WINDOW_MS || timeSinceOutput < BURST_MODE_WINDOW_MS;
+      const isBurstMode =
+        timeSinceInput < BURST_MODE_WINDOW_MS || timeSinceOutput < BURST_MODE_WINDOW_MS;
       const tierDelay = getRefreshTier();
       const effectiveDelay = isBurstMode ? TerminalRefreshTier.BURST : tierDelay;
 
@@ -136,7 +145,8 @@ function createThrottledWriter(
       const now = Date.now();
       const timeSinceInput = now - lastInputTime;
       const timeSinceOutput = now - lastOutputTime;
-      const isBurstMode = timeSinceInput < BURST_MODE_WINDOW_MS || timeSinceOutput < BURST_MODE_WINDOW_MS;
+      const isBurstMode =
+        timeSinceInput < BURST_MODE_WINDOW_MS || timeSinceOutput < BURST_MODE_WINDOW_MS;
       const tierDelay = getRefreshTier();
       const effectiveDelay = isBurstMode ? TerminalRefreshTier.BURST : tierDelay;
       const fps = Math.round(1000 / effectiveDelay);
@@ -371,22 +381,42 @@ class TerminalInstanceService {
       managed.lastActiveTime = Date.now();
 
       if (isVisible) {
-        // Always bust cache when becoming visible to force fresh measurement
-        managed.lastWidth = 0;
-        managed.lastHeight = 0;
+        // Cancel pending WebGL disposal if becoming visible again
+        if (managed.webglDisposeTimer !== undefined) {
+          clearTimeout(managed.webglDisposeTimer);
+          managed.webglDisposeTimer = undefined;
+        }
 
-        // Force resize when becoming visible to sync dimensions
+        // Only bust geometry cache if dimensions actually changed
+        // This prevents redundant reflows on quick tab switches where container size is unchanged
+        // The XtermAdapter's performFit() will handle the actual resize and IPC
         const rect = managed.hostElement.getBoundingClientRect();
         if (rect.width > 0 && rect.height > 0) {
-          this.resize(id, rect.width, rect.height);
+          const widthChanged = Math.abs(managed.lastWidth - rect.width) >= 1;
+          const heightChanged = Math.abs(managed.lastHeight - rect.height) >= 1;
+
+          if (widthChanged || heightChanged) {
+            // Bust cache so performFit() will trigger a resize
+            managed.lastWidth = 0;
+            managed.lastHeight = 0;
+          }
         }
         // If becoming visible, try to upgrade to WebGL
         this.applyRendererPolicy(id, managed.getRefreshTier());
       } else {
-        // If hiding, release WebGL immediately to free resources
-        if (managed.webglAddon) {
-          this.releaseWebgl(id, managed);
-          managed.terminal.refresh(0, managed.terminal.rows - 1);
+        // If hiding, wait grace period before releasing WebGL (prevents flicker on quick tab switches)
+        if (managed.webglAddon && managed.webglDisposeTimer === undefined) {
+          managed.webglDisposeTimer = window.setTimeout(() => {
+            // Re-check: terminal might have become visible or been destroyed during grace period
+            const current = this.instances.get(id);
+            if (current && !current.isVisible && current.webglAddon) {
+              this.releaseWebgl(id, current);
+              current.terminal.refresh(0, current.terminal.rows - 1);
+            }
+            if (current) {
+              current.webglDisposeTimer = undefined;
+            }
+          }, WEBGL_DISPOSE_GRACE_MS);
         }
       }
     }
@@ -460,9 +490,9 @@ class TerminalInstanceService {
     const inputDisposable = terminal.onData((data) => {
       // Check for clear command (special handling for AI agents)
       if (inputTracker.process(data)) {
-        // 1. Clear pending output buffer (prevent ghost echoes)
-        throttledWriter.clear();
-        // 2. Force clear visual terminal state immediately
+        // Force clear visual terminal state immediately
+        // Note: We don't clear the throttledWriter buffer here - VT100_FULL_CLEAR handles
+        // the visual clear, and clearing the buffer could cause data loss on false positives
         terminal.write(VT100_FULL_CLEAR);
       }
 
@@ -755,6 +785,10 @@ class TerminalInstanceService {
    * Visible terminals with FOCUSED/BURST/VISIBLE tier get WebGL.
    * BACKGROUND terminals and hidden terminals surrender WebGL to save resources.
    * Also propagates activity tier to main process for IPC batching.
+   *
+   * Uses hysteresis for downgrades: tier changes from higher to lower priority
+   * are delayed by TIER_DOWNGRADE_HYSTERESIS_MS to prevent rapid WebGL churn
+   * during MCP state transitions.
    */
   applyRendererPolicy(id: string, tier: TerminalRefreshTier): void {
     const managed = this.instances.get(id);
@@ -766,6 +800,70 @@ class TerminalInstanceService {
       // Clear error flag on explicit user interaction
       managed.hasWebglError = false;
     }
+
+    // Use the last actually applied tier as baseline (not pending or getRefreshTier)
+    // Lower tier values = higher priority (BURST=8 < FOCUSED=16 < VISIBLE=100 < BACKGROUND=1000)
+    const currentAppliedTier =
+      managed.lastAppliedTier ?? managed.getRefreshTier() ?? TerminalRefreshTier.FOCUSED;
+
+    // Same tier as currently applied: nothing to do
+    if (tier === currentAppliedTier) {
+      // Cancel any pending downgrade since we're staying at current tier
+      if (managed.tierChangeTimer !== undefined) {
+        clearTimeout(managed.tierChangeTimer);
+        managed.tierChangeTimer = undefined;
+        managed.pendingTier = undefined;
+      }
+      return;
+    }
+
+    const isUpgrade = tier < currentAppliedTier;
+
+    // For upgrades: apply immediately and cancel any pending downgrade
+    if (isUpgrade) {
+      if (managed.tierChangeTimer !== undefined) {
+        clearTimeout(managed.tierChangeTimer);
+        managed.tierChangeTimer = undefined;
+      }
+      managed.pendingTier = undefined;
+      this.applyRendererPolicyImmediate(id, managed, tier);
+      return;
+    }
+
+    // For downgrades: apply with hysteresis to prevent flapping
+    // If already pending the same tier, skip scheduling another timer
+    if (managed.pendingTier === tier && managed.tierChangeTimer !== undefined) {
+      return;
+    }
+
+    // Cancel any existing timer and schedule new one
+    if (managed.tierChangeTimer !== undefined) {
+      clearTimeout(managed.tierChangeTimer);
+    }
+
+    managed.pendingTier = tier;
+    managed.tierChangeTimer = window.setTimeout(() => {
+      const current = this.instances.get(id);
+      if (current && current.pendingTier === tier) {
+        this.applyRendererPolicyImmediate(id, current, tier);
+        current.pendingTier = undefined;
+      }
+      if (current) {
+        current.tierChangeTimer = undefined;
+      }
+    }, TIER_DOWNGRADE_HYSTERESIS_MS);
+  }
+
+  /**
+   * Internal: Apply renderer policy immediately without hysteresis.
+   */
+  private applyRendererPolicyImmediate(
+    id: string,
+    managed: ManagedTerminal,
+    tier: TerminalRefreshTier
+  ): void {
+    // Track the last applied tier for hysteresis baseline
+    managed.lastAppliedTier = tier;
 
     // Terminal must be visible AND have appropriate tier to want WebGL
     const wantsWebgl =
@@ -938,6 +1036,18 @@ class TerminalInstanceService {
   destroy(id: string): void {
     const managed = this.instances.get(id);
     if (!managed) return;
+
+    // Clear pending WebGL dispose timer
+    if (managed.webglDisposeTimer !== undefined) {
+      clearTimeout(managed.webglDisposeTimer);
+      managed.webglDisposeTimer = undefined;
+    }
+
+    // Clear pending tier change timer
+    if (managed.tierChangeTimer !== undefined) {
+      clearTimeout(managed.tierChangeTimer);
+      managed.tierChangeTimer = undefined;
+    }
 
     managed.listeners.forEach((cleanup) => cleanup());
     managed.throttledWriter.dispose();


### PR DESCRIPTION
## Summary
Resolves terminal rendering artifacts (flashing and content jumping) during Codex MCP execution by replacing setTimeout-based throttling with requestAnimationFrame batching and removing the cursor-home blocking logic.

Closes #778

## Changes Made
- Replace setTimeout with requestAnimationFrame for BURST mode to batch Clear+Redraw operations in single paint frame
- Add document.visibilityState check to prevent RAF pause when document is hidden
- Track output activity in addition to input to maintain BURST mode during streaming agent responses
- Remove applyJankFix function that blocked cursor-home sequences and caused content jumping with TUI-style agent redraws
- Add proper cleanup for rafId in dispose, clear, notifyInput, and boost methods

## Technical Details

### Root Causes Fixed

1. **Flashing (Redrawing)**: The throttledWriter used setTimeout for output flushing. When Codex MCP outputs Clear+Redraw sequences, setTimeout allowed them to fall into different browser paint frames, creating visible flashes. RAF batches them atomically.

2. **Jumping (Scrolling)**: The applyJankFix function blocked cursor-home sequences during scroll events. This was designed for standard shells but breaks TUI-like AI agent rendering which relies on cursor positioning for redraws.

### Implementation

- BURST mode (delay ≤ 16ms) now uses requestAnimationFrame instead of setTimeout(8ms)
- Added document.visibilityState check: RAF pauses when hidden, so we fall back to setTimeout
- Track lastOutputTime alongside lastInputTime to maintain BURST during streaming (not just user input)
- Removed applyJankFix function and jankFixDisposers map entirely
- All RAF cancellation paths properly handle both timerId and rafId

### Testing
- Type check passes
- Lint passes (only pre-existing warnings)
- Codex review identified and resolved edge cases (hidden state RAF pause, output activity tracking)