### PR TITLE
feat(worktree): add auto-resolution for branch and path conflicts

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -9,6 +9,7 @@ export const CHANNELS = {
   WORKTREE_PR_REFRESH: "worktree:pr-refresh",
   WORKTREE_PR_STATUS: "worktree:pr-status",
   WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
+  WORKTREE_GET_AVAILABLE_BRANCH: "worktree:get-available-branch",
   WORKTREE_DELETE: "worktree:delete",
 
   TERMINAL_SPAWN: "terminal:spawn",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -133,6 +133,7 @@ const CHANNELS = {
   WORKTREE_PR_REFRESH: "worktree:pr-refresh",
   WORKTREE_PR_STATUS: "worktree:pr-status",
   WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
+  WORKTREE_GET_AVAILABLE_BRANCH: "worktree:get-available-branch",
   WORKTREE_DELETE: "worktree:delete",
 
   // Terminal channels
@@ -401,6 +402,9 @@ const api: ElectronAPI = {
 
     getDefaultPath: (rootPath: string, branchName: string): Promise<string> =>
       _typedInvoke(CHANNELS.WORKTREE_GET_DEFAULT_PATH, { rootPath, branchName }),
+
+    getAvailableBranch: (rootPath: string, branchName: string): Promise<string> =>
+      _typedInvoke(CHANNELS.WORKTREE_GET_AVAILABLE_BRANCH, { rootPath, branchName }),
 
     delete: (worktreeId: string, force?: boolean) =>
       _typedInvoke(CHANNELS.WORKTREE_DELETE, { worktreeId, force }),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -73,6 +73,7 @@ export interface ElectronAPI {
     create(options: CreateWorktreeOptions, rootPath: string): Promise<string>;
     listBranches(rootPath: string): Promise<BranchInfo[]>;
     getDefaultPath(rootPath: string, branchName: string): Promise<string>;
+    getAvailableBranch(rootPath: string, branchName: string): Promise<string>;
     delete(worktreeId: string, force?: boolean): Promise<void>;
     onUpdate(callback: (state: WorktreeState) => void): () => void;
     onRemove(callback: (data: { worktreeId: string }) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -120,6 +120,10 @@ export interface IpcInvokeMap {
     args: [payload: { rootPath: string; branchName: string }];
     result: string;
   };
+  "worktree:get-available-branch": {
+    args: [payload: { rootPath: string; branchName: string }];
+    result: string;
+  };
   "worktree:delete": {
     args: [payload: WorktreeDeletePayload];
     result: void;

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -43,6 +43,10 @@ export const worktreeClient = {
     return window.electron.worktree.getDefaultPath(rootPath, branchName);
   },
 
+  getAvailableBranch: (rootPath: string, branchName: string): Promise<string> => {
+    return window.electron.worktree.getAvailableBranch(rootPath, branchName);
+  },
+
   delete: (worktreeId: string, force?: boolean): Promise<void> => {
     return window.electron.worktree.delete(worktreeId, force);
   },


### PR DESCRIPTION
## Summary

Implements automatic conflict resolution when creating multiple worktrees for the same issue. Branch names and paths now auto-increment (e.g., `feature/issue-123-2`, `feature/issue-123-3`) instead of showing errors.

## Changes

### Backend (GitService)
- Added `findAvailableBranchName()` helper that checks existing local branches and appends `-2`, `-3`, etc.
- Added `findAvailablePath()` helper that checks filesystem and appends suffix
- Only checks local branches for conflicts (remote branches don't block local creation)
- Proper regex escaping for pattern matching

### IPC Layer
- Added `worktree:get-available-branch` channel
- Updated `handleWorktreeGetDefaultPath` to auto-resolve path conflicts
- Type-safe IPC contracts across all layers

### Frontend (NewWorktreeDialog)
- Replaced error states with auto-resolution feedback
- Added debounced auto-resolution (300ms) using Promise.allSettled
- Shows green status when branch/path auto-resolved
- Removed "Use existing branch" button (no longer needed)
- Input validation before IPC calls

## Testing

Tested scenarios:
- Creating multiple worktrees for same issue sequentially
- Branch name collision detection
- Path collision detection  
- Suffix increment logic correctness
- Graceful handling of partial failures

## Fixes

Resolves #1576