### PR TITLE
Fix: Restore browser panel URLs per project

### DIFF
--- a/src/hooks/app/useProjectSwitchRehydration.ts
+++ b/src/hooks/app/useProjectSwitchRehydration.ts
@@ -13,6 +13,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { HydrationCallbacks } from "./useAppHydration";
+import { useBrowserStateStore } from "@/store/browserStateStore";
 
 export function useProjectSwitchRehydration(callbacks: HydrationCallbacks) {
   useEffect(() => {
@@ -58,6 +59,9 @@ export function useProjectSwitchRehydration(callbacks: HydrationCallbacks) {
       console.log(
         "[useProjectSwitchRehydration] Received PROJECT_ON_SWITCH from main process, re-hydrating..."
       );
+      // Clear browser state before hydration for menu-driven switches
+      // (renderer-driven switches already reset via resetAllStoresForProjectSwitch)
+      useBrowserStateStore.getState().reset();
       window.dispatchEvent(new CustomEvent("project-switched"));
     });
 

--- a/src/store/resetStores.ts
+++ b/src/store/resetStores.ts
@@ -9,6 +9,7 @@ import { useErrorStore } from "./errorStore";
 import { useNotificationStore } from "./notificationStore";
 import { cleanupNotesStore } from "./notesStore";
 import { useRecipeStore } from "./recipeStore";
+import { useBrowserStateStore } from "./browserStateStore";
 
 export async function resetAllStoresForProjectSwitch(): Promise<void> {
   // Use resetWithoutKilling instead of reset
@@ -28,4 +29,7 @@ export async function resetAllStoresForProjectSwitch(): Promise<void> {
   useErrorStore.getState().reset();
   useNotificationStore.getState().reset();
   cleanupNotesStore();
+  // Reset browser state to ensure per-project URLs are restored from project persistence
+  // rather than using stale localStorage state from a different project
+  useBrowserStateStore.getState().reset();
 }


### PR DESCRIPTION
## Summary
Fixes browser panel URL restoration when switching between projects. Previously, browser panels would show default URLs (http://localhost:3000) after project switches because global localStorage state took precedence over per-project persisted URLs.

Closes #1653

## Changes Made
- Reset browserStateStore in resetAllStoresForProjectSwitch for renderer-driven switches
- Clear browser state in PROJECT_ON_SWITCH handler for menu-driven switches
- Ensures per-project persisted URLs take precedence over stale global localStorage

## Technical Details
The issue had two root causes:
1. **Renderer-driven switches** (via projectStore.switchProject): Didn't reset browserStateStore, allowing stale URLs from previous project
2. **Menu-driven switches** (via Electron menu → PROJECT_ON_SWITCH IPC): Completely bypassed store reset logic

Both paths now clear browserStateStore before hydration, ensuring the per-project browserUrl from persistence takes effect.