### PR TITLE
feat(worktree): initialize lastActivityTimestamp from git commit history

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -26,53 +26,53 @@ Main Process (electron/)     Renderer (src/)
 
 ### Main Process (`electron/`)
 
-| Path | Purpose |
-|------|---------|
-| `main.ts` | Entry point, window creation |
-| `preload.cts` | IPC bridge via contextBridge |
-| `ipc/channels.ts` | Channel name constants |
-| `ipc/handlers.ts` | Handler registration |
-| `ipc/handlers/*.ts` | Domain-specific handlers |
-| `services/` | Business logic (see below) |
-| `schemas/` | Zod validation for IPC |
+| Path                | Purpose                      |
+| ------------------- | ---------------------------- |
+| `main.ts`           | Entry point, window creation |
+| `preload.cts`       | IPC bridge via contextBridge |
+| `ipc/channels.ts`   | Channel name constants       |
+| `ipc/handlers.ts`   | Handler registration         |
+| `ipc/handlers/*.ts` | Domain-specific handlers     |
+| `services/`         | Business logic (see below)   |
+| `schemas/`          | Zod validation for IPC       |
 
 **Key Services:**
 
-| Service | Responsibility |
-|---------|----------------|
-| `PtyManager` | Terminal process pool, spawn/kill |
-| `pty/TerminalProcess` | Single PTY wrapper, data flow |
-| `pty/AgentStateService` | Idle/working/waiting detection |
-| `pty/TerminalSyncBuffer` | DEC 2026 sync for flicker-free TUI |
-| `GitService` | Git operations via simple-git |
-| `worktree/WorktreeService` | Worktree polling and status |
-| `CopyTreeService` | Context generation for agents |
-| `SidecarManager` | Localhost browser, log viewer |
-| `ProjectStore` | Multi-project persistence |
-| `HibernationService` | Terminal state save/restore |
+| Service                    | Responsibility                     |
+| -------------------------- | ---------------------------------- |
+| `PtyManager`               | Terminal process pool, spawn/kill  |
+| `pty/TerminalProcess`      | Single PTY wrapper, data flow      |
+| `pty/AgentStateService`    | Idle/working/waiting detection     |
+| `pty/TerminalSyncBuffer`   | DEC 2026 sync for flicker-free TUI |
+| `GitService`               | Git operations via simple-git      |
+| `worktree/WorktreeService` | Worktree polling and status        |
+| `CopyTreeService`          | Context generation for agents      |
+| `SidecarManager`           | Localhost browser, log viewer      |
+| `ProjectStore`             | Multi-project persistence          |
+| `HibernationService`       | Terminal state save/restore        |
 
 ### Renderer (`src/`)
 
-| Path | Purpose |
-|------|---------|
-| `components/Terminal/` | Xterm.js rendering, grid layout |
-| `components/Worktree/` | Dashboard cards, status display |
-| `components/Layout/` | App shell, toolbar, dock |
-| `components/Sidecar/` | Browser panel, artifact viewer |
-| `store/*.ts` | Zustand stores |
-| `hooks/` | React hooks for IPC subscriptions |
-| `clients/` | Typed wrappers for window.electron |
+| Path                   | Purpose                            |
+| ---------------------- | ---------------------------------- |
+| `components/Terminal/` | Xterm.js rendering, grid layout    |
+| `components/Worktree/` | Dashboard cards, status display    |
+| `components/Layout/`   | App shell, toolbar, dock           |
+| `components/Sidecar/`  | Browser panel, artifact viewer     |
+| `store/*.ts`           | Zustand stores                     |
+| `hooks/`               | React hooks for IPC subscriptions  |
+| `clients/`             | Typed wrappers for window.electron |
 
 **Key Stores:**
 
-| Store | State |
-|-------|-------|
-| `terminalStore` | Terminal instances, grid layout |
-| `terminalInputStore` | Hybrid input bar state |
-| `worktreeStore` | Active worktree, selection |
-| `worktreeDataStore` | Worktree list, git status |
-| `projectStore` | Current project, project list |
-| `sidecarStore` | Sidecar tabs, visibility |
+| Store                | State                           |
+| -------------------- | ------------------------------- |
+| `terminalStore`      | Terminal instances, grid layout |
+| `terminalInputStore` | Hybrid input bar state          |
+| `worktreeStore`      | Active worktree, selection      |
+| `worktreeDataStore`  | Worktree list, git status       |
+| `projectStore`       | Current project, project list   |
+| `sidecarStore`       | Sidecar tabs, visibility        |
 
 ### Shared Types (`shared/types/ipc/`)
 
