### PR TITLE
Fix: Agent terminals freeze after project switch due to tier desync

### DIFF
--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -158,6 +158,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
             spawnedAt: terminal.spawnedAt,
             isTrashed: terminal.isTrashed,
             trashExpiresAt: terminal.trashExpiresAt,
+            activityTier: terminal.activityTier,
           });
         }
       }
@@ -199,6 +200,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         cwd: terminal.cwd,
         agentState: terminal.agentState,
         lastStateChange: terminal.lastStateChange,
+        activityTier: terminal.activityTier,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1063,6 +1063,7 @@ port.on("message", async (rawMsg: any) => {
                 spawnedAt: terminal.spawnedAt,
                 isTrashed: terminal.isTrashed,
                 trashExpiresAt: terminal.trashExpiresAt,
+                activityTier: ptyManager.getActivityTier(msg.id),
               }
             : null,
         });

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -64,6 +64,7 @@ interface TerminalInfoResponse {
   spawnedAt: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;
+  activityTier?: "active" | "background";
 }
 
 export interface PtyClientConfig {

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -386,7 +386,7 @@ export class PtyManager extends EventEmitter {
       lastInputTime: terminalInfo.lastInputTime,
       lastOutputTime: terminalInfo.lastOutputTime,
       lastStateChange: terminalInfo.lastStateChange,
-      activityTier: "focused",
+      activityTier: terminal.getActivityTier() as "focused" | "visible" | "background",
       outputBufferSize: terminalInfo.outputBuffer.length,
       semanticBufferLines: terminalInfo.semanticBuffer.length,
       restartCount: terminalInfo.restartCount,
@@ -544,6 +544,14 @@ export class PtyManager extends EventEmitter {
     if (terminal) {
       terminal.setActivityMonitorTier(interval);
     }
+  }
+
+  /**
+   * Get the current activity tier for a terminal.
+   */
+  getActivityTier(id: string): "active" | "background" | undefined {
+    const terminal = this.registry.get(id);
+    return terminal?.getActivityTier();
   }
 
   /**

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -118,6 +118,7 @@ export class TerminalProcess {
   private readonly terminalInfo: TerminalInfo;
   private readonly isAgentTerminal: boolean;
   private forensicsBuffer = new TerminalForensicsBuffer();
+  private _activityTier: "active" | "background" = "active";
 
   private restoreSessionIfPresent(headlessTerminal: HeadlessTerminalType): void {
     if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
@@ -506,6 +507,7 @@ export class TerminalProcess {
       lastCheckTime: t.lastCheckTime,
       detectedAgentType: t.detectedAgentType,
       restartCount: t.restartCount,
+      activityTier: this._activityTier,
     };
   }
 
@@ -994,9 +996,17 @@ export class TerminalProcess {
   }
 
   setActivityMonitorTier(pollingIntervalMs: number): void {
+    // Track activity tier based on polling interval:
+    // 50ms = active (foreground), 500ms = background (project switched away)
+    this._activityTier = pollingIntervalMs <= 50 ? "active" : "background";
+
     if (this.activityMonitor) {
       this.activityMonitor.setPollingInterval(pollingIntervalMs);
     }
+  }
+
+  getActivityTier(): "active" | "background" {
+    return this._activityTier;
   }
 
   setSabModeEnabled(_enabled: boolean): void {

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -46,6 +46,8 @@ export interface TerminalPublicState {
   restartCount: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;
+  /** Current activity tier: "active" (foreground) or "background" (project switched away) */
+  activityTier?: "active" | "background";
 }
 
 /**

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -115,6 +115,8 @@ export interface BackendTerminalInfo {
   spawnedAt: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;
+  /** Current activity tier: "active" (foreground) or "background" (project switched away) */
+  activityTier?: "active" | "background";
 }
 
 /** Result from terminal reconnect operation */
