### PR TITLE
Fix worktree PR detection reliability and metadata handling

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -7,6 +7,7 @@ export const CHANNELS = {
   WORKTREE_CREATE: "worktree:create",
   WORKTREE_LIST_BRANCHES: "worktree:list-branches",
   WORKTREE_PR_REFRESH: "worktree:pr-refresh",
+  WORKTREE_PR_STATUS: "worktree:pr-status",
   WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
   WORKTREE_DELETE: "worktree:delete",
 

--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -42,6 +42,15 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
   ipcMain.handle(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_REFRESH));
 
+  const handleWorktreePRStatus = async () => {
+    if (!workspaceClient) {
+      return null;
+    }
+    return await workspaceClient.getPRStatus();
+  };
+  ipcMain.handle(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_STATUS));
+
   const handleWorktreeSetActive = async (
     _event: Electron.IpcMainInvokeEvent,
     payload: WorktreeSetActivePayload

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -131,6 +131,7 @@ const CHANNELS = {
   WORKTREE_CREATE: "worktree:create",
   WORKTREE_LIST_BRANCHES: "worktree:list-branches",
   WORKTREE_PR_REFRESH: "worktree:pr-refresh",
+  WORKTREE_PR_STATUS: "worktree:pr-status",
   WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
   WORKTREE_DELETE: "worktree:delete",
 
@@ -389,6 +390,8 @@ const api: ElectronAPI = {
     refresh: () => _typedInvoke(CHANNELS.WORKTREE_REFRESH),
 
     refreshPullRequests: () => _typedInvoke(CHANNELS.WORKTREE_PR_REFRESH),
+
+    getPRStatus: () => _typedInvoke(CHANNELS.WORKTREE_PR_STATUS),
 
     setActive: (worktreeId: string) => _typedInvoke(CHANNELS.WORKTREE_SET_ACTIVE, { worktreeId }),
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -347,6 +347,9 @@ export class WorkspaceClient extends EventEmitter {
           prNumber: event.prNumber,
           prUrl: event.prUrl,
           prState: event.prState,
+          prTitle: event.prTitle,
+          issueNumber: event.issueNumber,
+          issueTitle: event.issueTitle,
           timestamp: Date.now(),
         };
         events.emit("sys:pr:detected", prPayload);

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -68,6 +68,7 @@ export interface ElectronAPI {
     getAll(): Promise<WorktreeState[]>;
     refresh(): Promise<void>;
     refreshPullRequests(): Promise<void>;
+    getPRStatus(): Promise<import("../workspace-host.js").PRServiceStatus | null>;
     setActive(worktreeId: string): Promise<void>;
     create(options: CreateWorktreeOptions, rootPath: string): Promise<string>;
     listBranches(rootPath: string): Promise<BranchInfo[]>;

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -59,11 +59,13 @@ export interface PRDetectedPayload {
   prTitle?: string;
   issueNumber?: number;
   issueTitle?: string;
+  timestamp: number;
 }
 
 /** Payload for PR cleared notification */
 export interface PRClearedPayload {
   worktreeId: string;
+  timestamp: number;
 }
 
 /** Issue detected payload */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -91,6 +91,10 @@ export interface IpcInvokeMap {
     args: [];
     result: void;
   };
+  "worktree:pr-status": {
+    args: [];
+    result: import("../workspace-host.js").PRServiceStatus | null;
+  };
   "worktree:set-active": {
     args: [payload: WorktreeSetActivePayload];
     result: void;

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -1,4 +1,5 @@
 import type { WorktreeState, CreateWorktreeOptions, BranchInfo } from "@shared/types";
+import type { PRServiceStatus } from "@shared/types/workspace-host";
 
 /**
  * @example
@@ -20,6 +21,10 @@ export const worktreeClient = {
 
   refreshPullRequests: (): Promise<void> => {
     return window.electron.worktree.refreshPullRequests();
+  },
+
+  getPRStatus: (): Promise<PRServiceStatus | null> => {
+    return window.electron.worktree.getPRStatus();
   },
 
   setActive: (worktreeId: string): Promise<void> => {


### PR DESCRIPTION
## Summary

Improves worktree PR detection to fix inconsistent detection, missing metadata, and stale state issues identified in issue #1553.

Closes #1553

## Changes Made

- Query by branch when branchName exists (not only with issueNumber)
- Apply open > merged > closed preference for branch queries to avoid selecting wrong PR
- Include CONNECTED_EVENT for GitHub-linked PRs (official linking mechanism)
- Revalidate resolved PRs every 10 minutes to detect state changes
- Detect PR number, title, and URL changes during revalidation
- Forward PR metadata (prTitle, issueTitle) to renderer
- Add timestamp to PR event payload types for type safety
- Expose PR service health status via IPC API

## Technical Details

**Branch-only queries**: Modified GraphQL queries to fetch PRs by branch name even when no issue number is present, enabling detection of PRs created outside the issue workflow.

**State preference**: Fetch multiple PRs per branch (up to 10) and apply the same "open > merged > closed" preference logic used for issue-linked PRs, preventing closed/merged PRs from being selected when open ones exist.

**CONNECTED_EVENT support**: Added support for GitHub's CONNECTED_EVENT alongside CROSS_REFERENCED_EVENT in timeline queries, catching PRs linked via the "Linked pull requests" UI feature.

**Slow-cadence revalidation**: Implemented 10-minute polling for resolved PRs to detect state transitions (open → merged/closed) and metadata changes, ensuring the UI stays current.

**Metadata propagation**: Fixed missing prTitle and issueTitle in renderer by forwarding them through WorkspaceClient and adding proper type definitions.