### PR TITLE
Add dev server command configuration and toolbar button

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -257,6 +257,8 @@ export class ProjectStore {
           typeof parsed.defaultWorktreeRecipeId === "string"
             ? parsed.defaultWorktreeRecipeId
             : undefined,
+        devServerCommand:
+          typeof parsed.devServerCommand === "string" ? parsed.devServerCommand : undefined,
       };
 
       return settings;

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -190,7 +190,8 @@ export type ActionId =
   | "notes.openPalette"
   | "notes.create"
   | "notes.delete"
-  | "notes.reveal";
+  | "notes.reveal"
+  | "devServer.start";
 
 export interface ActionContext {
   projectId?: string;

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -610,4 +610,6 @@ export interface ProjectSettings {
   projectIconSvg?: string;
   /** ID of the default recipe to run when creating new worktrees */
   defaultWorktreeRecipeId?: string;
+  /** Dev server command (e.g., "npm run dev") for the toolbar button */
+  devServerCommand?: string;
 }

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -22,6 +22,7 @@ import {
   Globe,
   Clock,
   StickyNote,
+  Rocket,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
@@ -29,6 +30,7 @@ import { GitHubResourceList, CommitList } from "@/components/GitHub";
 import { AgentButton } from "./AgentButton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useWorktreeActions } from "@/hooks/useWorktreeActions";
+import { useProjectSettings } from "@/hooks";
 import { useProjectStore } from "@/store/projectStore";
 import { useSidecarStore, usePreferencesStore } from "@/store";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -76,6 +78,8 @@ export function Toolbar({
   const projects = useProjectStore((state) => state.projects);
   const loadProjects = useProjectStore((state) => state.loadProjects);
   const getCurrentProject = useProjectStore((state) => state.getCurrentProject);
+  const { settings: projectSettings } = useProjectSettings();
+  const devServerCommand = projectSettings?.devServerCommand?.trim();
   const { stats, refresh: refreshStats, isStale, lastUpdated } = useRepositoryStats();
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
   const activeWorktree = useWorktreeDataStore((state) =>
@@ -263,6 +267,20 @@ export function Toolbar({
           >
             <Globe />
           </Button>
+          {devServerCommand && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => {
+                void actionService.dispatch("devServer.start", undefined, { source: "user" });
+              }}
+              className="text-canopy-text hover:bg-white/[0.06] transition-colors hover:text-purple-400 focus-visible:text-purple-400"
+              title="Start Dev Server"
+              aria-label="Start Dev Server"
+            >
+              <Rocket />
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -18,6 +18,7 @@ import {
   FileDown,
   Play,
   AlertTriangle,
+  Rocket,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -71,6 +72,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
   const [defaultWorktreeRecipeId, setDefaultWorktreeRecipeId] = useState<string | undefined>(
     undefined
   );
+  const [devServerCommand, setDevServerCommand] = useState<string>("");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const {
@@ -172,6 +174,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
       setExcludedPaths(settings.excludedPaths || []);
       setProjectIconSvg(settings.projectIconSvg);
       setDefaultWorktreeRecipeId(settings.defaultWorktreeRecipeId);
+      setDevServerCommand(settings.devServerCommand || "");
       setIsInitialized(true);
     }
     if (!isOpen) {
@@ -181,6 +184,8 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
       setProjectIconSvg(undefined);
       setIconError(null);
       setDefaultWorktreeRecipeId(undefined);
+      setDevServerCommand("");
+      setSaveError(null);
     }
   }, [settings, isOpen, isInitialized]);
 
@@ -262,6 +267,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
         excludedPaths: sanitizedPaths.length > 0 ? sanitizedPaths : undefined,
         projectIconSvg: projectIconSvg,
         defaultWorktreeRecipeId: defaultWorktreeRecipeId,
+        devServerCommand: devServerCommand.trim() || undefined,
       });
       onClose();
     } catch (error) {
@@ -421,6 +427,30 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                   </div>
                 </div>
               )}
+
+              <div className="mb-6 pb-6 border-b border-canopy-border">
+                <h3 className="text-sm font-semibold text-canopy-text/80 mb-2 flex items-center gap-2">
+                  <Rocket className="h-4 w-4" />
+                  Dev Server Command
+                </h3>
+                <p className="text-xs text-canopy-text/60 mb-4">
+                  Command to start the development server (e.g., npm run dev). When configured, a
+                  button will appear in the toolbar to start the dev server.
+                </p>
+
+                <input
+                  id="dev-server-command"
+                  type="text"
+                  value={devServerCommand}
+                  onChange={(e) => setDevServerCommand(e.target.value)}
+                  className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-canopy-text/40"
+                  placeholder="npm run dev"
+                  spellCheck={false}
+                  autoCapitalize="off"
+                  autoComplete="off"
+                  aria-label="Dev server command"
+                />
+              </div>
 
               <div className="mb-6 pb-6 border-b border-canopy-border">
                 <h3 className="text-sm font-semibold text-canopy-text/80 mb-2 flex items-center gap-2">

--- a/src/services/actions/actionDefinitions.ts
+++ b/src/services/actions/actionDefinitions.ts
@@ -2,6 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "./actionTypes";
 import { registerAgentActions } from "./definitions/agentActions";
 import { registerAppActions } from "./definitions/appActions";
 import { registerBrowserActions } from "./definitions/browserActions";
+import { registerDevServerActions } from "./definitions/devServerActions";
 import { registerGithubActions } from "./definitions/githubActions";
 import { registerGitActions } from "./definitions/gitActions";
 import { registerIntrospectionActions } from "./definitions/introspectionActions";
@@ -39,6 +40,7 @@ export function createActionDefinitions(callbacks: ActionCallbacks): ActionRegis
   registerBrowserActions(actions, callbacks);
   registerNotesActions(actions, callbacks);
   registerIntrospectionActions(actions, callbacks);
+  registerDevServerActions(actions, callbacks);
 
   return actions;
 }

--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -1,0 +1,49 @@
+import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import { projectClient } from "@/clients";
+import { useTerminalStore } from "@/store/terminalStore";
+import { useProjectStore } from "@/store/projectStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+
+export function registerDevServerActions(
+  actions: ActionRegistry,
+  _callbacks: ActionCallbacks
+): void {
+  actions.set("devServer.start", () => ({
+    id: "devServer.start",
+    title: "Start Dev Server",
+    description: "Start the configured dev server and open a dev preview panel",
+    category: "devServer",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const currentProject = useProjectStore.getState().currentProject;
+      if (!currentProject) {
+        throw new Error("No project is currently open");
+      }
+
+      const settings = await projectClient.getSettings(currentProject.id);
+      const devServerCommand = settings?.devServerCommand?.trim();
+      if (!devServerCommand) {
+        throw new Error(
+          "No dev server command configured. Open project settings to configure one."
+        );
+      }
+
+      const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+      const activeWorktree = activeWorktreeId
+        ? useWorktreeDataStore.getState().worktrees.get(activeWorktreeId)
+        : null;
+      const cwd = activeWorktree?.path ?? currentProject.path;
+
+      await useTerminalStore.getState().addTerminal({
+        kind: "dev-preview",
+        title: "Dev Server",
+        cwd,
+        worktreeId: activeWorktreeId ?? undefined,
+        location: "grid",
+      });
+    },
+  }));
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to configure a custom dev server command in project settings and provides a toolbar button to launch it. When configured, the button appears in the toolbar and spawns a dev preview panel with the specified command.

Closes #1349

## Changes Made
- Add `devServerCommand` field to `ProjectSettings` type
- Add `devServer.start` action to spawn dev preview panel
- Add dev server command input field to project settings dialog
- Add conditional dev server button to toolbar (appears when configured)
- Implement `devServerActions` to handle dev server launch
- Fix settings persistence in `ProjectStore` to include `devServerCommand`
- Improve input field with proper attributes (`spellCheck`, `autoCapitalize`)
- Add proper error state cleanup on dialog close
- Use `trim()` for toolbar button gating to avoid whitespace-only values