### PR TITLE
Add 'Redraw Terminal' context menu action

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -138,6 +138,7 @@ export type ActionId =
   | "terminal.moveToGrid"
   | "terminal.toggleMaximize"
   | "terminal.restart"
+  | "terminal.redraw"
   | "terminal.forceResume"
   | "terminal.toggleInputLock"
   | "terminal.duplicate"

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -7,6 +7,7 @@ import { useNativeContextMenu } from "@/hooks";
 import { AGENT_IDS, getAgentConfig } from "@/config/agents";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 
 interface TerminalContextMenuProps {
   terminalId: string;
@@ -161,10 +162,12 @@ export function TerminalContextMenu({
 
     const isMac = navigator.platform.toLowerCase().includes("mac");
     const modifierKey = isMac ? "⌘" : "Ctrl";
+    const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
 
     // Terminal actions section
     const terminalActions: MenuItemOption[] = [
-      { id: "restart", label: "Restart Terminal" },
+      ...(hasPty ? [{ id: "restart", label: "Restart Terminal" }] : []),
+      ...(hasPty ? [{ id: "redraw", label: "Redraw Terminal" }] : []),
       ...(isPaused ? [{ id: "force-resume", label: "Force Resume (Paused)" }] : []),
       {
         id: "toggle-input-lock",
@@ -281,6 +284,13 @@ export function TerminalContextMenu({
         case "restart":
           void actionService.dispatch(
             "terminal.restart",
+            { terminalId },
+            { source: "context-menu" }
+          );
+          break;
+        case "redraw":
+          void actionService.dispatch(
+            "terminal.redraw",
             { terminalId },
             { source: "context-menu" }
           );

--- a/src/services/actions/definitions/terminalActions.ts
+++ b/src/services/actions/definitions/terminalActions.ts
@@ -109,6 +109,27 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
     },
   }));
 
+  actions.set("terminal.redraw", () => ({
+    id: "terminal.redraw",
+    title: "Redraw Terminal",
+    description: "Redraw terminal display to fix visual corruption",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
+    run: async (args: unknown) => {
+      const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
+      const state = useTerminalStore.getState();
+      const targetId = terminalId ?? state.focusedId;
+      if (targetId) {
+        const { terminalInstanceService } =
+          await import("@/services/terminal/TerminalInstanceService");
+        terminalInstanceService.resetRenderer(targetId);
+      }
+    },
+  }));
+
   actions.set("terminal.duplicate", () => ({
     id: "terminal.duplicate",
     title: "Duplicate Terminal",


### PR DESCRIPTION
## Summary
Adds a "Redraw Terminal" context menu item for terminals to fix visual corruption issues by calling the xterm.js resetRenderer method.

Closes #1500

## Changes Made
- Add terminal.redraw action to ActionId union type
- Create terminal.redraw action that calls resetRenderer to fix visual corruption
- Add Redraw Terminal menu item in context menu after Restart Terminal
- Gate Restart/Redraw actions on PTY availability using panelKindHasPty
- Handle optional args schema for actions invoked without parameters