### PR TITLE
Complete panel-first architecture with discriminated unions

### DIFF
--- a/.codex-fixes.md
+++ b/.codex-fixes.md
@@ -1,0 +1,13 @@
+# Codex Review Fixes
+
+## Issue 1: Type guards default undefined kind to "terminal"
+Fix type guards to detect legacy browser panels by checking for browserUrl
+
+## Issue 2: Persistence transform has same issue
+Fix persistence to derive kind from browserUrl when missing
+
+## Issue 3: Remaining hardcoded browser check
+Replace `requestedKind === "browser"` with registry-driven check
+
+## Issue 4: Unsafe type assertion
+Remove `as TerminalInstance` cast and ensure proper typing

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1128,22 +1128,9 @@ export class TerminalProcess {
     const CPU_ACTIVITY_THRESHOLD = 0.5;
 
     // Known shell helper processes that should be ignored even with hasChildren check
-    const shellHelperProcesses = new Set([
-      "gitstatus",
-      "gitstatusd",
-      "async",
-      "zsh-async",
-    ]);
+    const shellHelperProcesses = new Set(["gitstatus", "gitstatusd", "async", "zsh-async"]);
 
-    const shellProcesses = new Set([
-      "zsh",
-      "bash",
-      "sh",
-      "fish",
-      "powershell",
-      "pwsh",
-      "cmd",
-    ]);
+    const shellProcesses = new Set(["zsh", "bash", "sh", "fish", "powershell", "pwsh", "cmd"]);
 
     return {
       hasActiveChildren: () => {

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -43,8 +43,8 @@ export interface TerminalState {
   agentId?: AgentId;
   /** Display title */
   title: string;
-  /** Current working directory */
-  cwd: string;
+  /** Current working directory (required for PTY panels, optional for non-PTY) */
+  cwd?: string;
   /** Associated worktree ID */
   worktreeId?: string;
   /** Location in the UI - grid or dock */

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -12,6 +12,7 @@ import { keybindingService } from "@/services/KeybindingService";
 import { isRegisteredAgent, getAgentConfig } from "@/config/agents";
 import { normalizeScrollbackLines } from "@shared/config/scrollback";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 
 export interface HydrationOptions {
   addTerminal: (options: {
@@ -109,10 +110,10 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
           const cwd = terminal.cwd || projectRoot || "";
 
-          // Handle browser panes separately - they don't need backend PTY
-          if (terminal.kind === "browser") {
+          // Handle non-PTY panels separately - they don't need backend PTY
+          if (!panelKindHasPty(terminal.kind ?? "terminal")) {
             await addTerminal({
-              kind: "browser",
+              kind: terminal.kind ?? "browser",
               title: terminal.title,
               cwd,
               worktreeId: terminal.worktreeId,


### PR DESCRIPTION
## Summary

Completes Phase 2 of the panel-first architecture refactor by implementing discriminated union types for `PanelInstance`, eliminating dummy PTY fields on browser panels and moving all panel type logic to the registry.

Closes #1244

## Changes Made

- Define `BasePanelData`, `PtyPanelData`, and `BrowserPanelData` discriminated union types
- Add `isPtyPanel()` and `isBrowserPanel()` type guards for safe narrowing
- Replace all `kind === "browser"` checks with `panelKindHasPty()` registry calls
- Update persistence transform to use registry-driven logic (no PTY fields for browser panels)
- Make `TerminalState.cwd` optional to support non-PTY panels
- Remove dummy PTY fields (`cwd`, `cols`, `rows`) from browser panel creation
- Update hydration logic to use `panelKindHasPty()` for non-PTY detection

## Files Modified

- `shared/types/domain.ts` - Discriminated union types and type guards
- `shared/types/ipc/terminal.ts` - Make `cwd` optional in `TerminalState`
- `src/store/slices/terminalRegistrySlice.ts` - Registry-driven panel logic
- `src/store/persistence/terminalPersistence.ts` - Type-aware persistence
- `src/utils/stateHydration.ts` - Registry-driven hydration

## Testing

- ✅ Type check passes with no errors
- ✅ All existing tests pass
- ✅ Browser and terminal panels validated for correct type shapes