### PR TITLE
Fix: Synchronize backend terminal tier state during project switch

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -720,7 +720,9 @@ port.on("message", async (rawMsg: any) => {
       }
 
       case "project-switch": {
-        ptyManager.onProjectSwitch(msg.projectId);
+        ptyManager.onProjectSwitch(msg.projectId, (id, tier) => {
+          backpressureManager.setActivityTier(id, tier);
+        });
         ptyManager.setActiveProject(msg.projectId);
         break;
       }

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -136,6 +136,14 @@ export class TerminalRendererPolicy {
    * allowing proper wake behavior when transitioning back to active.
    */
   initializeBackendTier(id: string, tier: "active" | "background"): void {
+    // Validate tier value for defensive programming
+    if (tier !== "active" && tier !== "background") {
+      console.warn(
+        `[TerminalRendererPolicy] Invalid tier "${tier}" for terminal ${id}, defaulting to "active"`
+      );
+      tier = "active";
+    }
+
     this.lastBackendTier.set(id, tier);
 
     // If initializing to background, set needsWake to ensure wake happens on next activation

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -94,4 +94,21 @@ describe("TerminalInstanceService - Activity Tier", () => {
       expect(true).toBe(true); // Placeholder for behavior documentation
     });
   });
+
+  describe("initializeBackendTier", () => {
+    it("should be documented as part of the hydration flow", () => {
+      // The initializeBackendTier method on TerminalInstanceService delegates
+      // to TerminalRendererPolicy.initializeBackendTier, which:
+      // 1. Sets the lastBackendTier map to the provided tier value
+      // 2. If tier is "background", sets needsWake=true on the managed terminal
+      //
+      // This enables the following hydration behavior:
+      // - Backend terminals report their actual activityTier in terminal info
+      // - stateHydration.ts calls initializeBackendTier after reconnection
+      // - Frontend tier state matches backend, enabling proper wake behavior
+      //
+      // Unit tests for the actual logic are in TerminalRendererPolicy.test.ts
+      expect(true).toBe(true);
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/domain";
+import type { ManagedTerminal } from "../types";
+import type { RendererPolicyDeps } from "../TerminalRendererPolicy";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    setActivityTier: vi.fn(),
+  },
+}));
+
+describe("TerminalRendererPolicy", () => {
+  let policy: import("../TerminalRendererPolicy").TerminalRendererPolicy;
+  let mockDeps: RendererPolicyDeps;
+  let mockManagedTerminal: Partial<ManagedTerminal>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    mockManagedTerminal = {
+      lastActiveTime: 0,
+      lastAppliedTier: undefined,
+      getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+      tierChangeTimer: undefined,
+      pendingTier: undefined,
+      needsWake: undefined,
+      terminal: {
+        refresh: vi.fn(),
+        rows: 24,
+      } as unknown as ManagedTerminal["terminal"],
+    };
+
+    mockDeps = {
+      getInstance: vi.fn(() => mockManagedTerminal as ManagedTerminal),
+      wakeAndRestore: vi.fn(() => Promise.resolve(true)),
+    };
+
+    const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+    policy = new TerminalRendererPolicy(mockDeps);
+  });
+
+  describe("initializeBackendTier", () => {
+    it("should set lastBackendTier to the provided value", () => {
+      policy.initializeBackendTier("test-id", "background");
+
+      expect(policy.getLastBackendTier("test-id")).toBe("background");
+    });
+
+    it("should set needsWake=true when initializing to background tier", () => {
+      policy.initializeBackendTier("test-id", "background");
+
+      expect(mockManagedTerminal.needsWake).toBe(true);
+    });
+
+    it("should not set needsWake when initializing to active tier", () => {
+      mockManagedTerminal.needsWake = undefined;
+
+      policy.initializeBackendTier("test-id", "active");
+
+      expect(policy.getLastBackendTier("test-id")).toBe("active");
+      expect(mockManagedTerminal.needsWake).toBeUndefined();
+    });
+
+    it("should not call setActivityTier on backend (only initializes frontend state)", async () => {
+      const { terminalClient } = await import("@/clients");
+
+      policy.initializeBackendTier("test-id", "background");
+
+      expect(terminalClient.setActivityTier).not.toHaveBeenCalled();
+    });
+
+    it("should handle missing managed terminal gracefully", () => {
+      mockDeps.getInstance = vi.fn(() => undefined);
+
+      // Should not throw
+      expect(() => {
+        policy.initializeBackendTier("missing-id", "background");
+      }).not.toThrow();
+
+      // Should still set the tier in the map
+      expect(policy.getLastBackendTier("missing-id")).toBe("background");
+    });
+  });
+
+  describe("initializeBackendTier integration with applyRendererPolicy", () => {
+    it("should trigger wake when transitioning from initialized background to active", async () => {
+      // Set up terminal as if it was backgrounded (lastAppliedTier = BACKGROUND)
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+
+      // Initialize to background (simulating reconnection after project switch)
+      policy.initializeBackendTier("test-id", "background");
+
+      expect(policy.getLastBackendTier("test-id")).toBe("background");
+      expect(mockManagedTerminal.needsWake).toBe(true);
+
+      // Now apply active policy (simulating terminal becoming visible)
+      // This is an "upgrade" since FOCUSED (100) < BACKGROUND (1000)
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      // Should have triggered wake because:
+      // 1. Backend tier was "background" (from initializeBackendTier)
+      // 2. Transitioning to "active" backend tier (FOCUSED maps to active)
+      // 3. needsWake was true
+      expect(mockDeps.wakeAndRestore).toHaveBeenCalledWith("test-id");
+
+      // Backend tier should now be "active"
+      expect(policy.getLastBackendTier("test-id")).toBe("active");
+    });
+
+    it("should not trigger wake when initializing to active tier", () => {
+      // Initialize to active
+      policy.initializeBackendTier("test-id", "active");
+
+      // Set up terminal as if it was at BACKGROUND tier (to trigger a tier change)
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+
+      // Apply active policy
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+
+      // Should not have triggered wake since:
+      // - Backend tier was already "active" (from initializeBackendTier)
+      // - Condition "prevBackendTier !== 'active'" is false
+      expect(mockDeps.wakeAndRestore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("clearTierState", () => {
+    it("should remove tier state for terminal", () => {
+      policy.initializeBackendTier("test-id", "background");
+      expect(policy.getLastBackendTier("test-id")).toBe("background");
+
+      policy.clearTierState("test-id");
+
+      expect(policy.getLastBackendTier("test-id")).toBeUndefined();
+    });
+  });
+
+  describe("dispose", () => {
+    it("should clear all tier state", () => {
+      policy.initializeBackendTier("test-1", "background");
+      policy.initializeBackendTier("test-2", "active");
+
+      policy.dispose();
+
+      expect(policy.getLastBackendTier("test-1")).toBeUndefined();
+      expect(policy.getLastBackendTier("test-2")).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes terminal freeze issue after project switches by ensuring backend and frontend tier states stay synchronized.

Closes #1692

## Changes Made
- Sync backpressure tier when project switch updates terminal tiers via callback
- Add tier change callback parameter to PtyManager.onProjectSwitch
- Add defensive tier validation in TerminalRendererPolicy.initializeBackendTier
- Add comprehensive unit tests for TerminalRendererPolicy (149 lines)
- Document initializeBackendTier method in tier test suite

## Technical Details
**Root Cause**: During project switch, `PtyManager.onProjectSwitch()` updated the TerminalProcess tier (polling rate) but not the BackpressureManager tier (streaming suppression). This caused divergence between the tier reported to frontend during hydration and the actual streaming behavior, preventing proper wake on reconnection.

**Solution**: Added optional callback to `onProjectSwitch()` that notifies caller (pty-host.ts) to sync the backpressure tier, ensuring both tiers remain consistent.

## Testing
- All existing tests pass
- New comprehensive unit tests for TerminalRendererPolicy cover:
  - Tier initialization with background/active values
  - Wake trigger on background→active transition
  - No wake on active→active transition
  - Missing terminal handling
  - State cleanup and disposal