### PR TITLE
Reorder PR status tabs to Open, Merged, Closed

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -55,8 +55,8 @@ export function GitHubResourceList({
     if (type === "pr") {
       return [
         { id: "open", label: "Open" },
-        { id: "closed", label: "Closed" },
         { id: "merged", label: "Merged" },
+        { id: "closed", label: "Closed" },
       ];
     }
     return [


### PR DESCRIPTION
## Summary
Reorders the PR status filter tabs in the toolbar dropdown to better reflect usage priority, placing "Merged" before "Closed".

Closes #1461

## Changes Made
- Swap order of Merged and Closed tabs in PR dropdown
- Merged PRs now appear before Closed to reflect usage priority
- Improves discoverability of completed work over abandoned PRs