### PR TITLE
feat(worktree): automatically select newly created worktree

### DIFF
--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -60,11 +60,11 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
       rootPath: string;
       options: { baseBranch: string; newBranch: string; path: string; fromRemote?: boolean };
     }
-  ) => {
+  ): Promise<string> => {
     if (!workspaceClient) {
       throw new Error("Workspace client not initialized");
     }
-    await workspaceClient.createWorktree(payload.rootPath, payload.options);
+    return await workspaceClient.createWorktree(payload.rootPath, payload.options);
   };
   ipcMain.handle(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CREATE));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -375,7 +375,7 @@ const api: ElectronAPI = {
 
     setActive: (worktreeId: string) => _typedInvoke(CHANNELS.WORKTREE_SET_ACTIVE, { worktreeId }),
 
-    create: (options: CreateWorktreeOptions, rootPath: string) =>
+    create: (options: CreateWorktreeOptions, rootPath: string): Promise<string> =>
       _typedInvoke(CHANNELS.WORKTREE_CREATE, { rootPath, options }),
 
     listBranches: (rootPath: string) => _typedInvoke(CHANNELS.WORKTREE_LIST_BRANCHES, { rootPath }),

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -592,15 +592,17 @@ export class WorkspaceClient extends EventEmitter {
     return result.branches;
   }
 
-  async createWorktree(rootPath: string, options: CreateWorktreeOptions): Promise<void> {
+  async createWorktree(rootPath: string, options: CreateWorktreeOptions): Promise<string> {
     const requestId = this.generateRequestId();
 
-    await this.sendWithResponse({
+    const result = await this.sendWithResponse<{ worktreeId?: string }>({
       type: "create-worktree",
       requestId,
       rootPath,
       options,
     });
+
+    return result.worktreeId ?? options.path;
   }
 
   async deleteWorktree(worktreeId: string, force: boolean = false): Promise<void> {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -674,7 +674,16 @@ export class WorkspaceService {
 
       await this.syncMonitors(worktreeList, this.activeWorktreeId, this.mainBranch);
 
-      this.sendEvent({ type: "create-worktree-result", requestId, success: true });
+      // Find the created worktree in the updated list to get the canonical ID
+      const createdWorktree = worktreeList.find((wt) => wt.branch === newBranch);
+      const canonicalWorktreeId = createdWorktree?.id || path;
+
+      this.sendEvent({
+        type: "create-worktree-result",
+        requestId,
+        success: true,
+        worktreeId: canonicalWorktreeId,
+      });
     } catch (error) {
       this.sendEvent({
         type: "create-worktree-result",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -67,7 +67,7 @@ export interface ElectronAPI {
     refresh(): Promise<void>;
     refreshPullRequests(): Promise<void>;
     setActive(worktreeId: string): Promise<void>;
-    create(options: CreateWorktreeOptions, rootPath: string): Promise<void>;
+    create(options: CreateWorktreeOptions, rootPath: string): Promise<string>;
     listBranches(rootPath: string): Promise<BranchInfo[]>;
     getDefaultPath(rootPath: string, branchName: string): Promise<string>;
     delete(worktreeId: string, force?: boolean): Promise<void>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -89,7 +89,7 @@ export interface IpcInvokeMap {
   };
   "worktree:create": {
     args: [payload: { rootPath: string; options: CreateWorktreeOptions }];
-    result: void;
+    result: string;
   };
   "worktree:list-branches": {
     args: [payload: { rootPath: string }];

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -188,7 +188,13 @@ export type WorkspaceHostEvent =
   | { type: "refresh-prs-result"; requestId: string; success: boolean; error?: string }
   | { type: "get-pr-status-result"; requestId: string; status: PRServiceStatus | null }
   | { type: "reset-pr-state-result"; requestId: string; success: boolean }
-  | { type: "create-worktree-result"; requestId: string; success: boolean; error?: string }
+  | {
+      type: "create-worktree-result";
+      requestId: string;
+      success: boolean;
+      worktreeId?: string;
+      error?: string;
+    }
   | { type: "delete-worktree-result"; requestId: string; success: boolean; error?: string }
   // Branch operation responses
   | { type: "list-branches-result"; requestId: string; branches: BranchInfo[]; error?: string }

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -26,7 +26,7 @@ export const worktreeClient = {
     return window.electron.worktree.setActive(worktreeId);
   },
 
-  create: (options: CreateWorktreeOptions, rootPath: string): Promise<void> => {
+  create: (options: CreateWorktreeOptions, rootPath: string): Promise<string> => {
     return window.electron.worktree.create(options, rootPath);
   },
 

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -74,7 +74,14 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     }),
     run: async (args: unknown) => {
       const { rootPath, options } = args as { rootPath: string; options: unknown };
-      await worktreeClient.create(options as any, rootPath);
+      const worktreeId = await worktreeClient.create(options as any, rootPath);
+      if (worktreeId) {
+        useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
+      } else {
+        console.warn(
+          "[worktree.create] No worktreeId returned from creation - skipping auto-selection"
+        );
+      }
     },
   }));
 


### PR DESCRIPTION
## Summary
- Propagate worktree ID through the creation flow from `WorkspaceService` → `WorkspaceClient` → IPC handler → renderer
- Auto-select newly created worktree in the `worktree.create` action after successful creation
- Update type definitions across all layers to return `string` (worktree ID) instead of `void`

Closes #1325

## Test plan
- [ ] Create a new worktree via the "New Worktree" dialog
- [ ] Verify the newly created worktree is automatically selected in the worktree list
- [ ] Verify creation errors still fail gracefully without selection
- [ ] Verify existing worktree behavior (dialog closes, list refreshes) is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)