### PR TITLE
Remove black notch bar in fullscreen and hide redundant toolbar project selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "autoprefixer": "^10.4.20",
     "concurrently": "^9.1.0",
     "cross-env": "^7.0.3",
-    "electron": "^33.2.0",
+    "electron": "^33.4.11",
     "electron-builder": "^25.1.8",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
@@ -129,6 +129,9 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",
+      "extendInfo": {
+        "NSPrefersDisplaySafeAreaCompatibilityMode": false
+      },
       "target": [
         {
           "target": "dmg",

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -240,128 +240,130 @@ export function Toolbar({
         </div>
       </div>
 
-      {/* CENTER GROUP - Absolutely positioned dead center */}
-      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center z-10 pointer-events-none">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className={cn(
-                "flex items-center justify-center gap-2 px-3 h-9 rounded-[var(--radius-md)] select-none border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] app-no-drag pointer-events-auto",
-                "opacity-80 hover:opacity-100 transition-opacity cursor-pointer"
-              )}
-              style={{
-                background: currentProject
-                  ? getProjectGradient(currentProject.color)
-                  : "linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02))",
-              }}
-            >
-              {currentProject ? (
-                <>
-                  <span className="text-base leading-none" aria-label="Project emoji">
-                    {currentProject.emoji}
-                  </span>
-                  <span className="text-xs font-medium text-white/90 tracking-wide">
-                    {currentProject.name}
-                  </span>
-                  {branchName && (
-                    <span
-                      className="font-mono text-[10px] tabular-nums text-white/70 px-1.5 py-0.5 rounded-full bg-white/10"
-                      aria-label={`Current branch ${branchName}`}
-                    >
-                      {branchName}
+      {/* CENTER GROUP - Absolutely positioned dead center, hidden in fullscreen since info is in sidebar */}
+      {!isFullscreen && (
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center z-10 pointer-events-none">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className={cn(
+                  "flex items-center justify-center gap-2 px-3 h-9 rounded-[var(--radius-md)] select-none border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] app-no-drag pointer-events-auto",
+                  "opacity-80 hover:opacity-100 transition-opacity cursor-pointer"
+                )}
+                style={{
+                  background: currentProject
+                    ? getProjectGradient(currentProject.color)
+                    : "linear-gradient(135deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02))",
+                }}
+              >
+                {currentProject ? (
+                  <>
+                    <span className="text-base leading-none" aria-label="Project emoji">
+                      {currentProject.emoji}
                     </span>
-                  )}
-                  <ChevronsUpDown className="h-3 w-3 text-white/50 ml-0.5" />
-                </>
-              ) : (
-                <>
-                  <span className="text-xs font-medium text-canopy-text tracking-wide">
-                    Canopy Command Center
-                  </span>
-                  <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-canopy-accent/20 text-canopy-accent">
-                    Beta
-                  </span>
-                  <ChevronsUpDown className="h-3 w-3 text-canopy-text/50 ml-0.5" />
-                </>
-              )}
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-[260px] max-h-[60vh] overflow-y-auto p-1"
-            align="center"
-          >
-            {currentProject && (
-              <>
-                <DropdownMenuLabel className="text-[11px] font-semibold text-muted-foreground/50 uppercase tracking-widest px-2 py-1.5">
-                  Active
-                </DropdownMenuLabel>
-                <DropdownMenuItem
-                  className="gap-2 p-2 cursor-default mb-0.5 rounded-[var(--radius-md)] bg-white/[0.03]"
-                  disabled
-                >
-                  <div
-                    className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] text-sm shrink-0"
-                    style={{ background: getProjectGradient(currentProject.color) }}
-                  >
-                    {currentProject.emoji}
-                  </div>
-                  <div className="flex flex-col min-w-0 flex-1">
-                    <span className="truncate text-sm font-medium text-foreground">
+                    <span className="text-xs font-medium text-white/90 tracking-wide">
                       {currentProject.name}
                     </span>
-                    <span className="truncate text-[11px] font-mono text-muted-foreground/70">
-                      {currentProject.path.split(/[/\\]/).pop()}
-                    </span>
-                  </div>
-                  <Check className="h-4 w-4 text-canopy-accent shrink-0" />
-                </DropdownMenuItem>
-              </>
-            )}
-
-            {projects.filter((p) => p.id !== currentProject?.id).length > 0 && (
-              <>
-                <DropdownMenuSeparator className="my-1 bg-border/40" />
-                <DropdownMenuLabel className="text-[11px] font-semibold text-muted-foreground/50 uppercase tracking-widest px-2 py-1.5">
-                  Recent
-                </DropdownMenuLabel>
-                {projects
-                  .filter((p) => p.id !== currentProject?.id)
-                  .slice(0, 5)
-                  .map((project) => (
-                    <DropdownMenuItem
-                      key={project.id}
-                      onClick={() => handleProjectSwitch(project.id)}
-                      className="gap-2 p-2 cursor-pointer mb-0.5 rounded-[var(--radius-md)]"
-                    >
-                      <div
-                        className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] text-sm shrink-0"
-                        style={{ background: getProjectGradient(project.color) }}
+                    {branchName && (
+                      <span
+                        className="font-mono text-[10px] tabular-nums text-white/70 px-1.5 py-0.5 rounded-full bg-white/10"
+                        aria-label={`Current branch ${branchName}`}
                       >
-                        {project.emoji}
-                      </div>
-                      <div className="flex flex-col min-w-0 flex-1">
-                        <span className="truncate text-sm font-medium text-foreground/80">
-                          {project.name}
-                        </span>
-                        <span className="truncate text-[11px] font-mono text-muted-foreground/70">
-                          {project.path.split(/[/\\]/).pop()}
-                        </span>
-                      </div>
-                    </DropdownMenuItem>
-                  ))}
-              </>
-            )}
+                        {branchName}
+                      </span>
+                    )}
+                    <ChevronsUpDown className="h-3 w-3 text-white/50 ml-0.5" />
+                  </>
+                ) : (
+                  <>
+                    <span className="text-xs font-medium text-canopy-text tracking-wide">
+                      Canopy Command Center
+                    </span>
+                    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-canopy-accent/20 text-canopy-accent">
+                      Beta
+                    </span>
+                    <ChevronsUpDown className="h-3 w-3 text-canopy-text/50 ml-0.5" />
+                  </>
+                )}
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              className="w-[260px] max-h-[60vh] overflow-y-auto p-1"
+              align="center"
+            >
+              {currentProject && (
+                <>
+                  <DropdownMenuLabel className="text-[11px] font-semibold text-muted-foreground/50 uppercase tracking-widest px-2 py-1.5">
+                    Active
+                  </DropdownMenuLabel>
+                  <DropdownMenuItem
+                    className="gap-2 p-2 cursor-default mb-0.5 rounded-[var(--radius-md)] bg-white/[0.03]"
+                    disabled
+                  >
+                    <div
+                      className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] text-sm shrink-0"
+                      style={{ background: getProjectGradient(currentProject.color) }}
+                    >
+                      {currentProject.emoji}
+                    </div>
+                    <div className="flex flex-col min-w-0 flex-1">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {currentProject.name}
+                      </span>
+                      <span className="truncate text-[11px] font-mono text-muted-foreground/70">
+                        {currentProject.path.split(/[/\\]/).pop()}
+                      </span>
+                    </div>
+                    <Check className="h-4 w-4 text-canopy-accent shrink-0" />
+                  </DropdownMenuItem>
+                </>
+              )}
 
