### PR TITLE
Fix terminal spawn failures not surfaced to UI

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -11,6 +11,7 @@ export const CHANNELS = {
   WORKTREE_DELETE: "worktree:delete",
 
   TERMINAL_SPAWN: "terminal:spawn",
+  TERMINAL_SPAWN_RESULT: "terminal:spawn-result",
   TERMINAL_DATA: "terminal:data",
   TERMINAL_INPUT: "terminal:input",
   TERMINAL_SUBMIT: "terminal:submit",

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -30,6 +30,16 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   ptyClient.on("error", handlePtyError);
   handlers.push(() => ptyClient.off("error", handlePtyError));
 
+  // Spawn result events (success or failure)
+  const handleSpawnResult = (
+    id: string,
+    result: { success: boolean; id: string; error?: unknown }
+  ) => {
+    sendToRenderer(mainWindow, CHANNELS.TERMINAL_SPAWN_RESULT, id, result);
+  };
+  ptyClient.on("spawn-result", handleSpawnResult);
+  handlers.push(() => ptyClient.off("spawn-result", handleSpawnResult));
+
   // Terminal status for flow control visibility
   const handleTerminalStatus = (payload: {
     id: string;

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -27,6 +27,9 @@ import type {
   TerminalFlowStatus,
   PtyHostActivityTier,
   TerminalReliabilityMetricPayload,
+  SpawnResult,
+  SpawnError,
+  SpawnErrorCode,
 } from "../shared/types/pty-host.js";
 
 function getEmergencyLogPath(): string {
@@ -408,6 +411,38 @@ let rendererPortMessageHandler: ((event: any) => void) | null = null;
 // Helper to send events to Main process
 function sendEvent(event: PtyHostEvent): void {
   port.postMessage(event);
+}
+
+// Helper to parse spawn errors into structured SpawnError
+function parseSpawnError(error: unknown): SpawnError {
+  if (error instanceof Error) {
+    const nodeErr = error as NodeJS.ErrnoException;
+
+    // Map common errno codes to SpawnErrorCode
+    let code: SpawnErrorCode = "UNKNOWN";
+    if (nodeErr.code === "ENOENT") {
+      code = "ENOENT";
+    } else if (nodeErr.code === "EACCES") {
+      code = "EACCES";
+    } else if (nodeErr.code === "ENOTDIR") {
+      code = "ENOTDIR";
+    } else if (nodeErr.code === "EIO") {
+      code = "EIO";
+    }
+
+    return {
+      code,
+      message: nodeErr.message,
+      errno: nodeErr.errno,
+      syscall: nodeErr.syscall,
+      path: nodeErr.path,
+    };
+  }
+
+  return {
+    code: "UNKNOWN",
+    message: String(error),
+  };
 }
 
 // Helper to convert data to string for IPC fallback (IPC events expect string)
@@ -1001,16 +1036,29 @@ port.on("message", async (rawMsg: any) => {
         break;
       }
 
-      case "spawn":
-        ptyManager.spawn(msg.id, msg.options);
-        {
+      case "spawn": {
+        let spawnResult: SpawnResult;
+        try {
+          ptyManager.spawn(msg.id, msg.options);
+          spawnResult = { success: true, id: msg.id };
+
           const terminalInfo = ptyManager.getTerminal(msg.id);
           const pid = terminalInfo?.ptyProcess?.pid;
           if (pid !== undefined) {
             sendEvent({ type: "terminal-pid", id: msg.id, pid });
           }
+        } catch (error) {
+          console.error(`[PtyHost] Spawn failed for terminal ${msg.id}:`, error);
+          spawnResult = {
+            success: false,
+            id: msg.id,
+            error: parseSpawnError(error),
+          };
         }
+
+        sendEvent({ type: "spawn-result", id: msg.id, result: spawnResult });
         break;
+      }
 
       case "write":
         ptyManager.write(msg.id, msg.data, msg.traceId);

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -41,6 +41,7 @@ import type {
   PtyHostActivityTier,
   CrashType,
   HostCrashPayload,
+  SpawnResult,
 } from "../../shared/types/pty-host.js";
 import type { TerminalSnapshot } from "./PtyManager.js";
 import type { AgentStateChangeTrigger } from "../types/index.js";
@@ -582,6 +583,16 @@ export class PtyClient extends EventEmitter {
       case "terminal-pid":
         this.terminalPids.set(event.id, event.pid);
         break;
+
+      case "spawn-result": {
+        const spawnResultEvent = event as { type: "spawn-result"; id: string; result: SpawnResult };
+        if (!spawnResultEvent.result.success) {
+          // Remove from pending spawns since spawn failed
+          this.pendingSpawns.delete(spawnResultEvent.id);
+        }
+        this.emit("spawn-result", spawnResultEvent.id, spawnResultEvent.result);
+        break;
+      }
 
       default:
         console.warn("[PtyClient] Unknown event type:", (event as { type: string }).type);

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -437,9 +437,9 @@ export class TerminalProcess {
           env,
         });
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`Failed to spawn terminal ${id}:`, errorMessage);
-        throw new Error(`Failed to spawn terminal: ${errorMessage}`);
+        console.error(`Failed to spawn terminal ${id}:`, error);
+        // Re-throw original error to preserve code, errno, syscall, path metadata
+        throw error;
       }
     }
 

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -469,6 +469,8 @@ export interface TerminalInstance {
   restartKey?: number;
   isRestarting?: boolean;
   restartError?: TerminalRestartError;
+  /** Error that occurred when spawning the PTY process */
+  spawnError?: import("./pty-host.js").SpawnError;
   flowStatus?: TerminalFlowStatus;
   runtimeStatus?: TerminalRuntimeStatus;
   flowStatusTimestamp?: number;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -253,6 +253,9 @@ export type {
   AgentKilledPayload,
   TerminalFlowStatus,
   TerminalStatusPayload,
+  SpawnResult,
+  SpawnError,
+  SpawnErrorCode,
 } from "./pty-host.js";
 
 // Sidecar types - browser dock

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -54,7 +54,7 @@ import type { TerminalConfig } from "./config.js";
 import type { HibernationConfig } from "./hibernation.js";
 import type { SystemSleepMetrics } from "./systemSleep.js";
 import type { KeyAction } from "../keymap.js";
-import type { TerminalStatusPayload, PtyHostActivityTier } from "../pty-host.js";
+import type { TerminalStatusPayload, PtyHostActivityTier, SpawnResult } from "../pty-host.js";
 import type { ShowContextMenuPayload } from "../menu.js";
 import type { FileSearchPayload, FileSearchResult } from "./files.js";
 import type { SlashCommand, SlashCommandListRequest } from "../slashCommands.js";
@@ -117,6 +117,7 @@ export interface ElectronAPI {
     ): () => void;
     onBackendReady(callback: () => void): () => void;
     sendKey(id: string, key: string): void;
+    onSpawnResult(callback: (id: string, result: SpawnResult) => void): () => void;
   };
   files: {
     search(payload: FileSearchPayload): Promise<FileSearchResult>;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -112,6 +112,7 @@ export type PtyHostEvent =
   | { type: "data"; id: string; data: string }
   | { type: "exit"; id: string; exitCode: number }
   | { type: "error"; id: string; error: string }
+  | { type: "spawn-result"; id: string; result: SpawnResult }
   | {
       type: "wake-result";
       requestId: string;
@@ -256,6 +257,30 @@ export interface AgentKilledPayload {
 
 /** Terminal activity tier (streaming policy) */
 export type PtyHostActivityTier = "active" | "background";
+
+/** Error codes for spawn failures */
+export type SpawnErrorCode =
+  | "ENOENT" // Shell or command not found
+  | "EACCES" // Permission denied
+  | "ENOTDIR" // Working directory does not exist (or path component is not a directory)
+  | "EIO" // I/O error (e.g., PTY allocation failure)
+  | "UNKNOWN"; // Unknown error
+
+/** Result of a spawn operation */
+export interface SpawnResult {
+  success: boolean;
+  id: string;
+  error?: SpawnError;
+}
+
+/** Details of a spawn error */
+export interface SpawnError {
+  code: SpawnErrorCode;
+  message: string;
+  errno?: number;
+  syscall?: string;
+  path?: string;
+}
 
 /** Crash type classification based on exit codes */
 export type CrashType =

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -5,6 +5,7 @@ import type {
   BackendTerminalInfo,
   TerminalReconnectResult,
   TerminalStatusPayload,
+  SpawnResult,
 } from "@shared/types";
 
 let messagePort: MessagePort | null = null;
@@ -254,5 +255,13 @@ export const terminalClient = {
    */
   onBackendReady: (callback: () => void): (() => void) => {
     return window.electron.terminal.onBackendReady(callback);
+  },
+
+  /**
+   * Listen for spawn result events (success or failure).
+   * This is emitted for every spawn attempt with the result.
+   */
+  onSpawnResult: (callback: (id: string, result: SpawnResult) => void): (() => void) => {
+    return window.electron.terminal.onSpawnResult(callback);
   },
 } as const;

--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -119,6 +119,7 @@ export function DockedPanel({ terminal, onPopoverClose }: DockedPanelProps) {
       flowStatus: terminal.flowStatus,
       restartKey: terminal.restartKey,
       restartError: terminal.restartError,
+      spawnError: terminal.spawnError,
 
       // Browser-specific
       initialUrl: terminal.browserUrl || "http://localhost:3000",

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -130,6 +130,7 @@ export function GridPanel({
       flowStatus: terminal.flowStatus,
       restartKey: terminal.restartKey,
       restartError: terminal.restartError,
+      spawnError: terminal.spawnError,
 
       // Browser-specific
       initialUrl: terminal.browserUrl || "http://localhost:3000",

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect, useRef } from "react";
+import { AlertTriangle, RotateCcw, FolderEdit, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SpawnError } from "@/types";
+
+export interface SpawnErrorBannerProps {
+  terminalId: string;
+  error: SpawnError;
+  cwd?: string;
+  onUpdateCwd: (id: string) => void;
+  onRetry: (id: string) => void;
+  onTrash: (id: string) => void;
+  className?: string;
+}
+
+function getErrorTitle(code: SpawnError["code"]): string {
+  switch (code) {
+    case "ENOENT":
+      return "Shell or Command Not Found";
+    case "EACCES":
+      return "Permission Denied";
+    case "ENOTDIR":
+      return "Invalid Working Directory";
+    case "EIO":
+      return "PTY Allocation Failed";
+    default:
+      return "Failed to Start Terminal";
+  }
+}
+
+function getErrorDescription(error: SpawnError, cwd?: string): string {
+  switch (error.code) {
+    case "ENOENT":
+      if (error.path) {
+        return `Could not find: ${error.path}`;
+      }
+      return error.message;
+    case "EACCES":
+      return `You don't have permission to execute: ${error.path || "the shell"}`;
+    case "ENOTDIR":
+      return `The working directory is not valid: ${cwd || "(unknown)"}`;
+    case "EIO":
+      return "Failed to allocate a pseudo-terminal. The system may be running low on resources.";
+    default:
+      return error.message;
+  }
+}
+
+function SpawnErrorBannerComponent({
+  terminalId,
+  error,
+  cwd,
+  onUpdateCwd,
+  onRetry,
+  onTrash,
+  className,
+}: SpawnErrorBannerProps) {
+  const isCwdError = error.code === "ENOTDIR";
+  const [isVisible, setIsVisible] = useState(false);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      setIsVisible(true);
+    });
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, []);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 px-3 py-2 shrink-0",
+        "bg-[color-mix(in_oklab,var(--color-status-error)_10%,transparent)]",
+        "border-b border-[var(--color-status-error)]/20",
+        "transition-all duration-150",
+        "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
+        className
+      )}
+      role="alert"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle
+          className="w-4 h-4 shrink-0 mt-0.5 text-[var(--color-status-error)]"
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <span className="text-sm font-medium text-[var(--color-status-error)]">
+            {getErrorTitle(error.code)}
+          </span>
+          <p className="text-xs text-[var(--color-status-error)]/80 mt-0.5">
+            {getErrorDescription(error, cwd)}
+          </p>
+          {cwd && (
+            <p className="text-xs font-mono text-[var(--color-status-error)]/60 mt-1 truncate">
+              Directory: {cwd}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 ml-6">
+        {isCwdError && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUpdateCwd(terminalId);
+            }}
+            className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium bg-canopy-accent/10 text-canopy-accent hover:bg-canopy-accent/20 rounded transition-colors"
+            title="Update Working Directory"
+            aria-label="Update working directory"
+          >
+            <FolderEdit className="w-3 h-3" aria-hidden="true" />
+            Update Directory
+          </button>
+        )}
+
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRetry(terminalId);
+          }}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium bg-canopy-border text-canopy-text hover:bg-canopy-border/80 rounded transition-colors"
+          title="Retry"
+          aria-label="Retry starting terminal"
+        >
+          <RotateCcw className="w-3 h-3" aria-hidden="true" />
+          Retry
+        </button>
+
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onTrash(terminalId);
+          }}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-[var(--color-status-error)]/70 hover:text-[var(--color-status-error)] hover:bg-[var(--color-status-error)]/10 rounded transition-colors"
+          title="Move to Trash"
+          aria-label="Move to trash"
+        >
+          <Trash2 className="w-3 h-3" aria-hidden="true" />
+          Trash
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const SpawnErrorBanner = React.memo(SpawnErrorBannerComponent);

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1,13 +1,14 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { AlertTriangle, Loader2 } from "lucide-react";
-import type { TerminalType, TerminalRestartError } from "@/types";
+import type { TerminalType, TerminalRestartError, SpawnError } from "@/types";
 import { cn } from "@/lib/utils";
 import { XtermAdapter } from "./XtermAdapter";
 import { ArtifactOverlay } from "./ArtifactOverlay";
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { TerminalRestartBanner } from "./TerminalRestartBanner";
 import { TerminalErrorBanner } from "./TerminalErrorBanner";
