### PR TITLE
Redesign worktree selection indicator with left-side accent bar

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -268,7 +268,7 @@ export function WorktreeCard({
       className={cn(
         "group relative border-b border-divider transition-all duration-200",
         isActive
-          ? "bg-white/[0.03] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)]"
+          ? "bg-white/[0.03] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)] before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-canopy-accent before:content-[''] before:z-10 motion-safe:before:animate-in motion-safe:before:fade-in motion-safe:before:duration-200"
           : "hover:bg-white/[0.02] bg-transparent",
         isFocused && !isActive && "bg-white/[0.02]",
         (isIdleCard || isStaleCard) && !isActive && !isFocused && "opacity-70 hover:opacity-100",

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -24,7 +24,6 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "../../
 import {
   AlertCircle,
   Check,
-  CheckCircle2,
   CircleDot,
   Copy,
   CornerDownRight,
@@ -121,12 +120,6 @@ export function WorktreeHeader({
     <div className="space-y-1">
       <div className="flex items-center gap-2 min-h-[22px]">
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          {isActive && (
-            <CheckCircle2
-              className="w-3.5 h-3.5 text-canopy-accent shrink-0 motion-safe:animate-in motion-safe:fade-in motion-safe:zoom-in motion-safe:duration-200"
-              aria-hidden="true"
-            />
-          )}
           {isMainWorktree && <Shield className="w-3.5 h-3.5 text-canopy-text/30 shrink-0" />}
           <BranchLabel label={branchLabel} isActive={isActive} isMainWorktree={isMainWorktree} />
           {worktree.isDetached && (


### PR DESCRIPTION
## Summary
Replaces the CheckCircle2 icon with a left-side accent bar for indicating active worktree selection. This provides a more spatially efficient and visually distinct selection indicator that doesn't consume horizontal space on the critical first line.

Closes #1402

## Changes Made
- Remove CheckCircle2 icon from WorktreeHeader component
- Add 2px left-side accent bar to WorktreeCard when active
- Match TerminalListItem pattern for visual consistency
- Fix Tailwind v4 variant ordering for motion-safe animations
- Add z-10 to ensure bar appears above WorktreeStatusSpine

## Implementation Details
- Uses CSS pseudo-element (`before:`) for the accent bar
- Positioned from `top-2` to `bottom-2` with `w-[2px]` width
- Includes fade-in animation with motion-safe support
- Bar appears above WorktreeStatusSpine (z-index layering)
- Maintains all existing functionality (aria-labels, selection state, etc.)

## Visual Impact
- Selection state now indicated by background color + left accent bar (instead of background + icon)
- Frees up horizontal space previously consumed by the CheckCircle2 icon
- Creates stronger visual association with "taking over" the panel grid
- Visually distinct from circular issue/PR icons below