### PR TITLE
Rename terminal grid terminology to panel grid for consistency

### DIFF
--- a/.claude/commands/evaluate-feature.md
+++ b/.claude/commands/evaluate-feature.md
@@ -31,7 +31,7 @@ It is where you _direct_ work, not necessarily where you _do_ the work. It exist
 
 ### Core Pillars
 
-1. **Terminal Grid** - Manage multiple terminal sessions running AI agents in parallel
+1. **Panel Grid** - Manage multiple panel sessions running AI agents in parallel
 2. **Worktree Dashboard** - Visual monitoring of git worktrees with real-time status
 3. **Agent State Tracking** - Know when agents are working, waiting for you, or completed
 4. **Context Injection** - Generate and inject codebase context into agents via CopyTree

--- a/.claude/commands/tidy.md
+++ b/.claude/commands/tidy.md
@@ -135,7 +135,7 @@ Curate comments in these files:
 1. src/components/Layout/AppLayout.tsx
 2. src/components/Layout/Sidebar.tsx
 3. src/components/Layout/Toolbar.tsx
-4. src/components/Terminal/TerminalGrid.tsx
+4. src/components/Terminal/ContentGrid.tsx
 5. src/components/Terminal/TerminalPane.tsx
 
 For each file:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Electron-based IDE for orchestrating AI coding agents. Features terminal grid, worktree dashboard, and context injection.
+Electron-based IDE for orchestrating AI coding agents. Features panel grid, worktree dashboard, and context injection.
 
 ## Project Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The **Actions System** is the central orchestration layer for all UI operations.
 
 ### Panel Architecture
 
-Panels are the visual units in the terminal grid and dock. The system uses discriminated union types for type safety:
+Panels are the visual units in the panel grid and dock. The system uses discriminated union types for type safety:
 
 - `PanelInstance = PtyPanelData | BrowserPanelData`
 - Built-in panel kinds: `"terminal"` | `"agent"` | `"browser"`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Instead of juggling multiple terminal windows and manually copying context, Cano
 
 ### Agent Orchestration
 
-- **Smart Terminals**: Integrated terminal grid capable of running standard shells or AI agents
+- **Smart Terminals**: Integrated panel grid capable of running standard shells or AI agents
 - **Lifecycle Tracking**: Automatically detects agent states (`idle`, `working`, `waiting`, `completed`, `failed`) via output heuristics
 - **Waiting For You**: A dedicated notification strip that alerts you when an agent needs human input
 - **Activity Monitoring**: Semantic analysis of terminal output with human-readable status headlines
@@ -31,7 +31,7 @@ Instead of juggling multiple terminal windows and manually copying context, Cano
 
 ### Multi-Panel Terminal Environment
 
-- **Drag-and-Drop Layout**: Reorderable terminal grid with dnd-kit integration
+- **Drag-and-Drop Layout**: Reorderable panel grid with dnd-kit integration
 - **Resizable Panels**: Dock and trash system for terminal organization
 - **Performance Modes**: Optimized rendering for handling dozens of terminals
 - **Hybrid Input Bar**: Command submission without typing directly in terminal

--- a/docs/development.md
+++ b/docs/development.md
@@ -65,14 +65,14 @@ Main Process (electron/)     Renderer (src/)
 
 **Key Stores:**
 
-| Store                | State                           |
-| -------------------- | ------------------------------- |
-| `terminalStore`      | Terminal instances, grid layout |
-| `terminalInputStore` | Hybrid input bar state          |
-| `worktreeStore`      | Active worktree, selection      |
-| `worktreeDataStore`  | Worktree list, git status       |
-| `projectStore`       | Current project, project list   |
-| `sidecarStore`       | Sidecar tabs, visibility        |
+| Store                | State                         |
+| -------------------- | ----------------------------- |
+| `terminalStore`      | Panel instances, grid layout  |
+| `terminalInputStore` | Hybrid input bar state        |
+| `worktreeStore`      | Active worktree, selection    |
+| `worktreeDataStore`  | Worktree list, git status     |
+| `projectStore`       | Current project, project list |
+| `sidecarStore`       | Sidecar tabs, visibility      |
 
 ### Shared Types (`shared/types/ipc/`)
 

