### PR TITLE
Add refined loading indicator strip to toolbar git status icons

### DIFF
--- a/src/components/Layout/GitHubStatusIndicator.tsx
+++ b/src/components/Layout/GitHubStatusIndicator.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export type GitHubStatusIndicatorStatus = "idle" | "loading" | "success" | "error";
+
+interface GitHubStatusIndicatorProps {
+  status: GitHubStatusIndicatorStatus;
+  error?: string;
+  onTransitionEnd?: () => void;
+}
+
+export function GitHubStatusIndicator({
+  status,
+  error,
+  onTransitionEnd,
+}: GitHubStatusIndicatorProps) {
+  const [internalStatus, setInternalStatus] = useState<GitHubStatusIndicatorStatus>(status);
+
+  useEffect(() => {
+    if (status === "success") {
+      setInternalStatus("success");
+      const timer = setTimeout(() => {
+        setInternalStatus("idle");
+        onTransitionEnd?.();
+      }, 500);
+      return () => clearTimeout(timer);
+    }
+    setInternalStatus(status);
+    return undefined;
+  }, [status, onTransitionEnd]);
+
+  if (internalStatus === "idle") return null;
+
+  return (
+    <div
+      className={cn(
+        "absolute bottom-0 left-0 right-0 h-[2px] rounded-b-[var(--radius-md)]",
+        internalStatus === "loading" && "overflow-hidden github-status-loading",
+        internalStatus === "success" && "github-status-success",
+        internalStatus === "error" && "github-status-error"
+      )}
+      role="status"
+      aria-live="polite"
+      aria-label={
+        internalStatus === "loading"
+          ? "Loading GitHub data"
+          : internalStatus === "success"
+            ? "GitHub data updated"
+            : internalStatus === "error"
+              ? `GitHub error: ${error ?? "Unknown error"}`
+              : undefined
+      }
+    />
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -782,6 +782,117 @@ body,
   }
 }
 
+/* GitHub Status Indicator Animations
+ * Refined loading strip for toolbar git status icons.
+ * Uses GPU-accelerated transforms for smooth 60fps animation.
+ */
+
+/* Loading shimmer - left to right sweep */
+@keyframes github-status-shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+.github-status-loading {
+  background: rgba(59, 130, 246, 0.2); /* Blue-500 at 20% */
+}
+
+.github-status-loading::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 25%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.8), transparent);
+  animation: github-status-shimmer 1.5s ease-in-out infinite;
+  will-change: transform;
+}
+
+/* Success fade - scale in then fade out */
+@keyframes github-status-success-fade {
+  0% {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+  30% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scaleX(1);
+  }
+}
+
+.github-status-success {
+  background: rgb(74 222 128); /* Green-400 */
+  transform-origin: left;
+  animation: github-status-success-fade 500ms ease-out forwards;
+  will-change: opacity, transform;
+}
+
+/* Error pulse - subtle breathing animation */
+@keyframes github-status-error-pulse {
+  0%,
+  100% {
+    opacity: 0.8;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.github-status-error {
+  background: rgb(251 146 60); /* Orange-400 - less alarming than red */
+  animation: github-status-error-pulse 2s ease-in-out infinite;
+  will-change: opacity;
+}
+
+/* Respect user's motion preferences */
+@media (prefers-reduced-motion: reduce) {
+  .github-status-loading::after {
+    display: none;
+  }
+
+  .github-status-loading {
+    background: rgba(59, 130, 246, 0.6); /* Solid bar when motion disabled */
+  }
+
+  .github-status-success {
+    animation: none;
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  .github-status-error {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+/* Disable in performance mode */
+body[data-performance-mode="true"] .github-status-loading::after {
+  display: none !important;
+}
+
+body[data-performance-mode="true"] .github-status-loading {
+  background: rgba(59, 130, 246, 0.6) !important;
+}
+
+body[data-performance-mode="true"] .github-status-success {
+  opacity: 1 !important;
+  transform: scaleX(1) !important;
+}
+
+body[data-performance-mode="true"] .github-status-error {
+  opacity: 1 !important;
+}
+
 /* Section header pattern - for organizing content hierarchically */
 .section-header {
   @apply text-xs font-bold tracking-widest text-muted-foreground uppercase;


### PR DESCRIPTION
## Summary
Implements a refined, minimal 2px loading indicator strip below the toolbar GitHub stats buttons to communicate loading, success, and error states with smooth animations.

Closes #1636

## Changes Made
- Add GitHubStatusIndicator component with loading/success/error states
- Implement shimmer animation for loading state (left-to-right sweep)
- Add success fade animation (500ms green bar) after successful fetch
- Add error pulse animation (orange breathing effect) for failures
- Integrate indicator below GitHub stats button group in toolbar
- Track stats state changes with success detection logic
- Support reduced-motion preferences with solid bar fallback
- Support performance mode with animation disabling
- Add accessible ARIA live region for status announcements
- Fix state persistence bug preventing false success pulses
- Fix CSS positioning override breaking bottom anchoring

## Technical Details
- **Component**: `GitHubStatusIndicator.tsx` - manages internal state and transitions
- **Animations**: GPU-accelerated (transform/opacity) for 60fps smoothness
- **Accessibility**: ARIA live region with polite announcements
- **Performance**: Respects both `prefers-reduced-motion` and performance mode
- **State Management**: Success timer with automatic cleanup, prevents stale success states