### PR TITLE
Align github:create-issue and github:work-issue with refined skill prompts

### DIFF
--- a/electron/services/commands/githubCreateIssue.ts
+++ b/electron/services/commands/githubCreateIssue.ts
@@ -16,27 +16,32 @@ interface CreateIssueResult {
 export const githubCreateIssueCommand: CanopyCommand<CreateIssueArgs, CreateIssueResult> = {
   id: "github:create-issue",
   label: "/github:create-issue",
-  description: "Create a new GitHub issue in the current repository",
+  description:
+    "Create a GitHub issue in the current repository. " +
+    "Use structured sections, file links, and task lists to make issues self-contained for autonomous work.",
   category: "github",
-  keywords: ["issue", "create", "new", "bug", "feature", "ticket"],
+  keywords: ["issue", "create", "new", "bug", "feature", "ticket", "task", "request"],
 
   args: [
     {
       name: "title",
       type: "string",
-      description: "Issue title",
+      description:
+        "Concise title describing what needs to be done (e.g., 'Add dark mode toggle to settings')",
       required: true,
     },
     {
       name: "body",
       type: "string",
-      description: "Issue description/body",
+      description:
+        "Structured issue body with sections: Summary, Current Behavior, Expected Behavior, " +
+        "Deliverables, Files to Modify, and Acceptance Criteria. Include file links and code references.",
       required: true,
     },
     {
       name: "labels",
       type: "string",
-      description: "Comma-separated labels (e.g., 'bug,ui')",
+      description: "Comma-separated labels (e.g., 'enhancement,ui' or 'bug,critical')",
       required: false,
     },
   ],
@@ -45,36 +50,47 @@ export const githubCreateIssueCommand: CanopyCommand<CreateIssueArgs, CreateIssu
     steps: [
       {
         id: "issue-details",
-        title: "Issue Details",
-        description: "Enter the details for the new GitHub issue",
+        title: "Create GitHub Issue",
+        description:
+          "Create a well-structured issue that provides enough context for developers or AI agents to implement autonomously",
         fields: [
           {
             name: "title",
-            label: "Title",
+            label: "Issue Title",
             type: "text",
-            placeholder: "Brief description of the issue",
+            placeholder: "Add dark mode toggle to application settings",
             required: true,
             validation: {
               min: 10,
               message: "Title must be at least 10 characters",
             },
-            helpText: "A clear, concise title describing the issue",
+            helpText:
+              "A clear, action-oriented title. Start with a verb: Add, Fix, Update, Implement, Refactor",
           },
           {
             name: "body",
-            label: "Description",
+            label: "Issue Body",
             type: "textarea",
-            placeholder: "Detailed description of the issue...",
+            placeholder:
+              "## Summary\nBrief description of what needs to be done.\n\n" +
+              "## Current Behavior\nWhat currently happens (if applicable).\n\n" +
+              "## Expected Behavior\nWhat should happen after this is implemented.\n\n" +
+              "## Deliverables\n- [ ] Task 1\n- [ ] Task 2\n\n" +
+              "## Files to Modify\n- `src/path/to/file.ts` - Description of changes\n\n" +
+              "## Acceptance Criteria\n- [ ] Criterion 1\n- [ ] Criterion 2",
             required: true,
-            helpText: "Provide context, steps to reproduce, expected behavior, etc.",
+            helpText:
+              "Use markdown sections. Include file paths as links, code blocks for examples, " +
+              "and checkbox lists for tasks. The more context, the better for autonomous implementation.",
           },
           {
             name: "labels",
             label: "Labels",
             type: "text",
-            placeholder: "bug, enhancement, documentation",
+            placeholder: "enhancement, ui",
             required: false,
-            helpText: "Comma-separated labels to apply (optional)",
+            helpText:
+              "Common labels: bug, enhancement, documentation, refactor, testing, ui, api, performance",
           },
         ],
       },
@@ -87,7 +103,7 @@ export const githubCreateIssueCommand: CanopyCommand<CreateIssueArgs, CreateIssu
 
   disabledReason: () => {
     if (!getGitHubToken()) {
-      return "GitHub token not configured. Set it in Settings > GitHub.";
+      return "GitHub token not configured. Set it in Settings.";
     }
     return undefined;
   },
@@ -99,7 +115,7 @@ export const githubCreateIssueCommand: CanopyCommand<CreateIssueArgs, CreateIssu
         success: false,
         error: {
           code: "NO_TOKEN",
-          message: "GitHub token not configured. Set it in Settings > GitHub.",
+          message: "GitHub token not configured. Set it in Settings.",
         },
       };
     }

--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -160,26 +160,33 @@ async function detectBaseBranch(
 export const githubWorkIssueCommand: CanopyCommand<GitHubWorkIssueArgs, GitHubWorkIssueResult> = {
   id: "github:work-issue",
   label: "/github:work-issue",
-  description: "Create a worktree for a GitHub issue",
+  description:
+    "Start working on a GitHub issue by creating an isolated worktree. " +
+    "Fetches issue details, generates a branch name, creates a worktree, and switches to it. " +
+    "Perfect for parallel development without stashing changes.",
   category: "github",
 
   args: [
     {
       name: "issueNumber",
       type: "number",
-      description: "GitHub issue number",
+      description:
+        "GitHub issue number to work on. Can be extracted from issue URL or entered directly.",
       required: true,
     },
     {
       name: "branchName",
       type: "string",
-      description: "Custom branch name (auto-generated if not provided)",
+      description:
+        "Custom branch name. If not provided, auto-generates as 'issue-{number}-{slugified-title}'.",
       required: false,
     },
     {
       name: "baseBranch",
       type: "string",
-      description: "Base branch to branch from (defaults to main or develop)",
+      description:
+        "Base branch to branch from. Auto-detects: prefers 'develop' if exists, otherwise tries 'main', then 'master'. " +
+        "For hotfixes, use 'main' explicitly.",
       required: false,
     },
   ],
@@ -188,43 +195,50 @@ export const githubWorkIssueCommand: CanopyCommand<GitHubWorkIssueArgs, GitHubWo
     steps: [
       {
         id: "issue",
-        title: "Select Issue",
-        description: "Enter the GitHub issue number to work on",
+        title: "Work on GitHub Issue",
+        description:
+          "Create an isolated worktree for the issue. By default, the worktree is created in a sibling " +
+          "directory, allowing you to work on multiple issues simultaneously without conflicts.",
         fields: [
           {
             name: "issueNumber",
             label: "Issue Number",
             type: "number",
-            placeholder: "123",
+            placeholder: "1234",
             required: true,
             validation: {
               min: 1,
               message: "Issue number must be a positive integer",
             },
-            helpText: "The GitHub issue number (e.g., 123)",
+            helpText:
+              "Enter the issue number from the GitHub URL (e.g., 1234 from github.com/org/repo/issues/1234)",
           },
           {
             name: "branchName",
-            label: "Branch Name",
+            label: "Branch Name (Optional)",
             type: "text",
-            placeholder: "Auto-generated from issue title",
+            placeholder: "issue-1234-add-dark-mode",
             required: false,
-            helpText: "Optional custom branch name. If not provided, will be auto-generated.",
+            helpText:
+              "Leave empty to auto-generate from issue title. Format: issue-{number}-{slugified-title}. " +
+              "If the branch already exists, a suffix will be added automatically.",
           },
           {
             name: "baseBranch",
-            label: "Base Branch",
+            label: "Base Branch (Optional)",
             type: "text",
-            placeholder: "main",
+            placeholder: "develop",
             required: false,
-            helpText: "Branch to base off. Defaults to develop (if exists) or main.",
+            helpText:
+              "Branch to start from. Auto-detects: uses 'develop' if it exists, otherwise tries 'main', then 'master'. " +
+              "Override for hotfixes (use 'main') or feature branches (use specific branch).",
           },
         ],
       },
     ],
   },
 
-  keywords: ["github", "issue", "worktree", "branch", "work"],
+  keywords: ["github", "issue", "worktree", "branch", "work", "parallel", "isolate"],
 
   isEnabled: () => hasGitHubToken(),
 


### PR DESCRIPTION
## Summary
Enhanced command definitions for github:create-issue and github:work-issue to match the refined language and guidance from their corresponding skill prompts, improving discoverability and user experience.

Closes #1768

## Changes Made
- Enhanced command descriptions with full workflow context
- Updated builder field labels, placeholders, and help text
- Added structured templates showing recommended issue format
- Improved examples (realistic issue titles, branch patterns)
- Clarified auto-detection behavior for base branches (develop → main → master)
- Noted configurable worktree path (default sibling directory)
- Standardized token error messages across commands
- Fixed section naming inconsistency (Tasks → Files to Modify)
- Added keywords for better discoverability