### PR TITLE
Fix stale badge counts in Issue/PR dropdowns

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -14,7 +14,8 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
   const handleGitHubGetRepoStats = async (
     _event: Electron.IpcMainInvokeEvent,
-    cwd: string
+    cwd: string,
+    bypassCache = false
   ): Promise<RepositoryStats> => {
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
@@ -38,7 +39,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         };
       }
 
-      const statsResult = await getRepoStats(resolved);
+      const statsResult = await getRepoStats(resolved, bypassCache);
 
       const commitCount = await getCommitCount(resolved).catch(() => 0);
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -604,7 +604,8 @@ const api: ElectronAPI = {
 
   // GitHub API
   github: {
-    getRepoStats: (cwd: string) => _typedInvoke(CHANNELS.GITHUB_GET_REPO_STATS, cwd),
+    getRepoStats: (cwd: string, bypassCache?: boolean) =>
+      _typedInvoke(CHANNELS.GITHUB_GET_REPO_STATS, cwd, bypassCache),
 
     openIssues: (cwd: string) => _typedInvoke(CHANNELS.GITHUB_OPEN_ISSUES, cwd),
 

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -92,7 +92,7 @@ export async function getRepoContext(cwd: string): Promise<RepoContext | null> {
   }
 }
 
-export async function getRepoStats(cwd: string): Promise<RepoStatsResult> {
+export async function getRepoStats(cwd: string, bypassCache = false): Promise<RepoStatsResult> {
   const client = GitHubAuth.createClient();
   if (!client) {
     return { stats: null, error: "GitHub token not configured" };
@@ -104,9 +104,12 @@ export async function getRepoStats(cwd: string): Promise<RepoStatsResult> {
   }
 
   const cacheKey = `${context.owner}/${context.repo}`;
-  const cached = repoStatsCache.get(cacheKey);
-  if (cached) {
-    return { stats: cached };
+
+  if (!bypassCache) {
+    const cached = repoStatsCache.get(cacheKey);
+    if (cached) {
+      return { stats: cached };
+    }
   }
 
   try {

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1175,7 +1175,7 @@ export interface IpcInvokeMap {
 
   // GitHub channels
   "github:get-repo-stats": {
-    args: [cwd: string];
+    args: [cwd: string, bypassCache?: boolean];
     result: RepositoryStats;
   };
   "github:open-issues": {
@@ -1597,7 +1597,7 @@ export interface ElectronAPI {
     reset(agentType?: "claude" | "gemini" | "codex"): Promise<AgentSettings>;
   };
   github: {
-    getRepoStats(cwd: string): Promise<RepositoryStats>;
+    getRepoStats(cwd: string, bypassCache?: boolean): Promise<RepositoryStats>;
     openIssues(cwd: string): Promise<void>;
     openPRs(cwd: string): Promise<void>;
     openIssue(cwd: string, issueNumber: number): Promise<void>;

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -14,8 +14,8 @@ import type {
 } from "@shared/types/github";
 
 export const githubClient = {
-  getRepoStats: (cwd: string): Promise<RepositoryStats> => {
-    return window.electron.github.getRepoStats(cwd);
+  getRepoStats: (cwd: string, bypassCache = false): Promise<RepositoryStats> => {
+    return window.electron.github.getRepoStats(cwd, bypassCache);
   },
 
   openIssues: (cwd: string): Promise<void> => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -160,9 +160,12 @@ export function Toolbar({
                 variant="ghost"
                 size="sm"
                 onClick={() => {
-                  if (statsError) refreshStats();
                   setPrsOpen(false);
-                  setIssuesOpen((prev) => !prev);
+                  const willOpen = !issuesOpen;
+                  setIssuesOpen(willOpen);
+                  if (willOpen) {
+                    refreshStats({ force: true });
+                  }
                 }}
                 className={cn(
                   "text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-7 px-2 gap-1.5",
@@ -200,9 +203,12 @@ export function Toolbar({
                 variant="ghost"
                 size="sm"
                 onClick={() => {
-                  if (statsError) refreshStats();
                   setIssuesOpen(false);
-                  setPrsOpen((prev) => !prev);
+                  const willOpen = !prsOpen;
+                  setPrsOpen(willOpen);
+                  if (willOpen) {
+                    refreshStats({ force: true });
+                  }
                 }}
                 className={cn(
                   "text-canopy-text hover:bg-canopy-border hover:text-canopy-accent h-7 px-2 gap-1.5",

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -507,9 +507,7 @@ export function WorktreeCard({
                   isMainWorktree={isMainWorktree}
                 />
                 {!worktree.branch && (
-                  <span className="text-amber-500 text-xs font-medium shrink-0">
-                    (detached)
-                  </span>
+                  <span className="text-amber-500 text-xs font-medium shrink-0">(detached)</span>
                 )}
               </div>
 

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -187,9 +187,7 @@ export function WorktreeDetails({
       {/* Dev Server Controls */}
       {showDevServer && serverState && (
         <div className="space-y-2">
-          <div className="text-xs text-canopy-text/60 font-medium">
-            Dev Server
-          </div>
+          <div className="text-xs text-canopy-text/60 font-medium">Dev Server</div>
           <div className="flex items-center gap-3">
             <button
               onClick={(e) => {
@@ -330,9 +328,7 @@ export function WorktreeDetails({
       {/* Block 3: Artifacts (grouped file changes + system path) */}
       {hasChanges && worktree.worktreeChanges && (
         <div className="space-y-2">
-          <div className="text-xs text-canopy-text/60 font-medium">
-            Changed Files
-          </div>
+          <div className="text-xs text-canopy-text/60 font-medium">Changed Files</div>
           <FileChangeList
             changes={worktree.worktreeChanges.changes}
             rootPath={worktree.worktreeChanges.rootPath}

--- a/src/index.css
+++ b/src/index.css
@@ -422,7 +422,6 @@ body,
     0 2px 8px -2px rgba(0, 0, 0, 0.4);
 }
 
-
 /* Terminal Header Ping Animation - emerald sweep for visual feedback
  * A subtle "radar scan" effect that passes across the header to indicate
  * "Canopy just brought you to this terminal" without harsh white flashes.


### PR DESCRIPTION
## Summary
Fixes the issue where Issue and PR badge counts display stale cached data while the dropdowns show fresh data. When users click to open a dropdown, the badge now refreshes with the latest GitHub data.

Closes #870

## Changes Made
- Added bypassCache parameter throughout the IPC stack (GitHubService → IPC Handler → Preload → Client → Hook)
- Updated useRepositoryStats to reschedule polling after manual refresh (prevents polling from stopping permanently)
- Modified Toolbar onClick handlers to refresh stats only when opening dropdowns (not on close)
- Configured force refresh (cache bypass) on user-triggered dropdown opens
- Fixed preload layer to properly forward bypassCache parameter to IPC handler
- Updated all IPC type signatures to support the cache bypass parameter

## Technical Details
The root cause was a three-part issue:
1. Manual refresh stopped background polling permanently
2. The 60s cache TTL blocked fresh data even on manual refresh
3. Stats refreshed on both open and close (unnecessary API calls)

This PR addresses all three issues by:
1. Rescheduling the poll timer after manual refresh completes
2. Adding a bypassCache flag that skips the cache when users explicitly open dropdowns
3. Only triggering refresh when the dropdown is opened (willOpen check)