### PR TITLE
Fix: Issue list parsing throws on null assignee or label nodes

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -638,12 +638,12 @@ function parseIssueNode(node: Record<string, unknown>): GitHubIssue {
       login: author?.login ?? "unknown",
       avatarUrl: author?.avatarUrl ?? "",
     },
-    assignees: (assigneesData?.nodes ?? []).map((a) => ({
+    assignees: (assigneesData?.nodes ?? []).filter(Boolean).map((a) => ({
       login: a.login ?? "unknown",
       avatarUrl: a.avatarUrl ?? "",
     })),
     commentCount: commentsData?.totalCount ?? 0,
-    labels: (labelsData?.nodes ?? []).map((l) => ({
+    labels: (labelsData?.nodes ?? []).filter(Boolean).map((l) => ({
       name: l.name ?? "",
       color: l.color ?? "",
     })),
@@ -724,7 +724,7 @@ export async function listIssues(
       const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
 
       result = {
-        items: nodes.map(parseIssueNode),
+        items: nodes.filter(Boolean).map(parseIssueNode),
         pageInfo: {
           hasNextPage: search?.pageInfo?.hasNextPage ?? false,
           endCursor: search?.pageInfo?.endCursor ?? null,
@@ -745,7 +745,7 @@ export async function listIssues(
       const nodes = (issues?.nodes ?? []) as Array<Record<string, unknown>>;
 
       result = {
-        items: nodes.map(parseIssueNode),
+        items: nodes.filter(Boolean).map(parseIssueNode),
         pageInfo: {
           hasNextPage: issues?.pageInfo?.hasNextPage ?? false,
           endCursor: issues?.pageInfo?.endCursor ?? null,
@@ -811,7 +811,7 @@ export async function listPullRequests(
       const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
 
       result = {
-        items: nodes.map(parsePRNode),
+        items: nodes.filter(Boolean).map(parsePRNode),
         pageInfo: {
           hasNextPage: search?.pageInfo?.hasNextPage ?? false,
           endCursor: search?.pageInfo?.endCursor ?? null,
@@ -832,7 +832,7 @@ export async function listPullRequests(
       const nodes = (pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
 
       result = {
-        items: nodes.map(parsePRNode),
+        items: nodes.filter(Boolean).map(parsePRNode),
         pageInfo: {
           hasNextPage: pullRequests?.pageInfo?.hasNextPage ?? false,
           endCursor: pullRequests?.pageInfo?.endCursor ?? null,


### PR DESCRIPTION
## Summary
Fixes crashes in GitHub integration when GraphQL returns null nodes for deleted users or restricted labels. Added null filtering at all entry points where node arrays are mapped.

Closes #1530

## Changes Made
- Add null filtering to assignees and labels arrays in parseIssueNode
- Add null filtering to search results in listIssues
- Add null filtering to repository issues in listIssues
- Add null filtering to search results in listPullRequests
- Add null filtering to repository PRs in listPullRequests
- Prevents crashes when GraphQL returns null nodes for deleted users or restricted labels