### PR TITLE
Fix GitHub search functionality GraphQL variable name error

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -667,7 +667,7 @@ export async function listIssues(
         `repo:${context.owner}/${context.repo} is:issue ${stateFilter} sort:updated-desc ${options.search}`.trim();
 
       const response = (await client(SEARCH_QUERY, {
-        query: searchQuery,
+        searchQuery,
         type: "ISSUE",
         cursor: options.cursor,
         limit: 20,
@@ -754,7 +754,7 @@ export async function listPullRequests(
         `repo:${context.owner}/${context.repo} is:pr ${stateFilter} sort:updated-desc ${options.search}`.trim();
 
       const response = (await client(SEARCH_QUERY, {
-        query: searchQuery,
+        searchQuery,
         type: "ISSUE",
         cursor: options.cursor,
         limit: 20,

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -92,8 +92,8 @@ export const LIST_PRS_QUERY = `
 `;
 
 export const SEARCH_QUERY = `
-  query SearchItems($query: String!, $type: SearchType!, $cursor: String, $limit: Int = 20) {
-    search(query: $query, type: $type, first: $limit, after: $cursor) {
+  query SearchItems($searchQuery: String!, $type: SearchType!, $cursor: String, $limit: Int = 20) {
+    search(query: $searchQuery, type: $type, first: $limit, after: $cursor) {
       issueCount
       pageInfo {
         hasNextPage


### PR DESCRIPTION
## Summary
Fixes the GraphQL variable name error that was preventing issue and PR search functionality from working in the toolbar dropdowns.

Closes #1359

## Changes Made
- Renamed GraphQL variable from `$query` to `$searchQuery` in SEARCH_QUERY definition to avoid reserved keyword conflict
- Updated query body reference from `query: $query` to `query: $searchQuery`
- Updated listIssues call site to pass searchQuery variable correctly
- Updated listPullRequests call site to pass searchQuery variable correctly

## Root Cause
The word `query` is a reserved keyword in GraphQL and cannot be used as a variable name, even with the `$` prefix. This was causing all search requests to fail with the error: `[@octokit/graphql] "query" cannot be used as variable name`

## Testing
- Verified TypeScript compilation passes
- Codex review confirmed changes are correct and complete
- No other GraphQL queries have similar reserved keyword issues