### PR TITLE
Refactor TerminalPane and WorktreeCard to use compound components

### DIFF
--- a/src/components/Terminal/DockedTerminalPane.tsx
+++ b/src/components/Terminal/DockedTerminalPane.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useState, useEffect, useRef } from "react";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import { getTerminalAnimationDuration } from "@/lib/animationUtils";
+import { TerminalPane } from "./TerminalPane";
+
+export interface DockedTerminalPaneProps {
+  terminal: TerminalInstance;
+  onPopoverClose?: () => void;
+}
+
+export function DockedTerminalPane({ terminal, onPopoverClose }: DockedTerminalPaneProps) {
+  const setFocused = useTerminalStore((state) => state.setFocused);
+  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+  const removeTerminal = useTerminalStore((state) => state.removeTerminal);
+  const updateTitle = useTerminalStore((state) => state.updateTitle);
+  const moveTerminalToGrid = useTerminalStore((state) => state.moveTerminalToGrid);
+  const closeDockTerminal = useTerminalStore((state) => state.closeDockTerminal);
+
+  const [isTrashing, setIsTrashing] = useState(false);
+  const mountedRef = useRef(true);
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    setFocused(terminal.id);
+  }, [setFocused, terminal.id]);
+
+  const handleClose = useCallback(
+    (force?: boolean) => {
+      if (force) {
+        removeTerminal(terminal.id);
+        onPopoverClose?.();
+      } else {
+        const duration = getTerminalAnimationDuration();
+        setIsTrashing(true);
+        timeoutRef.current = setTimeout(() => {
+          try {
+            trashTerminal(terminal.id);
+          } catch (error) {
+            console.error("Failed to trash terminal:", error);
+          } finally {
+            if (mountedRef.current) {
+              setIsTrashing(false);
+            }
+            onPopoverClose?.();
+          }
+        }, duration);
+      }
+    },
+    [removeTerminal, trashTerminal, terminal.id, onPopoverClose]
+  );
+
+  const handleRestore = useCallback(() => {
+    onPopoverClose?.();
+    moveTerminalToGrid(terminal.id);
+  }, [moveTerminalToGrid, terminal.id, onPopoverClose]);
+
+  const handleMinimize = useCallback(() => {
+    closeDockTerminal();
+  }, [closeDockTerminal]);
+
+  const handleTitleChange = useCallback(
+    (newTitle: string) => {
+      updateTitle(terminal.id, newTitle);
+    },
+    [updateTitle, terminal.id]
+  );
+
+  return (
+    <TerminalPane
+      id={terminal.id}
+      title={terminal.title}
+      type={terminal.type}
+      worktreeId={terminal.worktreeId}
+      cwd={terminal.cwd}
+      isFocused={true}
+      agentState={terminal.agentState}
+      activity={
+        terminal.activityHeadline
+          ? {
+              headline: terminal.activityHeadline,
+              status: terminal.activityStatus ?? "working",
+              type: terminal.activityType ?? "interactive",
+            }
+          : null
+      }
+      location="dock"
+      restartKey={terminal.restartKey}
+      onFocus={handleFocus}
+      onClose={handleClose}
+      onRestore={handleRestore}
+      onMinimize={handleMinimize}
+      onTitleChange={handleTitleChange}
+      isTrashing={isTrashing}
+    />
+  );
+}

