### PR TITLE
Fix terminal resize clearing alternate screen buffer unnecessarily

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -289,7 +289,6 @@ class TerminalInstanceService {
       latestWasAtBottom: true,
       isUserScrolledBack: false,
       isFocused: false,
-      isInAlternateBuffer: false,
       writeChain: Promise.resolve(),
       restoreGeneration: 0,
       isSerializedRestoreInProgress: false,
@@ -639,8 +638,6 @@ class TerminalInstanceService {
   handleBackendRecovery(): void {
     this.instances.forEach((managed, id) => {
       try {
-        managed.isInAlternateBuffer = false;
-
         managed.terminal.write("\x1b[!p");
 
         this.resetRenderer(id);
@@ -824,8 +821,6 @@ class TerminalInstanceService {
 
       managed.isSerializedRestoreInProgress = true;
 
-      managed.isInAlternateBuffer = false;
-
       managed.terminal.reset();
       managed.terminal.write(serializedState, () => {
         const current = this.instances.get(id);
@@ -865,8 +860,6 @@ class TerminalInstanceService {
         if (this.instances.get(id) !== managed || managed.restoreGeneration !== restoreGeneration) {
           return false;
         }
-
-        managed.isInAlternateBuffer = false;
 
         managed.terminal.reset();
 

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -88,6 +88,8 @@ export class TerminalResizeController {
       this.resetWidthForFit(managed);
       managed.fitAddon.fit();
       const { cols, rows } = managed.terminal;
+      managed.latestCols = cols;
+      managed.latestRows = rows;
       terminalClient.resize(id, cols, rows);
       this.updateExactWidth(managed);
       return { cols, rows };
@@ -190,7 +192,7 @@ export class TerminalResizeController {
   }
 
   resizeTerminal(managed: ManagedTerminal, cols: number, rows: number): void {
-    if (managed.isInAlternateBuffer) {
+    if (managed.isAltBuffer) {
       managed.terminal.write("\x1b[2J\x1b[H");
     }
     managed.terminal.resize(cols, rows);

--- a/src/services/terminal/__tests__/TerminalParserHandler.test.ts
+++ b/src/services/terminal/__tests__/TerminalParserHandler.test.ts
@@ -43,12 +43,11 @@ describe("TerminalParserHandler", () => {
     process.env = originalEnv;
   });
 
-  it("should register alternate screen buffer handlers by default", () => {
+  it("should register alternate screen buffer exit handler", () => {
     new TerminalParserHandler(mockManaged);
-    // Alternate screen buffer handlers should be registered (benign observers)
-    const decset = csiHandlers.find((h) => h.opts.prefix === "?" && h.opts.final === "h");
+    // Only DECRST (exit) handler is registered to trigger deferred resize
+    // Buffer state itself is tracked via xterm.js onBufferChange in TerminalInstanceService
     const decrst = csiHandlers.find((h) => h.opts.prefix === "?" && h.opts.final === "l");
-    expect(decset).toBeDefined();
     expect(decrst).toBeDefined();
   });
 
@@ -93,8 +92,8 @@ describe("TerminalParserHandler", () => {
 
     new TerminalParserHandler(mockManaged);
     expect(escHandlers).toHaveLength(0);
-    // Should have 2 handlers for alternate screen buffer detection (?h and ?l)
-    expect(csiHandlers).toHaveLength(2);
+    // Should have 1 handler for alternate screen buffer exit (?l)
+    expect(csiHandlers).toHaveLength(1);
   });
 
   it("should dispose handlers correctly", () => {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -66,17 +66,15 @@ export interface ManagedTerminal {
   // Input lock state (read-only monitor mode)
   isInputLocked?: boolean;
 
-  // Alternate screen buffer state (tracked via escape sequences)
-  // When true, resize operations should skip xterm.js reflow and only notify the PTY
-  isInAlternateBuffer: boolean;
-
   // Incremental restore state
   writeChain: Promise<void>;
   restoreGeneration: number;
   isSerializedRestoreInProgress: boolean;
   deferredOutput: Array<string | Uint8Array>;
 
-  // Alt buffer state (for TUI applications like OpenCode, vim, htop)
+  // Alternate screen buffer state (tracked via xterm.js onBufferChange).
+  // When true, resize operations clear the screen before resizing to avoid
+  // reflow artifacts in TUI applications (OpenCode, vim, htop, etc.)
   isAltBuffer?: boolean;
   altBufferListeners: Set<(isAltBuffer: boolean) => void>;
 }


### PR DESCRIPTION
## Summary

Fixes terminal resize bug where property name mismatch prevented proper screen clearing for TUI applications in alternate screen buffer mode (OpenCode, vim, htop, etc.).

Closes #1592

## Changes Made

- Changed TerminalResizeController to check `isAltBuffer` instead of `isInAlternateBuffer`
- Removed duplicate `isInAlternateBuffer` property (never set to true)
- Consolidated alternate buffer tracking to single source: xterm.js `onBufferChange` event
- Updated `fit()` to maintain `latestCols/latestRows` for deferred resize correctness
- Fixed TerminalParserHandler tests to expect only DECRST handler
- Removed redundant DECSET handler that duplicated xterm.js tracking

## Root Cause

The resize logic checked `managed.isInAlternateBuffer` (always false) instead of `managed.isAltBuffer` (correctly tracked via xterm.js). This caused the conditional screen clear to never execute when needed, resulting in visual artifacts when resizing TUI applications.

## Testing

- All existing tests pass
- Updated TerminalParserHandler tests to reflect new single-handler architecture
- Codex review identified and fixed edge case with `latestCols/latestRows` not being updated in `fit()`