### PR TITLE
Fix terminal viewport jumps in TUI applications with smart sticky scrolling

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -200,6 +200,11 @@ function TerminalPaneComponent({
     }
   }, [isFocused, id]);
 
+  // Sync agent state to terminal service for scroll management
+  useEffect(() => {
+    terminalInstanceService.setAgentState(id, agentState ?? "idle");
+  }, [id, agentState]);
+
   const isWorking = agentState === "working";
 
   return (


### PR DESCRIPTION
## Summary
Implements smart sticky scrolling to fix terminal viewport instability when using TUI applications (Claude Code, Vim). The viewport now correctly maintains position at the bottom during active agent output while respecting user scroll intent when they manually review history.

Closes #864

## Changes Made
- Add state tracking for agent state and user scroll intent (persistent flags instead of timeout)
- Implement shouldSnapToBottom logic with three cases:
  - TUI mode (alternate buffer): always snap to cursor/bottom
  - Working agent: snap unless user scrolled up
  - Standard terminal: only snap if already at bottom
- Track user scroll with suppressScrollEvents flag to filter out system-triggered scrolls
- Apply scroll on data writes, resize operations, and visibility changes
- Sync React agent state to terminal service via useEffect
- Recalculate scroll decisions at execution time to avoid stale state issues
- Add visibility check in tab switch handler to prevent race conditions
- Use persistent userScrolledUp flag that only clears when user returns to bottom