### PR TITLE
Fix terminal scrolling jitter during TUI updates with large history

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -184,6 +184,19 @@ function TerminalPaneComponent({
       requestAnimationFrame(() => {
         terminalInstanceService.focus(id);
       });
+    } else {
+      // Background snap: only snap to bottom if user was already at bottom
+      // This preserves manual scroll position when viewing history
+      requestAnimationFrame(() => {
+        const managed = terminalInstanceService.get(id);
+        if (managed) {
+          const buffer = managed.terminal.buffer.active;
+          const isAtBottom = buffer.baseY - buffer.viewportY < 1;
+          if (isAtBottom) {
+            terminalInstanceService.scrollToBottom(id);
+          }
+        }
+      });
     }
   }, [isFocused, id]);
 

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -93,6 +93,7 @@ function XtermAdapterComponent({
       smoothScrollDuration: performanceMode ? 0 : 0, // Already 0, but keep explicit
       scrollback: effectiveScrollback,
       macOptionIsMeta: true,
+      scrollOnUserInput: false,
       fastScrollModifier: "alt" as const,
       fastScrollSensitivity: 5,
       scrollSensitivity: 1.5,


### PR DESCRIPTION
## Summary
Fixes terminal scroll jitter when running TUIs (like Claude Code) with large scrollback history. The viewport was jumping uncontrollably between top of history, middle positions, and current output due to conflicts between automatic scrolling and manual scrolling.

Closes #852

## Changes Made
- Disabled `scrollOnUserInput` in XtermAdapter to prevent forced scrolling during TUI updates while user is reading history
- Implemented scroll position preservation in resize operations - only scrolls to bottom if user was already at bottom
- Added `latestWasAtBottom` flag to track scroll state across async resize operations (prevents stale state issues)
- Added `scrollToBottom()` public method to TerminalInstanceService for explicit scroll control
- Made background snap conditional on scroll position to preserve manual scrolling when viewing history
- Updated all resize helper methods (scheduleIdleResize, debounceResizeX, throttleResizeY) to use stored scroll state
- Fixed flushResize to respect scroll position on unmount instead of forcing scroll-to-bottom

## Technical Details
The fix addresses three key issues identified by Codex review:
1. **Stale scroll state**: Now stores `wasAtBottom` alongside `latestCols/Rows` so deferred resize callbacks use current state, not outdated captures
2. **Forced scroll on flush**: `flushResize` now respects stored scroll position instead of defaulting to scroll-to-bottom
3. **Unconditional background snap**: Background snap now only triggers if user was already at bottom, preserving manual scroll position when viewing history

All changes validated with TypeScript type checking and ESLint (93 warnings, 0 errors - warnings are pre-existing).