### PR TITLE
fix(worktree): close overview modal when clicking terminal/panel

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -41,6 +41,7 @@ export interface WorktreeCardProps {
   agentSettings?: UseAgentLauncherReturn["agentSettings"];
   homeDir?: string;
   variant?: "sidebar" | "grid";
+  onAfterTerminalSelect?: () => void;
 }
 
 export function WorktreeCard({
@@ -57,6 +58,7 @@ export function WorktreeCard({
   agentSettings,
   homeDir,
   variant = "sidebar",
+  onAfterTerminalSelect,
 }: WorktreeCardProps) {
   const isExpanded = useWorktreeSelectionStore(
     useCallback((state) => state.expandedWorktrees.has(worktree.id), [worktree.id])
@@ -198,8 +200,11 @@ export function WorktreeCard({
 
       // Trigger the ping animation
       pingTerminal(terminal.id);
+
+      // Invoke callback (e.g. close modal) after focusing terminal
+      onAfterTerminalSelect?.();
     },
-    [isActive, onSelect, setFocused, pingTerminal, openDockTerminal, trackTerminalFocus]
+    [isActive, onSelect, setFocused, pingTerminal, openDockTerminal, trackTerminalFocus, onAfterTerminalSelect]
   );
 
   const handleToggleExpand = useCallback(

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -363,6 +363,7 @@ export function WorktreeOverviewModal({
                           agentAvailability={agentAvailability}
                           agentSettings={agentSettings}
                           homeDir={homeDir}
+                          onAfterTerminalSelect={onClose}
                         />
                       </div>
                     ))}
@@ -406,6 +407,7 @@ export function WorktreeOverviewModal({
                     agentAvailability={agentAvailability}
                     agentSettings={agentSettings}
                     homeDir={homeDir}
+                    onAfterTerminalSelect={onClose}
                   />
                 </div>
               ))}


### PR DESCRIPTION
## Summary
Fixes the Worktree Overview Modal to automatically close when clicking on a terminal or panel within a worktree card. Previously, the modal remained open even though the terminal was focused in the background, blocking the user's view.

Closes #1587

## Changes Made
- Add onAfterTerminalSelect callback prop to WorktreeCardProps
- Pass onClose from WorktreeOverviewModal to WorktreeCard instances  
- Invoke callback after terminal focus and ping animation
- Update useCallback dependency array to include new callback

## Implementation Details
- The optional callback is only provided when WorktreeCard is rendered in modal context
- Terminal clicks use `stopPropagation()` so the card's onClick is not triggered
- Both dock and grid terminals properly trigger modal close
- Sidebar worktree cards are unaffected (no callback provided)