### PR TITLE
feat(dock): implement conditional chevrons with overlay design

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -15,7 +15,7 @@ import {
   DOCK_PLACEHOLDER_ID,
 } from "@/components/DragDrop";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { useNativeContextMenu } from "@/hooks";
+import { useNativeContextMenu, useHorizontalScrollControls } from "@/hooks";
 import type { MenuItemOption } from "@/types";
 import { actionService } from "@/services/ActionService";
 
@@ -50,6 +50,8 @@ export function ContentDock() {
   const cwd = activeWorktree?.path ?? currentProject?.path ?? "";
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
+    useHorizontalScrollControls(scrollContainerRef);
 
   // Make the dock terminals area droppable
   const { setNodeRef: setDockDropRef, isOver } = useDroppable({
@@ -66,16 +68,6 @@ export function ContentDock() {
     },
     [setDockDropRef]
   );
-
-  const handleScroll = (direction: "left" | "right") => {
-    if (scrollContainerRef.current) {
-      const scrollAmount = 200;
-      scrollContainerRef.current.scrollBy({
-        left: direction === "left" ? -scrollAmount : scrollAmount,
-        behavior: "smooth",
-      });
-    }
-  };
 
   const handleAddTerminal = useCallback(
     (agentId: string) => {
@@ -142,17 +134,25 @@ export function ContentDock() {
       )}
       role="list"
     >
-      <div className="flex items-center gap-1.5 flex-1 min-w-0">
-        {/* Left Scroll Chevron */}
-        <button
-          onClick={() => handleScroll("left")}
-          disabled={activeDockTerminals.length === 0}
-          className="p-1.5 text-canopy-text/40 hover:text-canopy-text hover:bg-white/[0.06] rounded-[var(--radius-md)] transition-colors shrink-0 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-canopy-text/40 disabled:hover:bg-transparent"
-          aria-label="Scroll left"
-          title="Scroll left"
-        >
-          <ChevronLeft className="w-4 h-4" />
-        </button>
+      <div className="relative flex-1 min-w-0">
+        {/* Left Scroll Chevron - Overlay */}
+        {canScrollLeft && (
+          <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-4">
+            <button
+              type="button"
+              onClick={scrollLeft}
+              className={cn(
+                "pointer-events-auto p-1.5 text-canopy-text/60 hover:text-canopy-text",
+                "rounded-[var(--radius-md)] transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+              )}
+              aria-label="Scroll left"
+              title="Scroll left"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+          </div>
+        )}
 
         {/* Scrollable Container */}
         <div
@@ -182,16 +182,24 @@ export function ContentDock() {
           </SortableContext>
         </div>
 
-        {/* Right Scroll Chevron */}
-        <button
-          onClick={() => handleScroll("right")}
-          disabled={activeDockTerminals.length === 0}
-          className="p-1.5 text-canopy-text/40 hover:text-canopy-text hover:bg-white/[0.06] rounded-[var(--radius-md)] transition-colors shrink-0 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-canopy-text/40 disabled:hover:bg-transparent"
-          aria-label="Scroll right"
-          title="Scroll right"
-        >
-          <ChevronRight className="w-4 h-4" />
-        </button>
+        {/* Right Scroll Chevron - Overlay */}
+        {canScrollRight && (
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-4">
+            <button
+              type="button"
+              onClick={scrollRight}
+              className={cn(
+                "pointer-events-auto p-1.5 text-canopy-text/60 hover:text-canopy-text",
+                "rounded-[var(--radius-md)] transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+              )}
+              aria-label="Scroll right"
+              title="Scroll right"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Separator between terminals and action containers */}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -47,3 +47,6 @@ export { useMenuActions } from "./useMenuActions";
 export type { UseMenuActionsOptions } from "./useMenuActions";
 
 export { useNativeContextMenu } from "./useNativeContextMenu";
+
+export { useHorizontalScrollControls } from "./useHorizontalScrollControls";
+export type { UseHorizontalScrollControlsReturn } from "./useHorizontalScrollControls";

--- a/src/hooks/useHorizontalScrollControls.ts
+++ b/src/hooks/useHorizontalScrollControls.ts
@@ -1,0 +1,98 @@
+import { useState, useEffect, useCallback, useRef, type RefObject } from "react";
+import {
+  getHorizontalScrollState,
+  calculateScrollAmount,
+  type HorizontalScrollState,
+} from "@/lib/horizontalScroll";
+
+export interface UseHorizontalScrollControlsReturn extends HorizontalScrollState {
+  scrollLeft: () => void;
+  scrollRight: () => void;
+}
+
+export function useHorizontalScrollControls(
+  scrollRef: RefObject<HTMLElement | null>
+): UseHorizontalScrollControlsReturn {
+  const [state, setState] = useState<HorizontalScrollState>({
+    isOverflowing: false,
+    canScrollLeft: false,
+    canScrollRight: false,
+  });
+
+  const rafRef = useRef<number | null>(null);
+  const lastStateRef = useRef(state);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const newState = getHorizontalScrollState({
+      scrollLeft: el.scrollLeft,
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    });
+
+    if (
+      newState.isOverflowing !== lastStateRef.current.isOverflowing ||
+      newState.canScrollLeft !== lastStateRef.current.canScrollLeft ||
+      newState.canScrollRight !== lastStateRef.current.canScrollRight
+    ) {
+      lastStateRef.current = newState;
+      setState(newState);
+    }
+  }, [scrollRef]);
+
+  const throttledUpdate = useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      updateScrollState();
+    });
+  }, [updateScrollState]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+
+    const resizeObserver = new ResizeObserver(throttledUpdate);
+    resizeObserver.observe(el);
+
+    const firstChild = el.firstElementChild;
+    if (firstChild) {
+      resizeObserver.observe(firstChild);
+    }
+
+    el.addEventListener("scroll", throttledUpdate, { passive: true });
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      resizeObserver.disconnect();
+      el.removeEventListener("scroll", throttledUpdate);
+    };
+  }, [scrollRef.current, updateScrollState, throttledUpdate]);
+
+  const scrollLeft = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const amount = calculateScrollAmount(el.clientWidth);
+    el.scrollBy({ left: -amount, behavior: "smooth" });
+  }, [scrollRef]);
+
+  const scrollRight = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const amount = calculateScrollAmount(el.clientWidth);
+    el.scrollBy({ left: amount, behavior: "smooth" });
+  }, [scrollRef]);
+
+  return {
+    ...state,
+    scrollLeft,
+    scrollRight,
+  };
+}

