### PR TITLE
Make issue/PR numbers copyable and titles clickable

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -507,9 +507,7 @@ export function WorktreeCard({
                   isMainWorktree={isMainWorktree}
                 />
                 {!worktree.branch && (
-                  <span className="text-amber-500 text-xs font-medium shrink-0">
-                    (detached)
-                  </span>
+                  <span className="text-amber-500 text-xs font-medium shrink-0">(detached)</span>
                 )}
               </div>
 

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -187,9 +187,7 @@ export function WorktreeDetails({
       {/* Dev Server Controls */}
       {showDevServer && serverState && (
         <div className="space-y-2">
-          <div className="text-xs text-canopy-text/60 font-medium">
-            Dev Server
-          </div>
+          <div className="text-xs text-canopy-text/60 font-medium">Dev Server</div>
           <div className="flex items-center gap-3">
             <button
               onClick={(e) => {
@@ -330,9 +328,7 @@ export function WorktreeDetails({
       {/* Block 3: Artifacts (grouped file changes + system path) */}
       {hasChanges && worktree.worktreeChanges && (
         <div className="space-y-2">
-          <div className="text-xs text-canopy-text/60 font-medium">
-            Changed Files
-          </div>
+          <div className="text-xs text-canopy-text/60 font-medium">Changed Files</div>
           <FileChangeList
             changes={worktree.worktreeChanges.changes}
             rootPath={worktree.worktreeChanges.rootPath}

--- a/src/index.css
+++ b/src/index.css
@@ -422,7 +422,6 @@ body,
     0 2px 8px -2px rgba(0, 0, 0, 0.4);
 }
 
-
 /* Terminal Header Ping Animation - emerald sweep for visual feedback
  * A subtle "radar scan" effect that passes across the header to indicate
  * "Canopy just brought you to this terminal" without harsh white flashes.


### PR DESCRIPTION
## Summary
Improves the UX for issue and PR list items by making the numbers copyable and the titles directly clickable to open GitHub. This eliminates the need for the separate "Open in GitHub" button and provides quick access to copy just the number for workflow integration.

Closes #871

## Changes Made
- Replace plain text title with clickable button that opens GitHub
- Replace plain text number with clickable button that copies to clipboard
- Add visual feedback for copy action (checkmark for success, red for error)
- Remove separate "Open in GitHub" button (now redundant)
- Add proper timeout cleanup to prevent memory leaks
- Add clipboard availability check and error handling
- Improve accessibility with type="button", focus rings, and aria-labels
- Add screen reader support with aria-live region for copy status