### PR TITLE
Remove sidebar/sidecar toggles from toolbar customization settings

### DIFF
--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -51,6 +51,12 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
   },
 };
 
+const FIXED_BUTTON_IDS: ToolbarButtonId[] = ["sidebar-toggle", "sidecar-toggle"];
+
+function sanitizeButtonList(buttons: ToolbarButtonId[]): ToolbarButtonId[] {
+  return buttons.filter((id) => !FIXED_BUTTON_IDS.includes(id));
+}
+
 interface ToolbarPreferencesState extends ToolbarPreferences {
   setLeftButtons: (buttons: ToolbarButtonId[]) => void;
   setRightButtons: (buttons: ToolbarButtonId[]) => void;
@@ -72,11 +78,11 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
       ...DEFAULT_PREFERENCES,
       setLeftButtons: (buttons) =>
         set((state) => ({
-          layout: { ...state.layout, leftButtons: buttons },
+          layout: { ...state.layout, leftButtons: sanitizeButtonList(buttons) },
         })),
       setRightButtons: (buttons) =>
         set((state) => ({
-          layout: { ...state.layout, rightButtons: buttons },
+          layout: { ...state.layout, rightButtons: sanitizeButtonList(buttons) },
         })),
       moveButton: (buttonId, from, to, toIndex) =>
         set((state) => {
@@ -130,6 +136,21 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     {
       name: "canopy-toolbar-preferences",
       storage: createJSONStorage(() => getSafeStorage()),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<ToolbarPreferencesState>;
+        return {
+          ...currentState,
+          ...persisted,
+          layout: {
+            leftButtons: sanitizeButtonList(
+              persisted.layout?.leftButtons ?? currentState.layout.leftButtons
+            ),
+            rightButtons: sanitizeButtonList(
+              persisted.layout?.rightButtons ?? currentState.layout.rightButtons
+            ),
+          },
+        };
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary
Removes sidebar-toggle and sidecar-toggle buttons from the toolbar customization settings UI. These buttons are always visible at fixed positions in the actual toolbar (left and right edges), so displaying them in customization settings created unnecessary clutter without providing user value.

Closes #1656

## Changes Made
- Removed sidebar-toggle and sidecar-toggle from BUTTON_METADATA in ToolbarSettingsTab
- Simplified SortableButtonItem component by removing fixed button handling logic
- Added sanitization to filter fixed button IDs from persisted toolbar preferences
- Implemented merge function to clean up legacy configurations on hydration
- Updated button counts to accurately reflect customizable buttons only

## Rationale
**Signal-to-noise improvement**: The customization UI should only show items users can actually customize. Fixed UI elements that cannot be moved or hidden don't belong in a customization panel.

**Prevention of legacy issues**: The sanitization ensures that any persisted preferences containing these fixed button IDs (from before this change) are automatically cleaned up, preventing duplicate button rendering and UI confusion.