### PR TITLE
Fix worktree list keybindings validation errors

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -203,6 +203,7 @@ export type ActionId =
 export interface ActionContext {
   projectId?: string;
   activeWorktreeId?: string;
+  focusedWorktreeId?: string;
   focusedTerminalId?: string;
   isTerminalPaletteOpen?: boolean;
   isSettingsOpen?: boolean;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -677,6 +677,7 @@ function App() {
     actionService.setContextProvider(() => ({
       projectId: useProjectStore.getState().currentProject?.id,
       activeWorktreeId: useWorktreeSelectionStore.getState().activeWorktreeId ?? undefined,
+      focusedWorktreeId: useWorktreeSelectionStore.getState().focusedWorktreeId ?? undefined,
       focusedTerminalId: useTerminalStore.getState().focusedId ?? undefined,
     }));
 

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -139,10 +139,14 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string() }),
-    run: async (args: unknown) => {
-      const { worktreeId } = args as { worktreeId: string };
-      useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
+    run: async (args: unknown, ctx: ActionContext) => {
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+      if (!targetWorktreeId) {
+        throw new Error("No worktree selected");
+      }
+      useWorktreeSelectionStore.getState().selectWorktree(targetWorktreeId);
     },
   }));
 
@@ -370,22 +374,24 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "confirm",
     scope: "renderer",
-    argsSchema: z.object({
-      worktreeId: z.string().optional(),
-      format: z.enum(["xml", "json", "markdown", "tree", "ndjson"]).optional(),
-      modified: z.boolean().optional(),
-    }),
+    argsSchema: z
+      .object({
+        worktreeId: z.string().optional(),
+        format: z.enum(["xml", "json", "markdown", "tree", "ndjson"]).optional(),
+        modified: z.boolean().optional(),
+      })
+      .optional(),
     run: async (args: unknown, ctx: ActionContext) => {
       const {
         worktreeId,
         format: explicitFormat,
         modified,
-      } = args as {
+      } = (args ?? {}) as {
         worktreeId?: string;
         format?: "xml" | "json" | "markdown" | "tree" | "ndjson";
         modified?: boolean;
       };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return null;
 
       const terminal = ctx.focusedTerminalId
@@ -422,11 +428,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "confirm",
     scope: "renderer",
-    argsSchema: z.object({
-      worktreeId: z.string().optional(),
-      format: z.enum(["xml", "json", "markdown", "tree", "ndjson"]).optional(),
-      modified: z.boolean().optional(),
-    }),
+    argsSchema: z
+      .object({
+        worktreeId: z.string().optional(),
+        format: z.enum(["xml", "json", "markdown", "tree", "ndjson"]).optional(),
+        modified: z.boolean().optional(),
+      })
+      .optional(),
     run: async (args: unknown) => {
       const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch("worktree.copyTree", args, { source: "user" });
@@ -445,9 +453,11 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({
-      worktreeId: z.string().optional(),
-    }),
+    argsSchema: z
+      .object({
+        worktreeId: z.string().optional(),
+      })
+      .optional(),
     isEnabled: (ctx: ActionContext) => {
       const hasFocusedTerminal = Boolean(ctx.focusedTerminalId);
       return hasFocusedTerminal;
@@ -464,8 +474,8 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       if (!hasFocusedTerminal) {
         throw new Error("No focused terminal to inject into");
       }
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) {
         throw new Error("No worktree selected");
       }
@@ -481,10 +491,10 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string().optional() }),
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
 
       const worktree = useWorktreeDataStore.getState().worktrees.get(targetWorktreeId);
@@ -502,10 +512,10 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string().optional() }),
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
       const worktree = useWorktreeDataStore.getState().worktrees.get(targetWorktreeId);
       if (!worktree) return;
@@ -521,10 +531,10 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string().optional() }),
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
       const worktree = useWorktreeDataStore.getState().worktrees.get(targetWorktreeId);
       if (!worktree?.issueNumber) return;
@@ -540,10 +550,10 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string().optional() }),
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
       const worktree = useWorktreeDataStore.getState().worktrees.get(targetWorktreeId);
       if (!worktree?.prUrl) return;
@@ -559,10 +569,10 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string().optional() }),
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
 
       const worktree = useWorktreeDataStore.getState().worktrees.get(targetWorktreeId);
@@ -591,7 +601,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       );
     },
     isEnabled: (ctx: ActionContext) => {
-      const worktreeId = ctx.activeWorktreeId;
+      const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!worktreeId) return false;
       const worktree = useWorktreeDataStore.getState().worktrees.get(worktreeId);
       return typeof worktree?.prUrl === "string" && worktree.prUrl.trim().length > 0;
@@ -606,10 +616,10 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ worktreeId: z.string().optional() }),
+    argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
     run: async (args: unknown, ctx: ActionContext) => {
-      const { worktreeId } = args as { worktreeId?: string };
-      const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
 
       const worktree = useWorktreeDataStore.getState().worktrees.get(targetWorktreeId);
@@ -630,7 +640,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       );
     },
     isEnabled: (ctx: ActionContext) => {
-      const worktreeId = ctx.activeWorktreeId;
+      const worktreeId = ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!worktreeId) return false;
       const worktree = useWorktreeDataStore.getState().worktrees.get(worktreeId);
       return typeof worktree?.issueNumber === "number" && worktree.issueNumber > 0;


### PR DESCRIPTION
## Summary
Fix keybindings in worktree list (Enter, C, E) that were failing with VALIDATION_ERROR. The issue was that keybindings always pass undefined args, but worktree actions required args objects with worktreeId.

Closes #1520

## Changes Made
- Add focusedWorktreeId to ActionContext for keybinding context
- Make argsSchema optional for all worktree actions to accept undefined
- Update fallback logic: worktreeId → focusedWorktreeId → activeWorktreeId
- Add nullish guards when destructuring optional args
- Update isEnabled checks to use focusedWorktreeId fallback
- Fix validation errors when keybindings dispatch with undefined args

## Impact
- Enter in worktree list now selects the focused worktree
- C (copy context) in worktree list now works on focused worktree
- E (open editor) in worktree list now works on focused worktree
- All actions still work when called with explicit args