### PR TITLE
Adjust worktree overview modal to show 3 columns with tighter spacing

### DIFF
--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -329,8 +329,8 @@ export function WorktreeOverviewModal({
                   </div>
                   <div
                     className={cn(
-                      "grid gap-4",
-                      "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
+                      "grid gap-3",
+                      "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
                       "auto-rows-min"
                     )}
                   >
@@ -373,8 +373,8 @@ export function WorktreeOverviewModal({
           ) : (
             <div
               className={cn(
-                "grid gap-4",
-                "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
+                "grid gap-3",
+                "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
                 "items-start"
               )}
             >


### PR DESCRIPTION
## Summary
Improved space utilization in the Worktree Overview Modal by reducing the maximum column count from 4 to 3 worktrees per row and tightening the grid gap spacing, creating a more concentrated and easier-to-scan layout.

Closes #1588

## Changes Made
- Change grid gap from gap-4 (16px) to gap-3 (12px)
- Remove xl:grid-cols-4 to cap at 3 columns for all large screens
- Apply changes to both grouped and ungrouped grid sections
- Improves visual density and scannability of worktree cards