### PR TITLE
Wire agent state from AgentStateMachine to terminal rendering layer

### DIFF
--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -5,7 +5,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
-import { TerminalRefreshTier, TerminalType, TerminalKind } from "@/types";
+import { TerminalRefreshTier, TerminalType, TerminalKind, AgentState } from "@/types";
 
 export type RefreshTierProvider = () => TerminalRefreshTier;
 
@@ -29,11 +29,15 @@ export interface ThrottledWriter {
   clear: () => void;
 }
 
+export type AgentStateCallback = (state: AgentState) => void;
+
 export interface ManagedTerminal {
   terminal: Terminal;
   type: TerminalType;
   kind?: TerminalKind;
   agentId?: string;
+  agentState?: AgentState;
+  agentStateSubscribers: Set<AgentStateCallback>;
   fitAddon: FitAddon;
   webglAddon?: WebglAddon;
   serializeAddon: SerializeAddon;

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -22,6 +22,7 @@ import {
   isAgentReady,
 } from "./slices";
 import { terminalClient } from "@/clients";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 export type { TerminalInstance, AddTerminalOptions, QueuedCommand };
 export { isAgentReady };
@@ -305,6 +306,9 @@ export function setupTerminalStoreListeners() {
       console.warn(`Invalid agent state received: ${state} for terminal ${agentId}`);
       return;
     }
+
+    // Update terminal instance service (enables state-aware rendering in XtermAdapter)
+    terminalInstanceService.setAgentState(agentId, state as AgentState);
 
     useTerminalStore
       .getState()


### PR DESCRIPTION
## Summary
Connects agent state tracking from AgentStateMachine to the terminal rendering layer, enabling XtermAdapter to make state-aware rendering decisions that prevent jitter during intensive TUI updates.

Closes #1056

## Changes Made
- Add agentState field and agentStateSubscribers to ManagedTerminal type
- Implement setAgentState/getAgentState/addAgentStateListener in TerminalInstanceService
- Subscribe to agent state changes in XtermAdapter via useEffect
- Wire terminalStore IPC listener to call terminalInstanceService.setAgentState
- Enable state-aware rendering decisions for future defensive layers