### PR TITLE
Add hover tooltips for issue and PR badges in worktree cards

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -88,6 +88,8 @@ export const CHANNELS = {
   GITHUB_LIST_ISSUES: "github:list-issues",
   GITHUB_LIST_PRS: "github:list-prs",
   GITHUB_ASSIGN_ISSUE: "github:assign-issue",
+  GITHUB_GET_ISSUE_TOOLTIP: "github:get-issue-tooltip",
+  GITHUB_GET_PR_TOOLTIP: "github:get-pr-tooltip",
 
   APP_GET_STATE: "app:get-state",
   APP_SET_STATE: "app:set-state",

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -277,5 +277,53 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   ipcMain.handle(CHANNELS.GITHUB_ASSIGN_ISSUE, handleGitHubAssignIssue);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_ASSIGN_ISSUE));
 
+  const handleGitHubGetIssueTooltip = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: { cwd: string; issueNumber: number }
+  ) => {
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
+      return null;
+    }
+    if (
+      typeof payload.issueNumber !== "number" ||
+      !Number.isInteger(payload.issueNumber) ||
+      payload.issueNumber <= 0
+    ) {
+      return null;
+    }
+
+    const { getIssueTooltip } = await import("../../services/GitHubService.js");
+    return getIssueTooltip(payload.cwd.trim(), payload.issueNumber);
+  };
+  ipcMain.handle(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, handleGitHubGetIssueTooltip);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP));
+
+  const handleGitHubGetPRTooltip = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: { cwd: string; prNumber: number }
+  ) => {
+    if (!payload || typeof payload !== "object") {
+      return null;
+    }
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
+      return null;
+    }
+    if (
+      typeof payload.prNumber !== "number" ||
+      !Number.isInteger(payload.prNumber) ||
+      payload.prNumber <= 0
+    ) {
+      return null;
+    }
+
+    const { getPRTooltip } = await import("../../services/GitHubService.js");
+    return getPRTooltip(payload.cwd.trim(), payload.prNumber);
+  };
+  ipcMain.handle(CHANNELS.GITHUB_GET_PR_TOOLTIP, handleGitHubGetPRTooltip);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_PR_TOOLTIP));
+
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -215,6 +215,8 @@ const CHANNELS = {
   GITHUB_LIST_ISSUES: "github:list-issues",
   GITHUB_LIST_PRS: "github:list-prs",
   GITHUB_ASSIGN_ISSUE: "github:assign-issue",
+  GITHUB_GET_ISSUE_TOOLTIP: "github:get-issue-tooltip",
+  GITHUB_GET_PR_TOOLTIP: "github:get-pr-tooltip",
 
   // Notes channels
   NOTES_CREATE: "notes:create",
@@ -771,6 +773,12 @@ const api: ElectronAPI = {
 
     assignIssue: (cwd: string, issueNumber: number, username: string): Promise<void> =>
       ipcRenderer.invoke(CHANNELS.GITHUB_ASSIGN_ISSUE, { cwd, issueNumber, username }),
+
+    getIssueTooltip: (cwd: string, issueNumber: number) =>
+      ipcRenderer.invoke(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, { cwd, issueNumber }),
+
+    getPRTooltip: (cwd: string, prNumber: number) =>
+      ipcRenderer.invoke(CHANNELS.GITHUB_GET_PR_TOOLTIP, { cwd, prNumber }),
 
     onPRDetected: (callback: (data: PRDetectedPayload) => void) =>
       _typedOn(CHANNELS.PR_DETECTED, callback),

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -147,6 +147,72 @@ export const SEARCH_QUERY = `
   }
 `;
 
+export const GET_ISSUE_QUERY = `
+  query GetIssue($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        number
+        title
+        bodyText
+        url
+        state
+        createdAt
+        updatedAt
+        author {
+          login
+          avatarUrl
+        }
+        assignees(first: 5) {
+          nodes {
+            login
+            avatarUrl
+          }
+        }
+        labels(first: 10) {
+          nodes {
+            name
+            color
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const GET_PR_QUERY = `
+  query GetPR($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        title
+        bodyText
+        url
+        state
+        isDraft
+        merged
+        createdAt
+        updatedAt
+        author {
+          login
+          avatarUrl
+        }
+        assignees(first: 5) {
+          nodes {
+            login
+            avatarUrl
+          }
+        }
+        labels(first: 10) {
+          nodes {
+            name
+            color
+          }
+        }
+      }
+    }
+  }
+`;
+
 export function buildBatchPRQuery(
   owner: string,
   repo: string,

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -6,6 +6,8 @@ export {
   LIST_ISSUES_QUERY,
   LIST_PRS_QUERY,
   SEARCH_QUERY,
+  GET_ISSUE_QUERY,
+  GET_PR_QUERY,
   buildBatchPRQuery,
 } from "./GitHubQueries.js";
 

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -70,6 +70,48 @@ export interface GitHubPR {
   reviewCount?: number;
 }
 
+/** Issue tooltip data (subset of full issue for hover display) */
+export interface IssueTooltipData {
+  /** Issue number */
+  number: number;
+  /** Issue title */
+  title: string;
+  /** Issue body (truncated) */
+  bodyExcerpt: string;
+  /** Issue state */
+  state: "OPEN" | "CLOSED";
+  /** Creation date */
+  createdAt: string;
+  /** Issue author */
+  author: GitHubUser;
+  /** Assigned users */
+  assignees: GitHubUser[];
+  /** Issue labels */
+  labels: GitHubLabel[];
+}
+
+/** PR tooltip data (subset of full PR for hover display) */
+export interface PRTooltipData {
+  /** PR number */
+  number: number;
+  /** PR title */
+  title: string;
+  /** PR body (truncated) */
+  bodyExcerpt: string;
+  /** PR state */
+  state: "OPEN" | "CLOSED" | "MERGED";
+  /** Whether this is a draft PR */
+  isDraft: boolean;
+  /** Creation date */
+  createdAt: string;
+  /** PR author */
+  author: GitHubUser;
+  /** Assigned users */
+  assignees: GitHubUser[];
+  /** PR labels */
+  labels: GitHubLabel[];
+}
+
 // Git Commit Types
 
 /** Git commit author */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -247,6 +247,14 @@ export interface ElectronAPI {
       cursor?: string;
     }): Promise<import("../github.js").GitHubListResponse<import("../github.js").GitHubPR>>;
     assignIssue(cwd: string, issueNumber: number, username: string): Promise<void>;
+    getIssueTooltip(
+      cwd: string,
+      issueNumber: number
+    ): Promise<import("../github.js").IssueTooltipData | null>;
+    getPRTooltip(
+      cwd: string,
+      prNumber: number
+    ): Promise<import("../github.js").PRTooltipData | null>;
     onPRDetected(callback: (data: PRDetectedPayload) => void): () => void;
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;
     onIssueDetected(callback: (data: IssueDetectedPayload) => void): () => void;

--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,0 +1,173 @@
+import { memo } from "react";
+import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
+import { Loader2, User, Users, Calendar } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+interface TooltipLoadingProps {
+  type: "issue" | "pr";
+}
+
+export const TooltipLoading = memo(function TooltipLoading({ type }: TooltipLoadingProps) {
+  return (
+    <div className="flex items-center gap-2 text-canopy-text/70 py-1">
+      <Loader2 className="w-3 h-3 animate-spin" />
+      <span className="text-xs">Loading {type} details...</span>
+    </div>
+  );
+});
+
+interface LabelBadgeProps {
+  name: string;
+  color: string;
+}
+
+const LabelBadge = memo(function LabelBadge({ name, color }: LabelBadgeProps) {
+  return (
+    <span
+      className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium"
+      style={{
+        backgroundColor: `#${color}20`,
+        color: `#${color}`,
+        border: `1px solid #${color}40`,
+      }}
+    >
+      {name}
+    </span>
+  );
+});
+
+interface IssueTooltipContentProps {
+  data: IssueTooltipData;
+}
+
+export const IssueTooltipContent = memo(function IssueTooltipContent({
+  data,
+}: IssueTooltipContentProps) {
+  const stateColor = data.state === "OPEN" ? "text-emerald-400" : "text-red-400";
+
+  return (
+    <div className="space-y-2 max-w-[280px]">
+      <div className="flex items-start gap-2">
+        <span className={cn("text-xs font-medium shrink-0", stateColor)}>#{data.number}</span>
+        <span className="text-xs text-canopy-text/90 line-clamp-2">{data.title}</span>
+      </div>
+
+      {data.bodyExcerpt && (
+        <p className="text-[11px] text-canopy-text/60 line-clamp-3">{data.bodyExcerpt}</p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-canopy-text/50">
+        <span className="flex items-center gap-1">
+          <User className="w-3 h-3" />
+          {data.author.login}
+        </span>
+
+        {data.assignees.length > 0 && (
+          <span className="flex items-center gap-1">
+            <Users className="w-3 h-3" />
+            {data.assignees.length === 1
+              ? data.assignees[0].login
+              : `${data.assignees.length} assignees`}
+          </span>
+        )}
+
+        <span className="flex items-center gap-1">
+          <Calendar className="w-3 h-3" />
+          {formatDate(data.createdAt)}
+        </span>
+      </div>
+
+      {data.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1 pt-1">
+          {data.labels.slice(0, 4).map((label) => (
+            <LabelBadge key={label.name} name={label.name} color={label.color} />
+          ))}
+          {data.labels.length > 4 && (
+            <span className="text-[10px] text-canopy-text/40">+{data.labels.length - 4} more</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+interface PRTooltipContentProps {
+  data: PRTooltipData;
+}
+
+export const PRTooltipContent = memo(function PRTooltipContent({ data }: PRTooltipContentProps) {
+  const stateColor =
+    data.state === "MERGED"
+      ? "text-violet-400"
+      : data.state === "CLOSED"
+        ? "text-red-400"
+        : "text-sky-400";
+
+  const stateLabel = data.isDraft ? "Draft" : data.state.toLowerCase();
+
+  return (
+    <div className="space-y-2 max-w-[280px]">
+      <div className="flex items-start gap-2">
+        <span className={cn("text-xs font-medium shrink-0", stateColor)}>#{data.number}</span>
+        <span className="text-xs text-canopy-text/90 line-clamp-2">{data.title}</span>
+        <span
+          className={cn(
+            "text-[10px] px-1.5 py-0.5 rounded-full shrink-0 capitalize",
+            data.state === "MERGED"
+              ? "bg-violet-400/20 text-violet-400"
+              : data.state === "CLOSED"
+                ? "bg-red-400/20 text-red-400"
+                : "bg-sky-400/20 text-sky-400"
+          )}
+        >
+          {stateLabel}
+        </span>
+      </div>
+
+      {data.bodyExcerpt && (
+        <p className="text-[11px] text-canopy-text/60 line-clamp-3">{data.bodyExcerpt}</p>
+      )}
+
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-canopy-text/50">
+        <span className="flex items-center gap-1">
+          <User className="w-3 h-3" />
+          {data.author.login}
+        </span>
+
+        {data.assignees.length > 0 && (
+          <span className="flex items-center gap-1">
+            <Users className="w-3 h-3" />
+            {data.assignees.length === 1
+              ? data.assignees[0].login
+              : `${data.assignees.length} assignees`}
+          </span>
+        )}
+
+        <span className="flex items-center gap-1">
+          <Calendar className="w-3 h-3" />
+          {formatDate(data.createdAt)}
+        </span>
+      </div>
+
+      {data.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1 pt-1">
+          {data.labels.slice(0, 4).map((label) => (
+            <LabelBadge key={label.name} name={label.name} color={label.color} />
+          ))}
+          {data.labels.length > 4 && (
+            <span className="text-[10px] text-canopy-text/40">+{data.labels.length - 4} more</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState, memo } from "react";
 import type React from "react";
 import type { TerminalRecipe, WorktreeState } from "@/types";
 import { cn } from "@/lib/utils";
@@ -33,6 +33,8 @@ import {
   MoreHorizontal,
   Shield,
 } from "lucide-react";
+import { useIssueTooltip, usePRTooltip } from "@/hooks/useGitHubTooltip";
+import { IssueTooltipContent, PRTooltipContent, TooltipLoading } from "./GitHubTooltipContent";
 
 const DROPDOWN_COMPONENTS: WorktreeMenuComponents = {
   Item: DropdownMenuItem,
@@ -43,6 +45,151 @@ const DROPDOWN_COMPONENTS: WorktreeMenuComponents = {
   SubTrigger: DropdownMenuSubTrigger,
   SubContent: DropdownMenuSubContent,
 };
+
+interface IssueBadgeProps {
+  issueNumber: number;
+  issueTitle?: string;
+  worktreePath: string;
+  onOpen?: () => void;
+}
+
+const IssueBadge = memo(function IssueBadge({
+  issueNumber,
+  issueTitle,
+  worktreePath,
+  onOpen,
+}: IssueBadgeProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { data, loading, error, fetchTooltip, reset } = useIssueTooltip(worktreePath, issueNumber);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setIsOpen(open);
+      if (open) {
+        fetchTooltip();
+      } else {
+        reset();
+      }
+    },
+    [fetchTooltip, reset]
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen?.();
+            }}
+            className="flex items-center gap-1.5 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0"
+            aria-label={
+              issueTitle
+                ? `Open issue #${issueNumber}: ${issueTitle}`
+                : `Open issue #${issueNumber} on GitHub`
+            }
+          >
+            <CircleDot className="w-3 h-3 text-emerald-400 shrink-0" aria-hidden="true" />
+            <span className="truncate text-canopy-text/90 flex-1 min-w-0">
+              {issueTitle || <span className="text-emerald-400 font-mono">#{issueNumber}</span>}
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" align="start" className="p-3">
+          {loading ? (
+            <TooltipLoading type="issue" />
+          ) : data ? (
+            <IssueTooltipContent data={data} />
+          ) : error ? (
+            <span className="text-xs text-canopy-text/70">Failed to load issue details</span>
+          ) : (
+            <span className="text-xs text-canopy-text/70">Issue #{issueNumber}</span>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+});
+
+interface PRBadgeProps {
+  prNumber: number;
+  prState?: "open" | "merged" | "closed";
+  worktreePath: string;
+  isSubordinate: boolean;
+  onOpen?: () => void;
+}
+
+const PRBadge = memo(function PRBadge({
+  prNumber,
+  prState,
+  worktreePath,
+  isSubordinate,
+  onOpen,
+}: PRBadgeProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { data, loading, error, fetchTooltip, reset } = usePRTooltip(worktreePath, prNumber);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setIsOpen(open);
+      if (open) {
+        fetchTooltip();
+      } else {
+        reset();
+      }
+    },
+    [fetchTooltip, reset]
+  );
+
+  const prStateColor =
+    prState === "merged"
+      ? "text-violet-400"
+      : prState === "closed"
+        ? "text-red-400"
+        : "text-sky-400";
+
+  const prStateLabel = prState === "merged" ? "merged" : prState === "closed" ? "closed" : "open";
+
+  return (
+    <TooltipProvider>
+      <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen?.();
+            }}
+            className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+            aria-label={`Open ${prStateLabel} pull request #${prNumber} on GitHub`}
+          >
+            {isSubordinate && (
+              <CornerDownRight
+                className="w-3 h-3 text-canopy-text/30 shrink-0"
+                aria-hidden="true"
+              />
+            )}
+            <GitPullRequest className={cn("w-3 h-3 shrink-0", prStateColor)} aria-hidden="true" />
+            <span className={cn("font-mono", prStateColor)}>#{prNumber}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" align="start" className="p-3">
+          {loading ? (
+            <TooltipLoading type="pr" />
+          ) : data ? (
+            <PRTooltipContent data={data} />
+          ) : error ? (
+            <span className="text-xs text-canopy-text/70">Failed to load PR details</span>
+          ) : (
+            <span className="text-xs text-canopy-text/70">PR #{prNumber}</span>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+});
 
 export interface WorktreeHeaderProps {
   worktree: WorktreeState;
@@ -240,67 +387,22 @@ export function WorktreeHeader({
       {(worktree.issueNumber || worktree.prNumber) && (
         <div className="flex flex-col gap-0.5">
           {worktree.issueNumber && (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                badges.onOpenIssue?.();
-              }}
-              className="flex items-center gap-1.5 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0"
-              aria-label={
-                worktree.issueTitle
-                  ? `Open issue #${worktree.issueNumber}: ${worktree.issueTitle}`
-                  : `Open issue #${worktree.issueNumber} on GitHub`
-              }
-            >
-              <CircleDot className="w-3 h-3 text-emerald-400 shrink-0" aria-hidden="true" />
-              <span className="truncate text-canopy-text/90 flex-1 min-w-0">
-                {worktree.issueTitle || (
-                  <span className="text-emerald-400 font-mono">#{worktree.issueNumber}</span>
-                )}
-              </span>
-            </button>
+            <IssueBadge
+              issueNumber={worktree.issueNumber}
+              issueTitle={worktree.issueTitle}
+              worktreePath={worktree.path}
+              onOpen={badges.onOpenIssue}
+            />
           )}
-          {worktree.prNumber &&
-            (() => {
-              const prStateColor =
-                worktree.prState === "merged"
-                  ? "text-violet-400"
-                  : worktree.prState === "closed"
-                    ? "text-red-400"
-                    : "text-sky-400";
-              const prStateLabel =
-                worktree.prState === "merged"
-                  ? "merged"
-                  : worktree.prState === "closed"
-                    ? "closed"
-                    : "open";
-              const isSubordinate = !!worktree.issueNumber;
-
-              return (
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    badges.onOpenPR?.();
-                  }}
-                  className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-                  aria-label={`Open ${prStateLabel} pull request #${worktree.prNumber} on GitHub`}
-                >
-                  {isSubordinate && (
-                    <CornerDownRight
-                      className="w-3 h-3 text-canopy-text/30 shrink-0"
-                      aria-hidden="true"
-                    />
-                  )}
-                  <GitPullRequest
-                    className={cn("w-3 h-3 shrink-0", prStateColor)}
-                    aria-hidden="true"
-                  />
-                  <span className={cn("font-mono", prStateColor)}>#{worktree.prNumber}</span>
-                </button>
-              );
-            })()}
+          {worktree.prNumber && (
+            <PRBadge
+              prNumber={worktree.prNumber}
+              prState={worktree.prState}
+              worktreePath={worktree.path}
+              isSubordinate={!!worktree.issueNumber}
+              onOpen={badges.onOpenPR}
+            />
+          )}
         </div>
       )}
     </div>

--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -1,0 +1,131 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
+
+type TooltipState<T> = {
+  data: T | null;
+  loading: boolean;
+  error: boolean;
+};
+
+const issueCache = new Map<string, IssueTooltipData>();
+const prCache = new Map<string, PRTooltipData>();
+
+export function useIssueTooltip(cwd: string | undefined, issueNumber: number | undefined) {
+  const [state, setState] = useState<TooltipState<IssueTooltipData>>({
+    data: null,
+    loading: false,
+    error: false,
+  });
+  const fetchingKeyRef = useRef<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchTooltip = useCallback(async () => {
+    if (!cwd || !issueNumber) return;
+
+    const cacheKey = `${cwd}:${issueNumber}`;
+    const cached = issueCache.get(cacheKey);
+    if (cached) {
+      setState({ data: cached, loading: false, error: false });
+      return;
+    }
+
+    if (fetchingKeyRef.current === cacheKey) return;
+
+    fetchingKeyRef.current = cacheKey;
+    setState((prev) => ({ ...prev, loading: true, error: false }));
+
+    try {
+      const data = await window.electron.github.getIssueTooltip(cwd, issueNumber);
+      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
+
+      if (data) {
+        issueCache.set(cacheKey, data);
+        setState({ data, loading: false, error: false });
+      } else {
+        setState({ data: null, loading: false, error: true });
+      }
+    } catch {
+      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
+      setState({ data: null, loading: false, error: true });
+    } finally {
+      if (fetchingKeyRef.current === cacheKey) {
+        fetchingKeyRef.current = null;
+      }
+    }
+  }, [cwd, issueNumber]);
+
+  const reset = useCallback(() => {
+    if (!fetchingKeyRef.current) {
+      setState({ data: null, loading: false, error: false });
+    }
+  }, []);
+
+  return { ...state, fetchTooltip, reset };
+}
+
+export function usePRTooltip(cwd: string | undefined, prNumber: number | undefined) {
+  const [state, setState] = useState<TooltipState<PRTooltipData>>({
+    data: null,
+    loading: false,
+    error: false,
+  });
+  const fetchingKeyRef = useRef<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchTooltip = useCallback(async () => {
+    if (!cwd || !prNumber) return;
+
+    const cacheKey = `${cwd}:${prNumber}`;
+    const cached = prCache.get(cacheKey);
+    if (cached) {
+      setState({ data: cached, loading: false, error: false });
+      return;
+    }
+
+    if (fetchingKeyRef.current === cacheKey) return;
+
+    fetchingKeyRef.current = cacheKey;
+    setState((prev) => ({ ...prev, loading: true, error: false }));
+
+    try {
+      const data = await window.electron.github.getPRTooltip(cwd, prNumber);
+      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
+
+      if (data) {
+        prCache.set(cacheKey, data);
+        setState({ data, loading: false, error: false });
+      } else {
+        setState({ data: null, loading: false, error: true });
+      }
+    } catch {
+      if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
+      setState({ data: null, loading: false, error: true });
+    } finally {
+      if (fetchingKeyRef.current === cacheKey) {
+        fetchingKeyRef.current = null;
+      }
+    }
+  }, [cwd, prNumber]);
+
+  const reset = useCallback(() => {
+    if (!fetchingKeyRef.current) {
+      setState({ data: null, loading: false, error: false });
+    }
+  }, []);
+
+  return { ...state, fetchTooltip, reset };
+}


### PR DESCRIPTION
## Summary
Adds informative hover tooltips to issue and PR badges in worktree cards, displaying key metadata including body excerpt, author, assignees, labels, and state. Tooltips use lazy loading and 5-minute caching for optimal performance.

Closes #1405

## Changes Made
- Add GraphQL queries for fetching single issue/PR details (GET_ISSUE_QUERY, GET_PR_QUERY)
- Implement getIssueTooltip and getPRTooltip service functions with 5-minute caching
- Add IPC handlers and channels for tooltip fetching
- Create useGitHubTooltip React hook with race condition prevention
- Create GitHubTooltipContent component with loading and error states
- Wrap issue/PR badges in WorktreeHeader with Radix UI tooltips
- Display issue/PR metadata on hover: excerpt (~150 chars), author, assignees, labels, state
- Use bodyText instead of body field to prevent XSS vulnerabilities
- Add null-safe filtering for GraphQL connection nodes
- Implement lazy loading: tooltips fetch data only on hover