### PR TITLE
refactor(terminal): split TerminalInstanceService into focused helper modules

### DIFF
--- a/src/services/terminal/TerminalLinkHandler.ts
+++ b/src/services/terminal/TerminalLinkHandler.ts
@@ -1,0 +1,56 @@
+import { systemClient } from "@/clients";
+import { actionService } from "@/services/ActionService";
+import { isLocalhostUrl, normalizeBrowserUrl } from "@/components/Browser/browserUtils";
+import { useTerminalStore } from "@/store/terminalStore";
+
+export class TerminalLinkHandler {
+  openLink(url: string, terminalId: string, event?: MouseEvent): void {
+    const isMac = navigator.platform.toLowerCase().includes("mac");
+    const isModifierPressed = event ? (isMac ? event.metaKey : event.ctrlKey) : false;
+
+    const normalized = normalizeBrowserUrl(url);
+
+    if (isModifierPressed && normalized.url && isLocalhostUrl(normalized.url)) {
+      const store = useTerminalStore.getState();
+      const currentTerminal = store.terminals.find((t) => t.id === terminalId);
+
+      if (!currentTerminal) {
+        this.openExternal(url);
+        return;
+      }
+
+      const targetWorktreeId = currentTerminal.worktreeId ?? null;
+
+      const existingBrowser = store.terminals.find(
+        (t) => t.kind === "browser" && (t.worktreeId ?? null) === targetWorktreeId
+      );
+
+      if (existingBrowser) {
+        store.setBrowserUrl(existingBrowser.id, normalized.url);
+        store.activateTerminal(existingBrowser.id);
+      } else {
+        void store.addTerminal({
+          kind: "browser",
+          browserUrl: normalized.url,
+          worktreeId: targetWorktreeId ?? undefined,
+          cwd: currentTerminal?.cwd ?? "",
+        });
+      }
+    } else {
+      this.openExternal(url);
+    }
+  }
+
+  private openExternal(url: string): void {
+    const normalizedUrl = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+    actionService
+      .dispatch("system.openExternal", { url: normalizedUrl }, { source: "user" })
+      .then((result) => {
+        if (result.ok) return;
+        return systemClient.openExternal(normalizedUrl);
+      })
+      .catch((error) => {
+        console.error("[TerminalLinkHandler] Failed to open URL:", error);
+      });
+  }
+}

