### PR TITLE
Make Cmd+Shift+O toggle worktree overview modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -391,7 +391,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           <button
             onClick={onOpenOverview}
             className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-white/[0.06] rounded transition-colors"
-            title="Open worktrees overview (⌘⇧O)"
+            title="Toggle worktrees overview (⌘⇧O)"
             aria-label="Open worktrees overview"
           >
             <Maximize2 className="w-3.5 h-3.5" />
@@ -676,6 +676,10 @@ function App() {
     setIsNotesPaletteOpen(false);
   }, []);
 
+  const toggleWorktreeOverview = useCallback(() => {
+    setIsWorktreeOverviewOpen((prev) => !prev);
+  }, []);
+
   const openWorktreeOverview = useCallback(() => {
     setIsWorktreeOverviewOpen(true);
   }, []);
@@ -732,6 +736,7 @@ function App() {
     onToggleFocusMode: handleToggleSidebar,
     onOpenAgentPalette: terminalPalette.open,
     onOpenWorktreePalette: openWorktreePalette,
+    onToggleWorktreeOverview: toggleWorktreeOverview,
     onOpenWorktreeOverview: openWorktreeOverview,
     onCloseWorktreeOverview: closeWorktreeOverview,
     onOpenNewTerminalPalette: newTerminalPalette.open,

--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -667,7 +667,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
             <div className="px-4 py-3 border-b border-canopy-border bg-canopy-sidebar/50 flex items-center justify-between shrink-0">
               <div className="flex items-center gap-3">
                 <span className="text-sm font-medium text-canopy-text">Notes</span>
-                <span className="text-[11px] text-canopy-text/50 font-mono">⌘⇧O</span>
+                <span className="text-[11px] text-canopy-text/50 font-mono">⌘⇧N</span>
               </div>
               <div className="flex items-center gap-2">
                 <button

--- a/src/hooks/useActionRegistry.ts
+++ b/src/hooks/useActionRegistry.ts
@@ -31,6 +31,7 @@ export function useActionRegistry(options: ActionCallbacks): void {
       onToggleFocusMode: () => callbacksRef.current.onToggleFocusMode(),
       onOpenAgentPalette: () => callbacksRef.current.onOpenAgentPalette(),
       onOpenWorktreePalette: () => callbacksRef.current.onOpenWorktreePalette(),
+      onToggleWorktreeOverview: () => callbacksRef.current.onToggleWorktreeOverview(),
       onOpenWorktreeOverview: () => callbacksRef.current.onOpenWorktreeOverview(),
       onCloseWorktreeOverview: () => callbacksRef.current.onCloseWorktreeOverview(),
       onOpenNewTerminalPalette: () => callbacksRef.current.onOpenNewTerminalPalette(),

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -529,7 +529,7 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     combo: "Cmd+Shift+O",
     scope: "global",
     priority: 0,
-    description: "Open worktrees overview",
+    description: "Toggle worktrees overview",
     category: "Worktrees",
   },
   {
@@ -542,7 +542,7 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
   },
   {
     actionId: "notes.openPalette",
-    combo: "Cmd+Shift+O",
+    combo: "Cmd+Shift+N",
     scope: "global",
     priority: 0,
     description: "Open notes palette",

--- a/src/services/actions/__tests__/actionDefinitions.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.test.ts
@@ -10,6 +10,7 @@ async function createRegistry() {
     onToggleFocusMode: () => {},
     onOpenAgentPalette: () => {},
     onOpenWorktreePalette: () => {},
+    onToggleWorktreeOverview: () => {},
     onOpenWorktreeOverview: () => {},
     onCloseWorktreeOverview: () => {},
     onOpenNewTerminalPalette: () => {},

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -11,6 +11,7 @@ export interface ActionCallbacks {
   onToggleFocusMode: () => void;
   onOpenAgentPalette: () => void;
   onOpenWorktreePalette: () => void;
+  onToggleWorktreeOverview: () => void;
   onOpenWorktreeOverview: () => void;
   onCloseWorktreeOverview: () => void;
   onOpenNewTerminalPalette: () => void;

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -369,7 +369,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      callbacks.onOpenWorktreeOverview();
+      callbacks.onToggleWorktreeOverview();
     },
   }));
 


### PR DESCRIPTION
## Summary
Implements toggle behavior for the Cmd+Shift+O keybinding to open/close the worktree overview modal based on its current state, enabling quick peek workflows.

Closes #1599

## Changes Made
- Add toggleWorktreeOverview callback with state toggle logic using functional state update
- Update worktree.overview action to call toggle instead of open
- Keep worktree.overview.open and .close as explicit actions for programmatic control
- Resolve keybinding conflict by moving notes.openPalette from Cmd+Shift+O to Cmd+Shift+N
- Update UI labels and descriptions to reflect toggle behavior
- Add onToggleWorktreeOverview to ActionCallbacks interface

## Testing
- Type check passes
- All action definition tests pass
- Codex code review completed with issues resolved