### PR TITLE
feat(commands): add core command infrastructure

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -233,6 +233,11 @@ export const CHANNELS = {
   DEV_PREVIEW_SET_URL: "dev-preview:set-url",
   DEV_PREVIEW_STATUS: "dev-preview:status",
   DEV_PREVIEW_URL: "dev-preview:url",
+
+  COMMANDS_LIST: "commands:list",
+  COMMANDS_GET: "commands:get",
+  COMMANDS_EXECUTE: "commands:execute",
+  COMMANDS_GET_BUILDER: "commands:get-builder",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -25,6 +25,7 @@ import { registerGeminiHandlers } from "./handlers/gemini.js";
 import { registerEventsHandlers } from "./handlers/events.js";
 import { registerNotesHandlers } from "./handlers/notes.js";
 import { registerDevPreviewHandlers } from "./handlers/devPreview.js";
+import { registerCommandHandlers } from "./handlers/commands.js";
 import { events } from "../services/events.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
@@ -69,6 +70,7 @@ export function registerIpcHandlers(
     registerEventsHandlers(deps),
     registerNotesHandlers(deps),
     registerDevPreviewHandlers(deps),
+    registerCommandHandlers(),
   ];
 
   return () => {

--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -1,0 +1,103 @@
+/**
+ * IPC handlers for the command system.
+ * Exposes command registry and execution to the renderer process.
+ */
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import { commandService } from "../../services/CommandService.js";
+import type {
+  CommandContext,
+  CommandExecutePayload,
+  CommandGetPayload,
+  CommandManifestEntry,
+  CommandResult,
+  CanopyCommand,
+} from "../../../shared/types/commands.js";
+
+export function registerCommandHandlers(): () => void {
+  const handlers: Array<() => void> = [];
+
+  // List all commands
+  const handleCommandsList = async (
+    _event: Electron.IpcMainInvokeEvent,
+    context?: CommandContext
+  ): Promise<CommandManifestEntry[]> => {
+    return commandService.list(context);
+  };
+  ipcMain.handle(CHANNELS.COMMANDS_LIST, handleCommandsList);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_LIST));
+
+  // Get single command
+  const handleCommandsGet = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: CommandGetPayload
+  ): Promise<CommandManifestEntry | null> => {
+    if (!payload || typeof payload.commandId !== "string") {
+      console.warn("[CommandHandlers] Invalid commands:get payload", payload);
+      return null;
+    }
+    return commandService.getManifest(payload.commandId, payload.context) ?? null;
+  };
+  ipcMain.handle(CHANNELS.COMMANDS_GET, handleCommandsGet);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_GET));
+
+  // Execute command
+  const handleCommandsExecute = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: CommandExecutePayload
+  ): Promise<CommandResult> => {
+    if (!payload || typeof payload.commandId !== "string") {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_PAYLOAD",
+          message: "Invalid command execution payload",
+        },
+      };
+    }
+
+    // Validate context is a plain object
+    const context = payload.context ?? {};
+    if (typeof context !== "object" || Array.isArray(context)) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_PAYLOAD",
+          message: "Context must be a plain object",
+        },
+      };
+    }
+
+    // Validate args is a plain object
+    const args = payload.args ?? {};
+    if (args !== null && (typeof args !== "object" || Array.isArray(args))) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_PAYLOAD",
+          message: "Arguments must be a plain object",
+        },
+      };
+    }
+
+    return commandService.execute(payload.commandId, context, args);
+  };
+  ipcMain.handle(CHANNELS.COMMANDS_EXECUTE, handleCommandsExecute);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_EXECUTE));
+
+  // Get command builder
+  const handleCommandsGetBuilder = async (
+    _event: Electron.IpcMainInvokeEvent,
+    commandId: string
+  ): Promise<CanopyCommand["builder"] | null> => {
+    if (typeof commandId !== "string") {
+      return null;
+    }
+    return commandService.getBuilder(commandId) ?? null;
+  };
+  ipcMain.handle(CHANNELS.COMMANDS_GET_BUILDER, handleCommandsGetBuilder);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_GET_BUILDER));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -385,6 +385,12 @@ const CHANNELS = {
   // Gemini channels
   GEMINI_GET_STATUS: "gemini:get-status",
   GEMINI_ENABLE_ALTERNATE_BUFFER: "gemini:enable-alternate-buffer",
+
+  // Commands channels
+  COMMANDS_LIST: "commands:list",
+  COMMANDS_GET: "commands:get",
+  COMMANDS_EXECUTE: "commands:execute",
+  COMMANDS_GET_BUILDER: "commands:get-builder",
 } as const;
 
 const api: ElectronAPI = {
@@ -1096,6 +1102,42 @@ const api: ElectronAPI = {
     getStatus: () => _typedInvoke(CHANNELS.GEMINI_GET_STATUS),
 
     enableAlternateBuffer: () => _typedInvoke(CHANNELS.GEMINI_ENABLE_ALTERNATE_BUFFER),
+  },
+
+  // Commands API
+  commands: {
+    list: (context?: {
+      terminalId?: string;
+      worktreeId?: string;
+      projectId?: string;
+      cwd?: string;
+      agentId?: string;
+    }) => ipcRenderer.invoke(CHANNELS.COMMANDS_LIST, context),
+
+    get: (payload: {
+      commandId: string;
+      context?: {
+        terminalId?: string;
+        worktreeId?: string;
+        projectId?: string;
+        cwd?: string;
+        agentId?: string;
+      };
+    }) => ipcRenderer.invoke(CHANNELS.COMMANDS_GET, payload),
+
+    execute: (payload: {
+      commandId: string;
+      context: {
+        terminalId?: string;
+        worktreeId?: string;
+        projectId?: string;
+        cwd?: string;
+        agentId?: string;
+      };
+      args?: Record<string, unknown>;
+    }) => ipcRenderer.invoke(CHANNELS.COMMANDS_EXECUTE, payload),
+
+    getBuilder: (commandId: string) => ipcRenderer.invoke(CHANNELS.COMMANDS_GET_BUILDER, commandId),
   },
 };
 