--- a/src/lib/__tests__/horizontalScroll.test.ts
+++ b/src/lib/__tests__/horizontalScroll.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { getHorizontalScrollState, calculateScrollAmount } from "../horizontalScroll";
+
+describe("getHorizontalScrollState", () => {
+  describe("isOverflowing", () => {
+    it("should return false when content fits (scrollWidth <= clientWidth)", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 500,
+        clientWidth: 500,
+      });
+      expect(result.isOverflowing).toBe(false);
+    });
+
+    it("should return false when content fits with epsilon tolerance", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 501,
+        clientWidth: 500,
+      });
+      expect(result.isOverflowing).toBe(false);
+    });
+
+    it("should return true when content overflows", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.isOverflowing).toBe(true);
+    });
+  });
+
+  describe("canScrollLeft", () => {
+    it("should return false when at scroll start", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollLeft).toBe(false);
+    });
+
+    it("should return false when within epsilon of scroll start", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0.5,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollLeft).toBe(false);
+    });
+
+    it("should return true when scrolled past start", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 50,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollLeft).toBe(true);
+    });
+
+    it("should return false when no overflow even if scrollLeft is set", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 10,
+        scrollWidth: 500,
+        clientWidth: 500,
+      });
+      expect(result.canScrollLeft).toBe(false);
+    });
+  });
+
+  describe("canScrollRight", () => {
+    it("should return true when at scroll start with overflow", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollRight).toBe(true);
+    });
+
+    it("should return true when partially scrolled with more content", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 100,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollRight).toBe(true);
+    });
+
+    it("should return false when scrolled to end", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 300,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollRight).toBe(false);
+    });
+
+    it("should return false when within epsilon of scroll end", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 299.5,
+        scrollWidth: 800,
+        clientWidth: 500,
+      });
+      expect(result.canScrollRight).toBe(false);
+    });
+
+    it("should return false when no overflow", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 500,
+        clientWidth: 500,
+      });
+      expect(result.canScrollRight).toBe(false);
+    });
+  });
+
+  describe("combined states", () => {
+    it("should return all false when no overflow", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 300,
+        clientWidth: 500,
+      });
+      expect(result).toEqual({
+        isOverflowing: false,
+        canScrollLeft: false,
+        canScrollRight: false,
+      });
+    });
+
+    it("should allow scroll right only when at start with overflow", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 0,
+        scrollWidth: 1000,
+        clientWidth: 500,
+      });
+      expect(result).toEqual({
+        isOverflowing: true,
+        canScrollLeft: false,
+        canScrollRight: true,
+      });
+    });
+
+    it("should allow both directions when in middle", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 250,
+        scrollWidth: 1000,
+        clientWidth: 500,
+      });
+      expect(result).toEqual({
+        isOverflowing: true,
+        canScrollLeft: true,
+        canScrollRight: true,
+      });
+    });
+
+    it("should allow scroll left only when at end", () => {
+      const result = getHorizontalScrollState({
+        scrollLeft: 500,
+        scrollWidth: 1000,
+        clientWidth: 500,
+      });
+      expect(result).toEqual({
+        isOverflowing: true,
+        canScrollLeft: true,
+        canScrollRight: false,
+      });
+    });
+  });
+});
+
+describe("calculateScrollAmount", () => {
+  it("should return minimum scroll amount for small widths", () => {
+    expect(calculateScrollAmount(100)).toBe(200);
+    expect(calculateScrollAmount(200)).toBe(200);
+  });
+
+  it("should return 80% of width for medium widths", () => {
+    expect(calculateScrollAmount(400)).toBe(320);
+    expect(calculateScrollAmount(500)).toBe(400);
+  });
+
+  it("should return maximum scroll amount for large widths", () => {
+    expect(calculateScrollAmount(1000)).toBe(600);
+    expect(calculateScrollAmount(2000)).toBe(600);
+  });
+
+  it("should handle boundary value at 250px (200 / 0.8)", () => {
+    expect(calculateScrollAmount(250)).toBe(200);
+  });
+
+  it("should handle boundary value at 750px (600 / 0.8)", () => {
+    expect(calculateScrollAmount(750)).toBe(600);
+  });
+});