@@ -105,12 +105,14 @@ Tests live in `__tests__/` directories adjacent to source. Use Vitest. Mock IPC 
 **Renderer**: DevTools (Cmd+Opt+I). Console, Network, React DevTools.
 
 **Main**: Logs to terminal running `npm run dev`. Use logger:
+
 ```typescript
-import { logInfo, logError } from './utils/logger';
-logInfo('ServiceName', 'message', { data });
+import { logInfo, logError } from "./utils/logger";
+logInfo("ServiceName", "message", { data });
 ```
 
 **Common fixes:**
+
 - PTY errors: `npm run rebuild`
 - Type errors in electron/: `npm run build:main`
 - Stale cache: `rm -rf node_modules/.vite && npm run dev`

--- a/docs/feature-curation.md
+++ b/docs/feature-curation.md
@@ -36,12 +36,12 @@ If it increases cognitive load or demands manual interaction, **reject it**.
 
 A feature belongs in Canopy **only if it satisfies at least two** of these criteria:
 
-| Criterion                         | Description                                                                           |
-| --------------------------------- | ------------------------------------------------------------------------------------- |
-| **Accelerates Context Injection** | Makes it faster to feed the "right" files/errors/diffs to an agent                                        |
-| **Unblocks the Agent**            | Detects when an agent is stuck, waiting, or failed, and helps human intervene quickly                     |
-| **Manages Multiplicity**          | Helps manage _multiple_ concurrent workstreams that a human brain can't track alone                       |
-| **Bridges the Gap**               | Fixes a friction point between the CLI and the GUI                                                        |
+| Criterion                         | Description                                                                                                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **Accelerates Context Injection** | Makes it faster to feed the "right" files/errors/diffs to an agent                                             |
+| **Unblocks the Agent**            | Detects when an agent is stuck, waiting, or failed, and helps human intervene quickly                          |
+| **Manages Multiplicity**          | Helps manage _multiple_ concurrent workstreams that a human brain can't track alone                            |
+| **Bridges the Gap**               | Fixes a friction point between the CLI and the GUI                                                             |
 | **Provides Omniscience**          | Aggregates data from multiple isolated contexts (worktrees/agents) into a single view. (Pro Feature Candidate) |
 
 If a feature doesn't satisfy at least 2 of these, it doesn't belong in Canopy.

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGit = {
+  raw: vi.fn(),
+};
+
+vi.mock("simple-git", () => {
+  return {
+    simpleGit: vi.fn(() => mockGit),
+    default: vi.fn(() => mockGit),
+  };
+});
+
+import { getLatestTrackedFileMtime } from "../git.js";
+import { simpleGit } from "simple-git";
+
+describe("getLatestTrackedFileMtime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns commit timestamp for worktree with commits", async () => {
+    const commitUnixTime = 1702639200; // 2023-12-15 10:00:00 UTC
+    mockGit.raw.mockResolvedValue(`${commitUnixTime}`);
+
+    const timestamp = await getLatestTrackedFileMtime("/test/path");
+
+    expect(timestamp).toBe(commitUnixTime * 1000);
+    expect(simpleGit).toHaveBeenCalledWith("/test/path");
+    expect(mockGit.raw).toHaveBeenCalledWith(["log", "-1", "--format=%ct"]);
+  });
+
+  it("returns null for worktree with no commits", async () => {
+    mockGit.raw.mockResolvedValue("");
+
+    const timestamp = await getLatestTrackedFileMtime("/test/path");
+
+    expect(timestamp).toBeNull();
+  });
+
+  it("returns null when git operations fail", async () => {
+    mockGit.raw.mockRejectedValue(new Error("Not a git repository"));
+
+    const timestamp = await getLatestTrackedFileMtime("/invalid/path");
+
+    expect(timestamp).toBeNull();
+  });
+
+  it("returns null for invalid timestamp", async () => {
+    mockGit.raw.mockResolvedValue("not-a-number");
+
+    const timestamp = await getLatestTrackedFileMtime("/test/path");
+
+    expect(timestamp).toBeNull();
+  });
+
+  it("returns null for zero timestamp", async () => {
+    mockGit.raw.mockResolvedValue("0");
+
+    const timestamp = await getLatestTrackedFileMtime("/test/path");
+
+    expect(timestamp).toBeNull();
+  });
+
+  it("returns null for negative timestamp", async () => {
+    mockGit.raw.mockResolvedValue("-1");
+
+    const timestamp = await getLatestTrackedFileMtime("/test/path");
+
+    expect(timestamp).toBeNull();
+  });
+
+  it("handles timestamp with whitespace", async () => {
+    const commitUnixTime = 1702639200;
+    mockGit.raw.mockResolvedValue(`  ${commitUnixTime}  \n`);
+
+    const timestamp = await getLatestTrackedFileMtime("/test/path");
+
+    expect(timestamp).toBe(commitUnixTime * 1000);
+  });
+});

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -11,7 +11,11 @@ import type {
   BranchInfo,
   PRServiceStatus,
 } from "../../shared/types/workspace-host.js";
