### PR TITLE
Add keyboard shortcut tooltip for project switcher dialog

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -14,12 +14,14 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { projectClient, terminalClient } from "@/clients";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { Project, ProjectStats } from "@shared/types";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { groupProjects } from "./projectGrouping";
 import { ProjectActionRow } from "./ProjectActionRow";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 
 interface ProjectTerminalCounts {
   activeAgentCount: number;
@@ -50,6 +52,7 @@ export function ProjectSwitcher() {
   const [isLoadingStats, setIsLoadingStats] = useState(false);
   const [isLoadingTerminalCounts, setIsLoadingTerminalCounts] = useState(false);
   const switchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const projectSwitcherShortcut = useKeybindingDisplay("project.switcherPalette");
 
   const refreshStopCandidateCounts = useCallback(
     async (projectId: string) => {
@@ -632,34 +635,43 @@ export function ProjectSwitcher() {
     <>
       {stopDialog}
       <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            className={cn(
-              "w-full justify-between h-12 px-2.5",
-              "rounded-[var(--radius-lg)]",
-              "border border-white/[0.06]",
-              "bg-white/[0.02] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]",
-              "hover:bg-white/[0.04] transition-colors",
-              "active:scale-100"
-            )}
-            disabled={isLoading}
-          >
-            <div className="flex items-center gap-3 text-left min-w-0">
-              {renderIcon(currentProject.emoji || "🌲", currentProject.color, "h-9 w-9 text-xl")}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className={cn(
+                    "w-full justify-between h-12 px-2.5",
+                    "rounded-[var(--radius-lg)]",
+                    "border border-white/[0.06]",
+                    "bg-white/[0.02] shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]",
+                    "hover:bg-white/[0.04] transition-colors",
+                    "active:scale-100"
+                  )}
+                  disabled={isLoading}
+                >
+                  <div className="flex items-center gap-3 text-left min-w-0">
+                    {renderIcon(currentProject.emoji || "🌲", currentProject.color, "h-9 w-9 text-xl")}
 
-              <div className="flex flex-col min-w-0 gap-0.5">
-                <span className="truncate font-semibold text-canopy-text text-sm leading-none">
-                  {currentProject.name}
-                </span>
-                <span className="truncate text-xs text-muted-foreground/60 font-mono">
-                  {currentProject.path.split(/[/\\]/).pop()}
-                </span>
-              </div>
-            </div>
-            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors" />
-          </Button>
-        </DropdownMenuTrigger>
+                    <div className="flex flex-col min-w-0 gap-0.5">
+                      <span className="truncate font-semibold text-canopy-text text-sm leading-none">
+                        {currentProject.name}
+                      </span>
+                      <span className="truncate text-xs text-muted-foreground/60 font-mono">
+                        {currentProject.path.split(/[/\\]/).pop()}
+                      </span>
+                    </div>
+                  </div>
+                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              Switch project{projectSwitcherShortcut ? ` (${projectSwitcherShortcut})` : ""}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
 
         <DropdownMenuContent
           className="w-[484px] max-w-[calc(100vw-2rem)] max-h-[60vh] overflow-y-auto p-2"

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { ProjectActionRow } from "./ProjectActionRow";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 
 export interface ProjectSwitcherPaletteProps {
@@ -31,6 +32,7 @@ export function ProjectSwitcherPalette({
 }: ProjectSwitcherPaletteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
+  const projectSwitcherShortcut = useKeybindingDisplay("project.switcherPalette");
 
   useEffect(() => {
     if (isOpen && inputRef.current) {
@@ -101,7 +103,7 @@ export function ProjectSwitcherPalette({
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Project switcher">
-      <AppPaletteDialog.Header label="Switch Project" keyHint="⌘K, P">
+      <AppPaletteDialog.Header label="Switch Project" keyHint={projectSwitcherShortcut}>
         <AppPaletteDialog.Input
           inputRef={inputRef}
           value={query}

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -534,7 +534,7 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
   },
   {
     actionId: "project.switcherPalette",
-    combo: "Cmd+K P",
+    combo: "Cmd+Alt+P",
     scope: "global",
     priority: 0,
     description: "Open project switcher",


### PR DESCRIPTION
## Summary
Improves project switcher accessibility by adding a more intuitive keyboard shortcut and displaying it in a tooltip.

Closes #1613

## Changes Made
- Update project switcher keybinding from Cmd+K P to Cmd+Alt+P for better accessibility
- Add tooltip to project switcher button showing the keyboard shortcut
- Update palette header to display dynamic keybinding instead of hard-coded value
- Add fallback handling for empty shortcut display