### PR TITLE
Fix terminal stuck in loading state during project switch

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,4 +1,5 @@
 import { Menu, dialog, BrowserWindow, shell, app } from "electron";
+import { randomUUID } from "crypto";
 import { projectStore } from "./services/ProjectStore.js";
 import { getWorkspaceClient } from "./services/WorkspaceClient.js";
 import { CHANNELS } from "./ipc/channels.js";
@@ -277,7 +278,11 @@ async function handleDirectoryOpen(
 
     if (!mainWindow.isDestroyed() && !mainWindow.webContents.isDestroyed()) {
       try {
-        mainWindow.webContents.send(CHANNELS.PROJECT_ON_SWITCH, updatedProject);
+        const switchId = randomUUID();
+        mainWindow.webContents.send(CHANNELS.PROJECT_ON_SWITCH, {
+          project: updatedProject,
+          switchId,
+        });
       } catch {
         // Silently ignore send failures during window disposal.
       }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -757,7 +757,7 @@ const api: ElectronAPI = {
 
     openDialog: () => _typedInvoke(CHANNELS.PROJECT_OPEN_DIALOG),
 
-    onSwitch: (callback: (project: Project) => void) =>
+    onSwitch: (callback: (payload: { project: Project; switchId: string }) => void) =>
       _typedOn(CHANNELS.PROJECT_ON_SWITCH, callback),
 
     getSettings: (projectId: string) => _typedInvoke(CHANNELS.PROJECT_GET_SETTINGS, projectId),

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -7,6 +7,7 @@ import { projectStore } from "./ProjectStore.js";
 import { logBuffer } from "./LogBuffer.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { sendToRenderer } from "../ipc/utils.js";
+import { randomUUID } from "crypto";
 
 export interface ProjectSwitchDependencies {
   mainWindow: BrowserWindow;
@@ -56,9 +57,13 @@ export class ProjectSwitchService {
 
       await this.loadNewProject(project);
 
-      sendToRenderer(this.deps.mainWindow, CHANNELS.PROJECT_ON_SWITCH, updatedProject);
+      const switchId = randomUUID();
+      sendToRenderer(this.deps.mainWindow, CHANNELS.PROJECT_ON_SWITCH, {
+        project: updatedProject,
+        switchId,
+      });
 
-      console.log("[ProjectSwitch] Project switch complete");
+      console.log("[ProjectSwitch] Project switch complete, switchId:", switchId);
       return updatedProject;
     } catch (error) {
       console.error("[ProjectSwitch] Project switch failed, rolling back:", error);

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -227,7 +227,7 @@ export interface ElectronAPI {
     update(projectId: string, updates: Partial<Project>): Promise<Project>;
     switch(projectId: string): Promise<Project>;
     openDialog(): Promise<string | null>;
-    onSwitch(callback: (project: Project) => void): () => void;
+    onSwitch(callback: (payload: { project: Project; switchId: string }) => void): () => void;
     getSettings(projectId: string): Promise<ProjectSettings>;
     saveSettings(projectId: string, settings: ProjectSettings): Promise<void>;
     detectRunners(projectId: string): Promise<RunCommand[]>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -63,7 +63,7 @@ import type { AppState, HydrateResult } from "./app.js";
 import type { LogEntry, LogFilterOptions } from "./logs.js";
 import type { RetryAction, AppError } from "./errors.js";
 import type { EventRecord, EventFilterOptions } from "./events.js";
-import type { ProjectCloseResult, ProjectStats } from "./project.js";
+import type { ProjectCloseResult, ProjectStats, ProjectSwitchPayload } from "./project.js";
 import type {
   RepositoryStats,
   GitHubCliStatus,
@@ -466,12 +466,12 @@ export interface IpcInvokeMap {
     result: RunCommand[];
   };
   "project:close": {
-    args: [projectId: string];
+    args: [projectId: string, options?: { killTerminals?: boolean }];
     result: ProjectCloseResult;
   };
   "project:reopen": {
     args: [projectId: string];
-    result: void;
+    result: Project;
   };
   "project:get-stats": {
     args: [projectId: string];
@@ -957,7 +957,7 @@ export interface IpcEventMap {
   "event-inspector:event": EventRecord;
 
   // Project events
-  "project:on-switch": Project;
+  "project:on-switch": ProjectSwitchPayload;
 
   // System events
   "system:wake": SystemWakePayload;

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -1,3 +1,13 @@
+import type { Project } from "../domain.js";
+
+/** Payload for project:on-switch event with cancellation token */
+export interface ProjectSwitchPayload {
+  /** The project being switched to */
+  project: Project;
+  /** Unique identifier for this switch operation */
+  switchId: string;
+}
+
 /** Result from project:close operation */
 export interface ProjectCloseResult {
   /** Whether the operation succeeded */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -281,6 +281,7 @@ export type SpawnErrorCode =
   | "EACCES" // Permission denied
   | "ENOTDIR" // Working directory does not exist (or path component is not a directory)
   | "EIO" // I/O error (e.g., PTY allocation failure)
+  | "DISCONNECTED" // Terminal process no longer exists in backend (e.g., after project switch)
   | "UNKNOWN"; // Unknown error
 
 /** Result of a spawn operation */

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -14,7 +14,7 @@ import type {
  * import { projectClient } from "@/clients/projectClient";
  *
  * const projects = await projectClient.getAll();
- * const cleanup = projectClient.onSwitch((project) => console.log(project));
+ * const cleanup = projectClient.onSwitch(({ project, switchId }) => console.log(project, switchId));
  * ```
  */
 export const projectClient = {
@@ -46,7 +46,7 @@ export const projectClient = {
     return window.electron.project.openDialog();
   },
 
-  onSwitch: (callback: (project: Project) => void): (() => void) => {
+  onSwitch: (callback: (payload: { project: Project; switchId: string }) => void): (() => void) => {
     return window.electron.project.onSwitch(callback);
   },
 

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -23,6 +23,8 @@ function getErrorTitle(code: SpawnError["code"]): string {
       return "Invalid Working Directory";
     case "EIO":
       return "PTY Allocation Failed";
+    case "DISCONNECTED":
+      return "Terminal Disconnected";
     default:
       return "Failed to Start Terminal";
   }
@@ -41,6 +43,8 @@ function getErrorDescription(error: SpawnError, cwd?: string): string {
       return `The working directory is not valid: ${cwd || "(unknown)"}`;
     case "EIO":
       return "Failed to allocate a pseudo-terminal. The system may be running low on resources.";
+    case "DISCONNECTED":
+      return "The terminal process is no longer running. Click Retry to start a new session.";
     default:
       return error.message;
   }

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -5,9 +5,10 @@ import {
   useScrollbackStore,
   usePerformanceModeStore,
   useTerminalInputStore,
+  useTerminalStore,
 } from "@/store";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
-import type { TerminalType, AgentState, TerminalKind } from "@/types";
+import type { TerminalType, AgentState, TerminalKind, SpawnError } from "@/types";
 import { keybindingService } from "@/services/KeybindingService";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { generateAgentFlags } from "@shared/types";
@@ -47,15 +48,27 @@ export interface HydrationOptions {
   ) => void;
 }
 
-export async function hydrateAppState(options: HydrationOptions): Promise<void> {
+export async function hydrateAppState(
+  options: HydrationOptions,
+  _switchId?: string,
+  isCurrent?: () => boolean
+): Promise<void> {
   const { addTerminal, setActiveWorktree, loadRecipes, openDiagnosticsDock } = options;
+
+  // Helper to check if this hydration is still current (not superseded by newer switch)
+  const checkCurrent = (): boolean => {
+    if (!isCurrent) return true;
+    return isCurrent();
+  };
 
   try {
     await keybindingService.loadOverrides();
+    if (!checkCurrent()) return;
 
     // Initialize user agent registry for existing user-defined agents
     // (no UI exposure, but allows existing agents to function)
     await useUserAgentRegistryStore.getState().initialize();
+    if (!checkCurrent()) return;
 
     // Batch fetch initial state
     const {
@@ -64,6 +77,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
       project: currentProject,
       agentSettings,
     } = await appClient.hydrate();
+    if (!checkCurrent()) return;
 
     // Hydrate terminal config (scrollback, performance mode) BEFORE restoring terminals
     try {
@@ -110,6 +124,8 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     if (currentProjectId) {
       try {
         const backendTerminals = await terminalClient.getForProject(currentProjectId);
+        if (!checkCurrent()) return;
+
         console.log(
           `[Hydration] Found ${backendTerminals.length} running terminals for project ${currentProjectId}`
         );
@@ -292,7 +308,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
                       );
                     }
                   } else {
-                    // Terminal truly doesn't exist in backend - respawn
+                    // Terminal truly doesn't exist in backend
                     const effectiveAgentId =
                       saved.agentId ??
                       (saved.type && isRegisteredAgent(saved.type) ? saved.type : undefined);
@@ -311,26 +327,58 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
                         flags.length > 0 ? `${baseCommand} ${flags.join(" ")}` : baseCommand;
                     }
 
-                    console.log(`[Hydration] Respawning PTY panel: ${saved.id}`);
-
                     // Preserve the original kind (dev-preview, terminal, etc.) unless it's an agent
                     const respawnKind = isAgentPanel ? "agent" : kind;
                     const isDevPreview = kind === "dev-preview";
 
-                    await addTerminal({
-                      kind: respawnKind,
-                      type: saved.type,
-                      agentId,
-                      title: saved.title,
-                      cwd: saved.cwd || projectRoot || "",
-                      worktreeId: saved.worktreeId,
-                      location,
-                      requestedId: saved.id,
-                      command,
-                      isInputLocked: saved.isInputLocked,
-                      devCommand: isDevPreview ? command : undefined,
-                      browserUrl: isDevPreview ? saved.browserUrl : undefined,
-                    });
+                    if (isAgentPanel) {
+                      // For agent terminals, don't auto-respawn as it could re-execute commands.
+                      // Instead, create a placeholder terminal with DISCONNECTED error state.
+                      // User can manually retry to start a fresh session.
+                      console.log(
+                        `[Hydration] Agent terminal ${saved.id} disconnected - showing error state`
+                      );
+
+                      // Add terminal with existingId to create entry without spawning
+                      await addTerminal({
+                        kind: respawnKind,
+                        type: saved.type,
+                        agentId,
+                        title: saved.title,
+                        cwd: saved.cwd || projectRoot || "",
+                        worktreeId: saved.worktreeId,
+                        location,
+                        existingId: saved.id,
+                        command,
+                        isInputLocked: saved.isInputLocked,
+                      });
+
+                      // Set the DISCONNECTED error to show error UI
+                      const disconnectedError: SpawnError = {
+                        code: "DISCONNECTED",
+                        message:
+                          "Agent session was lost during project switch. Click Retry to start a new session.",
+                      };
+                      useTerminalStore.getState().setSpawnError(saved.id, disconnectedError);
+                    } else {
+                      // For regular terminals, respawn as before
+                      console.log(`[Hydration] Respawning PTY panel: ${saved.id}`);
+
+                      await addTerminal({
+                        kind: respawnKind,
+                        type: saved.type,
+                        agentId,
+                        title: saved.title,
+                        cwd: saved.cwd || projectRoot || "",
+                        worktreeId: saved.worktreeId,
+                        location,
+                        requestedId: saved.id,
+                        command,
+                        isInputLocked: saved.isInputLocked,
+                        devCommand: isDevPreview ? command : undefined,
+                        browserUrl: isDevPreview ? saved.browserUrl : undefined,
+                      });
+                    }
                   }
                 } else {
                   console.log(`[Hydration] Recreating ${kind} panel: ${saved.id}`);


### PR DESCRIPTION
## Summary
Fixes terminals getting stuck in loading state when switching between projects. Implements switchId guards to prevent overlapping hydrations and improves terminal reconnection handling during rapid project switches.

Closes #1801

## Changes Made
- Add switchId to PROJECT_ON_SWITCH IPC event for ordering guard
- Implement stale hydration cancellation in useProjectSwitchRehydration
- Add isCurrent callback to hydrateAppState for async cancellation checks
- Fix menu-driven project switch to include switchId in payload
- Add DISCONNECTED error code for terminals that can't be reconnected
- Agent terminals show error state instead of auto-respawning (prevents re-executing commands)
- Implement wake retry mechanism in TerminalWakeManager
- Fix IPC type map for project:close options and project:reopen return type
- Add comprehensive test coverage with stronger assertions

## Technical Details
The root cause was that terminals could attempt reconnection before the backend PTY switch completed, and overlapping project switches could cause stale hydrations to overwrite newer state. This PR:

1. **Prevents race conditions**: Each switch gets a unique ID, and hydration checks if it's still current before mutating state
2. **Handles disconnections gracefully**: Agent terminals show an error banner instead of auto-respawning (avoiding command re-execution)
3. **Fixes wake timing**: Terminals that mount late get retried wake attempts instead of being silently dropped

## Testing
- Updated stateHydration tests with stronger assertions for no-respawn guarantee
- All existing tests pass
- Type-safe IPC payloads prevent future regressions