### PR TITLE
Fix history view diff rendering gaps

### DIFF
--- a/src/components/Terminal/HistoryOverlayTerminalView.tsx
+++ b/src/components/Terminal/HistoryOverlayTerminalView.tsx
@@ -122,6 +122,8 @@ export const HistoryOverlayTerminalView = forwardRef<
 
   // HTML-rendered lines for display (with colors)
   const [historyHtmlLines, setHistoryHtmlLines] = useState<string[]>([]);
+  // Background colors for each row (for continuous diff backgrounds)
+  const [historyRowBackgrounds, setHistoryRowBackgrounds] = useState<(string | null)[]>([]);
   const historyStateRef = useRef<HistoryState | null>(null);
 
   const [scrollbackUnavailable, setScrollbackUnavailable] = useState(false);
@@ -296,6 +298,7 @@ export const HistoryOverlayTerminalView = forwardRef<
       // Update state
       historyStateRef.current = snapshot;
       setHistoryHtmlLines(snapshot.htmlLines);
+      setHistoryRowBackgrounds(snapshot.rowBackgrounds);
       setShowTruncationBanner(snapshot.windowStart > 0);
 
       // Initialize jump-back persistence state
@@ -451,6 +454,7 @@ export const HistoryOverlayTerminalView = forwardRef<
       historyStateRef.current = newSnapshot;
       lastAcceptedWindowStartRef.current = newSnapshot.windowStart;
       setHistoryHtmlLines(newSnapshot.htmlLines);
+      setHistoryRowBackgrounds(newSnapshot.rowBackgrounds);
       setShowTruncationBanner(newSnapshot.windowStart > 0);
 
       // 6) Restore scroll position after DOM update
@@ -882,15 +886,21 @@ export const HistoryOverlayTerminalView = forwardRef<
               className="flex flex-col"
               style={metrics ? { width: `${metrics.screenW}px`, gap: 0 } : { gap: 0 }}
             >
-              {historyHtmlLines.map((htmlLine, idx) => (
-                <div
-                  key={idx}
-                  data-idx={idx}
-                  className="history-row whitespace-pre overflow-hidden select-text"
-                  style={rowStyle}
-                  dangerouslySetInnerHTML={{ __html: htmlLine }}
-                />
-              ))}
+              {historyHtmlLines.map((htmlLine, idx) => {
+                const bg = historyRowBackgrounds[idx];
+                const mergedStyle = bg
+                  ? { ...rowStyle, backgroundColor: bg }
+                  : rowStyle;
+                return (
+                  <div
+                    key={idx}
+                    data-idx={idx}
+                    className="history-row whitespace-pre overflow-hidden select-text"
+                    style={mergedStyle}
+                    dangerouslySetInnerHTML={{ __html: htmlLine }}
+                  />
+                );
+              })}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Fixes git diff rendering in history view by eliminating black gaps between colored lines. The fix extracts dominant background colors from xterm's HTML output and applies them at the row level for continuous coloring.

Closes #1440

## Changes Made
- Extract dominant background colors from xterm HTML output
- Apply row-level backgrounds for continuous diff coloring (green for additions, red for deletions)
- Add 20% coverage threshold to prevent small highlights from coloring entire rows
- Filter transparent/default backgrounds to avoid false positives
- Enhance security: improve span injection prevention in HTML escaping
- Add comprehensive test coverage for background extraction and security edge cases

## Testing
- All existing tests pass (38 tests in historyUtils)
- Added 6 new tests for background extraction edge cases and security
- Build passes without errors