### PR TITLE
Fix snapshot request races with unique request IDs

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1423,6 +1423,7 @@ port.on("message", async (rawMsg: any) => {
         sendEvent({
           type: "snapshot",
           id: msg.id,
+          requestId: msg.requestId,
           snapshot: toHostSnapshot(msg.id),
         });
         break;
@@ -1430,6 +1431,7 @@ port.on("message", async (rawMsg: any) => {
       case "get-all-snapshots":
         sendEvent({
           type: "all-snapshots",
+          requestId: msg.requestId,
           snapshots: ptyManager.getAllTerminalSnapshots().map((s) => ({
             id: s.id,
             lines: s.lines,

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -53,8 +53,8 @@ export type PtyHostRequest =
   | { type: "project-switch"; projectId: string }
   | { type: "kill-by-project"; projectId: string; requestId: string }
   | { type: "get-project-stats"; projectId: string; requestId: string }
-  | { type: "get-snapshot"; id: string }
-  | { type: "get-all-snapshots" }
+  | { type: "get-snapshot"; id: string; requestId: string }
+  | { type: "get-all-snapshots"; requestId: string }
   | { type: "mark-checked"; id: string }
   | {
       type: "transition-state";
@@ -159,8 +159,8 @@ export type PtyHostEvent =
   | { type: "terminal-trashed"; id: string; expiresAt: number }
   | { type: "terminal-restored"; id: string }
   | { type: "terminal-pid"; id: string; pid: number }
-  | { type: "snapshot"; id: string; snapshot: PtyHostTerminalSnapshot | null }
-  | { type: "all-snapshots"; snapshots: PtyHostTerminalSnapshot[] }
+  | { type: "snapshot"; id: string; requestId: string; snapshot: PtyHostTerminalSnapshot | null }
+  | { type: "all-snapshots"; requestId: string; snapshots: PtyHostTerminalSnapshot[] }
   | { type: "transition-result"; id: string; requestId: string; success: boolean }
   | { type: "pong" }
   | { type: "ready" }


### PR DESCRIPTION
## Summary
Fixes race conditions in terminal snapshot requests where concurrent calls could overwrite callbacks or resolve the wrong request, causing hangs or incorrect results.

Closes #1537

## Changes Made
- Add requestId parameter to snapshot and all-snapshots requests/responses
- Store callbacks by unique requestId instead of terminal ID
- Fix transitionState to use broker-generated IDs (prevents same-millisecond collisions)
- Add timeout tracking Maps and cleanup for all async callbacks
- Update PtyHostRequest and PtyHostEvent type definitions

## Technical Details
Previously, `getTerminalSnapshot()` and `getAllTerminalSnapshots()` used single callbacks per terminal/globally. A second concurrent call would overwrite the first callback, and timeouts could delete newer callbacks. Now each request gets a unique ID via `RequestResponseBroker.generateId()`, ensuring proper isolation.

## Test Plan
- [x] Type checking passes
- [x] Build succeeds
- [x] Codex code review completed