### PR TITLE
Include issue and PR titles in worktree search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -533,10 +533,14 @@ function App() {
     const filtered = sorted.filter((worktree) => {
       if (!search) return true;
       const branch = worktree.branch ?? "";
+      const issueTitle = worktree.issueTitle ?? "";
+      const prTitle = worktree.prTitle ?? "";
       return (
         worktree.name.toLowerCase().includes(search) ||
         branch.toLowerCase().includes(search) ||
-        worktree.path.toLowerCase().includes(search)
+        worktree.path.toLowerCase().includes(search) ||
+        issueTitle.toLowerCase().includes(search) ||
+        prTitle.toLowerCase().includes(search)
       );
     });
 

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -169,6 +169,16 @@ describe("buildSearchableText", () => {
     expect(buildSearchableText(worktree)).toContain("working on feature x");
   });
 
+  it("includes issue title", () => {
+    const worktree = createMockWorktree({ issueTitle: "Add dark mode toggle" });
+    expect(buildSearchableText(worktree)).toContain("add dark mode toggle");
+  });
+
+  it("includes PR title", () => {
+    const worktree = createMockWorktree({ prTitle: "Fix authentication bug" });
+    expect(buildSearchableText(worktree)).toContain("fix authentication bug");
+  });
+
   it("includes aiNote", () => {
     const worktree = createMockWorktree({ aiNote: "Agent is implementing tests" });
     expect(buildSearchableText(worktree)).toContain("agent is implementing tests");

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -59,6 +59,8 @@ export function buildSearchableText(worktree: Worktree | WorktreeState): string 
     worktree.issueNumber ? `#${worktree.issueNumber}` : "",
     worktree.prNumber ? `#${worktree.prNumber}` : "",
     worktree.summary ?? "",
+    worktree.issueTitle ?? "",
+    worktree.prTitle ?? "",
     worktree.aiNote ?? "",
   ];
 


### PR DESCRIPTION
## Summary
Extends the worktree search filter to include GitHub issue titles and PR titles in addition to existing searchable fields. Users can now find worktrees by searching for text in issue or PR titles, not just issue numbers.

Closes #1749

## Changes Made
- Add issueTitle and prTitle to buildSearchableText function
- Update worktree palette filter to search issue and PR titles  
- Add test coverage for issueTitle and prTitle search