### PR TITLE
Fix: Propagate GitHub token to workspace-host for PR detection

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -7,6 +7,7 @@ import type {
   GitHubTokenConfig,
   GitHubTokenValidation,
 } from "../../types/index.js";
+import { getWorkspaceClient } from "../../services/WorkspaceClient.js";
 
 export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -161,6 +162,13 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
     if (validation.valid) {
       setGitHubToken(token.trim());
+
+      try {
+        const workspaceClient = getWorkspaceClient();
+        workspaceClient.updateGitHubToken(token.trim());
+      } catch {
+        // WorkspaceClient may not be initialized yet
+      }
     }
 
     return validation;
@@ -171,6 +179,13 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handleGitHubClearToken = async (): Promise<void> => {
     const { clearGitHubToken } = await import("../../services/GitHubService.js");
     clearGitHubToken();
+
+    try {
+      const workspaceClient = getWorkspaceClient();
+      workspaceClient.updateGitHubToken(null);
+    } catch {
+      // WorkspaceClient may not be initialized yet
+    }
   };
   ipcMain.handle(CHANNELS.GITHUB_CLEAR_TOKEN, handleGitHubClearToken);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_CLEAR_TOKEN));

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -15,8 +15,22 @@ export interface GitHubTokenValidation {
 }
 
 export class GitHubAuth {
+  private static memoryToken: string | null = null;
+  private static useMemoryOnly: boolean = false;
+
   static getToken(): string | undefined {
+    if (this.useMemoryOnly) {
+      return this.memoryToken ?? undefined;
+    }
+    if (this.memoryToken) {
+      return this.memoryToken;
+    }
     return secureStorage.get("userConfig.githubToken");
+  }
+
+  static setMemoryToken(token: string | null): void {
+    this.memoryToken = token;
+    this.useMemoryOnly = true;
   }
 
   static hasToken(): boolean {

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -33,6 +33,7 @@ import { AdaptivePollingStrategy, NoteFileReader } from "./services/worktree/ind
 import { initializeLogger } from "./utils/logger.js";
 import { copyTreeService } from "./services/CopyTreeService.js";
 import { DevServerParser } from "./services/devserver/DevServerParser.js";
+import { GitHubAuth } from "./services/github/GitHubAuth.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
 
 // Validate we're running in UtilityProcess context
@@ -1102,6 +1103,17 @@ port.on("message", async (rawMsg: any) => {
             error: (error as Error).message,
             requestId,
           });
+        }
+        break;
+      }
+
+      case "update-github-token": {
+        GitHubAuth.setMemoryToken(request.token);
+        const { pullRequestService } = await import("./services/PullRequestService.js");
+        if (request.token) {
+          pullRequestService.refresh();
+        } else {
+          pullRequestService.reset();
         }
         break;
       }

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -127,7 +127,9 @@ export type WorkspaceHostRequest =
     }
   | { type: "copytree:cancel"; operationId: string }
   // DevServer parsing operations
-  | { type: "devserver:parse-output"; requestId: string; worktreeId: string; output: string };
+  | { type: "devserver:parse-output"; requestId: string; worktreeId: string; output: string }
+  // GitHub token propagation
+  | { type: "update-github-token"; token: string | null };
 
 /** Result of DevServer URL detection */
 export interface DevServerDetectedUrls {


### PR DESCRIPTION
## Summary
Fixes PR detection in worktree cards by propagating the GitHub token from Main Process to Workspace Host (Utility Process). PullRequestService runs in workspace-host but couldn't access the token stored via Electron's safeStorage API (Main Process only).

Closes #841

## Changes Made
- Add memory token storage to GitHubAuth with useMemoryOnly flag to prevent workspace-host from accessing SecureStorage
- Add update-github-token IPC message to workspace-host types
- Send token to workspace-host on ready event for reliability after restarts
- Propagate token changes from IPC handlers (set/clear) to workspace-host
- Reset PR state when token is cleared to prevent stale data
- Workspace-host now uses memory-only token storage for security

## Technical Details
- Token passed via IPC on workspace-host "ready" event (not "spawn") to ensure proper initialization
- Token stored only in memory in workspace-host, never persisted to disk
- Maintains security model: Main Process continues using SecureStorage encryption
- Handles edge cases: token clearing, workspace-host crashes and restarts