### PR TITLE
Add panel self-exit capability and recipe integration

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -405,6 +405,8 @@ interface PtyPanelData extends BasePanelData {
   browserUrl?: string;
   /** Dev command override for dev-preview panels */
   devCommand?: string;
+  /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
+  exitBehavior?: PanelExitBehavior;
 }
 
 interface BrowserPanelData extends BasePanelData {
@@ -490,6 +492,8 @@ export interface TerminalInstance {
   createdAt?: number;
   /** Dev command override for dev-preview panels */
   devCommand?: string;
+  /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
+  exitBehavior?: PanelExitBehavior;
 }
 
 /** Options for spawning a new PTY process */
@@ -626,6 +630,9 @@ export interface ProjectState {
 /** Recipe terminal type */
 export type RecipeTerminalType = AgentId | "terminal" | "dev-preview";
 
+/** Exit behavior for panels/terminals after process exits */
+export type PanelExitBehavior = "keep" | "trash" | "remove";
+
 /** A single terminal definition within a recipe */
 export interface RecipeTerminal {
   /** Type of terminal to spawn */
@@ -640,6 +647,8 @@ export interface RecipeTerminal {
   initialPrompt?: string;
   /** Dev server command for dev-preview terminals (optional). Falls back to project devServerCommand if not set. */
   devCommand?: string;
+  /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely (optional, defaults to "keep") */
+  exitBehavior?: PanelExitBehavior;
 }
 
 /** A saved terminal recipe */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -72,6 +72,8 @@ export type {
   // Project settings types
   RunCommand,
   ProjectSettings,
+  // Panel exit behavior
+  PanelExitBehavior,
 } from "./domain.js";
 
 // IPC types - communication payloads

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -278,74 +278,175 @@ export function RecipeEditor({
                 </div>
 
                 {terminal.type === "terminal" && (
-                  <div className="mt-2">
-                    <label
-                      htmlFor={`terminal-command-${index}`}
-                      className="block text-xs font-medium text-canopy-text mb-1"
-                    >
-                      Command (optional)
-                    </label>
-                    <input
-                      id={`terminal-command-${index}`}
-                      type="text"
-                      value={terminal.command || ""}
-                      onChange={(e) => handleTerminalChange(index, "command", e.target.value)}
-                      placeholder="e.g., npm run dev"
-                      className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
-                    />
-                  </div>
+                  <>
+                    <div className="mt-2">
+                      <label
+                        htmlFor={`terminal-command-${index}`}
+                        className="block text-xs font-medium text-canopy-text mb-1"
+                      >
+                        Command (optional)
+                      </label>
+                      <input
+                        id={`terminal-command-${index}`}
+                        type="text"
+                        value={terminal.command || ""}
+                        onChange={(e) => handleTerminalChange(index, "command", e.target.value)}
+                        placeholder="e.g., npm run dev"
+                        className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
+                      />
+                    </div>
+                    <div className="mt-2">
+                      <label
+                        htmlFor={`terminal-exit-behavior-${index}`}
+                        className="block text-xs font-medium text-canopy-text mb-1"
+                      >
+                        After Exit
+                      </label>
+                      <select
+                        id={`terminal-exit-behavior-${index}`}
+                        value={terminal.exitBehavior || "trash"}
+                        onChange={(e) =>
+                          handleTerminalChange(
+                            index,
+                            "exitBehavior",
+                            e.target.value === "trash" ? "" : e.target.value
+                          )
+                        }
+                        aria-describedby={`terminal-exit-behavior-help-${index}`}
+                        className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
+                      >
+                        <option value="trash">Send to Trash (default)</option>
+                        <option value="keep">Keep for Review</option>
+                        <option value="remove">Remove Completely</option>
+                      </select>
+                      <p
+                        id={`terminal-exit-behavior-help-${index}`}
+                        className="text-xs text-canopy-muted mt-1"
+                      >
+                        Failures always preserve terminal for debugging
+                      </p>
+                    </div>
+                  </>
                 )}
 
                 {terminal.type !== "terminal" && terminal.type !== "dev-preview" && (
-                  <div className="mt-2">
-                    <label
-                      htmlFor={`terminal-initial-prompt-${index}`}
-                      className="block text-xs font-medium text-canopy-text mb-1"
-                    >
-                      Initial Prompt (optional)
-                    </label>
-                    <textarea
-                      id={`terminal-initial-prompt-${index}`}
-                      value={terminal.initialPrompt || ""}
-                      onChange={(e) => handleTerminalChange(index, "initialPrompt", e.target.value)}
-                      placeholder="e.g., Review the latest changes and suggest improvements"
-                      rows={2}
-                      aria-describedby={`terminal-initial-prompt-help-${index}`}
-                      className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text resize-y min-h-[60px]"
-                    />
-                    <p
-                      id={`terminal-initial-prompt-help-${index}`}
-                      className="text-xs text-canopy-muted mt-1"
-                    >
-                      This prompt will be sent to the agent when it starts
-                    </p>
-                  </div>
+                  <>
+                    <div className="mt-2">
+                      <label
+                        htmlFor={`terminal-initial-prompt-${index}`}
+                        className="block text-xs font-medium text-canopy-text mb-1"
+                      >
+                        Initial Prompt (optional)
+                      </label>
+                      <textarea
+                        id={`terminal-initial-prompt-${index}`}
+                        value={terminal.initialPrompt || ""}
+                        onChange={(e) =>
+                          handleTerminalChange(index, "initialPrompt", e.target.value)
+                        }
+                        placeholder="e.g., Review the latest changes and suggest improvements"
+                        rows={2}
+                        aria-describedby={`terminal-initial-prompt-help-${index}`}
+                        className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text resize-y min-h-[60px]"
+                      />
+                      <p
+                        id={`terminal-initial-prompt-help-${index}`}
+                        className="text-xs text-canopy-muted mt-1"
+                      >
+                        This prompt will be sent to the agent when it starts
+                      </p>
+                    </div>
+                    <div className="mt-2">
+                      <label
+                        htmlFor={`terminal-agent-exit-behavior-${index}`}
+                        className="block text-xs font-medium text-canopy-text mb-1"
+                      >
+                        After Exit
+                      </label>
+                      <select
+                        id={`terminal-agent-exit-behavior-${index}`}
+                        value={terminal.exitBehavior || "keep"}
+                        onChange={(e) =>
+                          handleTerminalChange(
+                            index,
+                            "exitBehavior",
+                            e.target.value === "keep" ? "" : e.target.value
+                          )
+                        }
+                        aria-describedby={`terminal-agent-exit-behavior-help-${index}`}
+                        className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
+                      >
+                        <option value="keep">Keep for Review (default)</option>
+                        <option value="trash">Send to Trash</option>
+                        <option value="remove">Remove Completely</option>
+                      </select>
+                      <p
+                        id={`terminal-agent-exit-behavior-help-${index}`}
+                        className="text-xs text-canopy-muted mt-1"
+                      >
+                        Failures always preserve terminal for debugging
+                      </p>
+                    </div>
+                  </>
                 )}
 
                 {terminal.type === "dev-preview" && (
-                  <div className="mt-2">
-                    <label
-                      htmlFor={`terminal-dev-command-${index}`}
-                      className="block text-xs font-medium text-canopy-text mb-1"
-                    >
-                      Dev Command (optional)
-                    </label>
-                    <input
-                      id={`terminal-dev-command-${index}`}
-                      type="text"
-                      value={terminal.devCommand || ""}
-                      onChange={(e) => handleTerminalChange(index, "devCommand", e.target.value)}
-                      placeholder="e.g., npm run dev"
-                      aria-describedby={`terminal-dev-command-help-${index}`}
-                      className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
-                    />
-                    <p
-                      id={`terminal-dev-command-help-${index}`}
-                      className="text-xs text-canopy-muted mt-1"
-                    >
-                      Leave empty to use project default or auto-detect from package.json
-                    </p>
-                  </div>
+                  <>
+                    <div className="mt-2">
+                      <label
+                        htmlFor={`terminal-dev-command-${index}`}
+                        className="block text-xs font-medium text-canopy-text mb-1"
+                      >
+                        Dev Command (optional)
+                      </label>
+                      <input
+                        id={`terminal-dev-command-${index}`}
+                        type="text"
+                        value={terminal.devCommand || ""}
+                        onChange={(e) => handleTerminalChange(index, "devCommand", e.target.value)}
+                        placeholder="e.g., npm run dev"
+                        aria-describedby={`terminal-dev-command-help-${index}`}
+                        className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
+                      />
+                      <p
+                        id={`terminal-dev-command-help-${index}`}
+                        className="text-xs text-canopy-muted mt-1"
+                      >
+                        Leave empty to use project default or auto-detect from package.json
+                      </p>
+                    </div>
+                    <div className="mt-2">
+                      <label
+                        htmlFor={`terminal-dev-exit-behavior-${index}`}
+                        className="block text-xs font-medium text-canopy-text mb-1"
+                      >
+                        After Exit
+                      </label>
+                      <select
+                        id={`terminal-dev-exit-behavior-${index}`}
+                        value={terminal.exitBehavior || "trash"}
+                        onChange={(e) =>
+                          handleTerminalChange(
+                            index,
+                            "exitBehavior",
+                            e.target.value === "trash" ? "" : e.target.value
+                          )
+                        }
+                        aria-describedby={`terminal-dev-exit-behavior-help-${index}`}
+                        className="w-full px-2 py-1.5 bg-canopy-sidebar border border-canopy-border rounded text-sm text-canopy-text"
+                      >
+                        <option value="trash">Send to Trash (default)</option>
+                        <option value="keep">Keep for Review</option>
+                        <option value="remove">Remove Completely</option>
+                      </select>
+                      <p
+                        id={`terminal-dev-exit-behavior-help-${index}`}
+                        className="text-xs text-canopy-muted mt-1"
+                      >
+                        Failures always preserve terminal for debugging
+                      </p>
+                    </div>
+                  </>
                 )}
               </div>
             ))}

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -129,6 +129,7 @@ export const createTerminalRegistrySlice =
               rows: 24,
               devCommand: options.devCommand,
               browserUrl: options.browserUrl,
+              exitBehavior: options.exitBehavior,
             };
           } else {
             terminal = {
@@ -338,6 +339,7 @@ export const createTerminalRegistrySlice =
             isVisible: location === "grid" ? true : false,
             runtimeStatus,
             isInputLocked: options.isInputLocked,
+            exitBehavior: options.exitBehavior,
           };
 
           set((state) => {
@@ -350,12 +352,13 @@ export const createTerminalRegistrySlice =
                 `[TerminalStore] Terminal ${id} already exists, updating instead of adding`
               );
               const existing = state.terminals[existingIndex];
-              // Preserve existing agentState/lastStateChange if new values are undefined
+              // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
               const preservedTerminal = isReconnect
                 ? {
                     ...terminal,
                     agentState: terminal.agentState ?? existing.agentState,
                     lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                    exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
                   }
                 : terminal;
               newTerminals = state.terminals.map((t, i) =>

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -8,6 +8,7 @@ import type {
   TerminalFlowStatus,
   TerminalRuntimeStatus,
   SpawnError,
+  PanelExitBehavior,
 } from "@/types";
 import type { PanelKind } from "@/types";
 
@@ -48,6 +49,8 @@ export interface AddTerminalOptions {
   devCommand?: string;
   /** Environment variables to set for this terminal */
   env?: Record<string, string>;
+  /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
+  exitBehavior?: PanelExitBehavior;
 }
 
 export interface TrashedTerminal {


### PR DESCRIPTION
## Summary
Implements panel self-exit capability allowing terminals to automatically exit, trash, or remove themselves after command completion through the new exitBehavior field.

Closes #1674

## Changes Made
- Add PanelExitBehavior type with keep/trash/remove options
- Implement exit handler logic respecting exitBehavior settings
- Add UI controls in RecipeEditor for all terminal types (terminal, agent, dev-preview)
- Preserve exitBehavior during reconnection and hydration
- Add tolerant import validation for recipe exitBehavior field
- Handle explicit "keep" behavior to prevent auto-trash
- Non-zero exit codes always preserve terminals for debugging