### PR TITLE
Increase notes interface width for better usability

### DIFF
--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -113,7 +113,7 @@ export type SidecarNewTabMenuAction =
 
 export const DEFAULT_SIDECAR_TABS: SidecarTab[] = [];
 
-export const SIDECAR_MIN_WIDTH = 340;
+export const SIDECAR_MIN_WIDTH = 480;
 export const SIDECAR_MAX_WIDTH = 1200;
-export const SIDECAR_DEFAULT_WIDTH = 600;
+export const SIDECAR_DEFAULT_WIDTH = 640;
 export const MIN_GRID_WIDTH = 400;

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -211,7 +211,7 @@ export function AppLayout({
     window.addEventListener("resize", handleResize);
     handleResize();
     return () => window.removeEventListener("resize", handleResize);
-  }, [sidebarWidth, layout.updateSidecarLayoutMode, layout.isFocusMode]);
+  }, [sidebarWidth, layout.updateSidecarLayoutMode, layout.isFocusMode, layout.sidecarWidth]);
 
   useEffect(() => {
     if (!layout.sidecarOpen) {


### PR DESCRIPTION
## Summary
Increases sidecar width constraints to provide more comfortable markdown editing space, particularly for the notes interface. Minimum width increased from 340px to 480px (supporting 60-75 character line width), and default width from 600px to 640px for a better out-of-box experience.

Closes #1399

## Changes Made
- Increase SIDECAR_MIN_WIDTH from 340px to 480px for comfortable markdown editing (60-75 char line width)
- Increase SIDECAR_DEFAULT_WIDTH from 600px to 640px for better out-of-box experience
- Fix layout mode recalculation to trigger on sidecar width changes (prevents stale overlay/push state after width clamping or manual resize)

## Technical Notes
- Settings UI automatically reflects new constraints (uses constants directly)
- Persisted widths below 480px will be automatically clamped upward on next load
- Layout mode now correctly recalculates when sidecar width changes, preventing stale overlay/push mode
- On 1366px displays with auto mode, sidecar may default to overlay (provides more usable grid space)