### PR TITLE
Fix: Remove dead IPC channels and fix type mismatches

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -29,8 +29,6 @@ export const CHANNELS = {
   TERMINAL_RECONNECT: "terminal:reconnect",
   TERMINAL_REPLAY_HISTORY: "terminal:replay-history",
   TERMINAL_GET_SERIALIZED_STATE: "terminal:get-serialized-state",
-  TERMINAL_GET_SNAPSHOT: "terminal:get-snapshot",
-  TERMINAL_GET_CLEAN_LOG: "terminal:get-clean-log",
   TERMINAL_GET_SHARED_BUFFERS: "terminal:get-shared-buffers",
   TERMINAL_GET_ANALYSIS_BUFFER: "terminal:get-analysis-buffer",
   TERMINAL_GET_INFO: "terminal:get-info",
@@ -44,7 +42,6 @@ export const CHANNELS = {
   FILES_SEARCH: "files:search",
 
   AGENT_STATE_CHANGED: "agent:state-changed",
-  AGENT_GET_STATE: "agent:get-state",
   AGENT_DETECTED: "agent:detected",
   AGENT_EXITED: "agent:exited",
 
@@ -70,7 +67,6 @@ export const CHANNELS = {
   SYSTEM_GET_CLI_AVAILABILITY: "system:get-cli-availability",
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",
   SYSTEM_WAKE: "system:wake",
-  SYSTEM_BACKEND_READY: "system:backend-ready",
 
   PR_DETECTED: "pr:detected",
   PR_CLEARED: "pr:cleared",
@@ -212,8 +208,6 @@ export const CHANNELS = {
   NOTIFICATION_UPDATE: "notification:update",
 
   SLASH_COMMANDS_LIST: "slash-commands:list",
-
-  WINDOW_VISIBILITY_CHANGE: "window:visibility-change",
 
   GEMINI_GET_STATUS: "gemini:get-status",
   GEMINI_ENABLE_ALTERNATE_BUFFER: "gemini:enable-alternate-buffer",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -556,8 +556,6 @@ async function createWindow(): Promise<void> {
     }
   }
 
-  sendToRenderer(mainWindow, CHANNELS.SYSTEM_BACKEND_READY);
-
   // Spawn Default Terminal
   console.log("[MAIN] Spawning default terminal...");
   try {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -169,7 +169,6 @@ const CHANNELS = {
 
   // Agent state channels
   AGENT_STATE_CHANGED: "agent:state-changed",
-  AGENT_GET_STATE: "agent:get-state",
   AGENT_DETECTED: "agent:detected",
   AGENT_EXITED: "agent:exited",
 

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -153,9 +153,12 @@ export interface IpcInvokeMap {
     args: [terminalId: string];
     result: string | null;
   };
-  "terminal:get-shared-buffer": {
+  "terminal:get-shared-buffers": {
     args: [];
-    result: SharedArrayBuffer | null;
+    result: {
+      visualBuffers: SharedArrayBuffer[];
+      signalBuffer: SharedArrayBuffer | null;
+    };
   };
   "terminal:get-analysis-buffer": {
     args: [];
@@ -183,10 +186,6 @@ export interface IpcInvokeMap {
   };
 
   // Agent channels
-  "agent:get-state": {
-    args: [agentId: string];
-    result: string | null;
-  };
   "agent-help:get": {
     args: [request: AgentHelpRequest];
     result: AgentHelpResult;


### PR DESCRIPTION
## Summary
Cleans up the IPC channel surface by removing 5 dead channels that were defined but never exposed in preload or lacked handlers. Also fixes a type mismatch in the terminal:get-shared-buffers channel definition.

Closes #1542

## Changes Made
- Remove SYSTEM_BACKEND_READY channel (emitted from main but never consumed by renderer)
- Remove TERMINAL_GET_SNAPSHOT channel (defined but unused)
- Remove TERMINAL_GET_CLEAN_LOG channel (defined but unused)
- Remove WINDOW_VISIBILITY_CHANGE channel (defined but unused)
- Remove AGENT_GET_STATE channel (defined but no handler registered)
- Fix terminal:get-shared-buffers type definition to match actual return shape (was singular, wrong type)

## Testing
- TypeScript compilation passes
- No references to removed channels remain in codebase