### PR TITLE
Add tooltips showing issue and PR titles to WorkTree card badges

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -199,6 +199,7 @@ function parseBatchPRResponse(
       for (const node of issueData as Array<{
         source?: {
           number?: number;
+          title?: string;
           url?: string;
           state?: string;
           isDraft?: boolean;
@@ -209,6 +210,7 @@ function parseBatchPRResponse(
         if (source?.number && source?.url) {
           prs.push({
             number: source.number,
+            title: source.title || "",
             url: source.url,
             state: source.merged
               ? "merged"
@@ -237,6 +239,7 @@ function parseBatchPRResponse(
       if (branchData && Array.isArray(branchData) && branchData.length > 0) {
         const pr = branchData[0] as {
           number?: number;
+          title?: string;
           url?: string;
           state?: string;
           isDraft?: boolean;
@@ -245,6 +248,7 @@ function parseBatchPRResponse(
         if (pr?.number && pr?.url) {
           foundPR = {
             number: pr.number,
+            title: pr.title || "",
             url: pr.url,
             state: pr.merged ? "merged" : (pr.state?.toLowerCase() as "open" | "closed") || "open",
             isDraft: pr.isDraft ?? false,

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -293,6 +293,7 @@ class PullRequestService {
             prNumber: checkResult.pr.number,
             prUrl: checkResult.pr.url,
             prState: checkResult.pr.state,
+            prTitle: checkResult.pr.title,
             issueNumber:
               checkResult.issueNumber ?? this.candidates.get(worktreeId)?.issueNumber ?? undefined,
             timestamp: Date.now(),

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -37,6 +37,7 @@ describe("PullRequestService", () => {
             branchName: candidates[0].branchName,
             pr: {
               number: 42,
+              title: "Add new feature",
               url: "https://github.com/o/r/pull/42",
               state: "open",
               isDraft: false,
@@ -74,6 +75,7 @@ describe("PullRequestService", () => {
       prNumber: 42,
       prUrl: "https://github.com/o/r/pull/42",
       prState: "open",
+      prTitle: "Add new feature",
     });
     expect(detected[0].issueNumber).toBeUndefined();
 
@@ -114,7 +116,13 @@ describe("PullRequestService", () => {
           {
             issueNumber: c.issueNumber,
             branchName: c.branchName,
-            pr: { number: 7, url: "https://github.com/o/r/pull/7", state: "open", isDraft: false },
+            pr: {
+              number: 7,
+              title: "Fix bug",
+              url: "https://github.com/o/r/pull/7",
+              state: "open",
+              isDraft: false,
+            },
           },
         ])
       ),

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -440,6 +440,7 @@ export type CanopyEventMap = {
     prNumber: number;
     prUrl: string;
     prState: "open" | "merged" | "closed";
+    prTitle?: string;
     issueNumber?: number;
     timestamp: number;
   };

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -160,6 +160,7 @@ export function buildBatchPRQuery(
                   source {
                     ... on PullRequest {
                       number
+                      title
                       url
                       state
                       isDraft
@@ -181,6 +182,7 @@ export function buildBatchPRQuery(
           pullRequests(first: 1, states: [OPEN, MERGED, CLOSED], headRefName: "${escapedBranch}", orderBy: {field: UPDATED_AT, direction: DESC}) {
             nodes {
               number
+              title
               url
               state
               isDraft

--- a/electron/services/github/types.ts
+++ b/electron/services/github/types.ts
@@ -20,6 +20,7 @@ export interface LinkedPR {
   url: string;
   state: "open" | "merged" | "closed";
   isDraft: boolean;
+  title: string;
 }
 
 export interface PRCheckResult {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -548,6 +548,8 @@ export class WorkspaceService {
       prNumber: monitor.prNumber,
       prUrl: monitor.prUrl,
       prState: monitor.prState,
+      prTitle: monitor.prTitle,
+      issueTitle: monitor.issueTitle,
       worktreeChanges: monitor.worktreeChanges,
       worktreeId: monitor.worktreeId,
       timestamp: Date.now(),
@@ -944,6 +946,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           monitor.prNumber = data.prNumber;
           monitor.prUrl = data.prUrl;
           monitor.prState = data.prState;
+          monitor.prTitle = data.prTitle;
           this.emitUpdate(monitor);
         }
 
@@ -953,6 +956,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           prNumber: data.prNumber,
           prUrl: data.prUrl,
           prState: data.prState,
+          prTitle: data.prTitle,
+          issueNumber: data.issueNumber,
         });
       })
     );
@@ -964,6 +969,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           monitor.prNumber = undefined;
           monitor.prUrl = undefined;
           monitor.prState = undefined;
+          monitor.prTitle = undefined;
           this.emitUpdate(monitor);
         }
 

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -124,6 +124,12 @@ export interface Worktree {
   /** Pull request state: open, merged, or closed */
   prState?: "open" | "merged" | "closed";
 
+  /** Pull request title */
+  prTitle?: string;
+
+  /** GitHub issue title */
+  issueTitle?: string;
+
   /** Worktree changes snapshot */
   worktreeChanges?: WorktreeChanges | null;
 }

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -52,6 +52,7 @@ export interface PRDetectedPayload {
   prNumber: number;
   prUrl: string;
   prState: "open" | "merged" | "closed";
+  prTitle?: string;
   issueNumber?: number;
 }
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -67,6 +67,8 @@ export interface WorktreeSnapshot {
   prNumber?: number;
   prUrl?: string;
   prState?: "open" | "merged" | "closed";
+  prTitle?: string;
+  issueTitle?: string;
   worktreeChanges?: WorktreeChanges | null;
   worktreeId: string;
   timestamp?: number;
@@ -204,6 +206,8 @@ export type WorkspaceHostEvent =
       prNumber: number;
       prUrl: string;
       prState: "open" | "merged" | "closed";
+      prTitle?: string;
+      issueNumber?: number;
     }
   | { type: "pr-cleared"; worktreeId: string }
   // CopyTree events

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -261,41 +261,53 @@ export function WorktreeHeader({
         </div>
       </div>
 
-      {worktree.issueNumber && (
+      {(worktree.issueNumber || worktree.prNumber) && (
         <div className="flex items-center gap-2">
           {worktree.issueNumber && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                badges.onOpenIssue?.();
-              }}
-              className="flex items-center gap-1 text-xs text-emerald-400/80 hover:text-emerald-400 hover:underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-              title="Open Issue on GitHub"
-            >
-              <CircleDot className="w-2.5 h-2.5" />
-              <span className="font-mono">#{worktree.issueNumber}</span>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    badges.onOpenIssue?.();
+                  }}
+                  className="flex items-center gap-1 text-xs text-emerald-400/80 hover:text-emerald-400 hover:underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+                >
+                  <CircleDot className="w-2.5 h-2.5" />
+                  <span className="font-mono">#{worktree.issueNumber}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {worktree.issueTitle || "Open Issue on GitHub"}
+              </TooltipContent>
+            </Tooltip>
           )}
           {worktree.prNumber && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                badges.onOpenPR?.();
-              }}
-              className={cn(
-                "flex items-center gap-1 text-xs hover:underline transition-colors",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
-                worktree.prState === "merged"
-                  ? "text-violet-400/80 hover:text-violet-400"
-                  : worktree.prState === "closed"
-                    ? "text-red-400/80 hover:text-red-400"
-                    : "text-sky-400/80 hover:text-sky-400"
-              )}
-              title={`PR #${worktree.prNumber} · ${worktree.prState ?? "open"}`}
-            >
-              <GitPullRequest className="w-2.5 h-2.5" />
-              <span className="font-mono">#{worktree.prNumber}</span>
-            </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    badges.onOpenPR?.();
+                  }}
+                  className={cn(
+                    "flex items-center gap-1 text-xs hover:underline transition-colors",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
+                    worktree.prState === "merged"
+                      ? "text-violet-400/80 hover:text-violet-400"
+                      : worktree.prState === "closed"
+                        ? "text-red-400/80 hover:text-red-400"
+                        : "text-sky-400/80 hover:text-sky-400"
+                  )}
+                >
+                  <GitPullRequest className="w-2.5 h-2.5" />
+                  <span className="font-mono">#{worktree.prNumber}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {worktree.prTitle || `PR #${worktree.prNumber} · ${worktree.prState ?? "open"}`}
+              </TooltipContent>
+            </Tooltip>
           )}
         </div>
       )}

--- a/src/store/__tests__/worktreeDataStore.prEvents.test.ts
+++ b/src/store/__tests__/worktreeDataStore.prEvents.test.ts
@@ -82,6 +82,7 @@ function createMockWorktree(id: string, prNumber?: number): WorktreeState {
     prNumber,
     prUrl: prNumber ? `https://github.com/test/repo/pull/${prNumber}` : undefined,
     prState: prNumber ? "open" : undefined,
+    prTitle: prNumber ? `Test PR ${prNumber}` : undefined,
   };
 }
 
@@ -107,12 +108,14 @@ describe("worktreeDataStore PR events", () => {
       prNumber: 123,
       prUrl: "https://github.com/test/repo/pull/123",
       prState: "open",
+      prTitle: "Add new feature",
     });
 
     const updated = store.getState().worktrees.get("wt-1");
     expect(updated?.prNumber).toBe(123);
     expect(updated?.prUrl).toBe("https://github.com/test/repo/pull/123");
     expect(updated?.prState).toBe("open");
+    expect(updated?.prTitle).toBe("Add new feature");
     expect(updated?.name).toBe("worktree-wt-1");
   });
 
@@ -152,6 +155,7 @@ describe("worktreeDataStore PR events", () => {
     expect(updated?.prNumber).toBeUndefined();
     expect(updated?.prUrl).toBeUndefined();
     expect(updated?.prState).toBeUndefined();
+    expect(updated?.prTitle).toBeUndefined();
     expect(updated?.name).toBe("worktree-wt-2");
   });
 
@@ -198,11 +202,13 @@ describe("worktreeDataStore PR events", () => {
       prNumber: 999,
       prUrl: "https://github.com/test/repo/pull/999",
       prState: "merged",
+      prTitle: "Merged feature",
     });
 
     const updated = store.getState().worktrees.get("wt-3");
     expect(updated?.prNumber).toBe(999);
     expect(updated?.prState).toBe("merged");
+    expect(updated?.prTitle).toBe("Merged feature");
   });
 
   it("handles closed PR state", async () => {
@@ -218,11 +224,13 @@ describe("worktreeDataStore PR events", () => {
       prNumber: 888,
       prUrl: "https://github.com/test/repo/pull/888",
       prState: "closed",
+      prTitle: "Closed PR",
     });
 
     const updated = store.getState().worktrees.get("wt-4");
     expect(updated?.prNumber).toBe(888);
     expect(updated?.prState).toBe("closed");
+    expect(updated?.prTitle).toBe("Closed PR");
   });
 
   it("overwrites existing PR with new PR", async () => {
@@ -240,11 +248,13 @@ describe("worktreeDataStore PR events", () => {
       prNumber: 200,
       prUrl: "https://github.com/test/repo/pull/200",
       prState: "open",
+      prTitle: "Updated PR",
     });
 
     const updated = store.getState().worktrees.get("wt-5");
     expect(updated?.prNumber).toBe(200);
     expect(updated?.prUrl).toBe("https://github.com/test/repo/pull/200");
     expect(updated?.prState).toBe("open");
+    expect(updated?.prTitle).toBe("Updated PR");
   });
 });

--- a/src/store/worktreeDataStore.ts
+++ b/src/store/worktreeDataStore.ts
@@ -82,6 +82,7 @@ export const useWorktreeDataStore = create<WorktreeDataStore>()((set, get) => ({
                   prNumber: state.prNumber ?? existing.prNumber,
                   prUrl: state.prUrl ?? existing.prUrl,
                   prState: state.prState ?? existing.prState,
+                  prTitle: state.prTitle ?? existing.prTitle,
                 });
               } else {
                 next.set(state.id, state);
@@ -147,6 +148,7 @@ export const useWorktreeDataStore = create<WorktreeDataStore>()((set, get) => ({
                 prNumber: data.prNumber,
                 prUrl: data.prUrl,
                 prState: data.prState,
+                prTitle: data.prTitle,
               });
               return { worktrees: next };
             });
@@ -163,6 +165,7 @@ export const useWorktreeDataStore = create<WorktreeDataStore>()((set, get) => ({
                 prNumber: undefined,
                 prUrl: undefined,
                 prState: undefined,
+                prTitle: undefined,
               });
               return { worktrees: next };
             });


### PR DESCRIPTION
## Summary
Adds informative tooltips to issue and PR badges in WorkTree card headers that display the full title when hovered, providing quick context without opening GitHub.

Closes #1321

## Changes Made
- Add title field to LinkedPR interface and GraphQL queries
- Propagate prTitle through PR detection events and WorkspaceService  
- Add prTitle and issueTitle to Worktree and WorktreeSnapshot types
- Replace HTML title attributes with Radix UI tooltips in WorktreeHeader
- Show PR badges even for branches without issue numbers
- Display full titles in tooltips without truncation
- Update tests to include prTitle in PR event payloads