### PR TITLE
fix: prevent agent terminal crashes and add forensic logging

### DIFF
--- a/src/services/terminal/TerminalParserHandler.ts
+++ b/src/services/terminal/TerminalParserHandler.ts
@@ -1,0 +1,62 @@
+import { ManagedTerminal } from "./types";
+
+export class TerminalParserHandler {
+  private managed: ManagedTerminal;
+  private disposables: Array<{ dispose: () => void }> = [];
+  private allowResets = false;
+
+  constructor(managed: ManagedTerminal) {
+    this.managed = managed;
+    this.attachHandlers();
+  }
+
+  setAllowResets(allow: boolean): void {
+    this.allowResets = allow;
+  }
+
+  private attachHandlers(): void {
+    const { terminal } = this.managed;
+
+    if (!terminal.parser || !terminal.parser.registerEscHandler) {
+      return; // Graceful degradation if proposed API missing
+    }
+
+    // Block RIS (Reset Initial State) - ESC c
+    const risHandler = terminal.parser.registerEscHandler({ final: "c" }, () => {
+      if (this.allowResets) return false;
+      if (!this.shouldBlock()) return false;
+
+      if (process.env.NODE_ENV === "development") {
+        console.warn(
+          `[TerminalParser] Blocked RIS (ESC c) for agent terminal ${this.managed.agentId || "unknown"}`
+        );
+      }
+      return true; // Swallow the sequence
+    });
+    this.disposables.push(risHandler);
+
+    // Block DECSTR (Soft Terminal Reset) - CSI ! p
+    const decstrHandler = terminal.parser.registerCsiHandler({ prefix: "!", final: "p" }, () => {
+      if (this.allowResets) return false;
+      if (!this.shouldBlock()) return false;
+
+      if (process.env.NODE_ENV === "development") {
+        console.warn(
+          `[TerminalParser] Blocked DECSTR (CSI ! p) for agent terminal ${this.managed.agentId || "unknown"}`
+        );
+      }
+      return true; // Swallow the sequence
+    });
+    this.disposables.push(decstrHandler);
+  }
+
+  private shouldBlock(): boolean {
+    // Block for all agent terminals by default
+    return this.managed.kind === "agent";
+  }
+
+  dispose(): void {
+    this.disposables.forEach((d) => d.dispose());
+    this.disposables = [];
+  }
+}

