### PR TITLE
Fix: Improve waiting terminals overlay visibility and accessibility

### DIFF
--- a/src/components/Layout/DockStatusOverlay.tsx
+++ b/src/components/Layout/DockStatusOverlay.tsx
@@ -39,9 +39,13 @@ export function DockStatusOverlay({
         "absolute bottom-2 right-4 z-50",
         "flex items-center gap-2",
         "p-1.5 rounded-full",
-        "bg-[var(--dock-bg)]/95 backdrop-blur-sm",
-        "border border-[var(--dock-border)]",
-        "shadow-lg"
+        "bg-[var(--dock-bg)]/60 backdrop-blur-sm",
+        "border border-[var(--dock-border)]/60",
+        "shadow-lg",
+        "transition-[opacity,background-color,border-color] duration-200",
+        "opacity-85 hover:opacity-100 focus-within:opacity-100",
+        "hover:bg-[var(--dock-bg)]/95 hover:border-[var(--dock-border)]",
+        "focus-within:bg-[var(--dock-bg)]/95 focus-within:border-[var(--dock-border)]"
       )}
       aria-live="polite"
       aria-label="Dock status indicators"

--- a/src/components/Layout/FailedContainer.tsx
+++ b/src/components/Layout/FailedContainer.tsx
@@ -62,7 +62,7 @@ export function FailedContainer({ compact = false }: FailedContainerProps) {
           <span className="relative">
             <XCircle className="w-3.5 h-3.5 text-red-400" aria-hidden="true" />
             {compact && count > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-red-500 text-[10px] font-bold text-white">
+              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-red-400 text-[10px] font-bold text-red-950 shadow-sm">
                 {count > 9 ? "9+" : count}
               </span>
             )}

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -62,7 +62,7 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
           <span className="relative">
             <AlertCircle className="w-3.5 h-3.5 text-amber-400" aria-hidden="true" />
             {compact && count > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-amber-500 text-[10px] font-bold text-white">
+              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-amber-400 text-[10px] font-bold text-amber-950 shadow-sm">
                 {count > 9 ? "9+" : count}
               </span>
             )}


### PR DESCRIPTION
## Summary
This PR improves the UX and accessibility of the waiting terminals overlay by making it more subtle and ensuring proper contrast ratios for text readability.

Closes #1460

## Changes Made
- Make dock status overlay semi-transparent (85% opacity) by default with smooth transitions
- Add hover and focus-within states that increase opacity to 100%
- Fix count badge contrast ratios to meet WCAG AA standards (amber-400/amber-950, red-400/red-950)
- Add smooth color transitions for background and border on hover/focus
- Improve overall readability without obstructing the hybrid input bar

## Technical Details
- Changed overlay from 95% to 60% background opacity with 85% default container opacity
- Improved badge contrast from white-on-dark to dark-on-light for better readability
- Added focus-within states for keyboard accessibility
- Implemented smooth transitions for opacity, background-color, and border-color

## Testing
- Verified WCAG AA contrast compliance for badge text
- Validated TypeScript compilation
- Reviewed implementation with Codex for edge cases and accessibility