--- a/src/services/terminal/TerminalOffscreenManager.ts
+++ b/src/services/terminal/TerminalOffscreenManager.ts
@@ -1,0 +1,86 @@
+export class TerminalOffscreenManager {
+  private hiddenContainer: HTMLDivElement | null = null;
+  private offscreenSlots = new Map<string, HTMLDivElement>();
+
+  ensureHiddenContainer(): HTMLDivElement | null {
+    if (this.hiddenContainer) return this.hiddenContainer;
+    if (typeof document === "undefined") return null;
+
+    const container = document.createElement("div");
+    container.className = "terminal-offscreen-container";
+    container.style.cssText = [
+      "position: fixed",
+      "left: -20000px",
+      "top: 0",
+      "width: 2000px",
+      "height: 2000px",
+      "overflow: hidden",
+      "opacity: 0",
+      "pointer-events: none",
+    ].join(";");
+    document.body.appendChild(container);
+
+    this.hiddenContainer = container;
+    return this.hiddenContainer;
+  }
+
+  getOrCreateOffscreenSlot(id: string, widthPx: number, heightPx: number): HTMLDivElement {
+    if (typeof document === "undefined") {
+      throw new Error("Offscreen slot requires DOM");
+    }
+
+    const existing = this.offscreenSlots.get(id);
+    if (existing) {
+      existing.style.width = `${widthPx}px`;
+      existing.style.height = `${heightPx}px`;
+      return existing;
+    }
+
+    const hiddenContainer = this.ensureHiddenContainer();
+    if (!hiddenContainer) {
+      throw new Error("Offscreen container unavailable");
+    }
+
+    const slot = document.createElement("div");
+    slot.dataset.terminalId = id;
+    slot.style.width = `${widthPx}px`;
+    slot.style.height = `${heightPx}px`;
+    slot.style.position = "absolute";
+    slot.style.left = "0";
+    slot.style.top = "0";
+    hiddenContainer.appendChild(slot);
+
+    this.offscreenSlots.set(id, slot);
+    return slot;
+  }
+
+  getOffscreenSlot(id: string): HTMLDivElement | undefined {
+    return this.offscreenSlots.get(id);
+  }
+
+  removeOffscreenSlot(id: string): void {
+    const slot = this.offscreenSlots.get(id);
+    if (slot && slot.parentElement) {
+      slot.parentElement.removeChild(slot);
+    }
+    this.offscreenSlots.delete(id);
+  }
+
+  getHiddenContainer(): HTMLDivElement | null {
+    return this.hiddenContainer;
+  }
+
+  dispose(): void {
+    this.offscreenSlots.forEach((slot) => {
+      if (slot.parentElement) {
+        slot.parentElement.removeChild(slot);
+      }
+    });
+    this.offscreenSlots.clear();
+
+    if (this.hiddenContainer && this.hiddenContainer.parentElement) {
+      this.hiddenContainer.parentElement.removeChild(this.hiddenContainer);
+    }
+    this.hiddenContainer = null;
+  }
+}

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -1,0 +1,121 @@
+import { terminalClient } from "@/clients";
+import { TerminalRefreshTier } from "@/types";
+import type { ManagedTerminal } from "./types";
+import { TIER_DOWNGRADE_HYSTERESIS_MS } from "./types";
+
+export interface RendererPolicyDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  wakeAndRestore: (id: string) => Promise<boolean>;
+}
+
+export class TerminalRendererPolicy {
+  private lastBackendTier = new Map<string, "active" | "background">();
+  private deps: RendererPolicyDeps;
+
+  constructor(deps: RendererPolicyDeps) {
+    this.deps = deps;
+  }
+
+  getLastBackendTier(id: string): "active" | "background" | undefined {
+    return this.lastBackendTier.get(id);
+  }
+
+  setBackendTier(id: string, tier: "active" | "background"): void {
+    this.lastBackendTier.set(id, tier);
+    terminalClient.setActivityTier(id, tier);
+  }
+
+  applyRendererPolicy(id: string, tier: TerminalRefreshTier): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    if (tier === TerminalRefreshTier.FOCUSED || tier === TerminalRefreshTier.BURST) {
+      managed.lastActiveTime = Date.now();
+    }
+
+    const currentAppliedTier =
+      managed.lastAppliedTier ?? managed.getRefreshTier() ?? TerminalRefreshTier.FOCUSED;
+
+    if (tier === currentAppliedTier) {
+      if (managed.tierChangeTimer !== undefined) {
+        clearTimeout(managed.tierChangeTimer);
+        managed.tierChangeTimer = undefined;
+        managed.pendingTier = undefined;
+      }
+      return;
+    }
+
+    const isUpgrade = tier < currentAppliedTier;
+
+    if (isUpgrade) {
+      if (managed.tierChangeTimer !== undefined) {
+        clearTimeout(managed.tierChangeTimer);
+        managed.tierChangeTimer = undefined;
+      }
+      managed.pendingTier = undefined;
+      this.applyRendererPolicyImmediate(id, managed, tier);
+      return;
+    }
+
+    if (managed.pendingTier === tier && managed.tierChangeTimer !== undefined) {
+      return;
+    }
+
+    if (managed.tierChangeTimer !== undefined) {
+      clearTimeout(managed.tierChangeTimer);
+    }
+
+    managed.pendingTier = tier;
+    managed.tierChangeTimer = window.setTimeout(() => {
+      const current = this.deps.getInstance(id);
+      if (current && current.pendingTier === tier) {
+        this.applyRendererPolicyImmediate(id, current, tier);
+        current.pendingTier = undefined;
+      }
+      if (current) {
+        current.tierChangeTimer = undefined;
+      }
+    }, TIER_DOWNGRADE_HYSTERESIS_MS);
+  }
+
+  private applyRendererPolicyImmediate(
+    id: string,
+    managed: ManagedTerminal,
+    tier: TerminalRefreshTier
+  ): void {
+    managed.lastAppliedTier = tier;
+
+    const backendTier: "active" | "background" =
+      tier === TerminalRefreshTier.BACKGROUND ? "background" : "active";
+    const prevBackendTier = this.lastBackendTier.get(id) ?? "active";
+    this.setBackendTier(id, backendTier);
+
+    if (backendTier === "background" && prevBackendTier === "active") {
+      managed.needsWake = true;
+    }
+
+    if (backendTier === "active" && prevBackendTier !== "active") {
+      if (managed.needsWake !== false) {
+        void this.deps
+          .wakeAndRestore(id)
+          .then((ok) => {
+            const current = this.deps.getInstance(id);
+            if (!current) return;
+            current.needsWake = ok ? false : true;
+          })
+          .catch(() => {
+            const current = this.deps.getInstance(id);
+            if (current) current.needsWake = true;
+          });
+      }
+    }
+  }
+
+  clearTierState(id: string): void {
+    this.lastBackendTier.delete(id);
+  }
+
+  dispose(): void {
+    this.lastBackendTier.clear();
+  }
+}

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -1,0 +1,389 @@
+import { Terminal } from "@xterm/xterm";
+import { terminalClient } from "@/clients";
+import { TerminalRefreshTier } from "@/types";
+import type { ManagedTerminal, ResizeJobId } from "./types";
+import type { TerminalOutputIngestService } from "./TerminalOutputIngestService";
+
+const START_DEBOUNCING_THRESHOLD = 200;
+const HORIZONTAL_DEBOUNCE_MS = 100;
+const VERTICAL_THROTTLE_MS = 150;
+const IDLE_CALLBACK_TIMEOUT_MS = 1000;
+const RESIZE_LOCK_TTL_MS = 5000;
+
+export function getXtermCellDimensions(terminal: Terminal): { width: number; height: number } | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const core = (terminal as any)._core;
+    const dimensions = core?._renderService?.dimensions?.css?.cell;
+    if (
+      dimensions &&
+      typeof dimensions.width === "number" &&
+      typeof dimensions.height === "number"
+    ) {
+      return { width: dimensions.width, height: dimensions.height };
+    }
+  } catch {
+    // Fall through to null
+  }
+  return null;
+}
+
+export interface ResizeControllerDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  dataBuffer: TerminalOutputIngestService;
+}
+
+export class TerminalResizeController {
+  private resizeLocks = new Map<string, number>();
+  private deps: ResizeControllerDeps;
+
+  constructor(deps: ResizeControllerDeps) {
+    this.deps = deps;
+  }
+
+  lockResize(id: string, locked: boolean): void {
+    if (locked) {
+      this.resizeLocks.set(id, Date.now() + RESIZE_LOCK_TTL_MS);
+    } else {
+      this.resizeLocks.delete(id);
+    }
+  }
+
+  isResizeLocked(id: string): boolean {
+    const expiry = this.resizeLocks.get(id);
+    if (!expiry) return false;
+
+    if (Date.now() > expiry) {
+      this.resizeLocks.delete(id);
+      return false;
+    }
+    return true;
+  }
+
+  updateExactWidth(managed: ManagedTerminal): void {
+    const cellDims = getXtermCellDimensions(managed.terminal);
+    if (!cellDims) return;
+
+    const cols = managed.terminal.cols;
+    const exactWidth = Math.ceil(cols * cellDims.width);
+    managed.hostElement.style.width = `${exactWidth}px`;
+  }
+
+  resetWidthForFit(managed: ManagedTerminal): void {
+    managed.hostElement.style.width = "100%";
+  }
+
+  fit(id: string): { cols: number; rows: number } | null {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return null;
+
+    const rect = managed.hostElement.getBoundingClientRect();
+    if (rect.left < -10000 || rect.width < 50 || rect.height < 50) {
+      return null;
+    }
+
+    try {
+      this.resetWidthForFit(managed);
+      managed.fitAddon.fit();
+      const { cols, rows } = managed.terminal;
+      terminalClient.resize(id, cols, rows);
+      this.updateExactWidth(managed);
+      return { cols, rows };
+    } catch (error) {
+      console.warn("Terminal fit failed:", error);
+      return null;
+    }
+  }
+
+  flushResize(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    if (managed.resizeXJob || managed.resizeYJob) {
+      this.clearResizeJobs(managed);
+      this.applyResize(id, managed.latestCols, managed.latestRows);
+    }
+  }
+
+  resize(
+    id: string,
+    width: number,
+    height: number,
+    options: { immediate?: boolean } = {}
+  ): { cols: number; rows: number } | null {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return null;
+
+    if (this.isResizeLocked(id)) {
+      return null;
+    }
+
+    const currentTier =
+      managed.lastAppliedTier ?? managed.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED;
+    if (currentTier === TerminalRefreshTier.BACKGROUND && !managed.isFocused) {
+      return null;
+    }
+
+    if (Math.abs(managed.lastWidth - width) < 1 && Math.abs(managed.lastHeight - height) < 1) {
+      return null;
+    }
+
+    const buffer = managed.terminal.buffer.active;
+    const wasAtBottom = buffer.baseY - buffer.viewportY < 1;
+
+    try {
+      // @ts-expect-error - internal API
+      const proposed = managed.fitAddon.proposeDimensions?.({ width, height });
+
+      if (!proposed) {
+        managed.fitAddon.fit();
+        const cols = managed.terminal.cols;
+        const rows = managed.terminal.rows;
+        managed.lastWidth = width;
+        managed.lastHeight = height;
+        managed.latestCols = cols;
+        managed.latestRows = rows;
+        managed.latestWasAtBottom = wasAtBottom;
+        managed.isUserScrolledBack = !wasAtBottom;
+        terminalClient.resize(id, cols, rows);
+        this.updateExactWidth(managed);
+        return { cols, rows };
+      }
+
+      const cols = proposed.cols;
+      const rows = proposed.rows;
+
+      if (managed.terminal.cols === cols && managed.terminal.rows === rows) {
+        return null;
+      }
+
+      managed.lastWidth = width;
+      managed.lastHeight = height;
+      managed.latestCols = cols;
+      managed.latestRows = rows;
+      managed.latestWasAtBottom = wasAtBottom;
+      managed.isUserScrolledBack = !wasAtBottom;
+
+      const bufferLineCount = this.getBufferLineCount(id);
+
+      if (options.immediate || managed.isFocused || bufferLineCount < START_DEBOUNCING_THRESHOLD) {
+        this.clearResizeJobs(managed);
+        this.applyResize(id, cols, rows);
+        return { cols, rows };
+      }
+
+      if (!managed.isVisible) {
+        this.scheduleIdleResize(id, managed);
+        return { cols, rows };
+      }
+
+      this.throttleResizeY(id, managed, rows);
+      this.debounceResizeX(id, managed, cols);
+
+      return { cols, rows };
+    } catch (error) {
+      console.warn(`[TerminalResizeController] Resize failed for ${id}:`, error);
+      return null;
+    }
+  }
+
+  resizeTerminal(managed: ManagedTerminal, cols: number, rows: number): void {
+    if (managed.isInAlternateBuffer) {
+      managed.terminal.write("\x1b[2J\x1b[H");
+    }
+    managed.terminal.resize(cols, rows);
+  }
+
+  applyDeferredResize(id: string): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    const currentCols = managed.terminal.cols;
+    const currentRows = managed.terminal.rows;
+    const targetCols = managed.latestCols;
+    const targetRows = managed.latestRows;
+
+    if (currentCols !== targetCols || currentRows !== targetRows) {
+      managed.terminal.resize(targetCols, targetRows);
+      terminalClient.resize(id, targetCols, targetRows);
+    }
+    this.updateExactWidth(managed);
+  }
+
+  applyResize(id: string, cols: number, rows: number): void {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return;
+
+    if (this.isResizeLocked(id)) {
+      return;
+    }
+
+    this.deps.dataBuffer.flushForTerminal(id);
+    this.deps.dataBuffer.resetForTerminal(id);
+    this.resizeTerminal(managed, cols, rows);
+    terminalClient.resize(id, cols, rows);
+    this.updateExactWidth(managed);
+  }
+
+  clearResizeJobs(managed: ManagedTerminal): void {
+    if (managed.resizeXJob) {
+      this.clearJob(managed.resizeXJob);
+      managed.resizeXJob = undefined;
+    }
+    if (managed.resizeYJob) {
+      this.clearJob(managed.resizeYJob);
+      managed.resizeYJob = undefined;
+    }
+  }
+
+  clearResizeLock(id: string): void {
+    this.resizeLocks.delete(id);
+  }
+
+  private clearJob(job: ResizeJobId): void {
+    if (job.type === "idle") {
+      const win = window as typeof window & {
+        cancelIdleCallback?: (handle: number) => void;
+      };
+      win.cancelIdleCallback?.(job.id);
+    } else {
+      clearTimeout(job.id);
+    }
+  }
+
+  private scheduleIdleResize(id: string, managed: ManagedTerminal): void {
+    const win = window as typeof window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+      cancelIdleCallback?: (handle: number) => void;
+    };
+    const hasIdleCallback = typeof win.requestIdleCallback === "function";
+
+    if (!managed.resizeXJob) {
+      if (hasIdleCallback && win.requestIdleCallback) {
+        const idleId = win.requestIdleCallback(
+          () => {
+            const current = this.deps.getInstance(id);
+            if (current) {
+              this.deps.dataBuffer.flushForTerminal(id);
+              this.deps.dataBuffer.resetForTerminal(id);
+              this.resizeTerminal(current, current.latestCols, current.terminal.rows);
+              terminalClient.resize(id, current.latestCols, current.terminal.rows);
+              this.updateExactWidth(current);
+              current.resizeXJob = undefined;
+            }
+          },
+          { timeout: IDLE_CALLBACK_TIMEOUT_MS }
+        );
+        managed.resizeXJob = { type: "idle", id: idleId };
+      } else {
+        const timeoutId = window.setTimeout(() => {
+          const current = this.deps.getInstance(id);
+          if (current) {
+            this.deps.dataBuffer.flushForTerminal(id);
+            this.deps.dataBuffer.resetForTerminal(id);
+            this.resizeTerminal(current, current.latestCols, current.terminal.rows);
+            terminalClient.resize(id, current.latestCols, current.terminal.rows);
+            this.updateExactWidth(current);
+            current.resizeXJob = undefined;
+          }
+        }, IDLE_CALLBACK_TIMEOUT_MS);
+        managed.resizeXJob = { type: "timeout", id: timeoutId };
+      }
+    }
+
+    if (!managed.resizeYJob) {
+      if (hasIdleCallback && win.requestIdleCallback) {
+        const idleId = win.requestIdleCallback(
+          () => {
+            const current = this.deps.getInstance(id);
+            if (current) {
+              this.deps.dataBuffer.flushForTerminal(id);
+              this.deps.dataBuffer.resetForTerminal(id);
+              this.resizeTerminal(current, current.latestCols, current.latestRows);
+              terminalClient.resize(id, current.latestCols, current.latestRows);
+              this.updateExactWidth(current);
+              current.resizeYJob = undefined;
+            }
+          },
+          { timeout: IDLE_CALLBACK_TIMEOUT_MS }
+        );
+        managed.resizeYJob = { type: "idle", id: idleId };
+      } else {
+        const timeoutId = window.setTimeout(() => {
+          const current = this.deps.getInstance(id);
+          if (current) {
+            this.deps.dataBuffer.flushForTerminal(id);
+            this.deps.dataBuffer.resetForTerminal(id);
+            this.resizeTerminal(current, current.latestCols, current.latestRows);
+            terminalClient.resize(id, current.latestCols, current.latestRows);
+            this.updateExactWidth(current);
+            current.resizeYJob = undefined;
+          }
+        }, IDLE_CALLBACK_TIMEOUT_MS);
+        managed.resizeYJob = { type: "timeout", id: timeoutId };
+      }
+    }
+  }
+
+  private debounceResizeX(id: string, managed: ManagedTerminal, cols: number): void {
+    if (managed.resizeXJob) {
+      this.clearJob(managed.resizeXJob);
+      managed.resizeXJob = undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      const current = this.deps.getInstance(id);
+      if (current) {
+        this.deps.dataBuffer.flushForTerminal(id);
+        this.deps.dataBuffer.resetForTerminal(id);
+        this.resizeTerminal(current, cols, current.terminal.rows);
+        terminalClient.resize(id, cols, current.terminal.rows);
+        this.updateExactWidth(current);
+        current.resizeXJob = undefined;
+      }
+    }, HORIZONTAL_DEBOUNCE_MS);
+    managed.resizeXJob = { type: "timeout", id: timeoutId };
+  }
+
+  private throttleResizeY(id: string, managed: ManagedTerminal, rows: number): void {
+    const now = Date.now();
+    const timeSinceLastY = now - managed.lastYResizeTime;
+
+    if (timeSinceLastY >= VERTICAL_THROTTLE_MS) {
+      managed.lastYResizeTime = now;
+      if (managed.resizeYJob) {
+        this.clearJob(managed.resizeYJob);
+        managed.resizeYJob = undefined;
+      }
+      this.deps.dataBuffer.flushForTerminal(id);
+      this.deps.dataBuffer.resetForTerminal(id);
+      this.resizeTerminal(managed, managed.latestCols, rows);
+      terminalClient.resize(id, managed.latestCols, rows);
+      this.updateExactWidth(managed);
+      return;
+    }
+
+    if (!managed.resizeYJob) {
+      const remainingTime = VERTICAL_THROTTLE_MS - timeSinceLastY;
+      const timeoutId = window.setTimeout(() => {
+        const current = this.deps.getInstance(id);
+        if (current) {
+          current.lastYResizeTime = Date.now();
+          this.deps.dataBuffer.flushForTerminal(id);
+          this.deps.dataBuffer.resetForTerminal(id);
+          this.resizeTerminal(current, current.latestCols, current.latestRows);
+          terminalClient.resize(id, current.latestCols, current.latestRows);
+          this.updateExactWidth(current);
+          current.resizeYJob = undefined;
+        }
+      }, remainingTime);
+      managed.resizeYJob = { type: "timeout", id: timeoutId };
+    }
+  }
+
+  private getBufferLineCount(id: string): number {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return 0;
+    return managed.terminal.buffer.active.length;
+  }
+}

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -1,0 +1,64 @@
+import { terminalClient } from "@/clients";
+import type { ManagedTerminal } from "./types";
+import { INCREMENTAL_RESTORE_CONFIG } from "./types";
+
+const WAKE_RATE_LIMIT_MS = 1000;
+
+export interface WakeManagerDeps {
+  getInstance: (id: string) => ManagedTerminal | undefined;
+  hasInstance: (id: string) => boolean;
+  restoreFromSerialized: (id: string, state: string) => boolean;
+  restoreFromSerializedIncremental: (id: string, state: string) => Promise<boolean>;
+}
+
+export class TerminalWakeManager {
+  private lastWakeTime = new Map<string, number>();
+  private deps: WakeManagerDeps;
+
+  constructor(deps: WakeManagerDeps) {
+    this.deps = deps;
+  }
+
+  async wakeAndRestore(id: string): Promise<boolean> {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return false;
+
+    const { state } = await terminalClient.wake(id);
+    if (!state) return false;
+
+    if (state.length > INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes) {
+      await this.deps.restoreFromSerializedIncremental(id, state);
+    } else {
+      this.deps.restoreFromSerialized(id, state);
+    }
+
+    if (this.deps.getInstance(id) === managed) {
+      managed.terminal.refresh(0, managed.terminal.rows - 1);
+    }
+    return true;
+  }
+
+  wake(id: string): void {
+    if (!this.deps.hasInstance(id)) {
+      return;
+    }
+
+    const now = Date.now();
+    const lastWake = this.lastWakeTime.get(id) ?? 0;
+
+    if (now - lastWake < WAKE_RATE_LIMIT_MS) {
+      return;
+    }
+
+    this.lastWakeTime.set(id, now);
+    void this.wakeAndRestore(id);
+  }
+
+  clearWakeState(id: string): void {
+    this.lastWakeTime.delete(id);
+  }
+
+  dispose(): void {
+    this.lastWakeTime.clear();
+  }
+}


### PR DESCRIPTION
## Summary

Refactors the TerminalInstanceService (~1660 lines) into 5 focused helper modules to improve maintainability and separation of concerns. Each helper encapsulates a specific responsibility, making the codebase easier to understand and modify.

Closes #1596

## Changes Made

- **TerminalOffscreenManager** (86 lines): Manages hidden container and offscreen slot lifecycle for terminals
- **TerminalLinkHandler** (56 lines): Handles URL opening with modifier key detection and browser panel creation
- **TerminalResizeController** (389 lines): Manages resize scheduling, locking, dimension calculations, and alternate buffer handling
- **TerminalRendererPolicy** (121 lines): Controls renderer tier management and backend streaming state
- **TerminalWakeManager** (64 lines): Handles wake/restore operations with rate limiting
- **TerminalInstanceService** (953 lines, reduced from 1660): Refactored to delegate to helper modules while preserving all public APIs

## Technical Details

- All public methods and behavior preserved unchanged
- Dependency injection pattern used for helper module construction
- Type safety maintained throughout refactoring
- Tests pass (1387 passing, 9 pre-existing failures in unrelated PtyManager integration tests)