### PR TITLE
Fix clicking docked terminal items not opening popover

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -26,7 +26,6 @@ interface DockedTerminalItemProps {
 }
 
 export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
-  const setFocused = useTerminalStore((s) => s.setFocused);
   const activeDockTerminalId = useTerminalStore((s) => s.activeDockTerminalId);
   const openDockTerminal = useTerminalStore((s) => s.openDockTerminal);
   const closeDockTerminal = useTerminalStore((s) => s.closeDockTerminal);
@@ -272,7 +271,18 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
               isOpen &&
                 "bg-white/[0.08] text-canopy-text border-canopy-accent/40 ring-1 ring-inset ring-canopy-accent/30"
             )}
-            onClick={() => setFocused(terminal.id)}
+            onClick={(e) => {
+              // Explicitly toggle popover state on click
+              // This ensures the click always works, even if dnd-kit listeners
+              // interfere with Radix Popover's default trigger behavior
+              e.preventDefault();
+              e.stopPropagation();
+              if (isOpen) {
+                closeDockTerminal();
+              } else {
+                openDockTerminal(terminal.id);
+              }
+            }}
             title={`${terminal.title} - Click to preview, drag to reorder`}
             aria-label={`${terminal.title} - Click to preview, drag to reorder`}
           >


### PR DESCRIPTION
## Summary
Restores click functionality for docked terminal items in the dock. Previously, clicking a docked terminal item would not open the popover, preventing users from viewing the terminal content.

Closes #1719

## Changes Made
- Added explicit onClick handler to toggle popover state directly
- Implemented preventDefault() and stopPropagation() to bypass conflicts between dnd-kit drag listeners and Radix Popover's trigger behavior
- Removed unused setFocused store selector
- Directly calls openDockTerminal/closeDockTerminal actions instead of relying on Radix Popover's default trigger behavior

## Root Cause
The dnd-kit drag-and-drop listeners were interfering with Radix Popover's default click trigger mechanism, preventing the popover from opening when users clicked on docked terminal items.

## Solution
By implementing an explicit onClick handler that directly manipulates the popover state (via openDockTerminal/closeDockTerminal), we bypass the Radix Popover trigger mechanism entirely, ensuring clicks always work regardless of dnd-kit listener interference.