### PR TITLE
Document service instantiation patterns with JSDoc comments

### DIFF
--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -8,6 +8,22 @@ export type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress };
 
 export type ProgressCallback = (progress: CopyTreeProgress) => void;
 
+/**
+ * CopyTreeService - Generates context trees for AI agents.
+ *
+ * @pattern Exported Singleton Instance (Pattern A)
+ *
+ * Why this pattern:
+ * - Stateless request-response operations (generate context on demand)
+ * - No external dependencies at construction time
+ * - Cancellation handled per-operation via AbortController (no global state)
+ * - Lightweight instantiation: just initializes an empty Map
+ *
+ * When to use Pattern A:
+ * - Service performs stateless operations without persistent resources
+ * - No need for explicit lifecycle management (start/stop/dispose)
+ * - Wide usage across handlers benefits from simple import syntax
+ */
 class CopyTreeService {
   private activeOperations = new Map<string, AbortController>();
 

--- a/electron/services/DevServerManager.ts
+++ b/electron/services/DevServerManager.ts
@@ -13,8 +13,23 @@ const MAX_LOG_LINES = 100;
 const RESTART_COOLDOWN_MS = 60000; // Prevent restart loops
 
 /**
- * DevServerManager manages dev server processes for worktrees.
+ * DevServerManager - Manages dev server processes for worktrees.
+ *
+ * @pattern Dependency Injection via main.ts (Pattern B)
+ *
  * State changes emitted via event bus (server:update, server:error).
+ *
+ * Why this pattern:
+ * - Manages multiple child processes (dev server per worktree) via execa
+ * - Needs WorkspaceClient reference for URL parsing (cross-service dependency)
+ * - Lifecycle tied to app: servers must be stopped on app quit
+ * - Created in main.ts composition root, injected into IPC handlers
+ *
+ * When to use Pattern B:
+ * - Service spawns/manages external processes
+ * - Service has runtime dependencies on other services (setWorkspaceClient)
+ * - Explicit cleanup required on application shutdown
+ * - Service state must be coordinated with window lifecycle
  */
 export class DevServerManager {
   private servers = new Map<string, ResultPromise>();

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -11,6 +11,23 @@ const DEFAULT_CONFIG: HibernationConfig = {
   inactiveThresholdHours: 24,
 };
 
+/**
+ * HibernationService - Auto-hibernates inactive projects to free resources.
+ *
+ * @pattern Factory/Accessor Methods (Pattern C)
+ *
+ * Why this pattern:
+ * - Requires lazy initialization: depends on PtyManager which uses dynamic import
+ * - Has explicit lifecycle (start/stop) that callers control
+ * - Singleton with deferred construction: getHibernationService() + initializeHibernationService()
+ * - Factory separates creation from start(), allowing config check at runtime
+ *
+ * When to use Pattern C:
+ * - Service has circular or dynamic dependencies (import() at runtime)
+ * - Lazy initialization saves startup time if service isn't always needed
+ * - Explicit dispose() method pairs with factory for resource management
+ * - Initialization timing matters (must wait for other services to be ready)
+ */
 export class HibernationService {
   private checkInterval: NodeJS.Timeout | null = null;
   private readonly CHECK_INTERVAL_MS = 60 * 60 * 1000; // Every hour

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1,11 +1,23 @@
 /**
  * PtyClient - Main process stub for terminal management.
  *
+ * @pattern Dependency Injection via main.ts (Pattern B)
+ *
  * This class provides a drop-in replacement for PtyManager in the Main process.
  * It forwards all operations to the Pty Host (UtilityProcess) via IPC,
  * keeping the Main thread responsive.
  *
- * Interface matches PtyManager for seamless integration with existing code.
+ * Why this pattern:
+ * - Manages critical child process (UtilityProcess) requiring explicit lifecycle control
+ * - Constructor accepts configuration: must be instantiated with specific options
+ * - Needs coordination with other services (MessagePort distribution, error handlers)
+ * - Lifecycle tied to app lifecycle: created in main.ts, passed to IPC handlers
+ *
+ * When to use Pattern B:
+ * - Service manages child processes, sockets, or system resources
+ * - Service requires configuration at construction time
+ * - Service needs explicit startup/shutdown coordination
+ * - Multiple services need to interact (composition root in main.ts)
  */
 
 import { utilityProcess, UtilityProcess, dialog, app, MessagePortMain } from "electron";

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -19,10 +19,24 @@ import {
 /**
  * PtyManager - Facade for terminal process management.
  *
+ * @pattern Factory/Accessor Methods (Pattern C)
+ *
  * Orchestrates the pty subsystem by delegating to specialized services:
  * - TerminalRegistry: Terminal instance management and project filtering
  * - AgentStateService: Agent state transitions and event emission
  * - TerminalProcess: Individual terminal session handling
+ *
+ * Why this pattern:
+ * - Has explicit dispose() method to clean up terminals and listeners
+ * - Shared singleton accessed dynamically via getPtyManager() from IPC handlers and services
+ * - Lifecycle paired with disposePtyManager() for clean shutdown
+ * - Factory function provides control over instantiation timing
+ *
+ * When to use Pattern C:
+ * - Service manages resources that need explicit cleanup (terminals, listeners)
+ * - Service is accessed from multiple places but disposal must be coordinated
+ * - Factory function provides control over instantiation timing
+ * - Dispose function enables clean shutdown without import-time side effects
  */
 export class PtyManager extends EventEmitter {
   private registry: TerminalRegistry;

--- a/electron/services/SystemSleepService.ts
+++ b/electron/services/SystemSleepService.ts
@@ -15,6 +15,23 @@ export interface SystemSleepMetrics {
 
 type WakeCallback = (sleepDurationMs: number) => void;
 
+/**
+ * SystemSleepService - Tracks system sleep/wake cycles for accurate timing.
+ *
+ * @pattern Factory/Accessor Methods (Pattern C)
+ *
+ * Why this pattern:
+ * - Requires explicit initialization (powerMonitor listeners registered via initialize())
+ * - Has dispose() method that must be called to remove event listeners
+ * - Factory accessor pattern pairs initialize()/dispose() for resource management
+ * - Stateful resource: tracks sleep periods, must be reset/disposed properly
+ *
+ * When to use Pattern C:
+ * - Service registers system-level event handlers that need cleanup
+ * - Service has initialize()/dispose() lifecycle methods
+ * - Creation and initialization are separate concerns
+ * - Memory/resource cleanup is critical (removing listeners, clearing state)
+ */
 class SystemSleepService {
   private sleepStart: number | null = null;
   private sleepPeriods: SleepPeriod[] = [];

--- a/electron/services/WorktreeService.ts
+++ b/electron/services/WorktreeService.ts
@@ -81,6 +81,23 @@ interface PendingSyncRequest {
   monitorConfig?: MonitorConfig;
 }
 
+/**
+ * WorktreeService - Manages Git worktree monitoring and state synchronization.
+ *
+ * @pattern Exported Singleton Instance (Pattern A)
+ *
+ * Why this pattern:
+ * - No external dependencies required at construction time
+ * - Stateful singleton with lightweight constructor (no external deps, no child processes)
+ * - Safe for eager instantiation: no heavy initialization at import time
+ * - Simple access: `import { worktreeService } from './WorktreeService'`
+ *
+ * When to use Pattern A:
+ * - Service has no constructor dependencies
+ * - Service doesn't manage child processes or system resources requiring explicit lifecycle
+ * - Service is used widely across the codebase (simple import pattern)
+ * - Initialization is lightweight (no async setup or resource allocation)
+ */
 export class WorktreeService {
   private monitors = new Map<string, WorktreeMonitor>();
   private pollQueue = new PQueue({ concurrency: 3 });


### PR DESCRIPTION
## Summary
Added comprehensive JSDoc comments to service files documenting the three service instantiation patterns used throughout the electron/ folder.

Closes #843

## Changes Made
- **Pattern A (Exported Singleton)**: Added JSDoc to WorktreeService and CopyTreeService explaining when to use this pattern for stateless/simple services
- **Pattern B (Dependency Injection)**: Added JSDoc to DevServerManager and PtyClient documenting usage for services managing child processes
- **Pattern C (Factory/Accessor)**: Added JSDoc to HibernationService, SystemSleepService, and PtyManager explaining the lazy initialization pattern
- Each comment includes rationale for why that pattern was chosen and guidelines for when to use each pattern

## Pattern Documentation

### Pattern A: Exported Singleton Instance
```typescript
export const service = new Service()
```
**Use when:**
- Service has no constructor dependencies
- Lightweight initialization
- Wide usage benefits from simple import syntax

### Pattern B: Dependency Injection via main.ts
```typescript
const service = new Service(config);
registerIpcHandlers(mainWindow, service, ...);
```
**Use when:**
- Service manages child processes or system resources
- Requires configuration at construction time
- Needs explicit lifecycle coordination

### Pattern C: Factory/Accessor Methods
```typescript
let instance = null;
export function getService() { ... }
export function initializeService() { ... }
```
**Use when:**
- Service has circular/dynamic dependencies
- Explicit initialize()/dispose() lifecycle needed
- Creation and initialization are separate concerns