### PR TITLE
Add toolbar customization settings

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -615,3 +615,45 @@ export interface ProjectSettings {
   /** Dev server command (e.g., "npm run dev") for the toolbar button */
   devServerCommand?: string;
 }
+
+// Toolbar Customization Types
+
+/** Unique identifier for toolbar buttons */
+export type ToolbarButtonId =
+  | "sidebar-toggle"
+  | "claude"
+  | "gemini"
+  | "codex"
+  | "terminal"
+  | "browser"
+  | "dev-server"
+  | "github-stats"
+  | "notes"
+  | "copy-tree"
+  | "settings"
+  | "problems"
+  | "sidecar-toggle";
+
+/** Configuration for which toolbar buttons are visible and their order */
+export interface ToolbarLayout {
+  /** Ordered list of button IDs to show on the left side (excluding sidebar-toggle which is always first) */
+  leftButtons: ToolbarButtonId[];
+  /** Ordered list of button IDs to show on the right side (excluding sidecar-toggle which is always last) */
+  rightButtons: ToolbarButtonId[];
+}
+
+/** Launcher palette default behaviors */
+export interface LauncherDefaults {
+  /** Always show dev server option in palette, even if devServerCommand not configured */
+  alwaysShowDevServer: boolean;
+  /** Default panel type to highlight when palette opens */
+  defaultSelection?: "terminal" | "claude" | "gemini" | "codex" | "browser" | "dev-server";
+}
+
+/** Complete toolbar preferences configuration */
+export interface ToolbarPreferences {
+  /** Layout configuration (button visibility and ordering) */
+  layout: ToolbarLayout;
+  /** Launcher palette defaults */
+  launcher: LauncherDefaults;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -603,6 +603,7 @@ function App() {
       "agents",
       "github",
       "sidecar",
+      "toolbar",
       "troubleshooting",
     ];
     if (!allowedTabs.includes(tab as SettingsTab)) {

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import {
   Keyboard,
   GitBranch,
   Terminal,
+  Settings as SettingsIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { appClient } from "@/clients";
@@ -22,6 +23,7 @@ import { TroubleshootingTab } from "./TroubleshootingTab";
 import { SidecarSettingsTab } from "./SidecarSettingsTab";
 import { KeyboardShortcutsTab } from "./KeyboardShortcutsTab";
 import { WorktreeSettingsTab } from "./WorktreeSettingsTab";
+import { ToolbarSettingsTab } from "./ToolbarSettingsTab";
 
 interface SettingsDialogProps {
   isOpen: boolean;
@@ -39,6 +41,7 @@ export type SettingsTab =
   | "agents"
   | "github"
   | "sidecar"
+  | "toolbar"
   | "troubleshooting";
 
 export function SettingsDialog({
@@ -86,6 +89,7 @@ export function SettingsDialog({
     agents: "Agent Settings",
     github: "GitHub Integration",
     sidecar: "Sidecar Links",
+    toolbar: "Toolbar Customization",
     troubleshooting: "Troubleshooting",
   };
 
@@ -153,6 +157,13 @@ export function SettingsDialog({
             Sidecar
           </NavButton>
           <NavButton
+            active={activeTab === "toolbar"}
+            onClick={() => setActiveTab("toolbar")}
+            icon={<SettingsIcon className="w-4 h-4" />}
+          >
+            Toolbar
+          </NavButton>
+          <NavButton
             active={activeTab === "troubleshooting"}
             onClick={() => setActiveTab("troubleshooting")}
           >
@@ -206,6 +217,10 @@ export function SettingsDialog({
 
             <div className={activeTab === "sidecar" ? "" : "hidden"}>
               <SidecarSettingsTab />
+            </div>
+
+            <div className={activeTab === "toolbar" ? "" : "hidden"}>
+              <ToolbarSettingsTab />
             </div>
 
             <div className={activeTab === "troubleshooting" ? "" : "hidden"}>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useMemo } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  GripVertical,
+  PanelLeft,
+  Terminal,
+  Globe,
+  Rocket,
+  AlertTriangle,
+  StickyNote,
+  Copy,
+  Settings,
+  AlertCircle,
+  PanelRight,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useToolbarPreferencesStore } from "@/store";
+import type { ToolbarButtonId } from "@/../../shared/types/domain";
+import { Bot } from "lucide-react";
+
+const BUTTON_METADATA: Record<
+  ToolbarButtonId,
+  { label: string; icon: React.ReactNode; description: string; fixed?: boolean }
+> = {
+  "sidebar-toggle": {
+    label: "Sidebar Toggle",
+    icon: <PanelLeft className="h-4 w-4" />,
+    description: "Toggle sidebar visibility",
+    fixed: true,
+  },
+  claude: {
+    label: "Claude Agent",
+    icon: <Bot className="h-4 w-4" />,
+    description: "Launch Claude AI agent",
+  },
+  gemini: {
+    label: "Gemini Agent",
+    icon: <Bot className="h-4 w-4" />,
+    description: "Launch Gemini AI agent",
+  },
+  codex: {
+    label: "Codex Agent",
+    icon: <Bot className="h-4 w-4" />,
+    description: "Launch Codex AI agent",
+  },
+  terminal: {
+    label: "Terminal",
+    icon: <Terminal className="h-4 w-4" />,
+    description: "Open new terminal",
+  },
+  browser: {
+    label: "Browser",
+    icon: <Globe className="h-4 w-4" />,
+    description: "Open browser panel",
+  },
+  "dev-server": {
+    label: "Dev Server",
+    icon: <Rocket className="h-4 w-4" />,
+    description: "Start development server",
+  },
+  "github-stats": {
+    label: "GitHub Stats",
+    icon: <AlertTriangle className="h-4 w-4" />,
+    description: "GitHub issues, PRs, and commits",
+  },
+  notes: {
+    label: "Notes",
+    icon: <StickyNote className="h-4 w-4" />,
+    description: "Open notes palette",
+  },
+  "copy-tree": {
+    label: "Copy Context",
+    icon: <Copy className="h-4 w-4" />,
+    description: "Copy project context to clipboard",
+  },
+  settings: {
+    label: "Settings",
+    icon: <Settings className="h-4 w-4" />,
+    description: "Open settings dialog",
+  },
+  problems: {
+    label: "Problems",
+    icon: <AlertCircle className="h-4 w-4" />,
+    description: "Show problems panel",
+  },
+  "sidecar-toggle": {
+    label: "Sidecar Toggle",
+    icon: <PanelRight className="h-4 w-4" />,
+    description: "Toggle sidecar panel",
+    fixed: true,
+  },
+};
+
+interface SortableButtonItemProps {
+  buttonId: ToolbarButtonId;
+  isVisible: boolean;
+  onToggle: (buttonId: ToolbarButtonId) => void;
+}
+
+function SortableButtonItem({ buttonId, isVisible, onToggle }: SortableButtonItemProps) {
+  const metadata = BUTTON_METADATA[buttonId];
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: buttonId,
+    disabled: metadata.fixed,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "flex items-center gap-3 p-3 rounded-lg border border-divider bg-canopy-sidebar/30",
+        metadata.fixed && "opacity-60"
+      )}
+    >
+      {!metadata.fixed && (
+        <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing">
+          <GripVertical className="h-4 w-4 text-muted-foreground" />
+        </div>
+      )}
+      {metadata.fixed && <div className="w-4" />}
+      <div className="flex items-center gap-2 flex-1">
+        <div className="text-canopy-text">{metadata.icon}</div>
+        <div className="flex-1">
+          <div className="text-sm font-medium text-canopy-text">{metadata.label}</div>
+          <div className="text-xs text-muted-foreground">{metadata.description}</div>
+        </div>
+      </div>
+      {!metadata.fixed && (
+        <input
+          type="checkbox"
+          checked={isVisible}
+          onChange={() => onToggle(buttonId)}
+          aria-label={`Toggle ${metadata.label} visibility`}
+          className="w-4 h-4 rounded border-divider bg-canopy-sidebar text-canopy-accent focus:ring-canopy-accent focus:ring-2"
+        />
+      )}
+      {metadata.fixed && <div className="text-xs text-muted-foreground">Always visible</div>}
+    </div>
+  );
+}
+
+export function ToolbarSettingsTab() {
+  const {
+    layout,
+    launcher,
+    setLeftButtons,
+    setRightButtons,
+    toggleButtonVisibility,
+    setAlwaysShowDevServer,
+    setDefaultSelection,
+    reset,
+  } = useToolbarPreferencesStore();
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const leftButtonsWithFixed = useMemo(
+    () => ["sidebar-toggle" as ToolbarButtonId, ...layout.leftButtons],
+    [layout.leftButtons]
+  );
+
+  const rightButtonsWithFixed = useMemo(
+    () => [...layout.rightButtons, "sidecar-toggle" as ToolbarButtonId],
+    [layout.rightButtons]
+  );
+
+  const handleLeftDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = layout.leftButtons.indexOf(active.id as ToolbarButtonId);
+      const newIndex = layout.leftButtons.indexOf(over.id as ToolbarButtonId);
+
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newButtons = [...layout.leftButtons];
+      newButtons.splice(oldIndex, 1);
+      newButtons.splice(newIndex, 0, active.id as ToolbarButtonId);
+
+      setLeftButtons(newButtons);
+    },
+    [layout.leftButtons, setLeftButtons]
+  );
+
+  const handleRightDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = layout.rightButtons.indexOf(active.id as ToolbarButtonId);
+      const newIndex = layout.rightButtons.indexOf(over.id as ToolbarButtonId);
+
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newButtons = [...layout.rightButtons];
+      newButtons.splice(oldIndex, 1);
+      newButtons.splice(newIndex, 0, active.id as ToolbarButtonId);
+
+      setRightButtons(newButtons);
+    },
+    [layout.rightButtons, setRightButtons]
+  );
+
+  const handleToggleLeft = useCallback(
+    (buttonId: ToolbarButtonId) => {
+      toggleButtonVisibility(buttonId, "left");
+    },
+    [toggleButtonVisibility]
+  );
+
+  const handleToggleRight = useCallback(
+    (buttonId: ToolbarButtonId) => {
+      toggleButtonVisibility(buttonId, "right");
+    },
+    [toggleButtonVisibility]
+  );
+
+  return (
+    <div className="space-y-6 overflow-y-auto pr-2">
+      <div>
+        <h2 className="text-lg font-semibold text-canopy-text mb-1">Toolbar Customization</h2>
+        <p className="text-sm text-muted-foreground">
+          Configure which buttons appear in the toolbar and their order. Drag to reorder, uncheck to hide.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <label className="text-sm font-medium text-canopy-text">Left Side Buttons</label>
+            <span className="text-xs text-muted-foreground">
+              {layout.leftButtons.length + 1} buttons
+            </span>
+          </div>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleLeftDragEnd}
+          >
+            <SortableContext items={leftButtonsWithFixed} strategy={verticalListSortingStrategy}>
+              <div className="space-y-2">
+                {leftButtonsWithFixed.map((buttonId) => (
+                  <SortableButtonItem
+                    key={buttonId}
+                    buttonId={buttonId}
+                    isVisible={
+                      buttonId === "sidebar-toggle" || layout.leftButtons.includes(buttonId)
+                    }
+                    onToggle={handleToggleLeft}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <label className="text-sm font-medium text-canopy-text">Right Side Buttons</label>
+            <span className="text-xs text-muted-foreground">
+              {layout.rightButtons.length + 1} buttons
+            </span>
+          </div>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleRightDragEnd}
+          >
+            <SortableContext items={rightButtonsWithFixed} strategy={verticalListSortingStrategy}>
+              <div className="space-y-2">
+                {rightButtonsWithFixed.map((buttonId) => (
+                  <SortableButtonItem
+                    key={buttonId}
+                    buttonId={buttonId}
+                    isVisible={
+                      buttonId === "sidecar-toggle" || layout.rightButtons.includes(buttonId)
+                    }
+                    onToggle={handleToggleRight}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        </div>
+
+        <div className="border-t border-divider pt-6">
+          <h3 className="text-sm font-medium text-canopy-text mb-3">Launcher Palette</h3>
+          <div className="space-y-4">
+            <div className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                id="always-show-dev-server"
+                checked={launcher.alwaysShowDevServer}
+                onChange={(e) => setAlwaysShowDevServer(e.target.checked)}
+                className="w-4 h-4 mt-0.5 rounded border-divider bg-canopy-sidebar text-canopy-accent focus:ring-canopy-accent focus:ring-2"
+              />
+              <div className="flex-1">
+                <label
+                  htmlFor="always-show-dev-server"
+                  className="text-sm font-medium text-canopy-text cursor-pointer"
+                >
+                  Always show dev server in launcher
+                </label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Show dev server option even if no command is configured in project settings
+                </p>
+              </div>
+            </div>
+
+            <div>
+              <label className="text-sm font-medium text-canopy-text mb-2 block">
+                Default selection
+              </label>
+              <select
+                value={launcher.defaultSelection ?? ""}
+                onChange={(e) =>
+                  setDefaultSelection(
+                    e.target.value ? (e.target.value as typeof launcher.defaultSelection) : undefined
+                  )
+                }
+                className="w-full px-3 py-2 text-sm rounded-lg border border-divider bg-canopy-sidebar/30 text-canopy-text"
+              >
+                <option value="">None (first available)</option>
+                <option value="terminal">Terminal</option>
+                <option value="claude">Claude</option>
+                <option value="gemini">Gemini</option>
+                <option value="codex">Codex</option>
+                <option value="browser">Browser</option>
+                <option value="dev-server">Dev Server</option>
+              </select>
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Default option to highlight when opening the launcher palette
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-4 border-t border-divider">
+          <button
+            onClick={reset}
+            className="px-3 py-1.5 text-sm rounded-lg border border-divider bg-canopy-sidebar/30 text-canopy-text hover:bg-white/[0.06] transition-colors"
+          >
+            Reset to Defaults
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -13,6 +13,7 @@ export const SettingsTabSchema = z.enum([
   "agents",
   "github",
   "sidecar",
+  "toolbar",
   "troubleshooting",
 ]);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -57,5 +57,7 @@ export { usePulseStore } from "./pulseStore";
 
 export { usePreferencesStore } from "./preferencesStore";
 
+export { useToolbarPreferencesStore } from "./toolbarPreferencesStore";
+
 export { useBrowserStateStore } from "./browserStateStore";
 export type { BrowserPanelState, BrowserHistory } from "./browserStateStore";

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -1,0 +1,129 @@
+import { create } from "zustand";
+import { persist, createJSONStorage, type StateStorage } from "zustand/middleware";
+import type { ToolbarPreferences, ToolbarButtonId } from "@/../../shared/types/domain";
+
+const memoryStorage: StateStorage = (() => {
+  const storage = new Map<string, string>();
+  return {
+    getItem: (name) => storage.get(name) ?? null,
+    setItem: (name, value) => {
+      storage.set(name, value);
+    },
+    removeItem: (name) => {
+      storage.delete(name);
+    },
+  };
+})();
+
+function getSafeStorage(): StateStorage {
+  if (typeof localStorage !== "undefined") {
+    return localStorage;
+  }
+  return memoryStorage;
+}
+
+const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
+  "claude",
+  "gemini",
+  "codex",
+  "terminal",
+  "browser",
+  "dev-server",
+];
+
+const DEFAULT_RIGHT_BUTTONS: ToolbarButtonId[] = [
+  "github-stats",
+  "notes",
+  "copy-tree",
+  "settings",
+  "problems",
+];
+
+const DEFAULT_PREFERENCES: ToolbarPreferences = {
+  layout: {
+    leftButtons: DEFAULT_LEFT_BUTTONS,
+    rightButtons: DEFAULT_RIGHT_BUTTONS,
+  },
+  launcher: {
+    alwaysShowDevServer: false,
+    defaultSelection: undefined,
+  },
+};
+
+interface ToolbarPreferencesState extends ToolbarPreferences {
+  setLeftButtons: (buttons: ToolbarButtonId[]) => void;
+  setRightButtons: (buttons: ToolbarButtonId[]) => void;
+  moveButton: (buttonId: ToolbarButtonId, from: "left" | "right", to: "left" | "right", toIndex: number) => void;
+  toggleButtonVisibility: (buttonId: ToolbarButtonId, side: "left" | "right") => void;
+  setAlwaysShowDevServer: (value: boolean) => void;
+  setDefaultSelection: (selection: ToolbarPreferences["launcher"]["defaultSelection"]) => void;
+  reset: () => void;
+}
+
+export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
+  persist(
+    (set) => ({
+      ...DEFAULT_PREFERENCES,
+      setLeftButtons: (buttons) =>
+        set((state) => ({
+          layout: { ...state.layout, leftButtons: buttons },
+        })),
+      setRightButtons: (buttons) =>
+        set((state) => ({
+          layout: { ...state.layout, rightButtons: buttons },
+        })),
+      moveButton: (buttonId, from, to, toIndex) =>
+        set((state) => {
+          const leftButtons = [...state.layout.leftButtons];
+          const rightButtons = [...state.layout.rightButtons];
+
+          const fromList = from === "left" ? leftButtons : rightButtons;
+          const toList = to === "left" ? leftButtons : rightButtons;
+
+          const fromIndex = fromList.indexOf(buttonId);
+          if (fromIndex === -1) return state;
+
+          fromList.splice(fromIndex, 1);
+
+          if (from === to && fromIndex < toIndex) {
+            toIndex--;
+          }
+
+          toList.splice(toIndex, 0, buttonId);
+
+          return {
+            layout: { leftButtons, rightButtons },
+          };
+        }),
+      toggleButtonVisibility: (buttonId, side) =>
+        set((state) => {
+          const sideKey = side === "left" ? "leftButtons" : "rightButtons";
+          const buttons = [...state.layout[sideKey]];
+          const index = buttons.indexOf(buttonId);
+
+          if (index === -1) {
+            buttons.push(buttonId);
+          } else {
+            buttons.splice(index, 1);
+          }
+
+          return {
+            layout: { ...state.layout, [sideKey]: buttons },
+          };
+        }),
+      setAlwaysShowDevServer: (value) =>
+        set((state) => ({
+          launcher: { ...state.launcher, alwaysShowDevServer: value },
+        })),
+      setDefaultSelection: (selection) =>
+        set((state) => ({
+          launcher: { ...state.launcher, defaultSelection: selection },
+        })),
+      reset: () => set(DEFAULT_PREFERENCES),
+    }),
+    {
+      name: "canopy-toolbar-preferences",
+      storage: createJSONStorage(() => getSafeStorage()),
+    }
+  )
+);


### PR DESCRIPTION
## Summary
Adds a dedicated settings page for toolbar customization, allowing users to configure which buttons are displayed on the left and right sides of the toolbar and control their ordering through a drag-and-drop interface.

Closes #1400

## Changes Made
- Add toolbar configuration types (ToolbarButtonId, ToolbarLayout, LauncherDefaults) to shared/types/domain.ts
- Create toolbarPreferencesStore with Zustand persistence and localStorage support
- Implement ToolbarSettingsTab component with @dnd-kit for drag-and-drop button reordering
- Refactor Toolbar component to use button registry pattern and render from preferences
- Add "toolbar" settings tab to SettingsDialog navigation with appropriate icon
- Support button visibility toggles and launcher palette defaults
- Maintain fixed positions for sidebar-toggle (left) and sidecar-toggle (right) buttons
- Filter buttons based on runtime availability (dev-server, problems, github-stats)

## Implementation Details
- **Button Registry**: Created a registry mapping ToolbarButtonId to render functions and availability checks
- **Preferences Store**: Persists button visibility and order to localStorage
- **DnD Interface**: Uses @dnd-kit/core and @dnd-kit/sortable for accessible reordering
- **Fixed Buttons**: Sidebar toggle and sidecar toggle are always visible in their positions
- **Conditional Rendering**: Dev server, problems, and GitHub stats buttons respect runtime conditions