### PR TITLE
Batch ProcessDetector queries to eliminate per-terminal process spawns

### DIFF
--- a/electron/services/ProcessDetector.ts
+++ b/electron/services/ProcessDetector.ts
@@ -1,136 +1,10 @@
-import { exec } from "child_process";
-import { promisify } from "util";
 import type { TerminalType } from "../../shared/types/domain.js";
-
-const execAsync = promisify(exec);
+import type { ProcessTreeCache } from "./ProcessTreeCache.js";
 
 interface ChildProcess {
   pid: number;
   name: string;
   command?: string;
-}
-
-/**
- * Get child processes using PowerShell's Get-CimInstance (modern, fast).
- * Available on Windows 10+ with PowerShell 5.1+.
- */
-async function getChildProcessesPowerShell(pid: number): Promise<ChildProcess[]> {
-  const { stdout } = await execAsync(
-    `powershell -NoProfile -Command "Get-CimInstance Win32_Process | Where-Object {$_.ParentProcessId -eq ${pid}} | Select-Object ProcessId,Name | ConvertTo-Json -Compress"`,
-    { timeout: 5000 }
-  );
-
-  const trimmed = stdout.replace(/^\uFEFF/, "").trim();
-  if (!trimmed || trimmed === "null") {
-    return [];
-  }
-
-  let result;
-  try {
-    result = JSON.parse(trimmed);
-  } catch (error) {
-    console.warn("PowerShell process JSON parse failed", {
-      pid,
-      outputSample: trimmed.slice(0, 200),
-    });
-    throw error;
-  }
-  // Single object if one match, array if multiple
-  const processes = Array.isArray(result) ? result : [result];
-
-  return processes
-    .map((p) => ({
-      pid: Number.parseInt(String(p?.ProcessId), 10),
-      name: (p?.Name || "").replace(/\.exe$/i, ""),
-      command:
-        typeof p?.CommandLine === "string" && p.CommandLine.trim().length > 0
-          ? String(p.CommandLine).trim()
-          : undefined,
-    }))
-    .filter((p) => Number.isInteger(p.pid) && p.pid > 0 && p.name);
-}
-
-/**
- * Get child processes using wmic (legacy fallback for older Windows).
- * Deprecated but works on Windows 7-10 systems where wmic is still available.
- */
-async function getChildProcessesWmic(pid: number): Promise<ChildProcess[]> {
-  const { stdout } = await execAsync(
-    `wmic process where "ParentProcessId=${pid}" get ProcessId,Name /format:csv 2>nul`,
-    { timeout: 5000 }
-  );
-
-  const lines = stdout.split("\n").filter((line) => line.trim());
-  const processes: ChildProcess[] = [];
-
-  // Skip header line (first non-empty line is header in CSV format)
-  for (let i = 1; i < lines.length; i++) {
-    const parts = lines[i].trim().split(",");
-    // CSV format: Node,Name,ProcessId
-    if (parts.length >= 3) {
-      const name = parts[1];
-      const childPid = parseInt(parts[2], 10);
-      if (!isNaN(childPid) && name) {
-        processes.push({
-          pid: childPid,
-          name: name.replace(/\.exe$/i, ""),
-        });
-      }
-    }
-  }
-
-  return processes;
-}
-
-/**
- * Get child processes on Windows with PowerShell primary, wmic fallback.
- * Returns empty array if both methods fail (graceful degradation).
- */
-async function getChildProcessesWindows(pid: number): Promise<ChildProcess[]> {
-  // Try PowerShell first (modern, faster)
-  try {
-    return await getChildProcessesPowerShell(pid);
-  } catch (psError) {
-    // PowerShell failed, try wmic fallback
-    try {
-      return await getChildProcessesWmic(pid);
-    } catch (wmicError) {
-      // Both methods failed - log and return empty (graceful degradation)
-      console.warn("Windows process detection failed:", {
-        pid,
-        powershell: psError instanceof Error ? psError.message : String(psError),
-        wmic: wmicError instanceof Error ? wmicError.message : String(wmicError),
-      });
-      return [];
-    }
-  }
-}
-
-/**
- * Check if a process has any child processes running.
- * Used for shell terminals to determine busy/idle state.
- */
-export async function hasChildProcesses(pid: number): Promise<boolean> {
-  try {
-    if (!Number.isInteger(pid) || pid <= 0) {
-      return false;
-    }
-
-    if (process.platform === "win32") {
-      const children = await getChildProcessesWindows(pid);
-      return children.length > 0;
-    } else {
-      // macOS/Linux: pgrep returns 0 when children exist, 1 when none exist
-      try {
-        await execAsync(`pgrep -P ${pid}`, { timeout: 5000 });
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  } catch {
-    return false;
-  }
 }
 
 const AGENT_CLI_NAMES: Record<string, TerminalType> = {
@@ -143,9 +17,7 @@ export interface DetectionResult {
   detected: boolean;
   agentType?: TerminalType;
   processName?: string;
-  /** Whether the terminal has active child processes (busy/idle status) */
   isBusy?: boolean;
-  /** Best-effort current command line for the foreground process */
   currentCommand?: string;
 }
 
@@ -156,73 +28,64 @@ export class ProcessDetector {
   private spawnedAt: number;
   private ptyPid: number;
   private callback: DetectionCallback;
-  private intervalHandle: NodeJS.Timeout | null = null;
   private lastDetected: TerminalType | null = null;
   private lastBusyState: boolean | null = null;
   private lastCurrentCommand: string | undefined;
-  private pollInterval: number;
-  private isWindows: boolean;
-  private isDetecting: boolean = false;
+  private cache: ProcessTreeCache;
+  private unsubscribe: (() => void) | null = null;
+  private isStarted: boolean = false;
 
   constructor(
     terminalId: string,
     spawnedAt: number,
     ptyPid: number,
     callback: DetectionCallback,
-    pollInterval: number = 1000
+    cache: ProcessTreeCache
   ) {
     this.terminalId = terminalId;
     this.spawnedAt = spawnedAt;
     this.ptyPid = ptyPid;
     this.callback = callback;
-    this.pollInterval = pollInterval;
-    this.isWindows = process.platform === "win32";
+    this.cache = cache;
   }
 
   start(): void {
-    if (this.intervalHandle) {
+    if (this.isStarted) {
       console.warn(`ProcessDetector for terminal ${this.terminalId} already started`);
       return;
     }
 
     console.log(`Starting ProcessDetector for terminal ${this.terminalId}, PID ${this.ptyPid}`);
 
+    this.isStarted = true;
     this.detect();
 
-    this.intervalHandle = setInterval(() => {
+    this.unsubscribe = this.cache.onRefresh(() => {
       this.detect();
-    }, this.pollInterval);
+    });
   }
 
   stop(): void {
-    if (this.intervalHandle) {
-      clearInterval(this.intervalHandle);
-      this.intervalHandle = null;
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
       console.log(`Stopped ProcessDetector for terminal ${this.terminalId}`);
     }
+    this.isStarted = false;
   }
 
-  private async detect(): Promise<void> {
-    if (this.isDetecting) {
-      return;
-    }
-
-    this.isDetecting = true;
+  private detect(): void {
     try {
-      const result = await this.detectAgent();
+      const result = this.detectAgent();
 
-      // Check if agent detection changed
       const agentChanged =
         (result.detected && result.agentType !== this.lastDetected) ||
         (!result.detected && this.lastDetected !== null);
 
-      // Check if busy state changed
       const busyChanged = result.isBusy !== undefined && result.isBusy !== this.lastBusyState;
 
-      // Check if the foreground command changed (e.g., npm install -> npm run dev)
       const commandChanged = result.currentCommand !== this.lastCurrentCommand;
 
-      // Update tracked states
       if (result.detected) {
         this.lastDetected = result.agentType!;
       } else if (this.lastDetected !== null) {
@@ -235,178 +98,72 @@ export class ProcessDetector {
 
       this.lastCurrentCommand = result.currentCommand;
 
-      // Fire callback if agent, busy state, or current command changed
       if (agentChanged || busyChanged || commandChanged) {
         this.callback(result, this.spawnedAt);
       }
     } catch (_error) {
       console.error(`ProcessDetector error for terminal ${this.terminalId}:`, _error);
-    } finally {
-      this.isDetecting = false;
     }
   }
 
-  private async detectAgent(): Promise<DetectionResult> {
-    if (this.isWindows) {
-      return this.detectAgentWindows();
-    } else {
-      return this.detectAgentUnix();
+  private detectAgent(): DetectionResult {
+    if (!Number.isInteger(this.ptyPid) || this.ptyPid <= 0) {
+      console.warn(`Invalid PTY PID for terminal ${this.terminalId}: ${this.ptyPid}`);
+      return { detected: false, isBusy: false };
     }
-  }
 
-  private async detectAgentUnix(): Promise<DetectionResult> {
-    try {
-      if (!Number.isInteger(this.ptyPid) || this.ptyPid <= 0) {
-        console.warn(`Invalid PTY PID for terminal ${this.terminalId}: ${this.ptyPid}`);
-        return { detected: false, isBusy: false };
-      }
+    const children = this.cache.getChildren(this.ptyPid);
+    const isBusy = children.length > 0;
 
-      // Use pgrep to find direct children of the PTY process.
-      // -P <pid>: list children of the given parent
-      const { stdout } = await execAsync(`pgrep -P ${this.ptyPid}`, {
-        timeout: 5000,
-      });
-
-      const childPids = stdout
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0)
-        .map((line) => Number.parseInt(line, 10))
-        .filter((pid) => Number.isInteger(pid) && pid > 0);
-
-      // Any direct children mean the shell is running a foreground command
-      const isBusy = childPids.length > 0;
-      if (!isBusy) {
-        return { detected: false, isBusy: false, currentCommand: undefined };
-      }
-
-      let processes: ChildProcess[] = childPids.map((pid) => ({ pid, name: String(pid) }));
-      let currentCommand: string | undefined;
-
-      try {
-        // ps -o pid=,comm=,command= works on both macOS (BSD ps) and Linux.
-        const { stdout: psOut } = await execAsync(
-          `ps -o pid=,comm=,command= -p ${childPids.join(",")}`,
-          { timeout: 5000 }
-        );
-
-        const byPid = new Map<number, ChildProcess>();
-
-        psOut
-          .split("\n")
-          .map((line) => line.trim())
-          .filter((line) => line.length > 0)
-          .forEach((line) => {
-            // Robust parsing:
-            // 1. Extract PID (first digits)
-            // 2. Extract COMM (next non-whitespace token, might be path)
-            // 3. Everything else is COMMAND
-
-            // Match: Start, Optional Space, Digits (PID), Spaces, Non-Spaces (COMM), Spaces, Rest (COMMAND)
-
-            // Fix: Added \s* at start to handle padded PIDs from ps
-
-            const match = line.match(/^\s*(\d+)\s+(\S+)\s+(.*)$/);
-
-            const pid = match ? Number.parseInt(match[1], 10) : NaN;
-            if (!Number.isInteger(pid) || pid <= 0) return;
-
-            const name = match ? match[2] : "";
-            const command = match ? match[3].trim() : "";
-
-            byPid.set(pid, {
-              pid,
-              name: name || String(pid),
-              // If command is empty, fallback to name
-              command: command || name || undefined,
-            });
-          });
-
-        processes = childPids.map((pid) => byPid.get(pid) || { pid, name: String(pid) });
-        const primaryPid = childPids[0];
-        const primary = byPid.get(primaryPid);
-        if (primary?.command) {
-          currentCommand = primary.command;
-        }
-      } catch {
-        // If ps fails, fall back to pid-based names only
-        processes = childPids.map((pid) => ({ pid, name: String(pid) }));
-      }
-
-      // Check for agent CLIs in child processes
-      for (const proc of processes) {
-        const basename = proc.name.split("/").pop() || proc.name;
-        const agentType = AGENT_CLI_NAMES[basename.toLowerCase()];
-
-        if (agentType) {
-          return {
-            detected: true,
-            agentType,
-            processName: basename,
-            isBusy,
-            currentCommand,
-          };
-        }
-      }
-
-      return { detected: false, isBusy, currentCommand };
-    } catch (_error) {
-      // pgrep exits with code 1 when no processes are found – treat as idle shell
+    if (!isBusy) {
       return { detected: false, isBusy: false, currentCommand: undefined };
     }
-  }
 
-  private async detectAgentWindows(): Promise<DetectionResult> {
-    try {
-      if (!Number.isInteger(this.ptyPid) || this.ptyPid <= 0) {
-        console.warn(`Invalid PTY PID for terminal ${this.terminalId}: ${this.ptyPid}`);
-        return { detected: false, isBusy: false };
+    const processes: ChildProcess[] = children.map((p) => ({
+      pid: p.pid,
+      name: p.comm,
+      command: p.command,
+    }));
+
+    const primaryProcess = processes[0];
+    const currentCommand = primaryProcess?.command;
+
+    for (const proc of processes) {
+      const basename = proc.name.split("/").pop() || proc.name;
+      const agentType = AGENT_CLI_NAMES[basename.toLowerCase()];
+
+      if (agentType) {
+        return {
+          detected: true,
+          agentType,
+          processName: basename,
+          isBusy,
+          currentCommand,
+        };
       }
+    }
 
-      // Get direct children of the PTY process
-      const children = await getChildProcessesWindows(this.ptyPid);
-      const isBusy = children.length > 0;
-      const currentCommand = children[0]?.command || children[0]?.name;
-
-      // Check direct children for agent CLIs
-      for (const child of children) {
-        const agentType = AGENT_CLI_NAMES[child.name.toLowerCase()];
-        if (agentType) {
-          return {
-            detected: true,
-            agentType,
-            processName: child.name,
-            isBusy,
-            currentCommand,
-          };
-        }
-      }
-
-      // Check grandchildren (agent may be spawned by intermediate shell)
+    // On Windows, also check grandchildren for agent processes
+    if (process.platform === "win32") {
       for (const child of children.slice(0, 10)) {
-        try {
-          const grandchildren = await getChildProcessesWindows(child.pid);
-          for (const grandchild of grandchildren) {
-            const agentType = AGENT_CLI_NAMES[grandchild.name.toLowerCase()];
-            if (agentType) {
-              return {
-                detected: true,
-                agentType,
-                processName: grandchild.name,
-                isBusy,
-                currentCommand: grandchild.command || grandchild.name,
-              };
-            }
+        const grandchildren = this.cache.getChildren(child.pid);
+        for (const grandchild of grandchildren) {
+          const basename = grandchild.comm.split("/").pop() || grandchild.comm;
+          const agentType = AGENT_CLI_NAMES[basename.toLowerCase()];
+          if (agentType) {
+            return {
+              detected: true,
+              agentType,
+              processName: basename,
+              isBusy,
+              currentCommand: grandchild.command || grandchild.comm,
+            };
           }
-        } catch {
-          // Ignore errors checking grandchildren
         }
       }
-
-      return { detected: false, isBusy, currentCommand };
-    } catch (_error) {
-      return { detected: false, isBusy: false, currentCommand: undefined };
     }
+
+    return { detected: false, isBusy, currentCommand };
   }
 
   getLastDetected(): TerminalType | null {

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -1,0 +1,249 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+
+export interface ProcessInfo {
+  pid: number;
+  ppid: number;
+  comm: string;
+  command: string;
+}
+
+type RefreshCallback = () => void;
+
+export class ProcessTreeCache {
+  private cache: Map<number, ProcessInfo> = new Map();
+  private childrenMap: Map<number, number[]> = new Map();
+  private refreshInterval: NodeJS.Timeout | null = null;
+  private isRefreshing: boolean = false;
+  private lastRefreshTime: number = 0;
+  private isWindows: boolean = process.platform === "win32";
+  private refreshCallbacks: Set<RefreshCallback> = new Set();
+  private lastError: Error | null = null;
+
+  constructor(private pollIntervalMs: number = 1000) {}
+
+  start(): void {
+    if (this.refreshInterval) {
+      console.warn("[ProcessTreeCache] Already started");
+      return;
+    }
+
+    console.log(`[ProcessTreeCache] Starting with ${this.pollIntervalMs}ms poll interval`);
+
+    this.refresh();
+    this.refreshInterval = setInterval(() => {
+      this.refresh();
+    }, this.pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = null;
+      console.log("[ProcessTreeCache] Stopped");
+    }
+  }
+
+  onRefresh(callback: RefreshCallback): () => void {
+    this.refreshCallbacks.add(callback);
+    return () => {
+      this.refreshCallbacks.delete(callback);
+    };
+  }
+
+  async refresh(): Promise<void> {
+    if (this.isRefreshing) {
+      return;
+    }
+
+    this.isRefreshing = true;
+    try {
+      if (this.isWindows) {
+        await this.refreshWindows();
+      } else {
+        await this.refreshUnix();
+      }
+      this.lastRefreshTime = Date.now();
+      this.lastError = null;
+    } catch (error) {
+      this.lastError = error instanceof Error ? error : new Error(String(error));
+      if (process.env.CANOPY_VERBOSE) {
+        console.error("[ProcessTreeCache] Refresh failed:", error);
+      }
+    } finally {
+      this.isRefreshing = false;
+
+      // Invoke callbacks after isRefreshing is reset
+      for (const callback of this.refreshCallbacks) {
+        try {
+          callback();
+        } catch (err) {
+          console.error("[ProcessTreeCache] Refresh callback error:", err);
+        }
+      }
+    }
+  }
+
+  private async refreshUnix(): Promise<void> {
+    const { stdout } = await execAsync("ps -eo pid,ppid,comm,command", {
+      timeout: 5000,
+      maxBuffer: 10 * 1024 * 1024, // 10MB to handle systems with many processes
+    });
+
+    const newCache = new Map<number, ProcessInfo>();
+    const newChildrenMap = new Map<number, number[]>();
+
+    const lines = stdout.split("\n");
+    // Skip header line
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+
+      const parsed = this.parseUnixLine(line);
+      if (parsed) {
+        newCache.set(parsed.pid, parsed);
+
+        // Build children map
+        const children = newChildrenMap.get(parsed.ppid) || [];
+        children.push(parsed.pid);
+        newChildrenMap.set(parsed.ppid, children);
+      }
+    }
+
+    this.cache = newCache;
+    this.childrenMap = newChildrenMap;
+
+    // Sort children arrays for deterministic ordering
+    for (const children of newChildrenMap.values()) {
+      children.sort((a, b) => a - b);
+    }
+  }
+
+  private parseUnixLine(line: string): ProcessInfo | null {
+    // Format: PID PPID COMM COMMAND
+    // PID and PPID are right-aligned numbers, COMM is the basename, COMMAND is the full command line
+    // Example: "  123    1 bash /bin/bash --login"
+    // Make command optional in case ps omits it
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)(?:\s+(.*))?$/);
+    if (!match) {
+      return null;
+    }
+
+    const pid = parseInt(match[1], 10);
+    const ppid = parseInt(match[2], 10);
+    const comm = match[3];
+    const command = match[4]?.trim() || comm;
+
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid) || pid <= 0) {
+      return null;
+    }
+
+    return { pid, ppid, comm, command };
+  }
+
+  private async refreshWindows(): Promise<void> {
+    // Use PowerShell's Get-CimInstance for efficient batch query
+    const { stdout } = await execAsync(
+      `powershell -NoProfile -NonInteractive -NoLogo -Command "$ErrorActionPreference = 'SilentlyContinue'; Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress"`,
+      {
+        timeout: 10000,
+        maxBuffer: 10 * 1024 * 1024,
+      }
+    );
+
+    const trimmed = stdout.replace(/^\uFEFF/, "").trim();
+    if (!trimmed || trimmed === "null") {
+      this.cache = new Map();
+      this.childrenMap = new Map();
+      return;
+    }
+
+    let result;
+    try {
+      result = JSON.parse(trimmed);
+    } catch (error) {
+      console.warn("[ProcessTreeCache] PowerShell JSON parse failed:", {
+        outputSample: trimmed.slice(0, 200),
+      });
+      throw error;
+    }
+
+    const processes = Array.isArray(result) ? result : [result];
+
+    const newCache = new Map<number, ProcessInfo>();
+    const newChildrenMap = new Map<number, number[]>();
+
+    for (const p of processes) {
+      const pid = parseInt(String(p?.ProcessId), 10);
+      const ppid = parseInt(String(p?.ParentProcessId), 10);
+
+      if (!Number.isInteger(pid) || !Number.isInteger(ppid) || pid <= 0) {
+        continue;
+      }
+
+      const name = (p?.Name || "").replace(/\.exe$/i, "");
+      if (!name) {
+        continue;
+      }
+
+      const command =
+        typeof p?.CommandLine === "string" && p.CommandLine.trim().length > 0
+          ? p.CommandLine.trim()
+          : name;
+
+      newCache.set(pid, {
+        pid,
+        ppid,
+        comm: name,
+        command,
+      });
+
+      // Build children map
+      const children = newChildrenMap.get(ppid) || [];
+      children.push(pid);
+      newChildrenMap.set(ppid, children);
+    }
+
+    this.cache = newCache;
+    this.childrenMap = newChildrenMap;
+
+    // Sort children arrays for deterministic ordering
+    for (const children of newChildrenMap.values()) {
+      children.sort((a, b) => a - b);
+    }
+  }
+
+  getChildren(ppid: number): ProcessInfo[] {
+    const childPids = this.childrenMap.get(ppid) || [];
+    return childPids
+      .map((pid) => this.cache.get(pid))
+      .filter((p): p is ProcessInfo => p !== undefined);
+  }
+
+  getChildPids(ppid: number): number[] {
+    return this.childrenMap.get(ppid) || [];
+  }
+
+  getProcess(pid: number): ProcessInfo | undefined {
+    return this.cache.get(pid);
+  }
+
+  hasChildren(ppid: number): boolean {
+    const children = this.childrenMap.get(ppid);
+    return children !== undefined && children.length > 0;
+  }
+
+  getLastRefreshTime(): number {
+    return this.lastRefreshTime;
+  }
+
+  getLastError(): Error | null {
+    return this.lastError;
+  }
+
+  getCacheSize(): number {
+    return this.cache.size;
+  }
+}

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -3,6 +3,7 @@ import { events } from "./events.js";
 import type { AgentEvent } from "./AgentStateMachine.js";
 import type { AgentStateChangeTrigger } from "../schemas/agent.js";
 import type { PtyPool } from "./PtyPool.js";
+import type { ProcessTreeCache } from "./ProcessTreeCache.js";
 
 import {
   TerminalRegistry,
@@ -42,12 +43,17 @@ export class PtyManager extends EventEmitter {
   private agentStateService: AgentStateService;
   private terminals: Map<string, TerminalProcess> = new Map();
   private ptyPool: PtyPool | null = null;
+  private processTreeCache: ProcessTreeCache | null = null;
   private activeProjectId: string | null = null;
 
   constructor() {
     super();
     this.registry = new TerminalRegistry();
     this.agentStateService = new AgentStateService();
+  }
+
+  setProcessTreeCache(cache: ProcessTreeCache): void {
+    this.processTreeCache = cache;
   }
 
   /**
@@ -164,6 +170,7 @@ export class PtyManager extends EventEmitter {
       {
         agentStateService: this.agentStateService,
         ptyPool: this.ptyPool,
+        processTreeCache: this.processTreeCache,
       }
     );
 


### PR DESCRIPTION
## Summary
Replaces per-terminal `pgrep`/`ps` process spawns with a single shared `ProcessTreeCache` that batches all process detection into one query per poll interval.

Closes #986

## Changes Made
- Add `ProcessTreeCache` service that runs a single `ps -eo pid,ppid,comm,command` (Unix) or `Get-CimInstance Win32_Process` (Windows) query per interval
- Refactor `ProcessDetector` to read from shared cache instead of spawning processes
- Integrate cache lifecycle into `pty-host.ts` with proper start/stop
- Pass cache through `PtyManager` to `TerminalProcess` instances
- Apply robustness fixes from Codex review:
  - Deterministic child ordering (sorted by PID)
  - Optional command field handling in Unix parser
  - Empty process name filtering on Windows
  - Sanitized PowerShell output flags
  - Idempotent stop() cleanup

## Performance Impact
- **Before**: 50 terminals = 100 process spawns/sec (pgrep + ps per terminal)
- **After**: 50 terminals = 1 process spawn/sec (single batched query)
- **Reduction**: 99% fewer process spawns