### PR TITLE
Standardize store initialization pattern with Pattern B

### DIFF
--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -1,0 +1,106 @@
+import { create } from "zustand";
+import type { AgentSettings, ClaudeSettings, GeminiSettings, CodexSettings } from "@shared/types";
+import { agentSettingsClient } from "@/clients";
+
+interface AgentSettingsState {
+  settings: AgentSettings | null;
+  isLoading: boolean;
+  error: string | null;
+  isInitialized: boolean;
+}
+
+interface AgentSettingsActions {
+  initialize: () => Promise<void>;
+  setClaude: (updates: Partial<ClaudeSettings>) => Promise<void>;
+  setGemini: (updates: Partial<GeminiSettings>) => Promise<void>;
+  setCodex: (updates: Partial<CodexSettings>) => Promise<void>;
+  reset: (agentType?: "claude" | "gemini" | "codex") => Promise<void>;
+}
+
+type AgentSettingsStore = AgentSettingsState & AgentSettingsActions;
+
+let initPromise: Promise<void> | null = null;
+
+export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => ({
+  settings: null,
+  isLoading: true,
+  error: null,
+  isInitialized: false,
+
+  initialize: () => {
+    if (get().isInitialized) return Promise.resolve();
+    if (initPromise) return initPromise;
+
+    initPromise = (async () => {
+
+      try {
+        set({ isLoading: true, error: null });
+
+        const settings = await agentSettingsClient.get();
+        set({ settings, isLoading: false, isInitialized: true });
+      } catch (e) {
+        set({
+          error: e instanceof Error ? e.message : "Failed to load agent settings",
+          isLoading: false,
+          isInitialized: true,
+        });
+      }
+    })();
+
+    return initPromise;
+  },
+
+  setClaude: async (updates: Partial<ClaudeSettings>) => {
+    set({ error: null });
+    try {
+      const settings = await agentSettingsClient.setClaude(updates);
+      set({ settings });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : "Failed to update Claude settings" });
+      throw e;
+    }
+  },
+
+  setGemini: async (updates: Partial<GeminiSettings>) => {
+    set({ error: null });
+    try {
+      const settings = await agentSettingsClient.setGemini(updates);
+      set({ settings });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : "Failed to update Gemini settings" });
+      throw e;
+    }
+  },
+
+  setCodex: async (updates: Partial<CodexSettings>) => {
+    set({ error: null });
+    try {
+      const settings = await agentSettingsClient.setCodex(updates);
+      set({ settings });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : "Failed to update Codex settings" });
+      throw e;
+    }
+  },
+
+  reset: async (agentType?: "claude" | "gemini" | "codex") => {
+    set({ error: null });
+    try {
+      const settings = await agentSettingsClient.reset(agentType);
+      set({ settings });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : "Failed to reset agent settings" });
+      throw e;
+    }
+  },
+}));
+
+export function cleanupAgentSettingsStore() {
+  initPromise = null;
+  useAgentSettingsStore.setState({
+    settings: null,
+    isLoading: true,
+    error: null,
+    isInitialized: false,
+  });
+}

--- a/src/store/githubConfigStore.ts
+++ b/src/store/githubConfigStore.ts
@@ -1,0 +1,74 @@
+import { create } from "zustand";
+import type { GitHubTokenConfig } from "@/types";
+import { githubClient } from "@/clients";
+
+interface GitHubConfigState {
+  config: GitHubTokenConfig | null;
+  isLoading: boolean;
+  error: string | null;
+  isInitialized: boolean;
+}
+
+interface GitHubConfigActions {
+  initialize: () => Promise<void>;
+  refresh: () => Promise<void>;
+  updateConfig: (config: GitHubTokenConfig) => void;
+}
+
+type GitHubConfigStore = GitHubConfigState & GitHubConfigActions;
+
+let initPromise: Promise<void> | null = null;
+
+export const useGitHubConfigStore = create<GitHubConfigStore>()((set, get) => ({
+  config: null,
+  isLoading: true,
+  error: null,
+  isInitialized: false,
+
+  initialize: () => {
+    if (get().isInitialized) return Promise.resolve();
+    if (initPromise) return initPromise;
+
+    initPromise = (async () => {
+
+      try {
+        set({ isLoading: true, error: null });
+
+        const config = await githubClient.getConfig();
+        set({ config, isLoading: false, isInitialized: true });
+      } catch (e) {
+        set({
+          error: e instanceof Error ? e.message : "Failed to load GitHub config",
+          isLoading: false,
+          isInitialized: true,
+        });
+      }
+    })();
+
+    return initPromise;
+  },
+
+  refresh: async () => {
+    try {
+      set({ error: null });
+      const config = await githubClient.getConfig();
+      set({ config });
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : "Failed to refresh GitHub config" });
+    }
+  },
+
+  updateConfig: (config: GitHubTokenConfig) => {
+    set({ config, error: null });
+  },
+}));
+
+export function cleanupGitHubConfigStore() {
+  initPromise = null;
+  useGitHubConfigStore.setState({
+    config: null,
+    isLoading: true,
+    error: null,
+    isInitialized: false,
+  });
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,3 +40,7 @@ export { useTerminalFontStore } from "./terminalFontStore";
 export { useSidecarStore } from "./sidecarStore";
 
 export { useUIStore } from "./uiStore";
+
+export { useGitHubConfigStore, cleanupGitHubConfigStore } from "./githubConfigStore";
+
+export { useAgentSettingsStore, cleanupAgentSettingsStore } from "./agentSettingsStore";


### PR DESCRIPTION
## Summary
Standardizes store initialization patterns across the codebase using Pattern B (idempotent initialization with `initPromise` caching and `isInitialized` flag), following the reference implementation in `worktreeDataStore.ts`.

Closes #845

## Changes Made
- Add `githubConfigStore` with idempotent initialization (initPromise + isInitialized)
- Add `agentSettingsStore` with idempotent initialization
- Refactor `GitHubSettingsTab` to use store instead of component-local state
- Refactor `AgentSettings` to use store instead of component-local state
- Fix Pattern B guard order (check isInitialized before initPromise)
- Add error clearing to all mutator methods to prevent stale errors
- Add race condition guard to agent toggle handlers
- Improve error handling in clearToken callback

## Benefits
- **Idempotent**: Can be called multiple times safely
- **Promise caching**: Prevents concurrent initialization races
- **Global state**: Survives component unmount/remount
- **Consistent patterns**: All stores use the same initialization approach