### PR TITLE
Terminal: Mitigate noisy-neighbor starvation with sharded visual SAB

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -31,7 +31,7 @@ export const CHANNELS = {
   TERMINAL_GET_SERIALIZED_STATE: "terminal:get-serialized-state",
   TERMINAL_GET_SNAPSHOT: "terminal:get-snapshot",
   TERMINAL_GET_CLEAN_LOG: "terminal:get-clean-log",
-  TERMINAL_GET_SHARED_BUFFER: "terminal:get-shared-buffer",
+  TERMINAL_GET_SHARED_BUFFERS: "terminal:get-shared-buffers",
   TERMINAL_GET_ANALYSIS_BUFFER: "terminal:get-analysis-buffer",
   TERMINAL_GET_INFO: "terminal:get-info",
   TERMINAL_ACKNOWLEDGE_DATA: "terminal:acknowledge-data",

--- a/electron/ipc/handlers/terminal.ts
+++ b/electron/ipc/handlers/terminal.ts
@@ -619,17 +619,20 @@ export function registerTerminalHandlers(deps: HandlerDependencies): () => void 
   ipcMain.handle(CHANNELS.TERMINAL_GET_INFO, handleTerminalGetInfo);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_INFO));
 
-  // Get SharedArrayBuffer for zero-copy terminal I/O (visual rendering)
-  const handleTerminalGetSharedBuffer = async (): Promise<SharedArrayBuffer | null> => {
+  // Get SharedArrayBuffers for zero-copy terminal I/O (visual rendering)
+  const handleTerminalGetSharedBuffers = async (): Promise<{
+    visualBuffers: SharedArrayBuffer[];
+    signalBuffer: SharedArrayBuffer | null;
+  }> => {
     try {
-      return ptyClient.getSharedBuffer();
+      return ptyClient.getSharedBuffers();
     } catch (error) {
-      console.warn("[IPC] Failed to get shared buffer:", error);
-      return null;
+      console.warn("[IPC] Failed to get shared buffers:", error);
+      return { visualBuffers: [], signalBuffer: null };
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_SHARED_BUFFER, handleTerminalGetSharedBuffer);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_SHARED_BUFFER));
+  ipcMain.handle(CHANNELS.TERMINAL_GET_SHARED_BUFFERS, handleTerminalGetSharedBuffers);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_SHARED_BUFFERS));
 
   // Get SharedArrayBuffer for semantic analysis (Web Worker)
   const handleTerminalGetAnalysisBuffer = async (): Promise<SharedArrayBuffer | null> => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -117,7 +117,7 @@ const CHANNELS = {
   TERMINAL_GET_SERIALIZED_STATE: "terminal:get-serialized-state",
   TERMINAL_GET_SNAPSHOT: "terminal:get-snapshot",
   TERMINAL_GET_CLEAN_LOG: "terminal:get-clean-log",
-  TERMINAL_GET_SHARED_BUFFER: "terminal:get-shared-buffer",
+  TERMINAL_GET_SHARED_BUFFERS: "terminal:get-shared-buffers",
   TERMINAL_GET_ANALYSIS_BUFFER: "terminal:get-analysis-buffer",
   TERMINAL_GET_INFO: "terminal:get-info",
   TERMINAL_ACKNOWLEDGE_DATA: "terminal:acknowledge-data",
@@ -412,8 +412,10 @@ const api: ElectronAPI = {
 
     getInfo: (id: string) => _typedInvoke(CHANNELS.TERMINAL_GET_INFO, id),
 
-    getSharedBuffer: (): Promise<SharedArrayBuffer | null> =>
-      ipcRenderer.invoke(CHANNELS.TERMINAL_GET_SHARED_BUFFER),
+    getSharedBuffers: (): Promise<{
+      visualBuffers: SharedArrayBuffer[];
+      signalBuffer: SharedArrayBuffer | null;
+    }> => ipcRenderer.invoke(CHANNELS.TERMINAL_GET_SHARED_BUFFERS),
 
     getAnalysisBuffer: (): Promise<SharedArrayBuffer | null> =>
       ipcRenderer.invoke(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -96,7 +96,10 @@ export interface ElectronAPI {
       options?: TerminalGetScreenSnapshotOptions
     ): Promise<TerminalScreenSnapshot | null>;
     getCleanLog(request: TerminalGetCleanLogRequest): Promise<TerminalGetCleanLogResponse>;
-    getSharedBuffer(): Promise<SharedArrayBuffer | null>;
+    getSharedBuffers(): Promise<{
+      visualBuffers: SharedArrayBuffer[];
+      signalBuffer: SharedArrayBuffer | null;
+    }>;
     getAnalysisBuffer(): Promise<SharedArrayBuffer | null>;
     getInfo(id: string): Promise<TerminalInfoPayload>;
     getMessagePort(): Promise<any | null>;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -78,7 +78,12 @@ export type PtyHostRequest =
       options?: TerminalGetScreenSnapshotOptions;
     }
   | { type: "get-clean-log"; id: string; requestId: string; sinceSequence?: number; limit?: number }
-  | { type: "init-buffers"; visualBuffer: SharedArrayBuffer; analysisBuffer: SharedArrayBuffer }
+  | {
+      type: "init-buffers";
+      visualBuffers: SharedArrayBuffer[];
+      analysisBuffer: SharedArrayBuffer;
+      visualSignalBuffer: SharedArrayBuffer;
+    }
   | { type: "connect-port" }
   | { type: "get-terminal-info"; id: string; requestId: string }
   | { type: "force-resume"; id: string };

--- a/shared/types/terminal-output-worker-messages.ts
+++ b/shared/types/terminal-output-worker-messages.ts
@@ -1,5 +1,9 @@
 export type WorkerInboundMessage =
-  | { type: "INIT_BUFFER"; buffer: SharedArrayBuffer }
+  | {
+      type: "INIT_BUFFER";
+      buffers: SharedArrayBuffer[];
+      signalBuffer: SharedArrayBuffer;
+    }
   | { type: "SET_INTERACTIVE"; id: string; ttlMs: number }
   | { type: "FLUSH_TERMINAL"; id: string }
   | { type: "RESET_TERMINAL"; id: string }

--- a/shared/utils/shardSelection.ts
+++ b/shared/utils/shardSelection.ts
@@ -1,0 +1,12 @@
+export function selectShard(terminalId: string, shardCount: number): number {
+  if (shardCount <= 0) throw new Error("shardCount must be > 0");
+  if (shardCount === 1) return 0;
+
+  let hash = 0;
+  for (let i = 0; i < terminalId.length; i++) {
+    hash = (hash << 5) - hash + terminalId.charCodeAt(i);
+    hash |= 0;
+  }
+
+  return (hash >>> 0) % shardCount;
+}

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -162,11 +162,14 @@ export const terminalClient = {
   },
 
   /**
-   * Get SharedArrayBuffer for zero-copy terminal I/O.
-   * Returns null if SharedArrayBuffer is unavailable (fallback to IPC).
+   * Get SharedArrayBuffers for zero-copy terminal I/O.
+   * Returns empty arrays if SharedArrayBuffer is unavailable (fallback to IPC).
    */
-  getSharedBuffer: (): Promise<SharedArrayBuffer | null> => {
-    return window.electron.terminal.getSharedBuffer();
+  getSharedBuffers: (): Promise<{
+    visualBuffers: SharedArrayBuffer[];
+    signalBuffer: SharedArrayBuffer | null;
+  }> => {
+    return window.electron.terminal.getSharedBuffers();
   },
 
   /**


### PR DESCRIPTION
## Summary
This PR implements a sharded SharedArrayBuffer (SAB) architecture for terminal visual output to prevent noisy-neighbor starvation. Instead of a single 10MB visual buffer shared by all terminals, we now use 4 shards of 2.5MB each with deterministic terminal-to-shard mapping.

Closes #1120

## Changes Made
- Split single 10MB visual buffer into 4 shards of 2.5MB each for fairness/isolation
- Add deterministic shard selection hash function for stable terminal-to-shard mapping
- Implement global wake signal buffer for efficient cross-shard worker notification
- Add per-shard backpressure isolation (pausing PTY now only affects that terminal's shard)
- Implement round-robin draining in worker for fair shard consumption
- Fix worker throughput throttling (was limiting hot shards to 1 read per tick)
- Fix timer cleanup in worker reset to prevent stray timeouts after STOP
- Fix flow-control acknowledgement logic after worker errors (sabAvailable flag)
- Add graceful STOP termination with 50ms delay before worker.terminate()
- Clear pendingVisualPackets map only after successful pause (prevent leaks on fallback)
- Guard force-resume shard access when visualBuffers.length === 0
- Update legacy polling fallback (TerminalDataBuffer) to use round-robin as well

## Test Plan
- Typechecked with tsc (passes)
- Linted and formatted with Prettier (passes)
- Codex review identified and fixed 7 critical issues (all applied)
- Ready for integration testing with high-volume terminal output

## Technical Details
**Architecture:** Main process allocates 4 visual SABs + 1 signal SAB, sends to host process via init-buffers. Host uses stable hash to select shard per terminalId, writes framed packets, increments global signal. Worker uses Atomics.wait on signal, drains all shards round-robin with consecutive-empty-shards break condition.

**Isolation:** Backpressure (utilization check, pause/resume) now operates per-shard, so one noisy terminal can't cause others to pause.

**Fairness:** Round-robin draining with budget limits ensures all shards get serviced each tick, preventing hot-shard domination.