### PR TITLE
Fix excessive highlight intensity when only one terminal is present

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -228,9 +228,12 @@ export function DndProvider({ children }: DndProviderProps) {
       // Handle placeholder for cross-container drag (dock -> grid)
       const sourceContainer = activeDataCurrent?.sourceLocation;
       if (sourceContainer === "dock" && detectedContainer === "grid") {
+        const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
         // Find grid terminals to calculate insertion index (match TerminalGrid filter)
         const gridTerminals = terminals.filter(
-          (t) => t.location === "grid" || t.location === undefined
+          (t) =>
+            (t.location === "grid" || t.location === undefined) &&
+            (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
         );
         const overId = over.id as string;
         const overIndex = gridTerminals.findIndex((t) => t.id === overId);

--- a/src/components/Terminal/GridTerminalPane.tsx
+++ b/src/components/Terminal/GridTerminalPane.tsx
@@ -8,12 +8,14 @@ export interface GridTerminalPaneProps {
   terminal: TerminalInstance;
   isFocused: boolean;
   isMaximized?: boolean;
+  gridTerminalCount?: number;
 }
 
 export function GridTerminalPane({
   terminal,
   isFocused,
   isMaximized = false,
+  gridTerminalCount,
 }: GridTerminalPaneProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
   const trashTerminal = useTerminalStore((state) => state.trashTerminal);
@@ -115,6 +117,7 @@ export function GridTerminalPane({
         onTitleChange={handleTitleChange}
         onMinimize={handleMinimize}
         isTrashing={isTrashing}
+        gridTerminalCount={gridTerminalCount}
       />
     </ErrorBoundary>
   );


### PR DESCRIPTION
## Summary
Reduces visual noise in single-terminal grid views by conditionally disabling highlight and ping animations when only one terminal is present, eliminating unnecessary visual feedback that serves no purpose when there's no ambiguity.

Closes #1213

## Changes Made
- Add gridTerminalCount prop to TerminalPane for context-aware styling
- Skip .terminal-selected class and ping animations when only one grid terminal
- Preserve dock terminal pings with location-aware allowPing guard
- Unify gridItemCount calculation across layout and component props
- Fix DndProvider worktree filter to match TerminalGrid's active filter
- Default undefined gridTerminalCount to 2 for grid to preserve existing behavior