### PR TITLE
Refactor Terminal menu with dynamic agent items and availability filtering

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -166,6 +166,8 @@ async function initializeDeferredServices(
   const results = await Promise.allSettled([
     cliService.checkAvailability().then((availability) => {
       console.log("[MAIN] CLI availability checked:", availability);
+      console.log("[MAIN] Rebuilding menu with agent availability...");
+      createApplicationMenu(window, cliService);
       return availability;
     }),
   ]);
@@ -279,8 +281,9 @@ async function createWindow(): Promise<void> {
     sendToRenderer(mainWindow!, CHANNELS.WINDOW_FULLSCREEN_CHANGE, false);
   });
 
-  console.log("[MAIN] Creating application menu...");
-  createApplicationMenu(mainWindow);
+  console.log("[MAIN] Creating application menu (initial, no agent availability yet)...");
+  cliAvailabilityService = new CliAvailabilityService();
+  createApplicationMenu(mainWindow, cliAvailabilityService);
 
   // Initialize Notification Service
   notificationService.initialize(mainWindow);
@@ -304,7 +307,6 @@ async function createWindow(): Promise<void> {
   // Initialize Placeholder Services
   devServerManager = new DevServerManager();
   devServerManager.setWorkspaceClient(workspaceClient);
-  cliAvailabilityService = new CliAvailabilityService();
   eventBuffer = new EventBuffer(1000);
   sidecarManager = new SidecarManager(mainWindow);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -544,11 +544,12 @@ function App() {
     onOpenSettings: handleSettings,
     onToggleSidebar: handleToggleSidebar,
     onOpenAgentPalette: terminalPalette.open,
+    onLaunchAgent: handleLaunchAgent,
     defaultCwd: defaultTerminalCwd,
     activeWorktreeId: activeWorktree?.id,
   });
 
-  useKeybinding("terminal.palette", () => terminalPalette.toggle(), { enabled: electronAvailable });
+  useKeybinding("terminal.palette", () => terminalPalette.open(), { enabled: electronAvailable });
   useKeybinding("agent.palette", () => terminalPalette.open(), { enabled: electronAvailable });
   useKeybinding(
     "terminal.new",

--- a/src/hooks/useMenuActions.ts
+++ b/src/hooks/useMenuActions.ts
@@ -7,6 +7,7 @@ export interface UseMenuActionsOptions {
   onOpenSettings: () => void;
   onToggleSidebar: () => void;
   onOpenAgentPalette: () => void;
+  onLaunchAgent: (agentId: "claude" | "gemini" | "codex" | "terminal") => void;
   defaultCwd: string;
   activeWorktreeId?: string;
 }
@@ -15,6 +16,7 @@ export function useMenuActions({
   onOpenSettings,
   onToggleSidebar,
   onOpenAgentPalette,
+  onLaunchAgent,
   defaultCwd,
   activeWorktreeId,
 }: UseMenuActionsOptions): void {
@@ -25,6 +27,20 @@ export function useMenuActions({
     if (!isElectronAvailable()) return;
 
     const unsubscribe = window.electron.app.onMenuAction((action) => {
+      const LAUNCH_AGENT_PREFIX = "launch-agent:";
+
+      if (action.startsWith(LAUNCH_AGENT_PREFIX)) {
+        const agentId = action.slice(LAUNCH_AGENT_PREFIX.length);
+
+        if (!agentId) {
+          console.warn("[Menu] Empty agent ID in action:", action);
+          return;
+        }
+
+        onLaunchAgent(agentId as "claude" | "gemini" | "codex" | "terminal");
+        return;
+      }
+
       switch (action) {
         case "new-terminal":
           addTerminal({
@@ -53,9 +69,6 @@ export function useMenuActions({
           onOpenAgentPalette();
           break;
 
-        case "split-terminal":
-          break;
-
         default:
           console.warn("[Menu] Unhandled action:", action);
       }
@@ -68,6 +81,7 @@ export function useMenuActions({
     onOpenSettings,
     onToggleSidebar,
     onOpenAgentPalette,
+    onLaunchAgent,
     defaultCwd,
     activeWorktreeId,
   ]);


### PR DESCRIPTION
## Summary

Refactors the Terminal menu to make agent launchers dynamic based on the agent registry configuration and filter by CLI availability. This removes hardcoded agent menu items and prepares the system for future agent additions.

Closes #971

## Changes Made

**Dynamic Agent Menu Items:**
- Agent menu items now built from `AGENT_REGISTRY` config instead of hardcoded
- Menu automatically filters to show only CLI-available agents
- Shortcuts converted from registry format (`Cmd/Ctrl+Alt+C`) to Electron accelerators
- Menu rebuilds after CLI availability check completes

**Menu Cleanup:**
- Removed non-functional "Split Terminal" menu item
- Renamed "Run Agent..." to "Terminal Palette..." (Cmd+P)
- Removed hardcoded Claude/Gemini/Codex menu items

**Infrastructure:**
- Pass `CliAvailabilityService` to `createApplicationMenu` and related functions
- Initialize service earlier in main.ts for menu access
- Rebuild menu after availability check completes in deferred services

**Fixes:**
- Fixed type safety in `useMenuActions` agent ID handling (added empty string check)
- Fixed Cmd+P semantics mismatch (changed from toggle to open for consistency)

## Technical Details

**Files Modified:**
- `electron/menu.ts` - Dynamic menu building, availability filtering
- `electron/main.ts` - Service initialization timing, menu rebuild
- `src/hooks/useMenuActions.ts` - Type safety improvements
- `src/App.tsx` - Handler wiring, keyboard shortcut fix

**Architecture:**
- Main process checks CLI availability on startup
- Menu built twice: initial (no agents) → rebuild after availability check
- Future agents automatically appear when added to registry and CLI is available