### PR TITLE
Fix agent state lost during project switch

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -468,6 +468,7 @@ export class PtyManager extends EventEmitter {
 
   /**
    * Handle project switch.
+   * Preserves agent state across switches by using preserveState option when restarting monitors.
    */
   onProjectSwitch(newProjectId: string): void {
     console.log(`[PtyManager] Switching to project: ${newProjectId}`);
@@ -501,7 +502,9 @@ export class PtyManager extends EventEmitter {
         });
 
         terminalProcess.startProcessDetector();
-        terminalProcess.startActivityMonitor();
+        // Pass preserveState: true to prevent monitor from emitting spurious state changes
+        // This preserves the terminal's agent state (e.g., completed stays completed)
+        terminalProcess.startActivityMonitor({ preserveState: true });
       }
     }
 


### PR DESCRIPTION
## Summary
Prevents agent terminals from incorrectly transitioning to "working" state when switching projects. The fix ensures that terminals in completed/waiting states preserve their state across project switches.

Closes #1463

## Changes Made
- Add skipInitialStateEmit and initialState options to ActivityMonitor to prevent spurious state emissions on startup
- Map agent state to monitor's initial state in TerminalProcess when preserving state
- Pass preserveState flag when foregrounding terminals in PtyManager during project switches
- Conditionally skip boot detection based on resumed state (idle states skip boot, busy states keep boot protection)
- Disable fallback pattern matching on resume to avoid matching stale "esc to interrupt" text from previous runs

## Technical Details
The root cause was that `ActivityMonitor.startPolling()` always emitted a "busy" state on startup, which triggered state transitions via `AgentStateService.handleActivityState()`. When activity monitors were restarted during project switches, terminals in terminal states like "completed" would incorrectly transition to "working".

The fix introduces a state preservation mode that:
1. Skips the initial state emission when resuming
2. Preserves boot detection for busy states to prevent premature idle transitions
3. Disables sticky fallback pattern matching that could match stale output

## Testing
- Typecheck passed
- Codex review completed with all findings addressed