### PR TITLE
Fix: Codex/ChatGPT link not appearing in Sidecar

### DIFF
--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -29,11 +29,11 @@ export const LINK_TEMPLATES: Record<string, LinkTemplate> = {
     icon: "claude",
     cliDetector: "claude",
   },
-  chatgpt: {
+  codex: {
     title: "ChatGPT",
     url: "https://chatgpt.com/",
-    icon: "openai",
-    cliDetector: "openai",
+    icon: "codex",
+    cliDetector: "codex",
   },
   gemini: {
     title: "Gemini",

--- a/src/components/Settings/SidecarSettingsTab.tsx
+++ b/src/components/Settings/SidecarSettingsTab.tsx
@@ -3,9 +3,7 @@ import { RefreshCw, Plus, Trash2, Globe, Check, X, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSidecarStore } from "@/store/sidecarStore";
 import { useLinkDiscovery } from "@/hooks/useLinkDiscovery";
-import { CodexIcon } from "@/components/icons";
 import { LINK_TEMPLATES } from "@shared/types";
-import { getBrandColorHex } from "@/lib/colorUtils";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 
 function ServiceIcon({ name, size = 16 }: { name: string; size?: number }) {
@@ -17,10 +15,6 @@ function ServiceIcon({ name, size = 16 }: { name: string; size?: number }) {
   }
   if (name === "search") {
     return <Search className={className} />;
-  }
-  // Handle "openai" as codex icon (special mapping for sidecar)
-  if (name === "openai") {
-    return <CodexIcon className={className} brandColor={getBrandColorHex("codex")} />;
   }
 
   // Try to get agent config from registry
@@ -147,9 +141,7 @@ export function SidecarSettingsTab() {
         <h4 className="text-sm font-medium text-canopy-text mb-3">AI Services</h4>
         <div className="space-y-2">
           {knownServices.map(([key, template]) => {
-            const link = discoveredLinks.find(
-              (l) => l.id === `discovered-${key === "chatgpt" ? "chatgpt" : key}`
-            );
+            const link = discoveredLinks.find((l) => l.id === `discovered-${key}`);
             const isDetected = !!link;
 
             return (

--- a/src/components/Sidecar/SidecarIcon.tsx
+++ b/src/components/Sidecar/SidecarIcon.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { Globe, Search } from "lucide-react";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
-import { CodexIcon } from "@/components/icons";
-import { getBrandColorHex } from "@/lib/colorUtils";
 
 interface SidecarIconProps {
   icon: string;
@@ -26,11 +24,6 @@ export function SidecarIcon({ icon, size = "launchpad", url, type }: SidecarIcon
   // Handle special cases
   if (icon === "search") {
     return <Search className={iconClass} />;
-  }
-
-  // Handle "openai" as codex icon (special mapping for sidecar)
-  if (icon === "openai") {
-    return <CodexIcon className={iconClass} brandColor={getBrandColorHex("codex")} />;
   }
 
   // Try to get agent config from registry

--- a/src/components/Sidecar/__tests__/aiAgentDetection.test.ts
+++ b/src/components/Sidecar/__tests__/aiAgentDetection.test.ts
@@ -16,11 +16,11 @@ describe("getAIAgentInfo", () => {
   it("should detect ChatGPT URLs", () => {
     expect(getAIAgentInfo("https://chatgpt.com/")).toEqual({
       title: "ChatGPT",
-      icon: "openai",
+      icon: "codex",
     });
     expect(getAIAgentInfo("https://chatgpt.com/c/abc123")).toEqual({
       title: "ChatGPT",
-      icon: "openai",
+      icon: "codex",
     });
   });
 
@@ -62,7 +62,7 @@ describe("getAIAgentInfo", () => {
     });
     expect(getAIAgentInfo("https://www.chatgpt.com/")).toEqual({
       title: "ChatGPT",
-      icon: "openai",
+      icon: "codex",
     });
   });
 
@@ -84,7 +84,7 @@ describe("getAIAgentInfo", () => {
     });
     expect(getAIAgentInfo("https://ChatGPT.COM/")).toEqual({
       title: "ChatGPT",
-      icon: "openai",
+      icon: "codex",
     });
   });
 });

--- a/src/lib/aiAgentDetection.ts
+++ b/src/lib/aiAgentDetection.ts
@@ -7,7 +7,7 @@ export function getAIAgentInfo(url: string): { title: string; icon: string } | n
       return { title: "Claude", icon: "claude" };
     }
     if (hostname === "chatgpt.com" || hostname === "www.chatgpt.com") {
-      return { title: "ChatGPT", icon: "openai" };
+      return { title: "ChatGPT", icon: "codex" };
     }
     if (hostname === "gemini.google.com") {
       return { title: "Gemini", icon: "gemini" };


### PR DESCRIPTION
## Summary
Fixes the Codex/ChatGPT link not appearing in the Sidecar launchpad when Codex CLI is installed. The root cause was a key mismatch between the CLI availability system (which uses "codex") and the LINK_TEMPLATES definition (which used "chatgpt").

Closes #939

## Changes Made
- Update LINK_TEMPLATES key from "chatgpt" to "codex" in sidecar.ts
- Change icon and cliDetector properties from "openai" to "codex"
- Update aiAgentDetection to return "codex" icon for ChatGPT URLs
- Remove hardcoded "openai" special case checks in icon components
- Remove dead alias code in SidecarSettingsTab
- Update test expectations to use "codex" instead of "openai"

## Technical Details
The fix ensures consistent icon naming throughout the codebase:
- CLI discovery returns `codex` as the agent ID
- LINK_TEMPLATES now uses `codex` as the key (was `chatgpt`)
- Icon rendering falls through to `isRegisteredAgent("codex")` and uses `CodexIcon` from the agent registry
- All special-case "openai" checks have been removed in favor of unified agent registry lookup