### PR TITLE
Fix: Exclude orphaned terminals from Command+P and project selector

### DIFF
--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -159,6 +159,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
             isTrashed: terminal.isTrashed,
             trashExpiresAt: terminal.trashExpiresAt,
             activityTier: terminal.activityTier,
+            hasPty: terminal.hasPty,
           });
         }
       }
@@ -201,6 +202,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         agentState: terminal.agentState,
         lastStateChange: terminal.lastStateChange,
         activityTier: terminal.activityTier,
+        hasPty: terminal.hasPty,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1064,6 +1064,7 @@ port.on("message", async (rawMsg: any) => {
                 isTrashed: terminal.isTrashed,
                 trashExpiresAt: terminal.trashExpiresAt,
                 activityTier: ptyManager.getActivityTier(msg.id),
+                hasPty: terminal.hasPty,
               }
             : null,
         });

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -65,6 +65,8 @@ interface TerminalInfoResponse {
   isTrashed?: boolean;
   trashExpiresAt?: number;
   activityTier?: "active" | "background";
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
 }
 
 export interface PtyClientConfig {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -484,6 +484,8 @@ export class TerminalProcess {
 
   getPublicState(): TerminalPublicState {
     const t = this.terminalInfo;
+    // Terminal has a PTY when it hasn't been killed and hasn't exited
+    const hasPty = !t.wasKilled && !t.isExited;
     return {
       id: t.id,
       projectId: t.projectId,
@@ -508,6 +510,7 @@ export class TerminalProcess {
       detectedAgentType: t.detectedAgentType,
       restartCount: t.restartCount,
       activityTier: this._activityTier,
+      hasPty,
     };
   }
 

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -48,6 +48,8 @@ export interface TerminalPublicState {
   trashExpiresAt?: number;
   /** Current activity tier: "active" (foreground) or "background" (project switched away) */
   activityTier?: "active" | "background";
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
 }
 
 /**

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -494,6 +494,8 @@ export interface TerminalInstance {
   devCommand?: string;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
 }
 
 /** Options for spawning a new PTY process */

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -117,6 +117,8 @@ export interface BackendTerminalInfo {
   trashExpiresAt?: number;
   /** Current activity tier: "active" (foreground) or "background" (project switched away) */
   activityTier?: "active" | "background";
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
 }
 
 /** Result from terminal reconnect operation */
@@ -129,6 +131,7 @@ export interface TerminalReconnectResult {
   agentState?: AgentState;
   lastStateChange?: number;
   activityTier?: "active" | "background";
+  hasPty?: boolean;
   error?: string;
 }
 
@@ -150,6 +153,8 @@ export interface TerminalInfoPayload {
   outputBufferSize: number;
   semanticBufferLines: number;
   restartCount: number;
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
 }
 
 import type { TerminalActivityPayload } from "../terminal.js";

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -206,6 +206,8 @@ export interface PtyHostTerminalInfo {
   trashExpiresAt?: number;
   /** Current activity tier: "active" (foreground) or "background" (project switched away) */
   activityTier?: "active" | "background";
+  /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
+  hasPty?: boolean;
 }
 
 /** Payload for agent:spawned event */

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -204,6 +204,7 @@ export function Toolbar({
         for (const terminal of result.value) {
           if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
           if (terminal.kind === "dev-preview") continue;
+          if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
           const agentState = terminal.agentState;
           const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
@@ -331,6 +332,7 @@ export function Toolbar({
       for (const terminal of terminalsResult.value) {
         if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
         if (terminal.kind === "dev-preview") continue;
+        if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
         const agentState = terminal.agentState;
         const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -76,6 +76,7 @@ export function ProjectSwitcher() {
         for (const terminal of terminalsResult.value) {
           if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
           if (terminal.kind === "dev-preview") continue;
+          if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
           const agentState = terminal.agentState;
           const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
@@ -174,6 +175,7 @@ export function ProjectSwitcher() {
         for (const terminal of result.value) {
           if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
           if (terminal.kind === "dev-preview") continue;
+          if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
           const agentState = terminal.agentState;
           const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -114,6 +114,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         for (const terminal of result.value) {
           if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
           if (terminal.kind === "dev-preview") continue;
+          if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
           const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
           if (!isAgent) continue;

--- a/src/hooks/useTerminalPalette.ts
+++ b/src/hooks/useTerminalPalette.ts
@@ -76,6 +76,7 @@ export function useTerminalPalette(): UseTerminalPaletteReturn {
   const searchableTerminals = useMemo<SearchableTerminal[]>(() => {
     return terminals
       .filter((t) => t.location !== "trash")
+      .filter((t) => t.hasPty !== false) // Exclude orphaned terminals without active PTY processes
       .map((t) => ({
         id: t.id,
         title: t.title,


### PR DESCRIPTION
## Summary
Fixes issue where orphaned terminals (those whose PTY processes have exited) continue to appear in the Command+P palette and project selector, causing confusion and incorrect agent counts.

Closes #1673

## Changes Made
- Add hasPty field to track active PTY process lifecycle across IPC boundary
- Propagate hasPty through PTY host → Main process → Renderer IPC layer
- Filter orphaned terminals (hasPty === false) in Command+P palette
- Filter orphaned terminals in project selector agent counts
- Filter orphaned terminals in toolbar project counts (both loops)
- Ensure backward compatibility with optional hasPty field

## Technical Details
The hasPty field is computed in TerminalProcess.getPublicState() as `!wasKilled && !isExited` and propagated through:
1. PTY host terminal-info response
2. PtyClient TerminalInfoResponse
3. IPC handlers (getForProject, reconnect)
4. Shared type definitions (BackendTerminalInfo, TerminalInstance)
5. Frontend filtering logic (useTerminalPalette, ProjectSwitcher, Toolbar, useProjectSwitcherPalette)

All UI components now consistently filter by `hasPty !== false` for backward compatibility with existing terminals that don't have this field set.