--- a/src/services/terminal/__tests__/TerminalParserHandler.test.ts
+++ b/src/services/terminal/__tests__/TerminalParserHandler.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TerminalParserHandler } from "../TerminalParserHandler";
+import { ManagedTerminal } from "../types";
+
+// Mock global process.env
+const originalEnv = process.env;
+
+describe("TerminalParserHandler", () => {
+  let mockTerminal: any;
+  let mockManaged: ManagedTerminal;
+  let escHandlers: any[];
+  let csiHandlers: any[];
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: "test" };
+    escHandlers = [];
+    csiHandlers = [];
+
+    mockTerminal = {
+      parser: {
+        registerEscHandler: vi.fn((opts, handler) => {
+          const disposable = { dispose: vi.fn() };
+          escHandlers.push({ opts, handler, disposable });
+          return disposable;
+        }),
+        registerCsiHandler: vi.fn((opts, handler) => {
+          const disposable = { dispose: vi.fn() };
+          csiHandlers.push({ opts, handler, disposable });
+          return disposable;
+        }),
+      },
+    };
+
+    mockManaged = {
+      terminal: mockTerminal,
+      kind: "agent", // Default to agent for blocking tests
+      agentId: "claude-1",
+    } as any;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should register handlers on initialization", () => {
+    new TerminalParserHandler(mockManaged);
+    expect(mockTerminal.parser.registerEscHandler).toHaveBeenCalled();
+    expect(mockTerminal.parser.registerCsiHandler).toHaveBeenCalled();
+  });
+
+  it("should block RIS (ESC c) for agent terminals", () => {
+    new TerminalParserHandler(mockManaged);
+    const risHandler = escHandlers.find((h) => h.opts.final === "c");
+    expect(risHandler).toBeDefined();
+
+    // Test blocking
+    const result = risHandler.handler();
+    expect(result).toBe(true); // Should block
+  });
+
+  it("should block DECSTR (CSI ! p) for agent terminals", () => {
+    new TerminalParserHandler(mockManaged);
+    const decstrHandler = csiHandlers.find(
+      (h) => h.opts.prefix === "!" && h.opts.final === "p"
+    );
+    expect(decstrHandler).toBeDefined();
+
+    const result = decstrHandler.handler();
+    expect(result).toBe(true); // Should block
+  });
+
+  it("should NOT block for regular terminals", () => {
+    mockManaged.kind = "terminal";
+    mockManaged.agentId = undefined;
+
+    new TerminalParserHandler(mockManaged);
+
+    const risHandler = escHandlers.find((h) => h.opts.final === "c");
+    expect(risHandler.handler()).toBe(false); // Should pass through
+
+    const decstrHandler = csiHandlers.find(
+      (h) => h.opts.prefix === "!" && h.opts.final === "p"
+    );
+    expect(decstrHandler.handler()).toBe(false); // Should pass through
+  });
+
+  it("should dispose handlers correctly", () => {
+    const handler = new TerminalParserHandler(mockManaged);
+    expect(escHandlers.length).toBeGreaterThan(0);
+    expect(csiHandlers.length).toBeGreaterThan(0);
+
+    handler.dispose();
+
+    escHandlers.forEach((h) => expect(h.disposable.dispose).toHaveBeenCalled());
+    csiHandlers.forEach((h) => expect(h.disposable.dispose).toHaveBeenCalled());
+  });
+
+  it("should allow resets when explicitly allowed (recovery mode)", () => {
+    const handler = new TerminalParserHandler(mockManaged);
+    const risHandler = escHandlers.find((h) => h.opts.final === "c");
+
+    // Default: block
+    expect(risHandler.handler()).toBe(true);
+
+    // Allow
+    handler.setAllowResets(true);
+    expect(risHandler.handler()).toBe(false); // Pass through
+
+    // Disallow
+    handler.setAllowResets(false);
+    expect(risHandler.handler()).toBe(true); // Block again
+  });
+
+  it("should handle missing parser API gracefully", () => {
+    mockManaged.terminal.parser = undefined; // Simulate missing API
+    expect(() => new TerminalParserHandler(mockManaged)).not.toThrow();
+  });
+});

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -50,6 +50,7 @@ export interface ManagedTerminal {
   exitSubscribers: Set<(exitCode: number) => void>;
   outputSubscribers: Set<() => void>; // For tall canvas scroll sync
   throttledWriter: ThrottledWriter;
+  parserHandler?: { dispose: () => void; setAllowResets: (allow: boolean) => void };
   getRefreshTier: RefreshTierProvider;
   keyHandlerInstalled: boolean;
   lastAttachAt: number;


### PR DESCRIPTION
Closes #1108.

## Summary
Blocks destructive reset sequences (RIS, DECSTR) for agent terminals to prevent history loss during crashes, and adds forensic logging to capture the last 4KB of output before an abnormal exit.

## Changes
- **TerminalParserHandler**: New service that intercepts and blocks `ESC c` and `CSI ! p` for agent terminals.
- **TerminalProcess**: Added `recentOutputBuffer` and `logForensics` to capture and log output on crash.
- **TerminalInstanceService**: Integrated parser handler and added `handleBackendRecovery` bypass.
- **Tests**: Added unit tests for parser handler blocking logic.

## Notes
- Phase 3 (Height Locking) from the issue was skipped as the 'Tall Canvas' architecture was recently removed, making the fix unnecessary for standard xterm.js adapters.
- Forensic logging is restricted to agent terminals for privacy safety.