### PR TITLE
Fix ActivityMonitor triggering busy state on multi-line paste

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -3,6 +3,10 @@ export class ActivityMonitor {
   private debounceTimer: NodeJS.Timeout | null = null;
   // 1.5 seconds silence required to consider the agent "waiting"
   private readonly DEBOUNCE_MS = 1500;
+  private inBracketedPaste = false;
+  private partialEscape = "";
+  private pasteStartTime = 0;
+  private readonly PASTE_TIMEOUT_MS = 5000;
 
   constructor(
     private terminalId: string,
@@ -11,7 +15,7 @@ export class ActivityMonitor {
 
   /**
    * Called when user sends input to the terminal.
-   * Proactively transitions to BUSY on Enter key.
+   * Proactively transitions to BUSY on Enter key, but ignores pastes.
    */
   onInput(data: string): void {
     // Ignore Shift+Enter sequence (\x1b\r) sent by XtermAdapter for soft line breaks.
@@ -19,13 +23,58 @@ export class ActivityMonitor {
       return;
     }
 
-    // Use includes() to handle pasted text or grouped keystrokes.
-    // We look for \r (Return) or \n (Newline).
-    const hasEnter = data.includes("\r") || data.includes("\n");
+    // Fail-safe: exit paste mode if it has been open too long
+    if (
+      this.inBracketedPaste &&
+      this.pasteStartTime > 0 &&
+      Date.now() - this.pasteStartTime > this.PASTE_TIMEOUT_MS
+    ) {
+      this.inBracketedPaste = false;
+      this.pasteStartTime = 0;
+    }
 
-    // If we see an Enter key, we assume the user submitted a command.
-    if (hasEnter) {
-      this.becomeBusy();
+    // Prepend any partial escape sequence from the previous call
+    const fullData = this.partialEscape + data;
+    this.partialEscape = "";
+
+    // Iterate through the data character by character to track state
+    for (let i = 0; i < fullData.length; i++) {
+      // Check for potential escape sequence start near end of buffer
+      if (i >= fullData.length - 5 && fullData[i] === "\x1b") {
+        // Save remaining characters as partial escape for next call
+        this.partialEscape = fullData.substring(i);
+        break;
+      }
+
+      // Check for Bracketed Paste Start: \x1b[200~
+      if (
+        fullData[i] === "\x1b" &&
+        fullData.substring(i, i + 6) === "\x1b[200~"
+      ) {
+        this.inBracketedPaste = true;
+        this.pasteStartTime = Date.now();
+        i += 5; // Skip the sequence
+        continue;
+      }
+
+      // Check for Bracketed Paste End: \x1b[201~
+      if (
+        fullData[i] === "\x1b" &&
+        fullData.substring(i, i + 6) === "\x1b[201~"
+      ) {
+        this.inBracketedPaste = false;
+        this.pasteStartTime = 0;
+        i += 5; // Skip the sequence
+        continue;
+      }
+
+      // Only trigger busy on Enter if we are NOT inside a paste
+      const char = fullData[i];
+      if ((char === "\r" || char === "\n") && !this.inBracketedPaste) {
+        this.becomeBusy();
+        // Once busy is triggered, we don't need to keep checking this chunk
+        break;
+      }
     }
   }
 
@@ -68,6 +117,9 @@ export class ActivityMonitor {
     if (this.debounceTimer) {
       clearTimeout(this.debounceTimer);
     }
+    this.inBracketedPaste = false;
+    this.partialEscape = "";
+    this.pasteStartTime = 0;
   }
 
   getState(): "busy" | "idle" {


### PR DESCRIPTION
## Summary
Fixed the ActivityMonitor to correctly distinguish between pasted newlines and actual Enter key presses by implementing bracketed paste mode detection. This prevents the terminal from incorrectly transitioning to busy state when users paste multi-line text.

Closes #803

## Changes Made
- Detect bracketed paste mode sequences (\x1b[200~ start, \x1b[201~ end)
- Track paste state with inBracketedPaste flag to ignore newlines during paste
- Handle split escape sequences across multiple onInput() calls with partialEscape buffer
- Add 5-second timeout fail-safe to exit paste mode if end marker never arrives
- Clean up paste state in dispose() method
- Only trigger busy state on Enter key when not inside a paste operation

## Edge Cases Handled
- **Split sequences**: Escape sequences that arrive split across multiple onInput() calls
- **Unclosed paste**: Timeout fail-safe (5 seconds) if paste end marker never arrives
- **Multiple pastes**: Proper state tracking for consecutive paste operations