### PR TITLE
Improve terminal backend robustness and crash recovery

### DIFF
--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -137,6 +137,13 @@ export type PtyHostEvent =
       bufferUtilization?: number;
       pauseDuration?: number;
       timestamp: number;
+    }
+  | {
+      type: "host-throttled";
+      isThrottled: boolean;
+      reason?: string;
+      duration?: number;
+      timestamp: number;
     };
 
 /** Terminal info sent from Host → Main for getTerminal queries */
@@ -227,6 +234,14 @@ export interface HostCrashPayload {
   code: number | null;
   signal: string | null;
   crashType: CrashType;
+  timestamp: number;
+}
+
+/** Payload for host throttle events (memory pressure) */
+export interface HostThrottlePayload {
+  isThrottled: boolean;
+  reason?: string;
+  duration?: number;
   timestamp: number;
 }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,6 @@
 export { useTerminalStore, isAgentReady, getTerminalRefreshTier } from "./terminalStore";
 export type { TerminalInstance, AddTerminalOptions, QueuedCommand } from "./terminalStore";
+export type { CrashType } from "@shared/types/pty-host";
 export { MAX_GRID_TERMINALS } from "./slices/terminalRegistrySlice";
 
 export { useWorktreeSelectionStore } from "./worktreeStore";


### PR DESCRIPTION
## Summary
This PR implements comprehensive terminal backend resilience mechanisms to prevent crashes and improve recovery from failures, addressing issue #1094.

Closes #1094

## Changes Made
- **Watchdog timer**: Detects unresponsive PTY host after 3 missed heartbeats (~90s) and force-kills with SIGKILL
- **Configurable memory limits**: PTY host process spawned with configurable heap limit (default 4GB via --max-old-space-size)
- **Resource Governor**: Proactively monitors heap usage at 2s intervals and pauses all terminals at 80% utilization, resuming at 60% (with 10s force-resume failsafe)
- **Crash-specific UI feedback**: Contextual error messages with actionable recovery suggestions based on crash type (OUT_OF_MEMORY, SIGNAL_TERMINATED, etc.)
- **Type-safe crash classification**: Normalized crash type handling with guards against invalid values
- **Exception handling**: postMessage IPC calls wrapped in try/catch to prevent main process crashes

## Technical Details
- Fixed memory utilization calculation to use V8 heap limit instead of heapTotal
- Added accessibility attributes (role, aria-live) to crash overlays for screen readers
- Fixed opacity layering so crash overlay renders at full opacity
- Reset crash state in terminal store reset functions to prevent sticky overlays
- Re-exported CrashType from shared types to eliminate duplication