### PR TITLE
Add peek indicator bar when dock is hidden with terminals

### DIFF
--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -1,5 +1,6 @@
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useDockRenderState } from "@/hooks/useDockRenderState";
+import { useDockStore } from "@/store";
 import { ContentDock } from "./ContentDock";
 import { DockHandleOverlay } from "./DockHandleOverlay";
 import { DockStatusOverlay } from "./DockStatusOverlay";
@@ -8,12 +9,17 @@ export function TerminalDockRegion() {
   const {
     shouldShowInLayout,
     showStatusOverlay,
+    effectiveMode,
+    hasDocked,
+    dockedCount,
     density,
     isHydrated,
     waitingCount,
     failedCount,
     trashedCount,
   } = useDockRenderState();
+
+  const setMode = useDockStore((state) => state.setMode);
 
   // Before hydration, only show the handle overlay to prevent flash of incorrect state
   if (!isHydrated) {
@@ -38,6 +44,19 @@ export function TerminalDockRegion() {
           waitingCount={waitingCount}
           failedCount={failedCount}
           trashedCount={trashedCount}
+        />
+      )}
+
+      {/* Peek indicator bar when dock is hidden with docked terminals */}
+      {effectiveMode === "hidden" && hasDocked && !shouldShowInLayout && (
+        <button
+          type="button"
+          className="absolute bottom-0 left-0 right-0 h-1 bg-canopy-accent/60
+                     cursor-pointer hover:h-2 focus-visible:h-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent
+                     transition-[height,background-color,outline] duration-200 z-40"
+          onClick={() => setMode("expanded")}
+          title={`${dockedCount} terminal${dockedCount > 1 ? "s" : ""} in dock`}
+          aria-label={`Show ${dockedCount} hidden terminal${dockedCount > 1 ? "s" : ""}`}
         />
       )}
     </>

--- a/src/hooks/useDockRenderState.ts
+++ b/src/hooks/useDockRenderState.ts
@@ -13,6 +13,7 @@ import type { DockRenderState, DockMode } from "@shared/types";
 export function useDockRenderState(): DockRenderState & {
   setPeek: (peek: boolean) => void;
   hasDocked: boolean;
+  dockedCount: number;
   hasStatus: boolean;
   waitingCount: number;
   failedCount: number;
@@ -46,6 +47,7 @@ export function useDockRenderState(): DockRenderState & {
   const { waitingCount, failedCount } = useTerminalNotificationCounts();
 
   const hasDocked = dockTerminals.length > 0;
+  const dockedCount = dockTerminals.length;
   const hasStatus = waitingCount > 0 || failedCount > 0 || trashedCount > 0;
   const hasContent = hasDocked || hasStatus;
 
@@ -112,6 +114,7 @@ export function useDockRenderState(): DockRenderState & {
     isHydrated,
     setPeek,
     hasDocked,
+    dockedCount,
     hasStatus,
     waitingCount,
     failedCount,


### PR DESCRIPTION
## Summary
Adds a subtle visual indicator at the bottom of the screen to show that the dock contains terminals when it's in hidden mode, preventing users from forgetting about running background processes.

Closes #1606

## Changes Made
- Add full-width peek bar at bottom edge when dock is hidden with docked terminals
- Implement click-to-expand functionality via button element
- Add keyboard accessibility with focus-visible styling and proper ARIA labels
- Export dockedCount from useDockRenderState for terminal count tooltip
- Use proper semantic button with focus outline and height expansion on focus
- Layer peek bar at z-40 behind existing overlays (handle/status at z-50)