### PR TITLE
Fix HybridInputBar blocked state reactivity

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -159,6 +159,12 @@ function TerminalPaneComponent({
   const isInputLocked = useTerminalStore(
     (state) => state.terminals.find((t) => t.id === id)?.isInputLocked ?? false
   );
+  const stateChangeTrigger = useTerminalStore(
+    (state) => state.terminals.find((t) => t.id === id)?.stateChangeTrigger
+  );
+  const isRestarting = useTerminalStore(
+    (state) => state.terminals.find((t) => t.id === id)?.isRestarting ?? false
+  );
 
   const isBackendDisconnected = backendStatus === "disconnected";
   const isBackendRecovering = backendStatus === "recovering";
@@ -172,8 +178,6 @@ function TerminalPaneComponent({
         : undefined;
   const isAgentTerminal = effectiveAgentId !== undefined;
   const showHybridInputBar = isAgentTerminal && hybridInputEnabled;
-
-  const terminal = getTerminal(id);
 
   const queueCount = useTerminalStore(
     useShallow((state) => state.commandQueue.filter((c) => c.terminalId === id).length)
@@ -509,7 +513,7 @@ function TerminalPaneComponent({
         exitCode !== 130 &&
         !dismissedRestartPrompt &&
         !restartError &&
-        !terminal?.isRestarting && (
+        !isRestarting && (
           <TerminalRestartBanner
             exitCode={exitCode}
             onRestart={handleRestart}
@@ -633,7 +637,7 @@ function TerminalPaneComponent({
             cwd={cwd}
             agentId={effectiveAgentId}
             agentState={agentState}
-            agentHasLifecycleEvent={terminal?.stateChangeTrigger !== undefined}
+            agentHasLifecycleEvent={stateChangeTrigger !== undefined}
             restartKey={restartKey}
             onActivate={handleClick}
             onSend={({ trackerData, text }) => {


### PR DESCRIPTION
## Summary

Fixes the reactivity bug where HybridInputBar's blocked state wasn't updating when agent terminal state changed. The root cause was using non-reactive `getTerminal(id)` snapshots instead of reactive Zustand subscriptions for `stateChangeTrigger` and `isRestarting` properties.

Closes #1614

## Changes Made

- Add reactive Zustand subscription for `stateChangeTrigger` property
- Add reactive Zustand subscription for `isRestarting` property  
- Update `agentHasLifecycleEvent` prop to use reactive `stateChangeTrigger`
- Update restart banner condition to use reactive `isRestarting`
- Remove non-reactive `terminal` variable from `getTerminal(id)`

## Technical Details

Previously, `TerminalPane` called `getTerminal(id)` once during render, creating a snapshot. When `stateChangeTrigger` or `isRestarting` changed in the store, the component wouldn't re-render because it wasn't subscribed to those changes.

Now both properties use the standard reactive subscription pattern (matching `isInputLocked`), ensuring the component re-renders when these values change in the store.