### PR TITLE
Fix dock preferences persistence (issue #1517)

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -176,7 +176,30 @@ export function registerAppStateHandlers(): () => void {
       }
 
       if ("dockCollapsed" in partialState) {
-        updates.dockCollapsed = Boolean(partialState.dockCollapsed);
+        if (typeof partialState.dockCollapsed === "boolean") {
+          updates.dockCollapsed = partialState.dockCollapsed;
+        }
+      }
+
+      if ("dockMode" in partialState) {
+        const mode = partialState.dockMode;
+        if (mode === "expanded" || mode === "hidden" || mode === "slim") {
+          // Normalize legacy "slim" to "hidden"
+          updates.dockMode = mode === "slim" ? "hidden" : mode;
+        }
+      }
+
+      if ("dockBehavior" in partialState) {
+        const behavior = partialState.dockBehavior;
+        if (behavior === "auto" || behavior === "manual") {
+          updates.dockBehavior = behavior;
+        }
+      }
+
+      if ("dockAutoHideWhenEmpty" in partialState) {
+        if (typeof partialState.dockAutoHideWhenEmpty === "boolean") {
+          updates.dockAutoHideWhenEmpty = partialState.dockAutoHideWhenEmpty;
+        }
       }
 
       store.set("appState", { ...currentState, ...updates });

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -72,6 +72,9 @@ export interface StoreSchema {
     }>;
     terminalGridConfig?: TerminalGridConfig;
     dockCollapsed?: boolean;
+    dockMode?: "expanded" | "slim" | "hidden";
+    dockBehavior?: "auto" | "manual";
+    dockAutoHideWhenEmpty?: boolean;
   };
   projects: {
     list: Project[];
@@ -118,6 +121,9 @@ const storeOptions = {
       hasSeenWelcome: false,
       terminalGridConfig: { strategy: "automatic" as const, value: 3 },
       dockCollapsed: false,
+      dockMode: "hidden" as const,
+      dockBehavior: "auto" as const,
+      dockAutoHideWhenEmpty: false,
     },
     projects: {
       list: [],


### PR DESCRIPTION
## Summary
Fixes dock preferences not persisting across app restarts. The frontend was attempting to save `dockMode`, `dockBehavior`, and `dockAutoHideWhenEmpty`, but the backend store schema was missing these fields and the IPC handler wasn't processing them.

Closes #1517

## Changes Made
- Add dockMode, dockBehavior, and dockAutoHideWhenEmpty to store schema with defaults
- Add validation in app state handler for dock preference fields
- Normalize legacy "slim" mode to "hidden" during persistence for backward compatibility
- Use strict boolean validation to prevent type coercion issues
- Set sensible defaults: dockMode="hidden", dockBehavior="auto", dockAutoHideWhenEmpty=false

## Testing
- Type checking passes (0 errors)
- Codex review completed with all recommendations addressed
- Changes verified against the complete persistence flow from frontend → IPC → backend storage