### PR TITLE
Fix: Sync GitHub stats cache when fetching issues/PRs

### DIFF
--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -13,6 +13,7 @@ export const LIST_ISSUES_QUERY = `
   query GetIssues($owner: String!, $repo: String!, $states: [IssueState!], $cursor: String, $limit: Int = 20) {
     repository(owner: $owner, name: $repo) {
       issues(first: $limit, after: $cursor, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}) {
+        totalCount
         pageInfo {
           hasNextPage
           endCursor
@@ -76,6 +77,7 @@ export const LIST_PRS_QUERY = `
   query GetPRs($owner: String!, $repo: String!, $states: [PullRequestState!], $cursor: String, $limit: Int = 20) {
     repository(owner: $owner, name: $repo) {
       pullRequests(first: $limit, after: $cursor, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}) {
+        totalCount
         pageInfo {
           hasNextPage
           endCursor


### PR DESCRIPTION
## Summary
Fixes the issue where toolbar GitHub stats show stale counts when the dropdown fetches fresh data. The problem was that `repoStatsCache` and `issueListCache`/`prListCache` were completely independent - when the dropdown fetched fresh issues/PRs, the toolbar counts remained outdated.

Closes #1643

## Changes Made
- Add totalCount to LIST_ISSUES_QUERY and LIST_PRS_QUERY GraphQL queries
- Create updateRepoStatsCount() helper to sync counts to repoStatsCache
- Update listIssues() and listPullRequests() to sync counts on first-page open fetches
- Hydrate missing counts from persistent cache to prevent zero-seeding
- Write through to persistent GitHubStatsCache when both counts are fresh
- Fixes stale counts in toolbar when dropdown fetches fresh data

## Technical Details
The fix implements cache synchronization between the separate cache systems:
1. When `listIssues()` or `listPullRequests()` fetch open items (first page only), they now update `repoStatsCache` with the fresh count
2. To prevent showing "0" for the other count, the helper hydrates from persistent cache first
3. Once both counts are fresh in memory, they're written to persistent cache for offline/restart scenarios

## Testing
- Typecheck passes
- Build passes
- Code review completed with Codex