### PR TITLE
Move DevServer log parsing to workspace-host

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -351,6 +351,8 @@ async function createWindow(): Promise<void> {
   // Create placeholder instances for IPC registration
   // These will be properly initialized in deferred services
   devServerManager = new DevServerManager();
+  // Connect DevServerManager to WorkspaceClient for offloading URL parsing
+  devServerManager.setWorkspaceClient(workspaceClient);
   cliAvailabilityService = new CliAvailabilityService();
   eventBuffer = new EventBuffer(1000);
   sidecarManager = new SidecarManager(mainWindow);

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -5,9 +5,9 @@
  * responsive. It runs WorktreeService and GitService in an isolated context,
  * communicating with Main via IPC messages.
  *
- * Phase 1: Git operations (this implementation)
- * Phase 2: CopyTreeService (future - #790)
- * Phase 3: DevServerManager parsing (future - #789)
+ * Phase 1: Git operations (implemented)
+ * Phase 2: CopyTreeService (implemented - #790)
+ * Phase 3: DevServer log parsing (implemented - #789)
  */
 
 import { MessagePort } from "node:worker_threads";
@@ -32,6 +32,7 @@ import { extractIssueNumberSync, extractIssueNumber } from "./services/issueExtr
 import { AdaptivePollingStrategy, NoteFileReader } from "./services/worktree/index.js";
 import { initializeLogger } from "./utils/logger.js";
 import { copyTreeService } from "./services/CopyTreeService.js";
+import { DevServerParser } from "./services/devserver/DevServerParser.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
 
 // Validate we're running in UtilityProcess context
@@ -1079,6 +1080,26 @@ port.on("message", async (rawMsg: any) => {
       case "copytree:cancel":
         copyTreeService.cancel(request.operationId);
         break;
+
+      case "devserver:parse-output": {
+        const { requestId, worktreeId, output } = request;
+        try {
+          const detected = DevServerParser.detectUrl(output);
+          sendEvent({
+            type: "devserver:urls-detected",
+            requestId,
+            worktreeId,
+            detected,
+          });
+        } catch (error) {
+          sendEvent({
+            type: "error",
+            error: (error as Error).message,
+            requestId,
+          });
+        }
+        break;
+      }
 
       default:
         console.warn("[WorkspaceHost] Unknown message type:", (msg as { type: string }).type);

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -125,7 +125,15 @@ export type WorkspaceHostRequest =
       rootPath: string;
       options?: CopyTreeOptions;
     }
-  | { type: "copytree:cancel"; operationId: string };
+  | { type: "copytree:cancel"; operationId: string }
+  // DevServer parsing operations
+  | { type: "devserver:parse-output"; requestId: string; worktreeId: string; output: string };
+
+/** Result of DevServer URL detection */
+export interface DevServerDetectedUrls {
+  url?: string;
+  port?: number;
+}
 
 /**
  * Events sent from Workspace Host → Main.
@@ -173,7 +181,14 @@ export type WorkspaceHostEvent =
       operationId: string;
       result: CopyTreeResult;
     }
-  | { type: "copytree:error"; requestId: string; operationId: string; error: string };
+  | { type: "copytree:error"; requestId: string; operationId: string; error: string }
+  // DevServer events
+  | {
+      type: "devserver:urls-detected";
+      requestId: string;
+      worktreeId: string;
+      detected: DevServerDetectedUrls | null;
+    };
 
 /** Configuration for WorkspaceClient */
 export interface WorkspaceClientConfig {


### PR DESCRIPTION
## Summary

Moves DevServer log parsing (regex URL detection) from Main process to workspace-host UtilityProcess, completing Phase 3 of the workspace-host consolidation strategy. This offloads CPU-intensive regex work from the Main thread, keeping it responsive during dev server startup.

Closes #789

## Changes Made

- Add DevServer IPC types to workspace-host protocol (request/event)
- Implement devserver:parse-output handler in workspace-host with proper error handling
- Add parseDevOutput method to WorkspaceClient for URL detection
- Update DevServerManager to use WorkspaceClient for parsing with intelligent fallback
- Implement PID-based race condition protection for server restarts
- Wire DevServerManager to WorkspaceClient in main.ts

## Implementation Details

**Architecture**: DevServerManager continues to spawn processes in Main (using execa), but streams stdout to workspace-host for parsing. This keeps process management in Main while offloading regex work.

**Fallback Strategy**: Maintains backwards compatibility with dual fallback:
1. If workspace-host returns no match, tries local parser
2. If workspace-host fails/times out, falls back to local parser

**Race Condition Protection**: Uses PID validation to prevent stale URL detection when servers are restarted during async parse operations.

## Testing

- TypeScript compilation verified
- Codex code review completed with all critical issues addressed
- Maintains existing DevServer IPC interface (no breaking changes)