### PR TITLE
feat(dock): add compact mode to prevent overlay on hybrid input

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -231,7 +231,7 @@ export type PanelLocation = "grid" | "dock" | "trash";
 export type TerminalLocation = PanelLocation;
 
 /** Dock display mode (slim is legacy and treated as hidden) */
-export type DockMode = "expanded" | "slim" | "hidden";
+export type DockMode = "expanded" | "compact" | "slim" | "hidden";
 
 /**
  * Dock behavior controls how the dock mode is determined:

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -81,13 +81,23 @@ export function AppLayout({
         // Note: Focus mode is now restored via hydration callback (setFocusMode in HydrationCallbacks)
         // which reads per-project focus mode state. This ensures each project has its own focus mode.
         // Hydrate dock state with legacy migration and validation
-        const validModes: Array<"expanded" | "slim" | "hidden"> = ["expanded", "slim", "hidden"];
+        const validModes: Array<"expanded" | "compact" | "slim" | "hidden"> = [
+          "expanded",
+          "compact",
+          "slim",
+          "hidden",
+        ];
         const validBehaviors: Array<"auto" | "manual"> = ["auto", "manual"];
         const rawMode = appState.dockMode;
         const rawBehavior = appState.dockBehavior;
         const isValidMode = rawMode && validModes.includes(rawMode as any);
         const isValidBehavior = rawBehavior && validBehaviors.includes(rawBehavior as any);
-        const dockMode = isValidMode ? (rawMode === "expanded" ? "expanded" : "hidden") : "hidden";
+        // Map legacy "slim" to "hidden", preserve "compact" and other valid modes
+        const dockMode = isValidMode
+          ? rawMode === "slim"
+            ? "hidden"
+            : (rawMode as "expanded" | "compact" | "hidden")
+          : "hidden";
         const dockBehavior = isValidBehavior ? rawBehavior : "auto";
         useDockStore.getState().hydrate({
           mode: dockMode,

--- a/src/components/Layout/CompactDock.tsx
+++ b/src/components/Layout/CompactDock.tsx
@@ -1,0 +1,342 @@
+import { useCallback, useMemo, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
+import { useDroppable } from "@dnd-kit/core";
+import { ChevronUp, ChevronLeft, ChevronRight, Layers } from "lucide-react";
+import { cn, getBaseTitle } from "@/lib/utils";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import {
+  useTerminalStore,
+  useProjectStore,
+  useWorktreeSelectionStore,
+  useDockStore,
+} from "@/store";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { WaitingContainer } from "./WaitingContainer";
+import { FailedContainer } from "./FailedContainer";
+import { TrashContainer } from "./TrashContainer";
+import {
+  SortableDockItem,
+  SortableDockPlaceholder,
+  DOCK_PLACEHOLDER_ID,
+} from "@/components/DragDrop";
+import { useKeybindingDisplay, useHorizontalScrollControls, useNativeContextMenu } from "@/hooks";
+import { useWorktrees } from "@/hooks/useWorktrees";
+import type { MenuItemOption } from "@/types";
+import type { TerminalType, TerminalKind, AgentState } from "@shared/types";
+import { actionService } from "@/services/ActionService";
+
+const AGENT_OPTIONS = [
+  { type: "claude" as const, label: "Claude" },
+  { type: "gemini" as const, label: "Gemini" },
+  { type: "codex" as const, label: "Codex" },
+  { type: "opencode" as const, label: "OpenCode" },
+  { type: "terminal" as const, label: "Terminal" },
+  { type: "browser" as const, label: "Browser" },
+];
+
+interface CompactDockProps {
+  dockedCount: number;
+}
+
+export function CompactDock({ dockedCount }: CompactDockProps) {
+  const { showMenu } = useNativeContextMenu();
+  const setMode = useDockStore((state) => state.setMode);
+  const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
+  const toggleShortcut = useKeybindingDisplay("panel.toggleDock");
+
+  const dockTerminals = useTerminalStore(
+    useShallow((state) =>
+      state.terminals.filter(
+        (t) =>
+          t.location === "dock" && (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
+      )
+    )
+  );
+
+  const trashedTerminals = useTerminalStore(useShallow((state) => state.trashedTerminals));
+  const terminals = useTerminalStore((state) => state.terminals);
+  const activateTerminal = useTerminalStore((state) => state.activateTerminal);
+  const openDockTerminal = useTerminalStore((state) => state.openDockTerminal);
+  const currentProject = useProjectStore((s) => s.currentProject);
+
+  const { worktrees } = useWorktrees();
+
+  const activeWorktree = activeWorktreeId ? worktrees.find((w) => w.id === activeWorktreeId) : null;
+  const cwd = activeWorktree?.path ?? currentProject?.path ?? "";
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
+    useHorizontalScrollControls(scrollContainerRef);
+
+  const { setNodeRef: setDockDropRef, isOver } = useDroppable({
+    id: "dock-container",
+    data: { container: "dock" },
+  });
+
+  const combinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      scrollContainerRef.current = node;
+      setDockDropRef(node);
+    },
+    [setDockDropRef]
+  );
+
+  const handleAddTerminal = useCallback(
+    (agentId: string) => {
+      void actionService.dispatch(
+        "agent.launch",
+        {
+          agentId: agentId as any,
+          location: "dock",
+          cwd,
+          worktreeId: activeWorktreeId || undefined,
+        },
+        { source: "context-menu" }
+      );
+    },
+    [activeWorktreeId, cwd]
+  );
+
+  const handleContextMenu = useCallback(
+    async (event: React.MouseEvent) => {
+      const template: MenuItemOption[] = AGENT_OPTIONS.map(({ type, label }) => ({
+        id: `new:${type}`,
+        label: `New ${label}`,
+      }));
+
+      const actionId = await showMenu(event, template);
+      if (!actionId) return;
+
+      if (actionId.startsWith("new:")) {
+        handleAddTerminal(actionId.slice("new:".length));
+      }
+    },
+    [handleAddTerminal, showMenu]
+  );
+
+  const handleExpandClick = () => {
+    setMode("expanded");
+  };
+
+  const trashedItems = Array.from(trashedTerminals.values())
+    .map((trashed) => ({
+      terminal: terminals.find((t) => t.id === trashed.id),
+      trashedInfo: trashed,
+    }))
+    .filter((item) => item.terminal !== undefined) as {
+    terminal: (typeof terminals)[0];
+    trashedInfo: typeof trashedTerminals extends Map<string, infer V> ? V : never;
+  }[];
+
+  const terminalIds = useMemo(() => {
+    if (dockTerminals.length === 0) {
+      return [DOCK_PLACEHOLDER_ID];
+    }
+    return dockTerminals.map((t) => t.id);
+  }, [dockTerminals]);
+
+  const expandTooltip = ["Expand dock", toggleShortcut && `(${toggleShortcut})`]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      onContextMenu={handleContextMenu}
+      className={cn(
+        "bg-[var(--dock-bg)]/95 backdrop-blur-sm",
+        "border-t border-[var(--dock-border)]",
+        "shadow-[var(--dock-shadow)]",
+        "flex items-center h-10 px-2 gap-2",
+        "z-40 shrink-0"
+      )}
+      data-dock-mode="compact"
+      data-dock-density="compact"
+    >
+      {/* Left: Expand button + docked count */}
+      <div className="flex items-center gap-1.5 shrink-0">
+        <button
+          type="button"
+          onClick={handleExpandClick}
+          className={cn(
+            "flex items-center justify-center",
+            "w-7 h-7 rounded-[var(--radius-md)]",
+            "bg-white/[0.03] hover:bg-white/[0.06]",
+            "border border-white/[0.06] hover:border-white/[0.1]",
+            "text-canopy-text/50 hover:text-canopy-text/80",
+            "transition-colors duration-150",
+            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+          )}
+          title={expandTooltip}
+          aria-label={expandTooltip}
+        >
+          <ChevronUp className="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+
+        {dockedCount > 0 && (
+          <div
+            className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-white/[0.04] text-canopy-text/50"
+            title={`${dockedCount} docked panel${dockedCount === 1 ? "" : "s"}`}
+          >
+            <Layers className="w-3 h-3" aria-hidden="true" />
+            <span className="text-[11px] font-medium tabular-nums">{dockedCount}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Separator */}
+      {dockTerminals.length > 0 && <div className="w-px h-5 bg-[var(--dock-border)] shrink-0" />}
+
+      {/* Center: Panel icons (scrollable) */}
+      <div className="relative flex-1 min-w-0">
+        {canScrollLeft && (
+          <div className="absolute left-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-r from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pr-2">
+            <button
+              type="button"
+              onClick={scrollLeft}
+              className={cn(
+                "pointer-events-auto p-1 text-canopy-text/60 hover:text-canopy-text",
+                "rounded transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+              )}
+              aria-label="Scroll left"
+              title="Scroll left"
+            >
+              <ChevronLeft className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        )}
+
+        <div
+          ref={combinedRef}
+          className={cn(
+            "flex items-center gap-1 overflow-x-auto flex-1 min-h-7 no-scrollbar scroll-smooth px-0.5",
+            isOver &&
+              "bg-white/[0.03] ring-2 ring-canopy-accent/30 ring-inset rounded-[var(--radius-md)]"
+          )}
+        >
+          <SortableContext
+            id="dock-container"
+            items={terminalIds}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className="flex items-center gap-1 min-w-[60px] min-h-6">
+              {dockTerminals.length === 0 ? (
+                <SortableDockPlaceholder />
+              ) : (
+                dockTerminals.map((terminal, index) => (
+                  <SortableDockItem key={terminal.id} terminal={terminal} sourceIndex={index}>
+                    <CompactTerminalIcon
+                      terminal={terminal}
+                      onClick={() => {
+                        setMode("expanded");
+                        openDockTerminal(terminal.id);
+                      }}
+                      onDoubleClick={() => activateTerminal(terminal.id)}
+                    />
+                  </SortableDockItem>
+                ))
+              )}
+            </div>
+          </SortableContext>
+        </div>
+
+        {canScrollRight && (
+          <div className="absolute right-0 top-1/2 -translate-y-1/2 z-10 pointer-events-none bg-gradient-to-l from-[var(--dock-bg)] via-[var(--dock-bg)]/90 to-transparent pl-2">
+            <button
+              type="button"
+              onClick={scrollRight}
+              className={cn(
+                "pointer-events-auto p-1 text-canopy-text/60 hover:text-canopy-text",
+                "rounded transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+              )}
+              aria-label="Scroll right"
+              title="Scroll right"
+            >
+              <ChevronRight className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Separator before status */}
+      <div className="w-px h-5 bg-[var(--dock-border)] shrink-0" />
+
+      {/* Right: Status indicators */}
+      <div className="shrink-0 flex items-center gap-1.5">
+        <WaitingContainer compact />
+        <FailedContainer compact />
+        <TrashContainer trashedTerminals={trashedItems} compact />
+      </div>
+    </div>
+  );
+}
+
+interface CompactTerminalIconProps {
+  terminal: {
+    id: string;
+    type?: TerminalType;
+    kind?: TerminalKind;
+    agentId?: string;
+    title: string;
+    agentState?: AgentState;
+  };
+  onClick: () => void;
+  onDoubleClick: () => void;
+}
+
+function CompactTerminalIcon({ terminal, onClick, onDoubleClick }: CompactTerminalIconProps) {
+  const brandColor = getBrandColorHex(terminal.type);
+  const displayTitle = getBaseTitle(terminal.title);
+  const isActive = terminal.agentState === "working" || terminal.agentState === "running";
+  const isWaiting = terminal.agentState === "waiting";
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.shiftKey) {
+        onDoubleClick();
+      } else {
+        onClick();
+      }
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex items-center justify-center",
+        "w-7 h-7 rounded-[var(--radius-md)]",
+        "bg-white/[0.02] hover:bg-white/[0.06]",
+        "border border-transparent hover:border-white/[0.1]",
+        "transition-all duration-150",
+        "cursor-grab active:cursor-grabbing",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
+        isActive && "ring-1 ring-canopy-accent/40",
+        isWaiting && "ring-1 ring-amber-400/40"
+      )}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      onDoubleClick={(e) => {
+        e.stopPropagation();
+        onDoubleClick();
+      }}
+      onKeyDown={handleKeyDown}
+      title={`${displayTitle} - Click to expand and preview, double-click to restore, Shift+Enter to restore`}
+      aria-label={`${displayTitle} - Press Enter to expand and preview, Shift+Enter to restore to grid`}
+    >
+      <TerminalIcon
+        type={terminal.type}
+        kind={terminal.kind}
+        agentId={terminal.agentId}
+        className={cn("w-4 h-4", isActive && "animate-pulse motion-reduce:animate-none")}
+        brandColor={brandColor}
+      />
+    </button>
+  );
+}

