### PR TITLE
Add panel-specific drag placeholder designs

### DIFF
--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/lib/utils";
 import { useDndPlaceholder } from "./DndProvider";
+import { PlaceholderContent } from "./PlaceholderContent";
 
 interface DockPlaceholderProps {
   className?: string;
@@ -13,18 +14,31 @@ export function DockPlaceholder({ className }: DockPlaceholderProps) {
   const { activeTerminal } = useDndPlaceholder();
 
   if (!activeTerminal) {
-    return null;
+    return (
+      <div
+        className={cn(
+          "min-w-[120px] h-full rounded",
+          "border border-canopy-accent/30 bg-canopy-accent/5",
+          className
+        )}
+        aria-hidden="true"
+      />
+    );
   }
+
+  const { kind, agentId } = activeTerminal;
 
   return (
     <div
       className={cn(
-        "flex items-center justify-center gap-2 px-4 py-1 min-w-[120px] h-full",
-        "rounded",
+        "flex flex-col gap-1 px-3 py-2 min-w-[120px] h-full",
+        "rounded border border-canopy-accent/30 bg-canopy-accent/5",
         className
       )}
       aria-hidden="true"
-    />
+    >
+      <PlaceholderContent kind={kind ?? "terminal"} agentId={agentId} compact />
+    </div>
   );
 }
 

--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -3,6 +3,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/lib/utils";
 import { useDndPlaceholder, GRID_PLACEHOLDER_ID } from "./DndProvider";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { PlaceholderContent } from "./PlaceholderContent";
 
 interface GridPlaceholderProps {
   className?: string;
@@ -41,8 +42,10 @@ export function GridPlaceholder({ className }: GridPlaceholderProps) {
         <span className="font-medium text-canopy-accent/80 truncate opacity-80">{title}</span>
       </div>
 
-      {/* Empty Body */}
-      <div className="flex-1 w-full bg-transparent" />
+      {/* Panel-specific placeholder body */}
+      <div className="flex-1 w-full p-3">
+        <PlaceholderContent kind={kind ?? "terminal"} agentId={agentId} />
+      </div>
     </div>
   );
 }

--- a/src/components/DragDrop/PlaceholderContent.tsx
+++ b/src/components/DragDrop/PlaceholderContent.tsx
@@ -1,0 +1,385 @@
+import type { PanelKind } from "@shared/types/domain";
+import { getPanelKindColor } from "@shared/config/panelKindRegistry";
+
+interface PlaceholderContentProps {
+  kind: PanelKind;
+  agentId?: string;
+  /** Use compact mode for smaller spaces like dock */
+  compact?: boolean;
+}
+
+/**
+ * Panel-specific placeholder content for drag operations.
+ * Each panel type has a distinct visual representation.
+ */
+export function PlaceholderContent({ kind, agentId, compact = false }: PlaceholderContentProps) {
+  const color = getPanelKindColor(kind, agentId);
+
+  switch (kind) {
+    case "terminal":
+      return <TerminalPlaceholder color={color} compact={compact} />;
+    case "agent":
+      return <AgentPlaceholder color={color} compact={compact} />;
+    case "browser":
+      return <BrowserPlaceholder color={color} compact={compact} />;
+    case "notes":
+      return <NotesPlaceholder color={color} compact={compact} />;
+    case "dev-preview":
+      return <DevPreviewPlaceholder color={color} compact={compact} />;
+    default:
+      return <TerminalPlaceholder color={color} compact={compact} />;
+  }
+}
+
+interface PlaceholderProps {
+  color: string;
+  compact: boolean;
+}
+
+/**
+ * Terminal placeholder: 3 horizontal lines simulating text output
+ */
+function TerminalPlaceholder({ color, compact }: PlaceholderProps) {
+  const lineHeight = compact ? 4 : 6;
+  const gap = compact ? 3 : 4;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap, width: "100%" }}>
+      <div
+        style={{
+          height: lineHeight,
+          width: "70%",
+          backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+          borderRadius: "var(--radius-sm)",
+        }}
+      />
+      <div
+        style={{
+          height: lineHeight,
+          width: "50%",
+          backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+          borderRadius: "var(--radius-sm)",
+        }}
+      />
+      {!compact && (
+        <div
+          style={{
+            height: lineHeight,
+            width: "40%",
+            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Agent placeholder: Abstract chat UI with alternating message bubbles
+ */
+function AgentPlaceholder({ color, compact }: PlaceholderProps) {
+  const bubbleHeight = compact ? 4 : 6;
+  const gap = compact ? 3 : 5;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap, width: "100%" }}>
+      {/* User message (left-aligned, smaller) */}
+      <div style={{ display: "flex", justifyContent: "flex-start" }}>
+        <div
+          style={{
+            height: bubbleHeight,
+            width: "35%",
+            backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+      </div>
+      {/* Agent reply (right-aligned, larger) */}
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <div
+          style={{
+            height: bubbleHeight,
+            width: "55%",
+            backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+      </div>
+      {/* User message */}
+      <div style={{ display: "flex", justifyContent: "flex-start" }}>
+        <div
+          style={{
+            height: bubbleHeight,
+            width: "40%",
+            backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+      </div>
+      {!compact && (
+        /* Agent reply */
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <div
+            style={{
+              height: bubbleHeight,
+              width: "60%",
+              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Browser placeholder: Address bar + content area with page elements
+ */
+function BrowserPlaceholder({ color, compact }: PlaceholderProps) {
+  const barHeight = compact ? 5 : 6;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: compact ? 4 : 6, width: "100%" }}>
+      {/* Address bar */}
+      <div
+        style={{
+          height: barHeight,
+          width: "85%",
+          backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+          borderRadius: "var(--radius-sm)",
+        }}
+      />
+      {/* Page content area */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: compact ? 0 : 30,
+          padding: compact ? 4 : 6,
+          backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
+          borderRadius: "var(--radius-sm)",
+          display: "flex",
+          flexDirection: "column",
+          gap: compact ? 3 : 4,
+        }}
+      >
+        {/* Page elements row */}
+        <div style={{ display: "flex", gap: compact ? 3 : 4 }}>
+          <div
+            style={{
+              width: compact ? 8 : 10,
+              height: compact ? 8 : 10,
+              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+          <div
+            style={{
+              width: compact ? 8 : 10,
+              height: compact ? 8 : 10,
+              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+          <div
+            style={{
+              width: compact ? 8 : 10,
+              height: compact ? 8 : 10,
+              backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+        </div>
+        {/* Content line */}
+        {!compact && (
+          <div
+            style={{
+              height: 5,
+              width: "80%",
+              backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Notes placeholder: Title line + body text lines
+ */
+function NotesPlaceholder({ color, compact }: PlaceholderProps) {
+  const titleHeight = compact ? 5 : 7;
+  const lineHeight = compact ? 4 : 5;
+  const gap = compact ? 3 : 4;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap, width: "100%" }}>
+      {/* Title (thicker) */}
+      <div
+        style={{
+          height: titleHeight,
+          width: "75%",
+          backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+          borderRadius: "var(--radius-sm)",
+        }}
+      />
+      {/* Body text lines */}
+      <div style={{ display: "flex", flexDirection: "column", gap: compact ? 2 : 3, marginTop: 2 }}>
+        <div
+          style={{
+            height: lineHeight,
+            width: "90%",
+            backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        <div
+          style={{
+            height: lineHeight,
+            width: "70%",
+            backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        {!compact && (
+          <>
+            <div
+              style={{
+                height: lineHeight,
+                width: "80%",
+                backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+            <div
+              style={{
+                height: lineHeight,
+                width: "50%",
+                backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Dev Preview placeholder: Address bar with status indicator + split preview area
+ */
+function DevPreviewPlaceholder({ color, compact }: PlaceholderProps) {
+  const barHeight = compact ? 5 : 6;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: compact ? 4 : 6, width: "100%" }}>
+      {/* Address bar with status indicator */}
+      <div style={{ display: "flex", alignItems: "center", gap: compact ? 4 : 6 }}>
+        <div
+          style={{
+            height: barHeight,
+            flex: 1,
+            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        {/* Status indicator dot */}
+        <div
+          style={{
+            width: compact ? 6 : 8,
+            height: compact ? 6 : 8,
+            backgroundColor: color,
+            borderRadius: "50%",
+            opacity: 0.6,
+            flexShrink: 0,
+          }}
+        />
+      </div>
+      {/* Split preview content */}
+      <div
+        style={{
+          flex: 1,
+          minHeight: compact ? 0 : 30,
+          display: "flex",
+          gap: compact ? 3 : 4,
+        }}
+      >
+        {/* Code/terminal side (narrower) */}
+        <div
+          style={{
+            width: "30%",
+            backgroundColor: `color-mix(in srgb, ${color} 6%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+            padding: compact ? 3 : 4,
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+          }}
+        >
+          <div
+            style={{
+              height: 3,
+              width: "80%",
+              backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+          <div
+            style={{
+              height: 3,
+              width: "60%",
+              backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+        </div>
+        {/* Preview side (wider) */}
+        <div
+          style={{
+            flex: 1,
+            backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+            padding: compact ? 3 : 4,
+            display: "flex",
+            flexDirection: "column",
+            gap: compact ? 2 : 3,
+          }}
+        >
+          {/* Preview content elements */}
+          <div style={{ display: "flex", gap: compact ? 2 : 3 }}>
+            <div
+              style={{
+                width: compact ? 6 : 8,
+                height: compact ? 6 : 8,
+                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+            <div
+              style={{
+                width: compact ? 6 : 8,
+                height: compact ? 6 : 8,
+                backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+          </div>
+          {!compact && (
+            <div
+              style={{
+                height: 4,
+                width: "70%",
+                backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+                borderRadius: "var(--radius-sm)",
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -1,14 +1,14 @@
 import { Loader2 } from "lucide-react";
-import { getBrandColorHex } from "@/lib/colorUtils";
 import type { TerminalInstance } from "@/store";
+import { PlaceholderContent } from "./PlaceholderContent";
+import { getPanelKindColor } from "@shared/config/panelKindRegistry";
 
 interface TerminalDragPreviewProps {
   terminal: TerminalInstance;
 }
 
 export function TerminalDragPreview({ terminal }: TerminalDragPreviewProps) {
-  // Browser panes get blue, agents get their brand color
-  const brandColor = terminal.kind === "browser" ? "#3b82f6" : getBrandColorHex(terminal.type);
+  const brandColor = getPanelKindColor(terminal.kind ?? "terminal", terminal.agentId);
   const isWorking = terminal.agentState === "working";
 
   return (
@@ -76,41 +76,16 @@ export function TerminalDragPreview({ terminal }: TerminalDragPreviewProps) {
         )}
       </div>
 
-      {/* Terminal body (ghost content) */}
+      {/* Panel body (ghost content) */}
       <div
         style={{
           flex: 1,
           padding: 8,
           display: "flex",
           flexDirection: "column",
-          gap: 4,
         }}
       >
-        {/* Ghost lines to simulate terminal content */}
-        <div
-          style={{
-            height: 6,
-            width: "70%",
-            backgroundColor: "color-mix(in srgb, var(--color-canopy-text) 6%, transparent)",
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        <div
-          style={{
-            height: 6,
-            width: "50%",
-            backgroundColor: "color-mix(in srgb, var(--color-canopy-text) 6%, transparent)",
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
-        <div
-          style={{
-            height: 6,
-            width: "40%",
-            backgroundColor: "color-mix(in srgb, var(--color-canopy-text) 6%, transparent)",
-            borderRadius: "var(--radius-sm)",
-          }}
-        />
+        <PlaceholderContent kind={terminal.kind ?? "terminal"} agentId={terminal.agentId} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Implements panel-specific drag placeholder designs for all 5 panel types (terminal, agent, browser, notes, dev-preview). Each panel type now has a unique, low-fidelity visual representation during drag operations, making it easier to visually track what's being moved.

Closes #1663

## Changes Made
- Create PlaceholderContent component with designs for all 5 panel types
- Terminal: 3 horizontal lines (existing design)
- Agent: abstract chat UI with alternating message bubbles
- Browser: address bar with page content elements
- Notes: title line with body text lines
- Dev Preview: address bar with status indicator and split preview
- Integrate PlaceholderContent into TerminalDragPreview, GridPlaceholder, and DockPlaceholder
- Use getPanelKindColor for consistent header/body colors across drag components
- Add compact mode support for dock placeholders with reduced spacing
- Fix overflow issues in compact mode by removing minHeight constraints
- Add fallback container in DockPlaceholder for stable drop target