### PR TITLE
Fix agent state events to preserve real agentId

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -947,6 +947,7 @@ events.on("agent:state-changed", (payload) => {
     sendEvent({
       type: "agent-state",
       id: payload.terminalId,
+      agentId: payload.agentId,
       state: payload.state,
       previousState: payload.previousState,
       timestamp: payload.timestamp,

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -479,7 +479,7 @@ export type CanopyEventMap = {
    * Use this for status indicators and monitoring agent activity.
    */
   "agent:state-changed": WithContext<{
-    agentId: string;
+    agentId?: string;
     state: AgentState;
     previousState: AgentState;
     trigger: AgentStateChangeTrigger;

--- a/electron/services/pty/PtyEventsBridge.ts
+++ b/electron/services/pty/PtyEventsBridge.ts
@@ -37,7 +37,7 @@ export function bridgePtyEvent(event: PtyHostEvent, config?: PtyEventsBridgeConf
   switch (event.type) {
     case "agent-state":
       events.emit("agent:state-changed", {
-        agentId: event.id,
+        agentId: event.agentId,
         terminalId: event.id,
         state: event.state,
         previousState: event.previousState,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1721,7 +1721,7 @@ export class TerminalProcess {
         terminal.lastStateChange = Date.now();
 
         const stateChangePayload = {
-          agentId: this.id,
+          agentId: this.terminalInfo.agentId,
           terminalId: this.id,
           state: newState,
           previousState,

--- a/shared/types/ipc/agent.ts
+++ b/shared/types/ipc/agent.ts
@@ -31,10 +31,10 @@ export type AgentState = "idle" | "working" | "running" | "waiting" | "completed
 
 /** Payload for agent state change events */
 export interface AgentStateChangePayload {
-  /** Agent/terminal ID */
-  agentId: string;
+  /** Agent ID (e.g., "claude", "gemini") - identifies the agent type. May be undefined for non-agent terminals. */
+  agentId?: AgentId;
   /** Terminal ID (unique identifier for this terminal instance) */
-  terminalId?: string;
+  terminalId: string;
   /** Worktree ID (if terminal is associated with a worktree) */
   worktreeId?: string;
   /** New state */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -129,6 +129,7 @@ export type PtyHostEvent =
   | {
       type: "agent-state";
       id: string;
+      agentId?: AgentId;
       state: AgentState;
       previousState: AgentState;
       timestamp: number;


### PR DESCRIPTION
## Summary
Fixed issue where agent state change events were using terminal ID instead of the real agent ID (e.g., "claude", "gemini"). This allows downstream consumers to distinguish between different agent types.

Closes #1527

## Changes Made
- Add agentId field to agent-state event type in pty-host
- Forward agentId from payload in pty-host event emitter
- Use event.agentId in PtyEventsBridge instead of terminal ID
- Use terminalInfo.agentId in TerminalProcess instead of this.id
- Make agentId optional (AgentId type) and terminalId required in AgentStateChangePayload
- Update terminalStore to use terminalId directly with validation
- Make agentId optional in agent:state-changed event type

## Testing
- Type check passes
- Lint/format checks pass
- Codex review completed with recommendations applied