### PR TITLE
Fix Escape key closing docked terminal instead of sending to terminal process

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -217,6 +217,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         align="start"
         sideOffset={8}
         collisionPadding={collisionPadding}
+        onEscapeKeyDown={(e) => e.preventDefault()}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           // Small delay to ensure xterm is fully mounted before focusing


### PR DESCRIPTION
## Summary
Fixes the docked terminal popover behavior where pressing Escape would close the popover instead of sending the Esc key to the terminal process (xterm.js). This prevented users from using Esc for critical terminal operations like exiting vim, canceling commands, or clearing prompts.

Closes #890

## Changes Made
- Added `onEscapeKeyDown` handler to PopoverContent in DockedTerminalItem
- Prevents default Esc close behavior while allowing event propagation to xterm.js
- Enables terminal operations like exiting vim, canceling commands, etc.
- Click-outside behavior remains unchanged for closing the popover

## Technical Details
The fix uses Radix UI's `onEscapeKeyDown` event handler with `e.preventDefault()` to intercept and prevent the default close action while still allowing the event to propagate to the terminal. Users can still close docked terminals by clicking outside the popover (existing blur behavior).