### PR TITLE
Fix terminal selection from inactive worktree card

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -321,14 +321,22 @@ export function WorktreeCard({
 
   const handleTerminalSelect = useCallback(
     (terminal: TerminalInstance) => {
+      // Switch to this worktree if it isn't already active
+      if (!isActive) {
+        onSelect();
+      }
+
+      // Focus the terminal (Dock or Grid)
       if (terminal.location === "dock") {
         openDockTerminal(terminal.id);
       } else {
         setFocused(terminal.id);
       }
+
+      // Trigger the ping animation
       pingTerminal(terminal.id);
     },
-    [setFocused, pingTerminal, openDockTerminal]
+    [isActive, onSelect, setFocused, pingTerminal, openDockTerminal]
   );
 
   const handleCopyTree = useCallback(async () => {


### PR DESCRIPTION
## Summary
Fixes a bug where clicking on a terminal in an inactive worktree's activity dropdown would focus the terminal but not make it visible, since the terminal grid filters terminals based on the active worktree.

Closes #940

## Changes Made
- Add isActive check in handleTerminalSelect callback
- Call onSelect() to activate worktree when not already active
- Prevents terminal selection from being invisible due to grid filtering
- Update useCallback dependencies to include isActive and onSelect

## Testing
- Clicking terminal in inactive worktree card activates that worktree and shows terminal
- Clicking terminal in already-active worktree works as before
- Both grid and dock terminals behave correctly
- Ping animation plays in both scenarios