### PR TITLE
Add terminal information viewer to context menu

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -39,6 +39,7 @@ export const CHANNELS = {
   TERMINAL_GET_SERIALIZED_STATE: "terminal:get-serialized-state",
   TERMINAL_GET_SHARED_BUFFER: "terminal:get-shared-buffer",
   TERMINAL_GET_ANALYSIS_BUFFER: "terminal:get-analysis-buffer",
+  TERMINAL_GET_INFO: "terminal:get-info",
 
   AGENT_STATE_CHANGED: "agent:state-changed",
   AGENT_GET_STATE: "agent:get-state",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -123,6 +123,7 @@ const CHANNELS = {
   TERMINAL_GET_SERIALIZED_STATE: "terminal:get-serialized-state",
   TERMINAL_GET_SHARED_BUFFER: "terminal:get-shared-buffer",
   TERMINAL_GET_ANALYSIS_BUFFER: "terminal:get-analysis-buffer",
+  TERMINAL_GET_INFO: "terminal:get-info",
 
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",
@@ -417,6 +418,8 @@ const api: ElectronAPI = {
 
     getSerializedState: (terminalId: string) =>
       _typedInvoke(CHANNELS.TERMINAL_GET_SERIALIZED_STATE, terminalId),
+
+    getInfo: (id: string) => _typedInvoke(CHANNELS.TERMINAL_GET_INFO, id),
 
     getSharedBuffer: (): Promise<SharedArrayBuffer | null> =>
       ipcRenderer.invoke(CHANNELS.TERMINAL_GET_SHARED_BUFFER),

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -333,6 +333,38 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Get terminal information for diagnostic display.
+   */
+  getTerminalInfo(id: string): import("../../shared/types/ipc.js").TerminalInfoPayload | null {
+    const terminalInfo = this.registry.get(id);
+    if (!terminalInfo) {
+      return null;
+    }
+
+    return {
+      id: terminalInfo.id,
+      projectId: terminalInfo.projectId,
+      type: terminalInfo.type,
+      title: terminalInfo.title,
+      cwd: terminalInfo.cwd,
+      worktreeId: terminalInfo.worktreeId,
+      agentState: terminalInfo.agentState,
+      spawnedAt: terminalInfo.spawnedAt,
+      lastInputTime: terminalInfo.lastInputTime,
+      lastOutputTime: terminalInfo.lastOutputTime,
+      lastStateChange: terminalInfo.lastStateChange,
+      activityTier: terminalInfo.activityTier,
+      outputBufferSize: terminalInfo.outputBuffer.length,
+      queueState: terminalInfo.queueState,
+      isFlooded: terminalInfo.isFlooded,
+      bytesThisSecond: terminalInfo.bytesThisSecond,
+      semanticBufferLines: terminalInfo.semanticBuffer.length,
+      queuedBytes: terminalInfo.queuedBytes,
+      restartCount: terminalInfo.restartCount,
+    };
+  }
+
+  /**
    * Mark terminal's check time.
    */
   markChecked(id: string): void {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -227,6 +227,7 @@ export class TerminalProcess {
       batchTimer: null,
       headlessTerminal,
       serializeAddon,
+      restartCount: 0,
     };
 
     // Create output throttler

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -73,6 +73,8 @@ export interface TerminalInfo {
 
   headlessTerminal: HeadlessTerminal;
   serializeAddon: SerializeAddon;
+
+  restartCount: number;
 }
 
 export interface PtyManagerEvents {

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -118,6 +118,29 @@ export interface TerminalReconnectResult {
   error?: string;
 }
 
+/** Terminal information payload for diagnostic display */
+export interface TerminalInfoPayload {
+  id: string;
+  projectId?: string;
+  type?: TerminalType;
+  title?: string;
+  cwd: string;
+  worktreeId?: string;
+  agentState?: import("./domain.js").AgentState;
+  spawnedAt: number;
+  lastInputTime: number;
+  lastOutputTime: number;
+  lastStateChange?: number;
+  activityTier: "focused" | "visible" | "background";
+  outputBufferSize: number;
+  queueState: "normal" | "soft" | "hard";
+  isFlooded: boolean;
+  bytesThisSecond: number;
+  semanticBufferLines: number;
+  queuedBytes: number;
+  restartCount: number;
+}
+
 // CopyTree IPC Types
 
 /** CopyTree generation options */
@@ -985,6 +1008,10 @@ export interface IpcInvokeMap {
     args: [];
     result: SharedArrayBuffer | null;
   };
+  "terminal:get-info": {
+    args: [id: string];
+    result: TerminalInfoPayload;
+  };
 
   // Agent channels
   "agent:get-state": {
@@ -1515,6 +1542,7 @@ export interface ElectronAPI {
     getSerializedState(terminalId: string): Promise<string | null>;
     getSharedBuffer(): Promise<SharedArrayBuffer | null>;
     getAnalysisBuffer(): Promise<SharedArrayBuffer | null>;
+    getInfo(id: string): Promise<TerminalInfoPayload>;
     getMessagePort(): Promise<any | null>;
     isMessagePortAvailable(): boolean;
     onData(id: string, callback: (data: string | Uint8Array) => void): () => void;

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -16,11 +17,13 @@ import {
   RotateCcw,
   Copy,
   Eraser,
+  Info,
 } from "lucide-react";
 import { useTerminalStore } from "@/store";
 import type { TerminalLocation } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { VT100_FULL_CLEAR } from "@/services/clearCommandDetection";
+import { TerminalInfoDialog } from "./TerminalInfoDialog";
 
 interface TerminalContextMenuProps {
   terminalId: string;
@@ -37,6 +40,7 @@ export function TerminalContextMenu({
   children,
   forceLocation,
 }: TerminalContextMenuProps) {
+  const [isInfoDialogOpen, setIsInfoDialogOpen] = useState(false);
   const terminal = useTerminalStore((state) => state.terminals.find((t) => t.id === terminalId));
 
   const moveTerminalToDock = useTerminalStore((s) => s.moveTerminalToDock);
@@ -127,6 +131,11 @@ export function TerminalContextMenu({
           Clear Scrollback
         </ContextMenuItem>
 
+        <ContextMenuItem onClick={() => setIsInfoDialogOpen(true)}>
+          <Info className="w-4 h-4 mr-2" aria-hidden="true" />
+          View Terminal Info
+        </ContextMenuItem>
+
         <ContextMenuSeparator />
 
         <ContextMenuItem
@@ -145,6 +154,11 @@ export function TerminalContextMenu({
           Kill Terminal
         </ContextMenuItem>
       </ContextMenuContent>
+      <TerminalInfoDialog
+        isOpen={isInfoDialogOpen}
+        onClose={() => setIsInfoDialogOpen(false)}
+        terminalId={terminalId}
+      />
     </ContextMenu>
   );
 }

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect } from "react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { Info } from "lucide-react";
+import type { TerminalInfoPayload } from "@/types/electron";
+
+interface TerminalInfoDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  terminalId: string;
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${days}d ${hours % 24}h ${minutes % 60}m`;
+  }
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m ${seconds % 60}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}
+
+function formatTimestamp(timestamp: number): string {
+  if (timestamp === 0) return "Never";
+  const date = new Date(timestamp);
+  return date.toLocaleString();
+}
+
+function formatRelativeTime(timestamp: number): string {
+  if (timestamp === 0) return "Never";
+  const now = Date.now();
+  const diff = now - timestamp;
+  return `${formatDuration(diff)} ago`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 B";
+  const k = 1024;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
+  return `${Math.round(bytes / Math.pow(k, i))} ${sizes[i]}`;
+}
+
+interface InfoSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function InfoSection({ title, children }: InfoSectionProps) {
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-canopy-text/90 border-b border-canopy-border pb-2">
+        {title}
+      </h3>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+interface InfoRowProps {
+  label: string;
+  value: string | number | undefined;
+  mono?: boolean;
+}
+
+function InfoRow({ label, value, mono = false }: InfoRowProps) {
+  const displayValue = value ?? "N/A";
+  return (
+    <div className="flex justify-between items-start gap-4 text-sm">
+      <span className="text-canopy-text/70 shrink-0">{label}:</span>
+      <span
+        className={`text-canopy-text text-right ${mono ? "font-mono text-xs" : ""}`}
+        title={typeof displayValue === "string" ? displayValue : undefined}
+      >
+        {displayValue}
+      </span>
+    </div>
+  );
+}
+
+export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfoDialogProps) {
+  const [info, setInfo] = useState<TerminalInfoPayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setInfo(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchInfo = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const terminalInfo = await window.electron.terminal.getInfo(terminalId);
+        if (isMounted) {
+          setInfo(terminalInfo);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        if (isMounted) {
+          setError(message);
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchInfo();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isOpen, terminalId]);
+
+  const copyToClipboard = async () => {
+    if (!info) return;
+
+    const diagnosticInfo = `Terminal Diagnostic Information
+=====================================
+
+Session Metadata:
+  ID: ${info.id}
+  Type: ${info.type || "N/A"}
+  Title: ${info.title || "N/A"}
+  Project ID: ${info.projectId || "N/A"}
+  Worktree ID: ${info.worktreeId || "N/A"}
+  CWD: ${info.cwd}
+
+Runtime Statistics:
+  Running Time: ${formatDuration(Date.now() - info.spawnedAt)}
+  Spawned At: ${formatTimestamp(info.spawnedAt)}
+  Restart Count: ${info.restartCount}
+
+Activity Metrics:
+  Last Input: ${formatRelativeTime(info.lastInputTime)} (${formatTimestamp(info.lastInputTime)})
+  Last Output: ${formatRelativeTime(info.lastOutputTime)} (${formatTimestamp(info.lastOutputTime)})
+  Agent State: ${info.agentState || "N/A"}
+  Last State Change: ${info.lastStateChange != null ? formatRelativeTime(info.lastStateChange) : "N/A"}
+  Activity Tier: ${info.activityTier}
+
+Performance & Diagnostics:
+  Output Buffer Size: ${info.outputBufferSize} lines
+  Queue State: ${info.queueState}
+  Flooding Status: ${info.isFlooded ? "Yes" : "No"}
+  Bytes This Second: ${formatBytes(info.bytesThisSecond)}
+  Semantic Buffer: ${info.semanticBufferLines} lines
+  Queued Bytes: ${formatBytes(info.queuedBytes)}
+`;
+
+    try {
+      await navigator.clipboard.writeText(diagnosticInfo);
+    } catch (err) {
+      console.error("Failed to copy to clipboard:", err);
+    }
+  };
+
+  return (
+    <AppDialog isOpen={isOpen} onClose={onClose} size="lg">
+      <AppDialog.Header>
+        <AppDialog.Title icon={<Info className="h-5 w-5" />}>Terminal Information</AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <AppDialog.Body>
+        {loading && (
+          <div className="text-center text-canopy-text/70 py-8" role="status" aria-live="polite">
+            Loading terminal info...
+          </div>
+        )}
+
+        {error && (
+          <div
+            className="bg-red-500/10 border border-red-500/30 rounded-lg p-4 text-red-400"
+            role="alert"
+          >
+            <p className="font-semibold mb-1">Failed to load terminal information</p>
+            <p className="text-sm">{error}</p>
+          </div>
+        )}
+
+        {info && !loading && (
+          <div className="space-y-6">
+            <InfoSection title="Session Metadata">
+              <InfoRow label="Terminal ID" value={info.id} mono />
+              <InfoRow label="Type" value={info.type || "shell"} />
+              <InfoRow label="Title" value={info.title} />
+              <InfoRow label="Project ID" value={info.projectId} mono />
+              <InfoRow label="Worktree ID" value={info.worktreeId} mono />
+              <InfoRow label="Current Directory" value={info.cwd} mono />
+            </InfoSection>
+
+            <InfoSection title="Runtime Statistics">
+              <InfoRow label="Running Time" value={formatDuration(Date.now() - info.spawnedAt)} />
+              <InfoRow label="Spawned At" value={formatTimestamp(info.spawnedAt)} />
+              <InfoRow label="Restart Count" value={info.restartCount} />
+            </InfoSection>
+
+            <InfoSection title="Activity Metrics">
+              <InfoRow
+                label="Last Input"
+                value={`${formatRelativeTime(info.lastInputTime)} (${formatTimestamp(info.lastInputTime)})`}
+              />
+              <InfoRow
+                label="Last Output"
+                value={`${formatRelativeTime(info.lastOutputTime)} (${formatTimestamp(info.lastOutputTime)})`}
+              />
+              <InfoRow label="Agent State" value={info.agentState || "N/A"} />
+              <InfoRow
+                label="Last State Change"
+                value={
+                  info.lastStateChange != null
+                    ? `${formatRelativeTime(info.lastStateChange)} (${formatTimestamp(info.lastStateChange)})`
+                    : "N/A"
+                }
+              />
+              <InfoRow label="Activity Tier" value={info.activityTier} />
+            </InfoSection>
+
+            <InfoSection title="Performance & Diagnostics">
+              <InfoRow label="Output Buffer Size" value={`${info.outputBufferSize} lines`} />
+              <InfoRow label="Queue State" value={info.queueState} />
+              <InfoRow label="Flooding Status" value={info.isFlooded ? "Yes" : "No"} />
+              <InfoRow label="Bytes This Second" value={formatBytes(info.bytesThisSecond)} />
+              <InfoRow label="Semantic Buffer" value={`${info.semanticBufferLines} lines`} />
+              <InfoRow label="Queued Bytes" value={formatBytes(info.queuedBytes)} />
+            </InfoSection>
+          </div>
+        )}
+      </AppDialog.Body>
+
+      {info && !loading && (
+        <AppDialog.Footer>
+          <button
+            type="button"
+            onClick={copyToClipboard}
+            className="px-4 py-2 bg-canopy-accent text-white rounded-lg hover:bg-canopy-accent/90 transition-colors font-medium"
+          >
+            Copy to Clipboard
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 bg-canopy-border/30 text-canopy-text rounded-lg hover:bg-canopy-border/50 transition-colors font-medium"
+          >
+            Close
+          </button>
+        </AppDialog.Footer>
+      )}
+    </AppDialog>
+  );
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -2,7 +2,12 @@
  * Types are imported from the shared types module.
  */
 
-import type { ElectronAPI, BranchInfo, CreateWorktreeOptions } from "@shared/types";
+import type {
+  ElectronAPI,
+  BranchInfo,
+  CreateWorktreeOptions,
+  TerminalInfoPayload,
+} from "@shared/types";
 
 declare global {
   interface Window {
@@ -11,4 +16,4 @@ declare global {
 }
 
 // Re-export ElectronAPI for consumers that import from this file
-export type { ElectronAPI, BranchInfo, CreateWorktreeOptions };
+export type { ElectronAPI, BranchInfo, CreateWorktreeOptions, TerminalInfoPayload };


### PR DESCRIPTION
## Summary
Adds a "View Terminal Info" option to the terminal context menu that displays detailed diagnostic information about terminal sessions, including runtime statistics, activity metrics, and performance data.

Closes #784

## Changes Made
- Add terminal info IPC channel and handler for retrieving diagnostic data
- Implement getTerminalInfo method in PtyManager and PtyClient
- Add restartCount field to TerminalInfo type
- Create TerminalInfoDialog component with organized sections for:
  - Session metadata (ID, type, title, project, worktree, CWD)
  - Runtime statistics (uptime, spawn time, restart count)
  - Activity metrics (last input/output, agent state, activity tier)
  - Performance diagnostics (buffer sizes, queue state, flooding status)
- Add "View Terminal Info" menu item to terminal context menu
- Include copy-to-clipboard functionality for sharing diagnostic information
- Add proper error handling, loading states, and accessibility features (ARIA labels, keyboard navigation)
- Improve edge case handling (negative/TB-scale bytes, zero timestamps, unmounted component cleanup)

## Testing
- Type checking and linting passed
- Build successful
- Code reviewed by Codex for edge cases and best practices