-import { invalidateGitStatusCache, getWorktreeChangesWithStats } from "../utils/git.js";
+import {
+  invalidateGitStatusCache,
+  getWorktreeChangesWithStats,
+  getLatestTrackedFileMtime,
+} from "../utils/git.js";
 import { getGitDir, clearGitDirCache } from "../utils/gitUtils.js";
 import { WorktreeRemovedError } from "../utils/errorTypes.js";
 import { categorizeWorktree } from "../services/worktree/mood.js";
@@ -393,6 +397,10 @@ export class WorkspaceService {
 
       if (shouldUpdateTimestamp) {
         monitor.lastActivityTimestamp = Date.now();
+      }
+
+      if (isInitialLoad && isNowClean && monitor.lastActivityTimestamp === null) {
+        monitor.lastActivityTimestamp = newChanges.lastCommitTimestampMs ?? null;
       }
 
       // Use last commit message as summary

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -50,6 +50,8 @@ export interface WorktreeChanges {
   lastUpdated?: number;
   /** Last commit message (cached to avoid extra git log calls) */
   lastCommitMessage?: string;
+  /** Last commit time (ms since epoch, committer date) */
+  lastCommitTimestampMs?: number;
 }
 
 // Worktree Types

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -7,7 +7,7 @@ import { DEFAULT_TERMINAL_FONT_FAMILY } from "@/config/terminalFont";
 const MIN_FONT_SIZE = 8;
 const MAX_FONT_SIZE = 24;
 
-const SYSTEM_STACK = 'Menlo, Monaco, Consolas, monospace';
+const SYSTEM_STACK = "Menlo, Monaco, Consolas, monospace";
 
 const FONT_FAMILY_OPTIONS: Array<{ id: string; label: string; value: string }> = [
   {

--- a/src/index.css
+++ b/src/index.css
@@ -253,7 +253,15 @@
 
   body {
     @apply bg-background text-foreground;
-    font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-family:
+      system-ui,
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      Roboto,
+      Helvetica,
+      Arial,
+      sans-serif;
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary

Implements worktree activity timestamp initialization from git commit history on app startup. This allows the dashboard to correctly sort worktrees by recency from the very first load, instead of showing all worktrees with null timestamps until their first state change.

Closes #1187

## Changes Made

- Add `getLatestTrackedFileMtime()` function to efficiently fetch last commit timestamp using `%ct` format
- Reuse existing `git log` call in `getWorktreeChangesWithStats()` to capture both commit message and timestamp in a single operation
- Add `lastCommitTimestampMs` field to `WorktreeChanges` type for caching commit timestamps
- Initialize `lastActivityTimestamp` in `updateGitStatus()` for clean worktrees during initial load
- Add comprehensive unit tests covering edge cases (no commits, invalid timestamps, errors)
- Eliminate duplicate git operations (previously called `git log` and `git status` separately) for improved startup performance

## Performance Improvements

- Reduced git command overhead by combining commit message and timestamp fetch into single `git log` call
- Eliminated redundant `git status` call during timestamp initialization
- Uses cached commit timestamp from `WorktreeChanges` to avoid repeated git operations