### PR TITLE
Fix CSP frame-src directive rejecting IPv6 localhost format

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ const DEV_CSP = [
   "font-src 'self' data:",
   "connect-src 'self' http://localhost:5173 ws://localhost:5173",
   "img-src 'self' http://localhost:5173 https://avatars.githubusercontent.com data:",
-  "frame-src 'self' https://www.youtube.com http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:*",
+  "frame-src 'self' https://www.youtube.com http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
 ].join("; ");
 
 const PROD_CSP = [
@@ -22,7 +22,7 @@ const PROD_CSP = [
   "font-src 'self' data:",
   "connect-src 'self'",
   "img-src 'self' https://avatars.githubusercontent.com data: blob:",
-  "frame-src 'self' https://www.youtube.com http://localhost:* http://127.0.0.1:* http://[::1]:* https://localhost:* https://127.0.0.1:*",
+  "frame-src 'self' https://www.youtube.com http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
   "worker-src 'self' blob:",
   "object-src 'none'",
   "base-uri 'self'",


### PR DESCRIPTION
## Summary
Removes the invalid `http://[::1]:*` CSP source that was causing browser console warnings. The `http://localhost:*` directive already covers both IPv4 and IPv6 localhost resolution, making the explicit IPv6 entry unnecessary and invalid.

Closes #1611

## Changes Made
- Removed `http://[::1]:*` from DEV_CSP and PROD_CSP frame-src directives
- Fixes browser console warnings about invalid CSP source format
- `http://localhost:*` already covers both IPv4 and IPv6 localhost resolution