### PR TITLE
Fix duplicate timer display in worktree card when no panels are open

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -136,20 +136,22 @@ export function WorktreeDetailsSection({
               )}
             </span>
 
-            <div
-              className="flex items-center gap-1.5 text-xs text-canopy-text/40 shrink-0 ml-3"
-              title={
-                worktree.lastActivityTimestamp
-                  ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
-                  : "No recent activity recorded"
-              }
-            >
-              <ActivityLight
-                lastActivityTimestamp={worktree.lastActivityTimestamp}
-                className="w-1.5 h-1.5"
-              />
-              <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} />
-            </div>
+            {!showTimeInHeader && (
+              <div
+                className="flex items-center gap-1.5 text-xs text-canopy-text/40 shrink-0 ml-3"
+                title={
+                  worktree.lastActivityTimestamp
+                    ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
+                    : "No recent activity recorded"
+                }
+              >
+                <ActivityLight
+                  lastActivityTimestamp={worktree.lastActivityTimestamp}
+                  className="w-1.5 h-1.5"
+                />
+                <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} />
+              </div>
+            )}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
Fixes the duplicate timer display issue where the activity timer appeared twice in worktree cards that have no open panels - once in the header and once in the collapsed details bar.

Closes #1355

## Changes Made
- Added conditional check in `WorktreeDetailsSection.tsx` to hide timer in collapsed details bar when `showTimeInHeader` is true
- Ensures timer appears only once based on worktree state (either in header or details section)
- Maintains consistent timer visibility logic across collapsed and expanded states

## Technical Details
The fix adds a conditional wrapper `{!showTimeInHeader &&` around the timer display in the collapsed details bar (line 139). This prevents duplication when the timer is already showing in the header (which happens when `hasExpandableContent` is false).

**Logic flow:**
- When worktree has no panels/expandable content → `showTimeInHeader = true` → timer shows ONLY in header
- When worktree has panels/changes/errors → `showTimeInHeader = false` → timer shows ONLY in details bar

## Testing
- ✅ TypeScript compilation passes
- ✅ Linting passes (only pre-existing warnings)
- ✅ Codex code review completed - no issues found
- ✅ Logic verified across all three affected components (WorktreeCard, WorktreeHeader, WorktreeDetailsSection)