--- a/docs/feature-curation.md
+++ b/docs/feature-curation.md
@@ -16,7 +16,7 @@ It is where you _direct_ work, not necessarily where you _do_ the work. It exist
 
 ## Core Pillars
 
-1. **Terminal Grid** - Manage multiple terminal sessions running AI agents in parallel
+1. **Panel Grid** - Manage multiple panel sessions running AI agents in parallel
 2. **Worktree Dashboard** - Visual monitoring of git worktrees with real-time status
 3. **Agent State Tracking** - Know when agents are working, waiting for you, or completed
 4. **Context Injection** - Generate and inject codebase context into agents via CopyTree

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -336,8 +336,8 @@ export function registerAppStateHandlers(): () => void {
         }
       }
 
-      if ("terminalGridConfig" in partialState) {
-        const gridConfig = partialState.terminalGridConfig;
+      if ("panelGridConfig" in partialState) {
+        const gridConfig = partialState.panelGridConfig;
         if (gridConfig && typeof gridConfig === "object") {
           const strategy = gridConfig.strategy;
           const value = Number(gridConfig.value);
@@ -349,7 +349,7 @@ export function registerAppStateHandlers(): () => void {
             value >= 1 &&
             value <= 10
           ) {
-            updates.terminalGridConfig = {
+            updates.panelGridConfig = {
               strategy,
               value,
             };

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -1,10 +1,6 @@
 import Store from "electron-store";
 import type { Project } from "./types/index.js";
-import type {
-  AgentSettings,
-  TerminalGridConfig,
-  UserAgentRegistry,
-} from "../shared/types/index.js";
+import type { AgentSettings, PanelGridConfig, UserAgentRegistry } from "../shared/types/index.js";
 import { DEFAULT_AGENT_SETTINGS } from "../shared/types/index.js";
 
 export interface StoreSchema {
@@ -78,7 +74,7 @@ export interface StoreSchema {
       showInEmptyState?: boolean;
       lastUsedAt?: number;
     }>;
-    terminalGridConfig?: TerminalGridConfig;
+    panelGridConfig?: PanelGridConfig;
     dockCollapsed?: boolean;
     dockMode?: "expanded" | "slim" | "hidden";
     dockBehavior?: "auto" | "manual";
@@ -127,7 +123,7 @@ const storeOptions = {
       terminals: [],
       recipes: [],
       hasSeenWelcome: false,
-      terminalGridConfig: { strategy: "automatic" as const, value: 3 },
+      panelGridConfig: { strategy: "automatic" as const, value: 3 },
       dockCollapsed: false,
       dockMode: "hidden" as const,
       dockBehavior: "auto" as const,

--- a/shared/types/config.ts
+++ b/shared/types/config.ts
@@ -1,14 +1,14 @@
 import type { KeyMapConfig } from "./keymap.js";
 
-// Terminal Grid Layout Configuration
+// Panel Grid Layout Configuration
 
-/** Layout strategy for terminal grid */
-export type TerminalLayoutStrategy = "automatic" | "fixed-columns" | "fixed-rows";
+/** Layout strategy for panel grid */
+export type PanelLayoutStrategy = "automatic" | "fixed-columns" | "fixed-rows";
 
-/** Configuration for terminal grid layout */
-export interface TerminalGridConfig {
+/** Configuration for panel grid layout */
+export interface PanelGridConfig {
   /** Layout strategy to use */
-  strategy: TerminalLayoutStrategy;
+  strategy: PanelLayoutStrategy;
   /** Constraint value for fixed-columns/fixed-rows strategies */
   value: number;
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -177,9 +177,9 @@ export type {
 
 // Config types - application configuration
 export type {
-  // Terminal grid layout config
-  TerminalLayoutStrategy,
-  TerminalGridConfig,
+  // Panel grid layout config
+  PanelLayoutStrategy,
+  PanelGridConfig,
   // Opener config
   OpenerConfig,
   OpenersConfig,

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -72,8 +72,8 @@ export interface AppState {
     /** Focus events tab when diagnostics opens (requires autoOpenDiagnostics) */
     focusEventsTab: boolean;
   };
-  /** Terminal grid layout configuration */
-  terminalGridConfig?: import("../config.js").TerminalGridConfig;
+  /** Panel grid layout configuration */
+  panelGridConfig?: import("../config.js").PanelGridConfig;
   /** Whether the terminal dock is collapsed */
   dockCollapsed?: boolean;
   /** Dock display mode: expanded (full) or hidden (slim is legacy) */

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -37,7 +37,7 @@ import { parseAccordionDragId } from "./SortableWorktreeTerminal";
 // Placeholder ID used when dragging from dock to grid
 export const GRID_PLACEHOLDER_ID = "__grid-placeholder__";
 
-// Context to share placeholder state with TerminalGrid
+// Context to share placeholder state with ContentGrid
 interface DndPlaceholderContextValue {
   placeholderIndex: number | null;
   sourceContainer: "grid" | "dock" | null;
@@ -268,7 +268,7 @@ export function DndProvider({ children }: DndProviderProps) {
 
       if (!isAccordionDrag && sourceContainer === "dock" && detectedContainer === "grid") {
         const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-        // Find grid terminals to calculate insertion index (match TerminalGrid filter)
+        // Find grid terminals to calculate insertion index (match ContentGrid filter)
         const gridTerminals = terminals.filter(
           (t) =>
             (t.location === "grid" || t.location === undefined) &&
@@ -495,7 +495,7 @@ export function DndProvider({ children }: DndProviderProps) {
         const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
 
         // Only stabilize grid terminals in the ACTIVE worktree
-        // Use nullish coalescing to handle null/undefined mismatch (matches TerminalGrid filter)
+        // Use nullish coalescing to handle null/undefined mismatch (matches ContentGrid filter)
         const gridTerminalsList = currentTerminals.filter(
           (t) =>
             (t.location === "grid" || t.location === undefined) &&

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -408,7 +408,7 @@ export function GeneralTab({ appVersion, onNavigateToAgents }: GeneralTabProps) 
             <div className="text-left">
               <div className="text-sm font-medium">Project Pulse</div>
               <div className="text-xs opacity-70">
-                Show activity heatmap on the empty terminal grid
+                Show activity heatmap on the empty panel grid
               </div>
             </div>
           </div>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -83,7 +83,7 @@ export function SettingsDialog({
   const tabTitles: Record<SettingsTab, string> = {
     general: "General",
     keyboard: "Keyboard Shortcuts",
-    terminal: "Terminal Grid",
+    terminal: "Panel Grid",
     terminalAppearance: "Appearance",
     worktree: "Worktree Paths",
     agents: "Agent Settings",

--- a/src/components/Settings/SidecarSettingsTab.tsx
+++ b/src/components/Settings/SidecarSettingsTab.tsx
@@ -653,7 +653,7 @@ export function SidecarSettingsTab() {
         {layoutModePreference === "push" && (
           <p className="text-xs text-amber-500/80 flex items-center gap-1.5 mt-3">
             <AlertTriangle className="w-3 h-3" />
-            Forcing push mode on small windows may make the terminal grid unusable.
+            Forcing push mode on small windows may make the panel grid unusable.
           </p>
         )}
       </section>

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -17,7 +17,7 @@ import {
   useScrollbackStore,
   useTerminalInputStore,
 } from "@/store";
-import type { TerminalLayoutStrategy, TerminalType } from "@/types";
+import type { PanelLayoutStrategy, TerminalType } from "@/types";
 import {
   getScrollbackForType,
   estimateMemoryUsage,
@@ -27,7 +27,7 @@ import {
 import { actionService } from "@/services/ActionService";
 
 const STRATEGIES: Array<{
-  id: TerminalLayoutStrategy;
+  id: PanelLayoutStrategy;
   label: string;
   description: string;
   icon: typeof LayoutGrid;
@@ -112,7 +112,7 @@ export function TerminalSettingsTab() {
     }
   };
 
-  const handleStrategyChange = (strategy: TerminalLayoutStrategy) => {
+  const handleStrategyChange = (strategy: PanelLayoutStrategy) => {
     void actionService.dispatch(
       "terminal.gridLayout.setStrategy",
       { strategy },
@@ -447,7 +447,7 @@ export function TerminalSettingsTab() {
       <div className="pt-4 border-t border-canopy-border">
         <h4 className="text-sm font-medium text-canopy-text mb-2">Grid Layout Strategy</h4>
         <p className="text-xs text-canopy-text/50 mb-4">
-          Control how terminals arrange in the grid as you add more.
+          Control how panels arrange in the grid as you add more.
         </p>
       </div>
 

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -559,7 +559,7 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
             }}
             role="grid"
             id="terminal-grid"
-            aria-label="Terminal grid"
+            aria-label="Panel grid"
           >
             {isEmpty && !showPlaceholder ? (
               <div className="col-span-full row-span-full">

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -49,7 +49,7 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
 
   const directionCache = useRef(new Map<string, string | null>());
 
-  // Track container width for responsive layout (mirrors TerminalGrid)
+  // Track container width for responsive layout (mirrors ContentGrid)
   const [gridWidth, setGridWidth] = useState<number | null>(null);
 
   useEffect(() => {
@@ -80,7 +80,7 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     return () => observer.disconnect();
   }, [containerSelector]);
 
-  // Compute gridCols using the same logic as TerminalGrid
+  // Compute gridCols using the same logic as ContentGrid
   const gridCols = useMemo(() => {
     const { strategy, value } = layoutConfig;
     return computeGridColumns(gridTerminals.length, gridWidth, strategy, value);

--- a/src/index.css
+++ b/src/index.css
@@ -430,7 +430,7 @@ body,
   will-change: transform, opacity;
 }
 
-/* Slower spinner to reduce "chaos" in dense terminal grids */
+/* Slower spinner to reduce "chaos" in dense panel grids */
 @keyframes spin-slow {
   to {
     transform: rotate(360deg);

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -1,4 +1,7 @@
-import type { TerminalLayoutStrategy } from "@shared/types";
+import type { PanelLayoutStrategy } from "@shared/types";
+
+// Type alias for backward compatibility
+type TerminalLayoutStrategy = PanelLayoutStrategy;
 
 /**
  * Minimum terminal width in pixels for readability.
@@ -19,17 +22,17 @@ export const MIN_TERMINAL_HEIGHT_PX = 200;
 export const ABSOLUTE_MAX_GRID_TERMINALS = 16;
 
 /**
- * Calculate the maximum number of terminals that can fit in the grid
+ * Calculate the maximum number of panels that can fit in the grid
  * while maintaining readable dimensions.
  *
  * Examples:
- * - 15" laptop (~1200x700 usable): 3 cols × 3 rows = 9 terminals
- * - 27" monitor (~1800x1000 usable): 4 cols × 5 rows = 16 terminals (capped)
- * - 32" monitor (~2200x1200 usable): 5 cols × 6 rows = 16 terminals (capped)
+ * - 15" laptop (~1200x700 usable): 3 cols × 3 rows = 9 panels
+ * - 27" monitor (~1800x1000 usable): 4 cols × 5 rows = 16 panels (capped)
+ * - 32" monitor (~2200x1200 usable): 5 cols × 6 rows = 16 panels (capped)
  *
  * @param width - Grid container width in pixels
  * @param height - Grid container height in pixels
- * @returns Maximum number of terminals that fit with readable dimensions
+ * @returns Maximum number of panels that fit with readable dimensions
  */
 export function getMaxGridCapacity(width: number | null, height: number | null): number {
   if (!width || !height) return ABSOLUTE_MAX_GRID_TERMINALS;
@@ -99,7 +102,7 @@ export function getAutoGridCols(count: number, width: number | null): number {
  * Single source of truth for grid column calculation across all layout strategies.
  * Enforces the 2-pane invariant: exactly 2 panes should ALWAYS be 2x1 layout.
  *
- * This function is used by both TerminalGrid.tsx (for rendering) and
+ * This function is used by both ContentGrid.tsx (for rendering) and
  * useGridNavigation.ts (for keyboard navigation) to ensure consistency.
  */
 export function computeGridColumns(

--- a/src/services/actions/definitions/terminalActions.ts
+++ b/src/services/actions/definitions/terminalActions.ts
@@ -753,7 +753,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
   actions.set("terminal.gridLayout.setStrategy", () => ({
     id: "terminal.gridLayout.setStrategy",
     title: "Set Grid Layout Strategy",
-    description: "Set the terminal grid layout strategy",
+    description: "Set the panel grid layout strategy",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -770,7 +770,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
       const next = { ...previous, strategy };
       state.setLayoutConfig(next);
       try {
-        await appClient.setState({ terminalGridConfig: next as any });
+        await appClient.setState({ panelGridConfig: next as any });
       } catch (error) {
         state.setLayoutConfig(previous);
         throw error;
@@ -781,7 +781,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
   actions.set("terminal.gridLayout.setValue", () => ({
     id: "terminal.gridLayout.setValue",
     title: "Set Grid Layout Value",
-    description: "Set the terminal grid layout value (columns/rows count)",
+    description: "Set the panel grid layout value (columns/rows count)",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -794,7 +794,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
       const next = { ...previous, value };
       state.setLayoutConfig(next);
       try {
-        await appClient.setState({ terminalGridConfig: next as any });
+        await appClient.setState({ panelGridConfig: next as any });
       } catch (error) {
         state.setLayoutConfig(previous);
         throw error;

--- a/src/store/layoutConfigStore.ts
+++ b/src/store/layoutConfigStore.ts
@@ -1,8 +1,8 @@
 import { create } from "zustand";
-import type { TerminalGridConfig } from "@/types";
+import type { PanelGridConfig } from "@/types";
 import { getMaxGridCapacity, ABSOLUTE_MAX_GRID_TERMINALS } from "@/lib/terminalLayout";
 
-const DEFAULT_LAYOUT_CONFIG: TerminalGridConfig = {
+const DEFAULT_LAYOUT_CONFIG: PanelGridConfig = {
   strategy: "automatic",
   value: 3,
 };
@@ -13,8 +13,8 @@ interface GridDimensions {
 }
 
 interface LayoutConfigState {
-  layoutConfig: TerminalGridConfig;
-  setLayoutConfig: (config: TerminalGridConfig) => void;
+  layoutConfig: PanelGridConfig;
+  setLayoutConfig: (config: PanelGridConfig) => void;
 
   // Grid dimensions for dynamic capacity calculation
   gridDimensions: GridDimensions | null;

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for terminal grid capacity enforcement
- * Verifies that the 16-terminal limit is enforced for programmatic moves
+ * Tests for panel grid capacity enforcement
+ * Verifies that the 16-panel limit is enforced for programmatic moves
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -63,7 +63,7 @@ export function getTerminalRefreshTier(
 
 export type BackendStatus = "connected" | "disconnected" | "recovering";
 
-export interface TerminalGridState
+export interface PanelGridState
   extends
     TerminalRegistrySlice,
     TerminalFocusSlice,
@@ -78,7 +78,7 @@ export interface TerminalGridState
   restoreLastTrashed: () => void;
 }
 
-export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
+export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
   const getTerminals = () => get().terminals;
   const getTerminal = (id: string) => get().terminals.find((t) => t.id === id);
 
@@ -139,7 +139,7 @@ export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
       const state = get();
       registrySlice.moveTerminalToDock(id);
 
-      const updates: Partial<TerminalGridState> = {};
+      const updates: Partial<PanelGridState> = {};
 
       if (state.focusedId === id) {
         const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
@@ -167,7 +167,7 @@ export const useTerminalStore = create<TerminalGridState>()((set, get, api) => {
       const state = get();
       registrySlice.trashTerminal(id);
 
-      const updates: Partial<TerminalGridState> = {};
+      const updates: Partial<PanelGridState> = {};
 
       if (state.focusedId === id) {
         const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
@@ -416,7 +416,7 @@ export function setupTerminalStoreListeners() {
     const originalLocation: "dock" | "grid" = terminal?.location === "dock" ? "dock" : "grid";
     state.markAsTrashed(id, expiresAt, originalLocation);
 
-    const updates: Partial<TerminalGridState> = {};
+    const updates: Partial<PanelGridState> = {};
     if (state.focusedId === id) {
       const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
       updates.focusedId = gridTerminals[0]?.id ?? null;

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -356,8 +356,13 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
       openDiagnosticsDock(tab);
     }
 
-    if (appState.terminalGridConfig) {
-      useLayoutConfigStore.getState().setLayoutConfig(appState.terminalGridConfig);
+    // Migration: read from new key, fallback to old key for backward compatibility
+    const layoutConfig =
+      appState.panelGridConfig ??
+      (appState as unknown as { terminalGridConfig?: typeof appState.panelGridConfig })
+        .terminalGridConfig;
+    if (layoutConfig) {
+      useLayoutConfigStore.getState().setLayoutConfig(layoutConfig);
     }
 
     // Restore focus mode from per-project state (hydrate returns per-project focus mode)


### PR DESCRIPTION
## Summary

Renames "terminal grid" terminology to "panel grid" throughout the codebase for consistency with the current panel architecture. The grid displays multiple panel types (terminals, browsers, notes), not just terminals.

Closes #1666

## Changes Made

**Type System Updates:**
- Renamed `TerminalGridConfig` → `PanelGridConfig` in `shared/types/config.ts`
- Renamed `TerminalLayoutStrategy` → `PanelLayoutStrategy` throughout codebase
- Renamed `TerminalGridState` → `PanelGridState` in `src/store/terminalStore.ts`
- Updated exports in `shared/types/index.ts`

**State Management:**
- Renamed `terminalGridConfig` → `panelGridConfig` in `electron/store.ts`
- Updated IPC handler in `electron/ipc/handlers/app/state.ts` to read/write `panelGridConfig`
- Updated `shared/types/ipc/app.ts` AppState interface
- Updated store interfaces in `src/store/layoutConfigStore.ts`

**Backward Compatibility:**
- Added migration logic in `src/utils/stateHydration.ts` to read from old `terminalGridConfig` key if new key doesn't exist
- Added type alias in `src/lib/terminalLayout.ts` for internal backward compatibility

**Actions & UI:**
- Updated action descriptions in `src/services/actions/definitions/terminalActions.ts`
- Updated Settings dialog tab name from "Terminal Grid" → "Panel Grid"
- Updated UI text in settings components (GeneralTab, SidecarSettingsTab, TerminalSettingsTab)
- Updated aria-label in ContentGrid.tsx from "Terminal grid" → "Panel grid"

**Documentation:**
- Updated CLAUDE.md, README.md, AGENTS.md
- Updated docs/development.md and docs/feature-curation.md
- Updated .claude/commands/ files

**Code Comments:**
- Updated comments referencing "TerminalGrid" component to "ContentGrid"
- Updated test file comments in `gridCapacity.test.ts`
- Updated comments in DndProvider.tsx, terminalLayout.ts, useGridNavigation.ts
- Updated CSS comment in src/index.css

## Technical Details

The grid container displays `PanelInstance` items, which is a discriminated union:
```typescript
type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData
```

This refactor aligns configuration and type naming with the actual architecture where panels (not just terminals) are the primary abstraction.

## Testing

- ✅ TypeScript compilation passes with no errors
- ✅ Grid capacity tests pass (16 tests)
- ✅ Linting passes (261 pre-existing warnings, no new issues)
- ✅ Formatting passes
- ✅ State migration tested with backward compatibility for old `terminalGridConfig` key