### PR TITLE
Replace dock indicator bar with subtle badge

### DIFF
--- a/src/components/Layout/DockStatusOverlay.tsx
+++ b/src/components/Layout/DockStatusOverlay.tsx
@@ -4,11 +4,14 @@ import { useTerminalStore } from "@/store/terminalStore";
 import { WaitingContainer } from "./WaitingContainer";
 import { FailedContainer } from "./FailedContainer";
 import { TrashContainer } from "./TrashContainer";
+import { DockedContainer } from "./DockedContainer";
 
 interface DockStatusOverlayProps {
   waitingCount: number;
   failedCount: number;
   trashedCount: number;
+  dockedCount: number;
+  onExpandDock: () => void;
   shouldFadeForInput?: boolean;
 }
 
@@ -16,9 +19,11 @@ export function DockStatusOverlay({
   waitingCount,
   failedCount,
   trashedCount,
+  dockedCount,
+  onExpandDock,
   shouldFadeForInput = false,
 }: DockStatusOverlayProps) {
-  const hasAny = waitingCount > 0 || failedCount > 0 || trashedCount > 0;
+  const hasAny = waitingCount > 0 || failedCount > 0 || trashedCount > 0 || dockedCount > 0;
 
   const terminals = useTerminalStore((state) => state.terminals);
   const trashedTerminals = useTerminalStore(useShallow((state) => state.trashedTerminals));
@@ -53,6 +58,7 @@ export function DockStatusOverlay({
       aria-live="polite"
       aria-label="Dock status indicators"
     >
+      <DockedContainer dockedCount={dockedCount} onClick={onExpandDock} compact />
       <WaitingContainer compact />
       <FailedContainer compact />
       <TrashContainer trashedTerminals={trashedItems} compact />

--- a/src/components/Layout/DockedContainer.tsx
+++ b/src/components/Layout/DockedContainer.tsx
@@ -1,0 +1,34 @@
+import { PanelBottom } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DockedContainerProps {
+  dockedCount: number;
+  compact?: boolean;
+  onClick: () => void;
+}
+
+export function DockedContainer({ dockedCount, compact = false, onClick }: DockedContainerProps) {
+  if (dockedCount === 0) return null;
+
+  return (
+    <Button
+      variant="pill"
+      size="sm"
+      onClick={onClick}
+      className={cn(compact ? "px-1.5 min-w-0" : "px-3")}
+      title={`${dockedCount} terminal${dockedCount > 1 ? "s" : ""} in dock`}
+      aria-label={`Docked: ${dockedCount} terminal${dockedCount > 1 ? "s" : ""}`}
+    >
+      <span className="relative">
+        <PanelBottom className="w-3.5 h-3.5 text-canopy-accent" aria-hidden="true" />
+        {compact && dockedCount > 0 && (
+          <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-canopy-accent text-[10px] font-bold text-canopy-bg shadow-sm">
+            {dockedCount > 9 ? "9+" : dockedCount}
+          </span>
+        )}
+      </span>
+      {!compact && <span className="font-medium">Docked ({dockedCount})</span>}
+    </Button>
+  );
+}

--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -10,8 +10,6 @@ export function TerminalDockRegion() {
   const {
     shouldShowInLayout,
     showStatusOverlay,
-    effectiveMode,
-    hasDocked,
     dockedCount,
     density,
     isHydrated,
@@ -40,26 +38,15 @@ export function TerminalDockRegion() {
       {/* Handle overlay is always visible at bottom edge for discoverability */}
       <DockHandleOverlay />
 
-      {/* Status overlay when dock is hidden but has status counts */}
+      {/* Status overlay when dock is hidden but has status counts or docked panels */}
       {showStatusOverlay && (
         <DockStatusOverlay
           waitingCount={waitingCount}
           failedCount={failedCount}
           trashedCount={trashedCount}
+          dockedCount={dockedCount}
+          onExpandDock={() => setMode("expanded")}
           shouldFadeForInput={shouldFadeForInput}
-        />
-      )}
-
-      {/* Peek indicator bar when dock is hidden with docked terminals */}
-      {effectiveMode === "hidden" && hasDocked && !shouldShowInLayout && (
-        <button
-          type="button"
-          className="absolute bottom-0 left-0 right-0 h-1 bg-canopy-accent/60
-                     cursor-pointer hover:h-2 focus-visible:h-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent
-                     transition-[height,background-color,outline] duration-200 z-40"
-          onClick={() => setMode("expanded")}
-          title={`${dockedCount} terminal${dockedCount > 1 ? "s" : ""} in dock`}
-          aria-label={`Show ${dockedCount} hidden terminal${dockedCount > 1 ? "s" : ""}`}
         />
       )}
     </DockPanelOffscreenContainer>

--- a/src/hooks/useDockRenderState.ts
+++ b/src/hooks/useDockRenderState.ts
@@ -111,10 +111,10 @@ export function useDockRenderState(): DockRenderState & {
   // Compute density for ContentDock
   const density: DockRenderState["density"] = "normal";
 
-  // Show status overlay when dock is hidden and there are status indicators
+  // Show status overlay when dock is hidden and there are status indicators or docked panels
   // CRITICAL: Must be mutually exclusive with shouldShowInLayout
   const showStatusOverlay =
-    isHydrated && effectiveMode === "hidden" && hasStatus && !shouldShowInLayout;
+    isHydrated && effectiveMode === "hidden" && (hasStatus || hasDocked) && !shouldShowInLayout;
 
   // Whether the dock handle should indicate visible/hidden state
   const isHandleVisible = effectiveMode === "expanded";


### PR DESCRIPTION
## Summary
Replaces the full-width green indicator bar with a subtle badge component that appears in the bottom-right corner when the dock is hidden with docked terminals. The badge matches the existing pattern used by waiting, failed, and trashed terminal badges.

Closes #1668

## Changes Made
- Remove prominent green bar (h-1, full-width, bg-canopy-accent/60) that appeared when dock was hidden
- Add DockedContainer badge component matching existing badge pattern (pill variant, emerald accent)
- Integrate badge into DockStatusOverlay with waiting/failed/trashed badges
- Update useDockRenderState to show overlay when dock has panels
- Use consistent terminology ("terminal" vs "panel") and accessibility pattern
- Badge shows terminal count, clicking expands the dock
- In compact mode, shows emerald count badge; in normal mode shows "Docked (N)"