### PR TITLE
Fix: Restore compact hybrid input bar height

### DIFF
--- a/src/components/Commands/CommandPickerButton.tsx
+++ b/src/components/Commands/CommandPickerButton.tsx
@@ -18,7 +18,7 @@ export const CommandPickerButton = forwardRef<HTMLButtonElement, CommandPickerBu
         disabled={disabled}
         className={cn(
           "flex items-center justify-center",
-          "h-7 w-7 rounded-[var(--radius-sm)]",
+          "h-6 w-6 rounded-[var(--radius-sm)]",
           "text-canopy-text/50 hover:text-canopy-text/80 hover:bg-white/[0.06]",
           "transition-colors",
           "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-canopy-accent",
@@ -28,7 +28,7 @@ export const CommandPickerButton = forwardRef<HTMLButtonElement, CommandPickerBu
         title="Open command picker (⌘K)"
         aria-label="Open command picker"
       >
-        <Terminal className="h-4 w-4" />
+        <Terminal className="h-3.5 w-3.5" />
       </button>
     );
   }

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1032,13 +1032,13 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     }, [value]);
 
     const barContent = (
-      <div ref={barContentRef} className="group cursor-text bg-canopy-bg px-4 pb-5 pt-4">
+      <div ref={barContentRef} className="group cursor-text bg-canopy-bg px-4 pb-3 pt-3">
         <div className="flex items-end gap-2">
           <div
             ref={inputShellRef}
             className={cn(
               "relative",
-              "flex w-full items-stretch gap-1.5 rounded-sm border border-white/[0.06] bg-white/[0.03] py-2 shadow-[0_6px_12px_rgba(0,0,0,0.18)] transition-colors",
+              "flex w-full items-center gap-1.5 rounded-sm border border-white/[0.06] bg-white/[0.03] py-1 shadow-[0_6px_12px_rgba(0,0,0,0.18)] transition-colors",
               "group-hover:border-white/[0.08] group-hover:bg-white/[0.04]",
               "focus-within:border-white/[0.12] focus-within:ring-1 focus-within:ring-white/[0.06] focus-within:bg-white/[0.05]",
               disabled && "opacity-60",
@@ -1057,7 +1057,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               ariaLabel={activeMode === "command" ? "Command autocomplete" : "File autocomplete"}
             />
 
-            <div className="select-none self-start pl-2 pr-1 font-mono text-xs font-semibold leading-5 text-canopy-accent/85">
+            <div className="select-none pl-2 pr-1 font-mono text-xs font-semibold leading-5 text-canopy-accent/85">
               ❯
             </div>
 
@@ -1068,7 +1068,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               />
             </div>
 
-            <div className="self-center pr-2">
+            <div className="pr-1.5">
               <CommandPickerButton onClick={openPicker} disabled={disabled || isInitializing} />
             </div>
           </div>


### PR DESCRIPTION
## Summary
Restores the hybrid input bar to its compact height after PR #1765 added the CommandPickerButton, which increased the overall bar height and made the UI appear disproportionate.

Closes #1766

## Changes Made
- Reduce outer wrapper padding from pt-4 pb-5 to pt-3 pb-3
- Reduce inner input shell padding from py-2 to py-1
- Change input shell alignment from items-stretch to items-center
- Remove self-start from prompt glyph (now uses parent items-center)
- Reduce CommandPickerButton size from h-7 w-7 to h-6 w-6
- Reduce CommandPickerButton icon from h-4 w-4 to h-3.5 w-3.5
- Adjust button container padding from pr-2 to pr-1.5

## Testing
- Build validated successfully
- TypeScript checks pass
- Multiline input expansion remains functional
- CodeMirror height measurement (collapsedHeightPx) unaffected
- Touch targets remain accessible (6x6 button with 1.5 padding)