### PR TITLE
Fix: Pass devCommand to terminal spawn in devServer.start action

### DIFF
--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -43,6 +43,7 @@ export function registerDevServerActions(
         cwd,
         worktreeId: activeWorktreeId ?? undefined,
         location: "grid",
+        devCommand: devServerCommand,
       });
     },
   }));


### PR DESCRIPTION
## Summary
Fixes issue where the configured dev server command was validated but never passed to the terminal spawn, causing it to be ignored.

Closes #1531

## Changes Made
- Add `devCommand` parameter to `addTerminal` call in `devServer.start` action
- DevPreviewPane now receives the configured command instead of always falling back to auto-detection
- Auto-detection fallback still works when no command is configured