### PR TITLE
Restore filter-based flicker correction for agent terminals

### DIFF
--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -9,6 +9,8 @@ export interface AgentConfig {
   tooltip?: string;
   capabilities?: {
     scrollback?: number;
+    blockAltScreen?: boolean;
+    blockMouseReporting?: boolean;
   };
 }
 
@@ -24,6 +26,8 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     tooltip: "deep, focused work",
     capabilities: {
       scrollback: 10000,
+      blockAltScreen: true,
+      blockMouseReporting: true,
     },
   },
   gemini: {
@@ -37,6 +41,8 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     tooltip: "quick exploration",
     capabilities: {
       scrollback: 10000,
+      blockAltScreen: true,
+      blockMouseReporting: true,
     },
   },
   codex: {
@@ -50,6 +56,8 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     tooltip: "careful, methodical runs",
     capabilities: {
       scrollback: 10000,
+      blockAltScreen: true,
+      blockMouseReporting: true,
     },
   },
 };

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -12,6 +12,7 @@ import { TALL_CANVAS_ROWS, getSafeTallCanvasRows, measureCellHeight } from "./Te
 import { TerminalAddonManager } from "./TerminalAddonManager";
 import { TerminalDataBuffer } from "./TerminalDataBuffer";
 import { createThrottledWriter } from "./ThrottledWriter";
+import { setupParserHandlers } from "./TerminalParserHandler";
 
 const START_DEBOUNCING_THRESHOLD = 200;
 const HORIZONTAL_DEBOUNCE_MS = 100;
@@ -168,6 +169,19 @@ class TerminalInstanceService {
     hostElement.style.flexDirection = "column";
 
     const throttledWriter = createThrottledWriter(id, terminal, getRefreshTier);
+
+    // Create managed terminal placeholder for parser handler setup
+    const managedPlaceholder: Partial<ManagedTerminal> = {
+      terminal,
+      type,
+      kind: isTallCanvas ? "agent" : undefined,
+      agentId,
+    };
+
+    // Setup parser handlers BEFORE data subscriptions to prevent race conditions
+    if (isTallCanvas) {
+      setupParserHandlers(managedPlaceholder as ManagedTerminal);
+    }
 
     const listeners: Array<() => void> = [];
     const exitSubscribers = new Set<(exitCode: number) => void>();

--- a/src/services/terminal/TerminalParserHandler.ts
+++ b/src/services/terminal/TerminalParserHandler.ts
@@ -1,0 +1,95 @@
+import { getAgentConfig } from "@/config/agents";
+import { ManagedTerminal } from "./types";
+import { TerminalKind } from "@/types";
+
+/**
+ * Set up xterm.js parser hooks to intercept and block problematic sequences.
+ * This is more robust than regex filtering as it handles stream chunking correctly.
+ */
+export function setupParserHandlers(managed: ManagedTerminal): void {
+  const kind: TerminalKind | undefined = managed.kind;
+  const agentId = managed.agentId;
+  if (kind !== "agent" && managed.type !== "claude") return;
+
+  const agentConfig = agentId ? getAgentConfig(agentId) : null;
+  const shouldBlockSequences =
+    agentConfig?.capabilities?.blockAltScreen || agentConfig?.capabilities?.blockMouseReporting;
+
+  // Helper to check if we should block the sequence
+  const shouldBlock = () => {
+    // Block for configured agent terminals to prevent TUI mode hijacking and bouncing
+    return shouldBlockSequences ?? false;
+  };
+
+  // 1. Intercept DECSET (CSI ? ... h) - Enable Mode
+  managed.terminal.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+    if (!shouldBlock()) return false;
+
+    // Block Mouse Tracking (1000, 1002, 1003, 1006)
+    // Block Alt Screen (1049, 1047, 1048, 47)
+    const blockList = [1000, 1002, 1003, 1006, 1049, 1047, 1048, 47];
+    const hasBlockedParam = params.some((p) => {
+      // xterm.js params are (number | number[])[]
+      const val = typeof p === "number" ? p : p[0];
+      return blockList.includes(val);
+    });
+
+    return hasBlockedParam; // true = handled (swallowed), false = pass to default
+  });
+
+  // 2. Intercept DECRST (CSI ? ... l) - Disable Mode
+  managed.terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+    if (!shouldBlock()) return false;
+
+    // Same block list for disabling
+    const blockList = [1000, 1002, 1003, 1006, 1049, 1047, 1048, 47];
+    const hasBlockedParam = params.some((p) => {
+      const val = typeof p === "number" ? p : p[0];
+      return blockList.includes(val);
+    });
+
+    return hasBlockedParam;
+  });
+
+  // 3. Intercept DECSTBM (CSI ... r) - Set Scroll Region
+  managed.terminal.parser.registerCsiHandler({ final: "r" }, () => {
+    if (!shouldBlock()) return false;
+    // Block ALL scroll region changes for Claude to keep the buffer linear
+    return true;
+  });
+
+  // 4. Intercept ED (CSI ... J) - Erase in Display
+  managed.terminal.parser.registerCsiHandler({ final: "J" }, (params) => {
+    if (!shouldBlock()) return false;
+
+    // Block '2' (Clear Screen) and '3' (Clear Scrollback)
+    // This prevents the "blank slate" effect that usually precedes a jump-to-top
+    const hasBlockedParam = params.some((p) => {
+      const val = typeof p === "number" ? p : p[0];
+      return val === 2 || val === 3;
+    });
+
+    return hasBlockedParam;
+  });
+
+  // 5. Intercept CUP (CSI ... H) and HVP (CSI ... f) - Cursor Position
+  // Block attempts to move cursor to the top row (Row 1), which causes viewport jumping
+  const handleCursorMove = (params: (number | number[])[]) => {
+    if (!shouldBlock()) return false;
+
+    // Default is 1;1 if no params
+    if (params.length === 0) return true;
+
+    // Check Row (1st param)
+    const row = typeof params[0] === "number" ? params[0] : params[0][0];
+
+    // Block if explicit Row 1, Row 0 (treated as 1), or undefined (implies 1)
+    if (row === 0 || row === 1 || row === undefined) {
+      return true;
+    }
+    return false;
+  };
+
+  managed.terminal.parser.registerCsiHandler({ final: "H" }, handleCursorMove);
+  managed.terminal.parser.registerCsiHandler({ final: "f" }, handleCursorMove);
+}


### PR DESCRIPTION
## Summary
Restores the escape sequence filtering system that was removed in commit 4aa43c4. The filtering provides defense-in-depth alongside the tall-canvas architecture to prevent TUI applications from hijacking agent terminal behavior.

Closes #1006

## Changes Made
- Restored `TerminalParserHandler.ts` with xterm.js parser hooks for robust sequence filtering
- Added `blockAltScreen` and `blockMouseReporting` capabilities to `AgentConfig` interface
- Enabled filtering by default for Claude, Gemini, and Codex agents
- Blocks alt-screen modes (1049, 1047, 1048, 47), mouse tracking (1000-1006), scroll regions, clear screen, and cursor-to-top sequences
- Registers handlers before data subscriptions to prevent race conditions
- Provides complementary stability layer working alongside tall-canvas architecture

## Technical Details
**Two-Layer Stability Approach:**
1. **Tall Canvas (viewport layer)** - Handles scrollback and viewport management
2. **Sequence Filtering (control layer)** - Prevents problematic escape sequences from disrupting terminal behavior

The filtering system uses xterm.js parser hooks for stream-aware interception, more reliable than regex-based approaches. Agent terminals remain opt-in via configuration capabilities.