### PR TITLE
fix(dock): remove green bar artifact from empty dock

### DIFF
--- a/src/components/DragDrop/DockPlaceholder.tsx
+++ b/src/components/DragDrop/DockPlaceholder.tsx
@@ -11,19 +11,12 @@ interface DockPlaceholderProps {
 export const DOCK_PLACEHOLDER_ID = "__dock-placeholder__";
 
 export function DockPlaceholder({ className }: DockPlaceholderProps) {
-  const { activeTerminal } = useDndPlaceholder();
+  const { activeTerminal, isDragging } = useDndPlaceholder();
 
-  if (!activeTerminal) {
-    return (
-      <div
-        className={cn(
-          "min-w-[120px] h-full rounded",
-          "border border-canopy-accent/30 bg-canopy-accent/5",
-          className
-        )}
-        aria-hidden="true"
-      />
-    );
+  // When not dragging, render an invisible placeholder that still takes space
+  // This maintains the drop target for drag operations without showing a visible artifact
+  if (!isDragging || !activeTerminal) {
+    return <div className={cn("min-w-[100px] h-full", className)} aria-hidden="true" />;
   }
 
   const { kind, agentId } = activeTerminal;


### PR DESCRIPTION
## Summary
Fixes the green bar artifact that appeared in the empty dock when no panels were present. The issue was caused by the DockPlaceholder component always rendering a visible placeholder with green accent styling, even when not actively dragging.

Closes #1718

## Changes Made
- Add isDragging check to DockPlaceholder component
- Render invisible placeholder when not dragging to preserve drop target
- Remove visible green accent border/background from idle state
- Maintain minimum width for drop zone functionality

## Technical Details
The fix adds an `isDragging` state check from the `DndPlaceholderContext`. When not dragging, the placeholder renders as an invisible spacer that maintains the drop target functionality without showing any visible styling. The styled placeholder with the green accent border only appears during active drag operations.

## Testing
- Verified empty dock shows no green bar artifact when idle
- Confirmed drag-and-drop functionality still works correctly
- Tested dock transitions between empty and populated states
- Build and type checks pass