### PR TITLE
Fix OpenCode terminal scrollbar gap

### DIFF
--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -67,7 +67,15 @@ export class TerminalResizeController {
     if (!cellDims) return;
 
     const cols = managed.terminal.cols;
-    const exactWidth = Math.ceil(cols * cellDims.width);
+    const contentWidth = Math.ceil(cols * cellDims.width);
+
+    // Detect scrollbar width by querying the actual viewport element
+    // offsetWidth includes scrollbar, clientWidth excludes it
+    const viewport = managed.hostElement.querySelector(".xterm-viewport") as HTMLElement | null;
+    const scrollbarWidth = viewport ? viewport.offsetWidth - viewport.clientWidth : 0;
+
+    // Include scrollbar in total width to prevent gap
+    const exactWidth = contentWidth + scrollbarWidth;
     managed.hostElement.style.width = `${exactWidth}px`;
   }
 


### PR DESCRIPTION
## Summary
Fixes the OpenCode terminal scrollbar space issue by dynamically detecting scrollbar width and including it in the terminal width calculation.

Closes #1662

## Changes Made
- Detect scrollbar width dynamically using offsetWidth - clientWidth
- Add scrollbar width to content width to prevent right-side gap
- Handle null viewport gracefully with fallback to 0
- Fix OpenCode terminal content misalignment issue

## Implementation
Modified `TerminalResizeController.updateExactWidth()` to:
1. Query the `.xterm-viewport` element
2. Calculate scrollbar width as `offsetWidth - clientWidth`
3. Add scrollbar width to content width for proper fit

This approach works across all platforms (macOS overlay scrollbars, Windows/Linux always-visible scrollbars) without hardcoding values.