### PR TITLE
Allow /clear command feedback while preserving screen jump protections

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -178,7 +178,21 @@ function TerminalPaneComponent({
       const results = tracker.process(data);
 
       for (const result of results) {
-        // Let agents handle /clear and /new natively - don't intercept
+        // Intercept user-initiated clear commands to provide immediate visual feedback.
+        // This is separate from blocking agent-generated escape sequences (handled by
+        // setupParserHandlers in TerminalInstanceService) which prevent dangerous
+        // screen jumping that could trigger photosensitive epileptic seizures.
+        if (result.isClear) {
+          const managed = terminalInstanceService.get(id);
+          if (managed?.terminal) {
+            try {
+              managed.terminal.clear();
+            } catch (error) {
+              console.warn(`Failed to clear terminal ${id}:`, error);
+            }
+          }
+        }
+
         if (result.command) {
           updateLastCommand(id, result.command);
         }


### PR DESCRIPTION
## Summary

Restores visual feedback for `/clear` commands while maintaining critical escape sequence blocking that prevents screen jumping. When users type `/clear`, the terminal now clears immediately via the xterm.js API, while agent-generated escape sequences remain blocked by the parser handlers.

Closes #955

## Changes Made

- Intercept user-initiated clear commands in TerminalPane handleInput callback
- Call terminal.clear() directly when InputTracker detects /clear commands
- Preserve agent escape sequence blocking in setupParserHandlers (no changes to existing safety mechanism)
- Add try-catch safety guard for disposed terminal edge cases

## Technical Approach

The fix implements a dual-layer handling system:

**User Intent Path**: `/clear` typed by user → InputTracker detects → `terminal.clear()` called → immediate visual feedback

**Agent Output Path**: Agent sends `\x1b[2J\x1b[H` → setupParserHandlers blocks → prevents dangerous screen jumping

This separation ensures users see their commands execute while maintaining the critical accessibility protection against photosensitive epileptic seizures.