### PR TITLE
Add 'assign to current user' option in Create Worktree dialog

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -86,6 +86,7 @@ export const CHANNELS = {
   GITHUB_VALIDATE_TOKEN: "github:validate-token",
   GITHUB_LIST_ISSUES: "github:list-issues",
   GITHUB_LIST_PRS: "github:list-prs",
+  GITHUB_ASSIGN_ISSUE: "github:assign-issue",
 
   APP_GET_STATE: "app:get-state",
   APP_SET_STATE: "app:set-state",

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -240,5 +240,33 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   ipcMain.handle(CHANNELS.GITHUB_LIST_PRS, handleGitHubListPRs);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_LIST_PRS));
 
+  const handleGitHubAssignIssue = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: { cwd: string; issueNumber: number; username: string }
+  ): Promise<void> => {
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid payload");
+    }
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
+      throw new Error("Invalid working directory");
+    }
+    if (
+      typeof payload.issueNumber !== "number" ||
+      !Number.isInteger(payload.issueNumber) ||
+      payload.issueNumber <= 0
+    ) {
+      throw new Error("Invalid issue number");
+    }
+    const trimmedUsername = payload.username?.trim();
+    if (typeof payload.username !== "string" || !trimmedUsername) {
+      throw new Error("Invalid username");
+    }
+
+    const { assignIssue } = await import("../../services/GitHubService.js");
+    await assignIssue(payload.cwd.trim(), payload.issueNumber, trimmedUsername);
+  };
+  ipcMain.handle(CHANNELS.GITHUB_ASSIGN_ISSUE, handleGitHubAssignIssue);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_ASSIGN_ISSUE));
+
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -212,6 +212,7 @@ const CHANNELS = {
   GITHUB_VALIDATE_TOKEN: "github:validate-token",
   GITHUB_LIST_ISSUES: "github:list-issues",
   GITHUB_LIST_PRS: "github:list-prs",
+  GITHUB_ASSIGN_ISSUE: "github:assign-issue",
 
   // Notes channels
   NOTES_CREATE: "notes:create",
@@ -765,6 +766,9 @@ const api: ElectronAPI = {
       state?: "open" | "closed" | "merged" | "all";
       cursor?: string;
     }) => ipcRenderer.invoke(CHANNELS.GITHUB_LIST_PRS, options),
+
+    assignIssue: (cwd: string, issueNumber: number, username: string): Promise<void> =>
+      ipcRenderer.invoke(CHANNELS.GITHUB_ASSIGN_ISSUE, { cwd, issueNumber, username }),
 
     onPRDetected: (callback: (data: PRDetectedPayload) => void) =>
       _typedOn(CHANNELS.PR_DETECTED, callback),

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -308,6 +308,55 @@ export async function getIssueUrl(cwd: string, issueNumber: number): Promise<str
   return `${repoUrl}/issues/${issueNumber}`;
 }
 
+export async function assignIssue(
+  cwd: string,
+  issueNumber: number,
+  username: string
+): Promise<void> {
+  const token = getGitHubToken();
+  if (!token) {
+    throw new Error("GitHub token not configured");
+  }
+
+  const context = await getRepoContext(cwd);
+  if (!context) {
+    throw new Error("Not a GitHub repository");
+  }
+
+  const url = `https://api.github.com/repos/${context.owner}/${context.repo}/issues/${issueNumber}/assignees`;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ assignees: [username] }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error("Invalid GitHub token. Please update in Settings.");
+      }
+      if (response.status === 403) {
+        throw new Error("Token lacks required permissions. Required scopes: repo, read:org");
+      }
+      if (response.status === 404) {
+        throw new Error("Issue not found or you don't have access to this repository");
+      }
+      if (response.status === 422) {
+        throw new Error(`Cannot assign user "${username}" - they may not be a collaborator`);
+      }
+      throw new Error(`GitHub API error: ${response.statusText}`);
+    }
+  } catch (error) {
+    throw new Error(parseGitHubError(error));
+  }
+}
+
 function parseGitHubError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -245,6 +245,7 @@ export interface ElectronAPI {
       state?: "open" | "closed" | "merged" | "all";
       cursor?: string;
     }): Promise<import("../github.js").GitHubListResponse<import("../github.js").GitHubPR>>;
+    assignIssue(cwd: string, issueNumber: number, username: string): Promise<void>;
     onPRDetected(callback: (data: PRDetectedPayload) => void): () => void;
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;
   };

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -466,6 +466,10 @@ export interface IpcInvokeMap {
     ];
     result: import("../github.js").GitHubListResponse<import("../github.js").GitHubIssue>;
   };
+  "github:assign-issue": {
+    args: [payload: { cwd: string; issueNumber: number; username: string }];
+    result: void;
+  };
   "github:list-prs": {
     args: [
       options: {

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -66,6 +66,10 @@ export const githubClient = {
     return window.electron.github.listPullRequests(options);
   },
 
+  assignIssue: (cwd: string, issueNumber: number, username: string): Promise<void> => {
+    return window.electron.github.assignIssue(cwd, issueNumber, username);
+  },
+
   onPRDetected: (callback: (data: PRDetectedPayload) => void): (() => void) => {
     return window.electron.github.onPRDetected(callback);
   },

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -26,6 +26,8 @@ interface PreferencesState {
   setShowProjectPulse: (show: boolean) => void;
   showDeveloperTools: boolean;
   setShowDeveloperTools: (show: boolean) => void;
+  assignWorktreeToSelf: boolean;
+  setAssignWorktreeToSelf: (value: boolean) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -35,6 +37,8 @@ export const usePreferencesStore = create<PreferencesState>()(
       setShowProjectPulse: (show) => set({ showProjectPulse: show }),
       showDeveloperTools: false,
       setShowDeveloperTools: (show) => set({ showDeveloperTools: show }),
+      assignWorktreeToSelf: false,
+      setAssignWorktreeToSelf: (value) => set({ assignWorktreeToSelf: value }),
     }),
     {
       name: "canopy-preferences",


### PR DESCRIPTION
## Summary
Adds an optional toggle to automatically assign GitHub issues to the current user when creating a worktree linked to that issue. This streamlines the workflow by eliminating the manual step of assigning issues on GitHub.

Closes #1324

## Changes Made
- Add assignWorktreeToSelf preference with persistence
- Implement GitHub issue assignment via REST API
- Add IPC channel with input validation (integer check, trim)
- Use Bearer auth and current GitHub API headers
- Improve error handling with parseGitHubError integration
- Add type safety via IpcInvokeMap
- Show assignment toggle only when issue selected and auth available
- Add accessible aria-label to toggle control
- Display success/warning notifications for assignment results