### PR TITLE
Add detailed tooltips to agent state icons showing transition reasons

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -4,7 +4,7 @@ import { PanelHeader } from "./PanelHeader";
 import { useIsDragging } from "@/components/DragDrop";
 import { TitleEditingProvider, useTitleEditing } from "./TitleEditingContext";
 import { TerminalHeaderContent } from "@/components/Terminal/TerminalHeaderContent";
-import type { PanelKind, TerminalType, AgentState } from "@/types";
+import type { PanelKind, TerminalType, AgentState, AgentStateChangeTrigger } from "@/types";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 
 /**
@@ -56,6 +56,8 @@ export interface ContentPanelProps extends BasePanelProps {
   lastCommand?: string;
   queueCount?: number;
   flowStatus?: "running" | "paused-backpressure" | "paused-user" | "suspended";
+  stateChangeTrigger?: AgentStateChangeTrigger;
+  stateChangeConfidence?: number;
   onRestart?: () => void;
   isPinged?: boolean;
   wasJustSelected?: boolean;
@@ -97,6 +99,8 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     lastCommand,
     queueCount = 0,
     flowStatus,
+    stateChangeTrigger,
+    stateChangeConfidence,
     onRestart,
     isPinged,
     wasJustSelected,
@@ -132,6 +136,8 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           exitCode={exitCode}
           queueCount={queueCount}
           flowStatus={flowStatus}
+          stateChangeTrigger={stateChangeTrigger}
+          stateChangeConfidence={stateChangeConfidence}
         />
       );
     }
@@ -148,6 +154,8 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     exitCode,
     queueCount,
     flowStatus,
+    stateChangeTrigger,
+    stateChangeConfidence,
   ]);
 
   const handleTitleDoubleClick = useCallback(


### PR DESCRIPTION
## Summary
This PR enhances agent state icons with detailed tooltips that show why the agent transitioned to its current state, including the trigger reason and confidence level when available.

Closes #1670

## Changes Made
- Add stateChangeTrigger and stateChangeConfidence props throughout component hierarchy (TerminalPane → ContentPanel → TerminalHeaderContent)
- Create formatStateTransitionReason helper with user-friendly, non-technical messages
- Build detailed tooltips showing activity headline and state transition reason
- Use single-line format with bullet separators for cross-browser compatibility
- Decouple confidence display from trigger to show independently when available
- Consolidate terminal state selectors into single useShallow call for better performance and consistent snapshots
- Optimize TerminalHeaderContent selector to select boolean directly and avoid unnecessary re-renders