### PR TITLE
Fix agent classification inconsistency across terminal layers

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -31,8 +31,15 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     const rows = Math.max(1, Math.min(500, Math.floor(validatedOptions.rows) || 30));
 
     const type = validatedOptions.type || "terminal";
-    const kind = validatedOptions.kind || (validatedOptions.agentId ? "agent" : "terminal");
-    const agentId = validatedOptions.agentId;
+
+    // Normalize kind and agentId from type when type is a registered agent
+    // This ensures agent terminals are consistently identified across all layers
+    // Override kind when type is an agent to prevent mixed metadata
+    const { isRegisteredAgent } = await import("../../../shared/config/agentRegistry.js");
+    const isAgentType = type !== "terminal" && isRegisteredAgent(type);
+
+    const kind = isAgentType ? "agent" : (validatedOptions.kind || (validatedOptions.agentId ? "agent" : "terminal"));
+    const agentId = validatedOptions.agentId || (isAgentType ? type : undefined);
     const title = validatedOptions.title;
     const worktreeId = validatedOptions.worktreeId;
 

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -425,7 +425,11 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
   const terminalInfo = ptyManager.getTerminal(id);
   // Agent terminals use snapshot projection and do not consume the raw visual stream.
   // Writing agent output into the visual ring buffer would immediately backpressure the PTY.
-  const skipVisualStream = terminalInfo?.kind === "agent";
+  // Check kind, agentId, or type to determine if this is an agent terminal
+  const skipVisualStream =
+    terminalInfo?.kind === "agent" ||
+    !!terminalInfo?.agentId ||
+    (terminalInfo?.type && terminalInfo.type !== "terminal");
   // PRIORITY 1: VISUAL RENDERER (Zero-Latency Path)
   // Write to SharedArrayBuffer immediately before doing ANY processing.
   // This ensures terminal output reaches xterm.js with minimal latency.

--- a/electron/services/__tests__/AgentClassification.test.ts
+++ b/electron/services/__tests__/AgentClassification.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { randomUUID } from "crypto";
+import type { PtyManager } from "../PtyManager.js";
+import type { TerminalType, TerminalKind } from "../../../shared/types/domain.js";
+
+let PtyManagerClass: any;
+let testUtils: any;
+
+try {
+  PtyManagerClass = (await import("../PtyManager.js")).PtyManager;
+  testUtils = await import("./helpers/ptyTestUtils.js");
+} catch (_error) {
+  console.warn("node-pty not available, skipping agent classification tests");
+}
+
+const shouldSkip = !PtyManagerClass;
+
+describe.skipIf(shouldSkip)("Agent Classification Matrix", () => {
+  const { cleanupPtyManager, sleep } = testUtils || {};
+  let manager: PtyManager;
+
+  beforeEach(() => {
+    manager = new PtyManagerClass();
+  });
+
+  afterEach(async () => {
+    await cleanupPtyManager(manager);
+  });
+
+  describe("Agent terminals should be classified correctly", () => {
+    it("should treat terminal with kind='agent' as agent", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "agent" as TerminalKind,
+        type: "terminal" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+    }, 10000);
+
+    it("should treat terminal with agentId as agent", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "terminal" as TerminalType,
+        agentId: "claude",
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+    }, 10000);
+
+    it("should treat terminal with type='claude' as agent and set agentId from type", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "claude" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBe("idle");
+      expect(terminal?.agentId).toBe("claude");
+    }, 10000);
+
+    it("should treat terminal with type='gemini' as agent", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "gemini" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+    }, 10000);
+
+    it("should treat terminal with type='codex' as agent", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "codex" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+    }, 10000);
+
+    it("should treat terminal with type='opencode' as agent", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "opencode" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+    }, 10000);
+
+    it("should treat terminal with type='claude' but kind='terminal' as agent (type wins)", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal" as TerminalKind,
+        type: "claude" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+    }, 10000);
+
+    it("should treat terminal with kind='agent' and agentId as agent", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "agent" as TerminalKind,
+        agentId: "claude",
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBeDefined();
+      expect(terminal?.agentId).toBe("claude");
+    }, 10000);
+
+    it("should treat terminal with kind='terminal' but agentId set as agent (agentId wins)", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal" as TerminalKind,
+        type: "terminal" as TerminalType,
+        agentId: "gemini",
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(true);
+      expect(terminal?.agentState).toBe("idle");
+      expect(terminal?.agentId).toBe("gemini");
+    }, 10000);
+  });
+
+  describe("Shell terminals should NOT be classified as agents", () => {
+    it("should treat terminal with type='terminal' as shell", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "terminal" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(false);
+      expect(terminal?.agentState).toBeUndefined();
+    }, 10000);
+
+    it("should treat terminal with kind='terminal' and type='terminal' as shell", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal" as TerminalKind,
+        type: "terminal" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(false);
+      expect(terminal?.agentState).toBeUndefined();
+    }, 10000);
+
+    it("should treat terminal with no kind, type, or agentId as shell", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.analysisEnabled).toBe(false);
+      expect(terminal?.agentState).toBeUndefined();
+    }, 10000);
+  });
+
+  describe("ActivityMonitor initialization", () => {
+    it("should start ActivityMonitor for agent terminals", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "claude" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.agentState).toBeDefined();
+      expect(terminal?.agentState).toBe("idle");
+    }, 10000);
+
+    it("should NOT start ActivityMonitor for shell terminals", async () => {
+      const id = randomUUID();
+      manager.spawn(id, {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        type: "terminal" as TerminalType,
+      });
+
+      await sleep(100);
+
+      const terminal = manager.getTerminal(id);
+      expect(terminal).toBeDefined();
+      expect(terminal?.agentState).toBeUndefined();
+    }, 10000);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes inconsistent agent terminal classification across terminal lifecycle, pty-host, and TerminalProcess layers. Previously, terminals with `type: "claude"` but `kind: "terminal"` were treated as shells in some contexts, disabling critical agent features.

Closes #1501

## Changes Made
- Normalize kind and agentId from type at spawn in lifecycle handler
- Override kind to "agent" when type is a registered agent to prevent mixed metadata
- Enhance TerminalProcess agent detection to check kind, agentId, OR type
- Preserve type as agentId for agent detection config lookups
- Update pty-host skipVisualStream logic to check all three fields
- Add comprehensive agent classification test matrix
- Ensure ActivityMonitor, analysis buffer, and headless responder enabled for all agent types

## Impact
This fix ensures:
- ActivityMonitor starts for all agent terminals (Claude, Gemini, Codex, OpenCode)
- Analysis buffer is properly enabled for agent output processing
- Headless responder is activated for agent terminals
- SAB visual streaming is correctly skipped to prevent backpressure
- Agent state detection (idle/working/waiting) works consistently