### PR TITLE
perf(terminal): optimize transition performance in DockedTerminalItem

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -197,7 +197,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         <PopoverTrigger asChild>
           <button
             className={cn(
-              "flex items-center gap-2.5 px-3 py-1.5 h-8 rounded-[var(--radius-md)] text-xs border transition-all max-w-[280px]",
+              "flex items-center gap-2.5 px-3 py-1.5 h-8 rounded-[var(--radius-md)] text-xs border transition-[background-color,border-color,color,box-shadow] max-w-[280px]",
               "bg-[var(--color-surface)] border-canopy-border text-canopy-text/80",
               "hover:text-canopy-text hover:border-canopy-accent/30 hover:bg-[var(--color-surface-highlight)]",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",


### PR DESCRIPTION
## Summary

After comprehensive analysis with Codex MCP, this PR implements the **only viable change** from issue #1153 that maintains true visual equivalence: optimizing transition performance in `DockedTerminalItem`.

Closes #1153

## Changes Made

- Replace `transition-all` with property-specific `transition-[background-color,border-color,color,box-shadow]` in DockedTerminalItem
- Reduces unnecessary repaints by targeting only the properties that actually change
- Maintains smooth visual animations without performance overhead

## Analysis: Why Color Token Changes Were Not Implemented

During Codex review and mathematical analysis, we discovered that the suggested color token replacements are **mathematically impossible** to achieve visual equivalence:

### The Core Problem

1. **`border-black/20` → `border-canopy-border/50`** (TerminalHeader line 141)
   - `black/20` = `rgba(0,0,0,0.2)` - darkens the surface
   - `canopy-border` = `#27272a` - lighter than background `#18181b`
   - **Result**: Cannot replicate darkening effect with a lighter color
   - **Math**: Would require negative opacity α = -0.32 (impossible)

2. **`bg-black/10 border-white/10` → `bg-canopy-bg/50 border-canopy-border/50`** (command pill)
   - Border flips from faint light stroke to darker gray stroke
   - Fill opacity jumps from 10% to 50%
   - **Result**: Different edge definition and contrast

3. **`bg-white/10` → `bg-canopy-border`** (separator)
   - Removes translucency entirely
   - **Result**: Different divider prominence

### The Math

Using standard alpha blending formula: `C_result = C_fg × α + C_bg × (1 - α)`

For `black/20` over `zinc-950` background:
```
Target: rgba(19.2, 19.2, 21.6) (darker)
Background: #18181b (24, 24, 27)
New foreground: #27272a (39, 39, 42) (lighter!)

Required α = (19.2 - 24) / (39 - 24) = -4.8 / 15 = -0.32
```

Negative opacity is impossible. You cannot darken a surface with a lighter color overlay.

### Recommendation for Future Work

To achieve true token consistency while preserving visual appearance, the design system would need:

1. **Dedicated overlay tokens** that preserve the darkening/lightening semantics:
   - `--color-canopy-divider-dark: rgb(0 0 0 / 0.2)` for darkening borders
   - `--color-canopy-divider-light: rgb(255 255 255 / 0.1)` for lightening separators

2. **Use existing `--border-overlay`** token (already defined as `rgba(255, 255, 255, 0.08)`)

3. **Accept semantic tokens over strict color-matching** if visual fidelity is required

## Testing

- ✅ Build passes (`npm run check`)
- ✅ TypeScript compilation successful
- ✅ Lint warnings unchanged (143 pre-existing warnings, none new)
- ✅ Codex review confirmed transition change is safe
- ✅ No visual regressions - animation smoothness maintained

## References

- Issue: #1153
- Codex MCP analysis: Confirmed mathematical impossibility of proposed token replacements
- Color blending research: Standard alpha compositing cannot achieve darkening with lighter colors