### PR TITLE
Reduce worktree card hover and selection opacity

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -502,9 +502,9 @@ export function WorktreeCard({
       className={cn(
         "group relative border-b-2 border-white/5 transition-all duration-200",
         isActive
-          ? "bg-white/[0.08] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)]"
-          : "hover:bg-white/5 bg-transparent",
-        isFocused && !isActive && "bg-white/[0.04]",
+          ? "bg-white/[0.03] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)]"
+          : "hover:bg-white/[0.02] bg-transparent",
+        isFocused && !isActive && "bg-white/[0.02]",
         (isIdleCard || isStaleCard) && !isActive && !isFocused && "opacity-70 hover:opacity-100",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
       )}


### PR DESCRIPTION
## Summary
Reduces opacity values for worktree card background states to improve text legibility while maintaining clear visual feedback for hover, focus, and active states.

Closes #978

## Changes Made
- Reduce active state opacity from 0.08 to 0.03
- Reduce hover state opacity from 0.05 to 0.02
- Reduce focused state opacity from 0.04 to 0.02