### PR TITLE
Fix terminal backend crash recovery with UI feedback

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -41,6 +41,8 @@ export const CHANNELS = {
   TERMINAL_ACKNOWLEDGE_DATA: "terminal:acknowledge-data",
   TERMINAL_FORCE_RESUME: "terminal:force-resume",
   TERMINAL_STATUS: "terminal:status",
+  TERMINAL_BACKEND_CRASHED: "terminal:backend-crashed",
+  TERMINAL_BACKEND_READY: "terminal:backend-ready",
 
   AGENT_STATE_CHANGED: "agent:state-changed",
   AGENT_GET_STATE: "agent:get-state",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -121,6 +121,8 @@ const CHANNELS = {
   TERMINAL_ACKNOWLEDGE_DATA: "terminal:acknowledge-data",
   TERMINAL_FORCE_RESUME: "terminal:force-resume",
   TERMINAL_STATUS: "terminal:status",
+  TERMINAL_BACKEND_CRASHED: "terminal:backend-crashed",
+  TERMINAL_BACKEND_READY: "terminal:backend-ready",
 
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",
@@ -422,6 +424,28 @@ const api: ElectronAPI = {
 
     onStatus: (callback: (data: TerminalStatusPayload) => void) =>
       _typedOn(CHANNELS.TERMINAL_STATUS, callback),
+
+    onBackendCrashed: (
+      callback: (data: {
+        crashType: string;
+        code: number | null;
+        signal: string | null;
+        timestamp: number;
+      }) => void
+    ): (() => void) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        data: { crashType: string; code: number | null; signal: string | null; timestamp: number }
+      ) => callback(data);
+      ipcRenderer.on(CHANNELS.TERMINAL_BACKEND_CRASHED, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_BACKEND_CRASHED, handler);
+    },
+
+    onBackendReady: (callback: () => void): (() => void) => {
+      const handler = () => callback();
+      ipcRenderer.on(CHANNELS.TERMINAL_BACKEND_READY, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.TERMINAL_BACKEND_READY, handler);
+    },
   },
 
   // Artifact API

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -107,6 +107,15 @@ export interface ElectronAPI {
     onRestored(callback: (data: { id: string }) => void): () => void;
     forceResume(id: string): Promise<{ success: boolean; error?: string }>;
     onStatus(callback: (data: TerminalStatusPayload) => void): () => void;
+    onBackendCrashed(
+      callback: (data: {
+        crashType: string;
+        code: number | null;
+        signal: string | null;
+        timestamp: number;
+      }) => void
+    ): () => void;
+    onBackendReady(callback: () => void): () => void;
   };
   artifact: {
     onDetected(callback: (data: ArtifactDetectedPayload) => void): () => void;


### PR DESCRIPTION
## Summary
Implements comprehensive terminal backend crash recovery to fix silent failures when the PTY backend process terminates unexpectedly. When the backend crashes, users now see clear visual feedback and terminals automatically recover when the backend restarts.

Closes #1060

## Changes Made
- Add IPC channels for backend crash/ready events (TERMINAL_BACKEND_CRASHED, TERMINAL_BACKEND_READY)
- Forward crash events from PtyClient → Main → Renderer with crash metadata
- Track backend connection state in terminalStore (connected/disconnected/recovering)
- Implement handleBackendRecovery() to reset xterm renderers and fix white text glitch using soft terminal reset (DECSTR)
- Add disconnect overlay to TerminalPane with visual feedback (spinner during recovery, error dialog on disconnect)
- Fix race condition by attaching crash listeners immediately after PtyClient construction
- Fix MessagePort memory leak by closing old port on backend restart
- Fix timer leak by canceling recovery timer on subsequent crashes
- Make resetRenderer() non-throwing for safer error recovery
- Add error handling to MessagePort.postMessage with automatic fallback to IPC

## Technical Details
- Backend status flows: connected → disconnected (on crash) → recovering (on restart) → connected (after 500ms)
- Recovery process: soft reset ANSI sequence → renderer reset → dimension recalculation → recovery message injection
- All xterm instances are reset in parallel when backend recovers
- Overlay blocks user input and dims terminal content during disconnected/recovering states

## Testing
- Type checking passes
- Lint passes
- Code reviewed by Codex MCP
- All critical race conditions, memory leaks, and error handling paths addressed