### PR TITLE
Fix terminal wake state leaks across destroy and restart

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -397,6 +397,11 @@ class TerminalInstanceService {
    * Rate-limited to prevent excessive backend calls on rapid focus changes.
    */
   wake(id: string): void {
+    // Guard: Don't wake destroyed terminals to prevent repopulating stale state
+    if (!this.instances.has(id)) {
+      return;
+    }
+
     const now = Date.now();
     const lastWake = this.lastWakeTime.get(id) ?? 0;
 
@@ -1474,6 +1479,8 @@ class TerminalInstanceService {
     this.resizeLocks.delete(id);
     this.suppressedExitUntil.delete(id);
     this.cwdProviders.delete(id);
+    this.lastWakeTime.delete(id);
+    this.lastBackendTier.delete(id);
   }
 
   dispose(): void {


### PR DESCRIPTION
## Summary
Fixes memory leak in `TerminalInstanceService` where `lastWakeTime` and `lastBackendTier` maps were not cleaned up on terminal destroy. Since terminal IDs are reused on restart, stale entries caused new terminals to inherit incorrect wake rate-limiting and tier transition state.

Closes #1526

## Changes Made
- Add `lastWakeTime.delete(id)` to `destroy()` method
- Add `lastBackendTier.delete(id)` to `destroy()` method  
- Add instance check guard in `wake()` to prevent race condition where wake could repopulate maps after destroy
- Prevents stale wake/tier state from leaking to reused terminal IDs

## Testing
- Typecheck passed
- Codex review completed with race condition fix applied