### PR TITLE
Expose sidecar layout mode and default width in settings UI

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -238,6 +238,7 @@ export type {
 // Sidecar types - browser dock
 export type {
   SidecarLayoutMode,
+  SidecarLayoutModePreference,
   SidecarLinkType,
   SidecarLink,
   LinkTemplate,

--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -1,5 +1,7 @@
 export type SidecarLayoutMode = "push" | "overlay";
 
+export type SidecarLayoutModePreference = "auto" | "push" | "overlay";
+
 export type SidecarLinkType = "system" | "discovered" | "user";
 
 export interface SidecarLink {


### PR DESCRIPTION
## Summary
Adds user-configurable sidecar layout mode and width preferences to the Settings UI. Users can now choose between Auto/Push/Overlay layout modes and set their preferred default width with a slider control.

Closes #1039

## Changes Made
- Add SidecarLayoutModePreference type (auto/push/overlay)
- Add layoutModePreference state to sidecarStore with persistence
- Update updateLayoutMode to respect user preference override
- Remove hard-coded sidebar width from store (now pure)
- Add persistence validation with merge function for width clamping
- Add Layout Mode section with radio buttons to Settings UI
- Add Default Width section with slider control to Settings UI
- Fix slider state sync with useEffect and proper event handling
- Improve accessibility with type="button" and proper ARIA labels

## Technical Details
- **Store improvements**: Removed window/setTimeout calls from store actions, making the store pure and testable
- **Layout mode behavior**: Auto mode maintains current auto-detection logic; Push/Overlay modes force the respective layout
- **Persistence**: Both preferences are persisted with validation to prevent corrupted values
- **UI polish**: Slider uses pointer events and onBlur for reliable commits, supports keyboard navigation