### PR TITLE
Fix filter button z-index conflict in worktree overview modal

### DIFF
--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -219,7 +219,7 @@ export function WorktreeOverviewModal({
     <div
       ref={modalRef}
       className={cn(
-        "fixed inset-0 z-[100] flex items-center justify-center",
+        "fixed inset-0 z-[var(--z-modal)] flex items-center justify-center",
         "bg-black/60 backdrop-blur-sm",
         "motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
       )}


### PR DESCRIPTION
## Summary
Fixes the filter button in the worktree overview modal being unclickable due to a z-index conflict. The modal backdrop was using a hardcoded `z-[100]` value while the popover uses `z-[var(--z-popover)]` (70), causing the popover to render behind the modal.

Closes #1650

## Changes Made
- Replace hardcoded z-[100] with z-[var(--z-modal)] in WorktreeOverviewModal
- Ensures popover (z-70) renders above modal backdrop (z-60)
- Aligns with design system z-index hierarchy
- Fixes filter button clickability in worktree overview modal

## Technical Details
The fix implements Option 1 from the issue, which uses the CSS variable `--z-modal` (60) instead of the hardcoded value. This ensures the proper z-index hierarchy:
- Modal backdrop: z-60 (`--z-modal`)
- Popover: z-70 (`--z-popover`)

This change brings WorktreeOverviewModal in line with other modal components in the codebase, which already use `z-[var(--z-modal)]`.