### PR TITLE
Fix: Auto-select first sidecar tab on startup

### DIFF
--- a/src/components/Sidecar/SidecarVisibilityController.tsx
+++ b/src/components/Sidecar/SidecarVisibilityController.tsx
@@ -19,6 +19,15 @@ export function SidecarVisibilityController(): null {
   const prevHasOverlaysRef = useRef(hasOverlays);
   const prevSidecarOpenRef = useRef(sidecarOpen);
 
+  // Auto-select first tab on startup when sidecar is open with tabs but no active tab
+  useEffect(() => {
+    if (!sidecarOpen) return;
+    if (activeTabId != null) return;
+    if (tabs.length === 0) return;
+
+    useSidecarStore.getState().setActiveTab(tabs[0].id);
+  }, [sidecarOpen, tabs, activeTabId]);
+
   // Handle overlay visibility changes
   useEffect(() => {
     const wasHiddenByOverlay = prevHasOverlaysRef.current;


### PR DESCRIPTION
## Summary
Fixes the issue where the sidecar opens on app startup with persisted tabs but no tab is selected, showing an empty launchpad instead of the first tab's content.

Closes #1176

## Changes Made
- Add useEffect to auto-select first tab when sidecar opens with tabs but no active tab
- Use nullish check (!=) to handle both null and undefined activeTabId
- Delegate webview creation to existing tab-switching logic in SidecarDock
- Simplify implementation by relying on activeTabId state change to naturally stop reruns
- Remove unnecessary complexity (no ref-based initialization, no async webview creation)

## Implementation Details
The fix adds a simple initialization effect in `SidecarVisibilityController` that:
1. Checks if sidecar is open and has tabs but no activeTabId
2. Sets the first tab as active
3. Lets existing effects handle webview creation and display

This approach avoids race conditions and follows the single responsibility principle by delegating webview lifecycle to the existing tab-switching logic.