### PR TITLE
Allow copying worktree path when work is finished

### DIFF
--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -106,45 +106,7 @@ export function WorktreeDetails({
     (showTime && lastActivityTimestamp);
 
   if (!hasContent) {
-    return (
-      <div>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onPathClick();
-            }}
-            className={cn(
-              "text-xs text-canopy-text/40 hover:text-canopy-text/60 text-left font-mono truncate flex-1 min-w-0 flex items-center gap-1.5 rounded",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
-              isFocused && "text-canopy-text/60"
-            )}
-            title={`Open folder: ${worktree.path}`}
-          >
-            <ExternalLink className="w-3 h-3 shrink-0 opacity-60" />
-            <span className="truncate">{displayPath}</span>
-          </button>
-
-          <button
-            type="button"
-            onClick={handleCopyPath}
-            className="shrink-0 p-1 text-canopy-text/40 hover:text-canopy-text/60 hover:bg-white/5 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-            title={pathCopied ? "Copied!" : "Copy full path"}
-            aria-label={pathCopied ? "Path copied to clipboard" : "Copy path to clipboard"}
-          >
-            {pathCopied ? (
-              <Check className="w-3 h-3 text-green-400" />
-            ) : (
-              <Copy className="w-3 h-3" />
-            )}
-          </button>
-          <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-            {pathCopied ? "Path copied to clipboard" : ""}
-          </div>
-        </div>
-      </div>
-    );
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Summary
Adds an always-visible path footer to worktree cards, allowing users to access and copy the worktree directory path regardless of work state. Previously, the path was only accessible when the details accordion was expanded, which was hidden when work was complete.

Closes #1282

## Changes Made
- Add persistent path footer with copy button to WorktreeCard
- Add clipboard API guard and proper error handling
- Improve tooltip accessibility with hover support and title fallback
- Remove duplicate path display from WorktreeDetails when no content
- Add state management for path copy feedback with timeout cleanup

## Implementation Details
- Footer uses `formatPath()` utility to display paths relative to home directory (~/...)
- Copy button provides visual feedback (checkmark) for 2 seconds after successful copy
- Tooltip shows on hover and provides accessibility context
- Proper cleanup of timeouts on component unmount to prevent memory leaks
- Guards against missing clipboard API in restricted environments