+import { SpawnErrorBanner } from "./SpawnErrorBanner";
 import { GeminiAlternateBufferBanner } from "./GeminiAlternateBufferBanner";
 import { UpdateCwdDialog } from "./UpdateCwdDialog";
 import { ErrorBanner } from "../Errors/ErrorBanner";
@@ -61,6 +62,7 @@ export interface TerminalPaneProps {
   restartKey?: number;
   isTrashing?: boolean;
   restartError?: TerminalRestartError;
+  spawnError?: SpawnError;
   gridPanelCount?: number;
 }
 
@@ -87,6 +89,7 @@ function TerminalPaneComponent({
   restartKey = 0,
   isTrashing = false,
   restartError,
+  spawnError,
   gridPanelCount,
 }: TerminalPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -483,6 +486,17 @@ function TerminalPaneComponent({
         <TerminalErrorBanner
           terminalId={id}
           error={restartError}
+          onUpdateCwd={handleUpdateCwd}
+          onRetry={handleRestart}
+          onTrash={handleTrash}
+        />
+      )}
+
+      {spawnError && !restartError && (
+        <SpawnErrorBanner
+          terminalId={id}
+          error={spawnError}
+          cwd={cwd}
           onUpdateCwd={handleUpdateCwd}
           onRetry={handleRestart}
           onTrash={handleTrash}


### PR DESCRIPTION
## Summary
Implements comprehensive error handling for terminal PTY spawn failures, surfacing errors to the UI with actionable recovery options.

Closes #1505

## Changes Made
- Add SpawnResult, SpawnError, and SpawnErrorCode types for structured error reporting
- Preserve original error metadata in TerminalProcess by re-throwing instead of wrapping
- Implement parseSpawnError to map Node.js errno codes (ENOENT, EACCES, ENOTDIR, EIO) to user-friendly error messages
- Add spawn-result event flow from pty-host through PtyClient to renderer
- Create SpawnErrorBanner component with error-specific messages and recovery actions (Update Directory, Retry, Trash)
- Clear spawn errors on successful retry, directory update, or spawn success
- Add fallback error handling for spawn failures without error details
- Fix ENOTDIR type (was incorrectly ENODIR) and restrict Update Directory action to actual path errors
- Set runtimeStatus to error on spawn failure and clear on recovery

## Test Plan
- Test spawn failures with invalid shell paths (ENOENT)
- Test spawn failures with invalid working directories (ENOTDIR)
- Test spawn failures with permission denied scenarios (EACCES)
- Verify error banners display with correct messages and actions
- Verify retry clears error state on success
- Verify Update Directory action only appears for appropriate errors