### PR TITLE
Improve avatar fallback visibility and accessibility

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { User } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface AvatarProps {
@@ -18,15 +19,24 @@ export function Avatar({ src, alt, title, className }: AvatarProps) {
   }, [src]);
 
   return (
-    <div className="relative" role="img" aria-label={error ? alt : undefined}>
+    <div
+      className={cn("relative", className)}
+      role={error ? "img" : undefined}
+      aria-label={error ? alt : undefined}
+    >
       {(!loaded || error) && (
         <div
           className={cn(
-            "absolute inset-0 rounded-full bg-muted",
-            !error && "animate-pulse",
-            className
+            "absolute inset-0 rounded-full flex items-center justify-center",
+            error
+              ? "bg-muted-foreground/30 ring-2 ring-inset ring-muted-foreground/50"
+              : "bg-muted animate-pulse"
           )}
-        />
+        >
+          {error && (
+            <User className="w-3 h-3 text-muted-foreground" strokeWidth={2} aria-hidden="true" />
+          )}
+        </div>
       )}
       {!error && (
         <img
@@ -35,11 +45,8 @@ export function Avatar({ src, alt, title, className }: AvatarProps) {
           title={title}
           onLoad={() => setLoaded(true)}
           onError={() => setError(true)}
-          className={cn(
-            "rounded-full transition-opacity duration-200",
-            loaded ? "opacity-100" : "opacity-0",
-            className
-          )}
+          className="rounded-full transition-opacity duration-200 w-full h-full"
+          style={{ opacity: loaded ? 1 : 0 }}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
Improves the visibility of the Avatar component's fallback state when images fail to load (e.g., due to GitHub connection issues). The previous `bg-muted` fallback had low contrast and was difficult to distinguish from the background.

Closes #1615

## Changes Made
- Increase error state contrast with stronger ring (ring-2) and background opacity (30%/50%)
- Add User icon to clearly indicate fallback state
- Fix accessibility by conditionally applying role and aria-label only when needed
- Fix layout sizing by moving className to wrapper element to prevent collapse
- Prevent ring style conflicts with consumer components (IssueSelector)
- Optimize icon sizing (w-3 h-3) and stroke weight (2) for small avatars (w-5 h-5)

## Testing
- Manual testing in issue selector with connection failures
- Validated with Codex code review for accessibility and visual design
- All lint/format checks pass