### PR TITLE
Remove legacy init-buffer handler from pty-host

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -426,16 +426,6 @@ port.on("message", (rawMsg: any) => {
         }
         break;
 
-      case "init-buffer":
-        // Legacy: single buffer init (backwards compatibility)
-        if (msg.buffer instanceof SharedArrayBuffer) {
-          visualBuffer = new SharedRingBuffer(msg.buffer);
-          console.log("[PtyHost] Single SharedArrayBuffer ring buffer initialized (legacy)");
-        } else {
-          console.warn("[PtyHost] init-buffer received but buffer is not SharedArrayBuffer");
-        }
-        break;
-
       case "init-buffers":
         // Dual buffer init: visual + analysis
         if (msg.visualBuffer instanceof SharedArrayBuffer) {


### PR DESCRIPTION
## Summary
Removes the legacy `init-buffer` (singular) message handler from pty-host.ts as it's no longer used by PtyClient, which exclusively sends `init-buffers` (plural) with both visual and analysis buffers.

Closes #901

## Changes Made
- Remove unused init-buffer case from pty-host message handler
- PtyClient exclusively uses init-buffers (plural) since dual-buffer architecture
- Eliminates dead code path marked for backward compatibility