### PR TITLE
Fix worktree creation modal visibility in focus mode

### DIFF
--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -3,6 +3,7 @@ import { appClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@shared/types/domain";
 import type { GitHubIssue } from "@shared/types/github";
+import { useFocusStore } from "@/store/focusStore";
 
 interface CreateDialogState {
   isOpen: boolean;
@@ -154,7 +155,12 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       return { expandedTerminals: next };
     }),
 
-  openCreateDialog: (initialIssue = null) => set({ createDialog: { isOpen: true, initialIssue } }),
+  openCreateDialog: (initialIssue = null) => {
+    if (useFocusStore.getState().isFocusMode) {
+      window.dispatchEvent(new Event("canopy:toggle-focus-mode"));
+    }
+    set({ createDialog: { isOpen: true, initialIssue } });
+  },
 
   closeCreateDialog: () => set({ createDialog: { isOpen: false, initialIssue: null } }),
 


### PR DESCRIPTION
## Summary
Fixes the issue where the worktree creation modal does not appear when the sidebar is hidden (focus mode). The modal was invisible because it renders inside the sidebar content area, which is conditionally hidden when focus mode is active.

Closes #1448

## Changes Made
- Exit focus mode automatically before opening worktree creation dialog
- Trigger proper focus mode toggle event to restore saved panel state
- Centralize fix in `openCreateDialog()` to cover all entry points (action, GitHub issues list, etc.)
- Prevents modal from being invisible when sidebar is hidden
- Ensures proper state restoration including sidebar width and diagnostics panel state

## Technical Details
The fix is centralized in the `openCreateDialog()` method in `worktreeStore.ts`. When the dialog is opened while in focus mode, it dispatches the `canopy:toggle-focus-mode` event, which triggers the same exit flow as manual focus mode toggling. This ensures:
- Saved panel state (sidebar width, diagnostics state) is properly restored
- Persisted focus panel state is cleared from app state
- All entry points benefit from the fix (action dispatch, GitHub UI, etc.)