### PR TITLE
Restore terminal focus and cursor position when switching worktrees

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -31,6 +31,7 @@ const MAX_TEXTAREA_HEIGHT_PX = 160;
 
 export interface HybridInputBarHandle {
   focus: () => void;
+  focusWithCursorAtEnd: () => void;
 }
 
 export interface HybridInputBarProps {
@@ -355,6 +356,25 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       requestAnimationFrame(() => textarea.focus());
     }, []);
 
+    const focusTextareaWithCursorAtEnd = useCallback(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      requestAnimationFrame(() => {
+        // Verify element is still mounted and is the same instance
+        if (textareaRef.current !== textarea || !textarea.isConnected) return;
+
+        textarea.focus();
+        const len = textarea.value.length;
+        textarea.setSelectionRange(len, len);
+
+        // For long multi-line drafts, ensure caret is visible
+        if (textarea.scrollHeight > textarea.clientHeight) {
+          textarea.scrollTop = textarea.scrollHeight;
+        }
+      });
+    }, []);
+
     const handleHistoryNavigation = useCallback(
       (direction: "up" | "down"): boolean => {
         const result = navigateHistory(terminalId, direction, value);
@@ -374,7 +394,11 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       [navigateHistory, terminalId, value, resizeTextarea]
     );
 
-    useImperativeHandle(ref, () => ({ focus: focusTextarea }), [focusTextarea]);
+    useImperativeHandle(
+      ref,
+      () => ({ focus: focusTextarea, focusWithCursorAtEnd: focusTextareaWithCursorAtEnd }),
+      [focusTextarea, focusTextareaWithCursorAtEnd]
+    );
 
     const handleKeyPassthrough = useCallback(
       (event: KeyboardEvent<HTMLTextAreaElement>): boolean => {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -333,7 +333,7 @@ function TerminalPaneComponent({
 
       setFocused(id);
       terminalInstanceService.boostRefreshRate(id);
-      requestAnimationFrame(() => inputBarRef.current?.focus());
+      requestAnimationFrame(() => inputBarRef.current?.focusWithCursorAtEnd());
     },
     [
       id,
@@ -367,16 +367,18 @@ function TerminalPaneComponent({
 
     const focusTarget = getTerminalFocusTarget({
       isAgentTerminal,
-      isInputDisabled: isBackendDisconnected || isBackendRecovering,
+      isInputDisabled: isBackendDisconnected || isBackendRecovering || isInputLocked,
       hybridInputEnabled,
       hybridInputAutoFocus,
     });
 
     if (focusTarget === "hybridInput") {
-      const timeoutId = window.setTimeout(() => {
-        inputBarRef.current?.focus();
-      }, 10);
-      return () => window.clearTimeout(timeoutId);
+      const rafId = requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          inputBarRef.current?.focusWithCursorAtEnd();
+        });
+      });
+      return () => cancelAnimationFrame(rafId);
     }
 
     const rafId = requestAnimationFrame(() => terminalInstanceService.focus(id));
@@ -389,6 +391,7 @@ function TerminalPaneComponent({
     hybridInputAutoFocus,
     isBackendDisconnected,
     isBackendRecovering,
+    isInputLocked,
   ]);
 
   // Sync agent state to terminal service for scroll management

--- a/src/hooks/app/useTerminalStoreBootstrap.ts
+++ b/src/hooks/app/useTerminalStoreBootstrap.ts
@@ -6,12 +6,17 @@
 
 import { useEffect } from "react";
 import { setupTerminalStoreListeners } from "../../store/terminalStore";
+import { setupWorktreeFocusTracking } from "../../store/worktreeStore";
 import { isElectronAvailable } from "../useElectron";
 
 export function useTerminalStoreBootstrap() {
   useEffect(() => {
     if (!isElectronAvailable()) return;
-    const cleanup = setupTerminalStoreListeners();
-    return cleanup;
+    const cleanupTerminalStore = setupTerminalStoreListeners();
+    const cleanupFocusTracking = setupWorktreeFocusTracking();
+    return () => {
+      cleanupTerminalStore();
+      cleanupFocusTracking();
+    };
   }, []);
 }

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -86,6 +86,18 @@ export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
       get().clearQueue(id);
       get().handleTerminalRemoved(id, remainingTerminals, removedIndex);
       useTerminalInputStore.getState().clearDraftInput(id);
+
+      // Clean up worktree focus tracking if this was the last focused terminal
+      const terminal = get().terminals.find((t) => t.id === id);
+      if (terminal?.worktreeId) {
+        void import("@/store/worktreeStore").then(({ useWorktreeSelectionStore }) => {
+          const store = useWorktreeSelectionStore.getState();
+          const lastFocused = store.lastFocusedTerminalByWorktree.get(terminal.worktreeId!);
+          if (lastFocused === id) {
+            store.clearWorktreeFocusTracking(terminal.worktreeId!);
+          }
+        });
+      }
     },
   })(set, get, api);
 


### PR DESCRIPTION
## Summary
Fixes the issue where switching between worktrees loses terminal focus and cursor position. When returning to a worktree, the previously-focused terminal is now re-selected and the hybrid input cursor is positioned at the end of any draft text.

Closes #1191

## Changes Made
- Add per-worktree terminal focus tracking with Map in worktreeStore
- Implement Zustand subscription to track focus changes synchronously
- Add race condition protection with generation checks in selectWorktree
- Position cursor at end of hybrid input when restoring focus
- Add cleanup logic for removed terminals and worktrees
- Fix cursor positioning edge cases with lifecycle guards and scroll visibility
- Replace setTimeout with requestAnimationFrame for reliable focus timing
- Handle input lock state in focus target decisions

## Technical Details
**State Management:**
- Uses Zustand subscription instead of async dynamic imports to avoid race conditions
- Generation checks prevent stale focus restoration during rapid worktree switches
- Validates terminal still belongs to target worktree and isn't trashed

**UI Improvements:**
- Cursor always positioned at end via `focusWithCursorAtEnd()` method
- Scroll visibility ensured for long multi-line drafts
- Lifecycle guards prevent focus on unmounted/stale elements
- Consistent behavior for keyboard focus, click focus, and worktree switching