### PR TITLE
Handle orphan terminals gracefully when worktree deleted externally

### DIFF
--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -103,7 +103,7 @@ export interface TerminalRegistrySlice {
   toggleTerminalLocation: (id: string) => void;
 
   trashTerminal: (id: string) => void;
-  restoreTerminal: (id: string) => void;
+  restoreTerminal: (id: string, targetWorktreeId?: string) => void;
   markAsTrashed: (id: string, expiresAt: number, originalLocation: "dock" | "grid") => void;
   markAsRestored: (id: string) => void;
   isInTrash: (id: string) => boolean;
@@ -451,7 +451,7 @@ export const createTerminalRegistrySlice =
       terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
     },
 
-    restoreTerminal: (id) => {
+    restoreTerminal: (id, targetWorktreeId) => {
       const trashedInfo = get().trashedTerminals.get(id);
       const restoreLocation = trashedInfo?.originalLocation ?? "grid";
 
@@ -461,7 +461,13 @@ export const createTerminalRegistrySlice =
 
       set((state) => {
         const newTerminals = state.terminals.map((t) =>
-          t.id === id ? { ...t, location: restoreLocation } : t
+          t.id === id
+            ? {
+                ...t,
+                location: restoreLocation,
+                worktreeId: targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId,
+              }
+            : t
         );
         const newTrashed = new Map(state.trashedTerminals);
         newTrashed.delete(id);

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -155,8 +155,8 @@ export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
       }
     },
 
-    restoreTerminal: (id: string) => {
-      registrySlice.restoreTerminal(id);
+    restoreTerminal: (id: string, targetWorktreeId?: string) => {
+      registrySlice.restoreTerminal(id, targetWorktreeId);
       set({ focusedId: id, activeDockTerminalId: null });
     },
 


### PR DESCRIPTION
## Summary
When a worktree is deleted outside Canopy (via GitFox, CLI, or agent scripts), associated terminals are now gracefully moved to Trash instead of being immediately destroyed, preserving logs and providing recovery options.

Closes #950

## Changes Made
- Move orphaned terminals to Trash instead of hard-killing them
- Add notification when worktree deletion triggers terminal trashing
- Implement orphan terminal adoption to active worktree on restore
- Add visual indicator "(deleted tree)" for orphaned terminals in Trash
- Disable restore button when orphan has no active worktree to adopt to
- Filter already-trashed terminals to prevent duplicate notifications
- Forward targetWorktreeId parameter through terminalStore wrapper

## Implementation Details

**Graceful Degradation:**
- External worktree deletion now triggers `trashTerminal()` instead of `removeTerminal()`
- Terminals remain accessible in Trash for 120-second TTL period
- User receives notification: "Worktree Deleted Externally - X terminal(s) moved to trash"

**Orphan Adoption:**
- Orphaned terminals (worktree no longer exists) are detected in Trash UI
- Visual indicator shows "(deleted tree)" in amber text
- Restore button adopts orphan to currently active worktree
- Button disabled with helpful tooltip when no active worktree available

**Edge Cases Handled:**
- Already-trashed terminals filtered from re-trashing (prevents duplicate notifications)
- targetWorktreeId parameter properly forwarded through terminalStore wrapper
- Accessible aria-labels and tooltips adapt to orphan state