### PR TITLE
Add CLI argument support for initial prompts in agent terminals

### DIFF
--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -1,4 +1,5 @@
 import { AGENT_REGISTRY } from "../config/agentRegistry.js";
+import { escapeShellArg } from "../utils/shellEscape.js";
 
 export interface AgentSettingsEntry {
   enabled?: boolean;
@@ -59,4 +60,90 @@ export function generateAgentFlags(entry: AgentSettingsEntry, agentId?: string):
     }
   }
   return flags;
+}
+
+export interface GenerateAgentCommandOptions {
+  /** Initial prompt to pass to the agent CLI */
+  initialPrompt?: string;
+  /** If true, agent runs in interactive mode (default). If false, runs one-shot/print mode. */
+  interactive?: boolean;
+}
+
+/**
+ * Generates a complete agent command string including base command, flags, and optional initial prompt.
+ *
+ * @param baseCommand - The base command for the agent (e.g., "claude", "gemini")
+ * @param entry - Agent settings entry containing flags configuration
+ * @param agentId - The agent identifier (e.g., "claude", "gemini", "codex")
+ * @param options - Optional configuration including initial prompt and interactive mode
+ * @returns The complete command string to spawn the agent
+ *
+ * @example
+ * // Claude interactive with prompt
+ * generateAgentCommand("claude", entry, "claude", { initialPrompt: "Fix the bug" });
+ * // => "claude --flags 'Fix the bug'"
+ *
+ * // Claude one-shot (print mode)
+ * generateAgentCommand("claude", entry, "claude", { initialPrompt: "Fix the bug", interactive: false });
+ * // => "claude --flags -p 'Fix the bug'"
+ */
+export function generateAgentCommand(
+  baseCommand: string,
+  entry: AgentSettingsEntry,
+  agentId?: string,
+  options?: GenerateAgentCommandOptions
+): string {
+  const flags = generateAgentFlags(entry, agentId);
+  const parts: string[] = [baseCommand];
+
+  // Add flags, escaping non-flag values
+  for (const flag of flags) {
+    if (flag.startsWith("-")) {
+      parts.push(flag);
+    } else {
+      parts.push(escapeShellArg(flag));
+    }
+  }
+
+  // Add initial prompt if provided
+  const prompt = options?.initialPrompt?.trim();
+  if (prompt) {
+    const interactive = options?.interactive ?? true;
+    // Normalize multi-line prompts to single line (replace newlines with spaces)
+    const normalizedPrompt = prompt.replace(/\r\n/g, " ").replace(/\n/g, " ");
+    const escapedPrompt = escapeShellArg(normalizedPrompt);
+
+    switch (agentId) {
+      case "claude":
+        // Claude: -p for print mode (non-interactive), otherwise just the prompt
+        if (!interactive) {
+          parts.push("-p");
+        }
+        parts.push(escapedPrompt);
+        break;
+
+      case "gemini":
+        // Gemini: -i for interactive with prompt, otherwise just the prompt
+        if (interactive) {
+          parts.push("-i", escapedPrompt);
+        } else {
+          parts.push(escapedPrompt);
+        }
+        break;
+
+      case "codex":
+        // Codex: "exec" subcommand for non-interactive, otherwise just the prompt
+        if (!interactive) {
+          parts.push("exec");
+        }
+        parts.push(escapedPrompt);
+        break;
+
+      default:
+        // Generic agent: just append the prompt
+        parts.push(escapedPrompt);
+    }
+  }
+
+  return parts.join(" ");
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -196,7 +196,11 @@ export type {
 export type { KeyAction, KeymapPreset, KeyMapConfig } from "./keymap.js";
 
 // Agent settings types - AI agent CLI configuration
-export type { AgentSettingsEntry, AgentSettings } from "./agentSettings.js";
+export type {
+  AgentSettingsEntry,
+  AgentSettings,
+  GenerateAgentCommandOptions,
+} from "./agentSettings.js";
 
 // Agent settings helpers
 export {
@@ -204,6 +208,7 @@ export {
   DEFAULT_DANGEROUS_ARGS,
   getAgentSettingsEntry,
   generateAgentFlags,
+  generateAgentCommand,
 } from "./agentSettings.js";
 
 // User agent registry types - user-defined agent configuration

--- a/shared/utils/__tests__/shellEscape.test.ts
+++ b/shared/utils/__tests__/shellEscape.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import {
+  escapeShellArg,
+  escapeShellArgOptional,
+  isSafeUnescaped,
+  isWindows,
+} from "../shellEscape.js";
+
+describe("shellEscape", () => {
+  describe("escapeShellArg - POSIX", () => {
+    it("should wrap simple strings in single quotes", () => {
+      expect(escapeShellArg("hello", "posix")).toBe("'hello'");
+      expect(escapeShellArg("hello world", "posix")).toBe("'hello world'");
+    });
+
+    it("should handle empty strings", () => {
+      expect(escapeShellArg("", "posix")).toBe("''");
+    });
+
+    it("should escape single quotes by ending, escaping, and restarting", () => {
+      expect(escapeShellArg("it's working", "posix")).toBe("'it'\\''s working'");
+      expect(escapeShellArg("'quoted'", "posix")).toBe("''\\''quoted'\\'''");
+    });
+
+    it("should handle double quotes without special escaping", () => {
+      expect(escapeShellArg('he said "hello"', "posix")).toBe("'he said \"hello\"'");
+    });
+
+    it("should handle newlines", () => {
+      expect(escapeShellArg("line1\nline2", "posix")).toBe("'line1\nline2'");
+      expect(escapeShellArg("line1\r\nline2", "posix")).toBe("'line1\r\nline2'");
+    });
+
+    it("should handle special shell characters", () => {
+      expect(escapeShellArg("$HOME", "posix")).toBe("'$HOME'");
+      expect(escapeShellArg("`whoami`", "posix")).toBe("'`whoami`'");
+      expect(escapeShellArg("!important", "posix")).toBe("'!important'");
+      expect(escapeShellArg("a & b", "posix")).toBe("'a & b'");
+      expect(escapeShellArg("a ; b", "posix")).toBe("'a ; b'");
+      expect(escapeShellArg("a | b", "posix")).toBe("'a | b'");
+      expect(escapeShellArg("$(command)", "posix")).toBe("'$(command)'");
+    });
+
+    it("should handle backslashes", () => {
+      expect(escapeShellArg("path\\to\\file", "posix")).toBe("'path\\to\\file'");
+      expect(escapeShellArg("\\n", "posix")).toBe("'\\n'");
+    });
+
+    it("should handle unicode characters", () => {
+      expect(escapeShellArg("こんにちは", "posix")).toBe("'こんにちは'");
+      expect(escapeShellArg("🚀 rocket", "posix")).toBe("'🚀 rocket'");
+      expect(escapeShellArg("café", "posix")).toBe("'café'");
+    });
+
+    it("should handle mixed quotes and special characters", () => {
+      expect(escapeShellArg('it\'s a "test" with $vars', "posix")).toBe(
+        "'it'\\''s a \"test\" with $vars'"
+      );
+    });
+
+    it("should handle multiple single quotes", () => {
+      expect(escapeShellArg("''", "posix")).toBe("''\\'''\\'''");
+      expect(escapeShellArg("'''", "posix")).toBe("''\\'''\\'''\\'''");
+    });
+
+    it("should handle tabs and other whitespace", () => {
+      expect(escapeShellArg("hello\tworld", "posix")).toBe("'hello\tworld'");
+      expect(escapeShellArg("  spaced  ", "posix")).toBe("'  spaced  '");
+    });
+
+    it("should handle hash/comment characters", () => {
+      expect(escapeShellArg("# comment", "posix")).toBe("'# comment'");
+    });
+
+    it("should handle glob patterns", () => {
+      expect(escapeShellArg("*.txt", "posix")).toBe("'*.txt'");
+      expect(escapeShellArg("file?.txt", "posix")).toBe("'file?.txt'");
+      expect(escapeShellArg("[abc].txt", "posix")).toBe("'[abc].txt'");
+    });
+
+    it("should handle parentheses and braces", () => {
+      expect(escapeShellArg("(sub)", "posix")).toBe("'(sub)'");
+      expect(escapeShellArg("{a,b}", "posix")).toBe("'{a,b}'");
+    });
+  });
+
+  describe("escapeShellArg - Windows", () => {
+    it("should wrap simple strings in double quotes", () => {
+      expect(escapeShellArg("hello", "windows")).toBe('"hello"');
+      expect(escapeShellArg("hello world", "windows")).toBe('"hello world"');
+    });
+
+    it("should handle empty strings", () => {
+      expect(escapeShellArg("", "windows")).toBe('""');
+    });
+
+    it("should escape double quotes by doubling them", () => {
+      expect(escapeShellArg('say "hello"', "windows")).toBe('"say ""hello"""');
+      expect(escapeShellArg('test"test', "windows")).toBe('"test""test"');
+    });
+
+    it("should handle single quotes without special escaping", () => {
+      expect(escapeShellArg("it's working", "windows")).toBe('"it\'s working"');
+    });
+
+    it("should handle newlines", () => {
+      expect(escapeShellArg("line1\nline2", "windows")).toBe('"line1\nline2"');
+      expect(escapeShellArg("line1\r\nline2", "windows")).toBe('"line1\r\nline2"');
+    });
+
+    it("should handle special characters", () => {
+      expect(escapeShellArg("%PATH%", "windows")).toBe('"%PATH%"');
+      expect(escapeShellArg("a & b", "windows")).toBe('"a & b"');
+      expect(escapeShellArg("a | b", "windows")).toBe('"a | b"');
+    });
+
+    it("should double trailing backslashes", () => {
+      expect(escapeShellArg("path\\", "windows")).toBe('"path\\\\"');
+      expect(escapeShellArg("path\\\\", "windows")).toBe('"path\\\\\\\\"');
+    });
+
+    it("should handle backslashes not at the end", () => {
+      expect(escapeShellArg("path\\to\\file", "windows")).toBe('"path\\to\\file"');
+    });
+
+    it("should handle unicode characters", () => {
+      expect(escapeShellArg("こんにちは", "windows")).toBe('"こんにちは"');
+      expect(escapeShellArg("🚀 rocket", "windows")).toBe('"🚀 rocket"');
+    });
+
+    it("should handle mixed quotes", () => {
+      expect(escapeShellArg('it\'s a "test"', "windows")).toBe('"it\'s a ""test"""');
+    });
+
+    it("should handle multiple double quotes", () => {
+      expect(escapeShellArg('""', "windows")).toBe('""""""');
+      expect(escapeShellArg('"""', "windows")).toBe('""""""""');
+    });
+  });
+
+  describe("isSafeUnescaped", () => {
+    it("should return true for alphanumeric strings", () => {
+      expect(isSafeUnescaped("hello")).toBe(true);
+      expect(isSafeUnescaped("Hello123")).toBe(true);
+      expect(isSafeUnescaped("ABC")).toBe(true);
+    });
+
+    it("should return true for strings with hyphens and underscores", () => {
+      expect(isSafeUnescaped("my-flag")).toBe(true);
+      expect(isSafeUnescaped("my_var")).toBe(true);
+      expect(isSafeUnescaped("flag-name_123")).toBe(true);
+    });
+
+    it("should return true for strings with forward slashes", () => {
+      expect(isSafeUnescaped("path/to/file")).toBe(true);
+      expect(isSafeUnescaped("/usr/bin")).toBe(true);
+    });
+
+    it("should return false for empty strings", () => {
+      expect(isSafeUnescaped("")).toBe(false);
+    });
+
+    it("should return false for strings with spaces", () => {
+      expect(isSafeUnescaped("hello world")).toBe(false);
+    });
+
+    it("should return false for strings with special characters", () => {
+      expect(isSafeUnescaped("$HOME")).toBe(false);
+      expect(isSafeUnescaped("it's")).toBe(false);
+      expect(isSafeUnescaped('say "hi"')).toBe(false);
+      expect(isSafeUnescaped("a&b")).toBe(false);
+      expect(isSafeUnescaped("*.txt")).toBe(false);
+    });
+
+    it("should return false for strings with backslashes", () => {
+      expect(isSafeUnescaped("path\\to")).toBe(false);
+    });
+  });
+
+  describe("escapeShellArgOptional", () => {
+    it("should return safe strings unquoted", () => {
+      expect(escapeShellArgOptional("hello", "posix")).toBe("hello");
+      expect(escapeShellArgOptional("my-flag", "posix")).toBe("my-flag");
+      expect(escapeShellArgOptional("path/to/file", "posix")).toBe("path/to/file");
+    });
+
+    it("should escape unsafe strings", () => {
+      expect(escapeShellArgOptional("hello world", "posix")).toBe("'hello world'");
+      expect(escapeShellArgOptional("$HOME", "posix")).toBe("'$HOME'");
+    });
+
+    it("should handle empty strings", () => {
+      expect(escapeShellArgOptional("", "posix")).toBe("''");
+      expect(escapeShellArgOptional("", "windows")).toBe('""');
+    });
+  });
+
+  describe("isWindows", () => {
+    it("should return a boolean", () => {
+      expect(typeof isWindows()).toBe("boolean");
+    });
+  });
+
+  describe("real-world prompts", () => {
+    const testCases = [
+      "Implement a login feature",
+      "Fix the bug in user's profile page",
+      'Add a button that says "Submit"',
+      "Review the code and look for:\n- Security issues\n- Performance problems",
+      "Create a function that handles $variable interpolation",
+      "Write tests for the `calculate()` function",
+      "Update the README with installation instructions",
+      "Fix issue #123: Users can't log in with special chars like &, <, >",
+    ];
+
+    it.each(testCases)("should safely escape: %s", (prompt) => {
+      const posix = escapeShellArg(prompt, "posix");
+      const windows = escapeShellArg(prompt, "windows");
+
+      // Verify quotes are present
+      expect(posix.startsWith("'")).toBe(true);
+      expect(posix.endsWith("'")).toBe(true);
+      expect(windows.startsWith('"')).toBe(true);
+      expect(windows.endsWith('"')).toBe(true);
+    });
+  });
+
+  describe("security edge cases", () => {
+    it("should prevent command injection via semicolon", () => {
+      const malicious = "; rm -rf /";
+      expect(escapeShellArg(malicious, "posix")).toBe("'; rm -rf /'");
+    });
+
+    it("should prevent command injection via backticks", () => {
+      const malicious = "`rm -rf /`";
+      expect(escapeShellArg(malicious, "posix")).toBe("'`rm -rf /`'");
+    });
+
+    it("should prevent command injection via $() substitution", () => {
+      const malicious = "$(rm -rf /)";
+      expect(escapeShellArg(malicious, "posix")).toBe("'$(rm -rf /)'");
+    });
+
+    it("should prevent command injection via pipes", () => {
+      const malicious = "| cat /etc/passwd";
+      expect(escapeShellArg(malicious, "posix")).toBe("'| cat /etc/passwd'");
+    });
+
+    it("should handle null bytes (strings can't contain them in JS)", () => {
+      const withNull = "before\0after";
+      const escaped = escapeShellArg(withNull, "posix");
+      expect(escaped.includes("\0")).toBe(true);
+    });
+  });
+});

--- a/shared/utils/shellEscape.ts
+++ b/shared/utils/shellEscape.ts
@@ -1,0 +1,116 @@
+/**
+ * Platform detection utilities and shell escaping functions.
+ * Provides safe escaping for CLI arguments to prevent shell injection.
+ */
+
+/**
+ * Detects if the current platform is Windows.
+ * Works in both Node.js and browser environments.
+ */
+export function isWindows(): boolean {
+  // Node.js environment
+  if (typeof process !== "undefined" && process.platform) {
+    return process.platform === "win32";
+  }
+  // Browser environment - check navigator.userAgent
+  if (typeof navigator !== "undefined" && navigator.userAgent) {
+    return /\bWindows\b|\bWin(32|64)\b/.test(navigator.userAgent);
+  }
+  return false;
+}
+
+/**
+ * Escapes a string for safe use as a shell argument.
+ * Uses single quotes on Unix (POSIX) and double quotes on Windows (cmd.exe).
+ *
+ * @param arg - The string to escape
+ * @param platform - Optional platform override ('windows' or 'posix')
+ * @returns The escaped string safe for use as a shell argument
+ *
+ * @example
+ * // On Unix/macOS:
+ * escapeShellArg("hello world") // "'hello world'"
+ * escapeShellArg("it's working") // "'it'\\''s working'"
+ *
+ * // On Windows:
+ * escapeShellArg('say "hello"') // '"say ""hello"""'
+ */
+export function escapeShellArg(arg: string, platform?: "windows" | "posix"): string {
+  // Handle empty strings
+  if (arg === "") {
+    return platform === "windows" || (platform === undefined && isWindows()) ? '""' : "''";
+  }
+
+  const useWindows = platform === "windows" || (platform === undefined && isWindows());
+
+  if (useWindows) {
+    return escapeWindowsArg(arg);
+  }
+  return escapePosixArg(arg);
+}
+
+/**
+ * Escapes a string for use in Windows cmd.exe.
+ * Uses double quotes and escapes internal double quotes by doubling them.
+ *
+ * Windows cmd.exe rules:
+ * - Wrap in double quotes
+ * - Escape internal double quotes by doubling them (" → "")
+ * - Backslashes before quotes need special handling
+ */
+function escapeWindowsArg(arg: string): string {
+  // Replace double quotes with escaped double quotes
+  // Windows uses "" to escape a double quote inside a double-quoted string
+  let escaped = arg.replace(/"/g, '""');
+
+  // Handle trailing backslashes which can escape the closing quote
+  // Each backslash before the closing quote needs to be doubled
+  if (escaped.endsWith("\\")) {
+    const match = escaped.match(/\\+$/);
+    if (match) {
+      escaped = escaped + match[0]; // Double the trailing backslashes
+    }
+  }
+
+  return `"${escaped}"`;
+}
+
+/**
+ * Escapes a string for use in POSIX shells (bash, zsh, etc.).
+ * Uses single quotes which prevent all interpretation except single quotes themselves.
+ *
+ * POSIX single quote rules:
+ * - Everything inside single quotes is literal
+ * - Single quotes themselves cannot be escaped inside single quotes
+ * - To include a single quote: end quote, add escaped quote, restart quote
+ *   Example: 'it'\''s' (end single quote, escaped single quote, restart)
+ */
+function escapePosixArg(arg: string): string {
+  // Replace single quotes with: end quote, backslash-escaped quote, start quote
+  // 'foo'bar' becomes 'foo'\''bar'
+  const escaped = arg.replace(/'/g, "'\\''");
+  return `'${escaped}'`;
+}
+
+/**
+ * Checks if a string is safe to use without escaping.
+ * Returns true if the string contains only alphanumeric characters,
+ * hyphens, underscores, and forward slashes.
+ */
+export function isSafeUnescaped(arg: string): boolean {
+  return /^[a-zA-Z0-9_\-/]+$/.test(arg);
+}
+
+/**
+ * Escapes a string for shell argument, but returns it unquoted if it's "safe".
+ * Use this when you want cleaner output for simple strings.
+ */
+export function escapeShellArgOptional(arg: string, platform?: "windows" | "posix"): string {
+  if (arg === "") {
+    return escapeShellArg(arg, platform);
+  }
+  if (isSafeUnescaped(arg)) {
+    return arg;
+  }
+  return escapeShellArg(arg, platform);
+}


### PR DESCRIPTION
## Summary

This PR adds native support for passing initial prompts to agent terminals via CLI arguments, replacing the queue-based stdin approach. This simplifies terminal spawning, eliminates timing complexity, and enables programmatic prompt injection across the action system.

Closes #1390

## Changes Made

- Add shell escaping utility (shared/utils/shellEscape.ts) with platform-aware POSIX/Windows support
- Add comprehensive test suite with 49 test cases covering security edge cases
- Add generateAgentCommand() to centralize agent CLI construction with prompt escaping
- Update recipe execution to pass initial prompts as CLI args instead of stdin queue
- Refactor useAgentLauncher to use centralized command generation
- Handle multi-line prompts by normalizing to single line
- Support custom commands with initial prompts in recipes

## Key Benefits

- **Simpler**: CLI arguments are processed before shell starts, eliminating race conditions
- **More direct**: Agents start working immediately without boot detection
- **Action system ready**: `initialPrompt` parameter now available in terminal spawn actions
- **Centralized**: All agent command building goes through `generateAgentCommand()`
- **Secure**: Comprehensive shell escaping prevents command injection

## Testing

- 49 shell escaping tests covering security edge cases (quotes, newlines, special chars, injection attacks)
- All existing tests pass
- Type checking and linting pass