### PR TITLE
Unify design system usage across menu and popover components

### DIFF
--- a/src/components/Pulse/PulseHeatmap.tsx
+++ b/src/components/Pulse/PulseHeatmap.tsx
@@ -77,7 +77,7 @@ export function PulseHeatmap({ cells, rangeDays, compact = false }: PulseHeatmap
                       className={cn(
                         cellSize,
                         colorClass,
-                        "rounded-[2px] transition-all border-0 p-0 cursor-default",
+                        "rounded-[var(--radius-xs)] transition-all border-0 p-0 cursor-default",
                         cell.isToday && "ring-1 ring-white/30",
                         cell.isMostRecentActive && !cell.isToday && "ring-1 ring-emerald-400/40"
                       )}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -69,7 +69,7 @@ AppPaletteDialog.Header = function AppPaletteHeader({
 }: AppPaletteHeaderProps) {
   return (
     <div className={cn("px-3 pt-2 pb-1 border-b border-canopy-border", className)}>
-      <div className="flex justify-between items-center mb-1.5 text-[11px] text-canopy-text/40">
+      <div className="flex justify-between items-center mb-1.5 text-[11px] text-canopy-text/50">
         <span>{label}</span>
         {keyHint && <span className="font-mono">{keyHint}</span>}
       </div>
@@ -106,7 +106,7 @@ AppPaletteDialog.Footer = function AppPaletteFooter({
   return (
     <div
       className={cn(
-        "px-3 py-2 border-t border-canopy-border bg-canopy-sidebar/50 text-xs text-canopy-text/40 flex items-center gap-4",
+        "px-3 py-2 border-t border-canopy-border bg-canopy-sidebar/50 text-xs text-canopy-text/50 flex items-center gap-4",
         className
       )}
     >

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -24,7 +24,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   <ContextMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none focus:bg-canopy-accent focus:text-white data-[state=open]:bg-canopy-accent data-[state=open]:text-white",
+      "flex cursor-default select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1 text-xs outline-none focus:bg-canopy-accent focus:text-white data-[state=open]:bg-canopy-accent data-[state=open]:text-white",
       inset && "pl-8",
       className
     )}
@@ -43,7 +43,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
+      "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-canopy-border bg-canopy-sidebar backdrop-blur p-1 text-canopy-text shadow-xl",
       className
     )}
     {...props}
@@ -59,7 +59,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
+        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-canopy-border bg-canopy-sidebar backdrop-blur p-1 text-canopy-text shadow-xl",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
@@ -78,7 +78,7 @@ const ContextMenuItem = React.forwardRef<
   <ContextMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -94,7 +94,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   <ContextMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-[3px] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -117,7 +117,7 @@ const ContextMenuRadioItem = React.forwardRef<
   <ContextMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-[3px] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -22,7 +22,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none focus:bg-canopy-accent focus:text-white data-[state=open]:bg-canopy-accent data-[state=open]:text-white",
+      "flex cursor-default select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1 text-xs outline-none focus:bg-canopy-accent focus:text-white data-[state=open]:bg-canopy-accent data-[state=open]:text-white",
       inset && "pl-8",
       className
     )}
@@ -41,7 +41,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
+      "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-canopy-border bg-canopy-sidebar backdrop-blur p-1 text-canopy-text shadow-xl",
       className
     )}
     {...props}
@@ -58,7 +58,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-white/10 bg-[#1a1b1e]/95 backdrop-blur p-1 text-canopy-text shadow-xl",
+        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-lg border border-canopy-border bg-canopy-sidebar backdrop-blur p-1 text-canopy-text shadow-xl",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
@@ -77,7 +77,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-[3px] px-2.5 py-1 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className
     )}
@@ -133,7 +133,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-pointer select-none items-center rounded-[3px] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] py-1 pl-8 pr-2.5 text-xs outline-none transition-colors focus:bg-canopy-accent focus:text-white data-[highlighted]:bg-canopy-accent data-[highlighted]:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -77,12 +77,7 @@ function Toast({ notification }: { notification: Notification }) {
 
       <div className="flex-1 space-y-1 min-w-0">
         {notification.title && (
-          <h4
-            className={cn(
-              "font-medium leading-none tracking-tight font-mono text-sm",
-              config.accentClass
-            )}
-          >
+          <h4 className={cn("font-medium leading-none tracking-tight text-sm", config.accentClass)}>
             {notification.title}
           </h4>
         )}


### PR DESCRIPTION
## Summary
This PR unifies design system token usage across menu and popover components by replacing hardcoded colors, borders, and radii with design system tokens defined in `src/index.css`. This improves visual consistency and makes theme maintenance easier.

Closes #996

## Changes Made
- Replace hardcoded colors (`bg-[#1a1b1e]/95` → `bg-canopy-sidebar`, `border-white/10` → `border-canopy-border`) in dropdown-menu.tsx and context-menu.tsx
- Replace hardcoded border radii (`rounded-[3px]` → `rounded-[var(--radius-sm)]`, `rounded-[2px]` → `rounded-[var(--radius-xs)]`) across all menu components
- Update PulseHeatmap.tsx to use `--radius-xs` token for heatmap cells
- Improve text readability by increasing opacity from `/40` to `/50` in AppPaletteDialog.tsx
- Remove `font-mono` from toast titles for improved legibility

## Files Modified
- `src/components/ui/dropdown-menu.tsx`
- `src/components/ui/context-menu.tsx`
- `src/components/Pulse/PulseHeatmap.tsx`
- `src/components/ui/AppPaletteDialog.tsx`
- `src/components/ui/toaster.tsx`

## Visual Impact
- Menu and context menu surfaces now use consistent design tokens
- Border radii are slightly larger due to token values (3px→6px for menu items, 2px→4px for heatmap cells)
- Text labels have improved readability with increased opacity
- All changes are CSS-only with no logic modifications