### PR TITLE
Fix terminal orphaning when created by recipe during worktree creation

### DIFF
--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -72,16 +72,15 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       rootPath: z.string(),
       options: z.any(),
     }),
+    resultSchema: z.string(),
     run: async (args: unknown) => {
       const { rootPath, options } = args as { rootPath: string; options: unknown };
       const worktreeId = await worktreeClient.create(options as any, rootPath);
-      if (worktreeId) {
-        useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
-      } else {
-        console.warn(
-          "[worktree.create] No worktreeId returned from creation - skipping auto-selection"
-        );
+      if (!worktreeId) {
+        throw new Error("Failed to create worktree: no worktreeId returned from backend");
       }
+      useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
+      return worktreeId;
     },
   }));
 


### PR DESCRIPTION
## Summary
Fixes a critical UX bug where terminals spawned by recipes during worktree creation were orphaned and invisible in the UI.

Closes #1387

## Root Cause
The `worktree.create` action was not returning the `worktreeId`, causing `NewWorktreeDialog` to pass `undefined` as the `worktreeId` when running recipes. This resulted in terminals being created without a worktreeId, making them invisible when the UI filters terminals by `t.worktreeId === worktreeId`.

## Changes Made
- Return `worktreeId` from `worktree.create` action to properly propagate it to recipe execution
- Add `resultSchema: z.string()` to document the return type contract
- Improve error handling by throwing an error when `worktreeId` is missing instead of silent failure
- Ensures recipe terminals are properly associated with their parent worktree

## Testing
- Verified type checking passes
- Code review by Codex identified and addressed edge cases
- Changes ensure terminals created during worktree creation with recipes are now visible in the UI

## Impact
Users can now successfully create worktrees with recipes and see the spawned terminals immediately in the grid or dock, as expected.