### PR TITLE
Fix: Eliminate race condition in bulk terminal restart

### DIFF
--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -421,9 +421,7 @@ export function GeneralTab({ appVersion, onNavigateToAgents }: GeneralTabProps) 
             />
             <div className="text-left">
               <div className="text-sm font-medium">Developer Tools</div>
-              <div className="text-xs opacity-70">
-                Show problems panel button in the toolbar
-              </div>
+              <div className="text-xs opacity-70">Show problems panel button in the toolbar</div>
             </div>
           </div>
           <div

--- a/src/store/restartExitSuppression.ts
+++ b/src/store/restartExitSuppression.ts
@@ -1,0 +1,26 @@
+const restartingCounts = new Map<string, number>();
+
+export function markTerminalRestarting(id: string): void {
+  restartingCounts.set(id, (restartingCounts.get(id) ?? 0) + 1);
+}
+
+export function unmarkTerminalRestarting(id: string): void {
+  const next = (restartingCounts.get(id) ?? 0) - 1;
+  if (next > 0) {
+    restartingCounts.set(id, next);
+  } else {
+    restartingCounts.delete(id);
+  }
+}
+
+export function isTerminalRestarting(id: string): boolean {
+  return (restartingCounts.get(id) ?? 0) > 0;
+}
+
+export function clearTerminalRestartGuard(id: string): void {
+  restartingCounts.delete(id);
+}
+
+export function clearAllRestartGuards(): void {
+  restartingCounts.clear();
+}


### PR DESCRIPTION
## Summary
Fixes the intermittent issue where one terminal gets moved to trash during "Restart All Terminals" bulk operations. The root cause was a race condition between the async Zustand store state update and the synchronous PTY exit event handler.

Closes #1214

## Changes Made
- Added standalone `restartExitSuppression` module with ref-counted Map for synchronous restart guards
- Replaced Set with Map to safely handle overlapping restart operations (prevents premature guard release)
- Added cleanup on terminal removal to prevent stale restart guards
- Added `isRestarting` guard to `convertTerminalType` to prevent overlap with `restartTerminal`
- Set `isRestarting` flag immediately in `convertTerminalType` (before any async operations)
- Clear all restart guards in cleanup function to prevent leaks

## Technical Details
The fix addresses the race condition by:
1. **Synchronous guard before async state**: Mark terminal as restarting in a module-level Map before any async operations
2. **Ref-counting for safety**: Use Map with counts instead of Set to handle overlapping operations safely
3. **Comprehensive cleanup**: Clear guards on terminal removal, store cleanup, and all exit paths
4. **Prevent operation overlap**: Add guards to both `restartTerminal` and `convertTerminalType`

This ensures the `onExit` handler always sees the restart flag, regardless of async state propagation timing.