### PR TITLE
Enable SharedArrayBuffer in packaged app via custom protocol

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -55,8 +55,7 @@ let cachedToken: string | null = null;
 
 function isAllowedTerminalPortTarget(): boolean {
   const { protocol, origin } = window.location;
-  // file:// protocol always has origin "null" as a string, but check protocol as fallback
-  if (protocol === "file:") return true;
+  if (protocol === "app:" && origin === "app://canopy") return true;
   if (protocol === "http:" || protocol === "https:") return origin === "http://localhost:5173";
   return false;
 }
@@ -67,9 +66,7 @@ ipcRenderer.on("terminal-port-token", (_event, payload: { token: string }) => {
   if (window.top !== window) return;
   if (!isAllowedTerminalPortTarget()) return;
 
-  const targetOrigin =
-    window.location.origin === "null" ? window.location.origin : window.location.origin;
-  window.postMessage({ type: "terminal-port-token", token: payload.token }, targetOrigin);
+  window.postMessage({ type: "terminal-port-token", token: payload.token }, window.location.origin);
 });
 
 ipcRenderer.on("terminal-port", (event, payload: { token: string }) => {

--- a/electron/utils/__tests__/appProtocol.test.ts
+++ b/electron/utils/__tests__/appProtocol.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { resolveAppUrlToDistPath, getMimeType, buildHeaders } from "../appProtocol.js";
+
+describe("appProtocol utilities", () => {
+  describe("getMimeType", () => {
+    it("should return correct MIME type for known extensions", () => {
+      expect(getMimeType("index.html")).toBe("text/html");
+      expect(getMimeType("app.js")).toBe("text/javascript");
+      expect(getMimeType("styles.css")).toBe("text/css");
+      expect(getMimeType("data.json")).toBe("application/json");
+      expect(getMimeType("image.png")).toBe("image/png");
+      expect(getMimeType("photo.jpg")).toBe("image/jpeg");
+      expect(getMimeType("icon.svg")).toBe("image/svg+xml");
+      expect(getMimeType("module.wasm")).toBe("application/wasm");
+    });
+
+    it("should return default MIME type for unknown extensions", () => {
+      expect(getMimeType("file.xyz")).toBe("application/octet-stream");
+      expect(getMimeType("noext")).toBe("application/octet-stream");
+    });
+
+    it("should handle uppercase extensions", () => {
+      expect(getMimeType("FILE.HTML")).toBe("text/html");
+      expect(getMimeType("APP.JS")).toBe("text/javascript");
+    });
+  });
+
+  describe("buildHeaders", () => {
+    it("should return headers with correct COOP/COEP values", () => {
+      const headers = buildHeaders("text/html");
+      expect(headers["Content-Type"]).toBe("text/html");
+      expect(headers["Cross-Origin-Opener-Policy"]).toBe("same-origin");
+      expect(headers["Cross-Origin-Embedder-Policy"]).toBe("credentialless");
+    });
+
+    it("should accept any MIME type", () => {
+      const headers = buildHeaders("application/json");
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+  });
+
+  describe("resolveAppUrlToDistPath", () => {
+    const distRoot = "/fake/dist";
+
+    it("should resolve root path to index.html", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "index.html"));
+    });
+
+    it("should resolve empty path to index.html", () => {
+      const result = resolveAppUrlToDistPath("app://canopy", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "index.html"));
+    });
+
+    it("should resolve file paths correctly", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/assets/app.js", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "assets", "app.js"));
+    });
+
+    it("should handle URL encoding", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/path%20with%20spaces/file.js", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "path with spaces", "file.js"));
+    });
+
+    it("should handle path segments with .. (URL normalizes before reaching resolver)", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/../secret.txt", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "secret.txt"));
+    });
+
+    it("should handle nested path segments with .. (URL normalizes)", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/nested/../../outside.txt", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "outside.txt"));
+    });
+
+    it("should reject non-app:// protocol", () => {
+      const result = resolveAppUrlToDistPath("http://canopy/index.html", distRoot);
+      expect(result.error).toBe("Invalid protocol");
+      expect(result.filePath).toBe("");
+    });
+
+    it("should handle malformed URLs gracefully", () => {
+      const result = resolveAppUrlToDistPath("not-a-url", distRoot);
+      expect(result.error).toBeDefined();
+      expect(result.filePath).toBe("");
+    });
+
+    it("should resolve nested paths correctly", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/assets/images/logo.png", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "assets", "images", "logo.png"));
+    });
+
+    it("should handle paths with leading slash", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/app.js", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "app.js"));
+    });
+
+    it("should handle encoded dot segments (URL normalizes %2e%2e before resolver)", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/%2e%2e/secret.txt", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "secret.txt"));
+    });
+
+    it("should handle encoded absolute paths safely (URL preserves %2F encoding)", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/%2Fetc%2Fpasswd", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "etc", "passwd"));
+    });
+
+    it("should reject paths with null bytes", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/file%00.txt", distRoot);
+      expect(result.error).toBe("Invalid path");
+      expect(result.filePath).toBe("");
+    });
+
+    it("should reject paths with backslashes", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/path\\file.txt", distRoot);
+      expect(result.error).toBe("Invalid path separator");
+      expect(result.filePath).toBe("");
+    });
+
+    it("should ignore query strings and hashes", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/app.js?v=123#anchor", distRoot);
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "app.js"));
+    });
+
+    it("should validate hostname when expectedHostname option is provided", () => {
+      const result = resolveAppUrlToDistPath("app://canopy/index.html", distRoot, {
+        expectedHostname: "canopy",
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.filePath).toBe(path.join(distRoot, "index.html"));
+    });
+
+    it("should reject incorrect hostname when expectedHostname option is provided", () => {
+      const result = resolveAppUrlToDistPath("app://wrong/index.html", distRoot, {
+        expectedHostname: "canopy",
+      });
+      expect(result.error).toBe("Invalid host");
+      expect(result.filePath).toBe("");
+    });
+  });
+});

