### PR TITLE
Remove command summaries from dock terminal titles

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useDndMonitor } from "@dnd-kit/core";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { cn, getBaseTitle } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import {
   useTerminalInputStore,
@@ -171,6 +171,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const commandText = terminal.activityHeadline || terminal.lastCommand;
   const brandColor = getBrandColorHex(terminal.type);
   const agentState = terminal.agentState;
+  // Use shortened title without command summary for dock items
+  const displayTitle = getBaseTitle(terminal.title);
   // Only show icon for non-idle, non-completed states (reduce noise)
   const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";
   const StateIcon = showStateIcon ? STATE_ICONS[agentState] : null;
@@ -191,6 +193,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
             )}
             onClick={() => setFocused(terminal.id)}
             title={`${terminal.title} - Click to preview, drag to reorder`}
+            aria-label={`${terminal.title} - Click to preview, drag to reorder`}
           >
             <div
               className={cn(
@@ -206,7 +209,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
               />
             </div>
             <span className="truncate shrink-0 min-w-[60px] max-w-[120px] font-sans font-medium">
-              {terminal.title}
+              {displayTitle}
             </span>
 
             {isActive && commandText && (

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -9,7 +9,7 @@ import {
   Activity,
 } from "lucide-react";
 import type { PanelKind, TerminalType } from "@/types";
-import { cn } from "@/lib/utils";
+import { cn, getBaseTitle } from "@/lib/utils";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -92,6 +92,9 @@ function PanelHeaderComponent({
 
   // Get background activity stats for Zen Mode header
   const { activeCount, workingCount } = useBackgroundPanelStats(id);
+
+  // In dock, show shortened title without command summary for space efficiency
+  const displayTitle = location === "dock" ? getBaseTitle(title) : title;
 
   const handleHeaderDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
@@ -176,7 +179,7 @@ function PanelHeaderComponent({
                 title={onTitleChange ? `${title} — Double-click to edit` : title}
                 aria-label={onTitleChange ? getTitleAriaLabel() : undefined}
               >
-                {title}
+                {displayTitle}
               </span>
             </div>
           )}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,31 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Extracts the base title from a terminal/agent title that may contain a command summary.
+ * Command summaries are appended with separators like " – " (en dash), " — " (em dash), or " - ".
+ *
+ * Examples:
+ *   "Claude Code Agent – fix authentication bug" → "Claude Code Agent"
+ *   "Terminal — npm run dev" → "Terminal"
+ *   "Claude" → "Claude" (no change)
+ *
+ * @param title The full title that may contain a command summary
+ * @returns The base title without the command summary
+ */
+
+// Regex hoisted to module scope for performance (avoid per-call construction)
+// Matches: en dash (–), em dash (—), or spaced hyphen ( - ) with content after
+const TITLE_SEPARATOR_REGEX = /^(.+?)\s*[–—]\s+.+$|^(.+?)\s+-\s+.+$/;
+
+export function getBaseTitle(title: string): string {
+  // Match common separators: en dash (–), em dash (—), or spaced hyphen ( - )
+  // Only match if there's content before and after the separator
+  const separatorMatch = title.match(TITLE_SEPARATOR_REGEX);
+  if (separatorMatch) {
+    // Return the first capture group that matched
+    return (separatorMatch[1] ?? separatorMatch[2] ?? title).trim();
+  }
+  return title;
+}


### PR DESCRIPTION
## Summary
Removes verbose command summaries from terminal agent titles in the dock interface to save horizontal space. Dock terminal titles now display only the agent/terminal name (e.g., "Claude" instead of "Claude – fix authentication bug"), making the dock more scannable while preserving full titles in tooltips and for screen readers.

Closes #1660

## Changes Made
- Add `getBaseTitle` utility function to strip command summaries from titles using separator patterns (en dash, em dash, spaced hyphen)
- Apply shortened titles to dock terminal items for space efficiency
- Apply shortened titles to dock panel headers when in dock location
- Add explicit `aria-label` for screen reader accessibility with full title information
- Optimize regex performance by hoisting to module scope

## Implementation Details
The implementation uses a regex pattern to detect common separators (`–`, `—`, ` - `) and extract the base title before the separator. The shortening only applies to dock locations—grid terminals continue to show full titles. Full titles remain accessible via tooltips and aria-labels for accessibility.

## Testing
- Typecheck passed
- Build completed successfully
- Codex review conducted with findings addressed (accessibility improvements, performance optimization)