### PR TITLE
Delay skeleton shimmer to prevent flash on fast loads

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -179,35 +179,38 @@ export function GitHubResourceList({
     const renderCount = Math.min(Math.max(1, safeCount), MAX_SKELETON_ITEMS);
 
     return (
-      <div className="divide-y divide-canopy-border">
-        {Array.from({ length: renderCount }).map((_, i) => (
-          <div
-            key={i}
-            className="p-3 animate-pulse box-border"
-            style={{ height: `${ITEM_HEIGHT_PX}px` }}
-          >
-            <div className="flex items-start gap-3 h-full">
-              <div className="w-4 h-4 rounded-full bg-muted mt-0.5 shrink-0" />
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <div className="h-5 bg-muted rounded w-3/4" />
-                  <div className="h-4 bg-muted rounded w-10 shrink-0" />
+      <div role="status" aria-live="polite" aria-busy="true" aria-label="Loading GitHub results">
+        <span className="sr-only">Loading GitHub results</span>
+        <div aria-hidden="true" className="divide-y divide-canopy-border">
+          {Array.from({ length: renderCount }).map((_, i) => (
+            <div
+              key={i}
+              className="p-3 animate-pulse-delayed box-border"
+              style={{ height: `${ITEM_HEIGHT_PX}px` }}
+            >
+              <div className="flex items-start gap-3 h-full">
+                <div className="w-4 h-4 rounded-full bg-muted mt-0.5 shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <div className="h-5 bg-muted rounded w-3/4" />
+                    <div className="h-4 bg-muted rounded w-10 shrink-0" />
+                  </div>
+                  <div className="mt-1 flex items-center gap-1.5">
+                    <div className="h-4 bg-muted rounded w-10" />
+                    <div className="h-4 bg-muted rounded w-12" />
+                    <div className="h-4 bg-muted rounded w-14" />
+                  </div>
                 </div>
-                <div className="mt-1 flex items-center gap-1.5">
-                  <div className="h-4 bg-muted rounded w-10" />
-                  <div className="h-4 bg-muted rounded w-12" />
-                  <div className="h-4 bg-muted rounded w-14" />
-                </div>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <div className="flex -space-x-1.5">
-                  <div className="w-5 h-5 rounded-full bg-muted border-2 border-canopy-sidebar" />
-                  <div className="w-5 h-5 rounded-full bg-muted border-2 border-canopy-sidebar" />
+                <div className="flex items-center gap-2 shrink-0">
+                  <div className="flex -space-x-1.5">
+                    <div className="w-5 h-5 rounded-full bg-muted border-2 border-canopy-sidebar" />
+                    <div className="w-5 h-5 rounded-full bg-muted border-2 border-canopy-sidebar" />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     );
   };

--- a/src/components/Worktree/WorktreeCardSkeleton.tsx
+++ b/src/components/Worktree/WorktreeCardSkeleton.tsx
@@ -6,7 +6,7 @@ export function WorktreeCardSkeleton() {
       className={cn(
         "border rounded-lg p-3 mb-2",
         "border-transparent bg-canopy-bg/50",
-        "motion-safe:animate-pulse motion-reduce:animate-none"
+        "animate-pulse-delayed"
       )}
       role="status"
       aria-live="polite"

--- a/src/index.css
+++ b/src/index.css
@@ -339,6 +339,32 @@ body,
   will-change: opacity;
 }
 
+/* Delayed pulse animation for skeleton loading states
+ * Prevents "flash of loading state" (FOLS) for fast operations (<400ms).
+ * Skeleton starts invisible and fades in only when animation begins after delay.
+ */
+@keyframes pulse-delayed {
+  0% {
+    opacity: 0;
+  }
+  0.1% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.animate-pulse-delayed {
+  opacity: 0;
+  animation: pulse-delayed 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation-delay: 400ms;
+  will-change: opacity;
+}
+
 /* Agent status working state - pulsing gradient animation */
 @keyframes status-pulse {
   0%,
@@ -359,6 +385,7 @@ body,
 @media (prefers-reduced-motion: reduce) {
   .animate-activity-pulse,
   .animate-agent-pulse,
+  .animate-pulse-delayed,
   .status-working {
     animation: none;
     opacity: 1;
@@ -838,4 +865,9 @@ body[data-performance-mode="true"] *::after {
   animation: none !important;
   animation-play-state: paused !important;
   transition: none !important;
+}
+
+/* Ensure delayed skeletons don't stay invisible when animations are disabled */
+body[data-performance-mode="true"] .animate-pulse-delayed {
+  opacity: 1 !important;
 }


### PR DESCRIPTION
## Summary
Implements 400ms delayed pulse animation for skeleton loading states to prevent "flash of loading state" (FOLS) when data loads quickly (<400ms). This improves perceived performance by only showing loading animations when operations actually take noticeable time.

Closes #968

## Changes Made
- Add pulse-delayed keyframe animation with 400ms delay and will-change optimization
- Update WorktreeCardSkeleton to use animate-pulse-delayed class
- Update GitHubResourceList skeleton with delayed animation and proper accessibility
- Add performance mode override to ensure skeletons remain visible when animations disabled
- Add reduced-motion support to disable animation while maintaining visibility
- Wrap GitHub skeleton with role="status", aria-busy, and sr-only text for screen readers