--- a/electron/utils/appProtocol.ts
+++ b/electron/utils/appProtocol.ts
@@ -1,0 +1,100 @@
+import path from "node:path";
+
+export interface AppProtocolHeaders extends Record<string, string> {
+  "Content-Type": string;
+  "Cross-Origin-Opener-Policy": string;
+  "Cross-Origin-Embedder-Policy": string;
+  "X-Content-Type-Options": string;
+  "Cross-Origin-Resource-Policy": string;
+}
+
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html",
+  ".js": "text/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".eot": "application/vnd.ms-fontobject",
+  ".wasm": "application/wasm",
+};
+
+export function getMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] || "application/octet-stream";
+}
+
+export function buildHeaders(mimeType: string): AppProtocolHeaders {
+  return {
+    "Content-Type": mimeType,
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Embedder-Policy": "credentialless",
+    "X-Content-Type-Options": "nosniff",
+    "Cross-Origin-Resource-Policy": "same-origin",
+  };
+}
+
+export function resolveAppUrlToDistPath(
+  urlString: string,
+  distRoot: string,
+  options: { expectedHostname?: string } = {}
+): { filePath: string; error?: string } {
+  try {
+    const url = new URL(urlString);
+
+    if (url.protocol !== "app:") {
+      return { filePath: "", error: "Invalid protocol" };
+    }
+
+    if (options.expectedHostname && url.hostname !== options.expectedHostname) {
+      return { filePath: "", error: "Invalid host" };
+    }
+
+    let pathname = url.pathname;
+
+    if (pathname === "/" || pathname === "") {
+      pathname = "/index.html";
+    }
+
+    const relativePath = pathname.startsWith("/") ? pathname.slice(1) : pathname;
+
+    const decodedPath = decodeURIComponent(relativePath);
+
+    if (decodedPath.includes("\0")) {
+      return { filePath: "", error: "Invalid path" };
+    }
+    if (decodedPath.includes("\\")) {
+      return { filePath: "", error: "Invalid path separator" };
+    }
+
+    const normalizedPosix = path.posix.normalize("/" + decodedPath).slice(1);
+
+    if (normalizedPosix.split("/").some((seg) => seg === "..")) {
+      return { filePath: "", error: "Path traversal detected" };
+    }
+
+    const absoluteDistRoot = path.resolve(distRoot);
+    const absoluteResolvedPath = path.resolve(absoluteDistRoot, normalizedPosix);
+
+    if (
+      !absoluteResolvedPath.startsWith(absoluteDistRoot + path.sep) &&
+      absoluteResolvedPath !== absoluteDistRoot
+    ) {
+      return { filePath: "", error: "Path outside dist root" };
+    }
+
+    return { filePath: absoluteResolvedPath };
+  } catch (error) {
+    return {
+      filePath: "",
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Implements a custom `app://` protocol to enable SharedArrayBuffer in the packaged Electron app by serving files with the required COOP/COEP headers. The `file://` protocol cannot set HTTP headers, which blocks cross-origin isolation needed for SharedArrayBuffer.

Closes #1220

## Changes Made
- Register privileged `app://` scheme with COOP/COEP headers for cross-origin isolation
- Implement protocol handler serving dist/ files with security headers
- Add hostname validation (`app://canopy` only) and method filtering (GET/HEAD)
- Update preload origin checks to allow `app://canopy` in production
- Remove `file://` protocol support (production now exclusively uses `app://`)
- Add comprehensive URL resolver with path traversal protection
- Include defense-in-depth headers (X-Content-Type-Options, CORP)
- Add 22 unit tests covering edge cases, encoding attacks, and security boundaries

## Testing
- All unit tests pass (22/22)
- Type checking, linting, and formatting verified
- Manual verification needed: build packaged app and confirm `window.crossOriginIsolated === true`