### PR TITLE
Fix: Standardize dev server icon across toolbar and panel headers

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -22,7 +22,7 @@ import {
   Settings2,
   Globe,
   StickyNote,
-  Rocket,
+  Monitor,
   Circle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -659,11 +659,11 @@ export function Toolbar({
             onClick={() => {
               void actionService.dispatch("devServer.start", undefined, { source: "user" });
             }}
-            className="text-canopy-text hover:bg-white/[0.06] transition-colors hover:text-purple-400 focus-visible:text-purple-400"
+            className="text-canopy-text hover:bg-white/[0.06] transition-colors hover:text-canopy-accent focus-visible:text-canopy-accent"
             title="Start Dev Server"
             aria-label="Start Dev Server"
           >
-            <Rocket />
+            <Monitor />
           </Button>
         ),
         isAvailable: !!devServerCommand,

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -20,7 +20,7 @@ import {
   PanelLeft,
   Terminal,
   Globe,
-  Rocket,
+  Monitor,
   AlertTriangle,
   StickyNote,
   Copy,
@@ -75,7 +75,7 @@ const BUTTON_METADATA: Record<
   },
   "dev-server": {
     label: "Dev Server",
-    icon: <Rocket className="h-4 w-4" />,
+    icon: <Monitor className="h-4 w-4" />,
     description: "Start development server",
   },
   "github-stats": {


### PR DESCRIPTION
## Summary
Standardizes the dev server icon from Rocket to Monitor across the toolbar and settings UI. This change improves visual consistency by using the same icon that appears in dev-preview panel headers, creating a cohesive visual language throughout the application.

Closes #1657

## Changes Made
- Replace Rocket icon with Monitor in toolbar dev-server button
- Replace Rocket icon with Monitor in toolbar settings preview
- Change hover color from purple-400 to canopy-accent for consistency
- Align dev server button styling with other toolbar icons (Terminal, Browser)

## Rationale
- The Monitor icon better represents the dev server preview concept (what it IS vs what it DOES)
- Maintains visual consistency with dev-preview panel title bars which already use Monitor
- Standardizes hover color to match other toolbar system icons
- Creates a more neutral, professional appearance matching the toolbar design system