### PR TITLE
Fix button spacing by removing explicit icon margins

### DIFF
--- a/src/components/EventInspector/EventFilters.tsx
+++ b/src/components/EventInspector/EventFilters.tsx
@@ -181,6 +181,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
               size="icon-sm"
               onClick={clearSearch}
               className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
+              aria-label="Clear search"
             >
               <X className="w-4 h-4" />
             </Button>
@@ -210,6 +211,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
                 size="icon-sm"
                 onClick={clearTraceId}
                 className="absolute right-1 top-1/2 -translate-y-1/2 h-6 w-6"
+                aria-label="Clear trace ID filter"
               >
                 <X className="w-4 h-4" />
               </Button>

--- a/src/components/GitHub/CommitList.tsx
+++ b/src/components/GitHub/CommitList.tsx
@@ -161,7 +161,7 @@ export function CommitList({ projectPath, onClose, initialCount }: CommitListPro
         onClick={handleRetry}
         className="mt-2 text-[var(--color-status-error)] hover:brightness-110"
       >
-        <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+        <RefreshCw />
         Retry
       </Button>
     </div>
@@ -240,7 +240,7 @@ export function CommitList({ projectPath, onClose, initialCount }: CommitListPro
                 >
                   {loadingMore ? (
                     <>
-                      <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                      <RefreshCw className="animate-spin" />
                       Loading...
                     </>
                   ) : (

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -229,7 +229,7 @@ export function GitHubResourceList({
         onClick={handleRetry}
         className="mt-2 text-[var(--color-status-error)] hover:brightness-110"
       >
-        <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+        <RefreshCw />
         Retry
       </Button>
     </div>
@@ -339,7 +339,7 @@ export function GitHubResourceList({
                 >
                   {loadingMore ? (
                     <>
-                      <RefreshCw className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                      <RefreshCw className="animate-spin" />
                       Loading...
                     </>
                   ) : (

--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -576,11 +576,11 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                               size="sm"
                               onClick={() => fileInputRef.current?.click()}
                             >
-                              <Upload className="h-4 w-4 mr-1" />
+                              <Upload />
                               Replace
                             </Button>
                             <Button variant="ghost" size="sm" onClick={handleRemoveIcon}>
-                              <X className="h-4 w-4" />
+                              <X />
                             </Button>
                           </div>
                         </div>
@@ -670,7 +670,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                           }}
                           className="w-full"
                         >
-                          <Plus className="h-4 w-4 mr-2" />
+                          <Plus />
                           Add Path Pattern
                         </Button>
                       </div>
@@ -800,7 +800,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                           }}
                           className="w-full"
                         >
-                          <Plus className="h-4 w-4 mr-2" />
+                          <Plus />
                           Add Variable
                         </Button>
                       </div>
@@ -938,7 +938,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                           }}
                           className="w-full"
                         >
-                          <Plus className="h-4 w-4 mr-2" />
+                          <Plus />
                           Add Command
                         </Button>
                       </div>
@@ -1088,7 +1088,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                                         title="Edit recipe"
                                         aria-label={`Edit recipe ${recipe.name}`}
                                       >
-                                        <Edit3 className="h-3.5 w-3.5" />
+                                        <Edit3 />
                                       </Button>
                                       <Button
                                         variant="ghost"
@@ -1103,9 +1103,9 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                                         }
                                       >
                                         {exported ? (
-                                          <Check className="h-3.5 w-3.5 text-[var(--color-status-success)]" />
+                                          <Check className="text-[var(--color-status-success)]" />
                                         ) : (
-                                          <Download className="h-3.5 w-3.5" />
+                                          <Download />
                                         )}
                                       </Button>
                                       <Button
@@ -1116,7 +1116,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                                         title="Delete recipe"
                                         aria-label={`Delete recipe ${recipe.name}`}
                                       >
-                                        <Trash2 className="h-3.5 w-3.5 text-[var(--color-status-error)]" />
+                                        <Trash2 className="text-[var(--color-status-error)]" />
                                       </Button>
                                     </div>
                                   </div>
@@ -1135,11 +1135,11 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
                         )}
                         <div className="flex gap-2">
                           <Button variant="outline" onClick={handleAddRecipe} className="flex-1">
-                            <Plus className="h-4 w-4 mr-2" />
+                            <Plus />
                             Add Recipe
                           </Button>
                           <Button variant="outline" onClick={() => setShowImportDialog(true)}>
-                            <FileDown className="h-4 w-4 mr-2" />
+                            <FileDown />
                             Import Recipe
                           </Button>
                         </div>

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -591,7 +591,7 @@ export function ProjectSwitcher() {
                 disabled={isLoading}
               >
                 <span>Select Project...</span>
-                <ChevronsUpDown className="h-4 w-4 opacity-50" />
+                <ChevronsUpDown className="opacity-50" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent
@@ -623,7 +623,7 @@ export function ProjectSwitcher() {
           onClick={addProject}
           disabled={isLoading}
         >
-          <Plus className="mr-2 h-4 w-4" />
+          <Plus />
           Open Project...
         </Button>
       </>
@@ -666,7 +666,7 @@ export function ProjectSwitcher() {
                       </span>
                     </div>
                   </div>
-                  <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors" />
+                  <ChevronsUpDown className="shrink-0 text-muted-foreground/40 group-hover:text-muted-foreground/70 transition-colors" />
                 </Button>
               </DropdownMenuTrigger>
             </TooltipTrigger>

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -170,7 +170,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
               disabled={isLoading}
               className="text-canopy-text/50 hover:text-canopy-text"
             >
-              <RefreshCw size={14} className="mr-1.5" />
+              <RefreshCw size={14} />
               {helpResult ? "Refresh" : "Load"}
             </Button>
 
@@ -182,7 +182,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
                 disabled={isLoading}
                 className="text-canopy-text/50 hover:text-canopy-text"
               >
-                <Copy size={14} className="mr-1.5" />
+                <Copy size={14} />
                 {isCopied ? "Copied!" : "Copy"}
               </Button>
             )}

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -280,7 +280,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       }
                     }}
                   >
