### PR TITLE
Cache project settings in store for instant toolbar updates

### DIFF
--- a/src/hooks/useProjectSettings.ts
+++ b/src/hooks/useProjectSettings.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { ProjectSettings, RunCommand } from "../types";
 import { useProjectStore } from "../store/projectStore";
+import { useProjectSettingsStore } from "../store/projectSettingsStore";
 import { projectClient } from "@/clients";
 
 interface UseProjectSettingsReturn {
@@ -19,25 +20,40 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
   const currentProject = useProjectStore((state) => state.currentProject);
   const targetId = projectId || currentProject?.id;
 
-  const [settings, setSettings] = useState<ProjectSettings | null>(null);
-  const [detectedRunners, setDetectedRunners] = useState<RunCommand[]>([]);
-  const [allDetectedRunners, setAllDetectedRunners] = useState<RunCommand[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Get store state and actions
+  const storeSettings = useProjectSettingsStore((state) => state.settings);
+  const storeDetectedRunners = useProjectSettingsStore((state) => state.detectedRunners);
+  const storeAllDetectedRunners = useProjectSettingsStore((state) => state.allDetectedRunners);
+  const storeProjectId = useProjectSettingsStore((state) => state.projectId);
+  const storeIsLoading = useProjectSettingsStore((state) => state.isLoading);
+  const storeError = useProjectSettingsStore((state) => state.error);
+  const loadSettings = useProjectSettingsStore((state) => state.loadSettings);
+  const setSettings = useProjectSettingsStore((state) => state.setSettings);
+
+  // Determine if we should use the global store or fetch locally
+  // Use global store only when targeting the current project (no explicit projectId or same as current)
+  const useGlobalStore = !projectId || projectId === currentProject?.id;
+
+  // Local state for when fetching settings for a different project (e.g., ProjectSettingsDialog with explicit ID)
+  const [localSettings, setLocalSettings] = useState<ProjectSettings | null>(null);
+  const [localDetectedRunners, setLocalDetectedRunners] = useState<RunCommand[]>([]);
+  const [localAllDetectedRunners, setLocalAllDetectedRunners] = useState<RunCommand[]>([]);
+  const [localIsLoading, setLocalIsLoading] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
 
   const latestTargetIdRef = useRef(targetId);
   latestTargetIdRef.current = targetId;
 
-  const fetchSettings = useCallback(async () => {
+  const fetchLocalSettings = useCallback(async () => {
     if (!targetId) {
-      setSettings({ runCommands: [] });
-      setDetectedRunners([]);
-      setAllDetectedRunners([]);
+      setLocalSettings({ runCommands: [] });
+      setLocalDetectedRunners([]);
+      setLocalAllDetectedRunners([]);
       return;
     }
 
-    setIsLoading(true);
-    setError(null);
+    setLocalIsLoading(true);
+    setLocalError(null);
 
     const requestedProjectId = targetId;
     try {
@@ -47,27 +63,43 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
       ]);
 
       if (requestedProjectId === latestTargetIdRef.current) {
-        setSettings(data);
-        setAllDetectedRunners(detected);
+        setLocalSettings(data);
+        setLocalAllDetectedRunners(detected);
 
         const savedCommandStrings = new Set(data.runCommands?.map((c) => c.command) || []);
         const newDetected = detected.filter((d) => !savedCommandStrings.has(d.command));
-        setDetectedRunners(newDetected);
+        setLocalDetectedRunners(newDetected);
       }
     } catch (err) {
       console.error("Failed to load project settings:", err);
       if (requestedProjectId === latestTargetIdRef.current) {
-        setError(err instanceof Error ? err.message : "Unknown error");
-        setSettings({ runCommands: [] });
-        setDetectedRunners([]);
-        setAllDetectedRunners([]);
+        setLocalError(err instanceof Error ? err.message : "Unknown error");
+        setLocalSettings({ runCommands: [] });
+        setLocalDetectedRunners([]);
+        setLocalAllDetectedRunners([]);
       }
     } finally {
       if (requestedProjectId === latestTargetIdRef.current) {
-        setIsLoading(false);
+        setLocalIsLoading(false);
       }
     }
   }, [targetId]);
+
+  // Fetch from global store if needed (when store is for wrong project or not loaded)
+  useEffect(() => {
+    if (!targetId) return;
+
+    if (useGlobalStore) {
+      // Check if store has correct data
+      if (storeProjectId !== targetId && !storeIsLoading) {
+        // Store is for a different project, trigger a load
+        void loadSettings(targetId);
+      }
+    } else {
+      // Using local state for different project
+      void fetchLocalSettings();
+    }
+  }, [targetId, useGlobalStore, storeProjectId, storeIsLoading, loadSettings, fetchLocalSettings]);
 
   const saveSettings = useCallback(
     async (newSettings: ProjectSettings) => {
@@ -78,92 +110,188 @@ export function useProjectSettings(projectId?: string): UseProjectSettingsReturn
 
       try {
         await projectClient.saveSettings(targetId, newSettings);
-        setSettings(newSettings);
 
-        const savedCommandStrings = new Set(newSettings.runCommands?.map((c) => c.command) || []);
-        setDetectedRunners((prev) => prev.filter((d) => !savedCommandStrings.has(d.command)));
+        // Guard against race condition: verify project hasn't changed during save
+        if (latestTargetIdRef.current !== targetId) {
+          return;
+        }
 
-        setError(null);
+        // Update global store if saving to current project
+        if (useGlobalStore) {
+          // Double-check store still belongs to this project after await
+          if (useProjectSettingsStore.getState().projectId === targetId) {
+            setSettings(newSettings);
+          }
+        } else {
+          // Update local state - recompute detected runners from full list
+          setLocalSettings(newSettings);
+          const savedCommandStrings = new Set(newSettings.runCommands?.map((c) => c.command) || []);
+          setLocalDetectedRunners(
+            localAllDetectedRunners.filter((d) => !savedCommandStrings.has(d.command))
+          );
+        }
+
+        // Also update global store if this is the current project
+        // (handles case where dialog opens with explicit projectId for current project)
+        if (targetId === currentProject?.id) {
+          if (useProjectSettingsStore.getState().projectId === targetId) {
+            setSettings(newSettings);
+          }
+        }
+
+        setLocalError(null);
       } catch (err) {
         console.error("Failed to save project settings:", err);
-        setError(err instanceof Error ? err.message : "Unknown error");
+        const errorMsg = err instanceof Error ? err.message : "Unknown error";
+        setLocalError(errorMsg);
         throw err;
       }
     },
-    [targetId]
+    [targetId, useGlobalStore, setSettings, currentProject?.id]
   );
 
   const promoteToSaved = useCallback(
     async (command: RunCommand) => {
-      if (!settings || !targetId) return;
-      if (settings.runCommands.some((c) => c.command === command.command)) return;
+      const currentSettings = useGlobalStore ? storeSettings : localSettings;
+      if (!currentSettings || !targetId) return;
+      if (currentSettings.runCommands.some((c) => c.command === command.command)) return;
 
-      const updated = [...settings.runCommands, command];
+      const updated = [...currentSettings.runCommands, command];
 
       try {
         await projectClient.saveSettings(targetId, {
-          ...settings,
+          ...currentSettings,
           runCommands: updated,
         });
 
-        setSettings({
-          ...settings,
+        // Guard against race condition: verify project hasn't changed
+        if (latestTargetIdRef.current !== targetId) {
+          return;
+        }
+
+        const newSettings = {
+          ...currentSettings,
           runCommands: updated,
-        });
+        };
 
-        const savedCommandStrings = new Set(updated.map((c) => c.command));
-        setDetectedRunners((prev) => prev.filter((d) => !savedCommandStrings.has(d.command)));
+        if (useGlobalStore) {
+          // Double-check store still belongs to this project
+          if (useProjectSettingsStore.getState().projectId === targetId) {
+            setSettings(newSettings);
+          }
+        } else {
+          setLocalSettings(newSettings);
+          const savedCommandStrings = new Set(updated.map((c) => c.command));
+          setLocalDetectedRunners(
+            localAllDetectedRunners.filter((d) => !savedCommandStrings.has(d.command))
+          );
+        }
 
-        setError(null);
+        // Also update global store if this is the current project
+        if (targetId === currentProject?.id) {
+          if (useProjectSettingsStore.getState().projectId === targetId) {
+            setSettings(newSettings);
+          }
+        }
+
+        setLocalError(null);
       } catch (err) {
         console.error("Failed to promote command:", err);
-        setError(err instanceof Error ? err.message : "Unknown error");
+        setLocalError(err instanceof Error ? err.message : "Unknown error");
         throw err;
       }
     },
-    [settings, targetId]
+    [useGlobalStore, storeSettings, localSettings, targetId, setSettings, currentProject?.id]
   );
 
   const removeFromSaved = useCallback(
     async (commandString: string) => {
-      if (!settings || !targetId) return;
+      const currentSettings = useGlobalStore ? storeSettings : localSettings;
+      if (!currentSettings || !targetId) return;
 
-      const updated = settings.runCommands.filter((c) => c.command !== commandString);
+      const updated = currentSettings.runCommands.filter((c) => c.command !== commandString);
 
       try {
         await projectClient.saveSettings(targetId, {
-          ...settings,
+          ...currentSettings,
           runCommands: updated,
         });
 
-        setSettings({
-          ...settings,
-          runCommands: updated,
-        });
+        // Guard against race condition: verify project hasn't changed
+        if (latestTargetIdRef.current !== targetId) {
+          return;
+        }
 
-        setError(null);
+        const newSettings = {
+          ...currentSettings,
+          runCommands: updated,
+        };
+
+        if (useGlobalStore) {
+          // Double-check store still belongs to this project
+          if (useProjectSettingsStore.getState().projectId === targetId) {
+            setSettings(newSettings);
+          }
+        } else {
+          setLocalSettings(newSettings);
+          // Recompute detected runners after removal
+          const savedCommandStrings = new Set(updated.map((c) => c.command));
+          setLocalDetectedRunners(
+            localAllDetectedRunners.filter((d) => !savedCommandStrings.has(d.command))
+          );
+        }
+
+        // Also update global store if this is the current project
+        if (targetId === currentProject?.id) {
+          if (useProjectSettingsStore.getState().projectId === targetId) {
+            setSettings(newSettings);
+          }
+        }
+
+        setLocalError(null);
       } catch (err) {
         console.error("Failed to remove command:", err);
-        setError(err instanceof Error ? err.message : "Unknown error");
+        setLocalError(err instanceof Error ? err.message : "Unknown error");
         throw err;
       }
     },
-    [settings, targetId]
+    [useGlobalStore, storeSettings, localSettings, targetId, setSettings, currentProject?.id]
   );
 
-  useEffect(() => {
-    fetchSettings();
-  }, [fetchSettings]);
+  const refresh = useCallback(async () => {
+    if (!targetId) return;
+
+    if (useGlobalStore) {
+      await loadSettings(targetId);
+    } else {
+      await fetchLocalSettings();
+    }
+  }, [targetId, useGlobalStore, loadSettings, fetchLocalSettings]);
+
+  // Return appropriate state based on whether using global store or local state
+  if (useGlobalStore) {
+    return {
+      settings: storeSettings,
+      detectedRunners: storeDetectedRunners,
+      allDetectedRunners: storeAllDetectedRunners,
+      isLoading: storeIsLoading,
+      error: storeError,
+      saveSettings,
+      promoteToSaved,
+      removeFromSaved,
+      refresh,
+    };
+  }
 
   return {
-    settings,
-    detectedRunners,
-    allDetectedRunners,
-    isLoading,
-    error,
+    settings: localSettings,
+    detectedRunners: localDetectedRunners,
+    allDetectedRunners: localAllDetectedRunners,
+    isLoading: localIsLoading,
+    error: localError,
     saveSettings,
     promoteToSaved,
     removeFromSaved,
-    refresh: fetchSettings,
+    refresh,
   };
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -25,6 +25,8 @@ export { useEventStore } from "./eventStore";
 
 export { useProjectStore } from "./projectStore";
 
+export { useProjectSettingsStore, cleanupProjectSettingsStore } from "./projectSettingsStore";
+
 export { useFocusStore } from "./focusStore";
 export type { PanelState } from "./focusStore";
 

--- a/src/store/projectSettingsStore.ts
+++ b/src/store/projectSettingsStore.ts
@@ -1,0 +1,119 @@
+import { create, type StateCreator } from "zustand";
+import type { ProjectSettings, RunCommand } from "@shared/types";
+import { projectClient } from "@/clients";
+
+interface ProjectSettingsState {
+  /** Cached settings for the current project */
+  settings: ProjectSettings | null;
+  /** Detected runners for the current project */
+  detectedRunners: RunCommand[];
+  /** All detected runners before filtering */
+  allDetectedRunners: RunCommand[];
+  /** Project ID these settings belong to */
+  projectId: string | null;
+  /** Whether settings are currently being loaded */
+  isLoading: boolean;
+  /** Error message if loading failed */
+  error: string | null;
+}
+
+interface ProjectSettingsActions {
+  /** Load settings for a project (used on project switch) */
+  loadSettings: (projectId: string) => Promise<void>;
+  /** Update cached settings after save */
+  setSettings: (settings: ProjectSettings) => void;
+  /** Update detected runners after filtering */
+  setDetectedRunners: (runners: RunCommand[]) => void;
+  /** Reset store state (used on project switch) */
+  reset: () => void;
+}
+
+const initialState: ProjectSettingsState = {
+  settings: null,
+  detectedRunners: [],
+  allDetectedRunners: [],
+  projectId: null,
+  isLoading: false,
+  error: null,
+};
+
+const createProjectSettingsStore: StateCreator<ProjectSettingsState & ProjectSettingsActions> = (
+  set,
+  get
+) => ({
+  ...initialState,
+
+  loadSettings: async (projectId: string) => {
+    // Skip if already loading this project's settings
+    const currentState = get();
+    if (currentState.projectId === projectId && currentState.isLoading) {
+      return;
+    }
+
+    set({ isLoading: true, error: null, projectId });
+
+    try {
+      const [data, detected] = await Promise.all([
+        projectClient.getSettings(projectId),
+        projectClient.detectRunners(projectId),
+      ]);
+
+      // Verify we're still loading for this project (handle race conditions)
+      if (get().projectId !== projectId) {
+        return;
+      }
+
+      const savedCommandStrings = new Set(data.runCommands?.map((c) => c.command) || []);
+      const newDetected = detected.filter((d) => !savedCommandStrings.has(d.command));
+
+      set({
+        settings: data,
+        allDetectedRunners: detected,
+        detectedRunners: newDetected,
+        isLoading: false,
+        error: null,
+      });
+    } catch (err) {
+      console.error("Failed to load project settings:", err);
+
+      // Verify we're still loading for this project
+      if (get().projectId !== projectId) {
+        return;
+      }
+
+      set({
+        error: err instanceof Error ? err.message : "Unknown error",
+        settings: { runCommands: [] },
+        detectedRunners: [],
+        allDetectedRunners: [],
+        isLoading: false,
+      });
+    }
+  },
+
+  setSettings: (settings: ProjectSettings) => {
+    const savedCommandStrings = new Set(settings.runCommands?.map((c) => c.command) || []);
+    set((state) => ({
+      settings,
+      detectedRunners: state.allDetectedRunners.filter((d) => !savedCommandStrings.has(d.command)),
+      error: null,
+    }));
+  },
+
+  setDetectedRunners: (runners: RunCommand[]) => {
+    set({ detectedRunners: runners });
+  },
+
+  reset: () => {
+    set(initialState);
+  },
+});
+
+export const useProjectSettingsStore = create<ProjectSettingsState & ProjectSettingsActions>()(
+  createProjectSettingsStore
+);
+
+/** Cleanup function for project switch */
+export function cleanupProjectSettingsStore(): void {
+  useProjectSettingsStore.getState().reset();
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -5,6 +5,7 @@ import { resetAllStoresForProjectSwitch } from "./resetStores";
 import { forceReinitializeWorktreeDataStore } from "./worktreeDataStore";
 import { flushTerminalPersistence } from "./slices";
 import { useNotificationStore } from "./notificationStore";
+import { useProjectSettingsStore } from "./projectSettingsStore";
 
 interface ProjectState {
   projects: Project[];
@@ -172,6 +173,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const project = await projectClient.switch(projectId);
       set({ currentProject: project, isLoading: false });
 
+      // Clear old settings and pre-load new project settings for instant toolbar updates
+      console.log("[ProjectSwitch] Pre-loading project settings...");
+      useProjectSettingsStore.getState().reset();
+      void useProjectSettingsStore.getState().loadSettings(projectId);
+
       // Now that backend has switched, reinitialize worktree data for the new project
       console.log("[ProjectSwitch] Reinitializing worktree data store...");
       forceReinitializeWorktreeDataStore();
@@ -282,6 +288,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       console.log("[ProjectStore] Reopening project...");
       const project = await projectClient.reopen(projectId);
       set({ currentProject: project, isLoading: false });
+
+      // Clear old settings and pre-load project settings for instant toolbar updates
+      console.log("[ProjectStore] Pre-loading project settings...");
+      useProjectSettingsStore.getState().reset();
+      void useProjectSettingsStore.getState().loadSettings(projectId);
 
       await get().loadProjects();
 

--- a/src/store/resetStores.ts
+++ b/src/store/resetStores.ts
@@ -9,6 +9,7 @@ import { useErrorStore } from "./errorStore";
 import { useNotificationStore } from "./notificationStore";
 import { cleanupNotesStore } from "./notesStore";
 import { useRecipeStore } from "./recipeStore";
+import { cleanupProjectSettingsStore } from "./projectSettingsStore";
 
 export async function resetAllStoresForProjectSwitch(): Promise<void> {
   // Use resetWithoutKilling instead of reset
@@ -17,6 +18,9 @@ export async function resetAllStoresForProjectSwitch(): Promise<void> {
 
   useWorktreeSelectionStore.getState().reset();
   cleanupWorktreeDataStore();
+  // Note: projectSettingsStore is NOT cleaned up here to avoid triggering
+  // a reload of old project settings. It will be reset and reloaded by
+  // projectStore after the switch completes.
   useRecipeStore.getState().reset();
   useLogsStore.getState().reset();
   useEventStore.getState().reset();


### PR DESCRIPTION
## Summary
Implements global Zustand store for project settings to eliminate toolbar button delay. Settings are now cached for the current project and pre-loaded on project switch, providing instant access without async fetch delays.

Closes #1610

## Changes Made
- Created `projectSettingsStore.ts` with Zustand for caching current project settings
- Updated `useProjectSettings` hook to use global store for current project, local state for dialogs
- Pre-load settings on project switch (both `switchProject` and `reopenProject`)
- Added race condition guards in save/promote/remove operations to prevent cross-project state writes
- Recompute local detected runners from full list after any runCommands change
- Clear error on successful setSettings in store
- Reset settings store before loading new project to avoid old project reload during switch
- Skip settings cleanup in resetStores to prevent redundant fetch

## Testing
- Verified type checking passes
- Verified linting and formatting pass
- Codex review completed with race condition fixes applied