### PR TITLE
Terminal: Add reliability metrics for backpressure/suspend/wake

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -676,6 +676,11 @@ export class PtyClient extends EventEmitter {
         });
         break;
 
+      case "terminal-reliability-metric":
+        // Forward reliability metrics for visibility in diagnostics
+        events.emit("terminal:reliability-metric", event.payload);
+        break;
+
       default:
         console.warn("[PtyClient] Unknown event type:", (event as { type: string }).type);
     }

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types/index.js";
 import type { EventContext } from "../../shared/types/events.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
+import type { TerminalReliabilityMetricPayload } from "../../shared/types/pty-host.js";
 
 export type { EventCategory };
 
@@ -255,6 +256,12 @@ export const EVENT_META: Record<keyof CanopyEventMap, EventMetadata> = {
     requiresContext: false,
     requiresTimestamp: true,
     description: "Terminal foregrounded during project switch (visible again)",
+  },
+  "terminal:reliability-metric": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Terminal reliability metric (pause/suspend/wake timing)",
   },
 
   // Task events
@@ -599,6 +606,12 @@ export type CanopyEventMap = {
     timestamp: number;
   };
 
+  /**
+   * Emitted when a terminal reliability metric is recorded.
+   * Includes pause, suspend, and wake latency metrics.
+   */
+  "terminal:reliability-metric": TerminalReliabilityMetricPayload;
+
   // Task Lifecycle Events (Future-proof for task management)
 
   /**
@@ -691,6 +704,7 @@ export const ALL_EVENT_TYPES: Array<keyof CanopyEventMap> = [
   "terminal:status",
   "terminal:backgrounded",
   "terminal:foregrounded",
+  "terminal:reliability-metric",
   "task:created",
   "task:assigned",
   "task:state-changed",

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -196,6 +196,10 @@ export type PtyHostEvent =
       reason?: string;
       duration?: number;
       timestamp: number;
+    }
+  | {
+      type: "terminal-reliability-metric";
+      payload: TerminalReliabilityMetricPayload;
     };
 
 /** Terminal info sent from Host → Main for getTerminal queries */
@@ -298,6 +302,18 @@ export interface HostThrottlePayload {
   reason?: string;
   duration?: number;
   timestamp: number;
+}
+
+/** Payload for terminal reliability metrics (backpressure/suspend/wake) */
+export interface TerminalReliabilityMetricPayload {
+  terminalId: string;
+  metricType: "pause-start" | "pause-end" | "suspend" | "wake-latency";
+  timestamp: number;
+  durationMs?: number;
+  bufferUtilization?: number;
+  shardIndex?: number;
+  serializedStateBytes?: number;
+  wakeLatencyMs?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements lightweight instrumentation to quantify terminal reliability and performance for backpressure/suspend/wake paths. Metrics are gated behind `CANOPY_TERMINAL_METRICS=1` environment variable and visible in the Diagnostics → Events tab.

Closes #1116

## Changes Made
- Add `TerminalReliabilityMetricPayload` type for tracking pause/suspend/wake timing
- Emit metrics on pause-start, pause-end, suspend, and wake-latency events
- Gate all metrics behind `CANOPY_TERMINAL_METRICS=1` environment variable
- Forward metrics through PtyClient to event system for diagnostics visibility
- Optimize wake-latency computation with conditional Buffer.byteLength (avoid overhead when disabled)
- Fix missing pause-end metric emissions on force-resume and set-activity-tier paths
- Clean up pause interval and timing properly in wake-terminal handler
- Use `terminalId` instead of `id` for event inspector compatibility

## Testing
Enable metrics with `CANOPY_TERMINAL_METRICS=1 npm run dev` and check Diagnostics → Events tab for:
- How often terminals pause/suspend
- Average and p95 wake latency
- Typical pause durations