### PR TITLE
feat(github): optimize skeleton loading with smart count-based rendering

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -196,6 +196,7 @@ export function Toolbar({
                   type="issue"
                   projectPath={currentProject.path}
                   onClose={() => setIssuesOpen(false)}
+                  initialCount={stats.issueCount}
                 />
               </FixedDropdown>
 
@@ -239,6 +240,7 @@ export function Toolbar({
                   type="pr"
                   projectPath={currentProject.path}
                   onClose={() => setPrsOpen(false)}
+                  initialCount={stats.prCount}
                 />
               </FixedDropdown>
 


### PR DESCRIPTION
## Summary
This PR optimizes the loading experience for GitHub issue and PR dropdowns by using pre-fetched repository stats to show the exact number of skeleton items or immediately display the empty state when appropriate.

Closes #887

## Changes Made
- Add `initialCount` prop to `GitHubResourceList` for pre-fetched stats
- Implement dynamic skeleton rendering (0-6 items) based on actual count
- Show empty state immediately when count is 0 (eliminates skeleton flash)
- Guard against NaN/non-finite counts with `Number.isFinite` check
- Match skeleton structure to `GitHubListItem` DOM hierarchy exactly
- Set exact 64px height with `box-border` to prevent layout shift
- Add `ITEM_HEIGHT_PX` and `MAX_SKELETON_ITEMS` constants
- Pass `stats.issueCount` and `stats.prCount` from Toolbar to dropdowns

## Key Benefits
- Zero layout shift: Skeleton height matches real items exactly
- No unnecessary loading states: Empty state shows immediately when count is 0
- Better user experience: Skeleton count matches reality (1-6 items)
- Robust: Handles edge cases (NaN, null, undefined, negative numbers)