### PR TITLE
Fix waiting count includes zombie terminals from deleted worktrees

### DIFF
--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -5,7 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useTerminalStore } from "@/store/terminalStore";
-import { useWaitingTerminalIds } from "@/hooks/useTerminalSelectors";
+import { useWaitingTerminals } from "@/hooks/useTerminalSelectors";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import type { TerminalLocation } from "@shared/types";
@@ -17,7 +17,7 @@ function getLocationIcon(location: TerminalLocation | undefined) {
 
 export function WaitingContainer() {
   const [isOpen, setIsOpen] = useState(false);
-  const waitingIds = useWaitingTerminalIds();
+  const waitingTerminals = useWaitingTerminals();
   const { activateTerminal, pingTerminal } = useTerminalStore(
     useShallow((state) => ({
       activateTerminal: state.activateTerminal,
@@ -25,12 +25,6 @@ export function WaitingContainer() {
     }))
   );
   const shortcut = useKeybindingDisplay("agent.focusNextWaiting");
-
-  const waitingTerminals = useTerminalStore(
-    useShallow((state) =>
-      waitingIds.map((id) => state.terminals.find((t) => t.id === id)).filter(Boolean)
-    )
-  );
 
   if (waitingTerminals.length === 0) return null;
 
@@ -75,48 +69,41 @@ export function WaitingContainer() {
           </div>
 
           <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
-            {waitingTerminals.map((terminal) => {
-              if (!terminal) return null;
-
-              return (
-                <button
-                  key={terminal.id}
-                  onClick={() => {
-                    activateTerminal(terminal.id);
-                    pingTerminal(terminal.id);
-                    setIsOpen(false);
-                  }}
-                  className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-none hover:bg-white/5 focus:bg-white/5"
-                >
-                  <div className="flex items-center gap-2 min-w-0 flex-1">
-                    <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
-                      <TerminalIcon
-                        type={terminal.type}
-                        agentId={terminal.agentId}
-                        className="h-3 w-3"
-                      />
-                    </div>
-                    <span className="text-xs truncate font-medium text-canopy-text/70 group-hover:text-canopy-text transition-colors">
-                      {terminal.title}
-                    </span>
-                  </div>
-
-                  <div className="flex items-center gap-2.5 shrink-0">
-                    <AlertCircle
-                      className="w-3 h-3 text-amber-400"
-                      aria-label="Waiting for input"
+            {waitingTerminals.map((terminal) => (
+              <button
+                key={terminal.id}
+                onClick={() => {
+                  activateTerminal(terminal.id);
+                  pingTerminal(terminal.id);
+                  setIsOpen(false);
+                }}
+                className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-none hover:bg-white/5 focus:bg-white/5"
+              >
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
+                    <TerminalIcon
+                      type={terminal.type}
+                      agentId={terminal.agentId}
+                      className="h-3 w-3"
                     />
-
-                    <div
-                      className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors"
-                      title={terminal.location === "dock" ? "Docked" : "On Grid"}
-                    >
-                      {getLocationIcon(terminal.location)}
-                    </div>
                   </div>
-                </button>
-              );
-            })}
+                  <span className="text-xs truncate font-medium text-canopy-text/70 group-hover:text-canopy-text transition-colors">
+                    {terminal.title}
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-2.5 shrink-0">
+                  <AlertCircle className="w-3 h-3 text-amber-400" aria-label="Waiting for input" />
+
+                  <div
+                    className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors"
+                    title={terminal.location === "dock" ? "Docked" : "On Grid"}
+                  >
+                    {getLocationIcon(terminal.location)}
+                  </div>
+                </div>
+              </button>
+            ))}
           </div>
         </div>
       </PopoverContent>

--- a/src/hooks/useWindowNotifications.ts
+++ b/src/hooks/useWindowNotifications.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
-import { useShallow } from "zustand/react/shallow";
-import { useTerminalStore } from "@/store/terminalStore";
 import { updateFaviconBadge, clearFaviconBadge } from "@/services/FaviconBadgeService";
+import { useTerminalNotificationCounts } from "@/hooks/useTerminalSelectors";
 
 const DEBOUNCE_MS = 300;
 
@@ -10,15 +9,7 @@ export function useWindowNotifications(): void {
   const windowFocusedRef = useRef(true);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const { waitingCount, failedCount } = useTerminalStore(
-    useShallow((state) => {
-      const nonTrashedTerminals = state.terminals.filter((t) => !state.isInTrash(t.id));
-      return {
-        waitingCount: nonTrashedTerminals.filter((t) => t.agentState === "waiting").length,
-        failedCount: nonTrashedTerminals.filter((t) => t.agentState === "failed").length,
-      };
-    })
-  );
+  const { waitingCount, failedCount } = useTerminalNotificationCounts();
 
   // Handle window focus/blur for favicon badge clearing
   useEffect(() => {


### PR DESCRIPTION
## Summary
Fixes the issue where the "Waiting" indicator includes zombie terminals from deleted worktrees, causing inflated waiting counts and showing invisible terminals in the waiting list.

Closes #1206

## Changes Made
- Add orphan detection for terminals from deleted worktrees
- Implement shared notification counts hook to eliminate logic duplication  
- Refactor WaitingContainer to use single subscription pattern (eliminates race condition)
- Enhance startup cleanup with normalized worktreeId handling
- Include both id and worktreeId in known worktrees set for comprehensive matching

## Technical Details

**Root Cause:**
- Terminals persisted after their worktrees were deleted (especially during PR review workflows)
- Dual store subscriptions in WaitingContainer created race conditions
- No orphan detection logic to filter out terminals from non-existent worktrees

**Solution:**
1. **Orphan Detection:** Added `isTerminalOrphaned()` to check if a terminal's worktreeId exists in the worktree store
2. **Single Subscription Pattern:** Refactored `WaitingContainer` to use `useWaitingTerminals()` hook directly instead of mapping IDs
3. **Shared Logic:** Created `useTerminalNotificationCounts()` to unify waiting/failed terminal counting across components
4. **Startup Cleanup:** Enhanced worktree initialization to trash orphaned terminals on app start
5. **Comprehensive ID Matching:** Include both `id` and `worktreeId` fields from worktrees for robust orphan detection

## Testing
- Type checking passes
- Lint/format checks pass
- Codex review completed with all recommendations applied