### PR TITLE
refactor(pty): split TerminalProcess into focused modules

### DIFF
--- a/electron/services/pty/TerminalForensicsBuffer.ts
+++ b/electron/services/pty/TerminalForensicsBuffer.ts
@@ -1,0 +1,55 @@
+import type { TerminalInfo } from "./types.js";
+import { decideTerminalExitForensics } from "./terminalForensics.js";
+import { logError } from "../../utils/logger.js";
+
+const FORENSIC_BUFFER_SIZE = 4000;
+
+export class TerminalForensicsBuffer {
+  private recentOutputBuffer = "";
+  private textDecoder = new TextDecoder();
+
+  capture(data: string | Uint8Array): void {
+    const text = typeof data === "string" ? data : this.textDecoder.decode(data);
+    this.recentOutputBuffer += text;
+    if (this.recentOutputBuffer.length > FORENSIC_BUFFER_SIZE) {
+      this.recentOutputBuffer = this.recentOutputBuffer.slice(-FORENSIC_BUFFER_SIZE);
+    }
+  }
+
+  logForensics(
+    terminalId: string,
+    exitCode: number,
+    terminal: TerminalInfo,
+    isAgentTerminal: boolean,
+    signal?: number
+  ): void {
+    if (!isAgentTerminal) return;
+
+    const decision = decideTerminalExitForensics({
+      exitCode,
+      signal,
+      wasKilled: terminal.wasKilled,
+      recentOutput: this.recentOutputBuffer,
+    });
+
+    if (!decision.shouldLog || decision.strippedOutput.trim().length === 0) {
+      return;
+    }
+
+    logError(`Terminal ${terminalId} exited abnormally (code ${exitCode})`, undefined, {
+      terminalId,
+      exitCode,
+      signal: decision.normalizedSignal,
+      agentType: terminal.type,
+      agentId: terminal.agentId,
+      cwd: terminal.cwd,
+      lastOutput: decision.strippedOutput.slice(-1000),
+    });
+
+    if (process.env.CANOPY_VERBOSE || exitCode !== 0) {
+      console.error(
+        `\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\nTERMINAL CRASH FORENSICS\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\nTerminal ID: ${terminalId}\nAgent Type:  ${terminal.type || "unknown"}\nAgent ID:    ${terminal.agentId || "N/A"}\nExit Code:   ${exitCode}\nSignal:      ${decision.normalizedSignal ?? "none"}\nCWD:         ${terminal.cwd}\nTimestamp:   ${new Date().toISOString()}\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\nLAST OUTPUT (${decision.strippedOutput.length} chars):\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n${decision.strippedOutput}\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n`
+      );
+    }
+  }
+}

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -1,0 +1,139 @@
+import type { AgentDetectionConfig } from "../../../shared/config/agentRegistry.js";
+import type { PatternDetectionConfig } from "./AgentPatternDetector.js";
+import type { ProcessStateValidator } from "../ActivityMonitor.js";
+import type { ProcessTreeCache } from "../ProcessTreeCache.js";
+
+export function buildPatternConfig(
+  detection: AgentDetectionConfig | undefined,
+  agentId: string | undefined
+): PatternDetectionConfig | undefined {
+  if (!detection) {
+    return undefined;
+  }
+
+  const primaryPatterns = compilePatterns(detection.primaryPatterns, agentId, "primary");
+  if (primaryPatterns.length === 0) {
+    return undefined;
+  }
+
+  const fallbackPatterns = detection.fallbackPatterns
+    ? compilePatterns(detection.fallbackPatterns, agentId, "fallback")
+    : undefined;
+
+  return {
+    primaryPatterns,
+    fallbackPatterns: fallbackPatterns?.length ? fallbackPatterns : undefined,
+    scanLineCount: detection.scanLineCount,
+    primaryConfidence: detection.primaryConfidence,
+    fallbackConfidence: detection.fallbackConfidence,
+  };
+}
+
+export function buildBootCompletePatterns(
+  detection: AgentDetectionConfig | undefined,
+  agentId: string | undefined
+): RegExp[] | undefined {
+  if (!detection?.bootCompletePatterns || detection.bootCompletePatterns.length === 0) {
+    return undefined;
+  }
+
+  const bootPatterns = compilePatterns(detection.bootCompletePatterns, agentId, "boot");
+
+  return bootPatterns.length ? bootPatterns : undefined;
+}
+
+export function buildPromptPatterns(
+  detection: AgentDetectionConfig | undefined,
+  agentId: string | undefined
+): RegExp[] | undefined {
+  if (!detection?.promptPatterns || detection.promptPatterns.length === 0) {
+    return undefined;
+  }
+
+  const promptPatterns = compilePatterns(detection.promptPatterns, agentId, "prompt");
+
+  return promptPatterns.length ? promptPatterns : undefined;
+}
+
+export function buildPromptHintPatterns(
+  detection: AgentDetectionConfig | undefined,
+  agentId: string | undefined
+): RegExp[] | undefined {
+  if (!detection?.promptHintPatterns || detection.promptHintPatterns.length === 0) {
+    return undefined;
+  }
+
+  const promptHintPatterns = compilePatterns(detection.promptHintPatterns, agentId, "prompt hint");
+
+  return promptHintPatterns.length ? promptHintPatterns : undefined;
+}
+
+export function compilePatterns(
+  patterns: string[],
+  agentId: string | undefined,
+  label: string
+): RegExp[] {
+  const compiled: RegExp[] = [];
+  for (const pattern of patterns) {
+    try {
+      compiled.push(new RegExp(pattern, "im"));
+    } catch (error) {
+      if (process.env.CANOPY_VERBOSE) {
+        const prefix = agentId ? `${agentId} ${label}` : label;
+        console.warn(`[terminalActivityPatterns] Invalid ${prefix} pattern: ${pattern}`, error);
+      }
+    }
+  }
+  return compiled;
+}
+
+export function createProcessStateValidator(
+  ptyPid: number | undefined,
+  processTreeCache: ProcessTreeCache | null
+): ProcessStateValidator | undefined {
+  if (ptyPid === undefined || !processTreeCache) {
+    return undefined;
+  }
+
+  const CPU_ACTIVITY_THRESHOLD = 0.5;
+  const shellHelperProcesses = new Set(["gitstatus", "gitstatusd", "async", "zsh-async"]);
+  const shellProcesses = new Set(["zsh", "bash", "sh", "fish", "powershell", "pwsh", "cmd"]);
+
+  return {
+    hasActiveChildren: () => {
+      if (processTreeCache.hasActiveDescendants(ptyPid, CPU_ACTIVITY_THRESHOLD)) {
+        return true;
+      }
+
+      const children = processTreeCache.getChildren(ptyPid);
+      if (children.length === 0) {
+        return false;
+      }
+
+      const significantChildren = children.filter((child) => {
+        const basename = child.comm.split("/").pop()?.toLowerCase() || child.comm.toLowerCase();
+        const name = basename.replace(/\.exe$/, "");
+        return !shellHelperProcesses.has(name) && !shellProcesses.has(name);
+      });
+
+      if (significantChildren.length > 0) {
+        if (process.platform === "win32") {
+          for (const child of children) {
+            const grandchildren = processTreeCache.getChildren(child.pid);
+            const significantGrandchildren = grandchildren.filter((gc) => {
+              const basename = gc.comm.split("/").pop()?.toLowerCase() || gc.comm.toLowerCase();
+              const name = basename.replace(/\.exe$/, "");
+              return !shellHelperProcesses.has(name) && !shellProcesses.has(name);
+            });
+            if (significantGrandchildren.length > 0) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+
+      return false;
+    },
+  };
+}

--- a/electron/services/pty/terminalInput.ts
+++ b/electron/services/pty/terminalInput.ts
@@ -1,0 +1,96 @@
+import type { TerminalInfo } from "./types.js";
+import {
+  BRACKETED_PASTE_START,
+  BRACKETED_PASTE_END,
+  PASTE_THRESHOLD_CHARS,
+  getSoftNewlineSequence as getSoftNewlineSequenceShared,
+  containsFullBracketedPaste,
+} from "../../../shared/utils/terminalInputProtocol.js";
+import { WRITE_MAX_CHUNK_SIZE } from "./types.js";
+
+export { BRACKETED_PASTE_START, BRACKETED_PASTE_END, PASTE_THRESHOLD_CHARS };
+
+export const SUBMIT_ENTER_DELAY_MS = 200;
+export const OUTPUT_SETTLE_DEBOUNCE_MS = 200;
+export const OUTPUT_SETTLE_MAX_WAIT_MS = 2000;
+export const OUTPUT_SETTLE_POLL_INTERVAL_MS = 50;
+
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function normalizeSubmitText(text: string): string {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+export function splitTrailingNewlines(text: string): { body: string; enterCount: number } {
+  let body = text;
+  let enterCount = 0;
+  while (body.endsWith("\n")) {
+    body = body.slice(0, -1);
+    enterCount++;
+  }
+  if (enterCount === 0) {
+    enterCount = 1;
+  }
+  return { body, enterCount };
+}
+
+function isGeminiTerminal(terminal: TerminalInfo): boolean {
+  return (
+    terminal.type === "gemini" ||
+    terminal.detectedAgentType === "gemini" ||
+    (terminal.kind === "agent" && terminal.agentId === "gemini")
+  );
+}
+
+function isCodexTerminal(terminal: TerminalInfo): boolean {
+  return (
+    terminal.type === "codex" ||
+    terminal.detectedAgentType === "codex" ||
+    (terminal.kind === "agent" && terminal.agentId === "codex")
+  );
+}
+
+function getEffectiveAgentType(terminal: TerminalInfo): string | undefined {
+  return terminal.detectedAgentType ?? terminal.agentId ?? terminal.type;
+}
+
+export function supportsBracketedPaste(terminal: TerminalInfo): boolean {
+  return !isGeminiTerminal(terminal);
+}
+
+export function getSoftNewlineSequence(terminal: TerminalInfo): string {
+  const effectiveType = getEffectiveAgentType(terminal);
+  const agentType = isCodexTerminal(terminal) ? "codex" : effectiveType;
+  return getSoftNewlineSequenceShared(agentType);
+}
+
+export function isBracketedPaste(data: string): boolean {
+  return containsFullBracketedPaste(data);
+}
+
+export function chunkInput(data: string): string[] {
+  if (data.length === 0) {
+    return [];
+  }
+  if (data.length <= WRITE_MAX_CHUNK_SIZE) {
+    return [data];
+  }
+
+  const chunks: string[] = [];
+  let start = 0;
+
+  for (let i = 0; i < data.length - 1; i++) {
+    if (i - start + 1 >= WRITE_MAX_CHUNK_SIZE || data[i + 1] === "\x1b") {
+      chunks.push(data.substring(start, i + 1));
+      start = i + 1;
+    }
+  }
+
+  if (start < data.length) {
+    chunks.push(data.substring(start));
+  }
+
+  return chunks;
+}

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync, renameSync, writeFileSync, mkdirSync } from "fs";
+import { mkdir, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { Terminal as HeadlessTerminalType } from "@xterm/headless";
+
+export const TERMINAL_SESSION_PERSISTENCE_ENABLED: boolean =
+  process.env.CANOPY_TERMINAL_SESSION_PERSISTENCE !== "0";
+export const SESSION_SNAPSHOT_DEBOUNCE_MS = 5000;
+export const SESSION_SNAPSHOT_MAX_BYTES = 5 * 1024 * 1024;
+
+export function getSessionDir(): string | null {
+  const userData = process.env.CANOPY_USER_DATA;
+  if (!userData) return null;
+  return path.join(userData, "terminal-sessions");
+}
+
+export function getSessionPath(id: string): string | null {
+  const dir = getSessionDir();
+  if (!dir) return null;
+  return path.join(dir, `${id}.restore`);
+}
+
+export function restoreSessionFromFile(
+  headlessTerminal: HeadlessTerminalType,
+  terminalId: string
+): void {
+  const sessionPath = getSessionPath(terminalId);
+  if (!sessionPath) return;
+
+  try {
+    if (!existsSync(sessionPath)) return;
+    const content = readFileSync(sessionPath, "utf8");
+    if (Buffer.byteLength(content, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
+      return;
+    }
+    headlessTerminal.write(content);
+  } catch (error) {
+    console.warn(
+      `[terminalSessionPersistence] Failed to restore session for ${terminalId}:`,
+      error
+    );
+  }
+}
+
+export function persistSessionSnapshotSync(terminalId: string, state: string): void {
+  const sessionPath = getSessionPath(terminalId);
+  const dir = getSessionDir();
+  if (!sessionPath || !dir) return;
+
+  mkdirSync(dir, { recursive: true });
+
+  const tmpPath = `${sessionPath}.tmp`;
+  writeFileSync(tmpPath, state, "utf8");
+  renameSync(tmpPath, sessionPath);
+}
+
+export async function persistSessionSnapshotAsync(
+  terminalId: string,
+  state: string
+): Promise<void> {
+  const sessionPath = getSessionPath(terminalId);
+  const dir = getSessionDir();
+  if (!sessionPath || !dir) return;
+
+  await mkdir(dir, { recursive: true });
+
+  const tmpPath = `${sessionPath}.tmp`;
+  await writeFile(tmpPath, state, "utf8");
+  await rename(tmpPath, sessionPath);
+}

--- a/electron/services/pty/terminalShell.ts
+++ b/electron/services/pty/terminalShell.ts
@@ -1,0 +1,36 @@
+import { existsSync } from "fs";
+
+export function getDefaultShell(): string {
+  if (process.platform === "win32") {
+    return process.env.COMSPEC || "powershell.exe";
+  }
+
+  if (process.env.SHELL) {
+    return process.env.SHELL;
+  }
+
+  const commonShells = ["/bin/zsh", "/bin/bash", "/bin/sh"];
+  for (const shell of commonShells) {
+    try {
+      if (existsSync(shell)) {
+        return shell;
+      }
+    } catch {
+      // Continue to next shell
+    }
+  }
+
+  return "/bin/sh";
+}
+
+export function getDefaultShellArgs(shell: string): string[] {
+  const shellName = shell.toLowerCase();
+
+  if (process.platform !== "win32") {
+    if (shellName.includes("zsh") || shellName.includes("bash")) {
+      return ["-l"];
+    }
+  }
+
+  return [];
+}


### PR DESCRIPTION
## Summary
Refactors TerminalProcess.ts by extracting five focused modules to improve code organization, maintainability, and testability. Reduces the main file from 1,700 to 1,350 lines while preserving all functionality.

Closes #1593

## Changes Made
- Extract terminalInput.ts for input chunking, paste handling, and submit timing logic
- Extract terminalSessionPersistence.ts for session restore and persistence operations
- Extract terminalActivityPatterns.ts for pattern compilation and process state validation
- Extract TerminalForensicsBuffer.ts for crash forensics and logging
- Extract terminalShell.ts for shell detection and default configuration
- Fix agent type resolution bug in getSoftNewlineSequence to properly check detectedAgentType/agentId
- Update TerminalProcess.ts to use extracted modules with clean imports
- All tests passing, type checks clean