### PR TITLE
Fade dock status badges when agent hybrid input focused

### DIFF
--- a/src/components/Layout/DockStatusOverlay.tsx
+++ b/src/components/Layout/DockStatusOverlay.tsx
@@ -9,12 +9,14 @@ interface DockStatusOverlayProps {
   waitingCount: number;
   failedCount: number;
   trashedCount: number;
+  shouldFadeForInput?: boolean;
 }
 
 export function DockStatusOverlay({
   waitingCount,
   failedCount,
   trashedCount,
+  shouldFadeForInput = false,
 }: DockStatusOverlayProps) {
   const hasAny = waitingCount > 0 || failedCount > 0 || trashedCount > 0;
 
@@ -43,7 +45,8 @@ export function DockStatusOverlay({
         "border border-[var(--dock-border)]/60",
         "shadow-lg",
         "transition-[opacity,background-color,border-color] duration-200",
-        "opacity-85 hover:opacity-100 focus-within:opacity-100",
+        shouldFadeForInput ? "opacity-30" : "opacity-85",
+        "hover:opacity-100 focus-within:opacity-100",
         "hover:bg-[var(--dock-bg)]/95 hover:border-[var(--dock-border)]",
         "focus-within:bg-[var(--dock-bg)]/95 focus-within:border-[var(--dock-border)]"
       )}

--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -17,6 +17,7 @@ export function TerminalDockRegion() {
     waitingCount,
     failedCount,
     trashedCount,
+    shouldFadeForInput,
   } = useDockRenderState();
 
   const setMode = useDockStore((state) => state.setMode);
@@ -44,6 +45,7 @@ export function TerminalDockRegion() {
           waitingCount={waitingCount}
           failedCount={failedCount}
           trashedCount={trashedCount}
+          shouldFadeForInput={shouldFadeForInput}
         />
       )}
 


### PR DESCRIPTION
## Summary

Reduces opacity of dock status badges (waiting, failed, trash) to 30% when the focused terminal is an agent with hybrid input enabled, making it easier to read text in the hybrid input bar that would otherwise be obscured by the overlay badges.

Closes #1671

## Changes Made

- Add shouldFadeForInput state to useDockRenderState hook
- Use isAgentTerminal utility for proper agent detection across all terminal types
- Apply opacity-30 fade to dock status badges when focused terminal is agent with hybrid input enabled
- Fix state tearing by using single selector for focused terminal detection
- Maintain hover and focus-within opacity-100 for discoverability