### PR TITLE
Terminal: Auto-scroll resume button + new output indicator

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { AlertTriangle, Loader2 } from "lucide-react";
+import { AlertTriangle, Loader2, ArrowDown } from "lucide-react";
 import type { TerminalType, TerminalRestartError } from "@/types";
 import { cn } from "@/lib/utils";
 import { getTerminalAnimationDuration } from "@/lib/animationUtils";
@@ -26,6 +26,7 @@ import { getAgentConfig } from "@/config/agents";
 import { terminalClient } from "@/clients";
 import { HybridInputBar, type HybridInputBarHandle } from "./HybridInputBar";
 import { getTerminalFocusTarget } from "./terminalFocus";
+import { useTerminalUnseenOutput } from "@/hooks/useTerminalUnseenOutput";
 
 export type { TerminalType };
 
@@ -95,6 +96,8 @@ function TerminalPaneComponent({
   const [dismissedRestartPrompt, setDismissedRestartPrompt] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isUpdateCwdOpen, setIsUpdateCwdOpen] = useState(false);
+
+  const unseenOutput = useTerminalUnseenOutput(id);
 
   if (isFocused && !prevFocusedRef.current) {
     justFocusedUntilRef.current = performance.now() + 250;
@@ -510,6 +513,19 @@ function TerminalPaneComponent({
               getRefreshTier={getRefreshTierCallback}
             />
             <ArtifactOverlay terminalId={id} worktreeId={worktreeId} cwd={cwd} />
+            {unseenOutput.isUserScrolledBack && unseenOutput.unseen > 0 && (
+              <button
+                onClick={() => {
+                  terminalInstanceService.resumeAutoScroll(id);
+                  requestAnimationFrame(() => terminalInstanceService.focus(id));
+                }}
+                className="absolute bottom-4 left-4 z-10 flex items-center gap-2 bg-canopy-primary text-canopy-primary-fg px-3 py-2 rounded-md shadow-lg hover:bg-canopy-primary/90 transition-colors"
+                aria-label="Resume auto-scroll"
+              >
+                <ArrowDown className="h-4 w-4" />
+                <span className="text-sm font-medium">Resume</span>
+              </button>
+            )}
             {isSearchOpen && (
               <TerminalSearchBar
                 terminalId={id}

--- a/src/hooks/useTerminalUnseenOutput.ts
+++ b/src/hooks/useTerminalUnseenOutput.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore, useCallback } from "react";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import type { UnseenOutputSnapshot } from "@/services/terminal/TerminalUnseenOutputTracker";
+
+const SERVER_SNAPSHOT: UnseenOutputSnapshot = { isUserScrolledBack: false, unseen: 0 };
+
+export function useTerminalUnseenOutput(terminalId: string): UnseenOutputSnapshot {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) =>
+      terminalInstanceService.subscribeUnseenOutput(terminalId, onStoreChange),
+    [terminalId]
+  );
+
+  const getSnapshot = useCallback(
+    () => terminalInstanceService.getUnseenOutputSnapshot(terminalId),
+    [terminalId]
+  );
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => SERVER_SNAPSHOT);
+}

--- a/src/services/terminal/TerminalUnseenOutputTracker.ts
+++ b/src/services/terminal/TerminalUnseenOutputTracker.ts
@@ -1,0 +1,103 @@
+export interface UnseenOutputSnapshot {
+  isUserScrolledBack: boolean;
+  unseen: number;
+}
+
+type Listener = () => void;
+
+export class TerminalUnseenOutputTracker {
+  private unseenById = new Map<string, number>();
+  private listenersById = new Map<string, Set<Listener>>();
+  private snapshotById = new Map<string, UnseenOutputSnapshot>();
+
+  incrementUnseen(id: string, isUserScrolledBack: boolean): void {
+    if (!isUserScrolledBack) return;
+
+    const current = this.unseenById.get(id) ?? 0;
+    const next = current + 1;
+    this.unseenById.set(id, next);
+
+    if (current === 0) {
+      this.updateSnapshot(id, isUserScrolledBack, next);
+      this.notify(id);
+    }
+  }
+
+  clearUnseen(id: string, isUserScrolledBack: boolean): void {
+    const current = this.unseenById.get(id);
+    const hadUnseen = current !== undefined && current > 0;
+
+    if (hadUnseen) {
+      this.unseenById.set(id, 0);
+    }
+
+    const snapshot = this.snapshotById.get(id);
+    const needsUpdate =
+      hadUnseen || (snapshot && snapshot.isUserScrolledBack !== isUserScrolledBack);
+
+    if (needsUpdate) {
+      this.updateSnapshot(id, isUserScrolledBack, 0);
+      this.notify(id);
+    }
+  }
+
+  updateScrollState(id: string, isUserScrolledBack: boolean): void {
+    const unseen = this.unseenById.get(id) ?? 0;
+    const current = this.snapshotById.get(id);
+
+    if (current && current.isUserScrolledBack === isUserScrolledBack) {
+      return;
+    }
+
+    this.updateSnapshot(id, isUserScrolledBack, unseen);
+    this.notify(id);
+  }
+
+  subscribe(id: string, listener: Listener): () => void {
+    let listeners = this.listenersById.get(id);
+    if (!listeners) {
+      listeners = new Set();
+      this.listenersById.set(id, listeners);
+    }
+    listeners.add(listener);
+
+    return () => {
+      listeners?.delete(listener);
+      if (listeners?.size === 0) {
+        this.listenersById.delete(id);
+      }
+    };
+  }
+
+  getSnapshot(id: string): UnseenOutputSnapshot {
+    let snapshot = this.snapshotById.get(id);
+    if (!snapshot) {
+      snapshot = { isUserScrolledBack: false, unseen: 0 };
+      this.snapshotById.set(id, snapshot);
+    }
+    return snapshot;
+  }
+
+  destroy(id: string): void {
+    this.unseenById.delete(id);
+    const listeners = this.listenersById.get(id);
+    if (listeners) {
+      listeners.clear();
+    }
+    this.listenersById.delete(id);
+    this.snapshotById.delete(id);
+  }
+
+  private updateSnapshot(id: string, isUserScrolledBack: boolean, unseen: number): void {
+    this.snapshotById.set(id, { isUserScrolledBack, unseen });
+  }
+
+  private notify(id: string): void {
+    const listeners = this.listenersById.get(id);
+    if (!listeners) return;
+
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+}

--- a/src/services/terminal/__tests__/TerminalUnseenOutputTracker.test.ts
+++ b/src/services/terminal/__tests__/TerminalUnseenOutputTracker.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TerminalUnseenOutputTracker } from "../TerminalUnseenOutputTracker";
+
+describe("TerminalUnseenOutputTracker", () => {
+  let tracker: TerminalUnseenOutputTracker;
+  const terminalId = "test-terminal";
+
+  beforeEach(() => {
+    tracker = new TerminalUnseenOutputTracker();
+  });
+
+  describe("incrementUnseen", () => {
+    it("should increment unseen count when user is scrolled back", () => {
+      tracker.incrementUnseen(terminalId, true);
+      const snapshot = tracker.getSnapshot(terminalId);
+      expect(snapshot.unseen).toBe(1);
+    });
+
+    it("should not increment unseen count when user is at bottom", () => {
+      tracker.incrementUnseen(terminalId, false);
+      const snapshot = tracker.getSnapshot(terminalId);
+      expect(snapshot.unseen).toBe(0);
+    });
+
+    it("should notify listeners only on 0→1 transition", () => {
+      const listener = vi.fn();
+      tracker.subscribe(terminalId, listener);
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should maintain separate counters for different terminals", () => {
+      const terminal1 = "terminal-1";
+      const terminal2 = "terminal-2";
+
+      tracker.incrementUnseen(terminal1, true);
+      tracker.incrementUnseen(terminal2, true);
+      tracker.incrementUnseen(terminal2, true);
+
+      expect(tracker.getSnapshot(terminal1).unseen).toBe(1);
+      expect(tracker.getSnapshot(terminal2).unseen).toBe(1);
+    });
+  });
+
+  describe("clearUnseen", () => {
+    it("should clear unseen count and notify listeners", () => {
+      const listener = vi.fn();
+      tracker.subscribe(terminalId, listener);
+
+      tracker.incrementUnseen(terminalId, true);
+      listener.mockClear();
+
+      tracker.clearUnseen(terminalId, false);
+      expect(tracker.getSnapshot(terminalId).unseen).toBe(0);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not notify if unseen count is already 0", () => {
+      const listener = vi.fn();
+      tracker.subscribe(terminalId, listener);
+
+      tracker.clearUnseen(terminalId, false);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateScrollState", () => {
+    it("should update scroll state and notify listeners", () => {
+      const listener = vi.fn();
+      tracker.subscribe(terminalId, listener);
+
+      tracker.updateScrollState(terminalId, true);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(tracker.getSnapshot(terminalId).isUserScrolledBack).toBe(true);
+    });
+
+    it("should not notify if scroll state has not changed", () => {
+      const listener = vi.fn();
+      tracker.subscribe(terminalId, listener);
+
+      tracker.updateScrollState(terminalId, false);
+      listener.mockClear();
+
+      tracker.updateScrollState(terminalId, false);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("subscribe", () => {
+    it("should add listener and return unsubscribe function", () => {
+      const listener = vi.fn();
+      const unsubscribe = tracker.subscribe(terminalId, listener);
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      tracker.clearUnseen(terminalId, false);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support multiple listeners for the same terminal", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+
+      tracker.subscribe(terminalId, listener1);
+      tracker.subscribe(terminalId, listener2);
+
+      tracker.incrementUnseen(terminalId, true);
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getSnapshot", () => {
+    it("should return initial snapshot with default values", () => {
+      const snapshot = tracker.getSnapshot(terminalId);
+      expect(snapshot).toEqual({
+        isUserScrolledBack: false,
+        unseen: 0,
+      });
+    });
+
+    it("should return stable snapshot reference when state unchanged", () => {
+      const snapshot1 = tracker.getSnapshot(terminalId);
+      const snapshot2 = tracker.getSnapshot(terminalId);
+      expect(snapshot1).toBe(snapshot2);
+    });
+
+    it("should return new snapshot reference when state changes", () => {
+      const snapshot1 = tracker.getSnapshot(terminalId);
+      tracker.incrementUnseen(terminalId, true);
+      const snapshot2 = tracker.getSnapshot(terminalId);
+      expect(snapshot1).not.toBe(snapshot2);
+    });
+  });
+
+  describe("destroy", () => {
+    it("should clean up all state for a terminal", () => {
+      const listener = vi.fn();
+      const unsubscribe = tracker.subscribe(terminalId, listener);
+      tracker.incrementUnseen(terminalId, true);
+
+      unsubscribe();
+      tracker.destroy(terminalId);
+      listener.mockClear();
+
+      const snapshot = tracker.getSnapshot(terminalId);
+      expect(snapshot).toEqual({
+        isUserScrolledBack: false,
+        unseen: 0,
+      });
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a floating "Resume" button to terminals that appears when users scroll up and new output arrives, providing a clear way to resume auto-scroll and catch up on unseen output.

Closes #1121

## Changes Made
- Add `TerminalUnseenOutputTracker` service for efficient state management with edge-triggered notifications
- Integrate tracker into `TerminalInstanceService` with proper lifecycle management and cleanup
- Create `useTerminalUnseenOutput` hook using optimized `useSyncExternalStore` with stable callbacks
- Render Resume button when scrolled back with new output (positioned bottom-left to avoid overlay conflicts)
- Fix scroll state staleness bug in `clearUnseen` to maintain accurate snapshot state
- Prevent race condition in `resumeAutoScroll` by clearing state before scrolling
- Add comprehensive unit tests for tracker (14 test cases covering edge cases and cleanup)
- Restore terminal focus after resume to maintain seamless UX

## Technical Highlights
- **Performance**: Notification only on 0→1 transition prevents re-render storms during high-throughput output
- **Memory safety**: Proper cleanup in destroy() including listener set clearing
- **React 19 optimized**: Stable snapshot references and memoized callbacks prevent unnecessary re-renders
- **Accessibility**: Keyboard-focusable button with ARIA label, auto-restores terminal focus