### PR TITLE
Improve responsive grid layout for worktree overview modal

### DIFF
--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -330,7 +330,8 @@ export function WorktreeOverviewModal({
                   <div
                     className={cn(
                       "grid gap-3",
-                      "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+                      "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
+                      "justify-center",
                       "auto-rows-min"
                     )}
                   >
@@ -375,7 +376,8 @@ export function WorktreeOverviewModal({
             <div
               className={cn(
                 "grid gap-3",
-                "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+                "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
+                "justify-center",
                 "items-start"
               )}
             >


### PR DESCRIPTION
## Summary
Replaces the fixed 3-column grid layout in the worktree overview modal with a responsive CSS Grid auto-fit layout that dynamically adapts from 1 to 5+ columns based on viewport width.

Closes #1597

## Changes Made
- Replace fixed 3-column grid with CSS Grid auto-fit layout
- Add responsive column scaling from 1 to 5+ columns based on viewport width
- Set minimum card width to 320px to prevent cramped display on narrow screens
- Set maximum card width to 480px to prevent excessive stretching on wide displays
- Add justify-center to center cards when they don't fill entire row
- Apply consistent responsive behavior to both grouped and ungrouped views