### PR TITLE
Add note management actions to panel context menu

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -188,7 +188,9 @@ export type ActionId =
   | "terminal.gridLayout.setStrategy"
   | "terminal.gridLayout.setValue"
   | "notes.openPalette"
-  | "notes.create";
+  | "notes.create"
+  | "notes.delete"
+  | "notes.reveal";
 
 export interface ActionContext {
   projectId?: string;

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -79,6 +79,7 @@ export function TerminalContextMenu({
     if (!terminal) return [];
 
     const isBrowser = terminal.kind === "browser";
+    const isNotes = terminal.kind === "notes";
 
     // Layout section: worktree navigation first (most common workflow), then positioning
     const layoutItems: MenuItemOption[] = [];
@@ -130,6 +131,29 @@ export function TerminalContextMenu({
         ...browserActions,
         { type: "separator" },
         ...browserManagementItems,
+        { type: "separator" },
+        ...destructiveItems,
+      ];
+    }
+
+    // Notes-specific actions
+    if (isNotes) {
+      const hasNotePath = Boolean(terminal.notePath);
+
+      const notesManagementItems: MenuItemOption[] = [
+        { id: "rename", label: "Rename Note", enabled: hasNotePath },
+        { id: "reveal-in-palette", label: "Reveal in Notes Palette", enabled: hasNotePath },
+      ];
+
+      const destructiveItems: MenuItemOption[] = [
+        { id: "delete-note", label: "Delete Note", enabled: hasNotePath },
+        { id: "trash", label: "Close Note" },
+      ];
+
+      return [
+        ...layoutItems,
+        { type: "separator" },
+        ...notesManagementItems,
         { type: "separator" },
         ...destructiveItems,
       ];
@@ -320,6 +344,29 @@ export function TerminalContextMenu({
             void actionService.dispatch(
               "browser.copyUrl",
               { url: terminal.browserUrl },
+              { source: "context-menu" }
+            );
+          }
+          break;
+        // Notes-specific actions
+        case "delete-note":
+          if (terminal.notePath) {
+            void actionService.dispatch(
+              "notes.delete",
+              {
+                notePath: terminal.notePath,
+                panelId: terminalId,
+                noteTitle: terminal.title,
+              },
+              { source: "context-menu" }
+            );
+          }
+          break;
+        case "reveal-in-palette":
+          if (terminal.notePath) {
+            void actionService.dispatch(
+              "notes.reveal",
+              { notePath: terminal.notePath },
               { source: "context-menu" }
             );
           }

--- a/src/services/actions/definitions/notesActions.ts
+++ b/src/services/actions/definitions/notesActions.ts
@@ -1,3 +1,6 @@
+import { z } from "zod";
+import { notesClient } from "@/clients/notesClient";
+import { useTerminalStore } from "@/store";
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 
 export function registerNotesActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
@@ -24,6 +27,74 @@ export function registerNotesActions(actions: ActionRegistry, _callbacks: Action
     scope: "renderer",
     run: async () => {
       window.dispatchEvent(new CustomEvent("canopy:open-notes-palette"));
+    },
+  }));
+
+  const deleteArgsSchema = z.object({
+    notePath: z.string(),
+    panelId: z.string(),
+    noteTitle: z.string().optional(),
+  });
+  type DeleteArgs = z.infer<typeof deleteArgsSchema>;
+
+  actions.set("notes.delete", () => ({
+    id: "notes.delete",
+    title: "Delete Note",
+    description: "Delete a note file and close its panel",
+    category: "notes",
+    kind: "command",
+    danger: "confirm",
+    scope: "renderer",
+    argsSchema: deleteArgsSchema,
+    run: async (args: unknown) => {
+      const { notePath, panelId, noteTitle } = args as DeleteArgs;
+
+      const displayTitle = noteTitle || "this note";
+      const confirmed = window.confirm(
+        `Delete "${displayTitle}"?\n\nThis action cannot be undone.`
+      );
+
+      if (!confirmed) {
+        return { cancelled: true };
+      }
+
+      try {
+        await notesClient.delete(notePath);
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") {
+          const message = error instanceof Error ? error.message : "Unknown error";
+          window.alert(`Failed to delete note: ${message}`);
+          throw new Error(message);
+        }
+      }
+
+      useTerminalStore.getState().removeTerminal(panelId);
+      return { success: true };
+    },
+  }));
+
+  const revealArgsSchema = z.object({
+    notePath: z.string(),
+  });
+  type RevealArgs = z.infer<typeof revealArgsSchema>;
+
+  actions.set("notes.reveal", () => ({
+    id: "notes.reveal",
+    title: "Reveal in Notes Palette",
+    description: "Open the notes palette with this note highlighted",
+    category: "notes",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: revealArgsSchema,
+    run: async (args: unknown) => {
+      const { notePath } = args as RevealArgs;
+      window.dispatchEvent(
+        new CustomEvent("canopy:open-notes-palette", {
+          detail: { highlightNotePath: notePath },
+        })
+      );
     },
   }));
 }


### PR DESCRIPTION
## Summary
Implements note management actions for the notes panel context menu, enabling users to delete notes, reveal them in the notes palette, and rename them directly from the panel context menu.

Closes #1311

## Changes Made
- Add notes.delete and notes.reveal action IDs to ActionId type
- Implement notes.delete action with confirmation dialog and ENOENT handling for race conditions
- Implement notes.reveal action to open notes palette with the note highlighted
- Add notes-specific context menu items (Delete Note, Reveal in Notes Palette, Rename Note)
- Disable menu items when notePath is empty to prevent silent failures
- Use type-safe Zod schemas with z.infer for argument validation and compile-time safety