### PR TITLE
Derive terminal selection background from CSS token

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -55,6 +55,7 @@
   --color-canopy-success: #34d399; /* Emerald-400: Brighter green */
   --color-canopy-warning: #fbbf24; /* Amber-400 */
   --color-canopy-error: #f87171; /* Red-400: Soft Coral */
+  --color-terminal-selection: #064e3b; /* Emerald-950: Terminal selection background */
 
   /* Semantic status colors - for user-facing states (success, error, warning, info) */
   --color-status-success: #34d399; /* Emerald-400: Brighter green */

--- a/src/utils/terminalTheme.ts
+++ b/src/utils/terminalTheme.ts
@@ -42,7 +42,10 @@ export function getTerminalThemeFromCSS(): typeof CANOPY_TERMINAL_THEME_FALLBACK
     foreground: getVar("--color-canopy-text", CANOPY_TERMINAL_THEME_FALLBACK.foreground),
     cursor: getVar("--color-canopy-accent", CANOPY_TERMINAL_THEME_FALLBACK.cursor),
     cursorAccent: getVar("--color-canopy-bg", CANOPY_TERMINAL_THEME_FALLBACK.cursorAccent),
-    selectionBackground: "#064e3b",
+    selectionBackground: getVar(
+      "--color-terminal-selection",
+      CANOPY_TERMINAL_THEME_FALLBACK.selectionBackground
+    ),
     selectionForeground: getVar(
       "--color-canopy-text",
       CANOPY_TERMINAL_THEME_FALLBACK.selectionForeground


### PR DESCRIPTION
## Summary

Replaces hardcoded terminal selection background color with a CSS variable for better theme consistency and maintainability.

Closes #1146

## Changes Made

- Add `--color-terminal-selection` CSS variable to index.css
- Update terminalTheme.ts to use CSS variable instead of hardcoded hex value
- Maintain #064e3b as fallback for consistency