### PR TITLE
Replace white overlay surfaces in Pulse UI with Canopy surface tokens

### DIFF
--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -85,7 +85,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     return (
       <div
         className={cn(
-          "p-4 bg-white/[0.02] rounded-[var(--radius-lg)] border border-white/5",
+          "p-4 bg-[var(--color-surface)] rounded-[var(--radius-lg)] border border-canopy-border",
           className
         )}
       >
@@ -101,16 +101,16 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     return (
       <div
         className={cn(
-          "p-4 bg-white/[0.02] rounded-[var(--radius-lg)] border border-white/5",
+          "p-4 bg-[var(--color-surface)] rounded-[var(--radius-lg)] border border-canopy-border",
           className
         )}
       >
         <div className="flex items-center gap-2 text-canopy-text/50">
-          <AlertCircle className="w-4 h-4 text-red-400/70" />
+          <AlertCircle className="w-4 h-4 text-canopy-error/70" />
           <span className="text-xs">{error}</span>
           <button
             onClick={handleRefresh}
-            className="ml-auto p-1 hover:bg-white/10 rounded transition-colors"
+            className="ml-auto p-1 hover:bg-[var(--color-surface-highlight)] rounded transition-colors"
             aria-label="Retry"
           >
             <RefreshCw className="w-3 h-3" />
@@ -127,11 +127,11 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
   return (
     <div
       className={cn(
-        "w-fit bg-white/[0.02] rounded-[var(--radius-lg)] border border-white/5",
+        "w-fit bg-[var(--color-surface)] rounded-[var(--radius-lg)] border border-canopy-border",
         className
       )}
     >
-      <div className="px-4 py-3 border-b border-white/5 flex items-center justify-between">
+      <div className="px-4 py-3 border-b border-canopy-border flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-emerald-400/70" />
           <span className="text-sm font-medium text-canopy-text/80">{title}</span>
@@ -142,7 +142,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button
-                className="text-xs text-canopy-text/50 hover:text-canopy-text/70 transition-colors px-2 py-1 rounded hover:bg-white/5"
+                className="text-xs text-canopy-text/50 hover:text-canopy-text/70 transition-colors px-2 py-1 rounded hover:bg-[var(--color-surface-highlight)]"
                 aria-label="Change time range"
               >
                 {currentRangeLabel}
@@ -153,7 +153,9 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
                 <DropdownMenuItem
                   key={option.value}
                   onClick={() => handleRangeChange(option.value)}
-                  className={cn(option.value === rangeDays && "bg-white/5")}
+                  className={cn(
+                    option.value === rangeDays && "bg-[var(--color-surface-highlight)]"
+                  )}
                 >
                   {option.label}
                 </DropdownMenuItem>
@@ -164,7 +166,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
           <button
             onClick={handleRefresh}
             disabled={isLoading}
-            className="p-1 text-canopy-text/40 hover:text-canopy-text/70 hover:bg-white/5 rounded transition-colors disabled:opacity-50"
+            className="p-1 text-canopy-text/40 hover:text-canopy-text/70 hover:bg-[var(--color-surface-highlight)] rounded transition-colors disabled:opacity-50"
             aria-label="Refresh"
           >
             <RefreshCw className={cn("w-3 h-3", isLoading && "animate-spin")} />
@@ -177,7 +179,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <p className="text-xs text-canopy-text/60 italic">{getCoachLine(pulse)}</p>
 
-        <div className="border-t border-white/5 pt-3">
+        <div className="border-t border-canopy-border pt-3">
           <PulseSummary pulse={pulse} />
         </div>
       </div>

--- a/src/components/Pulse/PulseHeatmap.tsx
+++ b/src/components/Pulse/PulseHeatmap.tsx
@@ -10,15 +10,15 @@ interface PulseHeatmapProps {
 }
 
 const HEAT_COLORS = [
-  "bg-white/[0.04]",
+  "bg-[var(--color-surface-highlight)]",
   "bg-emerald-700/50",
   "bg-emerald-600/60",
   "bg-emerald-500/70",
   "bg-emerald-400/80",
 ] as const;
 
-const BEFORE_PROJECT_COLOR = "bg-white/[0.02]";
-const MISSED_DAY_COLOR = "bg-rose-900/20";
+const BEFORE_PROJECT_COLOR = "bg-canopy-bg";
+const MISSED_DAY_COLOR = "bg-[color-mix(in_oklab,var(--color-status-error)_20%,transparent)]";
 
 const COLUMNS_PER_ROW = 60;
 const CELL_SIZE_PX = 10;
@@ -92,7 +92,7 @@ export function PulseHeatmap({ cells, rangeDays, compact = false }: PulseHeatmap
                       className={cn(
                         colorClass,
                         "rounded-full shrink-0 transition-[transform,background-color] duration-150 border-0 p-0 cursor-default",
-                        cell.isToday && "ring-1 ring-white/30",
+                        cell.isToday && "ring-1 ring-canopy-accent/40",
                         cell.isMostRecentActive && !cell.isToday && "ring-1 ring-emerald-400/40"
                       )}
                       aria-label={`${formatted}: ${tooltipText}`}


### PR DESCRIPTION
## Summary
Replace translucent white overlay surfaces in Pulse UI components with Canopy design system tokens to align with the "forest floor" design language and ensure consistent theming across the application.

Closes #1044

## Changes Made
- Replace `bg-white/[0.02]` with `bg-[var(--color-surface)]` in ProjectPulseCard
- Replace `border-white/5` with `border-canopy-border` across all Pulse components
- Replace `hover:bg-white/5` with `hover:bg-[var(--color-surface-highlight)]` for interactive states
- Update `HEAT_COLORS[0]` to use `--color-surface-highlight` (prevents invisible cells on matching background)
- Replace `BEFORE_PROJECT_COLOR` with `bg-canopy-bg` for pre-project heatmap cells
- Replace `MISSED_DAY_COLOR` with `color-mix()` syntax for proper CSS variable opacity handling
- Update today ring indicator to use `ring-canopy-accent/40` (brand color)
- Replace hardcoded `text-red-400` with `text-canopy-error` semantic token

## Benefits
- Pulse UI now matches the overall Canopy aesthetic ("forest floor" palette)
- All surfaces use proper Canopy tokens for automatic theme propagation
- Semantic tokens (`--color-status-error`) enable future theme customization
- Improved visual consistency across the application
- No more "glass/frosted" aesthetic conflict with zinc-based surfaces