### PR TITLE
Convert terminal list from dropdown to expandable accordion section

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -194,7 +194,8 @@ export function AppLayout({
   useEffect(() => {
     const handleOpenProjectSettings = () => setIsProjectSettingsOpen(true);
     window.addEventListener("canopy:open-project-settings", handleOpenProjectSettings);
-    return () => window.removeEventListener("canopy:open-project-settings", handleOpenProjectSettings);
+    return () =>
+      window.removeEventListener("canopy:open-project-settings", handleOpenProjectSettings);
   }, []);
 
   useEffect(() => {

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -145,11 +145,8 @@ describe("getAutoGridCols", () => {
 });
 
 describe("getMaxGridCapacity", () => {
-  // Account for gap (4px) and padding (8px) in calculations
-  const gap = 4;
-  const padding = 8;
-  const cellWidth = MIN_TERMINAL_WIDTH_PX + gap;
-  const cellHeight = MIN_TERMINAL_HEIGHT_PX + gap;
+  // Layout constants: gap = 4px, padding = 8px
+  // cellWidth = MIN_TERMINAL_WIDTH_PX + gap, cellHeight = MIN_TERMINAL_HEIGHT_PX + gap
 
   describe("null dimensions", () => {
     it("returns absolute max when dimensions are null", () => {


### PR DESCRIPTION
## Summary
Converts the WorktreeCard terminal list from a DropdownMenu to an expandable accordion section, following the same pattern as the Details accordion. This provides better visibility and state persistence for terminal sessions.

Closes #1235

## Changes Made
- Replace DropdownMenu with accordion pattern for terminal sessions list
- Add expandedTerminals state to worktreeStore with toggle actions
- Implement auto-collapse when switching worktrees (both setActiveWorktree and selectWorktree)
- Fix policy generation race condition by passing generation to applyWorktreeTerminalPolicy
- Add proper ARIA accessibility (aria-controls, role="region", aria-labelledby) for both Details and Terminals accordions
- Remove unused test variables in terminalLayout.test.ts

## Implementation Details
- **State Management**: Added `expandedTerminals: Set<string>` with `toggleTerminalsExpanded` and `setTerminalsExpanded` actions
- **Auto-collapse**: Terminals accordion auto-collapses when switching worktrees via both `setActiveWorktree` and `selectWorktree`
- **Race Condition Fix**: Pass generation parameter to `applyWorktreeTerminalPolicy` to prevent double-increment that was breaking focus restore
- **Accessibility**: Both Details and Terminals accordions now have proper ARIA structure with dedicated panel IDs and labeling