### PR TITLE
Fix: Preserve panel order when switching between projects

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -10,16 +10,17 @@ export function registerAppStateHandlers(): () => void {
     const currentProject = projectStore.getCurrentProject();
     const globalAppState = store.get("appState");
 
-    // Don't restore terminals from saved state - terminals stay running in the backend
-    // and the frontend will query for running terminals via terminalClient.getForProject()
+    // Terminal processes are discovered from backend via terminalClient.getForProject(),
+    // but we preserve saved terminals array for ordering metadata (IDs and locations).
+    // The frontend uses this to restore panel order when reconnecting to running terminals.
     const appState: StoreSchema["appState"] = {
       ...globalAppState,
-      terminals: [], // Always start with empty - running terminals will be discovered
+      // Keep terminals for ordering - frontend sorts discovered terminals by this saved order
       activeWorktreeId: undefined,
     };
 
     console.log(
-      `[AppHydrate] Project: ${currentProject?.name ?? "none"} - terminals will be discovered from running processes`
+      `[AppHydrate] Project: ${currentProject?.name ?? "none"} - terminals will be discovered from running processes (${globalAppState.terminals?.length ?? 0} saved for ordering)`
     );
 
     return {


### PR DESCRIPTION
## Summary
Fixes panel order preservation when switching between projects. Previously, panel ordering was scrambled on project switch due to terminals being reconnected in arbitrary backend order.

Closes #1469

## Changes Made
- Sort reconnected terminals by saved appState order
- Restore panel location (grid/dock) from saved state
- Handle orphan terminals with stable ordering (maintain backend order for new terminals)
- Fix hydration to preserve terminal ordering metadata (was returning empty array)

## Technical Details
**Root Cause:**
1. `terminalPersistence.save()` correctly preserved panel order in `appState.terminals`
2. `handleAppHydrate` was returning `terminals: []`, discarding the ordering metadata
3. `stateHydration.ts` reconnected terminals in arbitrary `backendTerminals` order

**Solution:**
1. Modified `handleAppHydrate` to preserve `terminals` array for ordering metadata
2. Added sorting logic in `stateHydration.ts` to sort backend terminals by saved order
3. Orphan terminals (in backend but not saved) are appended at the end with stable ordering
4. Location (grid/dock) is restored from saved state

## Testing
- Type check and lint pass
- Codex code review completed with all critical issues addressed