### PR TITLE
Fix: Grid layout reverts to 1x4 after maximized panel restore

### DIFF
--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -10,6 +10,7 @@ export interface GridPanelProps {
   isFocused: boolean;
   isMaximized?: boolean;
   gridPanelCount?: number;
+  gridCols?: number;
 }
 
 export function GridPanel({
@@ -17,6 +18,7 @@ export function GridPanel({
   isFocused,
   isMaximized = false,
   gridPanelCount,
+  gridCols,
 }: GridPanelProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
   const trashTerminal = useTerminalStore((state) => state.trashTerminal);
@@ -66,8 +68,8 @@ export function GridPanel({
   );
 
   const handleToggleMaximize = useCallback(() => {
-    toggleMaximize(terminal.id);
-  }, [toggleMaximize, terminal.id]);
+    toggleMaximize(terminal.id, gridCols, gridPanelCount);
+  }, [toggleMaximize, terminal.id, gridCols, gridPanelCount]);
 
   const handleTitleChange = useCallback(
     (newTitle: string) => {

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTerminalFocusSlice, type TerminalFocusSlice } from "../terminalFocusSlice";
+import type { TerminalInstance } from "../terminalRegistrySlice";
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    wake: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: {
+    getState: vi.fn(() => ({
+      activeWorktreeId: "worktree-1",
+      trackTerminalFocus: vi.fn(),
+      selectWorktree: vi.fn(),
+    })),
+  },
+}));
+
+describe("TerminalFocusSlice - Layout Snapshot", () => {
+  const mockTerminals: TerminalInstance[] = [
+    {
+      id: "term-1",
+      title: "Terminal 1",
+      type: "claude",
+      cwd: "/test",
+      location: "grid",
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId: "worktree-1",
+    },
+    {
+      id: "term-2",
+      title: "Terminal 2",
+      type: "terminal",
+      cwd: "/test",
+      location: "grid",
+      agentState: "idle",
+      isVisible: true,
+      cols: 80,
+      rows: 24,
+      worktreeId: "worktree-1",
+    },
+  ] as TerminalInstance[];
+
+  const getTerminals = vi.fn(() => mockTerminals);
+
+  let state: TerminalFocusSlice;
+  let setState: any;
+  let getState: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setState = vi.fn((updater) => {
+      const currentState = getState();
+      const updates = typeof updater === "function" ? updater(currentState) : updater;
+      state = { ...currentState, ...updates };
+    });
+    getState = vi.fn(() => state);
+    state = createTerminalFocusSlice(getTerminals)(setState, getState, {} as never);
+  });
+
+  it("should capture layout snapshot when maximizing", () => {
+    state.toggleMaximize("term-1", 2, 4);
+
+    expect(state.maximizedId).toBe("term-1");
+    expect(state.preMaximizeLayout).toEqual({
+      gridCols: 2,
+      gridItemCount: 4,
+      worktreeId: "worktree-1",
+    });
+  });
+
+  it("should not capture snapshot when unmaximizing", () => {
+    state.preMaximizeLayout = { gridCols: 2, gridItemCount: 4, worktreeId: "worktree-1" };
+    state.maximizedId = "term-1";
+
+    state.toggleMaximize("term-1", 2, 4);
+
+    expect(state.maximizedId).toBe(null);
+  });
+
+  it("should clear snapshot when terminal is removed", () => {
+    state.maximizedId = "term-1";
+    state.preMaximizeLayout = { gridCols: 2, gridItemCount: 4, worktreeId: "worktree-1" };
+
+    state.handleTerminalRemoved("term-1", [mockTerminals[1]], 0);
+
+    expect(state.maximizedId).toBe(null);
+    expect(state.preMaximizeLayout).toBe(null);
+  });
+
+  it("should clear snapshot via clearPreMaximizeLayout", () => {
+    state.preMaximizeLayout = { gridCols: 2, gridItemCount: 4, worktreeId: "worktree-1" };
+
+    state.clearPreMaximizeLayout();
+
+    expect(state.preMaximizeLayout).toBe(null);
+  });
+
+  it("should not capture snapshot when gridCols or gridItemCount is undefined", () => {
+    state.toggleMaximize("term-1", undefined, undefined);
+
+    expect(state.maximizedId).toBe("term-1");
+    expect(state.preMaximizeLayout).toBeNull();
+  });
+
+  it("should preserve snapshot across multiple maximize/restore cycles", () => {
+    state.toggleMaximize("term-1", 2, 4);
+
+    expect(state.preMaximizeLayout).toEqual({
+      gridCols: 2,
+      gridItemCount: 4,
+      worktreeId: "worktree-1",
+    });
+    expect(state.maximizedId).toBe("term-1");
+
+    state.toggleMaximize("term-1");
+
+    expect(state.maximizedId).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes grid layout incorrectly reverting to 1x4 stacked vertical layout after restoring a maximized panel instead of returning to the original 2x2 grid configuration.

Closes #1248

## Changes Made
- Added `preMaximizeLayout` state to capture grid configuration before maximization
- Updated `toggleMaximize` to save/restore layout snapshot with worktree awareness
- Modified `ContentGrid` to use preserved layout when restoring from maximized state
- Added invalidation logic for snapshot on worktree switch, panel count changes, and layout config changes
- Enforced 2-pane invariant during snapshot restoration to prevent bypass
- Added comprehensive unit tests for snapshot capture/restore behavior
- Fixed ReferenceError by moving useEffect hooks after gridItemCount declaration
- Clear stale snapshots when maximize called without grid parameters

## Test Plan
- [x] Unit tests pass for snapshot capture/restore cycles
- [x] Typecheck and lint pass
- [x] Manual testing: 4-panel 2x2 grid → maximize → restore returns to 2x2 (not 1x4)