### PR TITLE
Add branch prefix dropdown selector in New Worktree Dialog

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -326,6 +326,7 @@ function parseIssueNode(node: Record<string, unknown>): GitHubIssue {
   const author = node.author as { login?: string; avatarUrl?: string } | null;
   const assigneesData = node.assignees as { nodes?: Array<{ login?: string; avatarUrl?: string }> };
   const commentsData = node.comments as { totalCount?: number };
+  const labelsData = node.labels as { nodes?: Array<{ name?: string; color?: string }> };
 
   return {
     number: node.number as number,
@@ -342,6 +343,10 @@ function parseIssueNode(node: Record<string, unknown>): GitHubIssue {
       avatarUrl: a.avatarUrl ?? "",
     })),
     commentCount: commentsData?.totalCount ?? 0,
+    labels: (labelsData?.nodes ?? []).map((l) => ({
+      name: l.name ?? "",
+      color: l.color ?? "",
+    })),
   };
 }
 

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -36,6 +36,12 @@ export const LIST_ISSUES_QUERY = `
           comments {
             totalCount
           }
+          labels(first: 10) {
+            nodes {
+              name
+              color
+            }
+          }
         }
       }
     }
@@ -98,6 +104,12 @@ export const SEARCH_QUERY = `
           }
           comments {
             totalCount
+          }
+          labels(first: 10) {
+            nodes {
+              name
+              color
+            }
           }
         }
         ... on PullRequest {

--- a/shared/config/branchPrefixes.ts
+++ b/shared/config/branchPrefixes.ts
@@ -1,0 +1,79 @@
+export interface BranchTypeColors {
+  bg: string;
+  border: string;
+  text: string;
+}
+
+export interface BranchType {
+  id: string;
+  displayName: string;
+  prefix: string;
+  aliases: string[];
+  colors: BranchTypeColors;
+}
+
+const COLORS = {
+  teal: { bg: "bg-teal-500/10", border: "border-teal-500/30", text: "text-teal-400" },
+  red: { bg: "bg-red-500/10", border: "border-red-500/30", text: "text-red-400" },
+  gray: { bg: "bg-canopy-border/20", border: "border-canopy-border", text: "text-canopy-text/60" },
+  blue: { bg: "bg-blue-500/10", border: "border-blue-500/30", text: "text-blue-400" },
+  purple: { bg: "bg-purple-500/10", border: "border-purple-500/30", text: "text-purple-400" },
+  yellow: { bg: "bg-yellow-500/10", border: "border-yellow-500/30", text: "text-yellow-400" },
+  orange: { bg: "bg-orange-500/10", border: "border-orange-500/30", text: "text-orange-400" },
+} as const;
+
+export const DEFAULT_BRANCH_TYPE: BranchType = {
+  id: "other",
+  displayName: "Other",
+  prefix: "other",
+  aliases: [],
+  colors: COLORS.gray,
+};
+
+export const BRANCH_TYPES: BranchType[] = [
+  {
+    id: "feature",
+    displayName: "Feature",
+    prefix: "feature",
+    aliases: ["feat"],
+    colors: COLORS.teal,
+  },
+  {
+    id: "bugfix",
+    displayName: "Bugfix",
+    prefix: "bugfix",
+    aliases: ["fix", "hotfix"],
+    colors: COLORS.red,
+  },
+  { id: "chore", displayName: "Chore", prefix: "chore", aliases: [], colors: COLORS.gray },
+  { id: "docs", displayName: "Docs", prefix: "docs", aliases: ["doc"], colors: COLORS.blue },
+  {
+    id: "refactor",
+    displayName: "Refactor",
+    prefix: "refactor",
+    aliases: ["refact"],
+    colors: COLORS.purple,
+  },
+  { id: "test", displayName: "Test", prefix: "test", aliases: ["tests"], colors: COLORS.yellow },
+  {
+    id: "release",
+    displayName: "Release",
+    prefix: "release",
+    aliases: ["rel"],
+    colors: COLORS.orange,
+  },
+  { id: "ci", displayName: "CI", prefix: "ci", aliases: ["build"], colors: COLORS.blue },
+  { id: "deps", displayName: "Deps", prefix: "deps", aliases: ["dependabot"], colors: COLORS.gray },
+  { id: "perf", displayName: "Perf", prefix: "perf", aliases: [], colors: COLORS.purple },
+  { id: "style", displayName: "Style", prefix: "style", aliases: [], colors: COLORS.blue },
+  { id: "wip", displayName: "WIP", prefix: "wip", aliases: [], colors: COLORS.yellow },
+];
+
+export const BRANCH_PREFIX_MAP: Record<string, BranchType> = {};
+
+BRANCH_TYPES.forEach((type) => {
+  BRANCH_PREFIX_MAP[type.prefix.toLowerCase()] = type;
+  type.aliases.forEach((alias) => {
+    BRANCH_PREFIX_MAP[alias.toLowerCase()] = type;
+  });
+});

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -8,6 +8,14 @@ export interface GitHubUser {
   avatarUrl: string;
 }
 
+/** GitHub label */
+export interface GitHubLabel {
+  /** Label name */
+  name: string;
+  /** Label color (hex without #) */
+  color: string;
+}
+
 /** GitHub issue representation */
 export interface GitHubIssue {
   /** Issue number */
@@ -26,6 +34,8 @@ export interface GitHubIssue {
   assignees: GitHubUser[];
   /** Number of comments */
   commentCount: number;
+  /** Issue labels */
+  labels?: GitHubLabel[];
 }
 
 /** GitHub pull request representation */

--- a/src/components/Worktree/BranchLabel.tsx
+++ b/src/components/Worktree/BranchLabel.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { cn } from "../../lib/utils";
 import { middleTruncate } from "../../utils/textParsing";
+import { BRANCH_PREFIX_MAP, DEFAULT_BRANCH_TYPE } from "@shared/config/branchPrefixes";
 
 interface BranchLabelProps {
   label: string;
@@ -9,86 +10,29 @@ interface BranchLabelProps {
   className?: string;
 }
 
-// Color schemes for prefix types
-const COLORS = {
-  teal: { bg: "bg-teal-500/10", border: "border-teal-500/30", text: "text-teal-400" },
-  red: { bg: "bg-red-500/10", border: "border-red-500/30", text: "text-red-400" },
-  gray: { bg: "bg-canopy-border/20", border: "border-canopy-border", text: "text-canopy-text/60" },
-  blue: { bg: "bg-blue-500/10", border: "border-blue-500/30", text: "text-blue-400" },
-  purple: { bg: "bg-purple-500/10", border: "border-purple-500/30", text: "text-purple-400" },
-  yellow: { bg: "bg-yellow-500/10", border: "border-yellow-500/30", text: "text-yellow-400" },
-  orange: { bg: "bg-orange-500/10", border: "border-orange-500/30", text: "text-orange-400" },
-} as const;
-
-// Prefix configuration: maps raw prefix to display name and color
-// Supports both long forms ("feature" → "Feature") and short forms ("feat" → "FEAT")
-const PREFIX_CONFIG: Record<
-  string,
-  { displayName: string; colors: (typeof COLORS)[keyof typeof COLORS] }
-> = {
-  // Feature branches
-  feature: { displayName: "Feature", colors: COLORS.teal },
-  feat: { displayName: "FEAT", colors: COLORS.teal },
-  // Bug fixes
-  bugfix: { displayName: "Bugfix", colors: COLORS.red },
-  hotfix: { displayName: "Hotfix", colors: COLORS.red },
-  fix: { displayName: "FIX", colors: COLORS.red },
-  // Maintenance
-  chore: { displayName: "Chore", colors: COLORS.gray },
-  // Documentation
-  docs: { displayName: "Docs", colors: COLORS.blue },
-  doc: { displayName: "DOC", colors: COLORS.blue },
-  // Refactoring
-  refactor: { displayName: "Refactor", colors: COLORS.purple },
-  refact: { displayName: "REFACT", colors: COLORS.purple },
-  // Testing
-  test: { displayName: "Test", colors: COLORS.yellow },
-  tests: { displayName: "Tests", colors: COLORS.yellow },
-  // Release
-  release: { displayName: "Release", colors: COLORS.orange },
-  rel: { displayName: "REL", colors: COLORS.orange },
-  // Dependency updates
-  deps: { displayName: "DEPS", colors: COLORS.gray },
-  dependabot: { displayName: "Dependabot", colors: COLORS.gray },
-  // CI/Build
-  ci: { displayName: "CI", colors: COLORS.blue },
-  build: { displayName: "Build", colors: COLORS.blue },
-  // Performance
-  perf: { displayName: "PERF", colors: COLORS.purple },
-  // Styling
-  style: { displayName: "Style", colors: COLORS.blue },
-  // Work in progress
-  wip: { displayName: "WIP", colors: COLORS.yellow },
-};
-
-// Default styling for unknown prefixes
-const DEFAULT_CONFIG = { colors: COLORS.gray };
-
 export function BranchLabel({ label, isActive, isMainWorktree, className }: BranchLabelProps) {
   const { displayName, colors, rest } = useMemo(() => {
     const parts = label.split("/");
     if (parts.length <= 1) {
-      // No prefix - just show the branch name
-      return { prefix: null, displayName: null, colors: null, rest: middleTruncate(label, 40) };
+      return { displayName: null, colors: null, rest: middleTruncate(label, 40) };
     }
-    const [p, ...tail] = parts;
-    const config = PREFIX_CONFIG[p.toLowerCase()];
+
+    const [prefix, ...tail] = parts;
+    const config = BRANCH_PREFIX_MAP[prefix.toLowerCase()];
 
     if (config) {
-      // Known prefix - use configured display name
       return {
-        prefix: p,
         displayName: config.displayName,
         colors: config.colors,
         rest: middleTruncate(tail.join("/"), 36),
       };
     } else {
-      // Unknown prefix - show as-is with gray styling
       return {
-        prefix: p,
         displayName:
-          p.length <= 4 ? p.toUpperCase() : p.charAt(0).toUpperCase() + p.slice(1).toLowerCase(),
-        colors: DEFAULT_CONFIG.colors,
+          prefix.length <= 4
+            ? prefix.toUpperCase()
+            : prefix.charAt(0).toUpperCase() + prefix.slice(1).toLowerCase(),
+        colors: DEFAULT_BRANCH_TYPE.colors,
         rest: middleTruncate(tail.join("/"), 36),
       };
     }


### PR DESCRIPTION
## Summary
Adds a centralized branch prefix configuration and dropdown selector to the New Worktree Dialog, allowing users to select from standard branch prefixes (feature, bugfix, chore, etc.) instead of manually typing the full branch name. The feature includes smart auto-detection of prefix based on GitHub issue labels.

Closes #942

## Changes Made
- Create shared/config/branchPrefixes.ts with centralized branch type configuration
- Refactor BranchLabel.tsx to use shared config instead of local PREFIX_CONFIG
- Add dropdown selector for branch prefixes in NewWorktreeDialog.tsx
- Implement auto-prefix selection based on GitHub issue labels
- Add GitHubLabel interface and labels property to GitHubIssue type
- Update GraphQL queries to fetch issue labels
- Normalize BRANCH_PREFIX_MAP keys to lowercase for consistent lookups
- Improve label matching with word boundaries to avoid false positives