### PR TITLE
Fix: Enforce 2x1 layout for exactly 2 terminal panes

### DIFF
--- a/src/components/Terminal/TerminalGrid.tsx
+++ b/src/components/Terminal/TerminalGrid.tsx
@@ -27,7 +27,7 @@ import { Kbd } from "@/components/ui/Kbd";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { systemClient } from "@/clients";
-import { getAutoGridCols, MIN_TERMINAL_HEIGHT_PX } from "@/lib/terminalLayout";
+import { computeGridColumns, MIN_TERMINAL_HEIGHT_PX } from "@/lib/terminalLayout";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useNativeContextMenu } from "@/hooks";
 import type { CliAvailability } from "@shared/types";
@@ -335,21 +335,8 @@ export function TerminalGrid({
   const gridItemCount = gridTerminals.length + (showPlaceholder ? 1 : 0);
 
   const gridCols = useMemo(() => {
-    if (gridItemCount === 0) return 1;
-
     const { strategy, value } = layoutConfig;
-
-    if (strategy === "fixed-columns") {
-      return Math.max(1, Math.min(value, 10));
-    }
-
-    if (strategy === "fixed-rows") {
-      const rows = Math.max(1, Math.min(value, 10));
-      return Math.ceil(gridItemCount / rows);
-    }
-
-    // Automatic rectangular layout via deterministic mapping
-    return getAutoGridCols(gridItemCount, gridWidth);
+    return computeGridColumns(gridItemCount, gridWidth, strategy, value);
   }, [gridItemCount, layoutConfig, gridWidth]);
 
   const handleLaunchAgent = useCallback(

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useRef, useEffect, useState } from "react";
 import { useTerminalStore, useLayoutConfigStore, useWorktreeSelectionStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
-import { getAutoGridCols } from "@/lib/terminalLayout";
+import { computeGridColumns } from "@/lib/terminalLayout";
 
 export type NavigationDirection = "up" | "down" | "left" | "right";
 
@@ -82,21 +82,8 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
 
   // Compute gridCols using the same logic as TerminalGrid
   const gridCols = useMemo(() => {
-    const count = gridTerminals.length;
-    if (count === 0) return 1;
-
     const { strategy, value } = layoutConfig;
-
-    if (strategy === "fixed-columns") {
-      return Math.max(1, Math.min(value, 10));
-    }
-
-    if (strategy === "fixed-rows") {
-      const rows = Math.max(1, Math.min(value, 10));
-      return Math.ceil(count / rows);
-    }
-
-    return getAutoGridCols(count, gridWidth);
+    return computeGridColumns(gridTerminals.length, gridWidth, strategy, value);
   }, [gridTerminals.length, layoutConfig, gridWidth]);
 
   // Compute grid layout from indices (no DOM measurement)

--- a/src/lib/__tests__/terminalLayout.test.ts
+++ b/src/lib/__tests__/terminalLayout.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getAutoGridCols,
   getMaxGridCapacity,
+  computeGridColumns,
   MIN_TERMINAL_WIDTH_PX,
   MIN_TERMINAL_HEIGHT_PX,
   ABSOLUTE_MAX_GRID_TERMINALS,
@@ -60,8 +61,10 @@ describe("getAutoGridCols", () => {
   });
 
   describe("width constraints", () => {
-    it("should return 1 column when width only fits 1", () => {
+    it("should return 1 column when width only fits 1 (except 2 panes which use computeGridColumns)", () => {
       const narrowWidth = MIN_TERMINAL_WIDTH_PX * 1.5;
+      // Note: 2 panes should use computeGridColumns which enforces 2x1 layout
+      // getAutoGridCols itself doesn't have the 2-pane invariant
       expect(getAutoGridCols(2, narrowWidth)).toBe(1);
       expect(getAutoGridCols(6, narrowWidth)).toBe(1);
       expect(getAutoGridCols(12, narrowWidth)).toBe(1);
@@ -189,6 +192,114 @@ describe("getMaxGridCapacity", () => {
     it("returns at least 1 for any valid dimensions", () => {
       expect(getMaxGridCapacity(400, 250)).toBeGreaterThanOrEqual(1);
       expect(getMaxGridCapacity(MIN_TERMINAL_WIDTH_PX, MIN_TERMINAL_HEIGHT_PX)).toBe(1);
+    });
+  });
+});
+
+describe("computeGridColumns", () => {
+  describe("2-pane invariant", () => {
+    const narrowWidth = MIN_TERMINAL_WIDTH_PX * 1.5;
+    const mediumWidth = MIN_TERMINAL_WIDTH_PX * 2.5;
+    const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+
+    it("should always return 2 columns for 2 panes in automatic mode", () => {
+      expect(computeGridColumns(2, narrowWidth, "automatic")).toBe(2);
+      expect(computeGridColumns(2, mediumWidth, "automatic")).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "automatic")).toBe(2);
+      expect(computeGridColumns(2, null, "automatic")).toBe(2);
+    });
+
+    it("should always return 2 columns for 2 panes in fixed-rows mode", () => {
+      expect(computeGridColumns(2, wideWidth, "fixed-rows", 1)).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-rows", 2)).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-rows", 3)).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-rows", 10)).toBe(2);
+    });
+
+    it("should always return 2 columns for 2 panes in fixed-columns mode", () => {
+      // Even when user explicitly sets columns=1, 2 panes should be 2x1
+      expect(computeGridColumns(2, wideWidth, "fixed-columns", 1)).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-columns", 2)).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-columns", 4)).toBe(2);
+    });
+
+    it("should return 2 columns for 2 panes regardless of narrow width", () => {
+      // This is the key fix: even at very narrow widths, 2 panes should be 2x1
+      expect(computeGridColumns(2, 300, "automatic")).toBe(2);
+      expect(computeGridColumns(2, 500, "fixed-rows", 3)).toBe(2);
+    });
+  });
+
+  describe("non-2-pane cases follow normal logic", () => {
+    const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+    const narrowWidth = MIN_TERMINAL_WIDTH_PX * 1.5;
+
+    it("should return 1 column for 0 or 1 pane in automatic/fixed-rows mode", () => {
+      expect(computeGridColumns(0, wideWidth, "automatic")).toBe(1);
+      expect(computeGridColumns(1, wideWidth, "automatic")).toBe(1);
+      expect(computeGridColumns(1, wideWidth, "fixed-rows", 3)).toBe(1);
+    });
+
+    it("should respect fixed-columns setting even for 1 pane", () => {
+      // fixed-columns respects the user's explicit column choice
+      expect(computeGridColumns(1, wideWidth, "fixed-columns", 2)).toBe(2);
+      expect(computeGridColumns(1, wideWidth, "fixed-columns", 1)).toBe(1);
+    });
+
+    it("should respect width constraints for 3+ panes", () => {
+      expect(computeGridColumns(6, narrowWidth, "automatic")).toBe(1);
+      expect(computeGridColumns(6, wideWidth, "automatic")).toBe(3);
+    });
+
+    it("should use fixed-columns value for 3+ panes", () => {
+      expect(computeGridColumns(4, wideWidth, "fixed-columns", 2)).toBe(2);
+      expect(computeGridColumns(4, wideWidth, "fixed-columns", 4)).toBe(4);
+    });
+
+    it("should calculate columns from fixed-rows for 3+ panes", () => {
+      expect(computeGridColumns(6, wideWidth, "fixed-rows", 2)).toBe(3);
+      expect(computeGridColumns(6, wideWidth, "fixed-rows", 3)).toBe(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle null width gracefully", () => {
+      expect(computeGridColumns(4, null, "automatic")).toBe(2);
+      expect(computeGridColumns(2, null, "automatic")).toBe(2);
+    });
+
+    it("should clamp fixed-columns value to valid range", () => {
+      const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+      expect(computeGridColumns(4, wideWidth, "fixed-columns", 0)).toBe(1);
+      expect(computeGridColumns(4, wideWidth, "fixed-columns", 15)).toBe(10);
+    });
+
+    it("should clamp fixed-rows value to valid range", () => {
+      const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+      expect(computeGridColumns(4, wideWidth, "fixed-rows", 0)).toBe(4);
+      expect(computeGridColumns(4, wideWidth, "fixed-rows", 15)).toBe(1);
+    });
+
+    it("should handle 2 panes with missing value parameter", () => {
+      const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+      // 2-pane invariant should work even without explicit value
+      expect(computeGridColumns(2, wideWidth, "fixed-rows")).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-columns")).toBe(2);
+    });
+
+    it("should handle 2 panes with invalid value parameters", () => {
+      const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+      // 2-pane invariant applies before value clamping
+      expect(computeGridColumns(2, wideWidth, "fixed-rows", 0)).toBe(2);
+      expect(computeGridColumns(2, wideWidth, "fixed-columns", 0)).toBe(2);
+    });
+
+    it("should handle non-even division for fixed-rows", () => {
+      const wideWidth = MIN_TERMINAL_WIDTH_PX * 5;
+      // 5 panes / 2 rows = ceil(2.5) = 3 columns
+      expect(computeGridColumns(5, wideWidth, "fixed-rows", 2)).toBe(3);
+      // 7 panes / 3 rows = ceil(2.33) = 3 columns
+      expect(computeGridColumns(7, wideWidth, "fixed-rows", 3)).toBe(3);
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes the terminal grid layout to always render exactly 2 panes as 2x1 (side-by-side) instead of 1x2 (stacked vertically), regardless of container width, layout strategy, or sidebar/sidecar state.

Closes #1243

## Changes Made
- Added `computeGridColumns` helper function with 2-pane invariant that overrides all layout strategies
- Refactored `TerminalGrid.tsx` to use shared helper for consistent column calculation
- Refactored `useGridNavigation.ts` to use same helper, ensuring keyboard navigation matches visual layout
- Added comprehensive test coverage for 2-pane invariant across automatic, fixed-rows, and fixed-columns strategies
- Added edge case tests for missing/invalid parameters and non-even division scenarios

## Technical Details
The new `computeGridColumns` function serves as a single source of truth for grid column calculation, eliminating logic duplication between UI rendering and keyboard navigation. The 2-pane special case is checked first, before any strategy-specific logic, ensuring the invariant applies universally.

## Testing
- All 37 tests pass in `terminalLayout.test.ts`
- Full test suite passes (752 tests)
- Verified 2x1 layout across all layout strategies (automatic, fixed-rows, fixed-columns)
- Tested edge cases including narrow widths, missing parameters, and extreme values