### PR TITLE
Improve stop button visual design in project selector

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
-import { ChevronsUpDown, Plus, Circle } from "lucide-react";
+import { ChevronsUpDown, Plus, Circle, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { useProjectStore } from "@/store/projectStore";
@@ -461,16 +461,13 @@ export function ProjectSwitcher() {
                     onClick={(e) => void handleCloseProject(project.id, e, true)}
                     className={cn(
                       "p-0.5 rounded transition-colors cursor-pointer",
-                      "text-muted-foreground/60 hover:text-red-500 hover:bg-red-500/10",
+                      "text-[var(--color-status-error)] hover:bg-red-500/10",
                       "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                     )}
-                    title="Stop project"
-                    aria-label="Stop project"
+                    title={`Stop project (${stats?.terminalCount ?? 0} session${(stats?.terminalCount ?? 0) === 1 ? "" : "s"})`}
+                    aria-label={`Stop project (${stats?.terminalCount ?? 0} session${(stats?.terminalCount ?? 0) === 1 ? "" : "s"})`}
                   >
-                    <span
-                      className="block w-3 h-3 box-border rounded-[2px] border-2 border-current"
-                      aria-hidden="true"
-                    />
+                    <X className="w-3.5 h-3.5" aria-hidden="true" />
                   </button>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Replaces the ambiguous square box stop button with a clear X icon and red error color to improve visual communication of the destructive action. This change makes the button consistent with the worktree "End All (Kill)" pattern and eliminates confusion with checkbox/selector UI patterns.

Closes #1661

## Changes Made

- Replace ambiguous square box icon with clear X icon from lucide-react
- Apply red error color by default (not just on hover) to signal destructive action
- Enhance tooltip with session count for clearer user feedback
- Ensure visual consistency with worktree "End All (Kill)" pattern
- Use terminalCount instead of processCount to match confirmation dialog terminology

## Visual Changes

**Before:** Muted gray box that only shows red on hover
**After:** Red X icon visible by default, providing immediate visual recognition of destructive action

## Acceptance Criteria Met

- ✅ Stop button uses clear, semantic icon (X) that communicates "terminate/stop"
- ✅ Visual design is consistent with worktree "End All (Kill)" destructive pattern
- ✅ Button color signals danger/destructive action without requiring hover
- ✅ Tooltip clearly describes action with session count
- ✅ No visual ambiguity with selector/checkbox UI patterns
- ✅ Maintains keyboard/screen reader accessibility
- ✅ Hover state provides additional visual feedback