### PR TITLE
Replace hardcoded scrollbar hover color with design token

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -258,7 +258,7 @@
   }
 
   *::-webkit-scrollbar-thumb:hover {
-    background: #71717a;
+    background: color-mix(in oklab, var(--color-state-idle) 85%, white);
   }
 
   *::-webkit-scrollbar-corner {
@@ -285,7 +285,7 @@
   }
 
   .xterm-viewport::-webkit-scrollbar-thumb:hover {
-    background: #71717a; /* Zinc-500: Lighter on hover */
+    background: color-mix(in oklab, var(--color-state-idle) 85%, white);
   }
 
   /* Consistent monospace font stack - VS Code defaults */


### PR DESCRIPTION
## Summary
Replaces hardcoded scrollbar hover color with token-based derivation to maintain design system consistency and adapt automatically to theme changes.

Closes #1046

## Changes Made
- Replace hardcoded `#71717a` with `color-mix(in oklab, var(--color-state-idle) 85%, white)`
- Apply to both global and terminal scrollbar hover states
- Use 85/15 mix ratio to closely match original Zinc-500 shade
- Ensures scrollbar hover adapts automatically when `--color-state-idle` changes