### PR TITLE
Migrate browser panels from iframe to Electron webview

### DIFF
--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="electron" />
+
 declare module "react-diff-view" {
   import { ComponentType, ReactNode } from "react";
 
@@ -48,4 +50,32 @@ declare module "react-diff-view" {
 
 declare module "refractor" {
   export const refractor: any;
+}
+
+// Electron webview types for renderer
+declare global {
+  namespace Electron {
+    export type WebviewTag = import("electron").WebviewTag;
+    export type DidFailLoadEvent = import("electron").DidFailLoadEvent;
+    export type DidNavigateEvent = import("electron").DidNavigateEvent;
+    export type DidNavigateInPageEvent = import("electron").DidNavigateInPageEvent;
+  }
+
+  namespace JSX {
+    interface IntrinsicElements {
+      webview: React.DetailedHTMLProps<
+        React.HTMLAttributes<Electron.WebviewTag>,
+        Electron.WebviewTag
+      > & {
+        src?: string;
+        partition?: string;
+        webpreferences?: string;
+        allowpopups?: boolean;
+      };
+    }
+  }
+
+  interface HTMLElementTagNameMap {
+    webview: Electron.WebviewTag;
+  }
 }


### PR DESCRIPTION
## Summary
Replaces iframe elements with Electron webview tags in browser and dev preview panels to resolve cross-origin restrictions and enable better control over embedded content. Includes security hardening and drag-and-drop integration.

Closes #1620

## Changes Made
- Enable webviewTag in Electron BrowserWindow webPreferences
- Add will-attach-webview security handler to prevent XSS attacks
- Replace iframe with webview in BrowserPane component
- Replace iframe with webview in DevPreviewPane component
- Add webview event listeners for navigation and loading states
- Integrate with drag system to hide webviews during panel drags
- Add TypeScript type declarations for webview JSX elements
- Add error handling for webview load failures in DevPreviewPane