### PR TITLE
Update 'Create Note' action to open notes palette

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -551,8 +551,8 @@ export function Toolbar({
             size="icon"
             onClick={() => actionService.dispatch("notes.create", {}, { source: "user" })}
             className="text-canopy-text hover:bg-white/[0.06] hover:text-canopy-accent transition-colors"
-            title="Create New Note"
-            aria-label="Create new note"
+            title="Notes"
+            aria-label="Open notes palette"
           >
             <StickyNote />
           </Button>

--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -4,6 +4,7 @@ import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { useNotesStore } from "@/store/notesStore";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import type { NoteListItem } from "@/clients/notesClient";
 import { FileText, Plus, Trash2 } from "lucide-react";
@@ -22,6 +23,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
   const { notes, isLoading, initialize, createNote, deleteNote } = useNotesStore();
   const { addTerminal } = useTerminalStore();
   const { getWorktree } = useWorktreeDataStore();
+  const { activeWorktreeId } = useWorktreeSelectionStore();
 
   useEffect(() => {
     if (isOpen) {
@@ -71,7 +73,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
         kind: "notes",
         title: noteContent.metadata.title,
         cwd: "",
-        worktreeId: undefined,
+        worktreeId: activeWorktreeId ?? undefined,
         notePath: noteContent.path,
         noteId: noteContent.metadata.id,
         scope: noteContent.metadata.scope,
@@ -82,7 +84,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
     } catch (error) {
       console.error("Failed to create note:", error);
     }
-  }, [createNote, addTerminal, onClose]);
+  }, [createNote, addTerminal, activeWorktreeId, onClose]);
 
   const handleOpenNote = useCallback(
     async (note: NoteListItem) => {

--- a/src/services/actions/definitions/notesActions.ts
+++ b/src/services/actions/definitions/notesActions.ts
@@ -1,43 +1,16 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import { z } from "zod";
-import { notesClient } from "@/clients/notesClient";
-import { useTerminalStore } from "@/store/terminalStore";
-import { useNotesStore } from "@/store/notesStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 export function registerNotesActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("notes.create", () => ({
     id: "notes.create",
-    title: "Create Note",
-    description: "Create a new notes panel",
+    title: "Notes...",
+    description: "Open the notes palette to browse and manage notes",
     category: "notes",
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ title: z.string().optional() }).optional(),
-    run: async (args: unknown) => {
-      const { title } = (args as { title?: string } | undefined) ?? {};
-      const noteTitle = title || `Note ${new Date().toLocaleDateString()}`;
-      const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-
-      try {
-        const noteContent = await notesClient.create(noteTitle, "project");
-
-        await useTerminalStore.getState().addTerminal({
-          kind: "notes",
-          title: noteContent.metadata.title,
-          cwd: "",
-          worktreeId: activeWorktreeId ?? undefined,
-          notePath: noteContent.path,
-          noteId: noteContent.metadata.id,
-          scope: noteContent.metadata.scope,
-          createdAt: noteContent.metadata.createdAt,
-        });
-
-        useNotesStore.getState().refresh();
-      } catch (error) {
-        console.error("Failed to create note:", error);
-      }
+    run: async () => {
+      window.dispatchEvent(new CustomEvent("canopy:open-notes-palette"));
     },
   }));
 


### PR DESCRIPTION
## Summary
Changes the existing "Create Note" action to open the notes palette dialog instead of immediately creating a new note. This makes the notes palette the primary interface for all note interactions.

Closes #1310

## Changes Made
- Updated notes.create action to dispatch canopy:open-notes-palette event
- Changed action title from "Create Note" to "Notes..."
- Removed direct note creation logic from action
- Updated toolbar button labels to reflect new behavior
- Fixed worktree scoping in NotesPalette to preserve active worktree ID when creating notes