### PR TITLE
Add move to worktree action in terminal context menu

### DIFF
--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -6,6 +6,9 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
   ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubTrigger,
+  ContextMenuSubContent,
 } from "@/components/ui/context-menu";
 import {
   Maximize2,
@@ -18,11 +21,13 @@ import {
   Copy,
   Eraser,
   Info,
+  GitBranch,
 } from "lucide-react";
 import { useTerminalStore } from "@/store";
 import type { TerminalLocation } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalInfoDialog } from "./TerminalInfoDialog";
+import { useWorktrees } from "@/hooks/useWorktrees";
 
 interface TerminalContextMenuProps {
   terminalId: string;
@@ -49,7 +54,9 @@ export function TerminalContextMenu({
   const toggleMaximize = useTerminalStore((s) => s.toggleMaximize);
   const restartTerminal = useTerminalStore((s) => s.restartTerminal);
   const addTerminal = useTerminalStore((s) => s.addTerminal);
+  const moveTerminalToWorktree = useTerminalStore((s) => s.moveTerminalToWorktree);
   const isMaximized = useTerminalStore((s) => s.maximizedId === terminalId);
+  const { worktrees } = useWorktrees();
 
   const handleDuplicate = async () => {
     if (!terminal) return;
@@ -113,6 +120,30 @@ export function TerminalContextMenu({
               </>
             )}
           </ContextMenuItem>
+        )}
+
+        {worktrees.length > 1 && (
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <GitBranch className="w-4 h-4 mr-2" aria-hidden="true" />
+              Move to Worktree
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent className="w-48">
+              {worktrees.map((wt) => {
+                const isCurrent = wt.id === terminal?.worktreeId;
+                const label = wt.branch || wt.name;
+                return (
+                  <ContextMenuItem
+                    key={wt.id}
+                    onClick={() => moveTerminalToWorktree(terminalId, wt.id)}
+                    disabled={isCurrent}
+                  >
+                    <span className={wt.isMainWorktree ? "font-semibold" : ""}>{label}</span>
+                  </ContextMenuItem>
+                );
+              })}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
         )}
 
         <ContextMenuSeparator />

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -114,6 +114,7 @@ export interface TerminalRegistrySlice {
   restartTerminal: (id: string) => Promise<void>;
   clearTerminalError: (id: string) => void;
   updateTerminalCwd: (id: string, cwd: string) => void;
+  moveTerminalToWorktree: (id: string, worktreeId: string) => void;
 }
 
 // Flush pending persistence - call on app quit to prevent data loss
@@ -854,6 +855,24 @@ export const createTerminalRegistrySlice =
         const newTerminals = state.terminals.map((t) =>
           t.id === id ? { ...t, cwd, restartError: undefined } : t
         );
+        terminalPersistence.save(newTerminals);
+        return { terminals: newTerminals };
+      });
+    },
+
+    moveTerminalToWorktree: (id, worktreeId) => {
+      set((state) => {
+        const terminal = state.terminals.find((t) => t.id === id);
+        if (!terminal) {
+          console.warn(`Cannot move terminal ${id}: terminal not found`);
+          return state;
+        }
+
+        if (terminal.worktreeId === worktreeId) {
+          return state;
+        }
+
+        const newTerminals = state.terminals.map((t) => (t.id === id ? { ...t, worktreeId } : t));
         terminalPersistence.save(newTerminals);
         return { terminals: newTerminals };
       });


### PR DESCRIPTION
## Summary
Implements a "Move to Worktree" feature that allows users to re-associate terminals with different worktrees via the context menu, enabling flexible terminal organization and lifecycle management.

Closes #952

## Changes Made
- Add moveTerminalToWorktree method to TerminalRegistrySlice interface
- Implement moveTerminalToWorktree with existence check and no-op guard
- Add "Move to Worktree" submenu in terminal context menu
- Display worktrees sorted by main/activity with current worktree disabled
- Handle persistence automatically via terminalPersistence

## Key Features
- Terminals can be moved between worktrees without disrupting the running process
- Current worktree is shown as disabled in the submenu for clarity
- Changes persist across app restarts
- Terminal lifecycle inherits from the new worktree association