### PR TITLE
Replace raw Tailwind colors with semantic tokens in state indicators

### DIFF
--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -200,10 +200,10 @@ export function FileChangeList({
 
         <div className="flex items-center gap-2 shrink-0 text-[11px]">
           {(change.insertions ?? 0) > 0 && (
-            <span className="text-green-500/80">+{change.insertions}</span>
+            <span className="text-[var(--color-status-success)]/80">+{change.insertions}</span>
           )}
           {(change.deletions ?? 0) > 0 && (
-            <span className="text-red-500/80">-{change.deletions}</span>
+            <span className="text-[var(--color-status-error)]/80">-{change.deletions}</span>
           )}
         </div>
       </div>

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -836,10 +836,12 @@ export function WorktreeCard({
       <div
         className={cn(
           "absolute left-0 top-0 bottom-0 w-[3px] transition-all duration-300 rounded-r-sm",
-          spineState === "error" && "bg-red-500",
-          spineState === "dirty" && "bg-amber-500 shadow-[0_0_6px_rgba(251,191,36,0.3)]",
-          spineState === "stale" && "bg-zinc-500",
-          spineState === "current" && "bg-teal-500 shadow-[0_0_8px_rgba(20,184,166,0.4)]",
+          spineState === "error" && "bg-[var(--color-status-error)]",
+          spineState === "dirty" &&
+            "bg-[var(--color-status-warning)] shadow-[0_0_6px_rgba(251,191,36,0.3)]",
+          spineState === "stale" && "bg-[var(--color-state-idle)]",
+          spineState === "current" &&
+            "bg-[var(--color-status-info)] shadow-[0_0_8px_rgba(56,189,248,0.4)]",
           spineState === "idle" && "bg-transparent"
         )}
         aria-hidden="true"


### PR DESCRIPTION
## Summary

Replaces raw Tailwind palette colors with semantic design tokens for better consistency and maintainability. WorktreeCard spine states and FileChangeList diff counts now use the defined semantic tokens.

Closes #1147

## Changes Made

- Update WorktreeCard spine colors to use semantic tokens (error, warning, idle, info)
- Update FileChangeList diff count colors to use semantic tokens (success, error)
- Change current state from teal to sky blue (info color) for consistency
- Update glow shadow RGBA values to match new token colors