### PR TITLE
Fix: Improve dev preview server status bar UI

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { RotateCw } from "lucide-react";
+import { Server, Power } from "lucide-react";
 import { BrowserToolbar } from "@/components/Browser/BrowserToolbar";
 import { isValidBrowserUrl, normalizeBrowserUrl } from "@/components/Browser/browserUtils";
 import { useIsDragging } from "@/components/DragDrop";
@@ -283,7 +283,9 @@ export function DevPreviewPane({
       if (payload.panelId !== id) return;
       setStatus(payload.status);
       setMessage(payload.message);
-      setError(payload.status === "error" ? (payload.error ?? payload.message) : undefined);
+      setError(
+        payload.status === "error" ? (payload.error?.trim() || payload.message || undefined) : undefined
+      );
       setIsBrowserOnly((prev) => prev || payload.message.includes("Browser-only mode"));
       if (
         payload.status === "running" ||
@@ -689,28 +691,31 @@ export function DevPreviewPane({
         </div>
         <div className="flex items-center justify-between gap-3 px-3 py-1.5 border-t border-canopy-border bg-[color-mix(in_oklab,var(--color-surface)_92%,transparent)] text-xs text-canopy-text/70">
           <div className="flex items-center gap-2 min-w-0" role="status" aria-live="polite">
+            <Server className="w-3.5 h-3.5 text-canopy-text/40 shrink-0" />
             <span className={cn("h-2 w-2 rounded-full shrink-0", statusStyle.dot)} />
-            <span className={cn("font-medium", statusStyle.text)}>{statusStyle.label}</span>
-            <span className="truncate">{message}</span>
-          </div>
-          <div className="flex items-center gap-2 min-w-0">
-            {hasValidUrl && (
-              <span className="font-mono text-canopy-text/50 truncate max-w-[45%]">
-                {currentUrl}
+            {status === "running" && !isBrowserOnly ? (
+              <span className={cn("font-medium", statusStyle.text)}>{statusStyle.label}</span>
+            ) : status === "error" && error ? (
+              <span className={cn("truncate", statusStyle.text)} title={error}>
+                {error}
+              </span>
+            ) : (
+              <span className="truncate text-canopy-text/60" title={message}>
+                {message}
               </span>
             )}
-            <button
-              type="button"
-              onClick={handleRestart}
-              disabled={showRestartSpinner}
-              className={cn(buttonClass, showRestartSpinner && "animate-spin")}
-              title="Restart dev server"
-              aria-label="Restart dev server"
-              aria-busy={showRestartSpinner}
-            >
-              <RotateCw className="w-4 h-4" />
-            </button>
           </div>
+          <button
+            type="button"
+            onClick={handleRestart}
+            disabled={showRestartSpinner}
+            className={cn(buttonClass, showRestartSpinner && "animate-pulse")}
+            title="Restart dev server"
+            aria-label="Restart dev server"
+            aria-busy={showRestartSpinner}
+          >
+            <Power className="w-4 h-4" />
+          </button>
         </div>
       </div>
     </ContentPanel>


### PR DESCRIPTION
## Summary
Redesigned the dev preview panel's server status bar to improve clarity and remove redundant information. The status bar now provides a cleaner, more informative display that better distinguishes server controls from browser navigation controls.

Closes #1646

## Changes Made
- Add Server icon to distinguish server controls from browser controls
- Remove duplicate URL display (already shown in address bar)
- Show concise status for running state, detailed messages for other states
- Preserve browser-only mode message visibility
- Apply error severity styling to error messages with title tooltips
- Change restart button icon from RotateCw to Power for distinction
- Change restart animation from spin to pulse
- Fix empty string error handling with trim check