### PR TITLE
Show all file changes in expanded worktree view

### DIFF
--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -338,7 +338,7 @@ export function WorktreeDetails({
           <FileChangeList
             changes={worktree.worktreeChanges.changes}
             rootPath={worktree.worktreeChanges.rootPath}
-            maxVisible={15}
+            maxVisible={worktree.worktreeChanges.changes.length}
             groupByFolder={worktree.worktreeChanges.changedFileCount > 5}
           />
         </div>


### PR DESCRIPTION
## Summary
Removes the 15-file truncation limit in expanded worktree cards, allowing users to see all changed files regardless of count.

Closes #979

## Changes Made
- Change maxVisible prop from fixed 15 to changes.length
- Remove truncation limit to display complete file change list
- Improve visibility into workspace state when card is expanded