### PR TITLE
feat: Dev Preview Panel with auto dev server management

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -210,6 +210,13 @@ export const CHANNELS = {
   NOTES_WRITE: "notes:write",
   NOTES_LIST: "notes:list",
   NOTES_DELETE: "notes:delete",
+
+  DEV_PREVIEW_START: "dev-preview:start",
+  DEV_PREVIEW_STOP: "dev-preview:stop",
+  DEV_PREVIEW_RESTART: "dev-preview:restart",
+  DEV_PREVIEW_SET_URL: "dev-preview:set-url",
+  DEV_PREVIEW_STATUS: "dev-preview:status",
+  DEV_PREVIEW_URL: "dev-preview:url",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -24,6 +24,7 @@ import { registerSlashCommandHandlers } from "./handlers/slashCommands.js";
 import { registerGeminiHandlers } from "./handlers/gemini.js";
 import { registerEventsHandlers } from "./handlers/events.js";
 import { registerNotesHandlers } from "./handlers/notes.js";
+import { registerDevPreviewHandlers } from "./handlers/devPreview.js";
 import { events } from "../services/events.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
@@ -67,6 +68,7 @@ export function registerIpcHandlers(
     registerGeminiHandlers(),
     registerEventsHandlers(deps),
     registerNotesHandlers(deps),
+    registerDevPreviewHandlers(deps),
   ];
 
   return () => {

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -1,0 +1,64 @@
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import type { HandlerDependencies } from "../types.js";
+import { DevPreviewService } from "../../services/DevPreviewService.js";
+
+let devPreviewService: DevPreviewService | null = null;
+
+export function registerDevPreviewHandlers(deps: HandlerDependencies): () => void {
+  const handlers: Array<() => void> = [];
+
+  if (!devPreviewService) {
+    devPreviewService = new DevPreviewService(deps.ptyClient);
+
+    devPreviewService.on("status", (data) => {
+      deps.mainWindow.webContents.send(CHANNELS.DEV_PREVIEW_STATUS, data);
+    });
+
+    devPreviewService.on("url", (data) => {
+      deps.mainWindow.webContents.send(CHANNELS.DEV_PREVIEW_URL, data);
+    });
+  }
+
+  const handleStart = async (
+    _event: Electron.IpcMainInvokeEvent,
+    panelId: string,
+    cwd: string,
+    cols: number,
+    rows: number
+  ) => {
+    if (!devPreviewService) throw new Error("DevPreviewService not initialized");
+    await devPreviewService.start({ panelId, cwd, cols, rows });
+  };
+  ipcMain.handle(CHANNELS.DEV_PREVIEW_START, handleStart);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_START));
+
+  const handleStop = async (_event: Electron.IpcMainInvokeEvent, panelId: string) => {
+    if (!devPreviewService) throw new Error("DevPreviewService not initialized");
+    await devPreviewService.stop(panelId);
+  };
+  ipcMain.handle(CHANNELS.DEV_PREVIEW_STOP, handleStop);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_STOP));
+
+  const handleRestart = async (_event: Electron.IpcMainInvokeEvent, panelId: string) => {
+    if (!devPreviewService) throw new Error("DevPreviewService not initialized");
+    await devPreviewService.restart(panelId);
+  };
+  ipcMain.handle(CHANNELS.DEV_PREVIEW_RESTART, handleRestart);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_RESTART));
+
+  const handleSetUrl = async (
+    _event: Electron.IpcMainInvokeEvent,
+    panelId: string,
+    url: string
+  ) => {
+    if (!devPreviewService) throw new Error("DevPreviewService not initialized");
+    devPreviewService.setUrl(panelId, url);
+  };
+  ipcMain.handle(CHANNELS.DEV_PREVIEW_SET_URL, handleSetUrl);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_SET_URL));
+
+  return () => {
+    handlers.forEach((dispose) => dispose());
+  };
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -36,6 +36,8 @@ import type {
   ArtifactDetectedPayload,
   SaveArtifactOptions,
   ApplyPatchOptions,
+  DevPreviewStatusPayload,
+  DevPreviewUrlPayload,
 } from "../shared/types/ipc.js";
 import type { TerminalActivityPayload } from "../shared/types/terminal.js";
 import type { TerminalStatusPayload } from "../shared/types/pty-host.js";
