### PR TITLE
Add interactive context chips for @file references

### DIFF
--- a/src/components/Terminal/hybridInputParsing.ts
+++ b/src/components/Terminal/hybridInputParsing.ts
@@ -71,3 +71,80 @@ export function getLeadingSlashCommand(text: string): SlashCommandToken | null {
     command: text.slice(0, tokenEnd),
   };
 }
+
+export interface AtFileToken {
+  start: number;
+  end: number;
+  path: string;
+  isQuoted: boolean;
+}
+
+export function getAllAtFileTokens(text: string): AtFileToken[] {
+  const tokens: AtFileToken[] = [];
+  let i = 0;
+
+  while (i < text.length) {
+    if (text[i] !== "@") {
+      i++;
+      continue;
+    }
+
+    // Check that @ is at start or preceded by whitespace or common delimiters
+    if (i > 0 && !/[\s([{]/.test(text[i - 1])) {
+      i++;
+      continue;
+    }
+
+    const atStart = i;
+    i++; // Move past @
+
+    if (i >= text.length) break;
+
+    // Check for quoted path
+    const quoteChar = text[i];
+    if (quoteChar === '"' || quoteChar === "'") {
+      i++; // Move past opening quote
+      const pathStart = i;
+      // Find closing quote, stopping at newlines to prevent multi-line paths
+      while (i < text.length && text[i] !== quoteChar && text[i] !== "\n" && text[i] !== "\r") {
+        // Support backslash-escaped quotes
+        if (text[i] === "\\" && i + 1 < text.length && text[i + 1] === quoteChar) {
+          i += 2; // Skip escaped quote
+          continue;
+        }
+        i++;
+      }
+      // Only create token if we found the closing quote (not newline or end)
+      if (i < text.length && text[i] === quoteChar) {
+        const path = text.slice(pathStart, i);
+        i++; // Move past closing quote
+        if (path.length > 0) {
+          // Unescape any escaped quotes in the path
+          const unescapedPath = path.replace(new RegExp(`\\\\${quoteChar}`, "g"), quoteChar);
+          tokens.push({ start: atStart, end: i, path: unescapedPath, isQuoted: true });
+        }
+      }
+      // If unterminated quote, skip it and continue scanning from next position
+    } else {
+      // Unquoted path - read until whitespace or common delimiters
+      const pathStart = i;
+      while (
+        i < text.length &&
+        !/[\s,;:)}\]]/.test(text[i]) &&
+        text[i] !== "\n" &&
+        text[i] !== "\r"
+      ) {
+        i++;
+      }
+      let path = text.slice(pathStart, i);
+      // Trim trailing punctuation that's likely not part of the path
+      path = path.replace(/[.,;:!?]+$/, "");
+      if (path.length > 0) {
+        const actualEnd = atStart + 1 + path.length;
+        tokens.push({ start: atStart, end: actualEnd, path, isQuoted: false });
+      }
+    }
+  }
+
+  return tokens;
+}


### PR DESCRIPTION
## Summary
Transforms raw `@filename` text in HybridInputBar into interactive visual chips (pills) that visually separate instructions from data and provide file path tooltips on hover.

Closes #1365

## Changes Made
- Add `getAllAtFileTokens` parser with quote escaping and delimiter support
- Implement CodeMirror decorations and tooltips for file chips with distinct blue styling
- Cache tokens in StateField to eliminate redundant parsing on hover
- Add equality checks for context updates to prevent unnecessary re-renders
- Support `@file` detection after delimiters like `([{` in addition to whitespace
- Handle edge cases: unterminated quotes, multi-line prevention, trailing punctuation trimming

## Implementation Details
- **Parsing**: New `getAllAtFileTokens` function handles both quoted (`@"path with spaces"`) and unquoted (`@src/file.ts`) paths with proper boundary detection
- **Decorations**: Blue chips rendered via CodeMirror mark decorations that preserve underlying text for CLI submission
- **Performance**: Tokens cached in StateField, reused by tooltip to avoid re-parsing on every hover
- **React optimization**: Context objects compared for equality before state updates to minimize re-renders

## Testing
- Verified TypeScript compilation passes
- Ran linting and formatting checks
- Codex review identified and fixed 5 critical edge cases