### PR TITLE
Fix: Project switch dialog shows target project name

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -47,6 +47,7 @@ export function AppLayout({
 
   const currentProject = useProjectStore((state) => state.currentProject);
   const isProjectSwitching = useProjectStore((state) => state.isSwitching);
+  const switchingToProjectName = useProjectStore((state) => state.switchingToProjectName);
   const layout = useLayoutState();
 
   useEffect(() => {
@@ -371,7 +372,10 @@ export function AppLayout({
         />
       )}
 
-      <ProjectSwitchOverlay isSwitching={isProjectSwitching} projectName={currentProject?.name} />
+      <ProjectSwitchOverlay
+        isSwitching={isProjectSwitching}
+        projectName={switchingToProjectName ?? undefined}
+      />
     </div>
   );
 }

--- a/src/components/Project/ProjectSwitchOverlay.tsx
+++ b/src/components/Project/ProjectSwitchOverlay.tsx
@@ -14,6 +14,7 @@ const MIN_DISPLAY_DURATION = 200;
 export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitchOverlayProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [shouldRender, setShouldRender] = useState(false);
+  const [cachedProjectName, setCachedProjectName] = useState<string | undefined>(undefined);
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const minDurationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rafRef = useRef<number | null>(null);
@@ -23,6 +24,9 @@ export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitch
   useEffect(() => {
     if (isSwitching) {
       pendingCloseRef.current = false;
+      if (projectName) {
+        setCachedProjectName(projectName);
+      }
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
         closeTimeoutRef.current = null;
@@ -50,10 +54,12 @@ export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitch
         const duration = getUiAnimationDuration();
         if (duration === 0) {
           setShouldRender(false);
+          setCachedProjectName(undefined);
         } else {
           closeTimeoutRef.current = setTimeout(() => {
             closeTimeoutRef.current = null;
             setShouldRender(false);
+            setCachedProjectName(undefined);
           }, duration);
         }
       };
@@ -86,7 +92,7 @@ export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitch
         rafRef.current = null;
       }
     };
-  }, [isSwitching]);
+  }, [isSwitching, projectName]);
 
   if (!shouldRender) return null;
 
@@ -116,9 +122,15 @@ export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitch
           aria-hidden="true"
         />
         <div>
-          <p className="text-sm font-medium text-canopy-text">Switching projects</p>
-          {projectName && (
-            <p className="text-xs text-canopy-text/60 mt-1">Loading {projectName}...</p>
+          {cachedProjectName ? (
+            <>
+              <p className="text-sm font-medium text-canopy-text">
+                Switching to {cachedProjectName}
+              </p>
+              <p className="text-xs text-canopy-text/60 mt-1">Loading workspace...</p>
+            </>
+          ) : (
+            <p className="text-sm font-medium text-canopy-text">Switching projects</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
Fixed the project switch overlay to display the name of the project being switched **to** instead of the project being switched **from**.

Closes #1639

## Changes Made
- Add `switchingToProjectName` state to track target project during switch
- Update AppLayout to pass target project name to overlay
- Cache project name in overlay to prevent flicker during fade-out
- Fix terminal persistence await in reopenProject for consistency
- Clear switchingToProjectName in finishProjectSwitch and error handlers

## Technical Details
The overlay now shows "Switching to {targetProject}" with the correct project name captured atomically when the switch begins, preventing confusion about which project is loading.