### PR TITLE
Fix: Context injection bypasses automation gating

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,7 +7,7 @@ export { useAgentLauncher } from "./useAgentLauncher";
 export type { LaunchAgentOptions, UseAgentLauncherReturn } from "./useAgentLauncher";
 
 export { useContextInjection } from "./useContextInjection";
-export type { UseContextInjectionReturn } from "./useContextInjection";
+export type { UseContextInjectionReturn, InjectionStatus } from "./useContextInjection";
 
 export { useErrors } from "./useErrors";
 


### PR DESCRIPTION
## Summary
Prevents context injection from corrupting active agent prompts or TUI screens by gating injection until the agent becomes idle. This aligns context injection with the existing automation command queue semantics.

Closes #1534

## Changes Made
- Added idle state checking before context injection (reuses `isAgentReady` semantics from command queue)
- Implemented pending injection queue with Promise-based waiting mechanism
- Added terminal store subscription to detect agent state transitions (working/running → idle/waiting)
- Handle race conditions: agent already ready, rapid state changes, terminal deletion during wait
- Cancel existing pending injections to prevent promise leaks
- Re-validate agent readiness after wait completes to prevent race condition bypasses
- Display "Waiting for agent" progress message during gating period
- Use updated terminal reference after wait to avoid stale data (format selection, etc.)
- Export new `InjectionStatus` type for UI feedback

## Technical Details
The implementation follows Option 2 from the issue (add idle check to injection) rather than routing through the command queue, since context injection is an async IPC operation (`injectToTerminal`) rather than a simple payload string that can be queued.

## Testing
- Typecheck passes
- Command queue tests pass (12/12)
- Codex review completed with all critical issues addressed