### PR TITLE
refactor(terminal): simplify rendering and remove manual refresh calls

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -146,24 +146,12 @@ function XtermAdapterComponent({
       if (width === 0 || height === 0) return;
       if (width < MIN_CONTAINER_SIZE || height < MIN_CONTAINER_SIZE) return;
 
-      // Service handles geometry caching check
       const dims = terminalInstanceService.resize(terminalId, width, height);
 
       if (dims) {
-        const managed = terminalInstanceService.get(terminalId);
         const { cols, rows } = dims;
-
-        // Preserve shrink refresh logic
-        if (prevDimensionsRef.current && managed) {
-          const shrunk =
-            cols < prevDimensionsRef.current.cols || rows < prevDimensionsRef.current.rows;
-          if (shrunk) {
-            managed.terminal.refresh(0, managed.terminal.rows - 1);
-          }
-        }
         prevDimensionsRef.current = { cols, rows };
 
-        // Debounce IPC to main process
         const bufferLines = terminalInstanceService.getBufferLineCount(terminalId);
         debouncerRef.current?.resize(cols, rows, {
           immediate: false,
@@ -196,16 +184,7 @@ function XtermAdapterComponent({
 
     const dims = terminalInstanceService.resize(terminalId, width, height);
     if (dims) {
-      const managed = terminalInstanceService.get(terminalId);
       const { cols, rows } = dims;
-
-      if (prevDimensionsRef.current && managed) {
-        const shrunk =
-          cols < prevDimensionsRef.current.cols || rows < prevDimensionsRef.current.rows;
-        if (shrunk) {
-          managed.terminal.refresh(0, managed.terminal.rows - 1);
-        }
-      }
       prevDimensionsRef.current = { cols, rows };
 
       const bufferLines = terminalInstanceService.getBufferLineCount(terminalId);


### PR DESCRIPTION
- Remove manual terminal.refresh() calls throughout XtermAdapter and TerminalInstanceService
- Replace adaptive polling (1ms/4ms/16ms) with rAF for active data, 16ms timeout for idle
- Remove shrink-triggered refresh logic in resize handlers
- Trust xterm.js to handle repaints after resize and theme changes
- Simplify refresh() and refreshAll() methods to only call fitAddon.fit()
- Remove manual refresh from WebGL fallback logic

Resolves https://github.com/gregpriday/canopy-electron/issues/800