### PR TITLE
feat(github): add persistent caching for repository stats

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -49,6 +49,8 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         prCount: statsResult.stats?.prCount ?? null,
         loading: false,
         ghError: statsResult.error,
+        stale: statsResult.stats?.stale,
+        lastUpdated: statsResult.stats?.lastUpdated,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/electron/services/GitHubStatsCache.ts
+++ b/electron/services/GitHubStatsCache.ts
@@ -1,0 +1,136 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import path from "path";
+import { app } from "electron";
+
+interface CachedStats {
+  issueCount: number;
+  prCount: number;
+  lastUpdated: number;
+  projectPath: string;
+}
+
+interface CacheFile {
+  version: 1;
+  projects: Record<string, CachedStats>;
+}
+
+const MAX_CACHE_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const MAX_PROJECTS = 10;
+
+let instance: GitHubStatsCache | null = null;
+
+export class GitHubStatsCache {
+  private cacheFilePath: string;
+  private memoryCache: CacheFile | null = null;
+
+  private constructor(userDataPath: string) {
+    this.cacheFilePath = path.join(userDataPath, "github-stats-cache.json");
+  }
+
+  static getInstance(): GitHubStatsCache {
+    if (!instance) {
+      const userDataPath = app.getPath("userData");
+      instance = new GitHubStatsCache(userDataPath);
+    }
+    return instance;
+  }
+
+  static resetInstance(): void {
+    instance = null;
+  }
+
+  private load(): CacheFile {
+    if (this.memoryCache) {
+      return this.memoryCache;
+    }
+
+    if (!existsSync(this.cacheFilePath)) {
+      this.memoryCache = { version: 1, projects: {} };
+      return this.memoryCache;
+    }
+
+    try {
+      const content = readFileSync(this.cacheFilePath, "utf8");
+      const data = JSON.parse(content) as CacheFile;
+
+      if (data.version !== 1) {
+        this.memoryCache = { version: 1, projects: {} };
+        return this.memoryCache;
+      }
+
+      if (!data.projects || typeof data.projects !== "object" || Array.isArray(data.projects)) {
+        console.warn("[GitHubStatsCache] Invalid cache structure, resetting");
+        this.memoryCache = { version: 1, projects: {} };
+        return this.memoryCache;
+      }
+
+      this.memoryCache = data;
+      return this.memoryCache;
+    } catch (error) {
+      console.warn("[GitHubStatsCache] Failed to load cache:", error);
+      this.memoryCache = { version: 1, projects: {} };
+      return this.memoryCache;
+    }
+  }
+
+  private save(cache: CacheFile): void {
+    try {
+      const dir = path.dirname(this.cacheFilePath);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      writeFileSync(this.cacheFilePath, JSON.stringify(cache, null, 2), "utf8");
+      this.memoryCache = cache;
+    } catch (error) {
+      console.error("[GitHubStatsCache] Failed to save cache:", error);
+    }
+  }
+
+  get(repoKey: string): CachedStats | null {
+    const cache = this.load();
+    const entry = cache.projects[repoKey];
+
+    if (!entry) {
+      return null;
+    }
+
+    if (
+      typeof entry.lastUpdated !== "number" ||
+      !Number.isFinite(entry.lastUpdated) ||
+      entry.lastUpdated <= 0
+    ) {
+      return null;
+    }
+
+    const age = Date.now() - entry.lastUpdated;
+    if (age > MAX_CACHE_AGE_MS || age < 0) {
+      return null;
+    }
+
+    return entry;
+  }
+
+  set(repoKey: string, stats: { issueCount: number; prCount: number }, projectPath: string): void {
+    const cache = this.load();
+
+    cache.projects[repoKey] = {
+      ...stats,
+      lastUpdated: Date.now(),
+      projectPath,
+    };
+
+    const entries = Object.entries(cache.projects);
+    if (entries.length > MAX_PROJECTS) {
+      const sorted = entries.sort(([, a], [, b]) => b.lastUpdated - a.lastUpdated);
+      cache.projects = Object.fromEntries(sorted.slice(0, MAX_PROJECTS));
+    }
+
+    this.save(cache);
+  }
+
+  clear(): void {
+    this.memoryCache = { version: 1, projects: {} };
+    this.save(this.memoryCache);
+  }
+}

--- a/electron/services/github/types.ts
+++ b/electron/services/github/types.ts
@@ -6,6 +6,8 @@ export interface RepoContext {
 export interface RepoStats {
   issueCount: number;
   prCount: number;
+  stale?: boolean;
+  lastUpdated?: number;
 }
 
 export interface RepoStatsResult {

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -10,6 +10,10 @@ export interface RepositoryStats {
   loading: boolean;
   /** Error message if GitHub API failed */
   ghError?: string;
+  /** Whether the stats are from cache and may be outdated */
+  stale?: boolean;
+  /** Timestamp when stats were last successfully fetched from API */
+  lastUpdated?: number;
 }
 
 /** GitHub CLI availability check result */


### PR DESCRIPTION
## Summary
Implements persistent caching for GitHub repository stats to maintain visibility during offline scenarios and across app restarts. When network connectivity is lost, the toolbar now displays cached stats with a visual stale indicator instead of disappearing completely.

Closes #1281

## Changes Made
- **Backend**: Added `GitHubStatsCache` service with disk-based persistence (7-day TTL, 10-project limit)
- **Fallback chain**: Modified `GitHubService` to return cached stats on API failures with `stale: true` flag
- **Cache validation**: Added corruption recovery and timestamp validation to prevent crashes
- **Frontend hook**: Updated `useRepositoryStats` to track and expose `isStale` and `lastUpdated` state
- **UI indicator**: Modified `Toolbar` to show dimmed stats with Clock icon when displaying cached data
- **Tooltips**: Added "last updated X ago - offline" messaging with safe timestamp handling
- **Type safety**: Extended `RepositoryStats` interface with optional `stale` and `lastUpdated` fields

## Testing
- Validated type checking, linting, and formatting (all pass)
- Comprehensive code review via Codex identified and fixed 7 issues:
  - Cache corruption handling
  - Invalid timestamp validation
  - Stats preservation on network errors
  - Tooltip edge cases
  - UI accessibility improvements