### PR TITLE
Improve sidebar UX with CSS variable and double-click resize

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,11 +163,11 @@ function SidebarContent() {
   return (
     <div className="flex flex-col h-full">
       {/* Header Section */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 bg-[#18181b] shrink-0">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-canopy-border bg-canopy-sidebar shrink-0">
         <h2 className="text-canopy-text font-semibold text-sm tracking-wide">Worktrees</h2>
         <button
           onClick={() => setIsNewWorktreeDialogOpen(true)}
-          className="flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 text-canopy-text/60 hover:text-canopy-text hover:bg-white/5 rounded transition-colors"
+          className="flex items-center gap-1.5 text-xs font-medium px-2.5 py-1 text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/50 rounded transition-colors"
           title="Create new worktree"
         >
           <span className="text-[10px]">+</span> New

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -22,9 +22,9 @@ interface AppLayoutProps {
   agentSettings?: AgentSettings | null;
 }
 
-const MIN_SIDEBAR_WIDTH = 200;
-const MAX_SIDEBAR_WIDTH = 600;
-const DEFAULT_SIDEBAR_WIDTH = 350;
+export const MIN_SIDEBAR_WIDTH = 200;
+export const MAX_SIDEBAR_WIDTH = 600;
+export const DEFAULT_SIDEBAR_WIDTH = 350;
 
 export function AppLayout({
   children,

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   QuickRun,
 } from "@/components/Project";
 import { useProjectStore } from "@/store/projectStore";
+import { DEFAULT_SIDEBAR_WIDTH } from "./AppLayout";
 
 interface SidebarProps {
   width: number;
@@ -45,6 +46,10 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
     },
     [width, onResize]
   );
+
+  const handleResetWidth = useCallback(() => {
+    onResize(DEFAULT_SIDEBAR_WIDTH);
+  }, [onResize]);
 
   const resize = useCallback(
     (e: MouseEvent) => {
@@ -119,6 +124,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           )}
           onMouseDown={startResizing}
           onKeyDown={handleKeyDown}
+          onDoubleClick={handleResetWidth}
         >
           <div
             className={cn(


### PR DESCRIPTION
## Summary
Replace hardcoded color values with CSS variables in the sidebar header and add double-click functionality to the resize handle for quickly resetting to default width.

Closes #859

## Changes Made
- Replace hardcoded `bg-[#18181b]` with `bg-canopy-sidebar` in sidebar header
- Replace `border-white/5` with `border-canopy-border` for consistency
- Replace `hover:bg-white/5` with `hover:bg-canopy-border/50` in New button
- Add double-click handler to sidebar resize handle to reset to default width (350px)
- Export sidebar width constants from AppLayout for shared use
- Import `DEFAULT_SIDEBAR_WIDTH` in Sidebar to avoid duplication