### PR TITLE
Fix sidecar navigation actions validation

### DIFF
--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -302,15 +302,26 @@ export function SidecarDock() {
   }, [setOpen]);
 
   const handleGoBack = useCallback(async () => {
-    await actionService.dispatch("sidecar.goBack", undefined, { source: "user" });
+    const result = await actionService.dispatch("sidecar.goBack", undefined, { source: "user" });
+    if (!result.ok) {
+      console.error("Failed to go back:", result.error);
+    }
   }, [activeTabId]);
 
   const handleGoForward = useCallback(async () => {
-    await actionService.dispatch("sidecar.goForward", undefined, { source: "user" });
+    const result = await actionService.dispatch("sidecar.goForward", undefined, {
+      source: "user",
+    });
+    if (!result.ok) {
+      console.error("Failed to go forward:", result.error);
+    }
   }, [activeTabId]);
 
   const handleReload = useCallback(async () => {
-    await actionService.dispatch("sidecar.reload", undefined, { source: "user" });
+    const result = await actionService.dispatch("sidecar.reload", undefined, { source: "user" });
+    if (!result.ok) {
+      console.error("Failed to reload:", result.error);
+    }
   }, [activeTabId]);
 
   const handleOpenExternal = useCallback(async () => {

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -393,11 +393,11 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ tabId: z.string().optional() }),
+    argsSchema: z.object({ tabId: z.string().min(1).optional() }).optional(),
     run: async (args: unknown) => {
-      const { tabId } = args as { tabId?: string };
+      const { tabId } = (args ?? {}) as { tabId?: string };
       const state = useSidecarStore.getState();
-      const targetId = tabId ?? state.activeTabId;
+      const targetId = tabId || state.activeTabId;
       if (targetId) {
         state.closeTab(targetId);
       }
@@ -582,11 +582,11 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ tabId: z.string().optional() }),
+    argsSchema: z.object({ tabId: z.string().min(1).optional() }).optional(),
     run: async (args: unknown) => {
-      const { tabId } = args as { tabId?: string };
+      const { tabId } = (args ?? {}) as { tabId?: string };
       const state = useSidecarStore.getState();
-      const targetId = tabId ?? state.activeTabId;
+      const targetId = tabId || state.activeTabId;
       if (!targetId) return false;
       if (!state.createdTabs.has(targetId)) return false;
       return await window.electron.sidecar.goBack(targetId);
@@ -601,11 +601,11 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ tabId: z.string().optional() }),
+    argsSchema: z.object({ tabId: z.string().min(1).optional() }).optional(),
     run: async (args: unknown) => {
-      const { tabId } = args as { tabId?: string };
+      const { tabId } = (args ?? {}) as { tabId?: string };
       const state = useSidecarStore.getState();
-      const targetId = tabId ?? state.activeTabId;
+      const targetId = tabId || state.activeTabId;
       if (!targetId) return false;
       if (!state.createdTabs.has(targetId)) return false;
       return await window.electron.sidecar.goForward(targetId);
@@ -620,11 +620,11 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ tabId: z.string().optional() }),
+    argsSchema: z.object({ tabId: z.string().min(1).optional() }).optional(),
     run: async (args: unknown) => {
-      const { tabId } = args as { tabId?: string };
+      const { tabId } = (args ?? {}) as { tabId?: string };
       const state = useSidecarStore.getState();
-      const targetId = tabId ?? state.activeTabId;
+      const targetId = tabId || state.activeTabId;
       if (!targetId) return;
       if (!state.createdTabs.has(targetId)) return;
       await window.electron.sidecar.reload(targetId);
@@ -639,11 +639,11 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ tabId: z.string().optional() }),
+    argsSchema: z.object({ tabId: z.string().min(1).optional() }).optional(),
     run: async (args: unknown) => {
-      const { tabId } = args as { tabId?: string };
+      const { tabId } = (args ?? {}) as { tabId?: string };
       const state = useSidecarStore.getState();
-      const targetId = tabId ?? state.activeTabId;
+      const targetId = tabId || state.activeTabId;
       if (!targetId) return;
       const tab = state.tabs.find((t) => t.id === targetId);
       if (!tab?.url) return;
@@ -659,11 +659,11 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ tabId: z.string().optional() }),
+    argsSchema: z.object({ tabId: z.string().min(1).optional() }).optional(),
     run: async (args: unknown) => {
-      const { tabId } = args as { tabId?: string };
+      const { tabId } = (args ?? {}) as { tabId?: string };
       const state = useSidecarStore.getState();
-      const targetId = tabId ?? state.activeTabId;
+      const targetId = tabId || state.activeTabId;
       if (!targetId) return;
       const tab = state.tabs.find((t) => t.id === targetId);
       if (!tab?.url) return;


### PR DESCRIPTION
## Summary
Fixes sidecar navigation buttons (back, forward, reload, close tab, copy URL, open external) that were broken due to action validation failures. The UI was dispatching these actions with `undefined` args, but the action schemas required an object.

Closes #1521

## Changes Made
- Make argsSchema optional for 6 sidecar actions (closeTab, goBack, goForward, reload, copyUrl, openExternal)
- Add min(1) validation to tabId to prevent empty string edge case
- Change from ?? to || operator for proper empty string fallback handling
- Add error handling to navigation callbacks (goBack, goForward, reload) for consistency with other handlers