### PR TITLE
Add window title and favicon alerts for terminal states

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -162,6 +162,8 @@ export const CHANNELS = {
   WORKTREE_CONFIG_SET_PATTERN: "worktree-config:set-pattern",
 
   WINDOW_FULLSCREEN_CHANGE: "window:fullscreen-change",
+
+  NOTIFICATION_UPDATE: "notification:update",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -17,6 +17,7 @@ import { registerHibernationHandlers } from "./handlers/hibernation.js";
 import { registerSystemSleepHandlers } from "./handlers/systemSleep.js";
 import { registerKeybindingHandlers } from "./handlers/keybinding.js";
 import { registerWorktreeConfigHandlers } from "./handlers/worktreeConfig.js";
+import { registerNotificationHandlers } from "./handlers/notifications.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
 export { typedHandle, typedSend, sendToRenderer };
@@ -54,6 +55,7 @@ export function registerIpcHandlers(
     registerSystemSleepHandlers(deps),
     registerKeybindingHandlers(deps),
     registerWorktreeConfigHandlers(deps),
+    registerNotificationHandlers(deps),
   ];
 
   return () => {

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -1,0 +1,19 @@
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import { notificationService, NotificationState } from "../../services/NotificationService.js";
+import type { HandlerDependencies } from "../types.js";
+
+export function registerNotificationHandlers(_deps: HandlerDependencies): () => void {
+  const handleNotificationUpdate = (
+    _event: Electron.IpcMainEvent,
+    state: NotificationState
+  ): void => {
+    notificationService.updateNotifications(state);
+  };
+
+  ipcMain.on(CHANNELS.NOTIFICATION_UPDATE, handleNotificationUpdate);
+
+  return () => {
+    ipcMain.removeListener(CHANNELS.NOTIFICATION_UPDATE, handleNotificationUpdate);
+  };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -32,6 +32,7 @@ import {
   initializeSystemSleepService,
   getSystemSleepService,
 } from "./services/SystemSleepService.js";
+import { notificationService } from "./services/NotificationService.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -273,6 +274,10 @@ async function createWindow(): Promise<void> {
   console.log("[MAIN] Creating application menu...");
   createApplicationMenu(mainWindow);
 
+  // Initialize Notification Service
+  notificationService.initialize(mainWindow);
+  console.log("[MAIN] NotificationService initialized");
+
   // Initialize Service Instances (Start processes in background)
   console.log("[MAIN] Starting critical services...");
 
@@ -471,6 +476,7 @@ async function createWindow(): Promise<void> {
     disposePtyClient();
 
     getSystemSleepService().dispose();
+    notificationService.dispose();
 
     setLoggerWindow(null);
     mainWindow = null;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -268,6 +268,9 @@ const CHANNELS = {
 
   // Window channels
   WINDOW_FULLSCREEN_CHANGE: "window:fullscreen-change",
+
+  // Notification channels
+  NOTIFICATION_UPDATE: "notification:update",
 } as const;
 
 const api: ElectronAPI = {
@@ -742,6 +745,12 @@ const api: ElectronAPI = {
       ipcRenderer.on(CHANNELS.WINDOW_FULLSCREEN_CHANGE, handler);
       return () => ipcRenderer.removeListener(CHANNELS.WINDOW_FULLSCREEN_CHANGE, handler);
     },
+  },
+
+  // Notification API
+  notification: {
+    updateBadge: (state: { waitingCount: number; failedCount: number }) =>
+      ipcRenderer.send(CHANNELS.NOTIFICATION_UPDATE, state),
   },
 };
 

--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -1,0 +1,121 @@
+import { BrowserWindow, app } from "electron";
+
+export interface NotificationState {
+  waitingCount: number;
+  failedCount: number;
+}
+
+const DEBOUNCE_MS = 300;
+const DEFAULT_TITLE = "Canopy";
+
+class NotificationService {
+  private mainWindow: BrowserWindow | null = null;
+  private debounceTimer: NodeJS.Timeout | null = null;
+  private currentState: NotificationState = { waitingCount: 0, failedCount: 0 };
+  private windowFocused = true;
+  private focusHandler: (() => void) | null = null;
+  private blurHandler: (() => void) | null = null;
+
+  initialize(window: BrowserWindow): void {
+    this.mainWindow = window;
+
+    // Initialize with actual focus state
+    this.windowFocused = window.isFocused();
+
+    this.focusHandler = () => {
+      this.windowFocused = true;
+      this.clearNotifications();
+    };
+
+    this.blurHandler = () => {
+      this.windowFocused = false;
+      // Immediately apply notifications when window loses focus if there are any
+      const { waitingCount, failedCount } = this.currentState;
+      if (waitingCount > 0 || failedCount > 0) {
+        this.applyNotifications();
+      }
+    };
+
+    window.on("focus", this.focusHandler);
+    window.on("blur", this.blurHandler);
+  }
+
+  updateNotifications(state: NotificationState): void {
+    this.currentState = state;
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      this.applyNotifications();
+    }, DEBOUNCE_MS);
+  }
+
+  private applyNotifications(): void {
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
+
+    // Don't show notifications when window is focused
+    if (this.windowFocused) {
+      this.clearNotifications();
+      return;
+    }
+
+    const { waitingCount, failedCount } = this.currentState;
+    const totalAttention = waitingCount + failedCount;
+
+    // Update window title
+    if (totalAttention > 0) {
+      this.mainWindow.setTitle(`(${totalAttention}) ${DEFAULT_TITLE}`);
+    } else {
+      this.mainWindow.setTitle(DEFAULT_TITLE);
+    }
+
+    // Update macOS dock badge
+    if (process.platform === "darwin") {
+      if (totalAttention > 0) {
+        app.setBadgeCount(totalAttention);
+      } else {
+        app.setBadgeCount(0);
+      }
+    }
+  }
+
+  private clearNotifications(): void {
+    if (!this.mainWindow || this.mainWindow.isDestroyed()) return;
+
+    this.mainWindow.setTitle(DEFAULT_TITLE);
+
+    if (process.platform === "darwin") {
+      app.setBadgeCount(0);
+    }
+  }
+
+  isWindowFocused(): boolean {
+    return this.windowFocused;
+  }
+
+  dispose(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
+    // Remove event listeners
+    if (this.mainWindow && this.focusHandler && this.blurHandler) {
+      this.mainWindow.off("focus", this.focusHandler);
+      this.mainWindow.off("blur", this.blurHandler);
+    }
+
+    // Clear notifications before disposing
+    this.clearNotifications();
+
+    this.focusHandler = null;
+    this.blurHandler = null;
+    this.mainWindow = null;
+  }
+}
+
+export const notificationService = new NotificationService();

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1666,4 +1666,8 @@ export interface ElectronAPI {
     /** Subscribe to fullscreen state changes */
     onFullscreenChange(callback: (isFullscreen: boolean) => void): () => void;
   };
+  notification: {
+    /** Update window title and dock badge based on terminal attention state */
+    updateBadge(state: { waitingCount: number; failedCount: number }): void;
+  };
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import {
   useProjectSettings,
   useLinkDiscovery,
   useGridNavigation,
+  useWindowNotifications,
   type AgentType,
 } from "./hooks";
 import { AppLayout } from "./components/Layout";
@@ -382,6 +383,7 @@ function App() {
   const loadRecipes = useRecipeStore((state) => state.loadRecipes);
   useTerminalConfig();
   useLinkDiscovery();
+  useWindowNotifications();
 
   // Grid navigation hook for directional terminal switching
   const { findNearest, findByIndex, findDockByIndex, getCurrentLocation } = useGridNavigation();

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -47,3 +47,5 @@ export type { NavigationDirection } from "./useGridNavigation";
 
 export { useLayoutState } from "./useLayoutState";
 export type { LayoutState } from "./useLayoutState";
+
+export { useWindowNotifications } from "./useWindowNotifications";

--- a/src/hooks/useWindowNotifications.ts
+++ b/src/hooks/useWindowNotifications.ts
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useTerminalStore } from "@/store/terminalStore";
+import { updateFaviconBadge, clearFaviconBadge } from "@/services/FaviconBadgeService";
+
+const DEBOUNCE_MS = 300;
+
+export function useWindowNotifications(): void {
+  const prevStateRef = useRef({ waitingCount: 0, failedCount: 0 });
+  const windowFocusedRef = useRef(true);
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const { waitingCount, failedCount } = useTerminalStore(
+    useShallow((state) => {
+      const nonTrashedTerminals = state.terminals.filter((t) => !state.isInTrash(t.id));
+      return {
+        waitingCount: nonTrashedTerminals.filter((t) => t.agentState === "waiting").length,
+        failedCount: nonTrashedTerminals.filter((t) => t.agentState === "failed").length,
+      };
+    })
+  );
+
+  // Handle window focus/blur for favicon badge clearing
+  useEffect(() => {
+    const handleFocus = () => {
+      windowFocusedRef.current = true;
+      clearFaviconBadge();
+    };
+
+    const handleBlur = () => {
+      windowFocusedRef.current = false;
+      // Update badge when window loses focus if there are notifications
+      const { waitingCount, failedCount } = prevStateRef.current;
+      if (waitingCount > 0 || failedCount > 0) {
+        updateFaviconBadge(waitingCount, failedCount);
+      }
+    };
+
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+
+    return () => {
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
+  useEffect(() => {
+    const prevState = prevStateRef.current;
+
+    // Only send update if counts have changed
+    if (prevState.waitingCount !== waitingCount || prevState.failedCount !== failedCount) {
+      prevStateRef.current = { waitingCount, failedCount };
+
+      // Clear existing debounce timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      // Debounce all updates to match main process debouncing
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+
+        // Update Electron main process (window title and macOS dock badge)
+        // Guard for browser/test environments
+        if (window.electron?.notification?.updateBadge) {
+          window.electron.notification.updateBadge({ waitingCount, failedCount });
+        }
+
+        // Update favicon badge (only if window is not focused)
+        if (!windowFocusedRef.current) {
+          if (waitingCount > 0 || failedCount > 0) {
+            updateFaviconBadge(waitingCount, failedCount);
+          } else {
+            clearFaviconBadge();
+          }
+        }
+      }, DEBOUNCE_MS);
+    }
+  }, [waitingCount, failedCount]);
+
+  // Clear notifications on unmount
+  useEffect(() => {
+    return () => {
+      // Clear debounce timer
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+
+      // Clear notifications (browser-safe)
+      if (window.electron?.notification?.updateBadge) {
+        window.electron.notification.updateBadge({ waitingCount: 0, failedCount: 0 });
+      }
+      clearFaviconBadge();
+    };
+  }, []);
+}

--- a/src/services/FaviconBadgeService.ts
+++ b/src/services/FaviconBadgeService.ts
@@ -1,0 +1,74 @@
+const BADGE_SIZE = 32;
+const BADGE_FONT_SIZE = 14;
+const BADGE_BG_WAITING = "#f59e0b"; // amber-500
+const BADGE_BG_FAILED = "#ef4444"; // red-500
+const BADGE_TEXT_COLOR = "#ffffff";
+
+let originalHref: string | null = null;
+
+function createBadgeCanvas(count: number, hasFailures: boolean): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = BADGE_SIZE;
+  canvas.height = BADGE_SIZE;
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) return canvas;
+
+  // Draw badge circle
+  ctx.fillStyle = hasFailures ? BADGE_BG_FAILED : BADGE_BG_WAITING;
+  ctx.beginPath();
+  ctx.arc(BADGE_SIZE / 2, BADGE_SIZE / 2, BADGE_SIZE / 2 - 2, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Draw count text
+  ctx.fillStyle = BADGE_TEXT_COLOR;
+  ctx.font = `bold ${BADGE_FONT_SIZE}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  const displayText = count > 9 ? "9+" : String(count);
+  ctx.fillText(displayText, BADGE_SIZE / 2, BADGE_SIZE / 2 + 1);
+
+  return canvas;
+}
+
+function getFaviconLink(): HTMLLinkElement {
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "icon";
+    document.head.appendChild(link);
+  }
+  return link;
+}
+
+export function updateFaviconBadge(waitingCount: number, failedCount: number): void {
+  const link = getFaviconLink();
+
+  // Store original href for restoration
+  if (originalHref === null && link.href && !link.href.startsWith("data:")) {
+    originalHref = link.href;
+  }
+
+  const totalCount = waitingCount + failedCount;
+
+  if (totalCount === 0) {
+    // Clear badge - restore original or remove favicon
+    if (originalHref) {
+      link.href = originalHref;
+    } else {
+      // Remove generated favicon
+      link.removeAttribute("href");
+    }
+    return;
+  }
+
+  // Generate badge favicon
+  const hasFailures = failedCount > 0;
+  const canvas = createBadgeCanvas(totalCount, hasFailures);
+  link.href = canvas.toDataURL("image/png");
+}
+
+export function clearFaviconBadge(): void {
+  updateFaviconBadge(0, 0);
+}


### PR DESCRIPTION
## Summary
Implements visual notifications when terminals need attention (waiting/failed states). When the app window is unfocused, users now get feedback through:
- Window title showing attention count: `(3) Canopy`
- macOS dock badge with count
- Favicon badge (amber for waiting terminals, red for failed)

All badges auto-clear when the window regains focus.

Closes #826

## Changes Made
- Update window title with attention count when unfocused
- Show macOS dock badge with count (platform-specific)
- Display favicon badge with count (amber for waiting, red for failed)
- Auto-clear all badges when window gains focus
- Debounce rapid state changes (300ms) to prevent flicker
- Filter out trashed terminals from notification counts
- Browser-safe implementation with graceful degradation

## Implementation
- Create NotificationService for Electron main process notifications
- Add useWindowNotifications React hook for state monitoring
- Implement FaviconBadgeService for dynamic favicon generation
- Add IPC bridge for renderer-to-main notification sync
- Fix event listener leaks and blur state synchronization
- Initialize with actual window focus state to handle minimized startup

## Test Plan
- [x] Typecheck passes
- [x] Build completes successfully
- [x] Code review completed with Codex
- [ ] Manual testing: launch agent, switch to another app, verify notifications appear
- [ ] Manual testing: return to app, verify badges clear immediately
- [ ] Cross-platform testing on macOS/Windows/Linux