### PR TITLE
Fix race condition: terminal agents spawning before worktree directory exists

### DIFF
--- a/electron/utils/__tests__/fs.test.ts
+++ b/electron/utils/__tests__/fs.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { access } from "fs/promises";
+import { waitForPathExists } from "../fs.js";
+
+vi.mock("fs/promises", () => ({
+  access: vi.fn(),
+}));
+
+describe("waitForPathExists", () => {
+  const mockAccess = vi.mocked(access);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("should resolve immediately if path exists", async () => {
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path");
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+    expect(mockAccess).toHaveBeenCalledWith("/test/path");
+  });
+
+  it("should retry with exponential backoff until path exists", async () => {
+    mockAccess
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 50,
+      backoffMultiplier: 2,
+      timeoutMs: 5000,
+    });
+
+    // First check fails
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+
+    // First retry after 50ms
+    await vi.advanceTimersByTimeAsync(50);
+    expect(mockAccess).toHaveBeenCalledTimes(2);
+
+    // Second retry after 100ms (50 * 2)
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mockAccess).toHaveBeenCalledTimes(3);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("should respect maxRetryDelayMs cap", async () => {
+    mockAccess
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockRejectedValueOnce(new Error("ENOENT"))
+      .mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 50,
+      backoffMultiplier: 2,
+      maxRetryDelayMs: 120,
+      timeoutMs: 5000,
+    });
+
+    // First check fails
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+
+    // First retry after 50ms
+    await vi.advanceTimersByTimeAsync(50);
+    expect(mockAccess).toHaveBeenCalledTimes(2);
+
+    // Second retry after 100ms (50 * 2)
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mockAccess).toHaveBeenCalledTimes(3);
+
+    // Third retry should be capped at 120ms instead of 200ms (100 * 2)
+    await vi.advanceTimersByTimeAsync(120);
+    expect(mockAccess).toHaveBeenCalledTimes(4);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("should timeout if path never appears", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 100,
+      backoffMultiplier: 2,
+      timeoutMs: 500,
+    });
+
+    // Advance past timeout
+    await vi.advanceTimersByTimeAsync(600);
+
+    await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
+    await expect(promise).rejects.toThrow("/test/path");
+  });
+
+  it("should use default options when none provided", async () => {
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path");
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("should respect initialDelayMs", async () => {
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      initialDelayMs: 100,
+      timeoutMs: 5000,
+    });
+
+    // Should not check immediately
+    expect(mockAccess).toHaveBeenCalledTimes(0);
+
+    // Should check after initial delay
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("should not exceed timeout even with long retry delays", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 200,
+      backoffMultiplier: 2,
+      maxRetryDelayMs: 1000,
+      timeoutMs: 500,
+    });
+
+    // First check at 0ms fails
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+
+    // Should try once at 200ms
+    await vi.advanceTimersByTimeAsync(200);
+    expect(mockAccess).toHaveBeenCalledTimes(2);
+
+    // Should try again at 400ms (200 * 2)
+    await vi.advanceTimersByTimeAsync(200);
+    expect(mockAccess).toHaveBeenCalledTimes(3);
+
+    // Next retry would be at 800ms (400 * 2) but that exceeds 500ms timeout
+    // So it should timeout before scheduling another retry
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
+  });
+
+  it("should clean up pending timers on success", async () => {
+    mockAccess.mockRejectedValueOnce(new Error("ENOENT")).mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 50,
+      timeoutMs: 5000,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(promise).resolves.toBeUndefined();
+
+    // Verify no pending timers
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("should clean up pending timers on timeout", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 100,
+      timeoutMs: 150,
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
+
+    // Verify no pending timers
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("should handle path with spaces and special characters", async () => {
+    const specialPath = "/test/path with spaces/special-chars_123";
+    mockAccess.mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists(specialPath);
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(mockAccess).toHaveBeenCalledWith(specialPath);
+  });
+
+  it("should fail fast on permission errors (EACCES, EPERM)", async () => {
+    const eaccesError = Object.assign(new Error("Permission denied"), {
+      code: "EACCES",
+    });
+    mockAccess.mockRejectedValueOnce(eaccesError);
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 50,
+      timeoutMs: 5000,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).rejects.toThrow(/Cannot access path/);
+    await expect(promise).rejects.toThrow(/EACCES/);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("should fail fast on ENOTDIR errors", async () => {
+    const enotdirError = Object.assign(new Error("Not a directory"), {
+      code: "ENOTDIR",
+    });
+    mockAccess.mockRejectedValueOnce(enotdirError);
+
+    const promise = waitForPathExists("/test/path/file", {
+      initialRetryDelayMs: 50,
+      timeoutMs: 5000,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(promise).rejects.toThrow(/Cannot access path/);
+    await expect(promise).rejects.toThrow(/ENOTDIR/);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("should retry only on ENOENT errors", async () => {
+    const enoentError = Object.assign(new Error("No such file or directory"), {
+      code: "ENOENT",
+    });
+    mockAccess
+      .mockRejectedValueOnce(enoentError)
+      .mockRejectedValueOnce(enoentError)
+      .mockResolvedValueOnce(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 50,
+      timeoutMs: 5000,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(mockAccess).toHaveBeenCalledTimes(3);
+  });
+
+  it("should calculate remaining time correctly to avoid exceeding timeout", async () => {
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const promise = waitForPathExists("/test/path", {
+      initialRetryDelayMs: 100,
+      backoffMultiplier: 2,
+      timeoutMs: 350,
+    });
+
+    // First check at 0ms
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockAccess).toHaveBeenCalledTimes(1);
+
+    // Retry at 100ms
+    await vi.advanceTimersByTimeAsync(100);
+    expect(mockAccess).toHaveBeenCalledTimes(2);
+
+    // Retry at 300ms (100 + 200)
+    await vi.advanceTimersByTimeAsync(200);
+    expect(mockAccess).toHaveBeenCalledTimes(3);
+
+    // Should timeout before next retry (would be at 700ms but timeout is 350ms)
+    await vi.advanceTimersByTimeAsync(60);
+
+    await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
+  });
+
+  it("should timeout immediately when initialDelayMs >= timeoutMs", async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      initialDelayMs: 1000,
+      timeoutMs: 500,
+    });
+
+    // Initial delay would be 1000ms but timeout is 500ms
+    await vi.advanceTimersByTimeAsync(500);
+
+    await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
+    // Should not have called access at all since initial delay exceeded timeout
+    expect(mockAccess).toHaveBeenCalledTimes(0);
+  });
+
+  it("should timeout immediately when timeoutMs is 0", async () => {
+    mockAccess.mockResolvedValue(undefined);
+
+    const promise = waitForPathExists("/test/path", {
+      timeoutMs: 0,
+    });
+
+    await vi.runAllTimersAsync();
+
+    await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
+  });
+});

--- a/electron/utils/fs.ts
+++ b/electron/utils/fs.ts
@@ -1,0 +1,137 @@
+import { access } from "fs/promises";
+
+/**
+ * Configuration for path existence polling
+ */
+interface WaitForPathOptions {
+  /**
+   * Initial check delay in milliseconds (default: 0 - check immediately)
+   */
+  initialDelayMs?: number;
+
+  /**
+   * Maximum total wait time in milliseconds (default: 5000)
+   */
+  timeoutMs?: number;
+
+  /**
+   * Backoff multiplier for retry delays (default: 2)
+   */
+  backoffMultiplier?: number;
+
+  /**
+   * Initial retry delay in milliseconds (default: 50)
+   */
+  initialRetryDelayMs?: number;
+
+  /**
+   * Maximum retry delay in milliseconds (default: 800)
+   */
+  maxRetryDelayMs?: number;
+}
+
+/**
+ * Waits for a filesystem path to become accessible with exponential backoff.
+ *
+ * This utility handles race conditions where git operations complete before
+ * the filesystem has flushed directory creation to disk. It's particularly
+ * useful for worktree creation where node-pty requires the cwd to exist.
+ *
+ * @param path - The filesystem path to check
+ * @param options - Configuration for polling behavior
+ * @returns Promise that resolves when the path exists
+ * @throws Error if the path doesn't exist within the timeout period
+ *
+ * @example
+ * // Wait for worktree directory to exist before spawning terminals
+ * await waitForPathExists('/path/to/worktree', { timeoutMs: 5000 });
+ */
+export async function waitForPathExists(
+  path: string,
+  options: WaitForPathOptions = {}
+): Promise<void> {
+  const {
+    initialDelayMs = 0,
+    timeoutMs = 5000,
+    backoffMultiplier = 2,
+    initialRetryDelayMs = 50,
+    maxRetryDelayMs = 800,
+  } = options;
+
+  const startTime = Date.now();
+  let retryDelayMs = initialRetryDelayMs;
+  let timerId: NodeJS.Timeout | undefined;
+
+  // Helper to check if path exists
+  const checkExists = async (): Promise<boolean> => {
+    try {
+      await access(path);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      // Only retry on ENOENT (path doesn't exist yet)
+      // Fail fast on permission errors (EACCES, EPERM) or ENOTDIR
+      if (code && code !== "ENOENT") {
+        throw new Error(`Cannot access path: ${path} (${code}: ${(error as Error).message})`);
+      }
+      return false;
+    }
+  };
+
+  // Helper to sleep with cleanup
+  const sleep = (ms: number): Promise<void> => {
+    return new Promise((resolve) => {
+      timerId = setTimeout(() => {
+        timerId = undefined;
+        resolve();
+      }, ms);
+      // Unref timer to avoid keeping process alive during shutdown
+      if (timerId) {
+        timerId.unref();
+      }
+    });
+  };
+
+  try {
+    // Initial delay if specified
+    if (initialDelayMs > 0) {
+      await sleep(initialDelayMs);
+    }
+
+    // Poll until path exists or timeout
+    while (true) {
+      // Check if timeout exceeded
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= timeoutMs) {
+        throw new Error(`Timeout waiting for path to exist: ${path} (waited ${elapsed}ms)`);
+      }
+
+      // Check if path exists
+      if (await checkExists()) {
+        return;
+      }
+
+      // Calculate next retry delay with backoff
+      const nextDelay = Math.min(retryDelayMs, maxRetryDelayMs);
+
+      // Ensure we don't exceed timeout on next attempt
+      const remainingTime = timeoutMs - elapsed;
+      const actualDelay = Math.min(nextDelay, remainingTime);
+
+      if (actualDelay <= 0) {
+        throw new Error(`Timeout waiting for path to exist: ${path} (waited ${elapsed}ms)`);
+      }
+
+      // Wait before next attempt
+      await sleep(actualDelay);
+
+      // Increase delay for next iteration
+      retryDelayMs = Math.floor(retryDelayMs * backoffMultiplier);
+    }
+  } finally {
+    // Clean up any pending timer
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
+  }
+}

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WorkspaceService } from "../WorkspaceService.js";
+
+vi.mock("simple-git");
+vi.mock("../../utils/fs.js");
+vi.mock("../../utils/git.js");
+vi.mock("../../utils/gitUtils.js");
+vi.mock("../../services/worktree/mood.js");
+vi.mock("../../services/issueExtractor.js");
+vi.mock("../../services/worktree/index.js");
+vi.mock("../../services/github/GitHubAuth.js");
+vi.mock("../../services/PullRequestService.js");
+vi.mock("../../services/events.js");
+vi.mock("fs/promises");
+
+describe("WorkspaceService.createWorktree", () => {
+  let service: WorkspaceService;
+  let simpleGit: any;
+  let waitForPathExists: any;
+  let ensureNoteFileSpy: any;
+
+  beforeEach(async () => {
+    // Reset mocks
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    // Mock simple-git
+    const gitModule = await import("simple-git");
+    simpleGit = vi.mocked(gitModule.simpleGit);
+    const mockGit = {
+      raw: vi.fn().mockResolvedValue(undefined),
+      branch: vi.fn().mockResolvedValue({ current: "main" }),
+    };
+    simpleGit.mockReturnValue(mockGit);
+
+    // Mock waitForPathExists
+    const fsModule = await import("../../utils/fs.js");
+    waitForPathExists = vi.mocked(fsModule.waitForPathExists);
+    waitForPathExists.mockResolvedValue(undefined);
+
+    // Mock other dependencies
+    const gitUtilsModule = await import("../../utils/gitUtils.js");
+    vi.mocked(gitUtilsModule.getGitDir).mockReturnValue("/test/worktree/.git");
+    vi.mocked(gitUtilsModule.clearGitDirCache).mockReturnValue(undefined);
+
+    const gitModule2 = await import("../../utils/git.js");
+    vi.mocked(gitModule2.invalidateGitStatusCache).mockReturnValue(undefined);
+    vi.mocked(gitModule2.getWorktreeChangesWithStats).mockResolvedValue({
+      branch: "test-branch",
+      head: "abc123",
+      isDirty: false,
+      stagedFileCount: 0,
+      unstagedFileCount: 0,
+      untrackedFileCount: 0,
+      conflictedFileCount: 0,
+      changedFileCount: 0,
+    });
+
+    const moodModule = await import("../../services/worktree/mood.js");
+    vi.mocked(moodModule.categorizeWorktree).mockReturnValue({
+      category: "ready",
+      reason: "Clean working tree",
+    });
+
+    const issueExtractorModule = await import("../../services/issueExtractor.js");
+    vi.mocked(issueExtractorModule.extractIssueNumberSync).mockReturnValue(null);
+    vi.mocked(issueExtractorModule.extractIssueNumber).mockResolvedValue(null);
+
+    const worktreeIndexModule = await import("../../services/worktree/index.js");
+    const MockAdaptivePollingStrategy = vi.fn().mockImplementation(() => ({
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+    }));
+    const MockNoteFileReader = vi.fn().mockImplementation(() => ({
+      read: vi.fn().mockResolvedValue({}),
+    }));
+    vi.mocked(worktreeIndexModule.AdaptivePollingStrategy).mockImplementation(
+      MockAdaptivePollingStrategy as any
+    );
+    vi.mocked(worktreeIndexModule.NoteFileReader).mockImplementation(MockNoteFileReader as any);
+
+    const githubAuthModule = await import("../../services/github/GitHubAuth.js");
+    vi.mocked(githubAuthModule.GitHubAuth).mockImplementation(
+      vi.fn().mockImplementation(() => ({
+        getToken: vi.fn().mockResolvedValue(null),
+      })) as any
+    );
+
+    const prServiceModule = await import("../../services/PullRequestService.js");
+    vi.mocked(prServiceModule.pullRequestService).mockReturnValue({
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockReturnValue({ state: "idle" }),
+    } as any);
+
+    const eventsModule = await import("../../services/events.js");
+    vi.mocked(eventsModule.events).mockReturnValue(new EventEmitter() as any);
+
+    // Mock fs/promises for ensureNoteFile
+    const fsPromisesModule = await import("fs/promises");
+    vi.mocked(fsPromisesModule.stat).mockRejectedValue(new Error("ENOENT"));
+    vi.mocked(fsPromisesModule.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fsPromisesModule.writeFile).mockResolvedValue(undefined);
+
+    // Import and create service
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(
+      "/test/root",
+      "main",
+      "/test/root",
+      "test-project"
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should call waitForPathExists after git worktree add", async () => {
+    const mockGit = simpleGit();
+    const requestId = "test-request-123";
+    const options = {
+      baseBranch: "main",
+      newBranch: "feature/test",
+      path: "/test/worktree",
+    };
+
+    // Capture the event
+    const events: any[] = [];
+    service["sendEvent"] = vi.fn((event) => {
+      events.push(event);
+    });
+
+    // Mock listWorktreesFromGit to return the created worktree
+    service["listWorktreesFromGit"] = vi.fn().mockResolvedValue([
+      {
+        path: "/test/worktree",
+        branch: "feature/test",
+        head: "abc123",
+        isDetached: false,
+        isMainWorktree: false,
+      },
+    ]);
+
+    await service.createWorktree(requestId, "/test/root", options);
+
+    // Verify git.raw was called with correct arguments
+    expect(mockGit.raw).toHaveBeenCalledWith([
+      "worktree",
+      "add",
+      "-b",
+      "feature/test",
+      "/test/worktree",
+      "main",
+    ]);
+
+    // Verify waitForPathExists was called after git.raw
+    expect(waitForPathExists).toHaveBeenCalledWith("/test/worktree", {
+      timeoutMs: 5000,
+      initialRetryDelayMs: 50,
+      maxRetryDelayMs: 800,
+    });
+
+    // Verify call order: git.raw must be called before waitForPathExists
+    const gitCallOrder = mockGit.raw.mock.invocationCallOrder[0];
+    const waitCallOrder = waitForPathExists.mock.invocationCallOrder[0];
+    expect(gitCallOrder).toBeLessThan(waitCallOrder);
+
+    // Verify success event was sent
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "create-worktree-result",
+      requestId: "test-request-123",
+      success: true,
+      worktreeId: "/test/worktree",
+    });
+  });
+
+  it("should call waitForPathExists for useExistingBranch flow", async () => {
+    const mockGit = simpleGit();
+    const requestId = "test-request-456";
+    const options = {
+      baseBranch: "main",
+      newBranch: "existing-branch",
+      path: "/test/worktree2",
+      useExistingBranch: true,
+    };
+
+    service["sendEvent"] = vi.fn();
+    service["listWorktreesFromGit"] = vi.fn().mockResolvedValue([
+      {
+        path: "/test/worktree2",
+        branch: "existing-branch",
+        head: "def456",
+        isDetached: false,
+        isMainWorktree: false,
+      },
+    ]);
+
+    await service.createWorktree(requestId, "/test/root", options);
+
+    expect(mockGit.raw).toHaveBeenCalledWith([
+      "worktree",
+      "add",
+      "/test/worktree2",
+      "existing-branch",
+    ]);
+    expect(waitForPathExists).toHaveBeenCalledWith("/test/worktree2", expect.any(Object));
+  });
+
+  it("should call waitForPathExists for fromRemote flow", async () => {
+    const mockGit = simpleGit();
+    const requestId = "test-request-789";
+    const options = {
+      baseBranch: "origin/main",
+      newBranch: "feature/remote",
+      path: "/test/worktree3",
+      fromRemote: true,
+    };
+
+    service["sendEvent"] = vi.fn();
+    service["listWorktreesFromGit"] = vi.fn().mockResolvedValue([
+      {
+        path: "/test/worktree3",
+        branch: "feature/remote",
+        head: "ghi789",
+        isDetached: false,
+        isMainWorktree: false,
+      },
+    ]);
+
+    await service.createWorktree(requestId, "/test/root", options);
+
+    expect(mockGit.raw).toHaveBeenCalledWith([
+      "worktree",
+      "add",
+      "-b",
+      "feature/remote",
+      "--track",
+      "/test/worktree3",
+      "origin/main",
+    ]);
+    expect(waitForPathExists).toHaveBeenCalledWith("/test/worktree3", expect.any(Object));
+  });
+
+  it("should propagate waitForPathExists timeout error", async () => {
+    const requestId = "test-request-timeout";
+    const options = {
+      baseBranch: "main",
+      newBranch: "feature/timeout",
+      path: "/test/worktree-timeout",
+    };
+
+    // Make waitForPathExists fail with timeout
+    waitForPathExists.mockRejectedValueOnce(
+      new Error("Timeout waiting for path to exist: /test/worktree-timeout (waited 5000ms)")
+    );
+
+    const events: any[] = [];
+    service["sendEvent"] = vi.fn((event) => {
+      events.push(event);
+    });
+
+    await service.createWorktree(requestId, "/test/root", options);
+
+    // Verify error event was sent
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "create-worktree-result",
+      requestId: "test-request-timeout",
+      success: false,
+      error: expect.stringContaining("Timeout waiting for path to exist"),
+    });
+  });
+
+  it("should handle delayed directory creation", async () => {
+    const mockGit = simpleGit();
+    const requestId = "test-request-delayed";
+    const options = {
+      baseBranch: "main",
+      newBranch: "feature/delayed",
+      path: "/test/worktree-delayed",
+    };
+
+    // Use fake timers for deterministic testing
+    vi.useFakeTimers();
+
+    // Simulate delayed path existence with a deferred promise
+    let resolveWait: (() => void) | undefined;
+    const waitPromise = new Promise<void>((resolve) => {
+      resolveWait = resolve;
+    });
+    waitForPathExists.mockReturnValue(waitPromise);
+
+    service["sendEvent"] = vi.fn();
+    service["listWorktreesFromGit"] = vi.fn().mockResolvedValue([
+      {
+        path: "/test/worktree-delayed",
+        branch: "feature/delayed",
+        head: "jkl012",
+        isDetached: false,
+        isMainWorktree: false,
+      },
+    ]);
+
+    const createPromise = service.createWorktree(requestId, "/test/root", options);
+
+    // Verify git.raw was called
+    await vi.runAllTimersAsync();
+    expect(mockGit.raw).toHaveBeenCalled();
+
+    // Verify waitForPathExists was called
+    expect(waitForPathExists).toHaveBeenCalledTimes(1);
+
+    // Resolve the wait after a simulated delay
+    resolveWait!();
+    await createPromise;
+
+    vi.useRealTimers();
+  });
+
+  it("should not proceed to ensureNoteFile if waitForPathExists fails", async () => {
+    const requestId = "test-request-fail";
+    const options = {
+      baseBranch: "main",
+      newBranch: "feature/fail",
+      path: "/test/worktree-fail",
+    };
+
+    // Make waitForPathExists fail
+    waitForPathExists.mockRejectedValueOnce(new Error("Path does not exist"));
+
+    const events: any[] = [];
+    service["sendEvent"] = vi.fn((event) => {
+      events.push(event);
+    });
+
+    // Mock fs.stat to track if ensureNoteFile is called
+    const fsPromisesModule = await import("fs/promises");
+    const statSpy = vi.mocked(fsPromisesModule.stat);
+    const mkdirSpy = vi.mocked(fsPromisesModule.mkdir);
+    const writeFileSpy = vi.mocked(fsPromisesModule.writeFile);
+    statSpy.mockClear();
+    mkdirSpy.mockClear();
+    writeFileSpy.mockClear();
+
+    // Also mock listWorktreesFromGit to track if it's called
+    const listWorktreesSpy = vi.spyOn(service as any, "listWorktreesFromGit");
+    listWorktreesSpy.mockClear();
+
+    await service.createWorktree(requestId, "/test/root", options);
+
+    // Verify error event was sent
+    expect(events[0].success).toBe(false);
+
+    // ensureNoteFile should not be reached - verify its fs operations not called
+    expect(statSpy).not.toHaveBeenCalled();
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(writeFileSpy).not.toHaveBeenCalled();
+
+    // listWorktreesFromGit should also not be called
+    expect(listWorktreesSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a race condition where terminal agents can spawn before the worktree directory has been fully created, resulting in ENOENT errors when node-pty tries to use the worktree path as cwd.

Closes #1728

## Changes Made
- Added `waitForPathExists` utility with exponential backoff (electron/utils/fs.ts)
- Integrated path existence check in WorkspaceService.createWorktree after git operation completes
- Normalized paths to absolute before checking to avoid cwd mismatches between git and fs.access
- Fail fast on permission errors (EACCES, EPERM, ENOTDIR) vs ENOENT to provide better error messages
- Unref timers to prevent keeping process alive during shutdown
- Added comprehensive unit tests for waitForPathExists (319 lines)
- Added integration tests for WorkspaceService.createWorktree (366 lines)
- Verified call order and error propagation with deterministic fake timers

## Technical Details
The fix ensures that after `git worktree add` completes, the system waits for the directory to be accessible on the filesystem before proceeding with recipe execution that spawns terminals. The wait uses exponential backoff (50ms initial, capped at 800ms) with a 5-second timeout.