### PR TITLE
Implement tall canvas mode for agent terminals

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -17,6 +17,7 @@ import type { AgentState } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { InputTracker } from "@/services/clearCommandDetection";
 import { getAgentConfig } from "@/config/agents";
+import { isAgentTerminal } from "@/utils/terminalType";
 
 export type { TerminalType };
 
@@ -397,7 +398,13 @@ function TerminalPaneComponent({
           onReady={handleReady}
           onExit={handleExit}
           onInput={handleInput}
-          className={cn("absolute", location === "dock" || isMaximized ? "inset-0" : "inset-2")}
+          className={cn(
+            "absolute",
+            // Agent terminals: no inset (scroll container needs full space for scrollbar)
+            // Standard terminals in grid: inset-2 for card padding
+            // Dock/maximized: no inset
+            location === "dock" || isMaximized || isAgentTerminal(type) ? "inset-0" : "inset-2"
+          )}
           getRefreshTier={getRefreshTierCallback}
         />
         <ArtifactOverlay terminalId={id} worktreeId={worktreeId} cwd={cwd} />

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -313,10 +313,12 @@ function XtermAdapterComponent({
     <div
       ref={scrollViewportRef}
       className={cn(
-        "w-full h-full bg-canopy-bg text-white rounded-b-[var(--radius-lg)]",
+        "w-full h-full bg-canopy-bg text-white",
         // Agent terminals use custom scrolling with flexbox for bottom-pinned layout
         // Standard terminals use overflow-hidden (xterm handles internal scrolling)
-        isAgent ? "overflow-y-auto overflow-x-hidden flex flex-col" : "overflow-hidden",
+        isAgent ? "overflow-y-auto overflow-x-hidden flex flex-col pl-2 pr-2 pt-2" : "overflow-hidden",
+        // Only apply rounded corners to standard terminals (agent scroll container fills to edge)
+        !isAgent && "rounded-b-[var(--radius-lg)]",
         className
       )}
       style={{
@@ -325,9 +327,17 @@ function XtermAdapterComponent({
         transform: "translateZ(0)",
       }}
     >
-      {/* Spacer pushes terminal to bottom for agent terminals */}
-      {isAgent && <div className="flex-1 min-h-0" />}
-      <div ref={containerRef} className={cn("pl-2 pt-2 pb-4", isAgent && "flex-shrink-0")} />
+      {isAgent ? (
+        <>
+          {/* Spacer pushes terminal to bottom */}
+          <div className="flex-1 min-h-0" />
+          {/* Terminal container - min-h-full ensures it starts at viewport size */}
+          <div ref={containerRef} className="flex-shrink-0" />
+        </>
+      ) : (
+        // Standard terminals: simple container with padding
+        <div ref={containerRef} className="pl-2 pt-2 pb-4 h-full" />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements tall canvas mode (issue #964) to eliminate viewport bouncing in agent terminals during TUI redraws. Agent terminals now use a fixed 500-row canvas with custom scrolling instead of standard terminal scrolling, providing ~10 screens of stable output space.

Closes #964

## Changes Made

- Add 500-row fixed canvas with custom scrolling for agent terminals (Claude, Gemini, Codex)
- Implement scrollToCursor with RAF throttling and user scroll detection to keep cursor visible
- Fork resize logic to maintain fixed rows while resizing columns dynamically
- Add scroll wrapper in XtermAdapter with conditional overflow for agent vs standard terminals
- Fix scroll listener memory leaks in attach/detach/destroy lifecycle methods
- Prevent programmatic scrolls from triggering user scroll detection flag
- Update host element height on font/DPI changes even when cols/rows unchanged

## Technical Details

**Bifurcated behavior:**
- **Agent terminals**: Fixed 500-row canvas, scrollback=0, custom viewport scrolling
- **Standard terminals**: Dynamic rows/cols, standard xterm scrolling (unchanged)

**Key implementation:**
- `TerminalInstanceService`: Tall canvas terminal options, scrollToCursor with RAF throttling, forked resize logic
- `XtermAdapter`: Scroll viewport wrapper with conditional overflow styles
- Proper cleanup of scroll listeners and timeouts to prevent memory leaks