### PR TITLE
Implement ultra-minimal dock bar state with color strip indicators

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -365,9 +365,11 @@ export function registerAppStateHandlers(): () => void {
 
       if ("dockMode" in partialState) {
         const mode = partialState.dockMode;
-        if (mode === "expanded" || mode === "hidden" || mode === "slim") {
-          // Normalize legacy "slim" to "hidden"
-          updates.dockMode = mode === "slim" ? "hidden" : mode;
+        if (typeof mode === "string") {
+          if (mode === "expanded" || mode === "compact" || mode === "hidden" || mode === "slim") {
+            // Normalize legacy "slim" to "hidden"
+            updates.dockMode = mode === "slim" ? "hidden" : mode;
+          }
         }
       }
 
@@ -381,6 +383,12 @@ export function registerAppStateHandlers(): () => void {
       if ("dockAutoHideWhenEmpty" in partialState) {
         if (typeof partialState.dockAutoHideWhenEmpty === "boolean") {
           updates.dockAutoHideWhenEmpty = partialState.dockAutoHideWhenEmpty;
+        }
+      }
+
+      if ("compactDockMinimal" in partialState) {
+        if (typeof partialState.compactDockMinimal === "boolean") {
+          updates.compactDockMinimal = partialState.compactDockMinimal;
         }
       }
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -76,9 +76,10 @@ export interface StoreSchema {
     }>;
     panelGridConfig?: PanelGridConfig;
     dockCollapsed?: boolean;
-    dockMode?: "expanded" | "slim" | "hidden";
+    dockMode?: "expanded" | "compact" | "slim" | "hidden";
     dockBehavior?: "auto" | "manual";
     dockAutoHideWhenEmpty?: boolean;
+    compactDockMinimal?: boolean;
   };
   projects: {
     list: Project[];

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -84,6 +84,8 @@ export interface AppState {
   dockBehavior?: import("../domain.js").DockBehavior;
   /** Whether to auto-hide dock when empty */
   dockAutoHideWhenEmpty?: boolean;
+  /** Whether compact dock should use ultra-minimal 6px strip mode */
+  compactDockMinimal?: boolean;
 }
 
 /** Result from app hydration */

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -103,6 +103,7 @@ export function AppLayout({
           mode: dockMode,
           behavior: dockBehavior,
           autoHideWhenEmpty: Boolean(appState.dockAutoHideWhenEmpty),
+          compactMinimal: Boolean(appState.compactDockMinimal),
           popoverHeight: appState.dockedPopoverHeight,
         });
       } catch (error) {

--- a/src/components/Layout/TerminalDockRegion.tsx
+++ b/src/components/Layout/TerminalDockRegion.tsx
@@ -19,6 +19,7 @@ export function TerminalDockRegion() {
     failedCount,
     trashedCount,
     shouldFadeForInput,
+    compactMinimal,
   } = useDockRenderState();
 
   const setMode = useDockStore((state) => state.setMode);
@@ -35,7 +36,11 @@ export function TerminalDockRegion() {
       {/* CompactDock for compact mode - minimal bar with inline status */}
       {isCompactMode && shouldShowInLayout && (
         <ErrorBoundary variant="section" componentName="CompactDock">
-          <CompactDock dockedCount={dockedCount} shouldFadeForInput={shouldFadeForInput} />
+          <CompactDock
+            dockedCount={dockedCount}
+            shouldFadeForInput={shouldFadeForInput}
+            ultraMinimal={compactMinimal}
+          />
         </ErrorBoundary>
       )}
 

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -11,6 +11,7 @@ import {
   SplitSquareHorizontal,
   Monitor,
   RotateCcw,
+  PanelBottom,
 } from "lucide-react";
 import { useState, useMemo } from "react";
 import { cn } from "@/lib/utils";
@@ -20,6 +21,7 @@ import {
   useScrollbackStore,
   useTerminalInputStore,
   useTwoPaneSplitStore,
+  useDockStore,
 } from "@/store";
 import type { PanelLayoutStrategy, TerminalType } from "@/types";
 import {
@@ -85,6 +87,9 @@ export function TerminalSettingsTab() {
   const setPreferPreview = useTwoPaneSplitStore((state) => state.setPreferPreview);
   const setDefaultRatio = useTwoPaneSplitStore((state) => state.setDefaultRatio);
   const resetAllWorktreeRatios = useTwoPaneSplitStore((state) => state.resetAllWorktreeRatios);
+
+  const compactMinimal = useDockStore((state) => state.compactMinimal);
+  const setCompactMinimal = useDockStore((state) => state.setCompactMinimal);
 
   const [showMemoryDetails, setShowMemoryDetails] = useState(false);
 
@@ -506,6 +511,73 @@ export function TerminalSettingsTab() {
             </button>
           </>
         )}
+      </div>
+
+      <div className="pt-4 border-t border-canopy-border space-y-4">
+        <div>
+          <h4
+            id="ultra-minimal-dock-heading"
+            className="text-sm font-medium text-canopy-text mb-2 flex items-center gap-2"
+          >
+            <PanelBottom className="w-4 h-4 text-canopy-accent" />
+            Ultra-Minimal Dock
+          </h4>
+          <p id="ultra-minimal-dock-description" className="text-xs text-canopy-text/50 mb-4">
+            When in compact dock mode, display an ultra-minimal 6px bar with color strips instead of
+            icons. Hover to reveal details, click to interact.
+          </p>
+        </div>
+
+        <button
+          onClick={() => setCompactMinimal(!compactMinimal)}
+          role="switch"
+          aria-checked={compactMinimal}
+          aria-labelledby="ultra-minimal-dock-heading"
+          aria-describedby="ultra-minimal-dock-description"
+          className={cn(
+            "w-full flex items-center justify-between p-4 rounded-[var(--radius-lg)] border transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
+            compactMinimal
+              ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
+              : "border-canopy-border hover:bg-white/5 text-canopy-text/70"
+          )}
+        >
+          <div className="flex items-center gap-3">
+            <PanelBottom
+              className={cn(
+                "w-5 h-5",
+                compactMinimal ? "text-canopy-accent" : "text-canopy-text/50"
+              )}
+            />
+            <div className="text-left">
+              <div className="text-sm font-medium">
+                {compactMinimal ? "Ultra-Minimal Mode Enabled" : "Enable Ultra-Minimal Mode"}
+              </div>
+              <div className="text-xs opacity-70">
+                {compactMinimal
+                  ? "6px bar with color-coded strips"
+                  : "Standard compact dock with icons"}
+              </div>
+            </div>
+          </div>
+          <div
+            className={cn(
+              "w-11 h-6 rounded-full relative transition-colors",
+              compactMinimal ? "bg-canopy-accent" : "bg-canopy-border"
+            )}
+            aria-hidden="true"
+          >
+            <div
+              className={cn(
+                "absolute top-1 w-4 h-4 rounded-full bg-white transition-transform",
+                compactMinimal ? "translate-x-6" : "translate-x-1"
+              )}
+            />
+          </div>
+        </button>
+
+        <p className="text-xs text-canopy-text/40">
+          Tip: Set dock mode to "Compact" using the keyboard shortcut or dock menu to use this mode.
+        </p>
       </div>
 
       <div className="pt-4 border-t border-canopy-border space-y-4">

--- a/src/hooks/useDockRenderState.ts
+++ b/src/hooks/useDockRenderState.ts
@@ -21,20 +21,23 @@ export function useDockRenderState(): DockRenderState & {
   failedCount: number;
   trashedCount: number;
   shouldFadeForInput: boolean;
+  compactMinimal: boolean;
 } {
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
   const isDragging = useIsDragging();
 
-  const { mode, behavior, autoHideWhenEmpty, peek, isHydrated, setPeek } = useDockStore(
-    useShallow((state) => ({
-      mode: state.mode,
-      behavior: state.behavior,
-      autoHideWhenEmpty: state.autoHideWhenEmpty,
-      peek: state.peek,
-      isHydrated: state.isHydrated,
-      setPeek: state.setPeek,
-    }))
-  );
+  const { mode, behavior, autoHideWhenEmpty, compactMinimal, peek, isHydrated, setPeek } =
+    useDockStore(
+      useShallow((state) => ({
+        mode: state.mode,
+        behavior: state.behavior,
+        autoHideWhenEmpty: state.autoHideWhenEmpty,
+        compactMinimal: state.compactMinimal,
+        peek: state.peek,
+        isHydrated: state.isHydrated,
+        setPeek: state.setPeek,
+      }))
+    );
 
   const dockTerminals = useTerminalStore(
     useShallow((state) =>
@@ -132,6 +135,7 @@ export function useDockRenderState(): DockRenderState & {
     density,
     isHandleVisible,
     isHydrated,
+    compactMinimal,
     setPeek,
     hasDocked,
     dockedCount,

--- a/src/store/dockStore.ts
+++ b/src/store/dockStore.ts
@@ -6,6 +6,7 @@ interface DockState {
   mode: DockMode;
   behavior: DockBehavior;
   autoHideWhenEmpty: boolean;
+  compactMinimal: boolean;
   peek: boolean;
   isHydrated: boolean;
   popoverHeight: number;
@@ -15,10 +16,16 @@ interface DockState {
   cycleMode: () => void;
   toggleExpanded: () => void;
   setAutoHideWhenEmpty: (enabled: boolean) => void;
+  setCompactMinimal: (enabled: boolean) => void;
   setPeek: (peek: boolean) => void;
   setPopoverHeight: (height: number) => void;
   hydrate: (
-    state: Partial<Pick<DockState, "mode" | "behavior" | "autoHideWhenEmpty" | "popoverHeight">>
+    state: Partial<
+      Pick<
+        DockState,
+        "mode" | "behavior" | "autoHideWhenEmpty" | "compactMinimal" | "popoverHeight"
+      >
+    >
   ) => void;
 }
 
@@ -32,6 +39,7 @@ export const useDockStore = create<DockState>()((set, get) => ({
   mode: "hidden",
   behavior: "auto",
   autoHideWhenEmpty: false,
+  compactMinimal: false,
   peek: false,
   isHydrated: false,
   popoverHeight: POPOVER_DEFAULT_HEIGHT,
@@ -45,6 +53,7 @@ export const useDockStore = create<DockState>()((set, get) => ({
       mode: normalizedMode,
       behavior: state.behavior,
       autoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactMinimal: state.compactMinimal,
     });
   },
 
@@ -55,6 +64,7 @@ export const useDockStore = create<DockState>()((set, get) => ({
       mode: state.mode,
       behavior: state.behavior,
       autoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactMinimal: state.compactMinimal,
     });
   },
 
@@ -74,6 +84,7 @@ export const useDockStore = create<DockState>()((set, get) => ({
       mode: state.mode,
       behavior: state.behavior,
       autoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactMinimal: state.compactMinimal,
     });
   },
 
@@ -91,6 +102,7 @@ export const useDockStore = create<DockState>()((set, get) => ({
       mode: state.mode,
       behavior: state.behavior,
       autoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactMinimal: state.compactMinimal,
     });
   },
 
@@ -101,6 +113,18 @@ export const useDockStore = create<DockState>()((set, get) => ({
       mode: state.mode,
       behavior: state.behavior,
       autoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactMinimal: state.compactMinimal,
+    });
+  },
+
+  setCompactMinimal: (enabled) => {
+    set({ compactMinimal: enabled });
+    const state = get();
+    void persistDockState({
+      mode: state.mode,
+      behavior: state.behavior,
+      autoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactMinimal: enabled,
     });
   },
 
@@ -132,12 +156,14 @@ async function persistDockState(state: {
   mode: DockMode;
   behavior: DockBehavior;
   autoHideWhenEmpty: boolean;
+  compactMinimal: boolean;
 }): Promise<void> {
   try {
     await appClient.setState({
       dockMode: state.mode,
       dockBehavior: state.behavior,
       dockAutoHideWhenEmpty: state.autoHideWhenEmpty,
+      compactDockMinimal: state.compactMinimal,
     });
   } catch (error) {
     console.error("Failed to persist dock state:", error);


### PR DESCRIPTION
## Summary
Implements an ultra-minimal 6px dock mode with color-coded terminal strips that expand to 20px on hover or keyboard focus. Includes comprehensive accessibility improvements, full state persistence, and a settings UI toggle.

Closes #1780

## Changes Made
- Add UltraMinimalDock component with color strip rendering for terminals and status indicators
- Support keyboard navigation with focus-within expansion and Shift+Enter for restore action
- Implement worktree switching logic for status strip clicks
- Add compactMinimal state to dockStore with full persistence through electron store
- Update electron store schema to include compact mode and compactDockMinimal
- Add settings UI toggle in Terminal Settings tab with proper aria-labelledby/describedby
- Fix CSS variable fallback for terminal strips (use rgb instead of undefined var)
- Gate hover width classes to prevent jitter when expanded
- Integrate compactMinimal through state hydration and TerminalDockRegion

## Technical Details
- 6px height when collapsed, 20px when hovered or focused
- Color strips use terminal brand colors with fallback
- Status strips show waiting (amber), failed (red), and trashed terminals
- Keyboard accessible with proper ARIA labels and focus management
- Persists preference across app restarts