### PR TITLE
Reduce 3-terminal column threshold from 1600px to 900px

### DIFF
--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -26,17 +26,17 @@ describe("getAutoGridCols", () => {
   });
 
   describe("count of 3 with responsive width", () => {
-    it("should return 2 for narrow screens (<= 1600px)", () => {
+    it("should return 2 for narrow screens (< 900px)", () => {
       expect(getAutoGridCols(3, 0)).toBe(2);
       expect(getAutoGridCols(3, 800)).toBe(2);
-      expect(getAutoGridCols(3, 1200)).toBe(2);
-      expect(getAutoGridCols(3, 1599)).toBe(2);
-      expect(getAutoGridCols(3, 1600)).toBe(2);
+      expect(getAutoGridCols(3, 899)).toBe(2);
     });
 
-    it("should return 3 for wide screens (> 1600px)", () => {
-      expect(getAutoGridCols(3, 1601)).toBe(3);
-      expect(getAutoGridCols(3, 1800)).toBe(3);
+    it("should return 3 for wide screens (>= 900px)", () => {
+      expect(getAutoGridCols(3, 900)).toBe(3);
+      expect(getAutoGridCols(3, 901)).toBe(3);
+      expect(getAutoGridCols(3, 1000)).toBe(3);
+      expect(getAutoGridCols(3, 1600)).toBe(3);
       expect(getAutoGridCols(3, 2560)).toBe(3);
     });
 

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -14,7 +14,7 @@ export function getAutoGridCols(count: number, width: number | null): number {
   // Width-responsive decision for 3 terminals
   if (count === 3) {
     const w = width ?? 0;
-    return w > 1600 ? 3 : 2; // 1x3 on wide, 2x2 on narrow
+    return w >= 900 ? 3 : 2; // Favor columns: ~300px per terminal
   }
 
   // Deterministic rectangular layouts


### PR DESCRIPTION
## Summary
Adjusts the terminal auto-layout algorithm to maintain a 1×3 column layout for 3 terminals on smaller screens by reducing the width threshold from 1600px to 900px.

Closes #821

## Changes Made
- Change layout threshold from >1600px to >=900px for 3 terminals
- Update comment to reflect ~300px per terminal rationale
- Update test expectations to match new >=900px boundary
- Add explicit boundary test case for 900px exact width

## Rationale
Terminal outputs are vertical streams of text. The previous 1600px threshold forced a less efficient 2×2 grid layout even on typical laptop screens. By lowering to 900px (3 terminals × ~300px each), we maximize vertical space for log viewing while maintaining readability. The layout only falls back to a grid when the screen is truly narrow (<900px).