-            <DropdownMenuSeparator className="my-1 bg-border/40" />
-            <DropdownMenuItem onClick={addProject} className="gap-2 p-2 cursor-pointer">
-              <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
-                <Plus className="h-3.5 w-3.5" />
-              </div>
-              <span className="font-medium text-sm text-muted-foreground">Add Project...</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+              {projects.filter((p) => p.id !== currentProject?.id).length > 0 && (
+                <>
+                  <DropdownMenuSeparator className="my-1 bg-border/40" />
+                  <DropdownMenuLabel className="text-[11px] font-semibold text-muted-foreground/50 uppercase tracking-widest px-2 py-1.5">
+                    Recent
+                  </DropdownMenuLabel>
+                  {projects
+                    .filter((p) => p.id !== currentProject?.id)
+                    .slice(0, 5)
+                    .map((project) => (
+                      <DropdownMenuItem
+                        key={project.id}
+                        onClick={() => handleProjectSwitch(project.id)}
+                        className="gap-2 p-2 cursor-pointer mb-0.5 rounded-[var(--radius-md)]"
+                      >
+                        <div
+                          className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] text-sm shrink-0"
+                          style={{ background: getProjectGradient(project.color) }}
+                        >
+                          {project.emoji}
+                        </div>
+                        <div className="flex flex-col min-w-0 flex-1">
+                          <span className="truncate text-sm font-medium text-foreground/80">
+                            {project.name}
+                          </span>
+                          <span className="truncate text-[11px] font-mono text-muted-foreground/70">
+                            {project.path.split(/[/\\]/).pop()}
+                          </span>
+                        </div>
+                      </DropdownMenuItem>
+                    ))}
+                </>
+              )}
+
+              <DropdownMenuSeparator className="my-1 bg-border/40" />
+              <DropdownMenuItem onClick={addProject} className="gap-2 p-2 cursor-pointer">
+                <div className="flex h-7 w-7 items-center justify-center rounded-[var(--radius-md)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
+                  <Plus className="h-3.5 w-3.5" />
+                </div>
+                <span className="font-medium text-sm text-muted-foreground">Add Project...</span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
 
       {/* RIGHT GROUP */}
       <div className="flex items-center gap-1.5 app-no-drag z-20">

