### PR TITLE
feat(commands): add project-level command overrides

### DIFF
--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -27,7 +27,7 @@ export function registerCommandHandlers(): () => void {
     _event: Electron.IpcMainInvokeEvent,
     context?: CommandContext
   ): Promise<CommandManifestEntry[]> => {
-    return commandService.list(context);
+    return await commandService.list(context);
   };
   ipcMain.handle(CHANNELS.COMMANDS_LIST, handleCommandsList);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_LIST));

--- a/shared/types/commands.ts
+++ b/shared/types/commands.ts
@@ -169,3 +169,19 @@ export interface CommandGetPayload {
   /** Context for checking enabled state */
   context?: CommandContext;
 }
+
+/** Command override for project-level customization */
+export interface CommandOverride {
+  /** Command ID this override applies to */
+  commandId: string;
+  /** Default argument values to apply when command is executed */
+  defaults?: Record<string, unknown>;
+  /** Whether this command is disabled for this project */
+  disabled?: boolean;
+}
+
+/** Project-level command settings */
+export interface ProjectCommandSettings {
+  /** List of command overrides for this project */
+  overrides: CommandOverride[];
+}

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -721,6 +721,8 @@ export interface ProjectSettings {
   devServerCommand?: string;
   /** CopyTree context generation configuration */
   copyTreeSettings?: CopyTreeSettings;
+  /** Command overrides for project-specific customization */
+  commandOverrides?: import("./commands.js").CommandOverride[];
 }
 
 // Toolbar Customization Types

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect } from "react";
+import { ChevronDown, ChevronRight, RotateCcw, Power, PowerOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { commandsClient } from "@/clients/commandsClient";
+import type { CommandManifestEntry, CommandOverride } from "@shared/types/commands";
+import { cn } from "@/lib/utils";
+
+interface CommandOverridesTabProps {
+  projectId: string;
+  overrides: CommandOverride[];
+  onChange: (overrides: CommandOverride[]) => void;
+}
+
+export function CommandOverridesTab({ projectId, overrides, onChange }: CommandOverridesTabProps) {
+  const [commands, setCommands] = useState<CommandManifestEntry[]>([]);
+  const [expandedCommands, setExpandedCommands] = useState<Set<string>>(new Set());
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadCommands = async () => {
+      try {
+        setIsLoading(true);
+        const result = await commandsClient.list({ projectId });
+        if (mounted) {
+          setCommands(result);
+        }
+      } catch (error) {
+        console.error("Failed to load commands:", error);
+      } finally {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadCommands();
+
+    return () => {
+      mounted = false;
+    };
+  }, [projectId]);
+
+  const getOverride = (commandId: string): CommandOverride | undefined => {
+    return overrides.find((o) => o.commandId === commandId);
+  };
+
+  const updateOverride = (commandId: string, updates: Partial<CommandOverride>) => {
+    const existing = getOverride(commandId);
+    if (existing) {
+      onChange(
+        overrides.map((o) =>
+          o.commandId === commandId ? { ...o, ...updates } : o
+        )
+      );
+    } else {
+      onChange([...overrides, { commandId, ...updates }]);
+    }
+  };
+
+  const removeOverride = (commandId: string) => {
+    onChange(overrides.filter((o) => o.commandId !== commandId));
+  };
+
+  const toggleDisabled = (commandId: string) => {
+    const override = getOverride(commandId);
+    const newDisabled = !override?.disabled;
+
+    if (newDisabled) {
+      updateOverride(commandId, { disabled: true });
+    } else {
+      if (override?.defaults && Object.keys(override.defaults).length > 0) {
+        updateOverride(commandId, { disabled: false });
+      } else {
+        removeOverride(commandId);
+      }
+    }
+  };
+
+  const toggleExpanded = (commandId: string) => {
+    setExpandedCommands((prev) => {
+      const next = new Set(prev);
+      if (next.has(commandId)) {
+        next.delete(commandId);
+      } else {
+        next.add(commandId);
+      }
+      return next;
+    });
+  };
+
+  const updateDefault = (commandId: string, argName: string, value: string) => {
+    const override = getOverride(commandId);
+    const currentDefaults = override?.defaults || {};
+
+    const newDefaults = {
+      ...currentDefaults,
+      [argName]: value,
+    };
+
+    updateOverride(commandId, { defaults: newDefaults });
+  };
+
+  const resetToDefaults = (commandId: string) => {
+    removeOverride(commandId);
+    setExpandedCommands((prev) => {
+      const next = new Set(prev);
+      next.delete(commandId);
+      return next;
+    });
+  };
+
+  const hasOverride = (commandId: string): boolean => {
+    const override = getOverride(commandId);
+    return override !== undefined && (override.disabled || (override.defaults && Object.keys(override.defaults).length > 0));
+  };
+
+  if (isLoading) {
+    return (
+      <div className="text-sm text-canopy-text/60 text-center py-8">
+        Loading commands...
+      </div>
+    );
+  }
+
+  if (commands.length === 0) {
+    return (
+      <div className="text-sm text-canopy-text/60 text-center py-8">
+        No commands available
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="mb-4">
+        <h3 className="text-sm font-semibold text-canopy-text/80 mb-2">
+          Command Overrides
+        </h3>
+        <p className="text-xs text-canopy-text/60">
+          Customize command behavior for this project. Set default argument values or disable commands entirely.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        {commands.map((command) => {
+          const override = getOverride(command.id);
+          const isDisabled = override?.disabled === true;
+          const isExpanded = expandedCommands.has(command.id);
+          const hasDefaults = command.args && command.args.length > 0;
+          const canExpand = hasDefaults && !isDisabled;
+
+          return (
+            <div
+              key={command.id}
+              className={cn(
+                "rounded-[var(--radius-md)] border transition-colors",
+                hasOverride(command.id)
+                  ? "border-canopy-accent/30 bg-canopy-accent/5"
+                  : "border-canopy-border bg-canopy-bg"
+              )}
+            >
+              <div className="flex items-center gap-2 p-3">
+                {canExpand && (
+                  <button
+                    onClick={() => toggleExpanded(command.id)}
+                    className="p-0.5 rounded hover:bg-canopy-border/50 transition-colors"
+                    aria-label={isExpanded ? "Collapse" : "Expand"}
+                  >
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-canopy-text/60" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-canopy-text/60" />
+                    )}
+                  </button>
+                )}
+                {!canExpand && <div className="w-5" />}
+
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        "text-sm font-medium font-mono",
+                        isDisabled ? "text-canopy-text/40 line-through" : "text-canopy-text"
+                      )}
+                    >
+                      {command.id}
+                    </span>
+                    {hasOverride(command.id) && (
+                      <span className="text-[11px] text-canopy-accent bg-canopy-accent/10 px-1.5 py-0.5 rounded font-medium">
+                        Modified
+                      </span>
+                    )}
+                  </div>
+                  <p
+                    className={cn(
+                      "text-xs mt-0.5",
+                      isDisabled ? "text-canopy-text/30" : "text-canopy-text/60"
+                    )}
+                  >
+                    {command.description}
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-1 shrink-0">
+                  {hasOverride(command.id) && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => resetToDefaults(command.id)}
+                      className="h-7 px-2"
+                      title="Reset to defaults"
+                    >
+                      <RotateCcw />
+                    </Button>
+                  )}
+                  <button
+                    onClick={() => toggleDisabled(command.id)}
+                    className={cn(
+                      "p-1.5 rounded transition-colors",
+                      isDisabled
+                        ? "text-red-500 hover:bg-red-900/30"
+                        : "text-green-500 hover:bg-green-900/30"
+                    )}
+                    title={isDisabled ? "Command disabled for this project" : "Command enabled"}
+                  >
+                    {isDisabled ? (
+                      <PowerOff className="h-4 w-4" />
+                    ) : (
+                      <Power className="h-4 w-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {isExpanded && hasDefaults && !isDisabled && (
+                <div className="px-3 pb-3 pt-0 border-t border-canopy-border/50 mt-2">
+                  <div className="space-y-3 mt-3">
+                    <p className="text-xs font-medium text-canopy-text/70">
+                      Default Argument Values
+                    </p>
+                    {command.args?.map((arg) => {
+                      const currentValue = (override?.defaults?.[arg.name] as string) ?? "";
+                      const hasDefaultValue = override?.defaults && arg.name in override.defaults;
+
+                      return (
+                        <div key={arg.name} className="space-y-1.5">
+                          <div className="flex items-center gap-2">
+                            <label
+                              htmlFor={`${command.id}-${arg.name}`}
+                              className="text-xs font-medium text-canopy-text/80"
+                            >
+                              {arg.name}
+                              {arg.required && (
+                                <span className="text-red-500 ml-1">*</span>
+                              )}
+                            </label>
+                            {hasDefaultValue && (
+                              <span className="text-[10px] text-canopy-accent bg-canopy-accent/10 px-1.5 py-0.5 rounded">
+                                Custom
+                              </span>
+                            )}
+                          </div>
+                          <input
+                            id={`${command.id}-${arg.name}`}
+                            type="text"
+                            value={currentValue}
+                            onChange={(e) => updateDefault(command.id, arg.name, e.target.value)}
+                            className="w-full bg-canopy-sidebar border border-canopy-border rounded px-2 py-1.5 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
+                            placeholder={arg.default ? `Default: ${arg.default}` : `Enter ${arg.name}`}
+                          />
+                          {arg.description && (
+                            <p className="text-xs text-canopy-text/50">{arg.description}</p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -28,6 +28,7 @@ import {
 } from "./hybridInputParsing";
 import { CommandPickerButton, CommandPickerHost } from "@/components/Commands";
 import { useCommandStore } from "@/store/commandStore";
+import { useProjectStore } from "@/store/projectStore";
 import type { CommandContext } from "@shared/types/commands";
 import { isEnterLikeLineBreakInputEvent } from "./hybridInputEvents";
 import {
@@ -141,13 +142,15 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const latestRef = useRef<LatestState | null>(null);
 
     const openPicker = useCommandStore((s) => s.openPicker);
+    const currentProject = useProjectStore((s) => s.currentProject);
 
     const commandContext = useMemo(
       (): CommandContext => ({
         terminalId,
         cwd,
+        projectId: currentProject?.id,
       }),
-      [terminalId, cwd]
+      [terminalId, cwd, currentProject?.id]
     );
 
     const isAgentTerminal = agentId !== undefined;


### PR DESCRIPTION
## Summary
This PR implements project-level command overrides, allowing users to customize command behavior on a per-project basis through project settings. Users can set default values for command arguments and disable commands entirely for specific projects.

Closes #1760

## Changes Made
- Add CommandOverride and ProjectCommandSettings types to the command system
- Extend ProjectSettings with commandOverrides field for persistence
- Implement override loading and application in CommandService with proper precedence (command defaults < override defaults < provided args)
- Filter disabled commands from the command picker (list) and block execution
- Create CommandOverridesTab UI component for viewing and editing overrides per command
- Integrate overrides tab into ProjectSettingsDialog with proper state management
- Add projectId to command execution context in HybridInputBar
- Sanitize overrides on load and save with validation and logging
- Make getManifest override-aware for consistency with list/execute behavior
- Add projectId change detection to reset dialog state when switching projects

## Test Plan
- Verified override defaults merge correctly with command and provided arguments
- Tested disabled commands are filtered from command picker
- Confirmed overrides persist across app restarts
- Validated sanitization rejects invalid override data
- Tested dialog state resets when projectId changes

## Implementation Details
The implementation follows the dependency roadmap from #1756 and #1759:
1. Type definitions in shared/types
2. Core logic in CommandService and ProjectStore
3. UI integration in ProjectSettingsDialog
4. Command context wiring in HybridInputBar

Override precedence ensures provided arguments always win, followed by override defaults, then command defaults.