### PR TITLE
Fix: Active worktree is never marked as current

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -223,6 +223,11 @@ export class WorkspaceService {
           continue;
         }
 
+        // Clear activeWorktreeId if this was the active worktree
+        if (this.activeWorktreeId === id) {
+          this.activeWorktreeId = null;
+        }
+
         this.stopMonitor(monitor);
         this.monitors.delete(id);
         this.sendEvent({ type: "worktree-removed", worktreeId: id });
@@ -238,8 +243,10 @@ export class WorkspaceService {
       if (existingMonitor) {
         // Check if branch changed - if so, re-extract issue number
         const branchChanged = existingMonitor.branch !== wt.branch;
+        const isCurrentChanged = existingMonitor.isCurrent !== isActive;
         existingMonitor.branch = wt.branch;
         existingMonitor.name = wt.name;
+        existingMonitor.isCurrent = isActive;
         const interval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
         existingMonitor.pollingInterval = interval;
         existingMonitor.pollingStrategy.setBaseInterval(interval);
@@ -248,6 +255,11 @@ export class WorkspaceService {
           this.pollIntervalMax,
           this.circuitBreakerThreshold
         );
+
+        // Emit update if isCurrent changed
+        if (isCurrentChanged && existingMonitor.hasInitialStatus) {
+          this.emitUpdate(existingMonitor);
+        }
 
         // Re-extract issue number when branch changes
         if (branchChanged && wt.branch) {
@@ -292,7 +304,7 @@ export class WorkspaceService {
           path: wt.path,
           name: wt.name,
           branch: wt.branch,
-          isCurrent: wt.isCurrent,
+          isCurrent: isActive,
           isMainWorktree: Boolean(wt.isMainWorktree),
           gitDir: wt.gitDir,
           worktreeId: wt.id,
@@ -664,6 +676,11 @@ export class WorkspaceService {
       return;
     }
 
+    // Clear activeWorktreeId if this was the active worktree
+    if (this.activeWorktreeId === worktreeId) {
+      this.activeWorktreeId = null;
+    }
+
     // Stop the monitor and remove from map
     this.stopMonitor(monitor);
     this.monitors.delete(worktreeId);
@@ -711,6 +728,10 @@ export class WorkspaceService {
       const interval = isActive ? this.pollIntervalActive : this.pollIntervalBackground;
       monitor.pollingInterval = interval;
       monitor.pollingStrategy.setBaseInterval(interval);
+      monitor.isCurrent = isActive;
+      if (monitor.hasInitialStatus) {
+        this.emitUpdate(monitor);
+      }
     }
 
     this.sendEvent({ type: "set-active-result", requestId, success: true });


### PR DESCRIPTION
## Summary
Fixes the bug where the active worktree is never marked with `isCurrent = true`, which broke refresh semantics, UI indicators, and delete safety checks.

Closes #1519

## Changes Made
- Set `isCurrent` in `setActiveWorktree` for all monitors (active = true, others = false)
- Update `isCurrent` in `syncMonitors` when creating or updating monitors
- Emit updates when `isCurrent` changes in `syncMonitors` to keep UI in sync
- Clear stale `activeWorktreeId` when worktree is removed (prevents dangling references)

## Impact
- **Delete safety**: Active worktree can no longer be deleted (guard now works correctly)
- **Refresh semantics**: Active worktree now uses `forceRefresh` on every poll
- **UI indicator**: Dashboard can now show "current" badge on active worktree
- **Race conditions**: Fixed potential race between `syncMonitors` and `setActiveWorktree`