--- a/src/components/Terminal/GridTerminalPane.tsx
+++ b/src/components/Terminal/GridTerminalPane.tsx
@@ -1,0 +1,118 @@
+import { useCallback, useState, useEffect, useRef } from "react";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import { getTerminalAnimationDuration } from "@/lib/animationUtils";
+import { TerminalPane } from "./TerminalPane";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+export interface GridTerminalPaneProps {
+  terminal: TerminalInstance;
+  isFocused: boolean;
+  isMaximized?: boolean;
+}
+
+export function GridTerminalPane({
+  terminal,
+  isFocused,
+  isMaximized = false,
+}: GridTerminalPaneProps) {
+  const setFocused = useTerminalStore((state) => state.setFocused);
+  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+  const removeTerminal = useTerminalStore((state) => state.removeTerminal);
+  const toggleMaximize = useTerminalStore((state) => state.toggleMaximize);
+  const updateTitle = useTerminalStore((state) => state.updateTitle);
+  const moveTerminalToDock = useTerminalStore((state) => state.moveTerminalToDock);
+
+  const [isTrashing, setIsTrashing] = useState(false);
+  const mountedRef = useRef(true);
+  const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    setFocused(terminal.id);
+  }, [setFocused, terminal.id]);
+
+  const handleClose = useCallback(
+    (force?: boolean) => {
+      if (force) {
+        removeTerminal(terminal.id);
+      } else {
+        const duration = getTerminalAnimationDuration();
+        setIsTrashing(true);
+        timeoutRef.current = setTimeout(() => {
+          try {
+            trashTerminal(terminal.id);
+          } catch (error) {
+            console.error("Failed to trash terminal:", error);
+          } finally {
+            if (mountedRef.current) {
+              setIsTrashing(false);
+            }
+          }
+        }, duration);
+      }
+    },
+    [removeTerminal, trashTerminal, terminal.id]
+  );
+
+  const handleToggleMaximize = useCallback(() => {
+    toggleMaximize(terminal.id);
+  }, [toggleMaximize, terminal.id]);
+
+  const handleTitleChange = useCallback(
+    (newTitle: string) => {
+      updateTitle(terminal.id, newTitle);
+    },
+    [updateTitle, terminal.id]
+  );
+
+  const handleMinimize = useCallback(() => {
+    moveTerminalToDock(terminal.id);
+  }, [moveTerminalToDock, terminal.id]);
+
+  return (
+    <ErrorBoundary
+      variant="component"
+      componentName="TerminalPane"
+      resetKeys={[terminal.id, terminal.worktreeId, terminal.agentState].filter(
+        (key): key is string => key !== undefined
+      )}
+      context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
+    >
+      <TerminalPane
+        id={terminal.id}
+        title={terminal.title}
+        type={terminal.type}
+        worktreeId={terminal.worktreeId}
+        cwd={terminal.cwd}
+        isFocused={isFocused}
+        isMaximized={isMaximized}
+        agentState={terminal.agentState}
+        activity={
+          terminal.activityHeadline
+            ? {
+                headline: terminal.activityHeadline,
+                status: terminal.activityStatus ?? "working",
+                type: terminal.activityType ?? "interactive",
+              }
+            : null
+        }
+        location="grid"
+        restartKey={terminal.restartKey}
+        onFocus={handleFocus}
+        onClose={handleClose}
+        onToggleMaximize={handleToggleMaximize}
+        onTitleChange={handleTitleChange}
+        onMinimize={handleMinimize}
+        isTrashing={isTrashing}
+      />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -3,7 +3,6 @@ import { useShallow } from "zustand/react/shallow";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import { useDroppable } from "@dnd-kit/core";
 import { cn } from "@/lib/utils";
-import { getTerminalAnimationDuration } from "@/lib/animationUtils";
 import {
   useTerminalStore,
   useLayoutConfigStore,
@@ -11,10 +10,9 @@ import {
   MAX_GRID_TERMINALS,
   type TerminalInstance,
 } from "@/store";
-import { TerminalPane } from "./TerminalPane";
+import { GridTerminalPane } from "./GridTerminalPane";
 import { TerminalCountWarning } from "./TerminalCountWarning";
 import { GridFullOverlay } from "./GridFullOverlay";
-import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   SortableTerminal,
   useDndPlaceholder,
@@ -267,31 +265,7 @@ export function TerminalGrid({
   const hasActiveWorktree = activeWorktreeId !== null;
 
   const addTerminal = useTerminalStore((state) => state.addTerminal);
-  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
-  const removeTerminal = useTerminalStore((state) => state.removeTerminal);
-  const updateTitle = useTerminalStore((state) => state.updateTitle);
-  const setFocused = useTerminalStore((state) => state.setFocused);
-  const toggleMaximize = useTerminalStore((state) => state.toggleMaximize);
-  const moveTerminalToDock = useTerminalStore((state) => state.moveTerminalToDock);
   const isInTrash = useTerminalStore((state) => state.isInTrash);
-
-  const [trashingIds, setTrashingIds] = useState<Set<string>>(new Set());
-
-  const handleTrashWithAnimation = useCallback(
-    (id: string) => {
-      const duration = getTerminalAnimationDuration();
-      setTrashingIds((prev) => new Set(prev).add(id));
-      setTimeout(() => {
-        trashTerminal(id);
-        setTrashingIds((prev) => {
-          const next = new Set(prev);
-          next.delete(id);
-          return next;
-        });
-      }, duration);
-    },
-    [trashTerminal]
-  );
 
   const gridTerminals = useMemo(
     () => terminals.filter((t) => t.location === "grid" || t.location === undefined),
@@ -430,43 +404,7 @@ export function TerminalGrid({
     if (terminal) {
       return (
         <div className={cn("h-full relative bg-canopy-bg", className)}>
-          <ErrorBoundary
-            variant="component"
-            componentName="TerminalPane"
-            resetKeys={[terminal.id, terminal.worktreeId, terminal.agentState].filter(
-              (key): key is string => key !== undefined
-            )}
-            context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
-          >
-            <TerminalPane
-              id={terminal.id}
-              title={terminal.title}
-              type={terminal.type}
-              worktreeId={terminal.worktreeId}
-              cwd={terminal.cwd}
-              isFocused={true}
-              isMaximized={true}
-              agentState={terminal.agentState}
-              activity={
-                terminal.activityHeadline
-                  ? {
-                      headline: terminal.activityHeadline,
-                      status: terminal.activityStatus ?? "working",
-                      type: terminal.activityType ?? "interactive",
-                    }
-                  : null
-              }
-              location="grid"
-              restartKey={terminal.restartKey}
-              onFocus={() => setFocused(terminal.id)}
-              onClose={(force) =>
-                force ? removeTerminal(terminal.id) : handleTrashWithAnimation(terminal.id)
-              }
-              onToggleMaximize={() => toggleMaximize(terminal.id)}
-              onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
-              isTrashing={trashingIds.has(terminal.id)}
-            />
-          </ErrorBoundary>
+          <GridTerminalPane terminal={terminal} isFocused={true} isMaximized={true} />
         </div>
       );
     }
@@ -527,46 +465,7 @@ export function TerminalGrid({
                       sourceIndex={index}
                       disabled={isTerminalInTrash}
                     >
-                      <ErrorBoundary
-                        variant="component"
-                        componentName="TerminalPane"
-                        resetKeys={[terminal.id, terminal.worktreeId, terminal.agentState].filter(
-                          (key): key is string => key !== undefined
-                        )}
-                        context={{ terminalId: terminal.id, worktreeId: terminal.worktreeId }}
-                      >
-                        <TerminalPane
-                          id={terminal.id}
-                          title={terminal.title}
-                          type={terminal.type}
-                          worktreeId={terminal.worktreeId}
-                          cwd={terminal.cwd}
-                          isFocused={terminal.id === focusedId}
-                          isMaximized={false}
-                          agentState={terminal.agentState}
-                          activity={
-                            terminal.activityHeadline
-                              ? {
-                                  headline: terminal.activityHeadline,
-                                  status: terminal.activityStatus ?? "working",
-                                  type: terminal.activityType ?? "interactive",
-                                }
-                              : null
-                          }
-                          location="grid"
-                          restartKey={terminal.restartKey}
-                          onFocus={() => setFocused(terminal.id)}
-                          onClose={(force) =>
-                            force
-                              ? removeTerminal(terminal.id)
-                              : handleTrashWithAnimation(terminal.id)
-                          }
-                          onToggleMaximize={() => toggleMaximize(terminal.id)}
-                          onTitleChange={(newTitle) => updateTitle(terminal.id, newTitle)}
-                          onMinimize={() => moveTerminalToDock(terminal.id)}
-                          isTrashing={trashingIds.has(terminal.id)}
-                        />
-                      </ErrorBoundary>
+                      <GridTerminalPane terminal={terminal} isFocused={terminal.id === focusedId} />
                     </SortableTerminal>
                   );
 

--- a/src/components/Terminal/index.ts
+++ b/src/components/Terminal/index.ts
@@ -18,3 +18,7 @@ export { TerminalIcon } from "./TerminalIcon";
 export type { TerminalIconProps } from "./TerminalIcon";
 export { TerminalRestartBanner } from "./TerminalRestartBanner";
 export type { TerminalRestartBannerProps } from "./TerminalRestartBanner";
+export { GridTerminalPane } from "./GridTerminalPane";
+export type { GridTerminalPaneProps } from "./GridTerminalPane";
+export { DockedTerminalPane } from "./DockedTerminalPane";
+export type { DockedTerminalPaneProps } from "./DockedTerminalPane";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -49,3 +49,9 @@ export { useLayoutState } from "./useLayoutState";
 export type { LayoutState } from "./useLayoutState";
 
 export { useWindowNotifications } from "./useWindowNotifications";
+
+export { useTerminalActions } from "./useTerminalActions";
+export type { UseTerminalActionsOptions, UseTerminalActionsReturn } from "./useTerminalActions";
+
+export { useWorktreeActions } from "./useWorktreeActions";
+export type { UseWorktreeActionsOptions, WorktreeActions } from "./useWorktreeActions";

--- a/src/hooks/useTerminalActions.ts
+++ b/src/hooks/useTerminalActions.ts
@@ -1,0 +1,84 @@
+import { useCallback, useState } from "react";
+import { useTerminalStore } from "@/store";
+import { getTerminalAnimationDuration } from "@/lib/animationUtils";
+
+export interface UseTerminalActionsOptions {
+  terminalId: string;
+  onTrashComplete?: () => void;
+}
+
+export interface UseTerminalActionsReturn {
+  onFocus: () => void;
+  onClose: (force?: boolean) => void;
+  onToggleMaximize: () => void;
+  onTitleChange: (newTitle: string) => void;
+  onMinimize: () => void;
+  onRestore: () => void;
+  isTrashing: boolean;
+}
+
+export function useTerminalActions({
+  terminalId,
+  onTrashComplete,
+}: UseTerminalActionsOptions): UseTerminalActionsReturn {
+  const setFocused = useTerminalStore((state) => state.setFocused);
+  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+  const removeTerminal = useTerminalStore((state) => state.removeTerminal);
+  const toggleMaximize = useTerminalStore((state) => state.toggleMaximize);
+  const updateTitle = useTerminalStore((state) => state.updateTitle);
+  const moveTerminalToDock = useTerminalStore((state) => state.moveTerminalToDock);
+  const moveTerminalToGrid = useTerminalStore((state) => state.moveTerminalToGrid);
+
+  const [isTrashing, setIsTrashing] = useState(false);
+
+  const onFocus = useCallback(() => {
+    setFocused(terminalId);
+  }, [setFocused, terminalId]);
+
+  const onClose = useCallback(
+    (force?: boolean) => {
+      if (force) {
+        removeTerminal(terminalId);
+        onTrashComplete?.();
+      } else {
+        const duration = getTerminalAnimationDuration();
+        setIsTrashing(true);
+        setTimeout(() => {
+          trashTerminal(terminalId);
+          setIsTrashing(false);
+          onTrashComplete?.();
+        }, duration);
+      }
+    },
+    [removeTerminal, trashTerminal, terminalId, onTrashComplete]
+  );
+
+  const onToggleMaximize = useCallback(() => {
+    toggleMaximize(terminalId);
+  }, [toggleMaximize, terminalId]);
+
+  const onTitleChange = useCallback(
+    (newTitle: string) => {
+      updateTitle(terminalId, newTitle);
+    },
+    [updateTitle, terminalId]
+  );
+
+  const onMinimize = useCallback(() => {
+    moveTerminalToDock(terminalId);
+  }, [moveTerminalToDock, terminalId]);
+
+  const onRestore = useCallback(() => {
+    moveTerminalToGrid(terminalId);
+  }, [moveTerminalToGrid, terminalId]);
+
+  return {
+    onFocus,
+    onClose,
+    onToggleMaximize,
+    onTitleChange,
+    onMinimize,
+    onRestore,
+    isTrashing,
+  };
+}

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -1,0 +1,159 @@
+import { useCallback } from "react";
+import type { WorktreeState, ProjectDevServerSettings, RecipeTerminal } from "@/types";
+import type { AgentType } from "@/hooks/useAgentLauncher";
+import { copyTreeClient, devServerClient, githubClient, systemClient } from "@/clients";
+import { useErrorStore, type AppError } from "@/store";
+import { useRecipeStore } from "@/store/recipeStore";
+import { formatBytes } from "@/lib/formatBytes";
+
+export interface UseWorktreeActionsOptions {
+  projectSettings?: { devServer?: ProjectDevServerSettings };
+  onOpenRecipeEditor?: (worktreeId: string, initialTerminals?: RecipeTerminal[]) => void;
+  launchAgent?: (type: AgentType, options: { worktreeId: string; location: "grid" }) => void;
+}
+
+export interface WorktreeActions {
+  handleCopyTree: (worktree: WorktreeState) => Promise<string | undefined>;
+  handleOpenEditor: (worktree: WorktreeState) => void;
+  handleToggleServer: (worktree: WorktreeState) => void;
+  handleOpenIssue: (worktree: WorktreeState) => void;
+  handleOpenPR: (worktree: WorktreeState) => void;
+  handleCreateRecipe: (worktreeId: string) => void;
+  handleSaveLayout: (worktree: WorktreeState) => void;
+  handleLaunchAgent: (worktreeId: string, type: AgentType) => void;
+}
+
+export function useWorktreeActions({
+  projectSettings,
+  onOpenRecipeEditor,
+  launchAgent,
+}: UseWorktreeActionsOptions = {}): WorktreeActions {
+  const addError = useErrorStore((state) => state.addError);
+
+  const handleCopyTree = useCallback(
+    async (worktree: WorktreeState): Promise<string | undefined> => {
+      try {
+        const isAvailable = await copyTreeClient.isAvailable();
+        if (!isAvailable) {
+          throw new Error(
+            "CopyTree SDK not available. Please restart the application or check installation."
+          );
+        }
+
+        const result = await copyTreeClient.generateAndCopyFile(worktree.id, {
+          format: "xml",
+        });
+
+        if (result.error) {
+          throw new Error(result.error);
+        }
+
+        console.log(`Copied ${result.fileCount} files as file reference`);
+        const sizeStr = result.stats?.totalSize ? formatBytes(result.stats.totalSize) : "";
+
+        return `Copied ${result.fileCount} files${sizeStr ? ` (${sizeStr})` : ""} to clipboard`;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Failed to copy context to clipboard";
+        const details = e instanceof Error ? e.stack : undefined;
+
+        let errorType: AppError["type"] = "process";
+        if (message.includes("not available") || message.includes("not installed")) {
+          errorType = "config";
+        } else if (
+          message.includes("permission") ||
+          message.includes("EACCES") ||
+          message.includes("denied")
+        ) {
+          errorType = "filesystem";
+        }
+
+        addError({
+          type: errorType,
+          message: `Copy context failed: ${message}`,
+          details,
+          source: "WorktreeCard",
+          context: {
+            worktreeId: worktree.id,
+          },
+          isTransient: true,
+          retryAction: "copytree",
+          retryArgs: {
+            worktreeId: worktree.id,
+          },
+        });
+
+        console.error("Failed to copy context:", message);
+        return undefined;
+      }
+    },
+    [addError]
+  );
+
+  const handleOpenEditor = useCallback((worktree: WorktreeState) => {
+    systemClient.openPath(worktree.path);
+  }, []);
+
+  const handleToggleServer = useCallback(
+    (worktree: WorktreeState) => {
+      const command = projectSettings?.devServer?.command;
+      devServerClient.toggle(worktree.id, worktree.path, command);
+    },
+    [projectSettings]
+  );
+
+  const handleOpenIssue = useCallback((worktree: WorktreeState) => {
+    if (worktree.issueNumber) {
+      githubClient.openIssue(worktree.path, worktree.issueNumber);
+    }
+  }, []);
+
+  const handleOpenPR = useCallback((worktree: WorktreeState) => {
+    if (worktree.prUrl) {
+      githubClient.openPR(worktree.prUrl);
+    }
+  }, []);
+
+  const handleCreateRecipe = useCallback(
+    (worktreeId: string) => {
+      onOpenRecipeEditor?.(worktreeId, undefined);
+    },
+    [onOpenRecipeEditor]
+  );
+
+  const handleSaveLayout = useCallback(
+    (worktree: WorktreeState) => {
+      const terminals = useRecipeStore.getState().generateRecipeFromActiveTerminals(worktree.id);
+
+      if (terminals.length === 0) {
+        addError({
+          type: "config",
+          message: "No active terminals to save in this worktree.",
+          source: "Save Layout",
+          isTransient: true,
+        });
+        return;
+      }
+
+      onOpenRecipeEditor?.(worktree.id, terminals);
+    },
+    [addError, onOpenRecipeEditor]
+  );
+
+  const handleLaunchAgent = useCallback(
+    (worktreeId: string, type: AgentType) => {
+      launchAgent?.(type, { worktreeId, location: "grid" });
+    },
+    [launchAgent]
+  );
+
+  return {
+    handleCopyTree,
+    handleOpenEditor,
+    handleToggleServer,
+    handleOpenIssue,
+    handleOpenPR,
+    handleCreateRecipe,
+    handleSaveLayout,
+    handleLaunchAgent,
+  };
+}


### PR DESCRIPTION
## Summary
Refactored TerminalPane and WorktreeCard to use compound component pattern with extracted hooks and wrapper components, simplifying callback management and reducing prop drilling.

Closes #844

## Changes Made
- Created `useTerminalActions` and `useWorktreeActions` hooks to encapsulate callback logic
- Added `GridTerminalPane` and `DockedTerminalPane` wrapper components that use store actions directly
- Simplified `TerminalGrid` and `DockedTerminalItem` by removing inline callback definitions (-174 lines)
- Simplified `App.tsx` by extracting worktree action callbacks into hook (-160 lines)
- Added proper cleanup and error handling for trash animation timeouts
- Added unmount safety guards to prevent state updates after component unmount

## Key Improvements
- **Reduced prop drilling**: Callbacks are now managed closer to where they're used
- **Better separation of concerns**: Store actions are encapsulated in wrapper components
- **Improved error handling**: Added try/catch blocks and cleanup for async operations
- **Memory leak prevention**: Added mounted refs and timeout cleanup on unmount