--- a/electron/services/CommandService.ts
+++ b/electron/services/CommandService.ts
@@ -1,0 +1,278 @@
+/**
+ * Command registry and execution service.
+ * Manages registration, retrieval, and execution of Canopy commands.
+ */
+
+import type {
+  CanopyCommand,
+  CommandContext,
+  CommandManifestEntry,
+  CommandResult,
+} from "../../shared/types/commands.js";
+
+class CommandServiceImpl {
+  private commands = new Map<string, CanopyCommand>();
+
+  /**
+   * Register a command with the service.
+   * @throws Error if command with same ID is already registered
+   */
+  register<TArgs = Record<string, unknown>, TResult = unknown>(
+    command: CanopyCommand<TArgs, TResult>
+  ): void {
+    if (this.commands.has(command.id)) {
+      throw new Error(`Command "${command.id}" is already registered`);
+    }
+    this.commands.set(command.id, command as CanopyCommand);
+  }
+
+  /**
+   * Unregister a command by ID.
+   * @returns true if command was removed, false if not found
+   */
+  unregister(id: string): boolean {
+    return this.commands.delete(id);
+  }
+
+  /**
+   * Get a command by ID.
+   * @returns The command or undefined if not found
+   */
+  get(id: string): CanopyCommand | undefined {
+    return this.commands.get(id);
+  }
+
+  /**
+   * Check if a command is registered.
+   */
+  has(id: string): boolean {
+    return this.commands.has(id);
+  }
+
+  /**
+   * List all registered commands as manifest entries.
+   * @param context Optional context for checking enabled state
+   */
+  list(context?: CommandContext): CommandManifestEntry[] {
+    const entries: CommandManifestEntry[] = [];
+    const safeContext = context ?? {};
+
+    for (const command of Array.from(this.commands.values())) {
+      try {
+        const enabled = command.isEnabled ? command.isEnabled(safeContext) : true;
+        const disabledReason =
+          !enabled && command.disabledReason ? command.disabledReason(safeContext) : undefined;
+
+        entries.push({
+          id: command.id,
+          label: command.label,
+          description: command.description,
+          category: command.category,
+          args: command.args,
+          keywords: command.keywords,
+          hasBuilder: !!command.builder,
+          enabled,
+          disabledReason,
+        });
+      } catch {
+        entries.push({
+          id: command.id,
+          label: command.label,
+          description: command.description,
+          category: command.category,
+          args: command.args,
+          keywords: command.keywords,
+          hasBuilder: !!command.builder,
+          enabled: false,
+          disabledReason: "Error evaluating command state",
+        });
+      }
+    }
+
+    return entries.sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  /**
+   * List commands filtered by category.
+   */
+  listByCategory(
+    category: string,
+    context?: CommandContext
+  ): CommandManifestEntry[] {
+    return this.list(context).filter((cmd) => cmd.category === category);
+  }
+
+  /**
+   * Execute a command by ID.
+   * @param id Command ID
+   * @param context Execution context
+   * @param args Command arguments
+   * @returns Command result
+   */
+  async execute<TResult = unknown>(
+    id: string,
+    context: CommandContext,
+    args: Record<string, unknown> = {}
+  ): Promise<CommandResult<TResult>> {
+    const command = this.commands.get(id);
+
+    if (!command) {
+      return {
+        success: false,
+        error: {
+          code: "COMMAND_NOT_FOUND",
+          message: `Command "${id}" not found`,
+        },
+      };
+    }
+
+    // Validate args is a plain object
+    if (args !== null && (typeof args !== "object" || Array.isArray(args))) {
+      return {
+        success: false,
+        error: {
+          code: "INVALID_ARGUMENTS",
+          message: "Arguments must be a plain object",
+        },
+      };
+    }
+
+    // Check if command is enabled (with error handling)
+    try {
+      if (command.isEnabled && !command.isEnabled(context)) {
+        const reason = command.disabledReason
+          ? command.disabledReason(context)
+          : "Command is currently disabled";
+        return {
+          success: false,
+          error: {
+            code: "COMMAND_DISABLED",
+            message: reason,
+          },
+        };
+      }
+    } catch {
+      return {
+        success: false,
+        error: {
+          code: "COMMAND_DISABLED",
+          message: "Error evaluating command state",
+        },
+      };
+    }
+
+    // Build effective arguments with defaults (without mutating input)
+    const effectiveArgs: Record<string, unknown> = { ...args };
+    if (command.args) {
+      for (const argDef of command.args) {
+        const hasArg =
+          Object.prototype.hasOwnProperty.call(effectiveArgs, argDef.name) &&
+          effectiveArgs[argDef.name] != null;
+
+        if (argDef.required && !hasArg) {
+          if (argDef.default !== undefined) {
+            effectiveArgs[argDef.name] = argDef.default;
+          } else {
+            return {
+              success: false,
+              error: {
+                code: "MISSING_ARGUMENT",
+                message: `Required argument "${argDef.name}" is missing`,
+                details: { argument: argDef.name },
+              },
+            };
+          }
+        }
+      }
+    }
+
+    try {
+      const result = await command.execute(context, effectiveArgs);
+      return result as CommandResult<TResult>;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        error: {
+          code: "EXECUTION_ERROR",
+          message,
+          details: err instanceof Error ? { stack: err.stack } : undefined,
+        },
+      };
+    }
+  }
+
+  /**
+   * Get manifest entry for a single command.
+   */
+  getManifest(id: string, context?: CommandContext): CommandManifestEntry | undefined {
+    const command = this.commands.get(id);
+    if (!command) return undefined;
+
+    const safeContext = context ?? {};
+    try {
+      const enabled = command.isEnabled ? command.isEnabled(safeContext) : true;
+      const disabledReason =
+        !enabled && command.disabledReason ? command.disabledReason(safeContext) : undefined;
+
+      return {
+        id: command.id,
+        label: command.label,
+        description: command.description,
+        category: command.category,
+        args: command.args,
+        keywords: command.keywords,
+        hasBuilder: !!command.builder,
+        enabled,
+        disabledReason,
+      };
+    } catch {
+      return {
+        id: command.id,
+        label: command.label,
+        description: command.description,
+        category: command.category,
+        args: command.args,
+        keywords: command.keywords,
+        hasBuilder: !!command.builder,
+        enabled: false,
+        disabledReason: "Error evaluating command state",
+      };
+    }
+  }
+
+  /**
+   * Get the builder configuration for a command.
+   */
+  getBuilder(id: string): CanopyCommand["builder"] | undefined {
+    const command = this.commands.get(id);
+    return command?.builder;
+  }
+
+  /**
+   * Get all registered command IDs.
+   */
+  getIds(): string[] {
+    return Array.from(this.commands.keys()).sort();
+  }
+
+  /**
+   * Get count of registered commands.
+   */
+  get count(): number {
+    return this.commands.size;
+  }
+
+  /**
+   * Clear all registered commands.
+   * Primarily for testing.
+   */
+  clear(): void {
+    this.commands.clear();
+  }
+}
+
+/** Singleton instance of the CommandService */
+export const commandService = new CommandServiceImpl();
+
+export type { CommandServiceImpl };

