### PR TITLE
Fix GitHub issue/PR count preservation during refresh

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -294,11 +294,9 @@ export function GitHubResourceList({
 
       <div className="overflow-y-auto flex-1 min-h-0">
         {loading && !data.length ? (
-          initialCount === 0 ? (
-            renderEmpty()
-          ) : (
-            renderSkeleton(initialCount ?? MAX_SKELETON_ITEMS)
-          )
+          // Always show skeleton during initial load - never show empty state based on initialCount
+          // Empty state should only appear after API confirms there are no results
+          renderSkeleton(initialCount && initialCount > 0 ? initialCount : MAX_SKELETON_ITEMS)
         ) : error ? (
           renderError()
         ) : data.length === 0 ? (

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -41,6 +41,13 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const [isStale, setIsStale] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
 
+  // Preserve last known non-zero counts to prevent empty state flash during refresh
+  const lastKnownCountsRef = useRef<{
+    issueCount: number | null;
+    prCount: number | null;
+    projectPath: string | null;
+  }>({ issueCount: null, prCount: null, projectPath: null });
+
   const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
   const isVisibleRef = useRef(!document.hidden);
   const mountedRef = useRef(true);
@@ -72,7 +79,52 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       const repoStats = await githubClient.getRepoStats(project.path, force);
 
       if (mountedRef.current) {
-        setStats(repoStats);
+        // Ignore results from previous project (race condition protection)
+        if (lastKnownCountsRef.current.projectPath !== null &&
+            lastKnownCountsRef.current.projectPath !== project.path) {
+          return;
+        }
+
+        // Track current project to detect stale fetches
+        lastKnownCountsRef.current.projectPath = project.path;
+
+        // Only preserve counts when data is stale or errored (not on successful fresh fetch)
+        const shouldPreserve = repoStats.stale === true || repoStats.ghError !== undefined;
+
+        if (shouldPreserve) {
+          // Preserve last known counts during transient failures/stale data
+          // Don't update preserved counts - keep the last good values
+        } else {
+          // Fresh successful data - update preserved counts and accept genuine 0s
+          if (repoStats.issueCount !== null && repoStats.issueCount > 0) {
+            lastKnownCountsRef.current.issueCount = repoStats.issueCount;
+          } else if (repoStats.issueCount === 0) {
+            // Clear preserved count on confirmed 0 from successful fetch
+            lastKnownCountsRef.current.issueCount = null;
+          }
+
+          if (repoStats.prCount !== null && repoStats.prCount > 0) {
+            lastKnownCountsRef.current.prCount = repoStats.prCount;
+          } else if (repoStats.prCount === 0) {
+            // Clear preserved count on confirmed 0 from successful fetch
+            lastKnownCountsRef.current.prCount = null;
+          }
+        }
+
+        // Apply preservation: use preserved counts only when data is stale/errored
+        const preservedStats: RepositoryStats = {
+          ...repoStats,
+          issueCount:
+            shouldPreserve && repoStats.issueCount === 0 && lastKnownCountsRef.current.issueCount !== null
+              ? lastKnownCountsRef.current.issueCount
+              : repoStats.issueCount,
+          prCount:
+            shouldPreserve && repoStats.prCount === 0 && lastKnownCountsRef.current.prCount !== null
+              ? lastKnownCountsRef.current.prCount
+              : repoStats.prCount,
+        };
+
+        setStats(preservedStats);
         setIsStale(repoStats.stale ?? false);
         setLastUpdated(repoStats.lastUpdated ?? null);
 
@@ -185,6 +237,9 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         clearTimeout(pollTimerRef.current);
         pollTimerRef.current = null;
       }
+
+      // Clear preserved counts on project switch to prevent cross-contamination
+      lastKnownCountsRef.current = { issueCount: null, prCount: null, projectPath: null };
 
       fetchStats().then(() => {
         if (mountedRef.current) {


### PR DESCRIPTION
## Summary
Prevents the GitHub issues and PRs list UI from momentarily showing an empty state during data refresh. The system now preserves last known counts when data is stale or errored, while accepting genuine 0s from successful fresh fetches.

Closes #1740

## Changes Made
- Add count preservation logic in useRepositoryStats hook
- Only preserve counts when data is stale or has errors
- Clear preserved counts on successful fresh fetch with genuine 0
- Protect against race conditions from previous project fetches
- Update GitHubResourceList to always show skeleton during load
- Clear preserved state on project switch to prevent cross-contamination

## Technical Details
The fix uses a ref-based approach to track last known non-zero counts and only applies preservation when:
1. Data is marked as stale (`repoStats.stale === true`)
2. API returns an error (`repoStats.ghError !== undefined`)

This ensures that:
- Users never see empty state flash during normal refresh operations
- Repositories can still correctly display 0 issues/PRs when genuinely empty
- Counts don't persist across project switches (prevents cross-contamination)
- Race conditions from previous project fetches are handled correctly