### PR TITLE
Fix context file extension to match format setting

### DIFF
--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -12,7 +12,23 @@ import type {
   CopyTreeResult,
   CopyTreeProgress,
   FileTreeNode,
+  CopyTreeOptions,
 } from "../../types/index.js";
+
+type CopyTreeFormat = NonNullable<CopyTreeOptions["format"]>;
+
+const FORMAT_TO_EXTENSION: Record<CopyTreeFormat, string> = {
+  json: "json",
+  markdown: "md",
+  tree: "txt",
+  ndjson: "ndjson",
+  xml: "xml",
+};
+
+const getExtensionForFormat = (format: CopyTreeFormat | undefined): string => {
+  if (!format) return "xml";
+  return FORMAT_TO_EXTENSION[format] ?? "xml";
+};
 import {
   CopyTreeGeneratePayloadSchema,
   CopyTreeGenerateAndCopyFilePayloadSchema,
@@ -145,7 +161,8 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
           .replace(/-+/g, "-")
           .replace(/^-+|-+$/g, "")
           .slice(0, 100) || "head";
-      const filename = `context-${safeBranch}-${timestamp}.xml`;
+      const extension = getExtensionForFormat(validated.options?.format);
+      const filename = `context-${safeBranch}-${timestamp}.${extension}`;
       const filePath = path.join(tempDir, filename);
 
       await fs.writeFile(filePath, result.content, "utf-8");

--- a/electron/services/ClipboardFileInjector.ts
+++ b/electron/services/ClipboardFileInjector.ts
@@ -168,6 +168,7 @@ export class ClipboardFileInjector {
       ".jsx": "application/javascript",
       ".tsx": "application/typescript",
       ".json": "application/json",
+      ".ndjson": "application/x-ndjson",
       ".png": "image/png",
       ".jpg": "image/jpeg",
       ".jpeg": "image/jpeg",


### PR DESCRIPTION
## Summary
Fixes context file extension to correctly match the selected format (json, markdown, tree, ndjson, xml) instead of always using .xml.

Closes #1541

## Changes Made
- Add format-to-extension mapping with exhaustive Record type for compile-time safety
- Update filename generation to use actual format (json, md, txt, ndjson, xml)
- Add .ndjson MIME type mapping for clipboard paste compatibility
- Default to .xml extension when format is undefined