### PR TITLE
Investigate migrating sidecar from WebContentsView to webview

### DIFF
--- a/SIDECAR_MIGRATION_INVESTIGATION.md
+++ b/SIDECAR_MIGRATION_INVESTIGATION.md
@@ -1,0 +1,202 @@
+# Sidecar Migration Investigation: WebContentsView vs `<webview>` Tag
+
+**Issue:** #1648
+**Date:** 2026-01-18
+**Status:** ✅ Investigation Complete
+**Decision:** **Migration NOT Recommended**
+
+> **Note on Terminology:** This document uses "discouraged" to reflect Electron's official stance. While `<webview>` is not formally deprecated, Electron explicitly does not recommend its use and does not guarantee future support.
+
+## Executive Summary
+
+This investigation assessed whether migrating the sidecar from Electron's `WebContentsView` API to the `<webview>` tag would simplify dropdown positioning logic. After thorough research and analysis, **we recommend against this migration** due to Electron's explicit discouragement and architectural direction away from webview.
+
+## Problem Statement
+
+Toolbar dropdowns (GitHub/Git) currently use complex positioning logic in `FixedDropdown` to avoid overlapping the WebContentsView-based sidecar. The dev preview panel uses `<webview>` tags without encountering this issue, suggesting webview might offer better z-index behavior.
+
+## Key Findings
+
+### 1. Electron's Official Position
+
+**Critical:** Electron explicitly **discourages** the use of `<webview>` tags:
+
+> "We do not recommend you to use WebViews, as this tag undergoes dramatic architectural changes that may affect stability of your application. Consider switching to alternatives, like iframe and **Electron's WebContentsView**, or an architecture that avoids embedded content altogether."
+>
+> — [Electron Documentation: Web Embeds](https://www.electronjs.org/docs/latest/tutorial/web-embeds)
+
+**Additional warnings:**
+- "We do not guarantee that the WebView API will remain available in future versions of Electron."
+- Based on Chromium's webview which is "undergoing dramatic architectural changes that impact stability of webviews, including rendering, navigation, and event routing."
+
+**WebContentsView is recommended as:**
+- "A reusable view directly tied to Chromium's rendering pipeline"
+- "Simplifying future upgrades and opening up the possibility for developers to integrate non-web UI elements"
+- Offering "reduced code complexity and fewer potential bugs in the long run"
+
+### 2. Architectural Comparison
+
+| Aspect | WebContentsView (Current) | `<webview>` Tag |
+|--------|--------------------------|-----------------|
+| **Electron Recommendation** | ✅ Recommended | ❌ Discouraged |
+| **Stability** | ✅ Stable, tied to Chromium pipeline | ⚠️ Undergoing dramatic changes |
+| **Future Support** | ✅ Actively maintained | ❌ Not guaranteed to remain |
+| **Ownership Model** | Main-process-owned View | Guest view (OOPIF) in renderer |
+| **Performance** | Optimal | Slightly slower |
+| **Z-index Behavior** | Above React DOM | Within React DOM |
+| **Implementation Location** | Main process (`SidecarManager`) | Renderer process (React component) |
+
+### 3. Feature Compatibility Analysis
+
+Audit of current `SidecarManager.ts` features vs webview capabilities:
+
+| Feature | WebContentsView | `<webview>` Tag | Notes |
+|---------|----------------|----------------|-------|
+| Navigation events | ✅ | ✅ | `did-navigate`, `did-navigate-in-page`, `page-title-updated` |
+| Page title updates | ✅ | ✅ | `page-title-updated` event |
+| Context menus | ✅ | ✅ | `context-menu` event available |
+| External links | ✅ `setWindowOpenHandler` | ⚠️ Requires main process | Guest webContents accessible via `getWebContentsId()` |
+| Partition isolation | ✅ | ✅ | Both support `persist:sidecar` |
+| Navigation control | ✅ | ✅ | back/forward/reload methods |
+| **Clipboard file paste** | ✅ `before-input-event` | ⚠️ **Main process only** | Not exposed as renderer event, requires IPC |
+
+**Critical finding:** The `before-input-event` used for advanced clipboard handling in `SidecarManager.ts:132-149` is **not exposed to the renderer** on `<webview>` tags. While it's accessible via the guest `webContents` in the main process (using `getWebContentsId()`), this would require additional IPC coordination, adding complexity rather than simplifying the architecture.
+
+### 4. Security Implications
+
+Current `will-attach-webview` policy (electron/main.ts:363-376):
+```typescript
+const allowedPartitions = ["persist:browser", "persist:dev-preview"];
+```
+
+**Note:** The `webviewTag` preference is already enabled (electron/main.ts:329), so the incremental security risk is not enabling webviews themselves, but rather widening the `will-attach-webview` security policy.
+
+Migration would require:
+- Adding `"persist:sidecar"` to allowed partitions
+- Allowing non-localhost URLs (sidecar loads external sites like documentation)
+- Broader security policy that increases potential attack surface
+
+### 5. Z-index Behavior
+
+**Why dev preview works differently:**
+- Dev preview webviews are **children of the React DOM tree**
+- They respect normal HTML/CSS stacking context
+- Positioned as regular DOM elements with CSS z-index
+
+**Why WebContentsView behaves differently:**
+- WebContentsView is **overlaid by the main process** above the entire renderer
+- Not part of the DOM tree, so CSS z-index doesn't apply
+- Requires explicit bounds coordination to avoid overlap
+
+**The positioning "complexity":** Approximately 20-25 lines of logic in `FixedDropdown.tsx` (primarily lines 73-95) that:
+- Calculate dropdown position relative to button
+- Use CSS `max()` to stay clear of sidecar offset
+- Handle resize/scroll events
+
+This is **working, tested, and maintainable** code.
+
+## Risk Assessment
+
+### Risks of Migration to `<webview>`
+
+1. **High Priority Risks:**
+   - ❌ **Discouraged API:** Electron explicitly does not recommend webview use and does not guarantee future support
+   - ❌ **Stability:** Chromium webview undergoing "dramatic architectural changes"
+   - ❌ **Feature Complexity:** `before-input-event` not exposed to renderer, requires additional IPC for clipboard file paste
+   - ❌ **Against Best Practices:** Contradicts Electron's recommended architectural direction
+
+2. **Medium Priority Risks:**
+   - ⚠️ **Security:** Requires broadening webview security policy
+   - ⚠️ **Maintenance Burden:** Moving to discouraged API means less community support
+   - ⚠️ **Testing:** Extensive testing required across platforms
+
+3. **Low Priority Risks:**
+   - ℹ️ **State Migration:** Existing sidecar tabs need migration
+   - ℹ️ **Performance:** Webview documented as "slightly slower"
+
+### Benefit vs. Risk Trade-off
+
+**Potential Benefit:**
+- Simplify approximately 20-25 lines of dropdown positioning logic
+- Natural z-index stacking in React DOM
+
+**Risks:**
+- Future Electron version incompatibility (no support guarantee)
+- Added complexity for clipboard file paste (requires IPC coordination)
+- Increased maintenance burden (discouraged API)
+- Potential stability issues (undergoing architectural changes)
+
+**Verdict:** Risk far outweighs benefit.
+
+## Alternative Solutions
+
+Instead of migrating away from the recommended WebContentsView, consider:
+
+### Option 1: Accept Current Solution (Recommended)
+The existing `FixedDropdown` positioning logic is:
+- Working reliably
+- Well-tested
+- Approximately 20-25 lines of focused code
+- Solves the problem completely
+
+**Cost:** None (already implemented)
+
+### Option 2: UI Architecture Improvements
+If positioning becomes problematic in the future:
+- Shared overlay layer for dropdowns (above WebContentsView)
+- Clearer z-index contracts in CSS architecture
+- Portal-based dropdown rendering with explicit bounds coordination
+
+**Cost:** Medium (architectural change)
+
+### Option 3: Rethink Sidecar UI Pattern
+If dropdown/sidecar conflict becomes a recurring issue:
+- Move sidecar to a separate window
+- Use a tabbed interface instead of overlay
+- Redesign toolbar to avoid overlap scenarios
+
+**Cost:** High (major UX change)
+
+## Technical Decision Rationale
+
+1. **Electron's Direction:** WebContentsView is the recommended, future-proof API
+2. **Feature Parity:** WebContentsView has features webview lacks (`before-input-event`)
+3. **Risk Profile:** Migration introduces high risk for minimal benefit
+4. **Working Solution:** Current dropdown positioning is functional and maintainable
+5. **Community Support:** WebContentsView has better documentation and support
+
+## Recommendation
+
+**DO NOT migrate sidecar from WebContentsView to `<webview>` tag.**
+
+Instead:
+1. ✅ Keep current WebContentsView-based architecture
+2. ✅ Maintain existing `FixedDropdown` positioning logic
+3. ✅ Monitor Electron updates for any WebContentsView improvements
+4. ✅ Document this decision to prevent future reconsideration
+
+If dropdown positioning becomes problematic in the future, explore UI-level solutions (Option 2) rather than architectural regression to deprecated APIs.
+
+## References
+
+### Electron Documentation
+- [Web Embeds Tutorial](https://www.electronjs.org/docs/latest/tutorial/web-embeds) - WebContentsView recommendation
+- [webview Tag API](https://www.electronjs.org/docs/latest/api/webview-tag) - Deprecation warnings
+- [Migrating to WebContentsView](https://www.electronjs.org/blog/migrate-to-webcontentsview) - Best practices
+
+### Affected Files
+- `electron/services/SidecarManager.ts` - Current WebContentsView implementation (383 lines)
+- `src/components/ui/fixed-dropdown.tsx:73-95` - Dropdown positioning logic core (~20-25 lines)
+- `src/components/DevPreview/DevPreviewPane.tsx:701-709` - Webview reference implementation
+- `electron/main.ts:363-376` - Webview security policy
+
+### Code Evidence
+- `SidecarManager.ts:132-149` - `before-input-event` clipboard handling (not exposed to renderer in webview)
+- `SidecarManager.ts:151-246` - Context menu implementation (equivalent events in webview)
+- `DevPreviewPane.tsx:397-402` - Webview event listeners (navigation event parity confirmed)
+
+## Conclusion
+
+This investigation conclusively demonstrates that migrating to `<webview>` would be **technically possible but architecturally inadvisable**. The current WebContentsView-based implementation aligns with Electron's recommended patterns, maintains all required features, and presents lower long-term risk.
+
+The dropdown positioning complexity, while non-trivial, is a solved problem that doesn't justify moving to a deprecated API. Future improvements should focus on incremental UI refinements within the stable WebContentsView architecture.


### PR DESCRIPTION
## Summary
Investigation for issue #1648 concludes that migrating sidecar from WebContentsView to `<webview>` tag is **not recommended**.

Closes #1648

## Key Findings

**Electron's Position:**
- Electron explicitly discourages `<webview>` use with no future support guarantee
- WebContentsView is the recommended modern approach with stable future

**Technical Analysis:**
- `before-input-event` not exposed to renderer in webview (requires additional IPC)
- Migration would increase architectural complexity rather than simplify
- Existing dropdown positioning logic is working and maintainable (~20-25 lines)
- WebContentsView provides better feature parity for clipboard handling

**Security:**
- Migration would require widening `will-attach-webview` policy to allow external URLs
- Increases potential attack surface for minimal benefit

## Decision

**Keep current WebContentsView architecture** and maintain existing FixedDropdown positioning logic as the optimal solution.

## Changes Made

- Document comprehensive investigation findings in `SIDECAR_MIGRATION_INVESTIGATION.md`
- Analyzed Electron API comparisons (WebContentsView vs webview)
- Audited feature compatibility with current SidecarManager implementation
- Assessed security implications and risk trade-offs
- Provided alternative solutions for future consideration
- Included complete references to Electron documentation and affected code