### PR TITLE
Fix: Decouple PTY flow control from renderer acknowledgments for background terminals

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -476,18 +476,27 @@ port.on("message", (rawMsg: any) => {
         break;
 
       case "init-buffers":
-        // Dual buffer init: visual + analysis
-        if (msg.visualBuffer instanceof SharedArrayBuffer) {
+        const visualOk = msg.visualBuffer instanceof SharedArrayBuffer;
+        const analysisOk = msg.analysisBuffer instanceof SharedArrayBuffer;
+
+        if (visualOk) {
           visualBuffer = new SharedRingBuffer(msg.visualBuffer);
+          ptyManager.setSabMode(true);
         } else {
-          console.warn("[PtyHost] init-buffers: visualBuffer is not SharedArrayBuffer");
+          console.warn("[PtyHost] init-buffers: visualBuffer is not SharedArrayBuffer (IPC mode)");
         }
-        if (msg.analysisBuffer instanceof SharedArrayBuffer) {
+
+        if (analysisOk) {
           analysisBuffer = new SharedRingBuffer(msg.analysisBuffer);
         } else {
           console.warn("[PtyHost] init-buffers: analysisBuffer is not SharedArrayBuffer");
         }
-        console.log("[PtyHost] Dual SharedArrayBuffer ring buffers initialized");
+
+        console.log(
+          `[PtyHost] Buffers initialized: visual=${visualOk ? "SAB" : "IPC"} analysis=${
+            analysisOk ? "SAB" : "disabled"
+          } sabMode=${ptyManager.isSabMode()}`
+        );
         break;
 
       case "spawn":

--- a/electron/services/__tests__/PtyManager.sabmode.test.ts
+++ b/electron/services/__tests__/PtyManager.sabmode.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { PtyManager } from "../PtyManager.js";
+
+let PtyManagerClass: typeof PtyManager | null = null;
+let testUtils: typeof import("./helpers/ptyTestUtils.js") | null = null;
+
+try {
+  PtyManagerClass = (await import("../PtyManager.js")).PtyManager;
+  testUtils = await import("./helpers/ptyTestUtils.js");
+} catch {
+  console.warn("node-pty not available, skipping PTY SAB mode tests");
+}
+
+const shouldSkip = !PtyManagerClass;
+
+describe.skipIf(shouldSkip)("PtyManager SAB Mode Flow Control", () => {
+  const { cleanupPtyManager, spawnShellTerminal, sleep, waitForData } = testUtils || {};
+  let manager: PtyManager;
+
+  beforeEach(() => {
+    manager = new PtyManagerClass!();
+  });
+
+  afterEach(async () => {
+    await cleanupPtyManager?.(manager);
+  });
+
+  describe("SAB Mode Configuration", () => {
+    it("should default to SAB mode disabled", () => {
+      expect(manager.isSabMode()).toBe(false);
+    });
+
+    it("should enable SAB mode when setSabMode(true) is called", () => {
+      manager.setSabMode(true);
+      expect(manager.isSabMode()).toBe(true);
+    });
+
+    it("should disable SAB mode when setSabMode(false) is called", () => {
+      manager.setSabMode(true);
+      manager.setSabMode(false);
+      expect(manager.isSabMode()).toBe(false);
+    });
+  });
+
+  describe("Flow Control in IPC Mode (SAB disabled)", () => {
+    it("should spawn terminal with per-terminal flow control active", async () => {
+      expect(manager.isSabMode()).toBe(false);
+      const id = await spawnShellTerminal!(manager);
+      await sleep!(200);
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+    });
+
+    it("should acknowledge data in IPC mode", async () => {
+      const id = await spawnShellTerminal!(manager);
+      await sleep!(200);
+      // acknowledgeData should not throw in IPC mode
+      expect(() => manager.acknowledgeData(id, 1000)).not.toThrow();
+    });
+  });
+
+  describe("Flow Control in SAB Mode (SAB enabled)", () => {
+    beforeEach(() => {
+      manager.setSabMode(true);
+    });
+
+    it("should spawn terminal with SAB mode flag propagated", async () => {
+      expect(manager.isSabMode()).toBe(true);
+      const id = await spawnShellTerminal!(manager);
+      await sleep!(200);
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+    });
+
+    it("should acknowledge data in SAB mode without error", async () => {
+      const id = await spawnShellTerminal!(manager);
+      await sleep!(200);
+      // acknowledgeData should be a no-op but not throw in SAB mode
+      expect(() => manager.acknowledgeData(id, 1000)).not.toThrow();
+    });
+
+    it("should allow high-output terminal without pausing in SAB mode", async () => {
+      // This test verifies that in SAB mode, terminals don't pause due to
+      // unacknowledged output. Without SAB mode bypass, terminals producing
+      // more than 100KB of output would pause waiting for renderer acks.
+      const id = await spawnShellTerminal!(manager);
+      await sleep!(200);
+
+      // Exceed HIGH_WATERMARK_CHARS (100KB) and ensure the final sentinel arrives
+      // This proves the terminal didn't pause mid-stream waiting for renderer acks
+      manager.write(id, `node -e "process.stdout.write('x'.repeat(120000) + '\\nEND\\n')"\n`);
+
+      const received = await waitForData!(manager, id, (data) => data.includes("END"), 5000);
+      expect(received).toContain("END");
+    });
+  });
+
+  describe("Mode Transition", () => {
+    it("should allow enabling SAB mode before spawning terminals", async () => {
+      manager.setSabMode(true);
+      const id = await spawnShellTerminal!(manager);
+      await sleep!(200);
+      expect(manager.getTerminal(id)).toBeDefined();
+    });
+
+    it("should apply SAB mode setting only to newly spawned terminals", async () => {
+      // Spawn terminal with SAB mode disabled
+      const id1 = await spawnShellTerminal!(manager);
+      await sleep!(200);
+
+      // Enable SAB mode and spawn another terminal
+      manager.setSabMode(true);
+      const id2 = await spawnShellTerminal!(manager);
+      await sleep!(200);
+
+      // Both terminals should work
+      expect(manager.getTerminal(id1)).toBeDefined();
+      expect(manager.getTerminal(id2)).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes background terminal stalls by decoupling per-terminal flow control from renderer acknowledgments when SharedArrayBuffer mode is enabled. Background terminals (not actively rendered) can now continue running without waiting for acknowledgments that will never arrive.

Closes #985

## Changes Made
- Added SAB mode flag to PtyManager to track SharedArrayBuffer usage
- Modified TerminalProcess to skip per-terminal flow control when SAB mode is enabled
- Implemented dynamic SAB mode propagation to existing terminals
- Added automatic resume of paused terminals when transitioning to SAB mode
- Enhanced buffer initialization logging to clearly indicate SAB vs IPC fallback mode
- Created comprehensive unit tests for SAB mode behavior
- Fixed high-output test to properly exceed 100KB watermark threshold

## Technical Details
**Problem:** Per-terminal flow control pauses PTY processes when unacknowledged character count exceeds 100KB. Acknowledgments are sent by the renderer after xterm.js consumes output. Background terminals (minimized, in other workspaces, or in trash) have no xterm instance, so acknowledgments never arrive, causing indefinite pauses.

**Solution:** When SharedArrayBuffer is available, successful SAB ring buffer writes serve as implicit acknowledgment. Per-terminal flow control is bypassed, and global SAB backpressure (already implemented in pty-host.ts) becomes the primary throttling mechanism.

## Testing
- Added unit tests verifying SAB mode configuration
- Tests confirm flow control bypass in SAB mode
- High-output test validates terminals don't pause when exceeding 100KB threshold
- All existing tests pass