### PR TITLE
Improve UI consistency for hover states and empty worktree display

### DIFF
--- a/src/components/TerminalPalette/TerminalListItem.tsx
+++ b/src/components/TerminalPalette/TerminalListItem.tsx
@@ -43,7 +43,7 @@ export function TerminalListItem({
         "transition-colors duration-100",
         isSelected
           ? "bg-canopy-accent/20 border border-canopy-accent"
-          : "hover:bg-canopy-sidebar border border-transparent"
+          : "hover:bg-white/5 border border-transparent"
       )}
       onClick={onClick}
       aria-selected={isSelected}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -444,7 +444,7 @@ export function WorktreeCard({
     <div
       className={cn(
         "group relative border-b-2 border-white/5 transition-all duration-200",
-        isActive ? "bg-white/[0.03]" : "hover:bg-white/[0.02] bg-transparent",
+        isActive ? "bg-white/[0.06]" : "hover:bg-white/5 bg-transparent",
         isFocused && "bg-white/[0.04]",
         (isIdleCard || isStaleCard) && !isActive && !isFocused && "opacity-70 hover:opacity-100",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
@@ -759,7 +759,7 @@ export function WorktreeCard({
                   onClick={handleToggleExpand}
                   aria-expanded={false}
                   aria-controls={detailsId}
-                  className="w-full p-3 flex items-center justify-between min-w-0 text-left rounded-lg transition-colors hover:bg-white/[0.02] focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-[-2px]"
+                  className="w-full p-3 flex items-center justify-between min-w-0 text-left rounded-lg transition-colors hover:bg-white/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-[-2px]"
                 >
                   {/* LEFT SLOT: Git Signal + Commit Message */}
                   <div className="flex items-center gap-2 min-w-0 flex-1 text-[11px] font-mono text-canopy-text/60">

--- a/src/components/Worktree/WorktreeList.tsx
+++ b/src/components/Worktree/WorktreeList.tsx
@@ -270,29 +270,29 @@ export function WorktreeList({
 
   if (sortedWorktrees.length === 0) {
     return (
-      <div
-        className="flex flex-col items-center justify-center h-full p-4 text-canopy-text/60"
-        role="status"
-        aria-live="polite"
-      >
-        <svg
-          className="w-8 h-8 mb-2 text-canopy-text/40"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-          />
-        </svg>
-        <span className="text-sm font-medium">No worktrees yet</span>
-        <span className="text-xs text-canopy-text/60 mt-1 text-center max-w-[200px]">
-          Use <strong>File → Open Directory</strong> to open a git repository
-        </span>
+      <div className="flex flex-col items-center justify-center h-full p-4">
+        <div className="bg-canopy-bg border border-canopy-border/40 rounded-xl p-8 flex flex-col items-center max-w-sm text-center shadow-sm">
+          <div className="h-12 w-12 bg-canopy-accent/10 rounded-full flex items-center justify-center mb-4">
+            <svg
+              className="w-6 h-6 text-canopy-accent"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
+              />
+            </svg>
+          </div>
+          <span className="text-sm font-medium text-canopy-text">No worktrees yet</span>
+          <span className="text-xs text-canopy-text/60 mt-2">
+            Use <strong>File → Open Directory</strong> to open a git repository
+          </span>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Standardizes hover effects across interactive list items and enhances the empty worktree state with a styled container for better visual cohesion with the Digital Ecology theme.

Closes #849

## Changes Made
- Standardized hover effect to `white/5` across WorktreeCard and TerminalListItem for consistent interaction feedback
- Increased active card background from 3% to 6% to maintain proper visual hierarchy (active state stronger than hover)
- Added bordered container with emerald icon circle to empty worktree state, matching Terminal Grid launcher card aesthetic
- Fixed nested hover states (collapsed pulse button) to use consistent 5% overlay