### PR TITLE
Move CopyTreeService to workspace-host for isolated context generation

### DIFF
--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Worktree, WorktreeChanges, FileChangeDetail, WorktreeMood } from "./domain.js";
+import type { CopyTreeOptions, CopyTreeProgress, CopyTreeResult } from "./ipc.js";
 
 /** Options for creating a new worktree */
 export interface CreateWorktreeOptions {
@@ -115,7 +116,16 @@ export type WorkspaceHostRequest =
   // Health check
   | { type: "health-check" }
   // Lifecycle
-  | { type: "dispose" };
+  | { type: "dispose" }
+  // CopyTree operations
+  | {
+      type: "copytree:generate";
+      requestId: string;
+      operationId: string;
+      rootPath: string;
+      options?: CopyTreeOptions;
+    }
+  | { type: "copytree:cancel"; operationId: string };
 
 /**
  * Events sent from Workspace Host → Main.
@@ -154,7 +164,16 @@ export type WorkspaceHostEvent =
       prUrl: string;
       prState: "open" | "merged" | "closed";
     }
-  | { type: "pr-cleared"; worktreeId: string };
+  | { type: "pr-cleared"; worktreeId: string }
+  // CopyTree events
+  | { type: "copytree:progress"; operationId: string; progress: CopyTreeProgress }
+  | {
+      type: "copytree:complete";
+      requestId: string;
+      operationId: string;
+      result: CopyTreeResult;
+    }
+  | { type: "copytree:error"; requestId: string; operationId: string; error: string };
 
 /** Configuration for WorkspaceClient */
 export interface WorkspaceClientConfig {


### PR DESCRIPTION
## Summary

Migrates CopyTreeService from Main process to workspace-host UtilityProcess to prevent UI freezes during large context generation operations. This is Phase 2 of the workspace-host consolidation strategy.

Closes #790

## Changes Made

- Add CopyTree request/event types to workspace-host protocol
- Implement copytree:generate and copytree:cancel handlers in workspace-host
- Add generateContext, cancelContext, cancelAllContext methods to WorkspaceClient
- Update IPC handlers to use WorkspaceClient with fallback to direct service
- Track active operations by operationId for proper cancellation
- Extend timeout to 120s for large context generation operations
- Ensure cancellation properly rejects pending promises

## Technical Details

**Architecture:**
- CopyTreeService now runs in workspace-host UtilityProcess instead of Main process
- Main process freed from file I/O orchestration and string concatenation
- Progress events forwarded from workspace-host to renderer via IPC
- Proper cancellation support that rejects pending promises immediately

**Performance Impact:**
- Main thread no longer blocks during context generation
- Expected: Zero frame drops during context generation
- No user-facing behavior changes

**Backward Compatibility:**
- IPC handlers use WorkspaceClient when available
- Falls back to direct CopyTreeService for compatibility