### PR TITLE
Fix browser panels not restored when switching back to project

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -142,6 +142,8 @@ export const CHANNELS = {
   PROJECT_ADD_RECIPE: "project:add-recipe",
   PROJECT_UPDATE_RECIPE: "project:update-recipe",
   PROJECT_DELETE_RECIPE: "project:delete-recipe",
+  PROJECT_GET_TERMINALS: "project:get-terminals",
+  PROJECT_SET_TERMINALS: "project:set-terminals",
 
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -296,6 +296,8 @@ const CHANNELS = {
   PROJECT_ADD_RECIPE: "project:add-recipe",
   PROJECT_UPDATE_RECIPE: "project:update-recipe",
   PROJECT_DELETE_RECIPE: "project:delete-recipe",
+  PROJECT_GET_TERMINALS: "project:get-terminals",
+  PROJECT_SET_TERMINALS: "project:set-terminals",
 
   // Agent settings channels
   AGENT_SETTINGS_GET: "agent-settings:get",
@@ -761,6 +763,16 @@ const api: ElectronAPI = {
 
     deleteRecipe: (projectId: string, recipeId: string): Promise<void> =>
       _typedInvoke(CHANNELS.PROJECT_DELETE_RECIPE, { projectId, recipeId }),
+
+    getTerminals: (
+      projectId: string
+    ): Promise<import("../shared/types/index.js").TerminalSnapshot[]> =>
+      _typedInvoke(CHANNELS.PROJECT_GET_TERMINALS, projectId),
+
+    setTerminals: (
+      projectId: string,
+      terminals: import("../shared/types/index.js").TerminalSnapshot[]
+    ): Promise<void> => _typedInvoke(CHANNELS.PROJECT_SET_TERMINALS, { projectId, terminals }),
   },
 
   // Agent Settings API

--- a/electron/schemas/index.ts
+++ b/electron/schemas/index.ts
@@ -31,6 +31,8 @@ export {
   DevPreviewStartPayloadSchema,
   WorktreeSetActivePayloadSchema,
   WorktreeCreatePayloadSchema,
+  TerminalSnapshotSchema,
+  filterValidTerminalEntries,
   type TerminalSpawnOptions as ValidatedTerminalSpawnOptions,
   type TerminalResizePayload as ValidatedTerminalResizePayload,
   type CopyTreeOptions as ValidatedCopyTreeOptions,
@@ -43,6 +45,7 @@ export {
   type DevPreviewStartPayload as ValidatedDevPreviewStartPayload,
   type WorktreeSetActivePayload as ValidatedWorktreeSetActivePayload,
   type WorktreeCreatePayload as ValidatedWorktreeCreatePayload,
+  type TerminalSnapshotEntry,
 } from "./ipc.js";
 
 export {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -6,6 +6,7 @@ import type {
   GitStatus,
   AgentId,
   TerminalRecipe,
+  TerminalSnapshot,
 } from "../domain.js";
 import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 
@@ -228,6 +229,16 @@ export interface ElectronAPI {
       updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>
     ): Promise<void>;
     deleteRecipe(projectId: string, recipeId: string): Promise<void>;
+    /**
+     * Get saved terminal snapshots for a project (per-project panel state).
+     * Used for restoring panel layout when switching projects.
+     */
+    getTerminals(projectId: string): Promise<TerminalSnapshot[]>;
+    /**
+     * Save terminal snapshots for a project (per-project panel state).
+     * Used for preserving panel layout when switching away from a project.
+     */
+    setTerminals(projectId: string, terminals: TerminalSnapshot[]): Promise<void>;
   };
   agentSettings: {
     get(): Promise<AgentSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -5,6 +5,7 @@ import type {
   RunCommand,
   AgentId,
   TerminalRecipe,
+  TerminalSnapshot,
 } from "../domain.js";
 import type { AgentSettings } from "../agentSettings.js";
 import type { UserAgentRegistry, UserAgentConfig } from "../userAgentRegistry.js";
@@ -474,6 +475,14 @@ export interface IpcInvokeMap {
   };
   "project:delete-recipe": {
     args: [payload: { projectId: string; recipeId: string }];
+    result: void;
+  };
+  "project:get-terminals": {
+    args: [projectId: string];
+    result: TerminalSnapshot[];
+  };
+  "project:set-terminals": {
+    args: [payload: { projectId: string; terminals: TerminalSnapshot[] }];
     result: void;
   };
 

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -5,6 +5,7 @@ import type {
   ProjectCloseResult,
   ProjectStats,
   TerminalRecipe,
+  TerminalSnapshot,
 } from "@shared/types";
 
 /**
@@ -102,5 +103,13 @@ export const projectClient = {
 
   deleteRecipe: (projectId: string, recipeId: string): Promise<void> => {
     return window.electron.project.deleteRecipe(projectId, recipeId);
+  },
+
+  getTerminals: (projectId: string): Promise<TerminalSnapshot[]> => {
+    return window.electron.project.getTerminals(projectId);
+  },
+
+  setTerminals: (projectId: string, terminals: TerminalSnapshot[]): Promise<void> => {
+    return window.electron.project.setTerminals(projectId, terminals);
   },
 } as const;

--- a/src/store/slices/terminalRegistry/persistence.ts
+++ b/src/store/slices/terminalRegistry/persistence.ts
@@ -1,4 +1,5 @@
 import { terminalPersistence } from "../../persistence/terminalPersistence";
+import { useProjectStore } from "../../projectStore";
 import type { TerminalInstance } from "./types";
 
 export function flushTerminalPersistence(): void {
@@ -6,5 +7,6 @@ export function flushTerminalPersistence(): void {
 }
 
 export function saveTerminals(terminals: TerminalInstance[]): void {
-  terminalPersistence.save(terminals);
+  const projectId = useProjectStore.getState().currentProject?.id;
+  terminalPersistence.save(terminals, projectId ?? undefined);
 }


### PR DESCRIPTION
## Summary
Implements per-project browser panel restoration to fix the issue where browser panels (and other panel types) are not restored when switching back to a project. Previously, panel state was stored globally and overwritten on each project switch. Now each project maintains its own panel state that is preserved across switches.

Closes #1628

## Changes Made
- Add IPC channels for per-project terminal state persistence (PROJECT_GET_TERMINALS, PROJECT_SET_TERMINALS)
- Update hydration logic to load terminals from per-project state with automatic migration from global state
- Modify TerminalPersistence class to use projectClient.setTerminals() instead of appClient.setState()
- Snapshot current panel state before project switching in projectStore (switchProject and reopenProject)
- Add kind inference for legacy terminals during migration to ensure browser/notes panels are properly restored
- Fix dev-preview command handling to preserve devCommand instead of command
- Add await for whenIdle() to prevent persistence race conditions during project switch
- Make empty per-project state authoritative to prevent redundant re-migration
- Update tests to reflect the new per-project persistence model

## Technical Details
- **IPC Layer**: New handlers in `electron/ipc/handlers/project.ts` with validation using `TerminalSnapshotSchema`
- **Migration**: Automatic one-time migration from global `appState.terminals` to `ProjectState.terminals` on first hydration
- **State Management**: Per-project state stored in `~/.config/canopy/projects/{projectId}/state.json`
- **Race Condition Fix**: Flush and await pending persistence before explicit snapshot to prevent overwrite
- **Browser Panel Support**: Correctly preserves `browserUrl` and other panel-specific metadata