### PR TITLE
fix(github): prevent cache file creation in project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ lerna-debug.log*
 *.tsbuildinfo
 .eslintcache
 .prettiercache
+github-stats-cache.json
 
 # Testing
 coverage/


### PR DESCRIPTION
## Summary
Fixes the GitHub stats cache file being incorrectly created in the project root directory instead of the Electron userData directory.

Closes #1319

## Changes Made
- Replace unsafe `process.cwd()` fallback with platform-specific userData paths (macOS, Windows, Linux)
- Add validation for `CANOPY_USER_DATA`, `APPDATA`, and `XDG_CONFIG_HOME` environment variables to reject non-absolute paths
- Validate `os.homedir()` availability and throw clear error if unavailable
- Add `github-stats-cache.json` to `.gitignore` Cache section to prevent accidental commits

## Technical Details
The root cause was an unsafe fallback in `getUserDataPath()` that returned `process.cwd()` when both the `CANOPY_USER_DATA` environment variable and Electron's `app.getPath("userData")` were unavailable. This caused the cache file to be created in the project working directory.

The fix implements proper platform-specific fallback paths:
- **macOS**: `~/Library/Application Support/Canopy`
- **Windows**: `%APPDATA%\Canopy` (or `%USERPROFILE%\AppData\Roaming\Canopy`)
- **Linux**: `$XDG_CONFIG_HOME/Canopy` (or `~/.config/Canopy`)

All environment variables and paths are now validated to ensure they are absolute paths before use, preventing project root pollution.