### PR TITLE
Optimistically update issue assignee in UI after assignment

### DIFF
--- a/electron/utils/cache.ts
+++ b/electron/utils/cache.ts
@@ -106,6 +106,16 @@ export class Cache<K, V> {
     return this.get(key) !== undefined;
   }
 
+  forEach(callback: (value: V, key: K) => void): void {
+    const now = Date.now();
+    const snapshot = Array.from(this.cache.entries());
+    for (const [key, entry] of snapshot) {
+      if (now <= entry.expiresAt) {
+        callback(entry.value, key);
+      }
+    }
+  }
+
   // Call this periodically to prevent memory leaks
   cleanup(): void {
     const now = Date.now();


### PR DESCRIPTION
## Summary
Implements optimistic cache updates for GitHub issue assignees, ensuring the UI immediately reflects assignment changes without waiting for cache expiration or manual refresh.

Closes #1342

## Changes Made
- Added `updateIssueAssigneeInCache()` function to immediately update all cached issue list entries after successful assignment
- Modified `assignIssue()` to return assignee information and validate API response structure
- Added `forEach()` method to `Cache` class for safe iteration over cached entries (filters expired, uses snapshot to prevent mutation issues)
- Improved error handling with response validation and detailed error messages
- Fixed potential race conditions by collecting updates before applying them to cache
- Added support for updating existing assignee avatars if they change

## Technical Details
- Cache updates happen synchronously after successful GitHub API assignment
- Handles all cache key variations (different states, search queries, pagination cursors)
- Uses case-insensitive login comparison to detect duplicate assignments
- Validates API response structure before updating cache to ensure data integrity

## Testing
- All type checks, linting, and formatting pass
- Codex review completed with fixes applied for race conditions and mutation safety