### PR TITLE
Refine context menus for native desktop app feel

### DIFF
--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -87,12 +87,12 @@ export function TerminalContextMenu({
         {/* Layout Actions */}
         {currentLocation === "grid" ? (
           <ContextMenuItem onClick={() => moveTerminalToDock(terminalId)}>
-            <ArrowDownToLine className="w-4 h-4 mr-2" aria-hidden="true" />
+            <ArrowDownToLine className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
             Move to Dock
           </ContextMenuItem>
         ) : (
           <ContextMenuItem onClick={() => moveTerminalToGrid(terminalId)}>
-            <ArrowUp className="w-4 h-4 mr-2" aria-hidden="true" />
+            <ArrowUp className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
             Move to Grid
           </ContextMenuItem>
         )}
@@ -101,13 +101,13 @@ export function TerminalContextMenu({
           <ContextMenuItem onClick={() => toggleMaximize(terminalId)}>
             {isMaximized ? (
               <>
-                <Minimize2 className="w-4 h-4 mr-2" aria-hidden="true" />
+                <Minimize2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                 Restore Size
                 <ContextMenuShortcut>^⇧F</ContextMenuShortcut>
               </>
             ) : (
               <>
-                <Maximize2 className="w-4 h-4 mr-2" aria-hidden="true" />
+                <Maximize2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                 Maximize
                 <ContextMenuShortcut>^⇧F</ContextMenuShortcut>
               </>
@@ -118,22 +118,22 @@ export function TerminalContextMenu({
         <ContextMenuSeparator />
 
         <ContextMenuItem onClick={() => restartTerminal(terminalId)}>
-          <RotateCcw className="w-4 h-4 mr-2" aria-hidden="true" />
+          <RotateCcw className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
           Restart Terminal
         </ContextMenuItem>
 
         <ContextMenuItem onClick={handleDuplicate}>
-          <Copy className="w-4 h-4 mr-2" aria-hidden="true" />
+          <Copy className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
           Duplicate Terminal
         </ContextMenuItem>
 
         <ContextMenuItem onClick={handleClearBuffer}>
-          <Eraser className="w-4 h-4 mr-2" aria-hidden="true" />
+          <Eraser className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
           Clear Scrollback
         </ContextMenuItem>
 
         <ContextMenuItem onClick={() => setIsInfoDialogOpen(true)}>
-          <Info className="w-4 h-4 mr-2" aria-hidden="true" />
+          <Info className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
           View Terminal Info
         </ContextMenuItem>
 
@@ -143,7 +143,7 @@ export function TerminalContextMenu({
           onClick={() => trashTerminal(terminalId)}
           className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
         >
-          <Trash2 className="w-4 h-4 mr-2" aria-hidden="true" />
+          <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
           Trash Terminal
         </ContextMenuItem>
 
@@ -151,7 +151,7 @@ export function TerminalContextMenu({
           onClick={() => removeTerminal(terminalId)}
           className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
         >
-          <X className="w-4 h-4 mr-2" aria-hidden="true" />
+          <X className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
           Kill Terminal
         </ContextMenuItem>
       </ContextMenuContent>

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -545,9 +545,9 @@ export function WorktreeCard({
                 aria-controls={detailsId}
               >
                 {isExpanded ? (
-                  <ChevronDown className="w-4 h-4" />
+                  <ChevronDown className="w-3.5 h-3.5" />
                 ) : (
-                  <ChevronRight className="w-4 h-4" />
+                  <ChevronRight className="w-3.5 h-3.5" />
                 )}
               </button>
             )}
@@ -646,15 +646,15 @@ export function WorktreeCard({
                     onClick={(e) => e.stopPropagation()}
                   >
                     <DropdownMenuItem onClick={() => handleCopyTree()} disabled={isCopyingTree}>
-                      <Copy className="w-3 h-3 mr-2" />
+                      <Copy className="w-3.5 h-3.5 mr-2" />
                       Copy Context
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => onOpenEditor()}>
-                      <Code className="w-3 h-3 mr-2" />
+                      <Code className="w-3.5 h-3.5 mr-2" />
                       Open in Editor
                     </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => handlePathClick()}>
-                      <Folder className="w-3 h-3 mr-2" />
+                      <Folder className="w-3.5 h-3.5 mr-2" />
                       Reveal in Finder
                     </DropdownMenuItem>
 
@@ -662,13 +662,13 @@ export function WorktreeCard({
 
                     {worktree.issueNumber && onOpenIssue && (
                       <DropdownMenuItem onClick={() => handleOpenIssue()}>
-                        <CircleDot className="w-3 h-3 mr-2" />
+                        <CircleDot className="w-3.5 h-3.5 mr-2" />
                         Open Issue #{worktree.issueNumber}
                       </DropdownMenuItem>
                     )}
                     {worktree.prNumber && onOpenPR && (
                       <DropdownMenuItem onClick={() => handleOpenPR()}>
-                        <GitPullRequest className="w-3 h-3 mr-2" />
+                        <GitPullRequest className="w-3.5 h-3.5 mr-2" />
                         Open PR #{worktree.prNumber}
                       </DropdownMenuItem>
                     )}
@@ -684,7 +684,7 @@ export function WorktreeCard({
                             onClick={() => handleRunRecipe(recipe.id)}
                             disabled={runningRecipeId !== null}
                           >
-                            <Play className="w-3 h-3 mr-2" />
+                            <Play className="w-3.5 h-3.5 mr-2" />
                             {recipe.name}
                           </DropdownMenuItem>
                         ))}
@@ -692,13 +692,13 @@ export function WorktreeCard({
                     )}
                     {onCreateRecipe && (
                       <DropdownMenuItem onClick={onCreateRecipe}>
-                        <Plus className="w-3 h-3 mr-2" />
+                        <Plus className="w-3.5 h-3.5 mr-2" />
                         Create Recipe...
                       </DropdownMenuItem>
                     )}
                     {onSaveLayout && totalTerminalCount > 0 && (
                       <DropdownMenuItem onClick={onSaveLayout}>
-                        <Save className="w-3 h-3 mr-2" />
+                        <Save className="w-3.5 h-3.5 mr-2" />
                         Save Layout as Recipe
                       </DropdownMenuItem>
                     )}
@@ -735,7 +735,7 @@ export function WorktreeCard({
                           }}
                           className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
                         >
-                          <Trash2 className="w-3 h-3 mr-2" />
+                          <Trash2 className="w-3.5 h-3.5 mr-2" />
                           Delete Worktree...
                         </DropdownMenuItem>
                       </>

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -24,14 +24,14 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-canopy-border data-[state=open]:bg-canopy-border",
+      "flex cursor-default select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none focus:bg-canopy-accent focus:text-white data-[state=open]:bg-canopy-accent data-[state=open]:text-white",
       inset && "pl-8",
       className
     )}
     {...props}
   >
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" aria-hidden="true" />
+    <ChevronRight className="ml-auto h-3.5 w-3.5" aria-hidden="true" />
   </ContextMenuPrimitive.SubTrigger>
 ));
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
@@ -43,7 +43,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-[var(--z-popover)] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+      "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
       className
     )}
     {...props}
@@ -59,7 +59,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-[var(--z-popover)] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
@@ -78,7 +78,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -94,7 +94,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[3px] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -102,7 +102,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <ContextMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" aria-hidden="true" />
+        <Check className="h-3.5 w-3.5" aria-hidden="true" />
       </ContextMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -117,7 +117,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[3px] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
@@ -165,7 +165,7 @@ ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
 const ContextMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest text-canopy-text/50", className)}
+      className={cn("ml-auto text-[10px] tracking-widest text-canopy-text/50", className)}
       {...props}
     />
   );

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { Check } from "lucide-react";
+import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -22,13 +22,14 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-canopy-border data-[state=open]:bg-canopy-border",
+      "flex cursor-default select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none focus:bg-canopy-accent focus:text-white data-[state=open]:bg-canopy-accent data-[state=open]:text-white",
       inset && "pl-8",
       className
     )}
     {...props}
   >
     {children}
+    <ChevronRight className="ml-auto h-3.5 w-3.5" aria-hidden="true" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
@@ -40,7 +41,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-[var(--z-popover)] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+      "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
       className
     )}
     {...props}
@@ -57,7 +58,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[var(--z-popover)] min-w-[8rem] overflow-hidden rounded-md border border-canopy-border bg-canopy-sidebar p-1 text-canopy-text shadow-lg",
+        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
@@ -76,7 +77,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -118,7 +119,7 @@ DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest text-canopy-text/50", className)}
+      className={cn("ml-auto text-[10px] tracking-widest text-canopy-text/50", className)}
       {...props}
     />
   );
@@ -132,7 +133,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-canopy-border focus:text-canopy-accent data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[3px] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -140,7 +141,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" aria-hidden="true" />
+        <Check className="h-3.5 w-3.5" aria-hidden="true" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}


