### PR TITLE
Reduce GitHub status indicator height and remove clock icons

### DIFF
--- a/src/components/Layout/GitHubStatusIndicator.tsx
+++ b/src/components/Layout/GitHubStatusIndicator.tsx
@@ -34,7 +34,7 @@ export function GitHubStatusIndicator({
   return (
     <div
       className={cn(
-        "absolute bottom-0 left-0 right-0 h-[2px] rounded-b-[var(--radius-md)]",
+        "absolute bottom-0 left-0 right-0 h-[1px] rounded-b-[var(--radius-md)]",
         internalStatus === "loading" && "overflow-hidden github-status-loading",
         internalStatus === "success" && "github-status-success",
         internalStatus === "error" && "github-status-error"

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -21,7 +21,6 @@ import {
   Plus,
   Settings2,
   Globe,
-  Clock,
   StickyNote,
   Rocket,
   Circle,
@@ -703,7 +702,6 @@ export function Toolbar({
               >
                 <AlertTriangle className="h-4 w-4" />
                 <span className="text-xs font-medium tabular-nums">{stats.issueCount ?? "?"}</span>
-                {isStale && <Clock className="h-3 w-3" />}
               </Button>
               <FixedDropdown
                 open={issuesOpen}
@@ -745,7 +743,6 @@ export function Toolbar({
               >
                 <GitPullRequest className="h-4 w-4" />
                 <span className="text-xs font-medium tabular-nums">{stats.prCount ?? "?"}</span>
-                {isStale && <Clock className="h-3 w-3" />}
               </Button>
               <FixedDropdown
                 open={prsOpen}


### PR DESCRIPTION
## Summary
Reduces the GitHub status indicator loading strip height from 2px to 1px for a more refined appearance, and removes redundant clock icons from the issues and PRs buttons since staleness is already communicated through the color bar indicator.

Closes #1644

## Changes Made
- Reduce GitHub status indicator strip height from 2px to 1px
- Remove Clock icon import from Toolbar component
- Remove clock icons from issues button (staleness shown via color bar)
- Remove clock icons from PRs button (staleness shown via color bar)