### PR TITLE
Fix worktree dropdown menu overflow near viewport edges

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -350,7 +350,9 @@ export function WorktreeHeader({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="end"
+              side="bottom"
               sideOffset={4}
+              collisionPadding={8}
               onClick={(e) => e.stopPropagation()}
               className="w-64"
             >

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -37,9 +37,11 @@ DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayNam
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, sideOffset = 4, collisionPadding = 8, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
+    sideOffset={sideOffset}
+    collisionPadding={collisionPadding}
     className={cn(
       "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
       className


### PR DESCRIPTION
## Summary
Adds Radix UI collision detection props to worktree dropdown menus to prevent overflow when cards are positioned near the bottom of the viewport.

Closes #1612

## Changes Made
- Add side and collisionPadding props to main worktree dropdown
- Add collision detection defaults to DropdownMenuSubContent wrapper
- Enables automatic flipping when menu near viewport edges