### PR TITLE
Fix non-PTY panels dropped during app restart

### DIFF
--- a/electron/store.ts
+++ b/electron/store.ts
@@ -44,9 +44,11 @@ export interface StoreSchema {
     };
     terminals: Array<{
       id: string;
-      type: "terminal" | "claude" | "gemini" | "codex" | "opencode";
+      kind?: "terminal" | "agent" | "browser" | "notes" | "dev-preview" | string;
+      type?: "terminal" | "claude" | "gemini" | "codex" | "opencode";
+      agentId?: string;
       title: string;
-      cwd: string;
+      cwd?: string;
       worktreeId?: string;
       location: "grid" | "dock";
       command?: string;
@@ -54,6 +56,12 @@ export interface StoreSchema {
         autoRestart?: boolean;
       };
       isInputLocked?: boolean;
+      browserUrl?: string;
+      notePath?: string;
+      noteId?: string;
+      scope?: "worktree" | "project";
+      createdAt?: number;
+      devCommand?: string;
     }>;
     /** @deprecated Recipes are now stored per-project. This field is kept for migration only. */
     recipes?: Array<{


### PR DESCRIPTION
## Summary
Browser and notes panels now persist correctly across app restarts. Previously, these non-PTY panels were dropped because the schema required `type` and `cwd` fields that only PTY-backed panels possess.

Closes #1518

## Changes Made
- Make `type` and `cwd` optional in `AppStateTerminalEntrySchema` for non-PTY panels
- Add kind inference from content fields (browserUrl, notePath) for backwards compatibility with older saved states
- Unify panel restoration logic to preserve saved order (mix of PTY reconnects and non-PTY recreations)
- Remove strict projectRoot guard that prevented non-PTY panel restoration
- Add `agentId` field to StoreSchema to match runtime validation

## Technical Details
**Schema Changes** (`electron/schemas/ipc.ts`):
- Added refinement logic that infers panel kind from content fields when missing
- PTY-backed panels (terminal, agent, dev-preview) still require `type` and `cwd`
- Non-PTY panels (browser, notes) have these fields as optional

**Hydration Changes** (`src/utils/stateHydration.ts`):
- Switched from two-pass restoration (PTY first, then non-PTY) to single-pass unified restoration
- Preserves exact saved panel ordering by interleaving PTY reconnects and non-PTY recreations
- Handles missing projectRoot gracefully with fallback to empty string

**Type Changes** (`electron/store.ts`):
- Updated StoreSchema to align with runtime schema validation
- Added optional fields: `kind`, `agentId`, `browserUrl`, `notePath`, `noteId`, `scope`, `createdAt`, `devCommand`

## Testing
All type checks and lint pass. Manual testing recommended:
1. Create browser and notes panels
2. Restart app
3. Verify panels are restored with correct ordering and state