### PR TITLE
Fix context injection cancel doesn't stop writes and cancels all operations

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -575,12 +575,16 @@ const api: ElectronAPI = {
     generateAndCopyFile: (worktreeId: string, options?: CopyTreeOptions) =>
       _typedInvoke(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, { worktreeId, options }),
 
-    injectToTerminal: (terminalId: string, worktreeId: string, options?: CopyTreeOptions) =>
-      _typedInvoke(CHANNELS.COPYTREE_INJECT, { terminalId, worktreeId, options }),
+    injectToTerminal: (
+      terminalId: string,
+      worktreeId: string,
+      options?: CopyTreeOptions,
+      injectionId?: string
+    ) => _typedInvoke(CHANNELS.COPYTREE_INJECT, { terminalId, worktreeId, options, injectionId }),
 
     isAvailable: () => _typedInvoke(CHANNELS.COPYTREE_AVAILABLE),
 
-    cancel: () => _typedInvoke(CHANNELS.COPYTREE_CANCEL),
+    cancel: (injectionId?: string) => _typedInvoke(CHANNELS.COPYTREE_CANCEL, { injectionId }),
 
     getFileTree: (worktreeId: string, dirPath?: string) =>
       _typedInvoke(CHANNELS.COPYTREE_GET_FILE_TREE, { worktreeId, dirPath }),

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -202,6 +202,11 @@ export const CopyTreeInjectPayloadSchema = z.object({
   terminalId: z.string().min(1),
   worktreeId: z.string().min(1),
   options: CopyTreeOptionsSchema,
+  injectionId: z.string().min(1).optional(),
+});
+
+export const CopyTreeCancelPayloadSchema = z.object({
+  injectionId: z.string().min(1).optional(),
 });
 
 export const CopyTreeProgressSchema = z.object({
@@ -291,6 +296,7 @@ export type CopyTreeGenerateAndCopyFilePayload = z.infer<
   typeof CopyTreeGenerateAndCopyFilePayloadSchema
 >;
 export type CopyTreeInjectPayload = z.infer<typeof CopyTreeInjectPayloadSchema>;
+export type CopyTreeCancelPayload = z.infer<typeof CopyTreeCancelPayloadSchema>;
 export type CopyTreeProgress = z.infer<typeof CopyTreeProgressSchema>;
 export type CopyTreeGetFileTreePayload = z.infer<typeof CopyTreeGetFileTreePayloadSchema>;
 export type SystemOpenExternalPayload = z.infer<typeof SystemOpenExternalPayloadSchema>;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -91,6 +91,7 @@ export type {
   CopyTreeGeneratePayload,
   CopyTreeGenerateAndCopyFilePayload,
   CopyTreeInjectPayload,
+  CopyTreeCancelPayload,
   CopyTreeGetFileTreePayload,
   CopyTreeResult,
   CopyTreeProgress,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -137,10 +137,11 @@ export interface ElectronAPI {
     injectToTerminal(
       terminalId: string,
       worktreeId: string,
-      options?: CopyTreeOptions
+      options?: CopyTreeOptions,
+      injectionId?: string
     ): Promise<CopyTreeResult>;
     isAvailable(): Promise<boolean>;
-    cancel(): Promise<void>;
+    cancel(injectionId?: string): Promise<void>;
     getFileTree(worktreeId: string, dirPath?: string): Promise<FileTreeNode[]>;
     onProgress(callback: (progress: CopyTreeProgress) => void): () => void;
   };

--- a/shared/types/ipc/copyTree.ts
+++ b/shared/types/ipc/copyTree.ts
@@ -41,6 +41,14 @@ export interface CopyTreeInjectPayload {
   terminalId: string;
   worktreeId: string;
   options?: CopyTreeOptions;
+  /** Unique identifier for this injection operation (for per-operation cancellation) */
+  injectionId?: string;
+}
+
+/** Payload for cancelling a specific injection operation */
+export interface CopyTreeCancelPayload {
+  /** If provided, only cancel this specific injection. If omitted, cancels all. */
+  injectionId?: string;
 }
 
 /** Payload for getting file tree */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -41,6 +41,7 @@ import type {
   CopyTreeResult,
   CopyTreeGenerateAndCopyFilePayload,
   CopyTreeInjectPayload,
+  CopyTreeCancelPayload,
   CopyTreeGetFileTreePayload,
   FileTreeNode,
   CopyTreeProgress,
@@ -223,7 +224,7 @@ export interface IpcInvokeMap {
     result: boolean;
   };
   "copytree:cancel": {
-    args: [];
+    args: [payload: CopyTreeCancelPayload];
     result: void;
   };
   "copytree:get-file-tree": {

--- a/src/clients/copyTreeClient.ts
+++ b/src/clients/copyTreeClient.ts
@@ -17,17 +17,18 @@ export const copyTreeClient = {
   injectToTerminal: (
     terminalId: string,
     worktreeId: string,
-    options?: CopyTreeOptions
+    options?: CopyTreeOptions,
+    injectionId?: string
   ): Promise<CopyTreeResult> => {
-    return window.electron.copyTree.injectToTerminal(terminalId, worktreeId, options);
+    return window.electron.copyTree.injectToTerminal(terminalId, worktreeId, options, injectionId);
   },
 
   isAvailable: (): Promise<boolean> => {
     return window.electron.copyTree.isAvailable();
   },
 
-  cancel: (): Promise<void> => {
-    return window.electron.copyTree.cancel();
+  cancel: (injectionId?: string): Promise<void> => {
+    return window.electron.copyTree.cancel(injectionId);
   },
 
   getFileTree: (worktreeId: string, dirPath?: string): Promise<FileTreeNode[]> => {


### PR DESCRIPTION
## Summary
Implements per-operation cancellation for context injection to fix issue where clicking "Cancel" would globally cancel all CopyTree operations and fail to stop the write loop.

Closes #1533

## Changes Made
- Add `injectionId` parameter to `CopyTreeInjectPayload` and cancel handler for per-operation tracking
- Track active injections with `terminalId->injectionId` mapping in main process
- Check cancellation signal in write loop before each chunk to stop immediately when canceled
- Block concurrent injections in renderer to prevent state corruption
- Clear stale progress on early aborts to prevent UI showing outdated "Waiting..." messages
- Validate cancel payloads and ignore unknown/completed injection IDs to prevent memory leaks
- Support both per-injection cancellation (new) and global cancel operations (legacy compatibility)
- Import shared `CopyTreeProgress` type to prevent type drift