--- a/src/components/Layout/DockHandleOverlay.tsx
+++ b/src/components/Layout/DockHandleOverlay.tsx
@@ -10,6 +10,11 @@ export function DockHandleOverlay() {
 
   const toggleShortcut = useKeybindingDisplay("panel.toggleDock");
 
+  // Hide the floating overlay when dock is in compact mode (compact mode has its own expand button)
+  if (effectiveMode === "compact") {
+    return null;
+  }
+
   const Icon = isHandleVisible ? ChevronDown : ChevronUp;
 
   const tooltipParts = [

--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -2,12 +2,14 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useDockRenderState } from "@/hooks/useDockRenderState";
 import { useDockStore } from "@/store";
 import { ContentDock } from "./ContentDock";
+import { CompactDock } from "./CompactDock";
 import { DockHandleOverlay } from "./DockHandleOverlay";
 import { DockStatusOverlay } from "./DockStatusOverlay";
 import { DockPanelOffscreenContainer } from "./DockPanelOffscreenContainer";
 
 export function TerminalDockRegion() {
   const {
+    effectiveMode,
     shouldShowInLayout,
     showStatusOverlay,
     dockedCount,
@@ -26,16 +28,25 @@ export function TerminalDockRegion() {
     return <DockHandleOverlay />;
   }
 
+  const isCompactMode = effectiveMode === "compact";
+
   return (
     <DockPanelOffscreenContainer>
-      {/* ContentDock in layout when visible */}
-      {shouldShowInLayout && (
+      {/* CompactDock for compact mode - minimal bar with inline status */}
+      {isCompactMode && shouldShowInLayout && (
+        <ErrorBoundary variant="section" componentName="CompactDock">
+          <CompactDock dockedCount={dockedCount} />
+        </ErrorBoundary>
+      )}
+
+      {/* ContentDock for expanded mode - full dock with all features */}
+      {!isCompactMode && shouldShowInLayout && (
         <ErrorBoundary variant="section" componentName="ContentDock">
           <ContentDock density={density} />
         </ErrorBoundary>
       )}
 
-      {/* Handle overlay is always visible at bottom edge for discoverability */}
+      {/* Handle overlay is visible in expanded and hidden modes (compact has its own expand button) */}
       <DockHandleOverlay />
 
       {/* Status overlay when dock is hidden but has status counts or docked panels */}

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -3,3 +3,4 @@ export { Toolbar } from "./Toolbar";
 export { Sidebar } from "./Sidebar";
 export { WaitingContainer } from "./WaitingContainer";
 export { AgentButton } from "./AgentButton";
+export { CompactDock } from "./CompactDock";

--- a/src/hooks/useDockRenderState.ts
+++ b/src/hooks/useDockRenderState.ts
@@ -76,8 +76,9 @@ export function useDockRenderState(): DockRenderState & {
       // Auto mode: hidden by default, expanded when there are docked terminals
       return hasDocked ? "expanded" : "hidden";
     }
-    // Manual mode: use the stored mode
-    return mode === "slim" ? "hidden" : mode;
+    // Manual mode: use the stored mode (slim is legacy, maps to hidden)
+    if (mode === "slim") return "hidden";
+    return mode;
   }, [isHydrated, behavior, mode, hasDocked]);
 
   // Determine if we should show dock in layout (takes up space)
@@ -91,6 +92,10 @@ export function useDockRenderState(): DockRenderState & {
 
     // Hidden mode never shows in layout
     if (effectiveMode === "hidden") return false;
+
+    // Compact and expanded modes take up layout space
+    // For expanded mode, auto-hide when empty can hide it
+    if (effectiveMode === "compact") return true;
 
     // Expanded mode shows unless auto-hide is on and empty
     if (autoHideWhenEmpty && !hasContent) return false;
@@ -108,8 +113,8 @@ export function useDockRenderState(): DockRenderState & {
     }
   }, [isDragging, effectiveMode, peek, setPeek]);
 
-  // Compute density for ContentDock
-  const density: DockRenderState["density"] = "normal";
+  // Compute density for ContentDock - compact mode uses compact density
+  const density: DockRenderState["density"] = effectiveMode === "compact" ? "compact" : "normal";
 
   // Show status overlay when dock is hidden and there are status indicators or docked panels
   // CRITICAL: Must be mutually exclusive with shouldShowInLayout
@@ -117,7 +122,8 @@ export function useDockRenderState(): DockRenderState & {
     isHydrated && effectiveMode === "hidden" && (hasStatus || hasDocked) && !shouldShowInLayout;
 
   // Whether the dock handle should indicate visible/hidden state
-  const isHandleVisible = effectiveMode === "expanded";
+  // Both expanded and compact modes are "visible" states
+  const isHandleVisible = effectiveMode === "expanded" || effectiveMode === "compact";
 
   return {
     effectiveMode,

--- a/src/store/dockStore.ts
+++ b/src/store/dockStore.ts
@@ -26,7 +26,7 @@ const POPOVER_DEFAULT_HEIGHT = 500;
 const POPOVER_MIN_HEIGHT = 300;
 const POPOVER_MAX_HEIGHT_RATIO = 0.8;
 
-const MODE_CYCLE: DockMode[] = ["expanded", "hidden"];
+const MODE_CYCLE: DockMode[] = ["expanded", "compact", "hidden"];
 
 export const useDockStore = create<DockState>()((set, get) => ({
   mode: "hidden",
@@ -83,7 +83,8 @@ export const useDockStore = create<DockState>()((set, get) => ({
     if (behavior === "auto") {
       set({ behavior: "manual" });
     }
-    const nextMode: DockMode = mode === "expanded" ? "hidden" : "expanded";
+    // Toggle between expanded and hidden, treating compact as expanded for toggle purposes
+    const nextMode: DockMode = mode === "expanded" || mode === "compact" ? "hidden" : "expanded";
     set({ mode: nextMode });
     const state = get();
     void persistDockState({


### PR DESCRIPTION
## Summary
This PR implements a new "compact" dock mode that provides a middle ground between the "expanded" and "hidden" modes. The compact mode addresses the issue where hidden mode's floating overlays (DockHandleOverlay and DockStatusOverlay) would overlap the hybrid input bar, creating visual distraction.

Closes #1769

## Changes Made
- Add "compact" DockMode type alongside expanded and hidden modes
- Implement CompactDock component with 40px minimal bar
- Show expand button, docked panel count, scrollable icons, and inline status indicators
- Update useDockRenderState to handle compact mode visibility and density computation
- Add compact to MODE_CYCLE for seamless mode transitions (expanded → compact → hidden)
- Hide DockHandleOverlay in compact mode (uses own expand button inline)
- Fix hydration validation to preserve compact mode on restart (was being dropped)
- Add keyboard accessibility (Enter/Shift+Enter) for panel icons
- Icons expand dock then open preview on click for better UX
- Add data-dock-density attribute for proper transition targeting

## Technical Details
**Compact Mode Behavior:**
- Takes up layout space (no floating overlays that can overlap input bar)
- 40px height minimal bar at bottom of viewport
- Left side: expand button + docked panel count badge
- Center: scrollable panel icons with click-to-expand-and-preview
- Right side: inline status indicators (waiting, failed, trashed)

**Integration:**
- TerminalDockRegion renders CompactDock when effectiveMode === "compact"
- DockHandleOverlay hidden in compact mode (compact has own expand button)
- DockStatusOverlay only shows when mode === "hidden" (mutually exclusive)
- Mode cycling: Cmd+D cycles through expanded → compact → hidden → expanded

## Testing
- Typecheck, lint, and format checks all pass
- Codex review conducted with fixes applied for:
  - Hydration validation (compact mode now persists correctly)
  - Icon interaction behavior (expands dock then opens preview)
  - Keyboard accessibility (Enter/Shift+Enter support)
  - Transition targeting (data-dock-density attribute)