### PR TITLE
Remember last selected recipe when creating worktrees

### DIFF
--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -28,6 +28,8 @@ interface PreferencesState {
   setShowDeveloperTools: (show: boolean) => void;
   assignWorktreeToSelf: boolean;
   setAssignWorktreeToSelf: (value: boolean) => void;
+  lastSelectedWorktreeRecipeId: string | null | undefined;
+  setLastSelectedWorktreeRecipeId: (id: string | null | undefined) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -39,6 +41,8 @@ export const usePreferencesStore = create<PreferencesState>()(
       setShowDeveloperTools: (show) => set({ showDeveloperTools: show }),
       assignWorktreeToSelf: false,
       setAssignWorktreeToSelf: (value) => set({ assignWorktreeToSelf: value }),
+      lastSelectedWorktreeRecipeId: undefined,
+      setLastSelectedWorktreeRecipeId: (id) => set({ lastSelectedWorktreeRecipeId: id }),
     }),
     {
       name: "canopy-preferences",


### PR DESCRIPTION
## Summary
Implements persistent recipe selection for the worktree creation dialog. The dialog now remembers the user's last selected recipe (or explicit "No recipe" choice) and pre-selects it on subsequent opens, reducing friction in the worktree creation workflow.

Closes #1403

## Changes Made
- Add `lastSelectedWorktreeRecipeId` to preferences store with tristate logic (undefined=unset, null=explicit no recipe, string=recipe ID)
- Implement recipe selection priority: last selected > project default > null
- Persist user recipe selections on both click and keyboard interaction
- Handle edge case where previously selected recipe is deleted by clearing persisted state and falling back to default
- Fix bug where explicit "No recipe" choice wasn't remembered when project default exists