### PR TITLE
Fix terminal input blocking via command queue

### DIFF
--- a/src/store/slices/__tests__/terminalCommandQueueSlice.test.ts
+++ b/src/store/slices/__tests__/terminalCommandQueueSlice.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createTerminalCommandQueueSlice,
+  type TerminalCommandQueueSlice,
+} from "../terminalCommandQueueSlice";
+import { terminalClient } from "@/clients";
+import type { TerminalInstance } from "../terminalRegistrySlice";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    write: vi.fn(),
+  },
+}));
+
+describe("TerminalCommandQueueSlice", () => {
+  const mockTerminal = {
+    id: "test-terminal",
+    title: "Test Terminal",
+    type: "claude",
+    cwd: "/test",
+    location: "grid",
+    agentState: "working",
+    isVisible: true,
+    cols: 80,
+    rows: 24,
+  } as TerminalInstance;
+
+  const getTerminal = vi.fn((id: string) => {
+    if (id === "test-terminal") {
+      return mockTerminal;
+    }
+    return undefined;
+  });
+
+  let slice: TerminalCommandQueueSlice;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const set = vi.fn();
+    const get = vi.fn(
+      () =>
+        ({
+          commandQueue: [],
+          queueCommand: vi.fn(),
+          processQueue: vi.fn(),
+          clearQueue: vi.fn(),
+          getQueueCount: vi.fn(),
+        }) as TerminalCommandQueueSlice
+    );
+    slice = createTerminalCommandQueueSlice(getTerminal)(set, get, {} as never);
+  });
+
+  describe("User input invariant", () => {
+    it("should write user input immediately when agent is working", () => {
+      mockTerminal.agentState = "working";
+      slice.queueCommand("test-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should write user input immediately when agent is running", () => {
+      mockTerminal.agentState = "running";
+      slice.queueCommand("test-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should write user input immediately when agent is waiting", () => {
+      mockTerminal.agentState = "waiting";
+      slice.queueCommand("test-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should write user input immediately when agent is idle", () => {
+      mockTerminal.agentState = "idle";
+      slice.queueCommand("test-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should write user input immediately when agent is completed", () => {
+      mockTerminal.agentState = "completed";
+      slice.queueCommand("test-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should write user input immediately when agent is failed", () => {
+      mockTerminal.agentState = "failed";
+      slice.queueCommand("test-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+  });
+
+  describe("Automation input queueing", () => {
+    it("should write automation input immediately when agent is idle", () => {
+      mockTerminal.agentState = "idle";
+      slice.queueCommand("test-terminal", "test data", "test description", "automation");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should write automation input immediately when agent is waiting", () => {
+      mockTerminal.agentState = "waiting";
+      slice.queueCommand("test-terminal", "test data", "test description", "automation");
+      expect(terminalClient.write).toHaveBeenCalledWith("test-terminal", "test data");
+    });
+
+    it("should queue automation input when agent is working", () => {
+      mockTerminal.agentState = "working";
+      slice.queueCommand("test-terminal", "test data", "test description", "automation");
+      expect(terminalClient.write).not.toHaveBeenCalled();
+    });
+
+    it("should queue automation input when agent is running", () => {
+      mockTerminal.agentState = "running";
+      slice.queueCommand("test-terminal", "test data", "test description", "automation");
+      expect(terminalClient.write).not.toHaveBeenCalled();
+    });
+
+    it("should default to automation when origin is not specified", () => {
+      mockTerminal.agentState = "working";
+      slice.queueCommand("test-terminal", "test data", "test description");
+      expect(terminalClient.write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should warn and not write when terminal does not exist", () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      slice.queueCommand("nonexistent-terminal", "test data", "test description", "user");
+      expect(terminalClient.write).not.toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Cannot queue command: terminal nonexistent-terminal not found"
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Prevents potential user input blocking by adding an InputOrigin parameter to the terminal command queue system. While `queueCommand` is not currently used for user input, this change creates a robust safeguard against future regressions and clearly documents the critical invariant that user input must never be blocked by agent state.

Closes #1070

## Changes Made
- Add `InputOrigin` type to distinguish user vs automation input
- Update `queueCommand` to accept origin parameter (defaults to "automation")
- User input (origin="user") always writes immediately regardless of agent state
- Automation input preserves queueing behavior during working/running states
- Add comprehensive tests for user input invariant across all agent states
- Document input invariant in `isAgentReady` function JSDoc

## Technical Details
The command queue slice had state-gating logic (`isAgentReady`) that could block writes during `working`/`running` states. While this isn't currently causing issues (user keyboard input flows through `terminal.onData` → `terminalClient.write` unconditionally), this change:

1. **Prevents future regressions**: If any code were to route user input through `queueCommand`, it would now bypass state checks
2. **Clarifies intent**: The new `InputOrigin` parameter and documentation make the invariant explicit
3. **Preserves automation queueing**: Context injection and scripted commands can still queue to avoid interleaving with TUI redraws

## Testing
- 12 new unit tests covering user input invariant across all agent states
- All existing tests pass
- Type checks pass
- Lint and format checks pass