### PR TITLE
Fix terminal restart race condition causing duplicate output

### DIFF
--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -51,6 +51,7 @@ export interface ManagedTerminal {
   lastAttachAt: number;
   lastDetachAt: number;
   webglRecoveryAttempts: number;
+  webglRecoveryToken?: number;
   // Visibility-aware LRU tracking
   isVisible: boolean;
   lastActiveTime: number;


### PR DESCRIPTION
## Summary

Eliminates the race condition in terminal restart sequence that caused duplicate headers, double-echoed input, and broken terminal state.

Closes #976

## Root Cause

The old restart sequence spawned the new PTY before destroying the old frontend instance, allowing the old instance to receive and render data from the new PTY process, resulting in data corruption.

## Changes Made

- **Reordered restart lifecycle**: Destroy frontend → Kill PTY → Update state → Spawn new PTY (prevents old frontend from consuming new data)
- **Synchronous listener cleanup**: `TerminalInstanceService.destroy()` now unsubscribes all IPC listeners before clearing buffers
- **Stale callback guard**: Added instance identity check in `writeToTerminal` callback to prevent post-destroy operations
- **WebGL recovery token**: Prevents cross-generation context loss callbacks from mutating wrong terminal instance
- **isRestarting flag timing**: Kept true throughout restart to prevent onExit event race
- **Concurrent restart guard**: Early return if restart already in progress

## Testing

- ✅ Typecheck and lint passed
- ✅ Codex comprehensive review completed (identified and fixed 7 critical issues)
- Manual testing recommended: Rapid terminal restarts (10+ consecutive) should produce clean output every time

## Files Modified

- `src/store/slices/terminalRegistrySlice.ts` - Reordered restart sequence
- `src/services/terminal/TerminalInstanceService.ts` - Synchronous listener cleanup + callback guard
- `src/services/terminal/TerminalAddonManager.ts` - WebGL recovery token implementation
- `src/services/terminal/types.ts` - Added webglRecoveryToken field