### PR TITLE
Worktree: Drag Sessions Out of "Active Sessions"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ npm run fix              # Auto-fix lint/format
 ### Actions System
 
 Central dispatcher for all UI operations (`src/services/ActionService.ts`):
+
 - `dispatch(actionId, args?)` - Execute actions by ID
 - `list()` - Get MCP-compatible action manifest
 - Definitions in `src/services/actions/definitions/`
@@ -43,6 +44,7 @@ Central dispatcher for all UI operations (`src/services/ActionService.ts`):
 ### Panel Architecture
 
 Panels (terminal, agent, browser) use discriminated unions:
+
 - `PanelInstance = PtyPanelData | BrowserPanelData`
 - `panelKindHasPty(kind)` - Check if panel needs PTY
 - Registry: `shared/config/panelKindRegistry.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,11 +33,13 @@ npm run rebuild      # Rebuild native modules
 The **Actions System** is the central orchestration layer for all UI operations. It provides a unified, typed API for menus, keybindings, context menus, and future agent automation.
 
 **Core Components:**
+
 - `ActionService` (`src/services/ActionService.ts`) - Registry and dispatcher singleton
 - Action definitions (`src/services/actions/definitions/`) - 17 domain-specific action files
 - Shared types (`shared/types/actions.ts`) - `ActionId`, `ActionDefinition`, `ActionManifestEntry`
 
 **Key Concepts:**
+
 - `dispatch(actionId, args?, options?)` - Execute any action by ID
 - `list()` / `get(id)` - Introspect available actions (MCP-compatible manifest)
 - `ActionSource` - Tracks origin: "user" | "keybinding" | "menu" | "agent" | "context-menu"
@@ -132,11 +134,13 @@ src/
 ## Common Tasks
 
 **Adding a new action:**
+
 1. Add action ID to `shared/types/actions.ts` (`ActionId` union)
 2. Create definition in appropriate `src/services/actions/definitions/*.ts` file
 3. Action is automatically registered via `useActionRegistry` hook
 
 **Adding IPC channel:**
+
 1. Define in `electron/ipc/channels.ts`
 2. Implement in `electron/ipc/handlers/` (domain-specific file)
 3. Expose in `electron/preload.cts`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -39,6 +39,7 @@ Central orchestration layer for all UI operations. Provides unified API for menu
 ### Panel Architecture
 
 Panels are visual units in the grid/dock. Uses discriminated unions:
+
 - `PanelInstance = PtyPanelData | BrowserPanelData`
 - Kinds: `"terminal"` | `"agent"` | `"browser"`
 - `panelKindHasPty(kind)` - Check if panel needs PTY


### PR DESCRIPTION
## Summary
Implements drag-and-drop functionality for terminal sessions in the WorktreeCard "Active Sessions" accordion list, allowing users to drag sessions between worktrees, the grid, and the dock.

Closes #1264

## Changes Made
- Add draggable terminal rows in WorktreeCard "Active Sessions" accordion
- Use unique IDs (`worktree-list:${terminal.id}`) to avoid dnd-kit conflicts with grid/dock
- Update DndProvider to resolve terminal from DragData instead of active.id
- Move drag handle attributes to GripVertical button for better accessibility
- Compute sourceIndex maps for grid and dock terminals
- Support dragging sessions between worktrees, grid, and dock

## Technical Details
- Added `DraggableTerminalRow` component using `useDraggable` from @dnd-kit/core
- Implemented `computeSourceIndexMaps` helper to correctly compute source indices for grid/dock terminals
- Fixed potential ID conflicts by using prefixed IDs for worktree list draggables
- Improved accessibility by moving drag attributes to the actual drag handle button
- Integrates seamlessly with existing DndProvider and drag preview overlay