@@ -217,6 +219,14 @@ const CHANNELS = {
   NOTES_WRITE: "notes:write",
   NOTES_LIST: "notes:list",
   NOTES_DELETE: "notes:delete",
+
+  // Dev Preview channels
+  DEV_PREVIEW_START: "dev-preview:start",
+  DEV_PREVIEW_STOP: "dev-preview:stop",
+  DEV_PREVIEW_RESTART: "dev-preview:restart",
+  DEV_PREVIEW_SET_URL: "dev-preview:set-url",
+  DEV_PREVIEW_STATUS: "dev-preview:status",
+  DEV_PREVIEW_URL: "dev-preview:url",
 
   // App state channels
   APP_GET_STATE: "app:get-state",
@@ -783,6 +793,25 @@ const api: ElectronAPI = {
     list: () => _typedInvoke(CHANNELS.NOTES_LIST),
 
     delete: (notePath: string) => _typedInvoke(CHANNELS.NOTES_DELETE, notePath),
+  },
+
+  // Dev Preview API
+  devPreview: {
+    start: (panelId: string, cwd: string, cols: number, rows: number) =>
+      _typedInvoke(CHANNELS.DEV_PREVIEW_START, panelId, cwd, cols, rows),
+
+    stop: (panelId: string) => _typedInvoke(CHANNELS.DEV_PREVIEW_STOP, panelId),
+
+    restart: (panelId: string) => _typedInvoke(CHANNELS.DEV_PREVIEW_RESTART, panelId),
+
+    setUrl: (panelId: string, url: string) =>
+      _typedInvoke(CHANNELS.DEV_PREVIEW_SET_URL, panelId, url),
+
+    onStatus: (callback: (payload: DevPreviewStatusPayload) => void) =>
+      _typedOn(CHANNELS.DEV_PREVIEW_STATUS, callback),
+
+    onUrl: (callback: (payload: DevPreviewUrlPayload) => void) =>
+      _typedOn(CHANNELS.DEV_PREVIEW_URL, callback),
   },
 
   // Git API

--- a/electron/services/DevPreviewService.ts
+++ b/electron/services/DevPreviewService.ts
@@ -1,0 +1,265 @@
+import crypto from "crypto";
+import { EventEmitter } from "events";
+import path from "path";
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+import type { PtyClient } from "./PtyClient.js";
+import { extractLocalhostUrls } from "../../shared/utils/urlUtils.js";
+
+export type DevPreviewStatus = "installing" | "starting" | "running" | "error" | "stopped";
+
+export interface DevPreviewSession {
+  panelId: string;
+  ptyId: string;
+  projectRoot: string;
+  cols: number;
+  rows: number;
+  status: DevPreviewStatus;
+  statusMessage: string;
+  url: string | null;
+  packageManager: string | null;
+  devCommand: string | null;
+  installCommand: string | null;
+  error?: string;
+  timestamp: number;
+}
+
+export interface DevPreviewStartOptions {
+  panelId: string;
+  cwd: string;
+  cols: number;
+  rows: number;
+}
+
+export class DevPreviewService extends EventEmitter {
+  private sessions = new Map<string, DevPreviewSession>();
+
+  constructor(private ptyClient: PtyClient) {
+    super();
+  }
+
+  async start(options: DevPreviewStartOptions): Promise<void> {
+    const { panelId, cwd, cols, rows } = options;
+
+    const packageManager = await this.detectPackageManager(cwd);
+    if (!packageManager) {
+      this.emitStatus(panelId, "error", "No package.json found", null);
+      return;
+    }
+
+    const devCommand = await this.detectDevCommand(cwd, packageManager);
+    if (!devCommand) {
+      this.emitStatus(panelId, "error", "No dev script found in package.json", null);
+      return;
+    }
+
+    const needsInstall = await this.needsDependencyInstall(cwd);
+    const installCommand = needsInstall ? this.getInstallCommand(packageManager) : null;
+
+    let fullCommand: string;
+    if (installCommand) {
+      fullCommand = `${installCommand} && ${devCommand}`;
+      this.emitStatus(panelId, "installing", "Installing dependencies...", null);
+    } else {
+      fullCommand = devCommand;
+      this.emitStatus(panelId, "starting", "Starting dev server...", null);
+    }
+
+    const ptyId = crypto.randomUUID();
+    this.ptyClient.spawn(ptyId, {
+      cwd,
+      cols,
+      rows,
+    });
+    setTimeout(() => {
+      if (this.ptyClient.hasTerminal(ptyId)) {
+        this.ptyClient.submit(ptyId, fullCommand);
+      }
+    }, 100);
+
+    const session: DevPreviewSession = {
+      panelId,
+      ptyId,
+      projectRoot: cwd,
+      cols,
+      rows,
+      status: needsInstall ? "installing" : "starting",
+      statusMessage: needsInstall ? "Installing dependencies..." : "Starting dev server...",
+      url: null,
+      packageManager,
+      devCommand,
+      installCommand,
+      timestamp: Date.now(),
+    };
+
+    this.sessions.set(panelId, session);
+
+    this.ptyClient.on("data", (data) => {
+      if (data.id === ptyId) {
+        this.handlePtyData(panelId, data.data);
+      }
+    });
+
+    this.ptyClient.on("exit", (data) => {
+      if (data.id === ptyId) {
+        this.handlePtyExit(panelId, data.code);
+      }
+    });
+  }
+
+  async stop(panelId: string): Promise<void> {
+    const session = this.sessions.get(panelId);
+    if (!session) return;
+
+    await this.ptyClient.kill(session.ptyId);
+    this.sessions.delete(panelId);
+    this.emitStatus(panelId, "stopped", "Dev server stopped", null);
+  }
+
+  async restart(panelId: string): Promise<void> {
+    const session = this.sessions.get(panelId);
+    if (!session) return;
+
+    const { projectRoot, cols, rows } = session;
+
+    await this.stop(panelId);
+
+    await this.start({
+      panelId,
+      cwd: projectRoot,
+      cols: cols || 80,
+      rows: rows || 24,
+    });
+  }
+
+  setUrl(panelId: string, url: string): void {
+    const session = this.sessions.get(panelId);
+    if (!session) return;
+
+    session.url = url;
+    session.status = "running";
+    session.statusMessage = "Running";
+    session.timestamp = Date.now();
+
+    this.emit("url", { panelId, url });
+    this.emitStatus(panelId, "running", "Running", url);
+  }
+
+  getSession(panelId: string): DevPreviewSession | undefined {
+    return this.sessions.get(panelId);
+  }
+
+  private handlePtyData(panelId: string, data: string): void {
+    const session = this.sessions.get(panelId);
+    if (!session) return;
+
+    const urls = extractLocalhostUrls(data);
+    if (urls.length > 0) {
+      const preferredUrl = this.selectPreferredUrl(urls);
+      if (preferredUrl && preferredUrl !== session.url) {
+        this.setUrl(panelId, preferredUrl);
+      }
+    }
+
+    if (session.status === "installing") {
+      if (data.includes("added") || data.includes("packages in")) {
+        this.emitStatus(panelId, "starting", "Starting dev server...", null);
+      }
+    }
+  }
+
+  private handlePtyExit(panelId: string, code: number): void {
+    const session = this.sessions.get(panelId);
+    if (!session) return;
+
+    if (code !== 0) {
+      this.emitStatus(panelId, "error", `Process exited with code ${code}`, null);
+    } else {
+      this.emitStatus(panelId, "stopped", "Dev server stopped", null);
+    }
+
+    this.sessions.delete(panelId);
+  }
+
+  private selectPreferredUrl(urls: string[]): string | null {
+    if (urls.length === 0) return null;
+    if (urls.length === 1) return urls[0];
+
+    const localPattern = /localhost/i;
+    const localUrls = urls.filter((url) => localPattern.test(url));
+    return localUrls.length > 0 ? localUrls[0] : urls[0];
+  }
+
+  private emitStatus(
+    panelId: string,
+    status: DevPreviewStatus,
+    message: string,
+    url: string | null
+  ): void {
+    const session = this.sessions.get(panelId);
+    if (session) {
+      session.status = status;
+      session.statusMessage = message;
+      session.url = url;
+      session.timestamp = Date.now();
+      if (status === "error") {
+        session.error = message;
+      }
+    }
+
+    this.emit("status", {
+      panelId,
+      status,
+      message,
+      timestamp: Date.now(),
+      error: status === "error" ? message : undefined,
+    });
+  }
+
+  private async detectPackageManager(cwd: string): Promise<string | null> {
+    const pkgPath = path.join(cwd, "package.json");
+    if (!existsSync(pkgPath)) return null;
+
+    if (existsSync(path.join(cwd, "pnpm-lock.yaml"))) return "pnpm";
+    if (existsSync(path.join(cwd, "yarn.lock"))) return "yarn";
+    if (existsSync(path.join(cwd, "bun.lockb"))) return "bun";
+    return "npm";
+  }
+
+  private async detectDevCommand(cwd: string, packageManager: string): Promise<string | null> {
+    const pkgPath = path.join(cwd, "package.json");
+    try {
+      const content = await readFile(pkgPath, "utf-8");
+      const pkg = JSON.parse(content);
+
+      if (pkg.scripts?.dev) {
+        return this.formatDevCommand(packageManager, "dev");
+      }
+      if (pkg.scripts?.start) {
+        return this.formatDevCommand(packageManager, "start");
+      }
+
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private formatDevCommand(packageManager: string, script: string): string {
+    if (packageManager === "yarn") return `yarn ${script}`;
+    if (packageManager === "bun") return `bun run ${script}`;
+    if (packageManager === "pnpm") return `pnpm run ${script}`;
+    return `npm run ${script}`;
+  }
+
+  private async needsDependencyInstall(cwd: string): Promise<boolean> {
+    return !existsSync(path.join(cwd, "node_modules"));
+  }
+
+  private getInstallCommand(packageManager: string): string {
+    if (packageManager === "pnpm") return "pnpm install";
+    if (packageManager === "yarn") return "yarn install";
+    if (packageManager === "bun") return "bun install";
+    return "npm install";
+  }
+}

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -68,6 +68,15 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     canRestart: false,
     canConvert: false,
   },
+  "dev-preview": {
+    id: "dev-preview",
+    name: "Dev Preview",
+    iconId: "monitor",
+    color: "#8b5cf6", // purple-500
+    hasPty: true,
+    canRestart: true,
+    canConvert: false,
+  },
 };
 
 /**
@@ -171,5 +180,5 @@ export function panelKindHasPty(kind: PanelKind): boolean {
  * Get all built-in panel kinds.
  */
 export function getBuiltInPanelKinds(): BuiltInPanelKind[] {
-  return ["terminal", "agent", "browser", "notes"];
+  return ["terminal", "agent", "browser", "notes", "dev-preview"];
 }

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -195,7 +195,7 @@ export type AgentId = string;
 export type LegacyAgentType = "claude" | "gemini" | "codex";
 
 /** Built-in panel kinds */
-export type BuiltInPanelKind = "terminal" | "agent" | "browser" | "notes";
+export type BuiltInPanelKind = "terminal" | "agent" | "browser" | "notes" | "dev-preview";
 
 /**
  * Panel kind: distinguishes between default terminals, agent-driven terminals, browser panels,
@@ -226,7 +226,13 @@ export type TerminalLocation = PanelLocation;
 
 /** Type guard to check if a panel kind is a built-in kind */
 export function isBuiltInPanelKind(kind: PanelKind): kind is BuiltInPanelKind {
-  return kind === "terminal" || kind === "agent" || kind === "browser" || kind === "notes";
+  return (
+    kind === "terminal" ||
+    kind === "agent" ||
+    kind === "browser" ||
+    kind === "notes" ||
+    kind === "dev-preview"
+  );
 }
 
 /**
@@ -236,7 +242,7 @@ export function isBuiltInPanelKind(kind: PanelKind): kind is BuiltInPanelKind {
  */
 export function isPtyPanelKind(kind: PanelKind): boolean {
   // Built-in kinds - for extension kinds, use panelKindHasPty() from registry
-  return kind === "terminal" || kind === "agent";
+  return kind === "terminal" || kind === "agent" || kind === "dev-preview";
 }
 
 /** Valid triggers for agent state changes */
@@ -293,7 +299,7 @@ interface BasePanelData {
 }
 
 interface PtyPanelData extends BasePanelData {
-  kind: "terminal" | "agent";
+  kind: "terminal" | "agent" | "dev-preview";
   /**
    * Legacy field retained for persistence; new code should prefer `kind`.
    * - "terminal" for default terminals
@@ -344,6 +350,8 @@ interface PtyPanelData extends BasePanelData {
   flowStatusTimestamp?: number;
   /** Whether user input is locked (read-only monitor mode) */
   isInputLocked?: boolean;
+  /** Current URL for dev-preview panels */
+  browserUrl?: string;
 }
 
 interface BrowserPanelData extends BasePanelData {
@@ -368,7 +376,7 @@ export type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData;
 
 export function isPtyPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
-  return kind === "terminal" || kind === "agent";
+  return kind === "terminal" || kind === "agent" || kind === "dev-preview";
 }
 
 export function isBrowserPanel(panel: PanelInstance | TerminalInstance): panel is BrowserPanelData {
@@ -378,6 +386,11 @@ export function isBrowserPanel(panel: PanelInstance | TerminalInstance): panel i
 
 export function isNotesPanel(panel: PanelInstance): panel is NotesPanelData {
   return panel.kind === "notes";
+}
+
+export function isDevPreviewPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
+  const kind = panel.kind ?? "terminal";
+  return kind === "dev-preview";
 }
 
 /**

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -56,6 +56,7 @@ import type { TerminalStatusPayload, PtyHostActivityTier } from "../pty-host.js"
 import type { ShowContextMenuPayload } from "../menu.js";
 import type { FileSearchPayload, FileSearchResult } from "./files.js";
 import type { SlashCommand, SlashCommandListRequest } from "../slashCommands.js";
+import type { DevPreviewStatusPayload, DevPreviewUrlPayload } from "./devPreview.js";
 
 // ElectronAPI Type (exposed via preload)
 
@@ -297,6 +298,14 @@ export interface ElectronAPI {
       }>
     >;
     delete(notePath: string): Promise<void>;
+  };
+  devPreview: {
+    start(panelId: string, cwd: string, cols: number, rows: number): Promise<void>;
+    stop(panelId: string): Promise<void>;
+    restart(panelId: string): Promise<void>;
+    setUrl(panelId: string, url: string): Promise<void>;
+    onStatus(callback: (data: DevPreviewStatusPayload) => void): () => void;
+    onUrl(callback: (data: DevPreviewUrlPayload) => void): () => void;
   };
   git: {
     getFileDiff(cwd: string, filePath: string, status: GitStatus): Promise<string>;

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -1,0 +1,14 @@
+export type DevPreviewStatus = "installing" | "starting" | "running" | "error" | "stopped";
+
+export interface DevPreviewStatusPayload {
+  panelId: string;
+  status: DevPreviewStatus;
+  message: string;
+  timestamp: number;
+  error?: string;
+}
+
+export interface DevPreviewUrlPayload {
+  panelId: string;
+  url: string;
+}

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -14,5 +14,6 @@ export * from "./agent.js";
 export * from "./git.js";
 export * from "./files.js";
 export * from "./config.js";
+export * from "./devPreview.js";
 export * from "./maps.js";
 export * from "./api.js";

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -64,6 +64,7 @@ import type { TerminalFlowStatus } from "../pty-host.js";
 import type { ShowContextMenuPayload } from "../menu.js";
 import type { FileSearchPayload, FileSearchResult } from "./files.js";
 import type { SlashCommand, SlashCommandListRequest } from "../slashCommands.js";
+import type { DevPreviewStatusPayload, DevPreviewUrlPayload } from "./devPreview.js";
 
 // IPC Contract Maps
 
@@ -698,6 +699,24 @@ export interface IpcInvokeMap {
     args: [notePath: string];
     result: void;
   };
+
+  // Dev Preview channels
+  "dev-preview:start": {
+    args: [panelId: string, cwd: string, cols: number, rows: number];
+    result: void;
+  };
+  "dev-preview:stop": {
+    args: [panelId: string];
+    result: void;
+  };
+  "dev-preview:restart": {
+    args: [panelId: string];
+    result: void;
+  };
+  "dev-preview:set-url": {
+    args: [panelId: string, url: string];
+    result: void;
+  };
 }
 
 /**
@@ -768,6 +787,10 @@ export interface IpcEventMap {
 
   // Menu events
   "menu:action": string;
+
+  // Dev Preview events
+  "dev-preview:status": DevPreviewStatusPayload;
+  "dev-preview:url": DevPreviewUrlPayload;
 }
 
 export type IpcInvokeArgs<K extends keyof IpcInvokeMap> = IpcInvokeMap[K]["args"];

--- a/shared/utils/urlUtils.ts
+++ b/shared/utils/urlUtils.ts
@@ -1,0 +1,79 @@
+const ALLOWED_HOSTS = ["localhost", "127.0.0.1", "::1"];
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
+
+export interface NormalizeResult {
+  url?: string;
+  error?: string;
+}
+
+export function normalizeBrowserUrl(input: string): NormalizeResult {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { error: "URL cannot be empty" };
+  }
+
+  let urlString = trimmed;
+
+  urlString = urlString.replace(/\b0\.0\.0\.0\b/g, "localhost");
+
+  if (!urlString.includes("://")) {
+    urlString = `http://${urlString}`;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(urlString);
+  } catch {
+    return { error: "Invalid URL format" };
+  }
+
+  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
+    return { error: `Protocol "${parsed.protocol}" not allowed. Use http: or https:` };
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (!ALLOWED_HOSTS.includes(hostname)) {
+    return { error: `Only localhost URLs are allowed (got "${hostname}")` };
+  }
+
+  parsed.username = "";
+  parsed.password = "";
+
+  return { url: parsed.toString() };
+}
+
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    return ALLOWED_HOSTS.includes(hostname) && ALLOWED_PROTOCOLS.includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+export function stripAnsiAndOscCodes(text: string): string {
+  return text
+    .replace(/\x1b\[\d+m/g, "")
+    .replace(/\x1b\[[0-9;]*[A-Za-z]/g, "")
+    .replace(/\x1b\]8;;[^\x07]*\x07([^\x1b]*)\x1b\]8;;\x07/g, "$1");
+}
+
+export function extractLocalhostUrls(text: string): string[] {
+  const urlRegex = /https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0|::1)(:\d+)?([^\s"'<>)]*)?/gi;
+  const matches = text.match(urlRegex) || [];
+  const cleaned = stripAnsiAndOscCodes(text);
+  const cleanMatches = cleaned.match(urlRegex) || [];
+
+  const allMatches = [...new Set([...matches, ...cleanMatches])];
+
+  const normalized: string[] = [];
+  for (const match of allMatches) {
+    const result = normalizeBrowserUrl(match);
+    if (result.url) {
+      normalized.push(result.url);
+    }
+  }
+
+  return [...new Set(normalized)];
+}

--- a/src/components/Browser/browserUtils.ts
+++ b/src/components/Browser/browserUtils.ts
@@ -1,61 +1,9 @@
-const ALLOWED_HOSTS = ["localhost", "127.0.0.1", "::1"];
-const ALLOWED_PROTOCOLS = ["http:", "https:"];
-
-export interface NormalizeResult {
-  url?: string;
-  error?: string;
-}
-
-export function normalizeBrowserUrl(input: string): NormalizeResult {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return { error: "URL cannot be empty" };
-  }
-
-  let urlString = trimmed;
-
-  // Map 0.0.0.0 to localhost (common dev server output)
-  urlString = urlString.replace(/\b0\.0\.0\.0\b/g, "localhost");
-
-  // Auto-prepend http:// if no protocol specified
-  if (!urlString.includes("://")) {
-    urlString = `http://${urlString}`;
-  }
-
-  let parsed: URL;
-  try {
-    parsed = new URL(urlString);
-  } catch {
-    return { error: "Invalid URL format" };
-  }
-
-  // Validate protocol
-  if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
-    return { error: `Protocol "${parsed.protocol}" not allowed. Use http: or https:` };
-  }
-
-  // Validate hostname (only allow localhost variants)
-  const hostname = parsed.hostname.toLowerCase();
-  if (!ALLOWED_HOSTS.includes(hostname)) {
-    return { error: `Only localhost URLs are allowed (got "${hostname}")` };
-  }
-
-  // Strip username/password for security
-  parsed.username = "";
-  parsed.password = "";
-
-  return { url: parsed.toString() };
-}
-
-export function isLocalhostUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    const hostname = parsed.hostname.toLowerCase();
-    return ALLOWED_HOSTS.includes(hostname) && ALLOWED_PROTOCOLS.includes(parsed.protocol);
-  } catch {
-    return false;
-  }
-}
+import { normalizeBrowserUrl as normalizeUrl } from "../../../shared/utils/urlUtils.js";
+export {
+  normalizeBrowserUrl,
+  isLocalhostUrl,
+  type NormalizeResult,
+} from "../../../shared/utils/urlUtils.js";
 
 export function getDisplayUrl(url: string): string {
   try {
@@ -80,6 +28,6 @@ export function extractHostPort(url: string): string {
 
 export function isValidBrowserUrl(url: string | undefined | null): boolean {
   if (!url || !url.trim()) return false;
-  const normalized = normalizeBrowserUrl(url);
+  const normalized = normalizeUrl(url);
   return !normalized.error && !!normalized.url;
 }

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useState } from "react";
+import { ContentPanel, type BasePanelProps } from "@/components/Panel";
+import { cn } from "@/lib/utils";
+import { useTerminalStore } from "@/store";
+import type { DevPreviewStatus } from "@shared/types/ipc/devPreview";
+
+const STATUS_STYLES: Record<DevPreviewStatus, { label: string; dot: string; text: string }> = {
+  installing: {
+    label: "Installing",
+    dot: "bg-[var(--color-status-warning)]",
+    text: "text-[var(--color-status-warning)]",
+  },
+  starting: {
+    label: "Starting",
+    dot: "bg-[var(--color-status-info)]",
+    text: "text-[var(--color-status-info)]",
+  },
+  running: {
+    label: "Running",
+    dot: "bg-[var(--color-status-success)]",
+    text: "text-[var(--color-status-success)]",
+  },
+  error: {
+    label: "Error",
+    dot: "bg-[var(--color-status-error)]",
+    text: "text-[var(--color-status-error)]",
+  },
+  stopped: {
+    label: "Stopped",
+    dot: "bg-canopy-text/40",
+    text: "text-canopy-text/50",
+  },
+};
+
+export interface DevPreviewPaneProps extends BasePanelProps {
+  cwd: string;
+}
+
+export function DevPreviewPane({
+  id,
+  title,
+  cwd,
+  isFocused,
+  isMaximized = false,
+  location = "grid",
+  onFocus,
+  onClose,
+  onToggleMaximize,
+  onTitleChange,
+  onMinimize,
+  onRestore,
+  isTrashing = false,
+  gridPanelCount,
+}: DevPreviewPaneProps) {
+  const [status, setStatus] = useState<DevPreviewStatus>("starting");
+  const [message, setMessage] = useState("Starting dev server...");
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const offStatus = window.electron.devPreview.onStatus((payload) => {
+      if (payload.panelId !== id) return;
+      setStatus(payload.status);
+      setMessage(payload.message);
+      setError(payload.status === "error" ? (payload.error ?? payload.message) : undefined);
+    });
+
+    const offUrl = window.electron.devPreview.onUrl((payload) => {
+      if (payload.panelId !== id) return;
+      setUrl(payload.url);
+    });
+
+    return () => {
+      offStatus();
+      offUrl();
+    };
+  }, [id]);
+
+  useEffect(() => {
+    setUrl(null);
+    setError(undefined);
+    setStatus("starting");
+    setMessage("Starting dev server...");
+
+    const terminal = useTerminalStore.getState().getTerminal(id);
+    const cols = terminal?.cols ?? 80;
+    const rows = terminal?.rows ?? 24;
+
+    void window.electron.devPreview.start(id, cwd, cols, rows);
+
+    return () => {
+      void window.electron.devPreview.stop(id);
+    };
+  }, [id, cwd]);
+
+  const handleRestart = useCallback(() => {
+    setUrl(null);
+    setError(undefined);
+    setStatus("starting");
+    setMessage("Restarting dev server...");
+    void window.electron.devPreview.restart(id);
+  }, [id]);
+
+  const statusStyle = STATUS_STYLES[status];
+
+  return (
+    <ContentPanel
+      id={id}
+      title={title}
+      kind="dev-preview"
+      isFocused={isFocused}
+      isMaximized={isMaximized}
+      location={location}
+      isTrashing={isTrashing}
+      gridPanelCount={gridPanelCount}
+      onFocus={onFocus}
+      onClose={onClose}
+      onToggleMaximize={onToggleMaximize}
+      onTitleChange={onTitleChange}
+      onMinimize={onMinimize}
+      onRestore={onRestore}
+      onRestart={handleRestart}
+    >
+      <div className="flex flex-1 min-h-0 flex-col">
+        <div className="relative flex-1 min-h-0 bg-white">
+          {url ? (
+            <iframe
+              src={url}
+              title={title}
+              className="w-full h-full border-0"
+              sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center bg-canopy-bg">
+              <div className="text-center max-w-md space-y-1 px-4">
+                <div className="text-sm font-medium text-canopy-text">Dev Preview</div>
+                <div className="text-xs text-canopy-text/60">{message}</div>
+                {error && <div className="text-xs text-[var(--color-status-error)]">{error}</div>}
+              </div>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-between gap-3 px-3 py-1.5 border-t border-canopy-border bg-[color-mix(in_oklab,var(--color-surface)_92%,transparent)] text-xs text-canopy-text/70">
+          <div className="flex items-center gap-2 min-w-0" role="status" aria-live="polite">
+            <span className={cn("h-2 w-2 rounded-full shrink-0", statusStyle.dot)} />
+            <span className={cn("font-medium", statusStyle.text)}>{statusStyle.label}</span>
+            <span className="truncate">{message}</span>
+          </div>
+          {url && <span className="font-mono text-canopy-text/50 truncate max-w-[45%]">{url}</span>}
+        </div>
+      </div>
+    </ContentPanel>
+  );
+}

--- a/src/components/PanelPalette/PanelKindIcon.tsx
+++ b/src/components/PanelPalette/PanelKindIcon.tsx
@@ -1,4 +1,4 @@
-import { Terminal, Globe, FileText, GitBranch, LucideIcon } from "lucide-react";
+import { Terminal, Globe, FileText, GitBranch, Monitor, LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const ICON_MAP: Record<string, LucideIcon> = {
@@ -6,6 +6,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   globe: Globe,
   "file-text": FileText,
   "git-branch": GitBranch,
+  monitor: Monitor,
 };
 
 export interface PanelKindIconProps {

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -1,4 +1,4 @@
-import { Terminal, Globe, StickyNote } from "lucide-react";
+import { Terminal, Globe, StickyNote, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TerminalType, TerminalKind } from "@/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
@@ -25,6 +25,11 @@ export function TerminalIcon({ type, kind, agentId, className, brandColor }: Ter
   // Notes panes get a sticky note icon
   if (kind === "notes") {
     return <StickyNote {...finalProps} className={cn(finalProps.className, "text-amber-400")} />;
+  }
+
+  // Dev preview panes get a monitor icon
+  if (kind === "dev-preview") {
+    return <Monitor {...finalProps} className={cn(finalProps.className, "text-violet-400")} />;
   }
 
   // Get effective agent ID - either from explicit agentId prop or from type (backward compat)

--- a/src/registry/builtInPanelRegistrations.ts
+++ b/src/registry/builtInPanelRegistrations.ts
@@ -6,6 +6,7 @@ import { registerPanelComponent } from "./panelComponentRegistry";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { BrowserPane } from "@/components/Browser/BrowserPane";
 import { NotesPane } from "@/components/Notes/NotesPane";
+import { DevPreviewPane } from "@/components/DevPreview/DevPreviewPane";
 
 // Registration flag to prevent double registration
 let registered = false;
@@ -37,5 +38,10 @@ export function registerBuiltInPanelComponents(): void {
   // Notes panel - Markdown note editor
   registerPanelComponent("notes", {
     component: NotesPane,
+  });
+
+  // Dev Preview panel - auto-starts dev server and shows iframe
+  registerPanelComponent("dev-preview", {
+    component: DevPreviewPane,
   });
 }


### PR DESCRIPTION
## Summary

Implements the Dev Preview Panel feature that automatically manages dev server lifecycle and displays localhost previews in an iframe. This panel auto-detects package managers, installs dependencies if needed, runs dev scripts, detects the localhost URL from PTY output, and shows a live preview with a status strip.

Closes #1256

## Changes Made

- **Panel Kind**: Added `dev-preview` to built-in panel kinds with PTY support, restart capability, and Monitor icon
- **Service Layer**: Implemented `DevPreviewService` with auto-detection of package manager (pnpm/yarn/bun/npm), dependency installation decision, dev script detection (dev → start fallback), and URL extraction from terminal output
- **IPC Contract**: Added channels (`dev-preview:start/stop/restart/set-url`), handlers, and preload API with typed event subscriptions for status and URL updates
- **UI Component**: Created `DevPreviewPane` with iframe preview (localhost-only), toggle between preview/terminal views, status strip showing install/starting/running/error states, and restart support
- **URL Utilities**: Extracted URL normalization and localhost validation into `shared/utils/urlUtils.ts` for reuse across main and renderer processes
- **Icons**: Added Monitor icon to `PanelKindIcon` and `TerminalIcon` components

## Implementation Details

- **Phase 1 MVP**: Iframe preview + terminal logs + auto-detection
- **Localhost-only security**: All URLs validated to localhost/127.0.0.1/::1 variants
- **PTY-backed**: Uses existing PTY infrastructure for terminal output capture
- **Type-safe**: Full TypeScript support with IPC type maps and discriminated unions

## Testing

- [x] TypeScript compilation passes
- [x] Linting passes (existing warnings only)
- [x] Formatting applied

## Next Steps

- Manual testing of panel creation and dev server lifecycle
- Potential follow-up: WebContentsView-based preview for console capture (v2)