### PR TITLE
fix: improve terminal robustness and logging to prevent silent crashes

### DIFF
--- a/.gemini/commands/github/create-issue.toml
+++ b/.gemini/commands/github/create-issue.toml
@@ -27,6 +27,9 @@ Use the following template for the issue body, adapting sections as necessary fo
 ## Proposed Solution / Approach (Optional)
 [If a specific approach has been discussed or is evident, outline it here. Otherwise, state that the approach needs to be determined during implementation.]
 
+## Implementation Guidance (Optional)
+[A free-form comment that sums up more detailed implementation information and overall guidance provided during the request.]
+
 ## Deliverables
 - [ ] Code changes addressing the core issue/feature.
 - [ ] New or updated unit tests (`npm run test`).

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1121,8 +1121,11 @@ export class TerminalProcess {
     }
     try {
       terminal.ptyProcess.write(chunk);
-    } catch {
-      // Process may already be dead; swallow write errors
+    } catch (error) {
+      // Process may already be dead, but log it for diagnostics
+      if (process.env.CANOPY_VERBOSE) {
+        console.warn(`[TerminalProcess] Write failed for ${this.id}:`, error);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #1109

## Summary
Improves visibility into terminal crashes and prevents single-terminal failures from taking down the entire backend process.

## Changes
- **`electron/pty-host.ts`**: Added synchronous file logging to `uncaughtException` and `unhandledRejection` handlers to ensure fatal errors are recorded before the process exits.
- **`electron/services/PtyClient.ts`**: 
    - Changed `stdio` to pipe mode to capture `stdout`/`stderr` from the host process.
    - Added listeners to redirect these logs to the main application logger.
    - Enhanced watchdog logging to include timestamp and clearer formatting.
- **`electron/services/pty/TerminalProcess.ts`**: Updated `write` method to log errors instead of silently swallowing them.

## Verification
- `npm run check` passes.
- `npm run test` passes (PtyClient handshake tests verified).
