### PR TITLE
Remove unused OpenAI API key references from codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,6 @@ Access native features via namespaced API in Renderer. Returns Promises or Clean
 - `copyTree`: generate, injectToTerminal, isAvailable, cancel, onProgress
 - `system`: openExternal, openPath, getConfig, checkCommand
 - `project`: getAll, getCurrent, add, remove, update, switch, onSwitch
-- `ai`: getConfig, setKey, clearKey, setModel, validateKey, generateProjectIdentity
 - `logs`: getAll, getSources, clear, openFile, onEntry
 - `errors`: onError, retry, openLogs
 - `eventInspector`: getEvents, getFiltered, clear, subscribe, onEvent
@@ -64,8 +63,7 @@ electron/
 │   ├── WorktreeService.ts   # Worktree monitoring
 │   ├── DevServerManager.ts  # Dev server lifecycle
 │   ├── AgentStateMachine.ts # Agent state tracking
-│   ├── CopyTreeService.ts   # Context generation
-│   └── ai/                  # AI integration (OpenAI)
+│   └── CopyTreeService.ts   # Context generation
 └── utils/
     ├── logger.ts        # Logging
     └── git.ts           # Git operations

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Instead of juggling multiple terminal windows and manually copying context, Cano
 ### Worktree Dashboard
 
 - **Visual Monitoring**: View all git worktrees at a glance with real-time status updates
-- **Smart Summaries**: AI-powered summaries of file changes in every branch (requires OpenAI key)
+- **Smart Summaries**: AI-powered summaries of file changes in every branch
 - **GitHub Integration**: Auto-detects associated Pull Requests and Issues based on branch names
 - **Dev Server Control**: Auto-detects `package.json` scripts and manages dev server lifecycles per worktree
 
@@ -39,7 +39,7 @@ Instead of juggling multiple terminal windows and manually copying context, Cano
 # Claude Code
 npm install -g @anthropic-ai/claude-code
 
-# OpenAI Codex
+# Codex CLI
 npm install -g @openai/codex
 ```
 
@@ -82,9 +82,8 @@ npm run dev
 
 Canopy works out of the box for local terminal management, but AI features require configuration via the **Settings** icon (bottom left sidebar).
 
-1. **OpenAI API Key**: Required for generating worktree summaries and project identities
-2. **GitHub Token**: Required for fetching PR statuses and issue details without hitting rate limits
-3. **Agent Settings**: Configure default models and flags for Claude, Gemini, and Codex
+1. **GitHub Token**: Required for fetching PR statuses and issue details without hitting rate limits
+2. **Agent Settings**: Configure default models and flags for Claude, Gemini, and Codex
 
 ## Architecture
 
@@ -96,17 +95,17 @@ Canopy uses a modern Electron architecture ensuring security and performance:
 
 ### Key Technologies
 
-| Component          | Technology                        |
-| ------------------ | --------------------------------- |
-| Runtime            | Electron 33                       |
-| UI Framework       | React 19 + TypeScript             |
-| Build              | Vite 6                            |
-| State Management   | Zustand                           |
-| Terminal Emulation | xterm.js + @xterm/addon-fit/webgl |
-| PTY                | node-pty (native module)          |
-| Git                | simple-git                        |
-| Styling            | Tailwind CSS v4                   |
-| AI Integration     | OpenAI SDK                        |
+| Component          | Technology                         |
+| ------------------ | ---------------------------------- |
+| Runtime            | Electron 33                        |
+| UI Framework       | React 19 + TypeScript              |
+| Build              | Vite 6                             |
+| State Management   | Zustand                            |
+| Terminal Emulation | xterm.js + @xterm/addon-fit/webgl  |
+| PTY                | node-pty (native module)           |
+| Git                | simple-git                         |
+| Styling            | Tailwind CSS v4                    |
+| AI Integration     | Agent CLIs (Claude, Gemini, Codex) |
 
 ## Build & Distribute
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,7 +162,7 @@ npm run dev
 | ---------- | -------------------------------- |
 | `NODE_ENV` | Set to `development` in dev mode |
 
-OpenAI API key and other secrets are stored via electron-store, not environment variables.
+Secrets like the GitHub token are stored via electron-store, not environment variables.
 
 ## Continuous Integration
 

--- a/electron/services/SecureStorage.ts
+++ b/electron/services/SecureStorage.ts
@@ -1,7 +1,7 @@
 import * as electron from "electron";
 import { store, type StoreSchema } from "../store.js";
 
-export type SecureKey = "userConfig.openaiApiKey" | "userConfig.githubToken";
+export type SecureKey = "userConfig.githubToken";
 
 type UserConfigKey = keyof StoreSchema["userConfig"];
 type DotNotatedUserConfigKey = `userConfig.${UserConfigKey}`;


### PR DESCRIPTION
## Summary
Removes all references to an unused OpenAI API key from the codebase. The app uses Claude, Gemini, and Codex agents via their respective CLI tools, not direct OpenAI API integration, so these references created confusion and technical debt.

Closes #1042

## Changes Made
- Remove openaiApiKey from SecureKey type in SecureStorage.ts
- Remove misleading OpenAI API key requirement from README configuration section
- Update README to clarify AI integration uses agent CLIs, not OpenAI SDK
- Remove stale window.electron.ai namespace from CLAUDE.md
- Remove non-existent electron/services/ai/ directory from CLAUDE.md
- Update development.md to reference GitHub token instead of OpenAI key

## Testing
- TypeScript compilation passes
- All tests pass
- Codex review completed