### PR TITLE
Add default recipe selection for new worktrees

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -251,6 +251,11 @@ export class ProjectStore {
         runCommands: Array.isArray(parsed.runCommands) ? parsed.runCommands : [],
         environmentVariables: parsed.environmentVariables,
         excludedPaths: parsed.excludedPaths,
+        projectIconSvg: typeof parsed.projectIconSvg === "string" ? parsed.projectIconSvg : undefined,
+        defaultWorktreeRecipeId:
+          typeof parsed.defaultWorktreeRecipeId === "string"
+            ? parsed.defaultWorktreeRecipeId
+            : undefined,
       };
 
       return settings;

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -608,4 +608,6 @@ export interface ProjectSettings {
   excludedPaths?: string[];
   /** Raw SVG text for project icon (max 250KB, validated/sanitized) */
   projectIconSvg?: string;
+  /** ID of the default recipe to run when creating new worktrees */
+  defaultWorktreeRecipeId?: string;
 }


### PR DESCRIPTION
## Summary
This PR adds the ability to configure a default recipe at the project level that automatically runs when creating new worktrees. Users can select a global recipe in the project settings dialog, and it will be offered as an opt-in checkbox when creating new worktrees.

Closes #1331

## Changes Made
- Add `defaultWorktreeRecipeId` field to `ProjectSettings` interface
- Add default recipe selector UI in project settings dialog with visual preview
- Add "Run default recipe" checkbox in new worktree dialog (shown when a default is configured)
- Implement auto-run logic after worktree creation with error handling
- Add persistence for `defaultWorktreeRecipeId` in `ProjectStore`
- Enforce global-only recipes in default recipe lookup (worktree-scoped recipes are excluded)
- Clear `defaultWorktreeRecipeId` when the selected recipe is deleted
- Add stale response guard for project settings fetch to prevent race conditions
- Handle edge case where selected recipe no longer exists (shows warning in UI)

## Implementation Details
- The feature is opt-in: users must configure a default recipe and can toggle it on/off per worktree creation
- Only global recipes (not worktree-scoped) can be set as defaults
- Recipe runs after worktree creation, with failures shown as non-blocking warnings
- Settings persist across application restarts via the project settings JSON file