### PR TITLE
Fix: Replace bright focus outlines with subtle white ring

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,14 +5,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-md)] text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform] focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-md)] text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
           "bg-primary text-primary-foreground shadow hover:bg-primary/90 active:scale-[0.98]",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 active:scale-[0.98]",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 active:scale-[0.98] focus-visible:ring-destructive",
         outline:
           "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground active:scale-[0.98]",
         secondary:
@@ -23,7 +23,7 @@ const buttonVariants = cva(
           "bg-canopy-bg text-canopy-text/60 hover:bg-white/[0.06] hover:text-canopy-text active:scale-[0.98]",
         pill: "rounded-full bg-canopy-bg/50 border border-canopy-border text-canopy-text/60 hover:bg-white/[0.06] hover:text-canopy-text/80 active:scale-[0.98]",
         "ghost-danger":
-          "text-[var(--color-status-error)] hover:bg-[var(--color-status-error)]/10 active:scale-[0.98]",
+          "text-[var(--color-status-error)] hover:bg-[var(--color-status-error)]/10 active:scale-[0.98] focus-visible:ring-[var(--color-status-error)]",
         "ghost-success":
           "text-[var(--color-status-success)] hover:bg-[var(--color-status-success)]/10 active:scale-[0.98]",
         "ghost-info":

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,9 @@
   /* Terminal surface background - lighter for contrast with grid */
   --color-surface: #1c1c20;
   --color-surface-highlight: #2a2a2f;
+
+  /* Subtle focus indicator - low opacity white for keyboard navigation */
+  --color-canopy-focus: rgba(255, 255, 255, 0.18);
 }
 
 :root {
@@ -218,8 +221,8 @@
   /* Input fields */
   --input: var(--color-canopy-border);
 
-  /* Focus rings - using brand accent */
-  --ring: var(--color-canopy-accent);
+  /* Focus rings - subtle white for keyboard navigation (not accent) */
+  --ring: var(--color-canopy-focus);
 
   /* Chart colors - unchanged (no Canopy equivalent) */
   --chart-1: oklch(0.488 0.243 264.376);
@@ -236,7 +239,7 @@
   --sidebar-accent: var(--color-canopy-border);
   --sidebar-accent-foreground: var(--color-canopy-text);
   --sidebar-border: var(--color-canopy-border);
-  --sidebar-ring: var(--color-canopy-accent);
+  --sidebar-ring: var(--color-canopy-focus);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Replaces the bright emerald focus outline with a subtle white ring for improved visual hierarchy. When clicking toolbar toggles (sidebar/sidecar) and pressing Escape, users previously saw a distracting bright green "stuck highlight". This fix implements a low-opacity white ring that maintains keyboard navigation visibility without the visual noise.

Closes #1254

## Changes Made
- Add `--color-canopy-focus` token for subtle keyboard navigation indicator (rgba white at 0.18 opacity)
- Update `--ring` and `--sidebar-ring` CSS tokens to use new focus color instead of accent
- Switch Button component from outline-based to ring-based focus styling with offset-2
- Add ring-offset-2 for proper visual separation from button borders
- Preserve semantic red focus rings for destructive and ghost-danger button variants

## Implementation Details
The focus system now uses a two-tier approach:
- **Default focus**: Subtle white ring (rgba 0.18) for general UI elements
- **Semantic focus**: Red ring preserved for destructive actions to maintain visual meaning

The ring-offset-2 ensures the focus indicator doesn't blend with button borders, especially for icon buttons in the toolbar.