--- a/src/components/Terminal/GeminiAlternateBufferBanner.tsx
+++ b/src/components/Terminal/GeminiAlternateBufferBanner.tsx
@@ -59,8 +59,8 @@ function GeminiAlternateBufferBannerComponent({
           and enable{" "}
           <code className="px-1 py-0.5 bg-canopy-text/10 rounded text-canopy-text/90 font-mono text-xs">
             Use Alternate Screen Buffer
-          </code>
-          {" "}(currently loses scrolling)
+          </code>{" "}
+          (currently loses scrolling)
         </span>
       </div>
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -470,7 +470,10 @@ export function WorktreeCard({
 
   // Priority-based computed subtitle for collapsed view
   // Note: Terminal states (waiting/failed) are shown in the footer, not here
-  const computedSubtitle = useMemo((): { text: string; tone: "error" | "warning" | "info" | "muted" } => {
+  const computedSubtitle = useMemo((): {
+    text: string;
+    tone: "error" | "warning" | "info" | "muted";
+  } => {
     // 1. Worktree errors take highest priority
     if (worktreeErrors.length > 0) {
       return {
@@ -1171,7 +1174,8 @@ export function WorktreeCard({
                       <span
                         className={cn(
                           computedSubtitle.tone === "error" && "text-[var(--color-status-error)]",
-                          computedSubtitle.tone === "warning" && "text-[var(--color-status-warning)]",
+                          computedSubtitle.tone === "warning" &&
+                            "text-[var(--color-status-warning)]",
                           computedSubtitle.tone === "info" && "text-[var(--color-status-info)]",
                           computedSubtitle.tone === "muted" && "text-canopy-text/50"
                         )}


### PR DESCRIPTION
## Summary

Fixes fullscreen display issues on MacBook Pro with notch by upgrading Electron and configuring macOS safe area compatibility. Also removes redundant project selector from toolbar in fullscreen mode since the same information is available in the sidebar.

Closes #1233

## Changes Made

- Upgraded Electron from 33.2.0 to 33.4.11 for built-in notch support
- Added `NSPrefersDisplaySafeAreaCompatibilityMode: false` to macOS build configuration to prevent black bar in fullscreen
- Hide center toolbar project selector when in fullscreen mode (information remains accessible via sidebar ProjectSwitcher)
- Applied code formatting fixes to affected components

## Testing Notes

- The `NSPrefersDisplaySafeAreaCompatibilityMode` setting only affects packaged builds, not development mode
- Fullscreen behavior should be tested on MacBook Pro with notch to verify black bar removal
- Project switching remains accessible via sidebar in fullscreen mode