### PR TITLE
Fix width of delete worktree dialog causing text wrapping

### DIFF
--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -119,7 +119,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     <AppDialog
       isOpen={isOpen}
       onClose={onClose}
-      size="sm"
+      size="md"
       variant="destructive"
       dismissible={!isDeleting}
     >


### PR DESCRIPTION
## Summary
Increases the delete worktree dialog width to prevent awkward text wrapping in the "Delete branch" checkbox label.

Closes #1681

## Changes Made
- Change dialog size from "sm" to "md" in WorktreeDeleteDialog
- Increases max-width from ~448px to ~576px
- Prevents "Delete branch" checkbox label from wrapping awkwardly