### PR TITLE
Remove required fields from Builder and change to explanation-based prompting

### DIFF
--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -167,8 +167,8 @@ export const githubWorkIssueCommand: CanopyCommand<GitHubWorkIssueArgs, GitHubWo
     {
       name: "issueNumber",
       type: "number",
-      description: "GitHub issue number",
-      required: true,
+      description: "GitHub issue number (optional - agent can detect from context)",
+      required: false,
     },
     {
       name: "branchName",
@@ -189,26 +189,24 @@ export const githubWorkIssueCommand: CanopyCommand<GitHubWorkIssueArgs, GitHubWo
       {
         id: "issue",
         title: "Select Issue",
-        description: "Enter the GitHub issue number to work on",
+        description: "Specify the issue to work on - the agent can help if you're unsure",
         fields: [
           {
             name: "issueNumber",
             label: "Issue Number",
             type: "number",
-            placeholder: "123",
-            required: true,
+            placeholder: "e.g., 123",
             validation: {
               min: 1,
               message: "Issue number must be a positive integer",
             },
-            helpText: "The GitHub issue number (e.g., 123)",
+            helpText: "The GitHub issue number. Leave empty to let the agent help you find one.",
           },
           {
             name: "branchName",
             label: "Branch Name",
             type: "text",
             placeholder: "Auto-generated from issue title",
-            required: false,
             helpText: "Optional custom branch name. If not provided, will be auto-generated.",
           },
           {
@@ -216,7 +214,6 @@ export const githubWorkIssueCommand: CanopyCommand<GitHubWorkIssueArgs, GitHubWo
             label: "Base Branch",
             type: "text",
             placeholder: "main",
-            required: false,
             helpText: "Branch to base off. Defaults to develop (if exists) or main.",
           },
         ],

--- a/shared/types/commands.ts
+++ b/shared/types/commands.ts
@@ -81,8 +81,8 @@ export interface BuilderField {
   type: BuilderFieldType;
   /** Placeholder text */
   placeholder?: string;
-  /** Whether field is required */
-  required: boolean;
+  /** Whether field is required (deprecated - all fields are now optional) */
+  required?: boolean;
   /** Validation rules */
   validation?: BuilderFieldValidation;
   /** Options for select fields */


### PR DESCRIPTION
## Summary
This PR removes required field validation from the CommandBuilder component and updates command definitions to support explanation-based prompting. Users can now provide minimal or natural language input, and agents will interpret their intent instead of enforcing rigid form validation.

Closes #1767

## Changes Made
- Remove required field validation from CommandBuilder component
- Change "Description" label to "Explanation" in githubCreateIssue builder
- Make all builder fields optional (BuilderField.required now optional type)
- Update execute functions to handle empty/missing arguments gracefully
- Normalize empty strings to undefined in form submission (agents see "unset" not "provided empty")
- Initialize checkbox fields to explicit false values
- Trim whitespace for empty field detection in validation

## Impact
- **Builder UX**: Fields no longer show required asterisks, validation messages updated
- **Agent workflow**: Commands can now be invoked with minimal structured input
- **Backward compatible**: Filling out fields still works as before