### PR TITLE
Add copy URL button to Sidecar navigation toolbar

### DIFF
--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -245,6 +245,16 @@ export function SidecarDock() {
     }
   }, [activeTabId, tabs]);
 
+  const handleCopyUrl = useCallback(async () => {
+    const activeTab = tabs.find((t) => t.id === activeTabId);
+    if (!activeTab?.url) return;
+    try {
+      await navigator.clipboard.writeText(activeTab.url);
+    } catch (error) {
+      console.error("Failed to copy URL:", error);
+    }
+  }, [activeTabId, tabs]);
+
   const RESIZE_STEP = 10;
 
   const handleResizeStart = useCallback(
@@ -339,6 +349,7 @@ export function SidecarDock() {
         onGoForward={handleGoForward}
         onReload={handleReload}
         onOpenExternal={handleOpenExternal}
+        onCopyUrl={handleCopyUrl}
         hasActiveUrl={hasActiveUrl}
       />
       {showLaunchpad ? (

--- a/src/components/Sidecar/SidecarToolbar.tsx
+++ b/src/components/Sidecar/SidecarToolbar.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { ArrowLeft, ArrowRight, RotateCw, X, Plus, ExternalLink } from "lucide-react";
+import { ArrowLeft, ArrowRight, RotateCw, X, Plus, ExternalLink, Link2 } from "lucide-react";
 import {
   DndContext,
   closestCorners,
@@ -103,6 +103,7 @@ interface SidecarToolbarProps {
   onGoForward?: () => void;
   onReload?: () => void;
   onOpenExternal?: () => void;
+  onCopyUrl?: () => void;
   hasActiveUrl?: boolean;
 }
 
@@ -117,6 +118,7 @@ export function SidecarToolbar({
   onGoForward,
   onReload,
   onOpenExternal,
+  onCopyUrl,
   hasActiveUrl = false,
 }: SidecarToolbarProps) {
   const reorderTabs = useSidecarStore((s) => s.reorderTabs);
@@ -166,6 +168,15 @@ export function SidecarToolbar({
             title="Reload"
           >
             <RotateCw className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={onCopyUrl}
+            disabled={!activeTabId || !hasActiveUrl}
+            aria-label="Copy URL"
+            className="p-1 rounded hover:bg-canopy-border text-muted-foreground hover:text-canopy-text transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Copy URL"
+          >
+            <Link2 className="w-3.5 h-3.5" />
           </button>
           <button
             onClick={onOpenExternal}


### PR DESCRIPTION
## Summary
Adds a copy URL button to the Sidecar navigation toolbar, allowing users to quickly copy the current tab's URL to the clipboard with a single click.

Closes #861

## Changes Made
- Import Link2 icon from lucide-react
- Add onCopyUrl prop to SidecarToolbarProps interface
- Add copy URL button between reload and external browser buttons
- Create handleCopyUrl callback using navigator.clipboard.writeText()
- Wire up handler to toolbar component
- Button disabled when no active tab or no URL present

## Implementation Details
- Button positioned between "Reload" and "Open in external browser" buttons as specified
- Uses same disabled state logic as external browser button (!activeTabId || !hasActiveUrl)
- Error handling with try/catch and console logging (consistent with existing clipboard operations)
- Follows existing codebase patterns for clipboard operations