### PR TITLE
Fix: Remove frame-ancestors from CSP meta tag

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,6 @@ const PROD_CSP = [
   "object-src 'none'",
   "base-uri 'self'",
   "form-action 'none'",
-  "frame-ancestors 'none'",
 ].join("; ");
 
 // Plugin to transform CSP meta tag based on build mode


### PR DESCRIPTION
## Summary
Removes the `frame-ancestors` directive from the production CSP meta tag, eliminating console warnings.

Closes #1221

## Changes Made
- Remove `frame-ancestors 'none'` directive from PROD_CSP in vite.config.ts
- Eliminates console warning about ignored frame-ancestors in meta tag
- The directive only works in HTTP headers, not meta tags in file:// context