### PR TITLE
feat(project): add quick project switcher palette

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -120,6 +120,9 @@ export type KeyAction =
   // Notes actions
   | "notes.openPalette"
 
+  // Project actions
+  | "project.switcherPalette"
+
   // Help/Settings
   | "help.shortcuts"
   | "help.shortcutsAlt"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   useTerminalPalette,
   useNewTerminalPalette,
   usePanelPalette,
+  useProjectSwitcherPalette,
   useTerminalConfig,
   useGlobalKeybindings,
   useContextInjection,
@@ -36,6 +37,7 @@ import { NewWorktreeDialog } from "./components/Worktree/NewWorktreeDialog";
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { TerminalPalette, NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
+import { ProjectSwitcherPalette } from "./components/Project/ProjectSwitcherPalette";
 import { RecipeEditor } from "./components/TerminalRecipe/RecipeEditor";
 import { NotesPalette } from "./components/Notes";
 import { SettingsDialog, type SettingsTab } from "./components/Settings";
@@ -469,6 +471,7 @@ function App() {
   const { worktrees, worktreeMap } = useWorktrees();
   const newTerminalPalette = useNewTerminalPalette({ launchAgent, worktreeMap });
   const panelPalette = usePanelPalette();
+  const projectSwitcherPalette = useProjectSwitcherPalette();
   const currentProject = useProjectStore((state) => state.currentProject);
   const { setActiveWorktree, selectWorktree, activeWorktreeId } = useWorktreeSelectionStore(
     useShallow((state) => ({
@@ -693,6 +696,7 @@ function App() {
     onOpenWorktreePalette: openWorktreePalette,
     onOpenNewTerminalPalette: newTerminalPalette.open,
     onOpenPanelPalette: panelPalette.open,
+    onOpenProjectSwitcherPalette: projectSwitcherPalette.open,
     onOpenShortcuts: () => setIsShortcutsOpen(true),
     onLaunchAgent: async (agentId, options) => {
       await launchAgent(agentId, options);
@@ -817,6 +821,17 @@ function App() {
           }
         }}
         onClose={panelPalette.close}
+      />
+      <ProjectSwitcherPalette
+        isOpen={projectSwitcherPalette.isOpen}
+        query={projectSwitcherPalette.query}
+        results={projectSwitcherPalette.results}
+        selectedIndex={projectSwitcherPalette.selectedIndex}
+        onQueryChange={projectSwitcherPalette.setQuery}
+        onSelectPrevious={projectSwitcherPalette.selectPrevious}
+        onSelectNext={projectSwitcherPalette.selectNext}
+        onSelect={projectSwitcherPalette.selectProject}
+        onClose={projectSwitcherPalette.close}
       />
 
       <NotesPalette isOpen={isNotesPaletteOpen} onClose={closeNotesPalette} />

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1,0 +1,221 @@
+import { useEffect, useRef, useCallback } from "react";
+import { Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getProjectGradient } from "@/lib/colorUtils";
+import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
+import { ProjectActionRow } from "./ProjectActionRow";
+import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
+
+export interface ProjectSwitcherPaletteProps {
+  isOpen: boolean;
+  query: string;
+  results: SearchableProject[];
+  selectedIndex: number;
+  onQueryChange: (query: string) => void;
+  onSelectPrevious: () => void;
+  onSelectNext: () => void;
+  onSelect: (project: SearchableProject) => void;
+  onClose: () => void;
+}
+
+export function ProjectSwitcherPalette({
+  isOpen,
+  query,
+  results,
+  selectedIndex,
+  onQueryChange,
+  onSelectPrevious,
+  onSelectNext,
+  onSelect,
+  onClose,
+}: ProjectSwitcherPaletteProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (listRef.current && selectedIndex >= 0) {
+      const selectedItem = listRef.current.children[selectedIndex] as HTMLElement;
+      if (selectedItem) {
+        selectedItem.scrollIntoView({ block: "nearest" });
+      }
+    }
+  }, [selectedIndex]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowUp":
+          e.preventDefault();
+          onSelectPrevious();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          onSelectNext();
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (results.length > 0 && selectedIndex >= 0) {
+            onSelect(results[selectedIndex]);
+          }
+          break;
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+        case "Tab":
+          e.preventDefault();
+          if (e.shiftKey) {
+            onSelectPrevious();
+          } else {
+            onSelectNext();
+          }
+          break;
+      }
+    },
+    [results, selectedIndex, onSelectPrevious, onSelectNext, onSelect, onClose]
+  );
+
+  const renderIcon = (emoji: string, color?: string) => (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-[var(--radius-lg)] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)] shrink-0 transition-all duration-200",
+        "h-8 w-8 text-base"
+      )}
+      style={{
+        background: color
+          ? `linear-gradient(to bottom, rgba(0,0,0,0.1), rgba(0,0,0,0.2)), ${getProjectGradient(color)}`
+          : "linear-gradient(to bottom, rgba(0,0,0,0.1), rgba(0,0,0,0.2)), var(--color-canopy-sidebar)",
+      }}
+    >
+      <span className="leading-none select-none filter drop-shadow-sm">{emoji}</span>
+    </div>
+  );
+
+  return (
+    <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Project switcher">
+      <AppPaletteDialog.Header label="Switch Project" keyHint="⌘K, P">
+        <AppPaletteDialog.Input
+          inputRef={inputRef}
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Search projects..."
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-label="Search projects"
+          aria-controls="project-list"
+          aria-activedescendant={
+            results.length > 0 && selectedIndex >= 0
+              ? `project-option-${results[selectedIndex].id}`
+              : undefined
+          }
+        />
+      </AppPaletteDialog.Header>
+
+      <AppPaletteDialog.Body>
+        <div ref={listRef} id="project-list" role="listbox" aria-label="Projects">
+          {results.length === 0 ? (
+            <AppPaletteDialog.Empty
+              query={query}
+              emptyMessage="No projects available"
+              noMatchMessage={`No projects match "${query}"`}
+            />
+          ) : (
+            results.map((project, index) => (
+              <button
+                key={project.id}
+                id={`project-option-${project.id}`}
+                role="option"
+                aria-selected={index === selectedIndex}
+                className={cn(
+                  "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
+                  index === selectedIndex
+                    ? "bg-white/[0.03] border-overlay text-canopy-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-canopy-accent before:content-['']"
+                    : "border-transparent text-canopy-text/70 hover:bg-white/[0.02] hover:text-canopy-text",
+                  project.isActive && "opacity-60"
+                )}
+                onClick={() => onSelect(project)}
+                disabled={project.isActive}
+                aria-disabled={project.isActive}
+              >
+                {renderIcon(project.emoji, project.color)}
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span
+                      className={cn(
+                        "truncate text-sm font-semibold leading-tight",
+                        index === selectedIndex ? "text-canopy-text" : "text-canopy-text/85"
+                      )}
+                    >
+                      {project.name}
+                    </span>
+
+                    {project.isActive && (
+                      <span className="text-[10px] font-medium uppercase tracking-wider text-canopy-accent shrink-0">
+                        Active
+                      </span>
+                    )}
+
+                    {project.isBackground && !project.isActive && (
+                      <Circle
+                        className="h-2 w-2 fill-green-500 text-green-500 shrink-0"
+                        aria-label="Running in background"
+                      />
+                    )}
+
+                    <div className="ml-auto flex items-center gap-1.5 shrink-0">
+                      <ProjectActionRow
+                        activeAgentCount={project.activeAgentCount}
+                        waitingAgentCount={project.waitingAgentCount}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex items-center min-w-0 mt-0.5">
+                    <span className="truncate text-[11px] leading-none font-mono text-canopy-text/50">
+                      {project.path.split(/[/\\]/).pop()}
+                    </span>
+                  </div>
+                </div>
+              </button>
+            ))
+          )}
+        </div>
+      </AppPaletteDialog.Body>
+
+      <AppPaletteDialog.Footer>
+        <span>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+            ↑
+          </kbd>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60 ml-1">
+            ↓
+          </kbd>
+          <span className="ml-1.5">to navigate</span>
+        </span>
+        <span>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+            Enter
+          </kbd>
+          <span className="ml-1.5">to switch</span>
+        </span>
+        <span>
+          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+            Esc
+          </kbd>
+          <span className="ml-1.5">to close</span>
+        </span>
+      </AppPaletteDialog.Footer>
+    </AppPaletteDialog>
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,6 +16,11 @@ export type { SearchableTerminal, UseTerminalPaletteReturn } from "./useTerminal
 export { useNewTerminalPalette } from "./useNewTerminalPalette";
 export { usePanelPalette } from "./usePanelPalette";
 export type { PanelKindOption, UsePanelPaletteReturn } from "./usePanelPalette";
+export { useProjectSwitcherPalette } from "./useProjectSwitcherPalette";
+export type {
+  SearchableProject,
+  UseProjectSwitcherPaletteReturn,
+} from "./useProjectSwitcherPalette";
 export { useTerminalConfig } from "./useTerminalConfig";
 
 export { useWorktreeTerminals } from "./useWorktreeTerminals";

--- a/src/hooks/useActionRegistry.ts
+++ b/src/hooks/useActionRegistry.ts
@@ -33,6 +33,7 @@ export function useActionRegistry(options: ActionCallbacks): void {
       onOpenWorktreePalette: () => callbacksRef.current.onOpenWorktreePalette(),
       onOpenNewTerminalPalette: () => callbacksRef.current.onOpenNewTerminalPalette(),
       onOpenPanelPalette: () => callbacksRef.current.onOpenPanelPalette(),
+      onOpenProjectSwitcherPalette: () => callbacksRef.current.onOpenProjectSwitcherPalette(),
       onOpenShortcuts: () => callbacksRef.current.onOpenShortcuts(),
       onLaunchAgent: (agentId, opts) => callbacksRef.current.onLaunchAgent(agentId, opts),
       onInject: (worktreeId) => callbacksRef.current.onInject(worktreeId),

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -1,0 +1,297 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import Fuse, { type IFuseOptions } from "fuse.js";
+import { useProjectStore } from "@/store/projectStore";
+import { useNotificationStore } from "@/store/notificationStore";
+import type { Project, ProjectStats } from "@shared/types";
+import { projectClient, terminalClient } from "@/clients";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isAgentTerminal } from "@/utils/terminalType";
+
+export interface SearchableProject {
+  id: string;
+  name: string;
+  path: string;
+  emoji: string;
+  color?: string;
+  status: Project["status"];
+  isActive: boolean;
+  isBackground: boolean;
+  activeAgentCount: number;
+  waitingAgentCount: number;
+  processCount: number;
+}
+
+export interface UseProjectSwitcherPaletteReturn {
+  isOpen: boolean;
+  query: string;
+  results: SearchableProject[];
+  selectedIndex: number;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  setQuery: (query: string) => void;
+  selectPrevious: () => void;
+  selectNext: () => void;
+  selectProject: (project: SearchableProject) => void;
+  confirmSelection: () => void;
+}
+
+const FUSE_OPTIONS: IFuseOptions<SearchableProject> = {
+  keys: [
+    { name: "name", weight: 2 },
+    { name: "path", weight: 1 },
+  ],
+  threshold: 0.4,
+  includeScore: true,
+};
+
+const MAX_RESULTS = 15;
+const DEBOUNCE_MS = 150;
+
+export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [projectStats, setProjectStats] = useState<Map<string, ProjectStats>>(new Map());
+  const [terminalCounts, setTerminalCounts] = useState<
+    Map<string, { activeAgentCount: number; waitingAgentCount: number }>
+  >(new Map());
+
+  const projects = useProjectStore((state) => state.projects);
+  const currentProject = useProjectStore((state) => state.currentProject);
+  const switchProject = useProjectStore((state) => state.switchProject);
+  const reopenProject = useProjectStore((state) => state.reopenProject);
+  const loadProjects = useProjectStore((state) => state.loadProjects);
+  const { addNotification } = useNotificationStore();
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(query);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [query]);
+
+  const fetchStats = useCallback(async () => {
+    if (projects.length === 0) return;
+
+    const currentProjects = projects;
+
+    const [statsResults, terminalsResults] = await Promise.allSettled([
+      Promise.allSettled(currentProjects.map((p) => projectClient.getStats(p.id))),
+      Promise.allSettled(currentProjects.map((p) => terminalClient.getForProject(p.id))),
+    ]);
+
+    if (statsResults.status === "fulfilled") {
+      const newStats = new Map<string, ProjectStats>();
+      statsResults.value.forEach((result, index) => {
+        if (result.status === "fulfilled") {
+          newStats.set(currentProjects[index].id, result.value);
+        }
+      });
+      setProjectStats(newStats);
+    }
+
+    if (terminalsResults.status === "fulfilled") {
+      const newCounts = new Map<string, { activeAgentCount: number; waitingAgentCount: number }>();
+      terminalsResults.value.forEach((result, index) => {
+        if (result.status !== "fulfilled") return;
+
+        let activeAgentCount = 0;
+        let waitingAgentCount = 0;
+
+        for (const terminal of result.value) {
+          if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
+          if (terminal.kind === "dev-preview") continue;
+
+          const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
+          if (!isAgent) continue;
+
+          if (terminal.agentState === "waiting") {
+            waitingAgentCount += 1;
+          } else if (terminal.agentState === "working" || terminal.agentState === "running") {
+            activeAgentCount += 1;
+          }
+        }
+
+        newCounts.set(currentProjects[index].id, { activeAgentCount, waitingAgentCount });
+      });
+      setTerminalCounts(newCounts);
+    }
+  }, [projects]);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadProjects();
+      fetchStats();
+    }
+  }, [isOpen, loadProjects, fetchStats]);
+
+  useEffect(() => {
+    if (isOpen && projects.length > 0) {
+      fetchStats();
+    }
+  }, [isOpen, projects, fetchStats]);
+
+  const searchableProjects = useMemo<SearchableProject[]>(() => {
+    return projects.map((p) => {
+      const stats = projectStats.get(p.id);
+      const counts = terminalCounts.get(p.id);
+      const isActive = p.id === currentProject?.id;
+      const hasProcesses = (stats?.processCount ?? 0) > 0;
+      const isBackground = p.status === "background" || (!isActive && hasProcesses);
+
+      return {
+        id: p.id,
+        name: p.name,
+        path: p.path,
+        emoji: p.emoji || "🌲",
+        color: p.color,
+        status: p.status,
+        isActive,
+        isBackground,
+        activeAgentCount: counts?.activeAgentCount ?? 0,
+        waitingAgentCount: counts?.waitingAgentCount ?? 0,
+        processCount: stats?.processCount ?? 0,
+      };
+    });
+  }, [projects, projectStats, terminalCounts, currentProject?.id]);
+
+  const sortedProjects = useMemo<SearchableProject[]>(() => {
+    return [...searchableProjects].sort((a, b) => {
+      if (a.isActive && !b.isActive) return -1;
+      if (!a.isActive && b.isActive) return 1;
+      if (a.isBackground && !b.isBackground) return -1;
+      if (!a.isBackground && b.isBackground) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [searchableProjects]);
+
+  const fuse = useMemo(() => {
+    return new Fuse(sortedProjects, FUSE_OPTIONS);
+  }, [sortedProjects]);
+
+  const results = useMemo<SearchableProject[]>(() => {
+    if (!debouncedQuery.trim()) {
+      return sortedProjects.slice(0, MAX_RESULTS);
+    }
+
+    const fuseResults = fuse.search(debouncedQuery);
+    return fuseResults.slice(0, MAX_RESULTS).map((r) => r.item);
+  }, [debouncedQuery, sortedProjects, fuse]);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [results]);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+    setQuery("");
+    setSelectedIndex(0);
+    setDebouncedQuery("");
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQuery("");
+    setSelectedIndex(0);
+    setDebouncedQuery("");
+  }, []);
+
+  const toggle = useCallback(() => {
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  }, [isOpen, open, close]);
+
+  const selectPrevious = useCallback(() => {
+    if (results.length === 0) return;
+    setSelectedIndex((prev) => (prev <= 0 ? results.length - 1 : prev - 1));
+  }, [results.length]);
+
+  const selectNext = useCallback(() => {
+    if (results.length === 0) return;
+    setSelectedIndex((prev) => (prev >= results.length - 1 ? 0 : prev + 1));
+  }, [results.length]);
+
+  const selectProject = useCallback(
+    async (project: SearchableProject) => {
+      close();
+
+      if (project.isActive) {
+        return;
+      }
+
+      if (project.isBackground) {
+        addNotification({
+          type: "info",
+          title: "Reopening project",
+          message: "Reconnecting to background terminals...",
+          duration: 1500,
+        });
+        try {
+          await reopenProject(project.id);
+        } catch (error) {
+          addNotification({
+            type: "error",
+            title: "Failed to reopen project",
+            message: error instanceof Error ? error.message : "Unknown error",
+            duration: 5000,
+          });
+        }
+      } else {
+        addNotification({
+          type: "info",
+          title: "Switching projects",
+          message: "Resetting state for clean project isolation",
+          duration: 1500,
+        });
+        try {
+          await switchProject(project.id);
+        } catch (error) {
+          addNotification({
+            type: "error",
+            title: "Failed to switch project",
+            message: error instanceof Error ? error.message : "Unknown error",
+            duration: 5000,
+          });
+        }
+      }
+    },
+    [close, switchProject, reopenProject, addNotification]
+  );
+
+  const confirmSelection = useCallback(() => {
+    if (results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length) {
+      selectProject(results[selectedIndex]);
+    }
+  }, [results, selectedIndex, selectProject]);
+
+  return {
+    isOpen,
+    query,
+    results,
+    selectedIndex,
+    open,
+    close,
+    toggle,
+    setQuery,
+    selectPrevious,
+    selectNext,
+    selectProject,
+    confirmSelection,
+  };
+}

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -525,6 +525,14 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Worktrees",
   },
   {
+    actionId: "project.switcherPalette",
+    combo: "Cmd+K P",
+    scope: "global",
+    priority: 0,
+    description: "Open project switcher",
+    category: "Project",
+  },
+  {
     actionId: "notes.openPalette",
     combo: "Cmd+Shift+O",
     scope: "global",

--- a/src/services/actions/__tests__/actionDefinitions.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.test.ts
@@ -12,6 +12,7 @@ async function createRegistry() {
     onOpenWorktreePalette: () => {},
     onOpenNewTerminalPalette: () => {},
     onOpenPanelPalette: () => {},
+    onOpenProjectSwitcherPalette: () => {},
     onOpenShortcuts: () => {},
     onLaunchAgent: async () => {},
     onInject: () => {},

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -13,6 +13,7 @@ export interface ActionCallbacks {
   onOpenWorktreePalette: () => void;
   onOpenNewTerminalPalette: () => void;
   onOpenPanelPalette: () => void;
+  onOpenProjectSwitcherPalette: () => void;
   onOpenShortcuts: () => void;
   onLaunchAgent: (
     agentId: string,

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -4,7 +4,20 @@ import { projectClient } from "@/clients";
 import { useNotificationStore } from "@/store/notificationStore";
 import { useProjectStore } from "@/store/projectStore";
 
-export function registerProjectActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
+export function registerProjectActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
+  actions.set("project.switcherPalette", () => ({
+    id: "project.switcherPalette",
+    title: "Open Project Switcher",
+    description: "Open the quick project switcher palette",
+    category: "project",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      callbacks.onOpenProjectSwitcherPalette();
+    },
+  }));
+
   actions.set("project.add", () => ({
     id: "project.add",
     title: "Add Project",


### PR DESCRIPTION
## Summary
Add a quick project switcher palette accessible via `Cmd+K P` keyboard shortcut, allowing users to rapidly switch between projects without using the sidebar dropdown.

Closes #1464

## Changes Made
- Add `useProjectSwitcherPalette` hook with fuzzy search (Fuse.js), async stats fetching, and proper error handling
- Create `ProjectSwitcherPalette` component with keyboard navigation (arrow keys, Tab, Enter, Escape)
- Add `project.switcherPalette` action with `Cmd+K P` chord keybinding
- Integrate palette into App.tsx with proper action registry wiring
- Include ARIA accessibility attributes for listbox pattern
- Show project emoji, color, status (active/background), and running agent counts
- Handle both project switching and background project reopening with user notifications

## Features
- **Fuzzy search**: Type to filter projects by name or path
- **Keyboard navigation**: Full keyboard support with arrow keys, Tab cycling, Enter to select
- **Visual indicators**: Shows active project, background projects (green dot), and agent counts
- **Error handling**: Displays notifications on switch/reopen failures
- **Debounced search**: 150ms debounce for smooth typing experience