### PR TITLE
Fix environment variable masking for GITHUB_TOKEN pattern

### DIFF
--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -54,7 +54,7 @@ interface EnvVar {
 
 type ProjectSettingsTab = "general" | "context" | "automation";
 
-const SENSITIVE_ENV_KEY_RE = /\b(key|secret|token|password)\b/i;
+const SENSITIVE_ENV_KEY_RE = /(key|secret|token|password)/i;
 
 export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSettingsDialogProps) {
   const { settings, saveSettings, isLoading, error } = useProjectSettings(projectId);


### PR DESCRIPTION
## Summary
Fixed sensitive environment variable masking regex to properly detect common secret patterns like GITHUB_TOKEN, API_KEY, and AWS_SECRET_ACCESS_KEY.

Closes #1515

## Changes Made
- Removed word boundaries (`\b`) from `SENSITIVE_ENV_KEY_RE` regex pattern
- Changed from `/\b(key|secret|token|password)\b/i` to `/(key|secret|token|password)/i`
- Word boundaries don't match underscores, causing variables like GITHUB_TOKEN, API_KEY, AWS_SECRET_ACCESS_KEY to be displayed unmasked
- Substring matching now correctly masks all common secret patterns while maintaining case-insensitivity

## Testing
Verified the regex now correctly masks:
- ✅ GITHUB_TOKEN
- ✅ API_KEY
- ✅ AWS_SECRET_ACCESS_KEY
- ✅ DATABASE_PASSWORD
- ✅ All other variations containing key/secret/token/password