@@ -126,6 +128,7 @@ export interface TerminalReconnectResult {
   cwd?: string;
   agentState?: AgentState;
   lastStateChange?: number;
+  activityTier?: "active" | "background";
   error?: string;
 }
 

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -204,6 +204,8 @@ export interface PtyHostTerminalInfo {
   spawnedAt: number;
   isTrashed?: boolean;
   trashExpiresAt?: number;
+  /** Current activity tier: "active" (foreground) or "background" (project switched away) */
+  activityTier?: "active" | "background";
 }
 
 /** Payload for agent:spawned event */

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -716,6 +716,15 @@ class TerminalInstanceService {
     this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
   }
 
+  /**
+   * Initialize the backend tier state for a reconnected terminal.
+   * This ensures proper wake behavior after project switch by setting
+   * the frontend's lastBackendTier to match the actual backend state.
+   */
+  initializeBackendTier(id: string, tier: "active" | "background"): void {
+    this.rendererPolicy.initializeBackendTier(id, tier);
+  }
+
   addExitListener(id: string, cb: (exitCode: number) => void): () => void {
     const managed = this.instances.get(id);
     if (!managed) return () => {};

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -130,6 +130,23 @@ export class TerminalRendererPolicy {
     this.lastBackendTier.delete(id);
   }
 
+  /**
+   * Initialize the backend tier state for a terminal that was reconnected.
+   * This ensures the frontend knows the actual backend tier state after project switch,
+   * allowing proper wake behavior when transitioning back to active.
+   */
+  initializeBackendTier(id: string, tier: "active" | "background"): void {
+    this.lastBackendTier.set(id, tier);
+
+    // If initializing to background, set needsWake to ensure wake happens on next activation
+    if (tier === "background") {
+      const managed = this.deps.getInstance(id);
+      if (managed) {
+        managed.needsWake = true;
+      }
+    }
+  }
+
   dispose(): void {
     this.lastBackendTier.clear();
   }

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -153,6 +153,16 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
                   lastStateChange: backendLastStateChange,
                 });
 
+                // Initialize frontend tier state from backend to ensure proper wake behavior
+                // after project switch. Without this, frontend defaults to "active" which prevents
+                // proper wake when transitioning from background to active tier.
+                if (backendTerminal.activityTier) {
+                  terminalInstanceService.initializeBackendTier(
+                    backendTerminal.id,
+                    backendTerminal.activityTier
+                  );
+                }
+
                 // Restore terminal content from backend headless state
                 try {
                   await terminalInstanceService.fetchAndRestore(backendTerminal.id);
@@ -275,6 +285,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
                 agentState: currentAgentState,
                 lastStateChange: backendLastStateChange,
               });
+
+              // Initialize frontend tier state from backend to ensure proper wake behavior
+              if (terminal.activityTier) {
+                terminalInstanceService.initializeBackendTier(terminal.id, terminal.activityTier);
+              }
 
               // Restore terminal content from backend headless state
               try {


### PR DESCRIPTION
## Summary
Fixes agent terminals freezing after project switch by synchronizing backend activity tier state to the frontend during reconnection.

Previously, when switching back to a project, the frontend would default to assuming terminals were in "active" tier, even though the backend had backgrounded them. This mismatch prevented proper wake operations, causing terminals to appear frozen.

Closes #1691

## Changes Made
- Add activityTier field to backend terminal info types (BackendTerminalInfo, PtyHostTerminalInfo, TerminalPublicState)
- Track activity tier in TerminalProcess based on polling interval (50ms=active, 500ms=background)
- Include activityTier in all IPC terminal responses (getForProject, reconnect, get-terminal)
- Initialize frontend lastBackendTier from backend state during hydration
- Set needsWake flag when initializing to background tier to ensure proper wake behavior
- Update diagnostic info to show actual tier instead of hard-coded "focused"

## Technical Details
The fix implements "Option C" from the issue analysis - backend notifies frontend of tier state. When terminals reconnect during project switch, the frontend now initializes its `lastBackendTier` map with the actual backend state, ensuring wake operations trigger correctly when transitioning back to active tier.