### PR TITLE
Fix clicking autocomplete items in hybrid input

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -616,16 +616,9 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
 
     const handleAutocompleteSelect = useCallback(
       (item: AutocompleteItem) => {
-        if (activeMode === "command") {
-          const idx = autocompleteItems.findIndex((i) => i.key === item.key);
-          setSelectedIndex(idx >= 0 ? idx : 0);
-          focusTextarea();
-          return;
-        }
-
         applyAutocompleteItem(item, "insert");
       },
-      [activeMode, applyAutocompleteItem, autocompleteItems, focusTextarea]
+      [applyAutocompleteItem]
     );
 
     const barContent = (


### PR DESCRIPTION
## Summary
Fixed autocomplete item clicks in the hybrid input bar that were previously non-functional. Clicking autocomplete suggestions now correctly inserts the selected item with a trailing space, matching Tab key behavior.

Closes #1635

## Changes Made
- Removed broken command mode special case in `handleAutocompleteSelect` that prevented insertion
- Both command and file mode now correctly call `applyAutocompleteItem` on click
- Keyboard navigation (Arrow keys, Tab, Enter) remains unaffected as it uses separate handlers
- Simplified callback dependencies from 4 to 1

## Root Cause
The `handleAutocompleteSelect` callback had a command mode branch that only updated selection index without inserting anything. This was likely intended for hover/keyboard selection, but was also triggered by clicks, causing clicks to do nothing.

## Testing
- ✅ TypeScript compilation passes
- ✅ ESLint passes
- ✅ Prettier formatting passes