### PR TITLE
Add usage links to agent settings page

### DIFF
--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -7,6 +7,7 @@ export interface AgentConfig {
   supportsContextInjection: boolean;
   shortcut?: string | null;
   tooltip?: string;
+  usageUrl?: string;
   capabilities?: {
     scrollback?: number;
     blockAltScreen?: boolean;
@@ -27,6 +28,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     supportsContextInjection: true,
     shortcut: "Cmd/Ctrl+Alt+C",
     tooltip: "deep, focused work",
+    usageUrl: "https://claude.ai/settings/usage",
     capabilities: {
       scrollback: 10000,
       blockAltScreen: false,
@@ -63,6 +65,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     supportsContextInjection: true,
     shortcut: "Cmd/Ctrl+Alt+X",
     tooltip: "careful, methodical runs",
+    usageUrl: "https://chatgpt.com/codex/settings/usage",
     capabilities: {
       scrollback: 10000,
       blockAltScreen: false,

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -8,7 +8,7 @@ import {
   getAgentSettingsEntry,
   DEFAULT_DANGEROUS_ARGS,
 } from "@shared/types";
-import { RotateCcw } from "lucide-react";
+import { RotateCcw, ExternalLink } from "lucide-react";
 
 interface AgentSettingsProps {
   onSettingsChange?: () => void;
@@ -45,23 +45,23 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
           const config = getAgentConfig(id);
           if (!config) return null;
           const entry = getAgentSettingsEntry(effectiveSettings, id);
-          const Icon = config.icon ? config.icon : null;
           return {
             id,
             name: config.name,
             color: config.color,
-            Icon,
+            Icon: config.icon,
+            usageUrl: config.usageUrl,
             enabled: entry.enabled ?? true,
             dangerousEnabled: entry.dangerousEnabled ?? false,
             hasCustomFlags: Boolean(entry.customFlags?.trim()),
           };
         })
-        .filter(Boolean),
+        .filter((a): a is NonNullable<typeof a> => a !== null),
     [agentIds, effectiveSettings]
   );
 
   const activeAgent = activeAgentId
-    ? agentOptions.find((a) => a?.id === activeAgentId)
+    ? agentOptions.find((a) => a.id === activeAgentId)
     : agentOptions[0];
   const activeEntry = activeAgent
     ? getAgentSettingsEntry(effectiveSettings, activeAgent.id)
@@ -155,18 +155,39 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                 </p>
               </div>
             </div>
-            <Button
-              size="sm"
-              variant="ghost"
-              className="text-canopy-text/50 hover:text-canopy-text"
-              onClick={async () => {
-                await reset(activeAgent.id);
-                onSettingsChange?.();
-              }}
-            >
-              <RotateCcw size={14} className="mr-1.5" />
-              Reset
-            </Button>
+            <div className="flex items-center gap-2">
+              {activeAgent.usageUrl && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-canopy-text/50 hover:text-canopy-text"
+                  onClick={async () => {
+                    const url = activeAgent.usageUrl?.trim();
+                    if (!url) return;
+                    try {
+                      await window.electron.system.openExternal(url);
+                    } catch (error) {
+                      console.error("Failed to open usage URL:", error);
+                    }
+                  }}
+                >
+                  <ExternalLink size={14} className="mr-1.5" />
+                  View Usage
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                className="text-canopy-text/50 hover:text-canopy-text"
+                onClick={async () => {
+                  await reset(activeAgent.id);
+                  onSettingsChange?.();
+                }}
+              >
+                <RotateCcw size={14} className="mr-1.5" />
+                Reset
+              </Button>
+            </div>
           </div>
 
           {/* Enabled Toggle */}

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -26,7 +26,7 @@ const ICON_MAP: Record<string, ComponentType<AgentIconProps>> = {
 
 export const AGENT_REGISTRY: Record<string, AgentConfig> = Object.fromEntries(
   Object.entries(BASE_AGENT_REGISTRY).map(([id, config]) => {
-    return [id, { ...config, icon: ICON_MAP[id] ?? ClaudeIcon }];
+    return [id, { ...config, icon: ICON_MAP[config.iconId] ?? ClaudeIcon }];
   })
 ) as Record<string, AgentConfig>;
 
@@ -35,7 +35,7 @@ export const AGENT_IDS = Object.keys(AGENT_REGISTRY) as string[];
 export function getAgentConfig(agentId: string): AgentConfig | undefined {
   const config = getBaseAgentConfig(agentId);
   if (!config) return undefined;
-  const icon = ICON_MAP[agentId] ?? ClaudeIcon;
+  const icon = ICON_MAP[config.iconId] ?? ClaudeIcon;
   return { ...config, icon };
 }
 


### PR DESCRIPTION
## Summary
Add usage tracking links for each agent in the Settings dialog, allowing users to quickly check their API usage for Claude and Codex directly from the app. Links only display when a usage URL is configured for the agent.

Closes #1179

## Changes Made
- Add usageUrl field to AgentConfig interface
- Configure usage URLs for Claude and Codex agents
- Add "View Usage" button in agent settings header
- Implement error handling for openExternal failures
- Fix icon mapping to use iconId instead of id
- Improve TypeScript type narrowing in agentOptions