### PR TITLE
Fix recipe env values ignored when running recipes

### DIFF
--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -217,6 +217,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             cwd: worktreePath,
             worktreeId: worktreeId,
             devCommand: terminal.devCommand?.trim() || undefined,
+            env: terminal.env,
           });
           continue;
         }
@@ -252,6 +253,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           cwd: worktreePath,
           command,
           worktreeId: worktreeId,
+          env: terminal.env,
         });
       } catch (error) {
         console.error(`Failed to spawn terminal for recipe ${recipeId}:`, error);

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -99,6 +99,8 @@ export interface AddTerminalOptions {
   createdAt?: number;
   /** Dev server command override for dev-preview panels (kind === 'dev-preview') */
   devCommand?: string;
+  /** Environment variables to set for this terminal */
+  env?: Record<string, string>;
 }
 
 function getDefaultTitle(kind?: PanelKind, type?: TerminalType, agentId?: string): string {
@@ -407,6 +409,7 @@ export const createTerminalRegistrySlice =
               agentId,
               title,
               worktreeId: options.worktreeId,
+              env: options.env,
             });
           }
 


### PR DESCRIPTION
## Summary
Fixes recipe environment variable configuration by forwarding env vars from recipe terminal definitions through to the terminal spawn chain.

Closes #1532

## Changes Made
- Add env property to AddTerminalOptions interface
- Forward env from addTerminal to terminalClient.spawn
- Pass terminal.env from runRecipe for both regular and dev-preview terminals

## Testing
- Typecheck passes
- Codex review completed (identified future enhancements out of scope)
- Backend already supports env parameter forwarding to PTY

## Notes
- Recipe env vars now flow correctly: RecipeTerminal.env → addTerminal(env) → terminalClient.spawn(env) → backend
- Future work identified: project env merge (#1516), dev-preview env support, terminal restart env persistence