### PR TITLE
Remove 'Create Recipe' from worktree context menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -351,7 +351,6 @@ function SidebarContent() {
         worktree.issueNumber ? () => worktreeActions.handleOpenIssue(worktree) : undefined
       }
       onOpenPR={worktree.prUrl ? () => worktreeActions.handleOpenPR(worktree) : undefined}
-      onCreateRecipe={() => worktreeActions.handleCreateRecipe(worktree.id)}
       onSaveLayout={() => worktreeActions.handleSaveLayout(worktree)}
       onLaunchAgent={(type) => worktreeActions.handleLaunchAgent(worktree.id, type)}
       agentAvailability={availability}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -36,7 +36,6 @@ export interface WorktreeCardProps {
   onOpenEditor: () => void;
   onOpenIssue?: () => void;
   onOpenPR?: () => void;
-  onCreateRecipe?: () => void;
   onSaveLayout?: () => void;
   onLaunchAgent?: (agentId: string) => void;
   agentAvailability?: UseAgentLauncherReturn["availability"];
@@ -53,7 +52,6 @@ export function WorktreeCard({
   onOpenEditor,
   onOpenIssue,
   onOpenPR,
-  onCreateRecipe,
   onSaveLayout,
   onLaunchAgent,
   agentAvailability,
@@ -257,7 +255,6 @@ export function WorktreeCard({
     onLaunchAgent,
     onOpenIssue,
     onOpenPR,
-    onCreateRecipe,
     onSaveLayout,
     onRestartAll: () => void handleRestartAll(),
     onCloseAll: handleCloseAll,
@@ -333,7 +330,6 @@ export function WorktreeCard({
             onOpenPR:
               worktree.issueNumber && worktree.prNumber && onOpenPR ? handleOpenPR : undefined,
             onRunRecipe: (recipeId) => void handleRunRecipe(recipeId),
-            onCreateRecipe,
             onSaveLayout,
             onLaunchAgent,
             onMinimizeAll: handleMinimizeAll,

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -81,7 +81,6 @@ export interface WorktreeHeaderProps {
     onOpenIssue?: () => void;
     onOpenPR?: () => void;
     onRunRecipe: (recipeId: string) => void;
-    onCreateRecipe?: () => void;
     onSaveLayout?: () => void;
     onLaunchAgent?: (agentId: string) => void;
     onMinimizeAll: () => void;
@@ -222,7 +221,6 @@ export function WorktreeHeader({
                 onOpenIssue={menu.onOpenIssue}
                 onOpenPR={menu.onOpenPR}
                 onRunRecipe={menu.onRunRecipe}
-                onCreateRecipe={menu.onCreateRecipe}
                 onSaveLayout={menu.onSaveLayout}
                 onMinimizeAll={menu.onMinimizeAll}
                 onMaximizeAll={menu.onMaximizeAll}

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
@@ -14,7 +14,6 @@ export function useWorktreeMenu({
   onLaunchAgent,
   onOpenIssue,
   onOpenPR,
-  onCreateRecipe,
   onSaveLayout,
   onRestartAll,
   onCloseAll,
@@ -37,7 +36,6 @@ export function useWorktreeMenu({
   onLaunchAgent?: (agentId: string) => void;
   onOpenIssue?: () => void;
   onOpenPR?: () => void;
-  onCreateRecipe?: () => void;
   onSaveLayout?: () => void;
   onRestartAll: () => void;
   onCloseAll: () => void;
@@ -133,8 +131,7 @@ export function useWorktreeMenu({
       }
     }
 
-    const hasRecipeSection =
-      recipes.length > 0 || !!onCreateRecipe || (onSaveLayout && counts.active > 0);
+    const hasRecipeSection = recipes.length > 0 || (onSaveLayout && counts.active > 0);
     if (hasRecipeSection) {
       template.push({ type: "separator" });
       template.push({ id: "label:recipes", label: "Recipes", enabled: false });
@@ -149,10 +146,6 @@ export function useWorktreeMenu({
             enabled: runningRecipeId === null,
           })),
         });
-      }
-
-      if (onCreateRecipe) {
-        template.push({ id: "recipes:create", label: "Create Recipe..." });
       }
 
       if (onSaveLayout && counts.active > 0) {
@@ -179,7 +172,6 @@ export function useWorktreeMenu({
     isMainWorktree,
     isRestartValidating,
     launchAgents,
-    onCreateRecipe,
     onLaunchAgent,
     onOpenIssue,
     onOpenPR,
@@ -291,13 +283,6 @@ export function useWorktreeMenu({
         case "worktree:open-pr":
           void actionService.dispatch(
             "worktree.openPR",
-            { worktreeId: worktree.id },
-            { source: "context-menu" }
-          );
-          break;
-        case "recipes:create":
-          void actionService.dispatch(
-            "recipe.editor.open",
             { worktreeId: worktree.id },
             { source: "context-menu" }
           );

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -10,7 +10,6 @@ import {
   Maximize2,
   Minimize2,
   Play,
-  Plus,
   RotateCcw,
   Save,
   Terminal,
@@ -61,7 +60,6 @@ export interface WorktreeMenuItemsProps {
   onOpenIssue?: () => void;
   onOpenPR?: () => void;
   onRunRecipe: (recipeId: string) => void;
-  onCreateRecipe?: () => void;
   onSaveLayout?: () => void;
   onMinimizeAll: () => void;
   onMaximizeAll: () => void;
@@ -88,7 +86,6 @@ export function WorktreeMenuItems({
   onOpenIssue,
   onOpenPR,
   onRunRecipe,
-  onCreateRecipe,
   onSaveLayout,
   onMinimizeAll,
   onMaximizeAll,
@@ -101,6 +98,7 @@ export function WorktreeMenuItems({
 }: WorktreeMenuItemsProps) {
   const hasIssueOrPr = Boolean(worktree.issueNumber || worktree.prNumber);
   const hasRecipes = recipes.length > 0;
+  const hasRecipeSection = hasRecipes || (onSaveLayout && counts.active > 0);
   const hasSessions = counts.all > 0;
 
   return (
@@ -209,9 +207,9 @@ export function WorktreeMenuItems({
         </C.Item>
       )}
 
-      {(hasRecipes || onCreateRecipe || onSaveLayout) && <C.Separator />}
+      {hasRecipeSection && <C.Separator />}
 
-      {(hasRecipes || onCreateRecipe || onSaveLayout) && (
+      {hasRecipeSection && (
         <>
           <C.Label>Recipes</C.Label>
           {hasRecipes && (
@@ -232,12 +230,6 @@ export function WorktreeMenuItems({
                 ))}
               </C.SubContent>
             </C.Sub>
-          )}
-          {onCreateRecipe && (
-            <C.Item onSelect={onCreateRecipe}>
-              <Plus className="w-3.5 h-3.5 mr-2" />
-              Create Recipe...
-            </C.Item>
           )}
           {onSaveLayout && counts.active > 0 && (
             <C.Item onSelect={onSaveLayout}>

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -15,7 +15,6 @@ export interface WorktreeActions {
   handleOpenEditor: (worktree: WorktreeState) => void;
   handleOpenIssue: (worktree: WorktreeState) => void;
   handleOpenPR: (worktree: WorktreeState) => void;
-  handleCreateRecipe: (worktreeId: string) => void;
   handleSaveLayout: (worktree: WorktreeState) => void;
   handleLaunchAgent: (worktreeId: string, agentId: string) => void;
 }
@@ -110,13 +109,6 @@ export function useWorktreeActions({
     }
   }, []);
 
-  const handleCreateRecipe = useCallback(
-    (worktreeId: string) => {
-      onOpenRecipeEditor?.(worktreeId, undefined);
-    },
-    [onOpenRecipeEditor]
-  );
-
   const handleSaveLayout = useCallback(
     (worktree: WorktreeState) => {
       const terminals = useRecipeStore.getState().generateRecipeFromActiveTerminals(worktree.id);
@@ -148,7 +140,6 @@ export function useWorktreeActions({
     handleOpenEditor,
     handleOpenIssue,
     handleOpenPR,
-    handleCreateRecipe,
     handleSaveLayout,
     handleLaunchAgent,
   };


### PR DESCRIPTION
## Summary
Removes the "Create Recipe..." option from worktree context menus to eliminate redundancy with Project Settings and improve UX clarity.

Closes #1381

## Changes Made
- Remove onCreateRecipe prop from WorktreeCard and related components
- Remove 'Create Recipe...' menu item from both context and dropdown menus
- Remove recipes:create case handler from useWorktreeMenu switch
- Remove handleCreateRecipe function from useWorktreeActions
- Fix hasRecipeSection logic to only show when recipes exist or layout can be saved
- Remove unused Plus icon import from WorktreeMenuItems

## Context
The "Create Recipe..." option was not contextually relevant to individual worktrees—it simply opened a blank recipe editor with no connection to the current worktree state. Recipe creation is a project configuration task that belongs in Project Settings, where users can manage all recipes (create, edit, delete, import, export) in one place.

"Save Layout as Recipe" remains in the context menu as it is truly worktree-contextual—it captures the current terminal layout state.