### PR TITLE
Add configurable dev command support to recipes with browser-only mode

### DIFF
--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -25,10 +25,14 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     panelId: string,
     cwd: string,
     cols: number,
-    rows: number
+    rows: number,
+    devCommand?: string
   ) => {
     if (!devPreviewService) throw new Error("DevPreviewService not initialized");
-    await devPreviewService.start({ panelId, cwd, cols, rows });
+    // Validate devCommand if provided
+    const validatedDevCommand =
+      devCommand !== undefined && typeof devCommand === "string" ? devCommand : undefined;
+    await devPreviewService.start({ panelId, cwd, cols, rows, devCommand: validatedDevCommand });
   };
   ipcMain.handle(CHANNELS.DEV_PREVIEW_START, handleStart);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_START));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -819,8 +819,8 @@ const api: ElectronAPI = {
 
   // Dev Preview API
   devPreview: {
-    start: (panelId: string, cwd: string, cols: number, rows: number) =>
-      _typedInvoke(CHANNELS.DEV_PREVIEW_START, panelId, cwd, cols, rows),
+    start: (panelId: string, cwd: string, cols: number, rows: number, devCommand?: string) =>
+      _typedInvoke(CHANNELS.DEV_PREVIEW_START, panelId, cwd, cols, rows, devCommand),
 
     stop: (panelId: string) => _typedInvoke(CHANNELS.DEV_PREVIEW_STOP, panelId),
 

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -358,6 +358,8 @@ interface PtyPanelData extends BasePanelData {
   isInputLocked?: boolean;
   /** Current URL for dev-preview panels */
   browserUrl?: string;
+  /** Dev command override for dev-preview panels */
+  devCommand?: string;
 }
 
 interface BrowserPanelData extends BasePanelData {
@@ -438,6 +440,8 @@ export interface TerminalInstance {
   noteId?: string;
   scope?: "worktree" | "project";
   createdAt?: number;
+  /** Dev command override for dev-preview panels */
+  devCommand?: string;
 }
 
 /** Options for spawning a new PTY process */
@@ -550,7 +554,7 @@ export interface ProjectState {
 // Terminal Recipe Types
 
 /** Recipe terminal type */
-export type RecipeTerminalType = AgentId | "terminal";
+export type RecipeTerminalType = AgentId | "terminal" | "dev-preview";
 
 /** A single terminal definition within a recipe */
 export interface RecipeTerminal {
@@ -564,6 +568,8 @@ export interface RecipeTerminal {
   env?: Record<string, string>;
   /** Initial prompt to send to agent terminals after boot (optional) */
   initialPrompt?: string;
+  /** Dev server command for dev-preview terminals (optional). Falls back to project devServerCommand if not set. */
+  devCommand?: string;
 }
 
 /** A saved terminal recipe */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -332,7 +332,13 @@ export interface ElectronAPI {
     ): () => void;
   };
   devPreview: {
-    start(panelId: string, cwd: string, cols: number, rows: number): Promise<void>;
+    start(
+      panelId: string,
+      cwd: string,
+      cols: number,
+      rows: number,
+      devCommand?: string
+    ): Promise<void>;
     stop(panelId: string): Promise<void>;
     restart(panelId: string): Promise<void>;
     setUrl(panelId: string, url: string): Promise<void>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -732,7 +732,7 @@ export interface IpcInvokeMap {
 
   // Dev Preview channels
   "dev-preview:start": {
-    args: [panelId: string, cwd: string, cols: number, rows: number];
+    args: [panelId: string, cwd: string, cols: number, rows: number, devCommand?: string];
     result: void;
   };
   "dev-preview:stop": {

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -78,6 +78,8 @@ export interface AddTerminalOptions {
   scope?: "worktree" | "project";
   /** Note creation timestamp (kind === 'notes') */
   createdAt?: number;
+  /** Dev server command override for dev-preview panels (kind === 'dev-preview') */
+  devCommand?: string;
 }
 
 function getDefaultTitle(kind?: PanelKind, type?: TerminalType, agentId?: string): string {
@@ -247,6 +249,7 @@ export const createTerminalRegistrySlice =
             cwd: options.cwd || "",
             cols: 80,
             rows: 24,
+            devCommand: options.devCommand,
           };
         } else {
           terminal = {


### PR DESCRIPTION
## Summary
This PR implements configurable dev command support for recipe dev-preview terminals with a three-tier fallback chain: recipe-provided command → auto-detection from package.json → browser-only mode with manual URL input.

Closes #1401

## Changes Made
- Add devCommand field to RecipeTerminal and TerminalInstance types
- Implement fallback chain: recipe override → auto-detect → browser-only
- Add dev-preview terminal type to recipe editor with devCommand input
- Preserve devCommand on restart in DevPreviewService
- Add runtime validation for devCommand in IPC handler
- Fix type switching to consolidate state updates and prevent race conditions
- Fix recipe generation to preserve dev-preview kind and devCommand
- Implement browser-only mode with manual URL input and validation
- Make browser-only detection non-sticky based on status messages
- Show error messages in browser-only mode UI