### PR TITLE
feat(ui): add loading placeholder for avatar images

### DIFF
--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -11,6 +11,7 @@ import {
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
+import { Avatar } from "@/components/ui/Avatar";
 
 interface GitHubListItemProps {
   item: GitHubIssue | GitHubPR;
@@ -183,12 +184,12 @@ export function GitHubListItem({ item, type, onCreateWorktree }: GitHubListItemP
           {type === "issue" && "assignees" in item && item.assignees.length > 0 && (
             <div className="flex -space-x-1.5">
               {item.assignees.slice(0, 3).map((assignee) => (
-                <img
+                <Avatar
                   key={assignee.login}
                   src={assignee.avatarUrl}
                   alt={assignee.login}
                   title={assignee.login}
-                  className="w-5 h-5 rounded-full border-2 border-canopy-sidebar"
+                  className="w-5 h-5 border-2 border-canopy-sidebar"
                 />
               ))}
               {item.assignees.length > 3 && (

--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -5,6 +5,7 @@ import { githubClient } from "@/clients/githubClient";
 import type { GitHubIssue } from "@shared/types/github";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Avatar } from "@/components/ui/Avatar";
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -151,12 +152,12 @@ export function IssueSelector({
                 {issue.assignees.length > 0 && (
                   <div className="flex -space-x-1.5 shrink-0">
                     {issue.assignees.slice(0, 3).map((assignee) => (
-                      <img
+                      <Avatar
                         key={assignee.login}
                         src={`${assignee.avatarUrl}${assignee.avatarUrl.includes("?") ? "&" : "?"}s=32`}
                         alt={assignee.login}
                         title={assignee.login}
-                        className="w-5 h-5 rounded-full ring-1 ring-canopy-bg"
+                        className="w-5 h-5 ring-1 ring-canopy-bg"
                       />
                     ))}
                     {issue.assignees.length > 3 && (

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+interface AvatarProps {
+  src: string;
+  alt: string;
+  title?: string;
+  className?: string;
+}
+
+export function Avatar({ src, alt, title, className }: AvatarProps) {
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    setLoaded(false);
+    setError(false);
+  }, [src]);
+
+  return (
+    <div className="relative" role="img" aria-label={error ? alt : undefined}>
+      {(!loaded || error) && (
+        <div
+          className={cn(
+            "absolute inset-0 rounded-full bg-muted",
+            !error && "animate-pulse",
+            className
+          )}
+        />
+      )}
+      {!error && (
+        <img
+          src={src}
+          alt={alt}
+          title={title}
+          onLoad={() => setLoaded(true)}
+          onError={() => setError(true)}
+          className={cn(
+            "rounded-full transition-opacity duration-200",
+            loaded ? "opacity-100" : "opacity-0",
+            className
+          )}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a loading placeholder to assignee avatars in the GitHub issue selector dropdown and issue list. Shows a gray animated placeholder while avatar images load, improving perceived performance and visual consistency on slow connections.

Closes #1369

## Changes Made
- Create reusable Avatar component with loading state management
- Show gray animated placeholder while images load
- Add smooth transition with 200ms opacity fade
- Reset loading state when src prop changes
- Handle failed image loads with static fallback
- Improve accessibility with role and aria-label
- Update IssueSelector to use Avatar component
- Update GitHubListItem to use Avatar component

## Technical Details
- Avatar component tracks loading and error states independently per instance
- Placeholder uses `bg-muted` with `animate-pulse` for loading indication
- Smooth opacity transition prevents jarring image appearance
- Error state shows static placeholder (no animation) and maintains accessibility
- Component applies styling classes to both placeholder and image for consistent appearance
- No layout shift during loading (dimensions preserved by wrapper)