### PR TITLE
Add PR status indicator to issues dropdown

### DIFF
--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -42,6 +42,20 @@ export const LIST_ISSUES_QUERY = `
               color
             }
           }
+          timelineItems(itemTypes: [CROSS_REFERENCED_EVENT], last: 10) {
+            nodes {
+              ... on CrossReferencedEvent {
+                source {
+                  ... on PullRequest {
+                    number
+                    state
+                    merged
+                    url
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -16,6 +16,16 @@ export interface GitHubLabel {
   color: string;
 }
 
+/** Linked PR information for an issue */
+export interface LinkedPRInfo {
+  /** PR number */
+  number: number;
+  /** PR state */
+  state: "OPEN" | "CLOSED" | "MERGED";
+  /** PR URL */
+  url: string;
+}
+
 /** GitHub issue representation */
 export interface GitHubIssue {
   /** Issue number */
@@ -36,6 +46,8 @@ export interface GitHubIssue {
   commentCount: number;
   /** Issue labels */
   labels?: GitHubLabel[];
+  /** Associated PR information (if any) */
+  linkedPR?: LinkedPRInfo;
 }
 
 /** GitHub pull request representation */

--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
-import type { GitHubIssue, GitHubPR } from "@shared/types/github";
+import type { GitHubIssue, GitHubPR, LinkedPRInfo } from "@shared/types/github";
 
 interface GitHubListItemProps {
   item: GitHubIssue | GitHubPR;
@@ -47,6 +47,32 @@ function formatTimeAgo(dateString: string): string {
 
 function isPR(item: GitHubIssue | GitHubPR): item is GitHubPR {
   return "isDraft" in item;
+}
+
+function getPRBadgeInfo(linkedPR: LinkedPRInfo): {
+  icon: typeof GitMerge;
+  color: string;
+  bgColor: string;
+} {
+  if (linkedPR.state === "MERGED") {
+    return {
+      icon: GitMerge,
+      color: "text-[var(--color-status-success)]",
+      bgColor: "bg-[var(--color-status-success)]/10",
+    };
+  }
+  if (linkedPR.state === "OPEN") {
+    return {
+      icon: GitPullRequest,
+      color: "text-[var(--color-status-info)]",
+      bgColor: "bg-[var(--color-status-info)]/10",
+    };
+  }
+  return {
+    icon: GitPullRequestClosed,
+    color: "text-muted-foreground",
+    bgColor: "bg-muted",
+  };
 }
 
 export function GitHubListItem({ item, type, onCreateWorktree }: GitHubListItemProps) {
@@ -108,7 +134,20 @@ export function GitHubListItem({ item, type, onCreateWorktree }: GitHubListItemP
     }
   };
 
+  const handleOpenLinkedPR = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    if (!isItemPR && "linkedPR" in item && item.linkedPR) {
+      void actionService.dispatch(
+        "system.openExternal",
+        { url: item.linkedPR.url },
+        { source: "user" }
+      );
+    }
+  };
+
   const status = getButtonStatus();
+  const linkedPR = !isItemPR && "linkedPR" in item ? item.linkedPR : undefined;
+  const prBadgeInfo = linkedPR ? getPRBadgeInfo(linkedPR) : null;
 
   return (
     <div className="p-3 hover:bg-muted/50 transition-colors group cursor-default">
@@ -128,6 +167,22 @@ export function GitHubListItem({ item, type, onCreateWorktree }: GitHubListItemP
             >
               {item.title}
             </button>
+            {prBadgeInfo && linkedPR && (
+              <button
+                type="button"
+                onClick={handleOpenLinkedPR}
+                className={cn(
+                  "shrink-0 text-[11px] px-1.5 py-0.5 rounded font-medium flex items-center gap-1 hover:opacity-80 transition-opacity cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  prBadgeInfo.color,
+                  prBadgeInfo.bgColor
+                )}
+                title={`Open PR #${linkedPR.number} (${linkedPR.state.toLowerCase()})`}
+                aria-label={`Open linked pull request #${linkedPR.number} (${linkedPR.state.toLowerCase()})`}
+              >
+                <prBadgeInfo.icon className="w-3 h-3" />
+                <span>#{linkedPR.number}</span>
+              </button>
+            )}
             {isItemPR && item.isDraft && (
               <span className="shrink-0 text-[11px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
                 Draft


### PR DESCRIPTION
## Summary
Adds a visual indicator to the issues dropdown showing whether an issue has an associated pull request. The badge displays the PR number and state (open/merged/closed) with appropriate icons and colors, improving workflow efficiency by helping users quickly identify which issues are being actively worked on.

Closes #1362

## Changes Made
- Add timelineItems to LIST_ISSUES_QUERY to fetch linked PR data from GitHub's cross-referenced events
- Add LinkedPRInfo interface with number, state, and url fields
- Add linkedPR optional field to GitHubIssue interface
- Implement extractLinkedPR function to map timeline events to PR info with state prioritization (open > merged > closed)
- Add PR status badge component with state-based icons (GitPullRequest, GitMerge, GitPullRequestClosed) and colors
- Use direct PR URL from API instead of brittle string manipulation
- Add keyboard focus styling (focus-visible ring) and enhanced screen reader support (state in aria-label)

## Implementation Details
- GraphQL query includes last 10 timeline items (CROSS_REFERENCED_EVENT type) to limit response size
- Badge only appears when linkedPR data exists
- Clicking badge opens PR in browser
- Supports same-repo and cross-repo PRs