### PR TITLE
Fix: Scroll to bottom when reinitializing terminal agents

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -844,6 +844,10 @@ class TerminalInstanceService {
         for (const data of deferred) {
           this.writeToTerminal(id, data);
         }
+
+        if (!current.isAltBuffer) {
+          this.scrollToBottom(id);
+        }
       });
       return true;
     } catch (error) {
@@ -920,6 +924,10 @@ class TerminalInstanceService {
 
           for (const data of deferredData) {
             this.writeToTerminal(id, data);
+          }
+
+          if (!managed.isAltBuffer) {
+            this.scrollToBottom(id);
           }
         }
       }

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -103,6 +103,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
           });
         }
       }),
+      scrollToBottom: vi.fn(),
       open: vi.fn(),
       dispose: vi.fn(),
       refresh: vi.fn(),


### PR DESCRIPTION
## Summary
Ensures terminal agents automatically scroll to the bottom after state restoration during worktree/project switches, so users always see the most recent output.

Closes #1641

## Changes Made
- Add scrollToBottom call after restoreFromSerialized completes
- Add scrollToBottom call after restoreFromSerializedIncremental completes
- Guard scrollToBottom with isAltBuffer check to preserve TUI apps (vim, htop)
- Add scrollToBottom mock to restore tests