--- a/src/lib/horizontalScroll.ts
+++ b/src/lib/horizontalScroll.ts
@@ -1,0 +1,28 @@
+export interface ScrollMetrics {
+  scrollLeft: number;
+  scrollWidth: number;
+  clientWidth: number;
+}
+
+export interface HorizontalScrollState {
+  isOverflowing: boolean;
+  canScrollLeft: boolean;
+  canScrollRight: boolean;
+}
+
+const EPSILON = 1;
+
+export function getHorizontalScrollState(metrics: ScrollMetrics): HorizontalScrollState {
+  const isOverflowing = metrics.scrollWidth > metrics.clientWidth + EPSILON;
+  const canScrollLeft = isOverflowing && metrics.scrollLeft > EPSILON;
+  const canScrollRight =
+    isOverflowing && metrics.scrollLeft + metrics.clientWidth < metrics.scrollWidth - EPSILON;
+  return { isOverflowing, canScrollLeft, canScrollRight };
+}
+
+export function calculateScrollAmount(clientWidth: number): number {
+  const minScroll = 200;
+  const maxScroll = 600;
+  const preferredScroll = clientWidth * 0.8;
+  return Math.max(minScroll, Math.min(preferredScroll, maxScroll));
+}


### PR DESCRIPTION
## Summary
This PR implements smart conditional chevrons for the dock that only appear when scrolling is possible, replacing the always-visible chevrons that consumed layout space unnecessarily.

Closes #1257

## Changes Made
- Add getHorizontalScrollState utility with epsilon-based overflow detection
- Add calculateScrollAmount for dynamic scroll step sizing  
- Create useHorizontalScrollControls hook with RAF throttling and ResizeObserver
- Update ContentDock to use overlay chevrons with gradient backgrounds
- Observe both container and content for accurate overflow tracking
- Use pointer-events-none on gradients to prevent drag interference
- Add focus-visible styling for keyboard accessibility
- Include 21 unit tests covering all scroll state edge cases

## Implementation Details
- Chevrons only appear when content overflows horizontally
- Only show left chevron when scrolled past start
- Only show right chevron when more content exists to the right
- Overlay design with gradient backgrounds prevents layout shift
- Smart hitbox design avoids interfering with drag-and-drop operations
- ResizeObserver tracks both container and content for accurate state