### PR TITLE
Fix PR detection events missing required timestamps

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -72,7 +72,7 @@ class PullRequestService {
       this.resolvedWorktrees.delete(state.worktreeId);
       this.detectedPRs.delete(state.worktreeId);
 
-      events.emit("sys:pr:cleared", { worktreeId: state.worktreeId });
+      events.emit("sys:pr:cleared", { worktreeId: state.worktreeId, timestamp: Date.now() });
     }
 
     const shouldTrack = isCandidateBranch(newBranchName);
@@ -109,7 +109,7 @@ class PullRequestService {
       this.resolvedWorktrees.delete(worktreeId);
       this.detectedPRs.delete(worktreeId);
 
-      events.emit("sys:pr:cleared", { worktreeId });
+      events.emit("sys:pr:cleared", { worktreeId, timestamp: Date.now() });
 
       logDebug("Worktree removed - cleared PR state", { worktreeId });
     }
@@ -295,6 +295,7 @@ class PullRequestService {
             prState: checkResult.pr.state,
             issueNumber:
               checkResult.issueNumber ?? this.candidates.get(worktreeId)?.issueNumber ?? undefined,
+            timestamp: Date.now(),
           });
         }
       }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -292,6 +292,7 @@ export class WorkspaceClient extends EventEmitter {
           prNumber: event.prNumber,
           prUrl: event.prUrl,
           prState: event.prState,
+          timestamp: Date.now(),
         };
         events.emit("sys:pr:detected", prPayload);
         this.sendToRenderer(CHANNELS.PR_DETECTED, prPayload);
@@ -299,7 +300,7 @@ export class WorkspaceClient extends EventEmitter {
       }
 
       case "pr-cleared": {
-        const clearPayload = { worktreeId: event.worktreeId };
+        const clearPayload = { worktreeId: event.worktreeId, timestamp: Date.now() };
         events.emit("sys:pr:cleared", clearPayload);
         this.sendToRenderer(CHANNELS.PR_CLEARED, clearPayload);
         break;

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -148,7 +148,7 @@ describe("PullRequestService", () => {
     );
 
     expect(cleared).toHaveLength(1);
-    expect(cleared[0]).toEqual({ worktreeId: "wt-1" });
+    expect(cleared[0]).toMatchObject({ worktreeId: "wt-1", timestamp: expect.any(Number) });
 
     unsubscribeCleared();
     pullRequestService.destroy();

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -433,9 +433,11 @@ export type CanopyEventMap = {
     prUrl: string;
     prState: "open" | "merged" | "closed";
     issueNumber?: number;
+    timestamp: number;
   };
   "sys:pr:cleared": {
     worktreeId: string;
+    timestamp: number;
   };
 
   /**

--- a/src/components/Terminal/GeminiAlternateBufferBanner.tsx
+++ b/src/components/Terminal/GeminiAlternateBufferBanner.tsx
@@ -50,10 +50,7 @@ function GeminiAlternateBufferBannerComponent({
       data-terminal-id={terminalId}
     >
       <div className="flex items-center gap-2 min-w-0">
-        <Terminal
-          className="w-4 h-4 shrink-0 text-[var(--color-status-info)]"
-          aria-hidden="true"
-        />
+        <Terminal className="w-4 h-4 shrink-0 text-[var(--color-status-info)]" aria-hidden="true" />
         <span className="text-sm text-canopy-text/80">
           Canopy supports synchronized rendering. For flicker-free Gemini output, run{" "}
           <code className="px-1 py-0.5 bg-canopy-text/10 rounded text-canopy-text/90 font-mono text-xs">


### PR DESCRIPTION
## Summary
Fixes EventBuffer validation warnings by adding required timestamp fields to `sys:pr:detected` and `sys:pr:cleared` events.

Closes #1230

## Changes Made
- Add timestamp field to sys:pr:detected and sys:pr:cleared event type definitions
- Include timestamp: Date.now() in all event emissions (PullRequestService, WorkspaceClient)
- Update test expectations to verify timestamp presence
- Fix prettier formatting in GeminiAlternateBufferBanner