### PR TITLE
Fix sidebar and sidecar toggle icon inconsistency

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -12,7 +12,7 @@ import {
   AlertTriangle,
   PanelRightOpen,
   PanelRightClose,
-  PanelLeft,
+  PanelLeftOpen,
   PanelLeftClose,
   Copy,
   Check,
@@ -565,7 +565,7 @@ export function Toolbar({
             aria-label="Toggle Sidebar"
             aria-pressed={!isFocusMode}
           >
-            {isFocusMode ? <PanelLeft /> : <PanelLeftClose />}
+            {isFocusMode ? <PanelLeftOpen /> : <PanelLeftClose />}
           </Button>
         ),
         isAvailable: true,


### PR DESCRIPTION
## Summary
This PR fixes the visual inconsistency between sidebar and sidecar toggle icons in the toolbar. Previously, when both panels were hidden, the sidebar showed `PanelLeft` (no arrow) while the sidecar showed `PanelRightOpen` (with arrow), creating an asymmetric appearance.

Closes #1654

## Changes Made
- Replace `PanelLeft` with `PanelLeftOpen` for hidden sidebar state
- Ensures visual symmetry with sidecar toggle icons
- Both toggles now use mirrored icon patterns (Open/Close)

## Result
Both toggle buttons now follow a consistent pattern:
- **Hidden state:** `PanelLeftOpen` ↔ `PanelRightOpen` (arrows pointing outward)
- **Shown state:** `PanelLeftClose` ↔ `PanelRightClose` (arrows pointing inward)