-                    <ExternalLink size={14} className="mr-1.5" />
+                    <ExternalLink size={14} />
                     View Usage
                   </Button>
                 )}
@@ -293,7 +293,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                     onSettingsChange?.();
                   }}
                 >
-                  <RotateCcw size={14} className="mr-1.5" />
+                  <RotateCcw size={14} />
                   Reset
                 </Button>
               </div>
@@ -514,7 +514,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                         }}
                         className="text-canopy-accent hover:text-canopy-accent/80"
                       >
-                        <ExternalLink size={14} className="mr-1.5" />
+                        <ExternalLink size={14} />
                         Open Install Docs
                       </Button>
                     </div>
@@ -538,7 +538,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
                       }}
                       className="w-full text-canopy-text/50 hover:text-canopy-text"
                     >
-                      <ExternalLink size={14} className="mr-1.5" />
+                      <ExternalLink size={14} />
                       View Official Documentation
                     </Button>
                   )}

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -200,10 +200,10 @@ export function GitHubSettingsTab() {
             className="min-w-[70px] text-canopy-text border-canopy-border hover:bg-canopy-border"
           >
             {isTesting ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
+              <Loader2 className="animate-spin" />
             ) : (
               <>
-                <FlaskConical className="w-4 h-4 mr-1" />
+                <FlaskConical />
                 Test
               </>
             )}
