### PR TITLE
Fix terminal link color inconsistency between live and history views

### DIFF
--- a/src/components/Terminal/HistoryOverlayTerminalView.tsx
+++ b/src/components/Terminal/HistoryOverlayTerminalView.tsx
@@ -843,8 +843,8 @@ export const HistoryOverlayTerminalView = forwardRef<
                 - Span styling preserves inline flow for proper text rendering */}
             <style>{`
               .history-overlay a:hover {
-                color: #79c0ff !important;
-                text-decoration-color: #79c0ff;
+                color: #7dd3fc !important;
+                text-decoration-color: #7dd3fc;
               }
               .history-overlay .history-row {
                 display: block;

--- a/src/components/Terminal/utils/htmlUtils.ts
+++ b/src/components/Terminal/utils/htmlUtils.ts
@@ -27,7 +27,7 @@ export function linkifyHtml(html: string): string {
           cleanUrl = cleanUrl.slice(0, -suffix.length);
         }
 
-        return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer" style="color:#58a6ff;text-decoration:underline;text-underline-offset:2px">${cleanUrl}</a>${suffix}`;
+        return `<a href="${cleanUrl}" target="_blank" rel="noopener noreferrer" style="color:#38bdf8;text-decoration:underline;text-underline-offset:2px">${cleanUrl}</a>${suffix}`;
       });
     })
     .join("");


### PR DESCRIPTION
## Summary
Standardizes link colors between live terminal view and history view to eliminate visual inconsistency. Links in both views now use the terminal theme's blue (#38bdf8) and brightBlue (#7dd3fc) colors.

Closes #1357

## Changes Made
- Update history view link color from #58a6ff (GitHub blue) to #38bdf8 (terminal theme sky-400)
- Update history view hover color from #79c0ff to #7dd3fc (terminal theme sky-300/brightBlue)
- Colors now match the live terminal's OSC 8 hyperlink styling
- Ensures consistent link appearance when scrolling between live output and history mode

## Testing
- Verified colors match terminal theme definition (terminalTheme.ts)
- Confirmed alignment with live terminal OSC 8 link color (UrlStyler.ts)
- Code review completed via Codex