### PR TITLE
Replace emerald ping animation with professional console focus effect

### DIFF
--- a/src/components/Terminal/TerminalHeader.tsx
+++ b/src/components/Terminal/TerminalHeader.tsx
@@ -119,7 +119,7 @@ function TerminalHeaderComponent({
             : location === "dock"
               ? "bg-[var(--color-surface)]"
               : "bg-transparent",
-          isPinged && !isMaximized && "animate-ping-header"
+          isPinged && !isMaximized && "animate-bg-flash"
         )}
         onDoubleClick={handleHeaderDoubleClick}
       >
@@ -158,7 +158,8 @@ function TerminalHeaderComponent({
                 className={cn(
                   "text-xs font-medium select-none transition-colors",
                   isFocused ? "text-canopy-text" : "text-canopy-text/70",
-                  onTitleChange && "cursor-text hover:text-canopy-text"
+                  onTitleChange && "cursor-text hover:text-canopy-text",
+                  isPinged && !isMaximized && "animate-text-shimmer"
                 )}
                 onDoubleClick={onTitleDoubleClick}
                 onKeyDown={onTitleKeyDown}

--- a/src/index.css
+++ b/src/index.css
@@ -454,54 +454,54 @@ body,
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
 }
 
-/* Terminal Header Ping Animation - emerald sweep for visual feedback
- * A subtle "radar scan" effect that passes across the header to indicate
- * "Canopy just brought you to this terminal" without harsh white flashes.
- * Fits the "calm partner / mission control" brand voice.
- */
-@keyframes ping-sweep {
+/* Terminal Header Ping Animation - Professional Focus Flash */
+@keyframes bg-flash-fade {
   0% {
-    transform: translateX(-120%);
-    opacity: 0;
-  }
-  20% {
-    opacity: 0.5;
-  }
-  80% {
-    opacity: 0.3;
+    background-color: rgba(255, 255, 255, 0.15);
   }
   100% {
-    transform: translateX(120%);
-    opacity: 0;
+    background-color: transparent;
   }
 }
 
-.animate-ping-header {
-  /* Parent styling - keeps the slightly brighter background */
+.animate-bg-flash {
+  animation: bg-flash-fade 4000ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
-.animate-ping-header::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  will-change: transform, opacity;
+@keyframes text-shimmer-scroll {
+  0% {
+    background-position: 150% center;
+  }
+  100% {
+    background-position: -50% center;
+  }
+}
 
-  /* Emerald-tinted scan line using the Digital Ecology palette */
+.animate-text-shimmer {
   background: linear-gradient(
-    90deg,
-    transparent 0%,
-    color-mix(in oklch, var(--color-canopy-accent) 45%, transparent) 50%,
-    transparent 100%
+    120deg,
+    var(--color-canopy-text) 40%,
+    #ffffff 50%,
+    var(--color-canopy-text) 60%
   );
-
-  animation: ping-sweep 600ms ease-out;
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: text-shimmer-scroll 1.5s ease-out forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-ping-header::before {
+  .animate-bg-flash {
     animation: none;
-    opacity: 0;
+  }
+
+  .animate-text-shimmer {
+    animation: none;
+    background: none;
+    -webkit-text-fill-color: var(--color-canopy-text);
+    color: var(--color-canopy-text);
   }
 }
 

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -67,7 +67,7 @@ export const createTerminalFocusSlice =
             set({ pingedId: null });
           }
           pingTimeout = null;
-        }, 600);
+        }, 4000);
       },
 
       toggleMaximize: (id) =>


### PR DESCRIPTION
## Summary
Replaces the emerald sweep ping animation with a cleaner, more professional focus effect that combines a white background flash with a text shimmer on the terminal title. The new animation provides clear visual feedback when Canopy focuses a terminal without the emerald branding color dominating the UI.

Closes #902

## Changes Made
- Replace emerald sweep animation with white background flash (4s fade)
- Add text shimmer effect on terminal title during focus
- Update ping timeout from 600ms to 4000ms to match animation duration
- Fix reduced-motion accessibility to preserve header backgrounds
- Gate shimmer animation with !isMaximized for consistency with header flash

## Technical Details
- Background flash uses GPU-friendly background-color animation
- Text shimmer uses background-clip: text with gradient scroll
- Both animations respect prefers-reduced-motion settings
- Animations only apply when terminal is pinged and not maximized