### PR TITLE
Add terminal view toggle to dev preview panel

### DIFF
--- a/electron/services/DevPreviewService.ts
+++ b/electron/services/DevPreviewService.ts
@@ -343,6 +343,7 @@ export class DevPreviewService extends EventEmitter {
       message,
       timestamp: Date.now(),
       error: status === "error" ? message : undefined,
+      ptyId: session?.ptyId ?? "",
     });
   }
 

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -6,6 +6,8 @@ export interface DevPreviewStatusPayload {
   message: string;
   timestamp: number;
   error?: string;
+  /** PTY ID for the dev server terminal (empty string in browser-only mode) */
+  ptyId: string;
 }
 
 export interface DevPreviewUrlPayload {


### PR DESCRIPTION
## Summary
Adds ability to view the underlying dev server terminal output within the dev preview panel. Users can now toggle between browser preview and terminal views to inspect server logs, errors, and status without switching to a separate terminal panel.

Closes #1647

## Changes Made
- Add ptyId to DevPreviewStatusPayload for renderer access to dev server PTY
- Add view toggle button in dev preview status bar (Terminal/Globe icons)
- Implement conditional rendering between browser webview and XtermAdapter
- Configure terminal as read-only for inspection purposes
- Preserve browser state when switching views using display:none
- Handle browser-only mode by hiding toggle button when no PTY exists

## Implementation Details
- The toggle button appears in the status bar when a dev server PTY exists
- Browser view is hidden using `display: none` to preserve webview state (scroll position, form data)
- Terminal view uses XtermAdapter with `isInputLocked={true}` for read-only access
- Button disabled in browser-only mode (no PTY available)