### PR TITLE
fix(terminal): resolve initialization failures for terminals in inactive worktrees

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -294,7 +294,9 @@ export function DndProvider({ children }: DndProviderProps) {
         console.log(`[DND_DEBUG] Worktree drop detected: ${overData.worktreeId}`);
         const currentTerminal = terminals.find((t) => t.id === draggedId);
         if (currentTerminal && currentTerminal.worktreeId !== overData.worktreeId) {
-          console.log(`[DND_DEBUG] Moving terminal ${draggedId} to worktree ${overData.worktreeId}`);
+          console.log(
+            `[DND_DEBUG] Moving terminal ${draggedId} to worktree ${overData.worktreeId}`
+          );
           moveTerminalToWorktree(draggedId, overData.worktreeId!);
           setFocused(null);
         }
@@ -418,7 +420,9 @@ export function DndProvider({ children }: DndProviderProps) {
             (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
 
-        console.log(`[DND_DEBUG] Stabilizing ${gridTerminalsList.length} terminals in active worktree ${activeWorktreeId}`);
+        console.log(
+          `[DND_DEBUG] Stabilizing ${gridTerminalsList.length} terminals in active worktree ${activeWorktreeId}`
+        );
 
         for (const terminal of gridTerminalsList) {
           // Flush any pending resize jobs that could have stale dimensions

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -58,9 +58,7 @@ function XtermAdapterComponent({
   // Create a STABLE proxy function that always calls the latest getRefreshTier.
   // This function's identity never changes, preventing stale closure issues.
   const stableRefreshTierProvider = useCallback(() => {
-    return getRefreshTierRef.current
-      ? getRefreshTierRef.current()
-      : TerminalRefreshTier.FOCUSED;
+    return getRefreshTierRef.current ? getRefreshTierRef.current() : TerminalRefreshTier.FOCUSED;
   }, []);
 
   // Agent state for state-aware rendering decisions (height ratchet, resize guard, scroll latch)

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -50,7 +50,13 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   };
 
   return (
-    <AppDialog isOpen={isOpen} onClose={onClose} size="sm" variant="destructive" dismissible={!isDeleting}>
+    <AppDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      size="sm"
+      variant="destructive"
+      dismissible={!isDeleting}
+    >
       <AppDialog.Body>
         <div className="flex items-center gap-3 mb-4 text-[var(--color-status-error)]">
           <div className="p-2 bg-[var(--color-status-error)]/10 rounded-full">
@@ -60,61 +66,61 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
         </div>
 
         <div className="space-y-4">
-            <p className="text-sm text-canopy-text/80">
-              Are you sure you want to delete{" "}
-              <span className="font-mono font-medium text-canopy-text">
-                {worktree.branch || worktree.name}
-              </span>
-              ?
-            </p>
+          <p className="text-sm text-canopy-text/80">
+            Are you sure you want to delete{" "}
+            <span className="font-mono font-medium text-canopy-text">
+              {worktree.branch || worktree.name}
+            </span>
+            ?
+          </p>
 
-            <div className="text-xs text-canopy-text/60 bg-canopy-bg/50 p-3 rounded border border-canopy-border font-mono break-all">
-              {worktree.path}
+          <div className="text-xs text-canopy-text/60 bg-canopy-bg/50 p-3 rounded border border-canopy-border font-mono break-all">
+            {worktree.path}
+          </div>
+
+          {hasChanges && !force && (
+            <div className="flex items-start gap-2 p-3 bg-amber-500/10 border border-amber-500/20 rounded text-amber-500 text-xs">
+              <AlertTriangle className="w-4 h-4 shrink-0" />
+              <p>This worktree has uncommitted changes. Standard deletion will fail.</p>
             </div>
+          )}
 
-            {hasChanges && !force && (
-              <div className="flex items-start gap-2 p-3 bg-amber-500/10 border border-amber-500/20 rounded text-amber-500 text-xs">
-                <AlertTriangle className="w-4 h-4 shrink-0" />
-                <p>This worktree has uncommitted changes. Standard deletion will fail.</p>
-              </div>
-            )}
+          {error && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="p-3 bg-red-500/10 border border-red-500/20 rounded text-[var(--color-status-error)] text-xs"
+            >
+              {error}
+            </div>
+          )}
 
-            {error && (
-              <div
-                role="alert"
-                aria-live="assertive"
-                className="p-3 bg-red-500/10 border border-red-500/20 rounded text-[var(--color-status-error)] text-xs"
-              >
-                {error}
-              </div>
-            )}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={force}
+              onChange={(e) => {
+                setForce(e.target.checked);
+                setError(null);
+              }}
+              className="rounded border-canopy-border bg-canopy-bg text-[var(--color-status-error)] focus:ring-[var(--color-status-error)]"
+            />
+            <span className="text-sm text-canopy-text">
+              Force delete (lose uncommitted changes)
+            </span>
+          </label>
 
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={force}
-                onChange={(e) => {
-                  setForce(e.target.checked);
-                  setError(null);
-                }}
-                className="rounded border-canopy-border bg-canopy-bg text-[var(--color-status-error)] focus:ring-[var(--color-status-error)]"
-              />
-              <span className="text-sm text-canopy-text">
-                Force delete (lose uncommitted changes)
-              </span>
-            </label>
-
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={closeTerminals}
-                onChange={(e) => setCloseTerminals(e.target.checked)}
-                className="rounded border-canopy-border bg-canopy-bg text-canopy-accent focus:ring-canopy-accent"
-              />
-              <span className="text-sm text-canopy-text">
-                Close all terminals{hasTerminals ? ` (${terminalCounts.total})` : ""}
-              </span>
-            </label>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={closeTerminals}
+              onChange={(e) => setCloseTerminals(e.target.checked)}
+              className="rounded border-canopy-border bg-canopy-bg text-canopy-accent focus:ring-canopy-accent"
+            />
+            <span className="text-sm text-canopy-text">
+              Close all terminals{hasTerminals ? ` (${terminalCounts.total})` : ""}
+            </span>
+          </label>
         </div>
       </AppDialog.Body>
 
@@ -122,11 +128,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
         <Button variant="ghost" onClick={onClose} disabled={isDeleting}>
           Cancel
         </Button>
-        <Button
-          variant="destructive"
-          onClick={handleDelete}
-          disabled={isDeleting}
-        >
+        <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
           {isDeleting ? "Deleting..." : "Delete Worktree"}
         </Button>
       </AppDialog.Footer>

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -269,9 +269,7 @@ AppDialog.BodyScroll = function AppDialogBodyScroll({
   children,
   className,
 }: AppDialogBodyScrollProps) {
-  return (
-    <div className={cn("flex-1 overflow-auto min-h-0 p-6", className)}>{children}</div>
-  );
+  return <div className={cn("flex-1 overflow-auto min-h-0 p-6", className)}>{children}</div>;
 };
 
 export interface DialogAction {


### PR DESCRIPTION
## Summary
Fixes terminal initialization failures when restoring terminals that belong to inactive worktrees at startup. Terminals in inactive worktrees now properly initialize in BACKGROUND tier and correctly wake up when their worktree becomes active.

Closes #1188

## Changes Made
- Fixed wake retry logic by returning boolean success/failure from wakeAndRestore method
- Set needsWake flag when transitioning to background tier to ensure wake on next activation
- Added generation guard in worktreeStore to prevent stale async policy applications from rapid worktree switches
- Prevented dock terminals from being incorrectly woken during worktree activation
- Removed redundant terminalClient.setActivityTier calls in worktreeStore (handled by applyRendererPolicy)
- Prewarmed all terminal types including agents in inactive worktrees for proper tier management
- Applied BACKGROUND policy to grid terminals in inactive worktrees at initialization

## Technical Details
**Root Cause:** Terminals in inactive worktrees were initialized without proper BACKGROUND tier setup, and the wake mechanism didn't handle "first wake" scenarios or retry failures correctly.

**Key Fixes:**
1. **Wake Retry Logic:** Changed wakeAndRestore to return boolean, properly handle success/failure in promise chain
2. **needsWake Tracking:** Set flag on active→background transitions, not just at initialization
3. **Race Condition Prevention:** Added generation counter to guard against stale async worktree policy applications
4. **Dock Terminal Isolation:** Only skip policy updates for dock terminals that are both active AND in the active worktree
5. **Prewarm Coverage:** Extended to all terminal types in inactive worktrees for consistent tier management