### PR TITLE
Fix slash command autocomplete text deletion and menu persistence

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -194,7 +194,8 @@ export function AppLayout({
   useEffect(() => {
     const handleOpenProjectSettings = () => setIsProjectSettingsOpen(true);
     window.addEventListener("canopy:open-project-settings", handleOpenProjectSettings);
-    return () => window.removeEventListener("canopy:open-project-settings", handleOpenProjectSettings);
+    return () =>
+      window.removeEventListener("canopy:open-project-settings", handleOpenProjectSettings);
   }, []);
 
   useEffect(() => {

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -553,6 +553,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             setAtContext(null);
             setSlashContext(null);
             setSelectedIndex(0);
+            lastQueryRef.current = "";
             requestAnimationFrame(() => resizeTextarea(textareaRef.current));
             return;
           }
@@ -561,6 +562,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           setAtContext(null);
           setSlashContext(null);
           setSelectedIndex(0);
+          lastQueryRef.current = "";
 
           requestAnimationFrame(() => {
             textarea.focus();
@@ -572,12 +574,14 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
 
         if (activeMode === "command" && slashCtx) {
           const before = currentValue.slice(0, slashCtx.start);
-          const after = currentValue.slice(slashCtx.tokenEnd);
+          const replaceEnd = Math.min(caret, slashCtx.tokenEnd);
+          const after = currentValue.slice(replaceEnd);
 
-          const shouldAppendSpace = action === "insert" && !after.startsWith(" ");
+          const hasLeadingSpace = after.startsWith(" ");
+          const shouldAppendSpace = action === "insert" && !hasLeadingSpace;
           const token = shouldAppendSpace ? `${item.value} ` : item.value;
           const nextValue = `${before}${token}${after}`;
-          const nextCaret = before.length + token.length;
+          const nextCaret = before.length + token.length + (action === "insert" && hasLeadingSpace ? 1 : 0);
 
           if (action === "execute") {
             const payload = buildTerminalSendPayload(nextValue);
@@ -588,6 +592,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             setAtContext(null);
             setSlashContext(null);
             setSelectedIndex(0);
+            lastQueryRef.current = "";
             requestAnimationFrame(() => resizeTextarea(textareaRef.current));
             return;
           }
@@ -596,6 +601,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           setAtContext(null);
           setSlashContext(null);
           setSelectedIndex(0);
+          lastQueryRef.current = "";
 
           requestAnimationFrame(() => {
             textarea.focus();


### PR DESCRIPTION
## Summary
Fixes the slash command autocomplete behavior when inserting commands before existing text. Previously, typing a slash command at the start of existing input would delete the first word and keep the autocomplete menu open after pressing Tab.

Closes #1238

## Changes Made
- Replace only up to cursor position to preserve existing content when inserting slash commands
- Advance cursor past leading space to prevent autocomplete from immediately reopening
- Reset query ref when closing autocomplete menu for consistent cleanup
- Add cleanup to both file and command autocomplete paths for consistency

## Testing
Manual testing verified:
- Typing text, moving cursor to start, inserting slash command via Tab preserves all text
- Autocomplete menu closes immediately after Tab insertion
- Cursor positioning is correct (past any leading space)
- No regressions in @file autocomplete behavior