### PR TITLE
fix(hydration): restore active worktree on app state hydration

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -21,11 +21,10 @@ export function registerAppStateHandlers(): () => void {
     // Terminal processes are discovered from backend via terminalClient.getForProject(),
     // but we preserve saved terminals array for ordering metadata (IDs and locations).
     // The frontend uses this to restore panel order when reconnecting to running terminals.
+    // activeWorktreeId is preserved so the frontend can validate it exists after worktrees load.
     const appState: StoreSchema["appState"] = {
       ...globalAppState,
       terminals: validatedTerminals,
-      // Keep terminals for ordering - frontend sorts discovered terminals by this saved order
-      activeWorktreeId: undefined,
     };
 
     console.log(


### PR DESCRIPTION
## Summary
Fixes the issue where the active worktree was not being restored when the app restarted, leaving the grid empty until the user manually selected a worktree again.

Closes #1525

## Changes Made
- **Backend (state.ts)**: Removed the explicit clearing of `activeWorktreeId: undefined` during hydration, preserving the saved value
- **Frontend (stateHydration.ts)**: Added validation logic that:
  - Fetches worktrees to validate the saved `activeWorktreeId` still exists
  - Restores the saved active worktree if it exists
  - Falls back to the first/main worktree if the saved one was deleted
  - Handles edge cases gracefully (no worktrees, fetch errors)

## Testing
1. Select worktree A
2. Restart app
3. Worktree A should be active on launch
4. Grid should show panels from worktree A

## Edge Cases Handled
- Saved worktree was deleted externally → falls back to first worktree
- No worktrees exist → handled gracefully (no error)
- `worktreeClient.getAll()` fails → falls back to saved ID if present