### PR TITLE
Fix undefined Canopy token class references

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -141,7 +141,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
 
       {/* Agent Configuration Card */}
       {activeAgent && (
-        <div className="rounded-[var(--radius-lg)] border border-canopy-border bg-canopy-bg-secondary p-4 space-y-4">
+        <div className="rounded-[var(--radius-lg)] border border-canopy-border bg-surface p-4 space-y-4">
           {/* Header with agent info */}
           <div className="flex items-center justify-between pb-3 border-b border-canopy-border">
             <div className="flex items-center gap-3">

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -151,7 +151,7 @@ export function RecipeEditor({
             value={recipeName}
             onChange={(e) => setRecipeName(e.target.value)}
             placeholder="e.g., Full Stack Dev"
-            className="w-full px-3 py-2 bg-canopy-background border border-canopy-border rounded-[var(--radius-md)] text-canopy-text focus:outline-none focus:ring-2 focus:ring-canopy-accent"
+            className="w-full px-3 py-2 bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] text-canopy-text focus:outline-none focus:ring-2 focus:ring-canopy-accent"
           />
         </div>
 
@@ -169,7 +169,7 @@ export function RecipeEditor({
             {terminals.map((terminal, index) => (
               <div
                 key={index}
-                className="bg-canopy-background border border-canopy-border rounded-[var(--radius-md)] p-3"
+                className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] p-3"
               >
                 <div className="flex items-start gap-3">
                   <div className="flex-1">


### PR DESCRIPTION
## Summary
Resolved undefined Canopy token class references that could cause fallback to inherited colors and create visual inconsistencies.

Closes #1045

## Changes Made
- Replaced `bg-canopy-bg-secondary` with `bg-surface` in AgentSettings component (semantically correct for elevated card surface)
- Fixed typo `bg-canopy-background` to `bg-canopy-bg` in RecipeEditor component (2 instances)
- Verified all Canopy token classes now match defined theme tokens in `src/index.css`

## Impact
- Eliminates undefined CSS variables that could compile without values
- Ensures consistent visual hierarchy using proper token semantics
- Improves maintainability by using only defined tokens from the theme system