### PR TITLE
Add zoom controls to browser panels for viewport testing

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -156,6 +156,7 @@ export type ActionId =
   | "browser.forward"
   | "browser.openExternal"
   | "browser.copyUrl"
+  | "browser.setZoomLevel"
   | "nav.toggleFocusMode"
   | "sidecar.toggle"
   | "sidecar.closeTab"

--- a/src/services/actions/definitions/browserActions.ts
+++ b/src/services/actions/definitions/browserActions.ts
@@ -132,4 +132,26 @@ export function registerBrowserActions(actions: ActionRegistry, _callbacks: Acti
       await navigator.clipboard.writeText(derivedUrl);
     },
   }));
+
+  actions.set("browser.setZoomLevel", () => ({
+    id: "browser.setZoomLevel",
+    title: "Set Browser Zoom Level",
+    description: "Set the zoom level for a browser panel",
+    category: "browser",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({
+      terminalId: z.string().optional(),
+      zoomFactor: z.number().min(0.25).max(2.0),
+    }),
+    run: async (args: unknown) => {
+      const { terminalId, zoomFactor } = args as { terminalId?: string; zoomFactor: number };
+      const targetId = terminalId ?? useTerminalStore.getState().focusedId;
+      if (!targetId) return;
+      window.dispatchEvent(
+        new CustomEvent("canopy:browser-set-zoom", { detail: { id: targetId, zoomFactor } })
+      );
+    },
+  }));
 }

--- a/src/store/browserStateStore.ts
+++ b/src/store/browserStateStore.ts
@@ -9,6 +9,7 @@ export interface BrowserHistory {
 export interface BrowserPanelState {
   url: string;
   history: BrowserHistory;
+  zoomFactor?: number;
 }
 
 interface BrowserStateState {
@@ -19,6 +20,7 @@ interface BrowserStateActions {
   getState: (panelId: string) => BrowserPanelState | undefined;
   setState: (panelId: string, state: BrowserPanelState) => void;
   updateUrl: (panelId: string, url: string, history: BrowserHistory) => void;
+  updateZoomFactor: (panelId: string, zoomFactor: number) => void;
   clearState: (panelId: string) => void;
   reset: () => void;
 }
@@ -47,7 +49,24 @@ const createBrowserStateStore: StateCreator<BrowserStateState & BrowserStateActi
     set((s) => ({
       panelStates: {
         ...s.panelStates,
-        [panelId]: { url, history },
+        [panelId]: {
+          ...s.panelStates[panelId],
+          url,
+          history,
+        },
+      },
+    })),
+
+  updateZoomFactor: (panelId, zoomFactor) =>
+    set((s) => ({
+      panelStates: {
+        ...s.panelStates,
+        [panelId]: {
+          ...s.panelStates[panelId],
+          url: s.panelStates[panelId]?.url ?? "",
+          history: s.panelStates[panelId]?.history ?? { past: [], future: [] },
+          zoomFactor,
+        },
       },
     })),
 


### PR DESCRIPTION
## Summary
Adds zoom level dropdown to browser panels, allowing users to zoom out and preview how websites would appear on larger displays while working within constrained browser panel space.

Closes #1627

## Changes Made
- Add browser.setZoomLevel action with validation (0.25-2.0 range)
- Implement zoom dropdown UI with presets (25%, 50%, 75%, 100%, 125%, 150%, 200%)
- Add ARIA attributes and keyboard navigation for accessibility
- Persist zoom level per panel in browser state store
- Apply zoom to webview using setZoomFactor() when ready
- Fix store feedback loop using Zustand selectors
- Add validation and clamping for zoom factor from events and storage
- Show visual feedback (blue color, bold weight) for non-100% zoom
- Close dropdown on Escape key or focus-out for keyboard users

## Test Plan
- [x] Zoom dropdown appears in browser toolbar between reload button and URL input
- [x] Selecting zoom levels immediately applies to webview
- [x] Zoom level persists when navigating to different URLs in same panel
- [x] Default zoom is 100% for newly spawned browser panels
- [x] Visual indicator (blue, bold) shows when zoom is not at 100%
- [x] Keyboard navigation works (Escape to close, focus management)
- [x] ARIA attributes for screen reader accessibility
- [x] Store feedback loop fixed using Zustand selectors
- [x] Zoom validation prevents out-of-range values