### PR DESCRIPTION
## Summary
This PR refines context menus and dropdown menus throughout Canopy to achieve a tighter, more native desktop application aesthetic. The changes reduce text size, tighten spacing, and update interaction states to match macOS/Windows native selection patterns with emerald accent colors.

Closes #954

## Changes Made
- Reduce menu text size from text-sm (14px) to text-xs (12px) for denser appearance
- Tighten menu item padding from px-2 py-1.5 to px-2.5 py-1
- Update hover/focus states to use emerald accent (focus:bg-canopy-accent focus:text-white)
- Add data-[highlighted] states for pointer hover interactions
- Reduce icon sizes from w-4 h-4 to w-3.5 h-3.5 throughout menus
- Update container styling: darker background (#1a1b1e/95), backdrop blur, refined borders (white/10)
- Reduce shortcut and label text to text-[10px] for improved hierarchy
- Add ChevronRight icon to DropdownMenuSubTrigger for consistency with context menus
- Update all consumer components (TerminalContextMenu, WorktreeCard) with consistent icon sizing

## Files Modified
- `src/components/ui/context-menu.tsx` - Base context menu primitives
- `src/components/ui/dropdown-menu.tsx` - Base dropdown menu primitives
- `src/components/Terminal/TerminalContextMenu.tsx` - Terminal right-click menu
- `src/components/Worktree/WorktreeCard.tsx` - Worktree action dropdown menu