### PR TITLE
Fix IPC backpressure to prevent OOM from agent output

### DIFF
--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -138,3 +138,10 @@ export const AGENT_SCROLLBACK = 10000;
 export const RAW_OUTPUT_BUFFER_MAX_SIZE = 100 * 1024;
 
 export const TRASH_TTL_MS = 120 * 1000;
+
+// IPC Flow Control Configuration
+export const IPC_MAX_QUEUE_BYTES = 4 * 1024 * 1024; // 4MB max per terminal
+export const IPC_HIGH_WATERMARK_PERCENT = 90; // Pause PTY at 90% full
+export const IPC_LOW_WATERMARK_PERCENT = 50; // Resume PTY when drops to 50%
+export const IPC_BACKPRESSURE_CHECK_INTERVAL_MS = 100; // Check every 100ms during backpressure
+export const IPC_MAX_PAUSE_MS = 5000; // Force resume after 5 seconds to prevent indefinite pause

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -288,7 +288,14 @@ class TerminalInstanceService {
     this.unseenTracker.incrementUnseen(id, managed.isUserScrolledBack);
 
     // Capture SAB mode decision before write to avoid mode-flip ambiguity during callback
-    const shouldAck = !this.dataBuffer.isEnabled();
+    const sabMode = this.dataBuffer.isEnabled();
+    // For agent terminals or systems without SAB, we need to acknowledge IPC data
+    // Check both kind and agentId to cover all agent terminal types (legacy and new)
+    const isAgentTerminal = managed.kind === "agent" || !!managed.agentId;
+    const shouldAck = !sabMode || isAgentTerminal;
+
+    // Calculate exact byte length for accurate flow control
+    const dataBytes = typeof data === "string" ? Buffer.byteLength(data, "utf8") : data.byteLength;
 
     // Write data and apply flow control acknowledgement after xterm processes the buffer update
     const terminal = managed.terminal;
@@ -299,11 +306,12 @@ class TerminalInstanceService {
 
       managed.pendingWrites = Math.max(0, (managed.pendingWrites ?? 1) - 1);
 
-      // Flow control: Only send acknowledgements in IPC fallback mode.
-      // In SAB mode, flow control is handled globally via SAB backpressure.
+      // Flow control: Send acknowledgements for IPC data (agent terminals or SAB disabled).
+      // Agent terminals always use IPC even when SAB is available, so they need acks.
+      // In pure SAB mode (non-agent terminals), flow control is handled via SAB backpressure.
+      // Send exact byte count (not character count) for accurate queue accounting.
       if (shouldAck) {
-        const len = typeof data === "string" ? data.length : data.byteLength;
-        terminalClient.acknowledgeData(id, len);
+        terminalClient.acknowledgeData(id, dataBytes);
       }
     });
   }


### PR DESCRIPTION
## Summary
Implements IPC backpressure mechanism to prevent out-of-memory crashes from high-volume agent terminal output. Agent terminals bypass SAB (SharedArrayBuffer) visual streaming and use IPC fallback, which previously had no flow control.

Closes #1503

## Changes Made
- Add bounded queue (4MB) with hard cap enforcement for IPC fallback
- Implement PTY pause at 90% queue full, resume at 50%
- Add exact byte count tracking for accurate flow control
- Fix agent detection to cover both kind and agentId-based agents
- Add telemetry for backpressure events and queue utilization
- Clean up all per-terminal state on exit to prevent memory leaks
- Add safety timeout to force resume after 5 seconds

## Technical Details
**IPC Flow Control:**
- Tracks exact byte count in IPC queue per terminal
- Pauses PTY when queue exceeds 90% of 4MB limit
- Resumes PTY when consumption brings queue below 50%
- Drops data if queue would exceed hard cap (prevents unbounded growth)
- Force resumes after 5 seconds to prevent indefinite pauses

**Telemetry:**
- Emits `terminal-status` events for pause/resume
- Tracks `bufferUtilization` and pause duration metrics
- Logs warnings for queue saturation and force resumes

## Testing Notes
- Verified with Codex review (fixed accounting mismatch and agent detection)
- Handles both legacy (`kind === "agent"`) and new (`agentId`-based) agent terminals
- Comprehensive cleanup prevents memory leaks on terminal exit