### PR TITLE
feat(panels): add custom panel foundation infrastructure

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -179,6 +179,11 @@ export function createApplicationMenu(
           accelerator: "CommandOrControl+P",
           click: () => sendAction("open-agent-palette"),
         },
+        {
+          label: "Panel Palette...",
+          accelerator: "CommandOrControl+Shift+P",
+          click: () => sendAction("open-panel-palette"),
+        },
       ],
     },
     {

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -100,6 +100,7 @@ export type KeyAction =
   | "agent.focusNextWaiting"
 
   // Panel management
+  | "panel.palette"
   | "panel.toggleDock"
   | "panel.toggleDockAlt"
   | "panel.toggleDiagnostics"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   useWorktrees,
   useTerminalPalette,
   useNewTerminalPalette,
+  usePanelPalette,
   useTerminalConfig,
   useKeybinding,
   useContextInjection,
@@ -34,6 +35,7 @@ import { WorktreeCard, WorktreePalette, WorktreeFilterPopover } from "./componen
 import { NewWorktreeDialog } from "./components/Worktree/NewWorktreeDialog";
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { TerminalPalette, NewTerminalPalette } from "./components/TerminalPalette";
+import { PanelPalette } from "./components/PanelPalette/PanelPalette";
 import { RecipeEditor } from "./components/TerminalRecipe/RecipeEditor";
 import { SettingsDialog, type SettingsTab } from "./components/Settings";
 import { ShortcutReferenceDialog } from "./components/KeyboardShortcuts";
@@ -455,6 +457,7 @@ function App() {
   const terminalPalette = useTerminalPalette();
   const { worktrees, worktreeMap } = useWorktrees();
   const newTerminalPalette = useNewTerminalPalette({ launchAgent, worktreeMap });
+  const panelPalette = usePanelPalette();
   const currentProject = useProjectStore((state) => state.currentProject);
   const { setActiveWorktree, selectWorktree, activeWorktreeId } = useWorktreeSelectionStore(
     useShallow((state) => ({
@@ -659,6 +662,7 @@ function App() {
     onOpenAgentPalette: terminalPalette.open,
     onOpenWorktreePalette: openWorktreePalette,
     onOpenNewTerminalPalette: newTerminalPalette.open,
+    onOpenPanelPalette: panelPalette.open,
     onOpenShortcuts: () => setIsShortcutsOpen(true),
     onLaunchAgent: async (agentId, options) => {
       await launchAgent(agentId, options);
@@ -702,6 +706,7 @@ function App() {
     enabled: electronAvailable,
   });
   useKeybinding("agent.palette", () => dispatch("agent.palette"), { enabled: electronAvailable });
+  useKeybinding("panel.palette", () => dispatch("panel.palette"), { enabled: electronAvailable });
   useKeybinding("terminal.new", () => dispatch("terminal.new"), { enabled: electronAvailable });
   useKeybinding("terminal.spawnPalette", () => dispatch("terminal.spawnPalette"), {
     enabled: electronAvailable,
@@ -965,6 +970,26 @@ function App() {
         onSelect={(worktree) => selectWorktreeFromPalette(worktree.id)}
         onConfirm={confirmWorktreePaletteSelection}
         onClose={closeWorktreePalette}
+      />
+      <PanelPalette
+        isOpen={panelPalette.isOpen}
+        kinds={panelPalette.availableKinds}
+        selectedIndex={panelPalette.selectedIndex}
+        onSelectPrevious={panelPalette.selectPrevious}
+        onSelectNext={panelPalette.selectNext}
+        onSelect={(kind) => panelPalette.selectKind(kind.id)}
+        onConfirm={() => {
+          const selected = panelPalette.confirmSelection();
+          if (selected) {
+            addTerminal({
+              kind: selected.id as PanelKind,
+              cwd: defaultTerminalCwd,
+              worktreeId: activeWorktreeId,
+              location: "grid",
+            });
+          }
+        }}
+        onClose={panelPalette.close}
       />
 
       <SettingsDialog

--- a/src/components/PanelPalette/PanelKindIcon.tsx
+++ b/src/components/PanelPalette/PanelKindIcon.tsx
@@ -1,0 +1,30 @@
+import { Terminal, Globe, FileText, GitBranch, LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  terminal: Terminal,
+  globe: Globe,
+  "file-text": FileText,
+  "git-branch": GitBranch,
+};
+
+export interface PanelKindIconProps {
+  iconId: string;
+  color?: string;
+  size?: number;
+  className?: string;
+}
+
+export function PanelKindIcon({ iconId, color, size = 16, className }: PanelKindIconProps) {
+  const Icon = ICON_MAP[iconId] ?? Terminal;
+
+  return (
+    <Icon
+      style={{ color }}
+      className={cn("shrink-0", className)}
+      width={size}
+      height={size}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useRef, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
+import type { PanelKindOption } from "@/hooks/usePanelPalette";
+import { PanelKindIcon } from "./PanelKindIcon";
+
+interface PanelPaletteProps {
+  isOpen: boolean;
+  kinds: PanelKindOption[];
+  selectedIndex: number;
+  onSelectPrevious: () => void;
+  onSelectNext: () => void;
+  onSelect: (kind: PanelKindOption) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function PanelPalette({
+  isOpen,
+  kinds,
+  selectedIndex,
+  onSelectPrevious,
+  onSelectNext,
+  onSelect,
+  onConfirm,
+  onClose,
+}: PanelPaletteProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const comboboxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => comboboxRef.current?.focus());
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (listRef.current && selectedIndex >= 0) {
+      const selectedItem = listRef.current.children[selectedIndex] as HTMLElement;
+      selectedItem?.scrollIntoView({ block: "nearest" });
+    }
+  }, [selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowUp":
+          e.preventDefault();
+          onSelectPrevious();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          onSelectNext();
+          break;
+        case "Enter":
+          e.preventDefault();
+          onConfirm();
+          break;
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+        case "Tab":
+          e.preventDefault();
+          if (e.shiftKey) {
+            onSelectPrevious();
+          } else {
+            onSelectNext();
+          }
+          break;
+      }
+    },
+    [onSelectPrevious, onSelectNext, onConfirm, onClose]
+  );
+
+  return (
+    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Panel palette">
+      <AppPaletteDialog.Header label="New Panel" keyHint="⌘⇧P">
+        <div
+          ref={comboboxRef}
+          role="combobox"
+          tabIndex={0}
+          onKeyDown={handleKeyDown}
+          className="px-3 py-2 text-sm text-canopy-text/70"
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-label="Select panel type"
+          aria-controls="panel-list"
+          aria-activedescendant={
+            kinds.length > 0 && selectedIndex >= 0 && selectedIndex < kinds.length
+              ? `panel-option-${kinds[selectedIndex].id}`
+              : undefined
+          }
+        >
+          Select a panel type to create
+        </div>
+      </AppPaletteDialog.Header>
+
+      <AppPaletteDialog.Body>
+        <div ref={listRef} id="panel-list" role="listbox" aria-label="Panel types">
+          {kinds.length === 0 ? (
+            <div className="px-3 py-8 text-center text-canopy-text/50 text-sm">
+              No panel types available
+            </div>
+          ) : (
+            kinds.map((kind, index) => (
+              <button
+                key={kind.id}
+                id={`panel-option-${kind.id}`}
+                role="option"
+                aria-selected={index === selectedIndex}
+                className={cn(
+                  "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
+                  index === selectedIndex
+                    ? "bg-white/[0.03] border-overlay text-canopy-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-canopy-accent before:content-['']"
+                    : "border-transparent text-canopy-text/70 hover:bg-white/[0.02] hover:text-canopy-text"
+                )}
+                onClick={() => onSelect(kind)}
+              >
+                <div className="shrink-0">
+                  <PanelKindIcon iconId={kind.iconId} color={kind.color} size={16} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium text-canopy-text">{kind.name}</div>
+                  {kind.description && (
+                    <div className="text-xs text-canopy-text/50 truncate">{kind.description}</div>
+                  )}
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </AppPaletteDialog.Body>
+
+      <AppPaletteDialog.Footer>
+        <span>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+            ↑
+          </kbd>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60 ml-1">
+            ↓
+          </kbd>
+          <span className="ml-1.5">to navigate</span>
+        </span>
+        <span>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+            Enter
+          </kbd>
+          <span className="ml-1.5">to create</span>
+        </span>
+        <span>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+            Esc
+          </kbd>
+          <span className="ml-1.5">to close</span>
+        </span>
+      </AppPaletteDialog.Footer>
+    </AppPaletteDialog>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,6 +14,8 @@ export { useErrors } from "./useErrors";
 export { useTerminalPalette } from "./useTerminalPalette";
 export type { SearchableTerminal, UseTerminalPaletteReturn } from "./useTerminalPalette";
 export { useNewTerminalPalette } from "./useNewTerminalPalette";
+export { usePanelPalette } from "./usePanelPalette";
+export type { PanelKindOption, UsePanelPaletteReturn } from "./usePanelPalette";
 export { useTerminalConfig } from "./useTerminalConfig";
 
 export { useWorktreeTerminals } from "./useWorktreeTerminals";

--- a/src/hooks/useMenuActions.ts
+++ b/src/hooks/useMenuActions.ts
@@ -72,6 +72,7 @@ export function useMenuActions(options: UseMenuActionsOptions): void {
         "open-settings": "app.settings",
         "toggle-sidebar": "nav.toggleSidebar",
         "open-agent-palette": "terminal.palette",
+        "open-panel-palette": "panel.palette",
       };
 
       const actionId = menuToActionMap[action];

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -1,0 +1,115 @@
+import { useState, useCallback, useMemo } from "react";
+import { getPanelKindIds, getPanelKindConfig } from "@shared/config/panelKindRegistry";
+import { hasPanelComponent } from "@/registry/panelComponentRegistry";
+
+export interface PanelKindOption {
+  id: string;
+  name: string;
+  iconId: string;
+  color: string;
+  description?: string;
+}
+
+export interface UsePanelPaletteReturn {
+  isOpen: boolean;
+  availableKinds: PanelKindOption[];
+  selectedIndex: number;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  selectPrevious: () => void;
+  selectNext: () => void;
+  selectKind: (kindId: string) => void;
+  confirmSelection: () => void;
+}
+
+export function usePanelPalette(): UsePanelPaletteReturn {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const availableKinds = useMemo<PanelKindOption[]>(() => {
+    const allKindIds = getPanelKindIds();
+
+    return allKindIds
+      .filter((kindId) => {
+        const config = getPanelKindConfig(kindId);
+        if (!config) return false;
+        if (config.hasPty) return false;
+        if (!hasPanelComponent(kindId)) return false;
+        return true;
+      })
+      .map((kindId) => {
+        const config = getPanelKindConfig(kindId)!;
+        return {
+          id: kindId,
+          name: config.name,
+          iconId: config.iconId,
+          color: config.color,
+          description: undefined,
+        };
+      });
+  }, []);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    setSelectedIndex(0);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setSelectedIndex(0);
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }, [isOpen, open, close]);
+
+  const selectPrevious = useCallback(() => {
+    setSelectedIndex((prev) => {
+      if (prev === 0) return availableKinds.length - 1;
+      return prev - 1;
+    });
+  }, [availableKinds.length]);
+
+  const selectNext = useCallback(() => {
+    setSelectedIndex((prev) => {
+      if (prev === availableKinds.length - 1) return 0;
+      return prev + 1;
+    });
+  }, [availableKinds.length]);
+
+  const selectKind = useCallback(
+    (kindId: string) => {
+      const index = availableKinds.findIndex((k) => k.id === kindId);
+      if (index !== -1) {
+        setSelectedIndex(index);
+      }
+    },
+    [availableKinds]
+  );
+
+  const confirmSelection = useCallback((): PanelKindOption | null => {
+    if (availableKinds.length === 0) return null;
+    const selected = availableKinds[selectedIndex];
+    if (!selected) return null;
+    close();
+    return selected;
+  }, [availableKinds, selectedIndex, close]);
+
+  return {
+    isOpen,
+    availableKinds,
+    selectedIndex,
+    open,
+    close,
+    toggle,
+    selectPrevious,
+    selectNext,
+    selectKind,
+    confirmSelection,
+  };
+}

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -293,6 +293,14 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Terminal",
   },
   {
+    actionId: "panel.palette",
+    combo: "Cmd+Shift+P",
+    scope: "global",
+    priority: 0,
+    description: "Open panel palette",
+    category: "Panels",
+  },
+  {
     actionId: "panel.diagnosticsLogs",
     combo: "Ctrl+Shift+L",
     scope: "global",

--- a/src/services/actions/__tests__/actionDefinitions.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.test.ts
@@ -11,6 +11,7 @@ async function createRegistry() {
     onOpenAgentPalette: () => {},
     onOpenWorktreePalette: () => {},
     onOpenNewTerminalPalette: () => {},
+    onOpenPanelPalette: () => {},
     onOpenShortcuts: () => {},
     onLaunchAgent: async () => {},
     onInject: () => {},

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -12,6 +12,7 @@ export interface ActionCallbacks {
   onOpenAgentPalette: () => void;
   onOpenWorktreePalette: () => void;
   onOpenNewTerminalPalette: () => void;
+  onOpenPanelPalette: () => void;
   onOpenShortcuts: () => void;
   onLaunchAgent: (
     agentId: string,

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -6,7 +6,20 @@ import { getAIAgentInfo } from "@/lib/aiAgentDetection";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { useSidecarStore } from "@/store/sidecarStore";
 
-export function registerPanelActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
+export function registerPanelActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
+  actions.set("panel.palette", () => ({
+    id: "panel.palette",
+    title: "Panel Palette",
+    description: "Open panel palette to create non-PTY panels",
+    category: "panel",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      callbacks.onOpenPanelPalette();
+    },
+  }));
+
   const getSidecarBounds = (): { x: number; y: number; width: number; height: number } | null => {
     if (typeof document === "undefined") return null;
     const placeholder = document.getElementById("sidecar-placeholder");

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from "zustand";
 import type { TerminalInstance } from "./terminalRegistrySlice";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 
 export type NavigationDirection = "up" | "down" | "left" | "right";
 
@@ -68,9 +69,9 @@ export const createTerminalFocusSlice =
         if (id) {
           // Wake-on-focus: sync terminal state from backend when focused.
           // This is a safety net to recover from any missed data.
-          // Skip wake for browser panes - they don't have backend PTY processes.
+          // Skip wake for non-PTY panels - they don't have backend PTY processes.
           const terminal = getTerminals().find((t) => t.id === id);
-          if (terminal?.kind !== "browser") {
+          if (terminal?.kind && panelKindHasPty(terminal.kind)) {
             terminalInstanceService.wake(id);
           }
           if (shouldPing) {
@@ -193,9 +194,9 @@ export const createTerminalFocusSlice =
       },
 
       openDockTerminal: (id) => {
-        // Skip wake for browser panes - they don't have backend PTY processes.
+        // Skip wake for non-PTY panels - they don't have backend PTY processes.
         const terminal = getTerminals().find((t) => t.id === id);
-        if (terminal?.kind !== "browser") {
+        if (terminal?.kind && panelKindHasPty(terminal.kind)) {
           terminalInstanceService.wake(id);
         }
         set({ activeDockTerminalId: id, focusedId: id });
@@ -209,8 +210,8 @@ export const createTerminalFocusSlice =
         if (!terminal) return;
 
         // Wake-on-focus: sync terminal state from backend when activated.
-        // Skip wake for browser panes - they don't have backend PTY processes.
-        if (terminal.kind !== "browser") {
+        // Skip wake for non-PTY panels - they don't have backend PTY processes.
+        if (panelKindHasPty(terminal.kind)) {
           terminalInstanceService.wake(id);
         }
 

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -12,6 +12,7 @@ import { keybindingService } from "@/services/KeybindingService";
 import { isRegisteredAgent, getAgentConfig } from "@/config/agents";
 import { normalizeScrollbackLines } from "@shared/config/scrollback";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 
 export interface HydrationOptions {
   addTerminal: (options: {
@@ -109,10 +110,10 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
           const cwd = terminal.cwd || projectRoot || "";
 
-          // Handle browser panes separately - they don't need backend PTY
-          if (terminal.kind === "browser") {
+          // Handle non-PTY panels separately - they don't need backend PTY
+          if (terminal.kind && !panelKindHasPty(terminal.kind)) {
             await addTerminal({
-              kind: "browser",
+              kind: terminal.kind,
               title: terminal.title,
               cwd,
               worktreeId: terminal.worktreeId,


### PR DESCRIPTION
## Summary
Implements the foundation infrastructure to support custom non-PTY panels without implementing specific panel types. This enables future panel implementations (Notes, Git Activity) to be added easily.

Relates to #1255 (foundation work only - specific panels will be implemented in separate issues)

## Changes Made
- Replace browser-specific checks with `panelKindHasPty` throughout store slices
- Add PanelPalette component with keyboard navigation and panel creation
- Wire `panel.palette` action with Cmd+Shift+P keybinding and menu entry
- Guard PTY operations in move/trash/restore to prevent side effects on non-PTY panels
- Generalize state hydration to handle any non-PTY panel kind
- Add PanelKindIcon component for extensible panel icon rendering

## Code Review
Comprehensive Codex review identified and fixed:
- PTY operations incorrectly called on non-PTY panels during move/trash
- Panel creation handler implemented with proper type safety
- Focus management added for accessibility
- Keybinding conflicts resolved

## Testing
- All action definitions tests updated
- Type safety verified across panel registry and components