### PR TITLE
Fix: Prevent stale validation results from token change race conditions

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -166,12 +166,14 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
     if (validation.valid) {
       setGitHubToken(token.trim());
+      const versionAfterSet = GitHubAuth.getTokenVersion();
 
       if (validation.username) {
         GitHubAuth.setValidatedUserInfo(
           validation.username,
           validation.avatarUrl,
-          validation.scopes
+          validation.scopes,
+          versionAfterSet
         );
       }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -298,13 +298,15 @@ async function createWindow(): Promise<void> {
   if (GitHubAuth.hasToken()) {
     const token = GitHubAuth.getToken();
     if (token) {
+      const versionAtStart = GitHubAuth.getTokenVersion();
       GitHubAuth.validate(token)
         .then((validation) => {
           if (validation.valid && validation.username) {
             GitHubAuth.setValidatedUserInfo(
               validation.username,
               validation.avatarUrl,
-              validation.scopes
+              validation.scopes,
+              versionAtStart
             );
             console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
           }


### PR DESCRIPTION
## Summary

Fixes race condition where stale token validation results could populate user info after the token was cleared or changed, causing the UI to display incorrect username/avatar/scopes.

Closes #1529

## Changes Made

- Add `tokenVersion` counter to track token state changes
- Clear cached user info when token changes (`setToken`, `setMemoryToken`, `clearToken`)
- Gate `getConfig()` return values on `hasToken` to prevent stale data from being displayed
- Add version checks to `setValidatedUserInfo()` to reject stale validation results
- Clear `pendingValidation` on token changes to avoid awaiting stale promises
- Update startup validation (main.ts) and IPC set-token handler (github.ts) to use version checks

## Technical Details

The fix implements token versioning to bind validation results to specific token states:

1. **Token version tracking**: Every token change increments `tokenVersion`
2. **Version-bound validation**: Validation results capture the version at start and check before applying
3. **Cache clearing**: All token mutations now clear cached user info and pending validations
4. **Gated returns**: `getConfig()` only returns cached values when `hasToken` is true

This prevents all identified race conditions:
- Stale validation completing after `clearToken()`
- Old username persisting after `setToken()` to new token
- Multiple rapid token changes showing wrong user