### PR TITLE
Improve terminal restart failure handling with validation and error feedback

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -64,6 +64,7 @@ export const CHANNELS = {
   SYSTEM_OPEN_EXTERNAL: "system:open-external",
   SYSTEM_OPEN_PATH: "system:open-path",
   SYSTEM_CHECK_COMMAND: "system:check-command",
+  SYSTEM_CHECK_DIRECTORY: "system:check-directory",
   SYSTEM_GET_HOME_DIR: "system:get-home-dir",
   SYSTEM_GET_CLI_AVAILABILITY: "system:get-cli-availability",
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",

--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -80,6 +80,31 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
   ipcMain.handle(CHANNELS.SYSTEM_CHECK_COMMAND, handleSystemCheckCommand);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_CHECK_COMMAND));
 
+  const handleSystemCheckDirectory = async (
+    _event: Electron.IpcMainInvokeEvent,
+    directoryPath: string
+  ): Promise<boolean> => {
+    if (typeof directoryPath !== "string" || !directoryPath.trim()) {
+      return false;
+    }
+
+    const path = await import("path");
+    if (!path.isAbsolute(directoryPath)) {
+      console.warn(`Directory path "${directoryPath}" is not absolute, rejecting`);
+      return false;
+    }
+
+    try {
+      const fs = await import("fs");
+      const stats = await fs.promises.stat(directoryPath);
+      return stats.isDirectory();
+    } catch {
+      return false;
+    }
+  };
+  ipcMain.handle(CHANNELS.SYSTEM_CHECK_DIRECTORY, handleSystemCheckDirectory);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_CHECK_DIRECTORY));
+
   const handleSystemGetHomeDir = async () => {
     return os.homedir();
   };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -153,6 +153,7 @@ const CHANNELS = {
   SYSTEM_OPEN_EXTERNAL: "system:open-external",
   SYSTEM_OPEN_PATH: "system:open-path",
   SYSTEM_CHECK_COMMAND: "system:check-command",
+  SYSTEM_CHECK_DIRECTORY: "system:check-directory",
   SYSTEM_GET_HOME_DIR: "system:get-home-dir",
   SYSTEM_GET_CLI_AVAILABILITY: "system:get-cli-availability",
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",
@@ -480,6 +481,8 @@ const api: ElectronAPI = {
     openPath: (path: string) => _typedInvoke(CHANNELS.SYSTEM_OPEN_PATH, { path }),
 
     checkCommand: (command: string) => _typedInvoke(CHANNELS.SYSTEM_CHECK_COMMAND, command),
+
+    checkDirectory: (path: string) => _typedInvoke(CHANNELS.SYSTEM_CHECK_DIRECTORY, path),
 
     getHomeDir: () => _typedInvoke(CHANNELS.SYSTEM_GET_HOME_DIR),
 

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -241,6 +241,27 @@ export enum TerminalRefreshTier {
   BACKGROUND = 1000, // 1fps
 }
 
+/** Structured error state for terminal restart failures */
+export interface TerminalRestartError {
+  /** Human-readable error message */
+  message: string;
+  /** Error code (e.g., ENOENT, EPERM, EACCES) */
+  code?: string;
+  /** Timestamp when error occurred (milliseconds since epoch) */
+  timestamp: number;
+  /** Whether this error can be fixed by user action (e.g., changing CWD) */
+  recoverable: boolean;
+  /** Additional context for debugging */
+  context?: {
+    /** The CWD that failed */
+    failedCwd?: string;
+    /** The command that failed */
+    command?: string;
+    /** Any additional metadata */
+    [key: string]: unknown;
+  };
+}
+
 /** Represents a terminal instance in the application */
 export interface TerminalInstance {
   /** Unique identifier for this terminal */
@@ -287,6 +308,8 @@ export interface TerminalInstance {
   restartKey?: number;
   /** Guard flag to prevent auto-trash during restart flow (exit event race condition) */
   isRestarting?: boolean;
+  /** Restart failure error - set when restart fails, cleared on success or manual action */
+  restartError?: TerminalRestartError;
 }
 
 /** Options for spawning a new PTY process */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -36,6 +36,7 @@ export type {
   TerminalType,
   TerminalLocation,
   AgentStateChangeTrigger,
+  TerminalRestartError,
   TerminalInstance,
   PtySpawnOptions,
   TerminalDimensions,

--- a/shared/types/ipc.ts
+++ b/shared/types/ipc.ts
@@ -1038,6 +1038,10 @@ export interface IpcInvokeMap {
     args: [command: string];
     result: boolean;
   };
+  "system:check-directory": {
+    args: [path: string];
+    result: boolean;
+  };
   "system:get-home-dir": {
     args: [];
     result: string;
@@ -1541,6 +1545,7 @@ export interface ElectronAPI {
     openExternal(url: string): Promise<void>;
     openPath(path: string): Promise<void>;
     checkCommand(command: string): Promise<boolean>;
+    checkDirectory(path: string): Promise<boolean>;
     getHomeDir(): Promise<string>;
     getCliAvailability(): Promise<CliAvailability>;
     refreshCliAvailability(): Promise<CliAvailability>;

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -20,6 +20,10 @@ export const systemClient = {
     return window.electron.system.checkCommand(command);
   },
 
+  checkDirectory: (path: string): Promise<boolean> => {
+    return window.electron.system.checkDirectory(path);
+  },
+
   getHomeDir: (): Promise<string> => {
     return window.electron.system.getHomeDir();
   },

--- a/src/components/Terminal/DockedTerminalPane.tsx
+++ b/src/components/Terminal/DockedTerminalPane.tsx
@@ -97,6 +97,7 @@ export function DockedTerminalPane({ terminal, onPopoverClose }: DockedTerminalP
       }
       location="dock"
       restartKey={terminal.restartKey}
+      restartError={terminal.restartError}
       onFocus={handleFocus}
       onClose={handleClose}
       onRestore={handleRestore}

--- a/src/components/Terminal/GridTerminalPane.tsx
+++ b/src/components/Terminal/GridTerminalPane.tsx
@@ -106,6 +106,7 @@ export function GridTerminalPane({
         }
         location="grid"
         restartKey={terminal.restartKey}
+        restartError={terminal.restartError}
         onFocus={handleFocus}
         onClose={handleClose}
         onToggleMaximize={handleToggleMaximize}

--- a/src/components/Terminal/TerminalErrorBanner.tsx
+++ b/src/components/Terminal/TerminalErrorBanner.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { AlertTriangle, RotateCcw, FolderEdit, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TerminalRestartError } from "@/types";
+
+export interface TerminalErrorBannerProps {
+  terminalId: string;
+  error: TerminalRestartError;
+  onUpdateCwd: (id: string) => void;
+  onRetry: (id: string) => void;
+  onTrash: (id: string) => void;
+  className?: string;
+}
+
+function TerminalErrorBannerComponent({
+  terminalId,
+  error,
+  onUpdateCwd,
+  onRetry,
+  onTrash,
+  className,
+}: TerminalErrorBannerProps) {
+  const isCwdError = error.code === "ENOENT" && error.context?.failedCwd;
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 px-3 py-2 shrink-0",
+        "bg-[color-mix(in_oklab,var(--color-status-error)_10%,transparent)]",
+        "border-b border-[var(--color-status-error)]/20",
+        className
+      )}
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle
+          className="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-status-error)]"
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <span className="text-sm font-medium text-[var(--color-status-error)]">
+            Terminal Restart Failed
+          </span>
+          <p className="text-xs text-[var(--color-status-error)]/80 mt-0.5">{error.message}</p>
+          {error.context?.failedCwd && (
+            <p className="text-xs font-mono text-[var(--color-status-error)]/60 mt-1 truncate">
+              Directory: {error.context.failedCwd}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 ml-6">
+        {error.recoverable && isCwdError && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUpdateCwd(terminalId);
+            }}
+            className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium bg-canopy-accent/10 text-canopy-accent hover:bg-canopy-accent/20 rounded transition-colors"
+            title="Update Working Directory"
+            aria-label="Update working directory"
+          >
+            <FolderEdit className="w-3 h-3" aria-hidden="true" />
+            Update Directory
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRetry(terminalId);
+          }}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium bg-canopy-border text-canopy-text hover:bg-canopy-border/80 rounded transition-colors"
+          title="Retry Restart"
+          aria-label="Retry restart"
+        >
+          <RotateCcw className="w-3 h-3" aria-hidden="true" />
+          Retry
+        </button>
+
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onTrash(terminalId);
+          }}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-[var(--color-status-error)]/70 hover:text-[var(--color-status-error)] hover:bg-[var(--color-status-error)]/10 rounded transition-colors"
+          title="Move to Trash"
+          aria-label="Move to trash"
+        >
+          <Trash2 className="w-3 h-3" aria-hidden="true" />
+          Trash
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const TerminalErrorBanner = React.memo(TerminalErrorBannerComponent);

--- a/src/components/Terminal/UpdateCwdDialog.tsx
+++ b/src/components/Terminal/UpdateCwdDialog.tsx
@@ -1,0 +1,145 @@
+import { useState, useCallback, useEffect, useRef } from "react";
+import type { KeyboardEvent } from "react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { Button } from "@/components/ui/button";
+import { FolderOpen, AlertCircle } from "lucide-react";
+import { systemClient } from "@/clients/systemClient";
+import { useTerminalStore } from "@/store/terminalStore";
+
+interface UpdateCwdDialogProps {
+  isOpen: boolean;
+  terminalId: string;
+  currentCwd: string;
+  onClose: () => void;
+}
+
+export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: UpdateCwdDialogProps) {
+  const [newCwd, setNewCwd] = useState(currentCwd);
+  const [validating, setValidating] = useState(false);
+  const [validationError, setValidationError] = useState<string>();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const updateTerminalCwd = useTerminalStore((state) => state.updateTerminalCwd);
+  const restartTerminal = useTerminalStore((state) => state.restartTerminal);
+
+  useEffect(() => {
+    if (isOpen) {
+      setNewCwd(currentCwd);
+      setValidationError(undefined);
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    }
+  }, [isOpen, currentCwd]);
+
+  const handleUpdate = useCallback(async () => {
+    if (!newCwd.trim()) {
+      setValidationError("Directory path is required");
+      return;
+    }
+
+    setValidating(true);
+    setValidationError(undefined);
+
+    try {
+      const exists = await systemClient.checkDirectory(newCwd);
+      if (!exists) {
+        setValidationError("Directory does not exist");
+        return;
+      }
+
+      updateTerminalCwd(terminalId, newCwd);
+      await restartTerminal(terminalId);
+
+      onClose();
+    } catch (error) {
+      setValidationError("Could not restart terminal. Please try again.");
+      console.error("Failed to update CWD and restart:", error);
+    } finally {
+      setValidating(false);
+    }
+  }, [terminalId, newCwd, updateTerminalCwd, restartTerminal, onClose]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && !validating) {
+        e.preventDefault();
+        handleUpdate();
+      }
+    },
+    [handleUpdate, validating]
+  );
+
+  return (
+    <AppDialog isOpen={isOpen} onClose={onClose} size="md">
+      <AppDialog.Header>
+        <AppDialog.Title icon={<FolderOpen className="w-5 h-5 text-canopy-accent" />}>
+          Update Working Directory
+        </AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <AppDialog.Body>
+        <AppDialog.Description className="mb-4">
+          The current working directory no longer exists. Choose a new directory to restart this
+          terminal.
+        </AppDialog.Description>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-canopy-text/70 mb-1">
+              Current (invalid):
+            </label>
+            <code className="block p-2 bg-[color-mix(in_oklab,var(--color-status-error)_10%,transparent)] border border-[var(--color-status-error)]/30 rounded text-sm text-[var(--color-status-error)] font-mono truncate">
+              {currentCwd}
+            </code>
+          </div>
+
+          <div>
+            <label
+              htmlFor="new-cwd-input"
+              className="block text-sm font-medium text-canopy-text/70 mb-1"
+            >
+              New Directory:
+            </label>
+            <input
+              ref={inputRef}
+              id="new-cwd-input"
+              type="text"
+              value={newCwd}
+              onChange={(e) => {
+                setNewCwd(e.target.value);
+                setValidationError(undefined);
+              }}
+              onKeyDown={handleKeyDown}
+              className="w-full p-2 bg-canopy-bg border border-canopy-border rounded font-mono text-sm text-canopy-text focus:outline-none focus:border-canopy-accent"
+              placeholder="/path/to/directory"
+              aria-invalid={!!validationError}
+              aria-describedby={validationError ? "cwd-error" : undefined}
+            />
+            {validationError && (
+              <div
+                id="cwd-error"
+                className="flex items-center gap-1 mt-1.5 text-sm text-[var(--color-status-error)]"
+                role="alert"
+              >
+                <AlertCircle className="w-3.5 h-3.5" aria-hidden="true" />
+                {validationError}
+              </div>
+            )}
+          </div>
+        </div>
+      </AppDialog.Body>
+
+      <AppDialog.Footer>
+        <Button variant="subtle" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={handleUpdate} disabled={validating}>
+          {validating ? "Updating..." : "Update & Restart"}
+        </Button>
+      </AppDialog.Footer>
+    </AppDialog>
+  );
+}

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -24,4 +24,5 @@ export {
 export {
   createTerminalBulkActionsSlice,
   type TerminalBulkActionsSlice,
+  type BulkRestartValidation,
 } from "./terminalBulkActionsSlice";

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -1,0 +1,63 @@
+import type { TerminalInstance } from "@/types";
+import { systemClient } from "@/clients/systemClient";
+
+export interface ValidationError {
+  type: "cwd" | "cli" | "config";
+  message: string;
+  code?: string;
+  recoverable: boolean;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+export async function validateTerminalConfig(
+  terminal: TerminalInstance
+): Promise<ValidationResult> {
+  const errors: ValidationError[] = [];
+
+  const cwdExists = await systemClient.checkDirectory(terminal.cwd);
+  if (!cwdExists) {
+    errors.push({
+      type: "cwd",
+      message: `Working directory does not exist: ${terminal.cwd}`,
+      code: "ENOENT",
+      recoverable: true,
+    });
+  }
+
+  if (["claude", "gemini", "codex"].includes(terminal.type)) {
+    const cliAvailable = await systemClient.checkCommand(terminal.type);
+    if (!cliAvailable) {
+      errors.push({
+        type: "cli",
+        message: `${terminal.type} CLI not found in PATH`,
+        recoverable: false,
+      });
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export async function validateTerminals(
+  terminals: TerminalInstance[]
+): Promise<Map<string, ValidationResult>> {
+  const results = new Map<string, ValidationResult>();
+
+  await Promise.all(
+    terminals.map(async (terminal) => {
+      const result = await validateTerminalConfig(terminal);
+      if (!result.valid) {
+        results.set(terminal.id, result);
+      }
+    })
+  );
+
+  return results;
+}


### PR DESCRIPTION
## Summary

Improves terminal restart failure handling by validating configuration before restart attempts and providing clear error feedback with recovery options instead of silently trashing terminals.

Closes #886

## Changes Made

- Add TerminalRestartError type with structured error state
- Add pre-restart validation for CWD and CLI availability  
- Set error state instead of trashing terminals on restart failure
- Add TerminalErrorBanner component with recovery actions
- Add UpdateCwdDialog for fixing invalid working directory
- Add system:check-directory IPC with absolute path validation
- Add preflight validation to bulk restart operations
- Prevent race conditions by re-reading state after async operations
- Include attempted command in error context for debugging
- Add proper error handling and accessibility to UI components

## Test Plan

1. Restart a terminal with an invalid CWD - error banner appears with "Update Directory" option
2. Use "Update Directory" dialog to fix CWD and restart successfully
3. Restart a terminal with missing CLI - error banner shows non-recoverable error
4. Use "Restart All Terminals" with some invalid terminals - preflight check warns about issues
5. Verify accessibility with keyboard navigation and screen readers