### PR TITLE
Fix: Agent terminal immediate working state on Enter submission

### DIFF
--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -542,7 +542,7 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("should enter busy after non-empty input even if prompt stays visible", () => {
+    it("should enter busy immediately after non-empty input (Issue #1638)", () => {
       const onStateChange = vi.fn();
       const monitor = new ActivityMonitor("test-1", 1000, onStateChange, {
         getVisibleLines: () => ["> "],
@@ -555,12 +555,7 @@ describe("ActivityMonitor", () => {
       monitor.onInput("ls");
       monitor.onInput("\r");
 
-      vi.advanceTimersByTime(350);
-      expect(onStateChange).not.toHaveBeenCalledWith("test-1", 1000, "busy", {
-        trigger: "input",
-      });
-
-      vi.advanceTimersByTime(200);
+      // Non-empty Enter should immediately transition to busy (Issue #1638)
       expect(onStateChange).toHaveBeenCalledWith("test-1", 1000, "busy", {
         trigger: "input",
       });


### PR DESCRIPTION
## Summary
Fixes the issue where agent terminals remained in "idle" or "waiting" state even after the user submitted a command by pressing Enter. This change provides instant visual feedback that the agent is processing.

Closes #1638

## Changes Made
- Make Enter with non-empty input immediately trigger busy state in polling mode
- Remove confirmation window delay for non-empty input submissions
- Update test expectations to reflect immediate state transition
- Keep confirmation window for empty Enter to avoid false positives

## Technical Details
Previously, when a user typed text and pressed Enter in an agent terminal, the ActivityMonitor would set a pending input window and wait for either:
1. A working signal (pattern, spinner, output activity), OR
2. A timeout (400ms for non-empty input)

This waiting period caused the terminal to remain in "idle"/"waiting" state. The fix immediately transitions to "working" when Enter is pressed with non-empty input, providing instant feedback while maintaining the confirmation window for empty Enter to avoid false positives.

## Testing
- All 63 ActivityMonitor tests pass
- Updated test expectations for immediate state transition on non-empty Enter