### PR TITLE
Add external browser button to sidecar toolbar

### DIFF
--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { SidecarToolbar } from "./SidecarToolbar";
 import { SidecarLaunchpad } from "./SidecarLaunchpad";
 import { SIDECAR_MIN_WIDTH, SIDECAR_MAX_WIDTH } from "@shared/types";
+import { systemClient } from "@/clients/systemClient";
 
 export function SidecarDock() {
   const {
@@ -45,6 +46,7 @@ export function SidecarDock() {
   const activeTab = tabs.find((t) => t.id === activeTabId);
   const isBlankTab = activeTabId !== null && activeTab && !activeTab.url;
   const showLaunchpad = activeTabId === null || tabs.length === 0 || isBlankTab;
+  const hasActiveUrl = activeTab?.url !== undefined && activeTab.url !== null && activeTab.url !== "";
 
   const syncBounds = useCallback(() => {
     if (!placeholderRef.current || !activeTabId) return;
@@ -232,6 +234,16 @@ export function SidecarDock() {
     }
   }, [activeTabId]);
 
+  const handleOpenExternal = useCallback(async () => {
+    const activeTab = tabs.find((t) => t.id === activeTabId);
+    if (!activeTab?.url) return;
+    try {
+      await systemClient.openExternal(activeTab.url);
+    } catch (error) {
+      console.error("Failed to open URL externally:", error);
+    }
+  }, [activeTabId, tabs]);
+
   const RESIZE_STEP = 10;
 
   const handleResizeStart = useCallback(
@@ -325,6 +337,8 @@ export function SidecarDock() {
         onGoBack={handleGoBack}
         onGoForward={handleGoForward}
         onReload={handleReload}
+        onOpenExternal={handleOpenExternal}
+        hasActiveUrl={hasActiveUrl}
       />
       {showLaunchpad ? (
         <SidecarLaunchpad links={enabledLinks} onOpenUrl={handleOpenUrl} />

--- a/src/components/Sidecar/SidecarToolbar.tsx
+++ b/src/components/Sidecar/SidecarToolbar.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { ArrowLeft, ArrowRight, RotateCw, X, Plus } from "lucide-react";
+import { ArrowLeft, ArrowRight, RotateCw, X, Plus, ExternalLink } from "lucide-react";
 import {
   DndContext,
   closestCorners,
@@ -102,6 +102,8 @@ interface SidecarToolbarProps {
   onGoBack?: () => void;
   onGoForward?: () => void;
   onReload?: () => void;
+  onOpenExternal?: () => void;
+  hasActiveUrl?: boolean;
 }
 
 export function SidecarToolbar({
@@ -114,6 +116,8 @@ export function SidecarToolbar({
   onGoBack,
   onGoForward,
   onReload,
+  onOpenExternal,
+  hasActiveUrl = false,
 }: SidecarToolbarProps) {
   const reorderTabs = useSidecarStore((s) => s.reorderTabs);
 
@@ -162,6 +166,15 @@ export function SidecarToolbar({
             title="Reload"
           >
             <RotateCw className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={onOpenExternal}
+            disabled={!activeTabId || !hasActiveUrl}
+            aria-label="Open in external browser"
+            className="p-1 rounded hover:bg-canopy-border text-muted-foreground hover:text-canopy-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Open in external browser"
+          >
+            <ExternalLink className="w-3.5 h-3.5" />
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
Adds a single "Open in External Browser" icon button to the Sidecar toolbar, enabling users to quickly open the current page in their system browser with full DevTools and extensions.

Closes #829

## Changes Made
- Add ExternalLink icon button after Reload button in SidecarToolbar
- Button disabled when no active tab or tab has no URL (prevents silent no-ops)
- Implement handleOpenExternal callback with proper error handling and logging
- Add hasActiveUrl prop to accurately track button enabled state
- Import systemClient for opening URLs in system default browser

## Implementation Details
- Uses existing `systemClient.openExternal()` API
- Button placement: after Reload, before Close
- Proper accessibility: aria-label, disabled states, tooltips
- Error handling: try/catch with console.error for failed opens
- UX improvement: button only enabled when active tab has a valid URL