### PR TITLE
Fix: Assignment toggle missing when linking issue in worktree creation

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -77,6 +77,7 @@ export function NewWorktreeDialog({
   );
   const githubConfig = useGitHubConfigStore((s) => s.config);
   const initializeGitHubConfig = useGitHubConfigStore((s) => s.initialize);
+  const refreshGitHubConfig = useGitHubConfigStore((s) => s.refresh);
   const addNotification = useNotificationStore((s) => s.addNotification);
   const { recipes, runRecipe, loadRecipes } = useRecipeStore();
   const currentProject = useProjectStore((s) => s.currentProject);
@@ -96,6 +97,13 @@ export function NewWorktreeDialog({
   useEffect(() => {
     initializeGitHubConfig();
   }, [initializeGitHubConfig]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (githubConfig?.hasToken && !githubConfig.username) {
+      refreshGitHubConfig();
+    }
+  }, [isOpen, githubConfig?.hasToken, githubConfig?.username, refreshGitHubConfig]);
 
   useEffect(() => {
     if (isOpen && currentProject) {


### PR DESCRIPTION
## Summary
Fixes the assignment toggle not appearing in the worktree creation dialog when GitHub config validation fails during app startup due to poor network connectivity.

Closes #1677

## Changes Made
- Add `refreshGitHubConfig` selector from `useGitHubConfigStore`
- Add `useEffect` hook to detect when dialog opens with a token but missing username
- Trigger config refresh to retry GitHub API validation when this state is detected
- Ensures assignment toggle appears after network recovers, even if initial validation failed

## Root Cause
When the app starts with poor internet, `GitHubAuth.getConfigAsync()` fails to validate the token. The error is caught silently, leaving `config` with `hasToken: true` but `username: undefined`. The store marks itself as initialized and never retries, even after internet recovers.

## Solution
The dialog now detects this partial config state (`hasToken && !username`) and calls `refresh()` when opened, giving the config a second chance to validate after network recovery.