### PR TITLE
Change CopyTree default format to always use XML

### DIFF
--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -4,7 +4,7 @@ import { useTerminalStore, type TerminalInstance } from "@/store/terminalStore";
 import { useErrorStore } from "@/store/errorStore";
 import type { AgentState, CopyTreeProgress } from "@/types";
 import { copyTreeClient } from "@/clients";
-import { getFormatForTerminal } from "@/lib/copyTreeFormat";
+import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 
 export type InjectionStatus = "idle" | "waiting" | "injecting";
 
@@ -317,10 +317,8 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
           );
         }
 
-        const format = getFormatForTerminal(terminal);
-
         const options = {
-          format,
+          format: DEFAULT_COPYTREE_FORMAT,
           ...(selectedPaths && selectedPaths.length > 0 ? { includePaths: selectedPaths } : {}),
         };
 
@@ -340,7 +338,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
             ? ` from ${selectedPaths.length} selected ${selectedPaths.length === 1 ? "path" : "paths"}`
             : "";
         console.log(
-          `Context injected (${result.fileCount} files as ${format.toUpperCase()}${pathInfo})`
+          `Context injected (${result.fileCount} files as ${DEFAULT_COPYTREE_FORMAT.toUpperCase()}${pathInfo})`
         );
 
         if (currentErrorIdRef.current) {

--- a/src/lib/copyTreeFormat.ts
+++ b/src/lib/copyTreeFormat.ts
@@ -1,28 +1,5 @@
 import type { CopyTreeOptions } from "@shared/types/ipc/copyTree";
-import type { TerminalInstance } from "@/store/terminalStore";
 
 type CopyTreeFormat = NonNullable<CopyTreeOptions["format"]>;
 
-const AGENT_FORMAT_MAP: Record<string, CopyTreeFormat> = {
-  claude: "xml",
-  gemini: "markdown",
-  codex: "xml",
-  terminal: "xml",
-};
-
-export function getFormatForAgent(agentIdOrType?: string): CopyTreeFormat {
-  if (!agentIdOrType) return "xml";
-  const format = AGENT_FORMAT_MAP[agentIdOrType];
-  if (!format) {
-    console.warn(`Unknown agent/terminal type "${agentIdOrType}", defaulting to XML format`);
-    return "xml";
-  }
-  return format;
-}
-
-export function getFormatForTerminal(
-  terminal: Pick<TerminalInstance, "agentId" | "type"> | undefined
-): CopyTreeFormat {
-  if (!terminal) return "xml";
-  return getFormatForAgent(terminal.agentId ?? terminal.type);
-}
+export const DEFAULT_COPYTREE_FORMAT: CopyTreeFormat = "xml";

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -4,8 +4,7 @@ import type { ActionContext, ActionId } from "@shared/types/actions";
 import { copyTreeClient, githubClient, systemClient, worktreeClient } from "@/clients";
 import { useWorktreeDataStore } from "@/store/worktreeDataStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { useTerminalStore } from "@/store/terminalStore";
-import { getFormatForTerminal } from "@/lib/copyTreeFormat";
+import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 
 export function registerWorktreeActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   actions.set("worktree.refresh", () => ({
@@ -441,10 +440,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return null;
 
-      const terminal = ctx.focusedTerminalId
-        ? useTerminalStore.getState().terminals.find((t) => t.id === ctx.focusedTerminalId)
-        : undefined;
-      const format = explicitFormat ?? getFormatForTerminal(terminal);
+      const format = explicitFormat ?? DEFAULT_COPYTREE_FORMAT;
 
       const result = await copyTreeClient.generateAndCopyFile(targetWorktreeId, {
         format,


### PR DESCRIPTION
## Summary
Removes agent-based format selection from CopyTree feature. All CopyTree operations now default to XML format regardless of which terminal is focused. Users can still explicitly specify a different format when needed.

Closes #1586

## Changes Made
- Removed AGENT_FORMAT_MAP and format detection functions (getFormatForAgent, getFormatForTerminal)
- Added DEFAULT_COPYTREE_FORMAT constant set to "xml"
- Updated worktreeActions.ts to use XML default instead of terminal-based lookup
- Updated useContextInjection.ts to use XML default for all injections
- Explicit format parameter overrides still supported for edge cases