### PR TITLE
Fix tab navigation in notes dialog after title edit

### DIFF
--- a/electron/utils/__tests__/fs.test.ts
+++ b/electron/utils/__tests__/fs.test.ts
@@ -22,7 +22,7 @@ describe("waitForPathExists", () => {
     mockAccess.mockResolvedValueOnce(undefined);
 
     const promise = waitForPathExists("/test/path");
-    
+
     // We expect it to resolve without time advancement because it's immediate
     await expect(promise).resolves.toBeUndefined();
 
@@ -44,16 +44,16 @@ describe("waitForPathExists", () => {
 
     // It should check immediately (0ms elapsed) and fail.
     // Then sleep(50).
-    
+
     // We advance time to trigger the first retry.
     await vi.advanceTimersByTimeAsync(50);
     // Now it should have checked again (2nd call). And failed.
     // Next delay: 50 * 2 = 100.
     // sleeps 100.
-    
+
     await vi.advanceTimersByTimeAsync(100);
     // Now it should have checked again (3rd call). And succeeded.
-    
+
     await expect(promise).resolves.toBeUndefined();
     expect(mockAccess).toHaveBeenCalledTimes(3);
   });
@@ -76,10 +76,10 @@ describe("waitForPathExists", () => {
     // 1st call: fails. sleep 50.
     await vi.advanceTimersByTimeAsync(50);
     // 2nd call: fails. next=100. sleep 100.
-    
+
     await vi.advanceTimersByTimeAsync(100);
     // 3rd call: fails. next=200. cap=120. sleep 120.
-    
+
     await vi.advanceTimersByTimeAsync(120);
     // 4th call: succeeds.
 
@@ -122,7 +122,7 @@ describe("waitForPathExists", () => {
 
     // Advance time
     await vi.advanceTimersByTimeAsync(100);
-    
+
     // Should call access now
     await expect(promise).resolves.toBeUndefined();
     expect(mockAccess).toHaveBeenCalledTimes(1);
@@ -140,16 +140,16 @@ describe("waitForPathExists", () => {
 
     // 1st call fails. Sleep 200.
     await vi.advanceTimersByTimeAsync(200); // 2nd call
-    
+
     // 2nd fails. next=400. Sleep 400?
     // remaining = 500 - 200 = 300.
     // actualDelay = min(400, 300) = 300.
-    
+
     await vi.advanceTimersByTimeAsync(200); // Only 200 elapsed. Total 400.
     // Still sleeping (need 100 more).
-    
-    expect(mockAccess).toHaveBeenCalledTimes(2); 
-    
+
+    expect(mockAccess).toHaveBeenCalledTimes(2);
+
     await vi.advanceTimersByTimeAsync(100); // Total 500. Sleep done?
     // It wakes up. Check checkExists? No.
     // Logic:
@@ -157,12 +157,13 @@ describe("waitForPathExists", () => {
     // loop continues.
     // elapsed = 500.
     // if (elapsed >= timeoutMs) throw.
-    
+
     await expect(promise).rejects.toThrow(/Timeout waiting for path to exist/);
   });
 
   it("should clean up pending timers on success", async () => {
-    mockAccess.mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+    mockAccess
+      .mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
       .mockResolvedValueOnce(undefined);
 
     const promise = waitForPathExists("/test/path", {

--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -835,6 +835,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
                       <button
                         type="button"
                         onClick={handleOpenAsPanel}
+                        tabIndex={-1}
                         className="px-2.5 py-1.5 rounded-[var(--radius-md)] text-xs text-canopy-text/60 hover:text-canopy-text hover:bg-white/5 transition-colors flex items-center gap-1.5 shrink-0"
                         title="Open as panel (Shift+Enter)"
                       >

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -914,7 +914,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         view.destroy();
         editorViewRef.current = null;
       };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Editor created once, updated via compartments
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- Editor created once, updated via compartments
     }, [terminalId]);
 
     useEffect(() => {
@@ -1033,12 +1033,8 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           focusEditor();
         }}
       >
-        {isOverlayMode && (
-          <div aria-hidden="true" style={{ height: `${collapsedHeightPx}px` }} />
-        )}
-        <div className={cn(isOverlayMode && "absolute inset-x-0 bottom-0 z-10")}>
-          {barContent}
-        </div>
+        {isOverlayMode && <div aria-hidden="true" style={{ height: `${collapsedHeightPx}px` }} />}
+        <div className={cn(isOverlayMode && "absolute inset-x-0 bottom-0 z-10")}>{barContent}</div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
This PR fixes the tab navigation flow in the Notes palette by removing the "Open Panel" button from the tab order. After editing a note title, pressing Tab now moves focus directly to the CodeMirror editor instead of stopping at the "Open Panel" button.

Closes #1737

## Changes Made
- Add `tabIndex={-1}` to Open Panel button in NotesPalette
- Allows Tab key to move focus from title input directly to editor
- Button remains accessible via mouse click and Shift+Enter shortcut
- Apply formatting fixes to maintain code quality

## Acceptance Criteria
- [x] After editing a note title, pressing Tab moves focus directly to the CodeMirror editor
- [x] The "Open Panel" button remains clickable with mouse
- [x] The Shift+Enter keyboard shortcut for opening as panel still works
- [x] The button is not focusable via Tab key