### PR TITLE
Fix main worktree disappearing from sidebar intermittently

### DIFF
--- a/electron/services/WorktreeMonitor.ts
+++ b/electron/services/WorktreeMonitor.ts
@@ -76,6 +76,7 @@ export class WorktreeMonitor {
       name: worktree.name,
       branch: worktree.branch,
       isCurrent: worktree.isCurrent,
+      isMainWorktree: Boolean(worktree.isMainWorktree),
       worktreeId: worktree.id,
       worktreeChanges: null,
       mood: "stable",

--- a/electron/services/WorktreeService.ts
+++ b/electron/services/WorktreeService.ts
@@ -224,6 +224,18 @@ export class WorktreeService {
       // 1. Remove stale monitors (worktrees that no longer exist)
       for (const [id, monitor] of this.monitors) {
         if (!currentIds.has(id)) {
+          const state = monitor.getState();
+
+          // Safeguard: Never remove main worktree monitor
+          if (state.isMainWorktree) {
+            logWarn("Attempted to remove main worktree monitor - blocked", {
+              id,
+              branch: state.branch,
+              reason: "Main worktree missing from git worktree list (possible transient git error)",
+            });
+            continue;
+          }
+
           logInfo("Removing stale WorktreeMonitor", { id });
           // Clean up event bus subscription to prevent memory leak
           const unsubscribe = (monitor as any)._eventBusUnsubscribe;

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -193,7 +193,8 @@ export function WorktreeCard({
   );
 
   const [now, setNow] = useState(() => Date.now());
-  const isMainWorktree = worktree.branch === "main" || worktree.branch === "master";
+  // Use the isMainWorktree flag from the worktree state for consistent detection
+  const isMainWorktree = worktree.isMainWorktree;
 
   useEffect(() => {
     if (!isMainWorktree || !worktree.aiNote || !worktree.aiNoteTimestamp) {

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -37,10 +37,15 @@ export function useWorktrees(): UseWorktreesReturn {
 
   const worktrees = useMemo(() => {
     return Array.from(worktreeMap.values()).sort((a, b) => {
-      const aIsMain = a.branch === "main" || a.branch === "master";
-      const bIsMain = b.branch === "main" || b.branch === "master";
-      if (aIsMain !== bIsMain) {
-        return aIsMain ? -1 : 1;
+      // Use isMainWorktree flag for consistent sorting
+      if (a.isMainWorktree && !b.isMainWorktree) return -1;
+      if (!a.isMainWorktree && b.isMainWorktree) return 1;
+
+      // Secondary sort by last activity
+      const timeA = a.lastActivityTimestamp ?? 0;
+      const timeB = b.lastActivityTimestamp ?? 0;
+      if (timeA !== timeB) {
+        return timeB - timeA;
       }
 
       return a.name.localeCompare(b.name);


### PR DESCRIPTION
## Summary
Fixes the intermittent disappearance of the main worktree from the sidebar by implementing multi-layer safeguards and standardizing the `isMainWorktree` flag usage across the codebase.

Closes #783

## Root Cause
The `isMainWorktree` flag was not being propagated through the `WorktreeMonitor` state to the renderer, causing all safeguards and sorting logic to fail. The main worktree could be removed via:
1. Stale monitor cleanup during transient git errors
2. IPC `WORKTREE_REMOVE` events that weren't blocked
3. Inconsistent sorting logic using branch names instead of the flag

## Changes Made
- **WorktreeMonitor**: Add `isMainWorktree` flag to state for propagation to renderer via IPC
- **WorktreeService.sync**: Add safeguard to prevent removal of main worktree monitor during stale cleanup
- **worktreeDataStore**: Add safeguard to block `WORKTREE_REMOVE` events for main worktree
- **useWorktrees**: Standardize sorting logic to use `isMainWorktree` flag with secondary sort by activity
- **worktreeDataStore.getWorktreeList**: Standardize sorting to use `isMainWorktree` flag
- **WorktreeCard**: Replace branch name check with `isMainWorktree` flag

## Technical Details
**Multi-layer defense:**
1. Backend prevents emitting `WORKTREE_REMOVE` for main worktree (WorktreeService.sync)
2. Backend prevents deletion via `deleteWorktree` API (already existed, now works)
3. Frontend blocks removal from store if event is received (worktreeDataStore)
4. Consistent sorting ensures main worktree always appears first

**Invariants enforced:**
- Main worktree (`isMainWorktree: true`) can never be removed from the store
- Main worktree always sorts first in all lists
- Main worktree flag is consistently used instead of branch name checks