@@ -214,7 +214,7 @@ export function GitHubSettingsTab() {
             size="sm"
             className="min-w-[70px]"
           >
-            {isValidating ? <Loader2 className="w-4 h-4 animate-spin" /> : "Save"}
+            {isValidating ? <Loader2 className="animate-spin" /> : "Save"}
           </Button>
           {githubConfig?.hasToken && (
             <Button
@@ -271,7 +271,7 @@ export function GitHubSettingsTab() {
           size="sm"
           className="text-canopy-text border-canopy-border hover:bg-canopy-border"
         >
-          <ExternalLink className="w-4 h-4 mr-2" />
+          <ExternalLink />
           Create Token on GitHub
         </Button>
         <div className="mt-2 space-y-1">

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -172,7 +172,7 @@ export function TroubleshootingTab() {
               }
               className="text-canopy-text border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
             >
-              <FileText className="w-4 h-4 mr-2" />
+              <FileText />
               Open Log File
             </Button>
             <Button
@@ -181,7 +181,7 @@ export function TroubleshootingTab() {
               onClick={handleClearLogs}
               className="text-[var(--color-status-error)] border-canopy-border hover:bg-red-900/20 hover:text-red-300 hover:border-red-900/30"
             >
-              <Trash2 className="w-4 h-4 mr-2" />
+              <Trash2 />
               Clear Logs
             </Button>
           </div>

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -759,7 +759,7 @@ export function NewWorktreeDialog({
                       <span className="truncate">
                         {selectedBranchOption?.labelText || "Select base branch..."}
                       </span>
-                      <ChevronsUpDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
+                      <ChevronsUpDown className="opacity-50 shrink-0" />
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-[400px] p-0" align="start">
@@ -976,7 +976,7 @@ export function NewWorktreeDialog({
                     }}
                     disabled={creating}
                   >
-                    <FolderOpen className="w-4 h-4" />
+                    <FolderOpen />
                   </Button>
                 </div>
                 {pathWasAutoResolved && (
@@ -1044,7 +1044,7 @@ export function NewWorktreeDialog({
                         disabled={creating}
                       >
                         <span className="flex items-center gap-2 truncate">
-                          <Play className="w-4 h-4 shrink-0 text-canopy-accent" />
+                          <Play className="shrink-0 text-canopy-accent" />
                           {selectedRecipe ? (
                             <>
                               <span>{selectedRecipe.name}</span>
@@ -1057,7 +1057,7 @@ export function NewWorktreeDialog({
                             <span className="text-canopy-text/60">No recipe</span>
                           )}
                         </span>
-                        <ChevronsUpDown className="h-4 w-4 opacity-50 shrink-0 ml-2" />
+                        <ChevronsUpDown className="opacity-50 shrink-0" />
                       </Button>
                     </PopoverTrigger>
                     <PopoverContent className="w-[400px] p-0" align="start">
@@ -1162,12 +1162,12 @@ export function NewWorktreeDialog({
         <Button onClick={handleCreate} disabled={creating || loading} className="min-w-[100px]">
           {creating ? (
             <>
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              <Loader2 className="animate-spin" />
               Creating...
             </>
           ) : (
             <>
-              <Check className="w-4 h-4 mr-2" />
+              <Check />
               Create
             </>
           )}

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -318,7 +318,7 @@ AppDialog.Footer = function AppDialogFooter({
           disabled={secondaryAction.disabled || secondaryAction.loading}
           className="text-canopy-text/70 hover:text-canopy-text"
         >
-          {secondaryAction.loading && <Loader2 className="h-4 w-4 animate-spin" />}
+          {secondaryAction.loading && <Loader2 className="animate-spin" />}
           {secondaryAction.label}
         </Button>
       )}
@@ -328,7 +328,7 @@ AppDialog.Footer = function AppDialogFooter({
           onClick={primaryAction.onClick}
           disabled={primaryAction.disabled || primaryAction.loading}
         >
-          {primaryAction.loading && <Loader2 className="h-4 w-4 animate-spin" />}
+          {primaryAction.loading && <Loader2 className="animate-spin" />}
           {primaryAction.label}
         </Button>
       )}


### PR DESCRIPTION
## Summary

This PR resolves the button spacing issues identified in #1742 by systematically removing explicit icon sizing and margin classes (`w-4 h-4 mr-2`, `ml-2`, etc.) from button children. This allows the button component's built-in gap system (`gap-2`, `[&_svg]:size-4`) to handle icon spacing and sizing consistently across all variants.

Closes #1742

## Changes Made

- **NewWorktreeDialog.tsx**: Removed icon margins from Create button (Check, Loader2), branch selector chevrons, folder picker button, and recipe selector
- **AppDialog.tsx**: Removed icon sizing from Loader2 in footer action buttons (primary/secondary)
- **GitHubSettingsTab.tsx**: Removed icon sizing/margins from Test and Save buttons
- **TroubleshootingTab.tsx**: Removed icon sizing from log action buttons
- **ProjectSettingsDialog.tsx**: Removed icon sizing/margins from icon replacement buttons, recipe edit/export/delete actions
- **ProjectSwitcher.tsx**: Removed icon sizing/margins from project selector chevrons
- **GitHubResourceList.tsx**: Removed icon sizing/margins from retry and load more buttons
- **CommitList.tsx**: Removed icon sizing/margins from retry and load more buttons
- **AgentSettings.tsx**: Removed margins from external link and reset buttons
- **AgentHelpOutput.tsx**: Removed margins from refresh and copy buttons
- **EventFilters.tsx**: Added aria-labels to icon-only clear buttons for accessibility

## Visual Impact

Before: Icons had explicit `mr-2` margins that compounded with the button's `gap-2`, creating inconsistent spacing
After: Icons inherit size from button variants (`[&_svg]:size-4` for default, `size-3.5` for sm, etc.) and spacing from gap system

## Testing

- ✅ TypeScript compilation passes
- ✅ All button variants maintain consistent icon-to-text spacing
- ✅ Loading states (animated spinners) work correctly
- ✅ Icon-only buttons remain visually balanced
- ✅ Accessibility improved with aria-labels on clear buttons