### PR TITLE
feat(security): harden MessagePort handoff with origin validation

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, ipcMain, dialog, powerMonitor, MessageChannelMain }
 import path from "path";
 import { fileURLToPath } from "url";
 import os from "os";
+import { randomBytes } from "crypto";
 import fixPath from "fix-path";
 
 fixPath();
@@ -337,6 +338,7 @@ async function createWindow(): Promise<void> {
 
   function createAndDistributePorts(): void {
     const { port1, port2 } = new MessageChannelMain();
+    const handshakeToken = randomBytes(32).toString("hex");
 
     if (ptyClient) {
       ptyClient.connectMessagePort(port2);
@@ -344,7 +346,8 @@ async function createWindow(): Promise<void> {
     }
 
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.postMessage("terminal-port", null, [port1]);
+      mainWindow.webContents.postMessage("terminal-port-token", { token: handshakeToken });
+      mainWindow.webContents.postMessage("terminal-port", { token: handshakeToken }, [port1]);
       // console.log("[MAIN] MessagePort sent to renderer");
     }
   }


### PR DESCRIPTION
## Summary
Implements secure MessagePort transfer between preload and renderer with cryptographic token handshake and origin validation to prevent potential security risks if the renderer ever hosts untrusted content.

Closes #1204

## Changes Made
- Generate cryptographic one-time token in main process for each port distribution
- Add origin allowlist validation in preload (dev http://localhost:5173, prod file://)
- Forward token-only message to renderer before port transfer
- Implement source/origin/token validation in terminalClient
- Handle out-of-order token/port delivery with pending buffers
- Close rejected ports to prevent resource leaks
- Add iframe protection with window.top check
- Clear tokens after successful handshake (one-time use)

## Security Improvements
- **Origin validation**: Only allows MessagePort transfer to trusted origins (localhost:5173 in dev, file:// in prod)
- **Token handshake**: One-time cryptographic token prevents replay/interception attacks
- **Source validation**: Verifies event.source === window to prevent cross-window spoofing
- **Iframe protection**: window.top === window check prevents token/port leaks to embedded frames
- **Resource cleanup**: Rejected ports are closed immediately to prevent memory leaks

## Testing
- All existing tests pass
- Type checking passes
- Linting passes