### PR TITLE
Make headless xterm creation lazy and conditional to reduce CPU and memory overhead

### DIFF
--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -47,8 +47,9 @@ export interface TerminalInfo {
   inputWriteQueue: string[];
   inputWriteTimeout: NodeJS.Timeout | null;
 
-  headlessTerminal: HeadlessTerminal;
-  serializeAddon: SerializeAddon;
+  headlessTerminal?: HeadlessTerminal;
+  serializeAddon?: SerializeAddon;
+  rawOutputBuffer?: string;
 
   restartCount: number;
 }
@@ -88,5 +89,8 @@ export const WRITE_INTERVAL_MS = 5;
 // Scrollback configuration
 export const DEFAULT_SCROLLBACK = 1000;
 export const AGENT_SCROLLBACK = 10000;
+
+// Raw output buffer for non-headless terminals (100KB max)
+export const RAW_OUTPUT_BUFFER_MAX_SIZE = 100 * 1024;
 
 export const TRASH_TTL_MS = 120 * 1000;


### PR DESCRIPTION
## Summary
Implements lazy headless xterm creation to reduce CPU and memory overhead at scale (50+ terminals). Agent terminals create headless xterm immediately for serialization needs, while shell terminals defer creation until first serialize request. Non-headless terminals buffer last 100KB of raw output instead of maintaining full xterm state.

Closes #988

## Changes Made
- Agent terminals (Claude/Gemini/Codex) create headless xterm immediately for serialization needs
- Shell terminals defer creation until first serialize request (lazy creation)
- Non-headless terminals buffer last 100KB of raw output instead of maintaining full xterm state
- Add ensureHeadlessTerminal() for on-demand creation with buffered output replay
- Add disposeHeadless() helper to safely dispose and clear references
- Store terminal dimensions for lazy headless creation after resize
- Reduce raw buffer allocation churn by trimming at 110% threshold
- Guard lazy creation against killed/disposed terminals and stale state

## Expected Impact
60-80% memory and CPU reduction for shell-heavy workloads