### PR TITLE
Standardize terminal container styles for consistency

### DIFF
--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -64,7 +64,7 @@ export function TrashContainer({ trashedTerminals }: TrashContainerProps) {
             <span className="text-[10px] text-canopy-text/40">Auto-clears</span>
           </div>
 
-          <div className="p-2 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
+          <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
             {sortedItems.map(({ terminal, trashedInfo }) => {
               const worktreeName = terminal.worktreeId
                 ? worktreeMap.get(terminal.worktreeId)?.name

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -34,10 +34,11 @@ function getLocationIcon(location: TerminalLocation | undefined) {
 export function WaitingContainer() {
   const [isOpen, setIsOpen] = useState(false);
   const waitingIds = useWaitingTerminalIds();
-  const { activateTerminal, pingTerminal } = useTerminalStore(
+  const { activateTerminal, pingTerminal, focusedId } = useTerminalStore(
     useShallow((state) => ({
       activateTerminal: state.activateTerminal,
       pingTerminal: state.pingTerminal,
+      focusedId: state.focusedId,
     }))
   );
   const shortcut = useKeybindingDisplay("agent.focusNextWaiting");
@@ -92,6 +93,7 @@ export function WaitingContainer() {
           <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
             {waitingTerminals.map((terminal) => {
               if (!terminal) return null;
+              const isFocused = terminal.id === focusedId;
 
               return (
                 <button
@@ -101,13 +103,22 @@ export function WaitingContainer() {
                     pingTerminal(terminal.id);
                     setIsOpen(false);
                   }}
-                  className="flex items-center justify-between gap-3 w-full px-2 py-2 rounded-sm hover:bg-canopy-accent/10 hover:text-canopy-accent transition-colors group text-left outline-none focus:bg-canopy-accent/10"
+                  className={cn(
+                    "flex items-center justify-between gap-3 w-full px-2 py-2 rounded-sm transition-colors group text-left outline-none",
+                    "hover:bg-white/5 focus:bg-white/5",
+                    isFocused && "bg-white/5"
+                  )}
                 >
                   <div className="flex items-center gap-2.5 min-w-0 flex-1">
                     <div className="shrink-0 opacity-70 group-hover:opacity-100 transition-opacity">
                       {getTerminalIcon(terminal.type)}
                     </div>
-                    <span className="text-sm font-medium truncate text-canopy-text/90 group-hover:text-canopy-text">
+                    <span
+                      className={cn(
+                        "text-sm truncate text-canopy-text/90 group-hover:text-canopy-text",
+                        isFocused ? "font-bold text-canopy-text" : "font-medium"
+                      )}
+                    >
                       {terminal.title}
                     </span>
                   </div>

--- a/src/components/Worktree/TerminalCountBadge.tsx
+++ b/src/components/Worktree/TerminalCountBadge.tsx
@@ -87,6 +87,7 @@ export function TerminalCountBadge({
   onSelectTerminal,
 }: TerminalCountBadgeProps) {
   const pingTerminal = useTerminalStore((s) => s.pingTerminal);
+  const focusedId = useTerminalStore((s) => s.focusedId);
 
   if (counts.total === 0) {
     return null;
@@ -134,72 +135,84 @@ export function TerminalCountBadge({
         className="w-64 p-0"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-3 py-2 border-b border-canopy-border bg-canopy-bg/50">
+        <div className="px-3 py-2 border-b border-canopy-border bg-canopy-bg/50 flex justify-between items-center">
           <span className="text-xs font-medium text-canopy-text/70">
             Active Sessions ({terminals.length})
           </span>
         </div>
         <div className="max-h-[300px] overflow-y-auto p-1">
-          {terminals.map((term) => (
-            <DropdownMenuItem
-              key={term.id}
-              onSelect={() => handleSelect(term)}
-              className="flex items-center justify-between gap-3 py-2 cursor-pointer group"
-            >
-              {/* LEFT SIDE: Icon + Title */}
-              <div className="flex items-center gap-2.5 min-w-0 flex-1">
-                <div className="shrink-0 opacity-70 group-hover:opacity-100 transition-opacity">
-                  {getTerminalIcon(term.type)}
+          {terminals.map((term) => {
+            const isFocused = term.id === focusedId;
+
+            return (
+              <DropdownMenuItem
+                key={term.id}
+                onSelect={() => handleSelect(term)}
+                className={cn(
+                  "flex items-center justify-between gap-3 py-2 cursor-pointer group",
+                  isFocused && "bg-accent"
+                )}
+              >
+                {/* LEFT SIDE: Icon + Title */}
+                <div className="flex items-center gap-2.5 min-w-0 flex-1">
+                  <div className="shrink-0 opacity-70 group-hover:opacity-100 transition-opacity">
+                    {getTerminalIcon(term.type)}
+                  </div>
+                  <span
+                    className={cn(
+                      "text-sm truncate text-canopy-text/90 group-hover:text-canopy-text",
+                      isFocused ? "font-bold" : "font-medium"
+                    )}
+                  >
+                    {term.title}
+                  </span>
                 </div>
-                <span className="text-sm font-medium truncate text-canopy-text/90 group-hover:text-canopy-text">
-                  {term.title}
-                </span>
-              </div>
 
-              {/* RIGHT SIDE: State Icons + Location */}
-              <div className="flex items-center gap-3 shrink-0">
-                {term.agentState === "working" && (
-                  <Loader2
-                    className="w-3.5 h-3.5 animate-spin text-[var(--color-state-working)]"
-                    aria-label="Working"
-                  />
-                )}
-
-                {term.agentState === "waiting" && (
-                  <AlertCircle
-                    className="w-3.5 h-3.5 text-amber-400"
-                    aria-label="Waiting for input"
-                  />
-                )}
-
-                {term.agentState === "failed" && (
-                  <XCircle
-                    className="w-3.5 h-3.5 text-[var(--color-status-error)]"
-                    aria-label="Failed"
-                  />
-                )}
-
-                {term.agentState === "completed" && (
-                  <CheckCircle2
-                    className="w-3.5 h-3.5 text-[var(--color-status-success)]"
-                    aria-label="Completed"
-                  />
-                )}
-
-                {/* Location Indicator (Grid vs Dock) */}
-                <div
-                  className="text-muted-foreground/40"
-                  title={term.location === "dock" ? "Docked" : "On Grid"}
-                >
-                  {term.location === "dock" ? (
-                    <PanelBottom className="w-3.5 h-3.5" />
-                  ) : (
-                    <LayoutGrid className="w-3.5 h-3.5" />
+                {/* RIGHT SIDE: State Icons + Location */}
+                <div className="flex items-center gap-3 shrink-0">
+                  {term.agentState === "working" && (
+                    <Loader2
+                      className="w-3.5 h-3.5 animate-spin text-[var(--color-state-working)]"
+                      aria-label="Working"
+                    />
                   )}
+
+                  {term.agentState === "waiting" && (
+                    <AlertCircle
+                      className="w-3.5 h-3.5 text-amber-400"
+                      aria-label="Waiting for input"
+                    />
+                  )}
+
+                  {term.agentState === "failed" && (
+                    <XCircle
+                      className="w-3.5 h-3.5 text-[var(--color-status-error)]"
+                      aria-label="Failed"
+                    />
+                  )}
+
+                  {term.agentState === "completed" && (
+                    <CheckCircle2
+                      className="w-3.5 h-3.5 text-[var(--color-status-success)]"
+                      aria-label="Completed"
+                    />
+                  )}
+
+                  {/* Location Indicator (Grid vs Dock) */}
+                  <div
+                    className="text-muted-foreground/40"
+                    title={term.location === "dock" ? "Docked" : "On Grid"}
+                  >
+                    {term.location === "dock" ? (
+                      <PanelBottom className="w-3.5 h-3.5" />
+                    ) : (
+                      <LayoutGrid className="w-3.5 h-3.5" />
+                    )}
+                  </div>
                 </div>
-              </div>
-            </DropdownMenuItem>
-          ))}
+              </DropdownMenuItem>
+            );
+          })}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Summary
Unifies styling across terminal container components (Waiting, Active Sessions, Trash) to provide consistent visual experience and clear indication of the currently focused terminal.

Closes #842

## Changes Made
- Add focusedId tracking to WaitingContainer and TerminalCountBadge to highlight the currently focused terminal
- Replace accent color hover states with consistent grey hover (hover:bg-white/5) across all terminal lists
- Apply bold font styling to currently focused terminal names in Waiting and Active Sessions lists
- Update TerminalCountBadge header structure to match standard flex layout pattern
- Normalize TrashContainer list padding from p-2 to p-1 for consistency