--- a/shared/types/commands.ts
+++ b/shared/types/commands.ts
@@ -1,0 +1,171 @@
+/**
+ * Core command types for Canopy's global command system.
+ * Commands are executable operations that can be invoked from terminals,
+ * UI, or AI agents.
+ */
+
+/** Command categories for grouping and discovery */
+export type CommandCategory = "github" | "git" | "workflow" | "project" | "system";
+
+/** Supported argument value types */
+export type CommandArgumentType = "string" | "number" | "boolean" | "select";
+
+/** Definition for a single command argument */
+export interface CommandArgument {
+  /** Unique name for this argument (e.g., "issueNumber", "branchName") */
+  name: string;
+  /** Argument value type */
+  type: CommandArgumentType;
+  /** Human-readable description */
+  description: string;
+  /** Whether this argument is required */
+  required: boolean;
+  /** Default value if not provided */
+  default?: string | number | boolean;
+  /** Available choices for select type */
+  choices?: Array<{ value: string; label: string }>;
+}
+
+/** Execution context passed to commands */
+export interface CommandContext {
+  /** ID of the terminal executing this command (if applicable) */
+  terminalId?: string;
+  /** ID of the worktree this command is executed in */
+  worktreeId?: string;
+  /** ID of the current project */
+  projectId?: string;
+  /** Current working directory */
+  cwd?: string;
+  /** ID of the agent executing this command (if applicable) */
+  agentId?: string;
+}
+
+/** Result returned from command execution */
+export interface CommandResult<T = unknown> {
+  /** Whether execution succeeded */
+  success: boolean;
+  /** Human-readable message about the result */
+  message?: string;
+  /** Optional data payload */
+  data?: T;
+  /** Error details if success is false */
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+/** Field types for command builder UI */
+export type BuilderFieldType = "text" | "number" | "select" | "checkbox" | "textarea";
+
+/** Validation rules for builder fields */
+export interface BuilderFieldValidation {
+  /** Minimum value (for number fields) or minimum length (for text) */
+  min?: number;
+  /** Maximum value (for number fields) or maximum length (for text) */
+  max?: number;
+  /** Regex pattern to match (for text fields) */
+  pattern?: string;
+  /** Error message when validation fails */
+  message?: string;
+}
+
+/** Field definition for command builder UI */
+export interface BuilderField {
+  /** Unique field identifier (maps to argument name) */
+  name: string;
+  /** Display label */
+  label: string;
+  /** Field input type */
+  type: BuilderFieldType;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Whether field is required */
+  required: boolean;
+  /** Validation rules */
+  validation?: BuilderFieldValidation;
+  /** Options for select fields */
+  options?: Array<{ value: string; label: string }>;
+  /** Help text shown below field */
+  helpText?: string;
+}
+
+/** Step in a multi-step command builder */
+export interface BuilderStep {
+  /** Unique step identifier */
+  id: string;
+  /** Step title */
+  title: string;
+  /** Step description */
+  description?: string;
+  /** Fields to collect in this step */
+  fields: BuilderField[];
+}
+
+/** Command definition */
+export interface CanopyCommand<TArgs = Record<string, unknown>, TResult = unknown> {
+  /** Unique command identifier using colon namespace (e.g., "github:create-issue") */
+  id: string;
+  /** Human-readable label */
+  label: string;
+  /** Brief description of what the command does */
+  description: string;
+  /** Category for grouping */
+  category: CommandCategory;
+  /** Command arguments definition */
+  args?: CommandArgument[];
+  /** Execute the command */
+  execute: (context: CommandContext, args: TArgs) => Promise<CommandResult<TResult>>;
+  /** Optional builder configuration for interactive UI */
+  builder?: {
+    /** Builder steps (single step if only one) */
+    steps: BuilderStep[];
+  };
+  /** Keywords for search/discovery */
+  keywords?: string[];
+  /** Whether command is currently available */
+  isEnabled?: (context: CommandContext) => boolean;
+  /** Reason why command is disabled */
+  disabledReason?: (context: CommandContext) => string | undefined;
+}
+
+/** Command manifest entry for introspection (without execute function) */
+export interface CommandManifestEntry {
+  /** Unique command identifier */
+  id: string;
+  /** Human-readable label */
+  label: string;
+  /** Brief description */
+  description: string;
+  /** Category */
+  category: CommandCategory;
+  /** Argument definitions */
+  args?: CommandArgument[];
+  /** Keywords for search */
+  keywords?: string[];
+  /** Whether command has a builder UI */
+  hasBuilder: boolean;
+  /** Whether command is currently enabled */
+  enabled: boolean;
+  /** Reason if disabled */
+  disabledReason?: string;
+}
+
+/** Payload for executing a command via IPC */
+export interface CommandExecutePayload {
+  /** Command ID to execute */
+  commandId: string;
+  /** Execution context */
+  context: CommandContext;
+  /** Command arguments */
+  args?: Record<string, unknown>;
+}
+
+/** Payload for getting a single command */
+export interface CommandGetPayload {
+  /** Command ID to retrieve */
+  commandId: string;
+  /** Context for checking enabled state */
+  context?: CommandContext;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -340,3 +340,20 @@ export type {
   ActionDispatchOptions,
   ActionDispatchPayload,
 } from "./actions.js";
+
+// Command system types - global command registry and execution
+export type {
+  CommandCategory,
+  CommandArgumentType,
+  CommandArgument,
+  CommandContext,
+  CommandResult,
+  BuilderFieldType,
+  BuilderFieldValidation,
+  BuilderField,
+  BuilderStep,
+  CanopyCommand,
+  CommandManifestEntry,
+  CommandExecutePayload,
+  CommandGetPayload,
+} from "./commands.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -60,6 +60,14 @@ import type { ShowContextMenuPayload } from "../menu.js";
 import type { FileSearchPayload, FileSearchResult } from "./files.js";
 import type { SlashCommand, SlashCommandListRequest } from "../slashCommands.js";
 import type { DevPreviewStatusPayload, DevPreviewUrlPayload } from "./devPreview.js";
+import type {
+  CommandContext,
+  CommandManifestEntry,
+  CommandResult,
+  CommandExecutePayload,
+  CommandGetPayload,
+  BuilderStep,
+} from "../commands.js";
 
 // ElectronAPI Type (exposed via preload)
 
@@ -514,5 +522,15 @@ export interface ElectronAPI {
     getStatus(): Promise<{ exists: boolean; alternateBufferEnabled: boolean; error?: string }>;
     /** Enable alternate buffer in Gemini settings */
     enableAlternateBuffer(): Promise<{ success: boolean }>;
+  };
+  commands: {
+    /** List all registered commands */
+    list(context?: CommandContext): Promise<CommandManifestEntry[]>;
+    /** Get a specific command by ID */
+    get(payload: CommandGetPayload): Promise<CommandManifestEntry | null>;
+    /** Execute a command */
+    execute(payload: CommandExecutePayload): Promise<CommandResult>;
+    /** Get builder configuration for a command */
+    getBuilder(commandId: string): Promise<{ steps: BuilderStep[] } | null>;
   };
 }

--- a/src/clients/commandsClient.ts
+++ b/src/clients/commandsClient.ts
@@ -1,0 +1,26 @@
+import type {
+  CommandContext,
+  CommandManifestEntry,
+  CommandResult,
+  CommandExecutePayload,
+  CommandGetPayload,
+  BuilderStep,
+} from "@shared/types/commands";
+
+export const commandsClient = {
+  list: (context?: CommandContext): Promise<CommandManifestEntry[]> => {
+    return window.electron.commands.list(context);
+  },
+
+  get: (payload: CommandGetPayload): Promise<CommandManifestEntry | null> => {
+    return window.electron.commands.get(payload);
+  },
+
+  execute: (payload: CommandExecutePayload): Promise<CommandResult> => {
+    return window.electron.commands.execute(payload);
+  },
+
+  getBuilder: (commandId: string): Promise<{ steps: BuilderStep[] } | null> => {
+    return window.electron.commands.getBuilder(commandId);
+  },
+};

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -17,3 +17,4 @@ export { systemClient } from "./systemClient";
 export { terminalClient } from "./terminalClient";
 export { worktreeClient } from "./worktreeClient";
 export { worktreeConfigClient } from "./worktreeConfigClient";
+export { commandsClient } from "./commandsClient";


### PR DESCRIPTION
## Summary
Implements the foundational command infrastructure for Canopy, providing a typed, extensible command registry and execution system with full IPC integration.

Closes #1756

## Changes Made
- Add CommandService for command registration and execution with error handling
- Implement comprehensive command type definitions with builder support
- Add IPC handlers for command system with payload validation
- Expose commands API in preload and create renderer client
- Add error handling for context evaluation and argument validation
- Integrate with existing IPC patterns and ElectronAPI types

## Implementation Details
- **Type Safety**: Full TypeScript types for commands, contexts, arguments, and results
- **Error Handling**: Try-catch guards around context evaluation to prevent main process crashes
- **Validation**: Input validation for IPC payloads (context and args must be plain objects)
- **API Consistency**: Follows existing Canopy patterns for services, IPC handlers, and clients
- **Builder Support**: Optional multi-step builder configuration for interactive command UIs
- **Codex Review**: Addressed high/medium priority issues from automated code review