### PR TITLE
Add loading overlay for project switching transitions

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -5,7 +5,7 @@ import { TerminalDockRegion } from "./TerminalDockRegion";
 import { DiagnosticsDock } from "../Diagnostics";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { SidecarDock, SidecarVisibilityController } from "../Sidecar";
-import { ProjectSettingsDialog } from "@/components/Project";
+import { ProjectSettingsDialog, ProjectSwitchOverlay } from "@/components/Project";
 import { useDiagnosticsStore, useDockStore, type PanelState } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import type { RetryAction } from "@/store";
@@ -44,6 +44,7 @@ export function AppLayout({
   const [isProjectSettingsOpen, setIsProjectSettingsOpen] = useState(false);
 
   const currentProject = useProjectStore((state) => state.currentProject);
+  const isProjectSwitching = useProjectStore((state) => state.isLoading);
   const layout = useLayoutState();
 
   useEffect(() => {
@@ -337,6 +338,8 @@ export function AppLayout({
           onClose={() => setIsProjectSettingsOpen(false)}
         />
       )}
+
+      <ProjectSwitchOverlay isLoading={isProjectSwitching} projectName={currentProject?.name} />
     </div>
   );
 }

--- a/src/components/Project/ProjectSwitchOverlay.tsx
+++ b/src/components/Project/ProjectSwitchOverlay.tsx
@@ -1,0 +1,128 @@
+import { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getUiAnimationDuration } from "@/lib/animationUtils";
+
+export interface ProjectSwitchOverlayProps {
+  isLoading: boolean;
+  projectName?: string;
+}
+
+const MIN_DISPLAY_DURATION = 200;
+
+export function ProjectSwitchOverlay({ isLoading, projectName }: ProjectSwitchOverlayProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const minDurationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const showStartTimeRef = useRef<number>(0);
+  const pendingCloseRef = useRef(false);
+
+  useEffect(() => {
+    if (isLoading) {
+      pendingCloseRef.current = false;
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+      if (minDurationTimeoutRef.current) {
+        clearTimeout(minDurationTimeoutRef.current);
+        minDurationTimeoutRef.current = null;
+      }
+      showStartTimeRef.current = Date.now();
+      setShouldRender(true);
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        setIsVisible(true);
+      });
+    } else {
+      const elapsed = Date.now() - showStartTimeRef.current;
+      const remaining = MIN_DISPLAY_DURATION - elapsed;
+
+      const doClose = () => {
+        setIsVisible(false);
+        if (rafRef.current !== null) {
+          cancelAnimationFrame(rafRef.current);
+          rafRef.current = null;
+        }
+        const duration = getUiAnimationDuration();
+        if (duration === 0) {
+          setShouldRender(false);
+        } else {
+          closeTimeoutRef.current = setTimeout(() => {
+            closeTimeoutRef.current = null;
+            setShouldRender(false);
+          }, duration);
+        }
+      };
+
+      if (remaining > 0 && showStartTimeRef.current > 0) {
+        pendingCloseRef.current = true;
+        minDurationTimeoutRef.current = setTimeout(() => {
+          minDurationTimeoutRef.current = null;
+          if (pendingCloseRef.current) {
+            pendingCloseRef.current = false;
+            doClose();
+          }
+        }, remaining);
+      } else {
+        doClose();
+      }
+    }
+
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+      if (minDurationTimeoutRef.current) {
+        clearTimeout(minDurationTimeoutRef.current);
+        minDurationTimeoutRef.current = null;
+      }
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [isLoading]);
+
+  if (!shouldRender) return null;
+
+  return createPortal(
+    <div
+      className={cn(
+        "fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-black/60 backdrop-blur-sm",
+        "transition-opacity duration-150",
+        "motion-reduce:transition-none motion-reduce:duration-0",
+        isVisible ? "opacity-100" : "opacity-0"
+      )}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-busy={isLoading}
+    >
+      <div
+        className={cn(
+          "flex flex-col items-center gap-4 text-center px-8 py-6 rounded-[var(--radius-xl)] bg-canopy-sidebar/95 border border-[var(--border-overlay)] shadow-xl",
+          "transition-all duration-150",
+          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
+          isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.96]"
+        )}
+      >
+        <Loader2
+          className="h-8 w-8 text-canopy-accent animate-spin motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+        <div>
+          <p className="text-sm font-medium text-canopy-text">Switching projects</p>
+          {projectName && (
+            <p className="text-xs text-canopy-text/60 mt-1">Loading {projectName}...</p>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/Project/index.ts
+++ b/src/components/Project/index.ts
@@ -1,4 +1,5 @@
 export { ProjectSwitcher } from "./ProjectSwitcher";
 export { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 export { ProjectResourceBadge } from "./ProjectResourceBadge";
+export { ProjectSwitchOverlay } from "./ProjectSwitchOverlay";
 export { QuickRun } from "./QuickRun";


### PR DESCRIPTION
## Summary
Replaces the abrupt project switching transition with a loading overlay that displays while data loads, preventing jarring visual "jumps" when UI elements populate asynchronously.

Closes #1468

## Changes Made
- Create ProjectSwitchOverlay component with blur backdrop and loading spinner
- Integrate overlay into AppLayout to display when projectStore.isLoading is true
- Add 200ms minimum display duration to prevent flicker on fast switches
- Apply backdrop-blur-sm for smooth visual transition without performance issues
- Implement accessibility features (role="status", aria-atomic, motion-reduce support)
- Align animation timings (150ms) with getUiAnimationDuration()

## Implementation Details
- Portal-based full-screen overlay with smooth fade transitions
- Shows current project name during transition
- Respects reduced-motion preferences
- Optimized blur effect to minimize GPU impact

## Known Limitation
The current implementation uses `projectStore.isLoading` which is cleared slightly before full hydration completes. A future PR should introduce a dedicated `isSwitching` state to ensure the overlay stays visible through the complete transition. See PR notes for details.