### PR TITLE
fix(terminal): redraw terminals when sidecar is toggled

### DIFF
--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -9,6 +9,7 @@ import {
   useWorktreeSelectionStore,
   usePreferencesStore,
   useTwoPaneSplitStore,
+  useSidecarStore,
   type TerminalInstance,
 } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
@@ -398,6 +399,10 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
   // Two-pane split mode settings
   const twoPaneSplitEnabled = useTwoPaneSplitStore((state) => state.config.enabled);
 
+  // Sidecar state - used to trigger terminal re-fit when sidecar visibility changes
+  const sidecarOpen = useSidecarStore((state) => state.isOpen);
+  const sidecarLayoutMode = useSidecarStore((state) => state.layoutMode);
+
   const gridTerminals = useMemo(
     () =>
       terminals.filter(
@@ -639,7 +644,7 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [gridCols, terminalIds, gridTerminals]);
+  }, [gridCols, terminalIds, gridTerminals, sidecarOpen, sidecarLayoutMode]);
 
   // Show "grid full" overlay when trying to drag from dock to a full grid
   const showGridFullOverlay = sourceContainer === "dock" && isGridFull;


### PR DESCRIPTION
## Summary
Fixes terminals not redrawing when the sidecar is toggled open/closed. The issue occurred because the ContentGrid batch-fit effect had no dependency on sidecar state, so in overlay mode (where the grid container dimensions don't physically change), the ResizeObserver never fired and terminals remained blank.

Closes #1806

## Changes Made
- Add sidecar state dependencies to ContentGrid batch-fit effect
- Subscribe to sidecarOpen and sidecarLayoutMode from sidecar store
- Ensure terminals redraw when sidecar visibility or layout mode changes
- Fixes issue where terminals remained blank after sidecar toggle in overlay mode

## Testing
- Tested terminal redraw behavior with sidecar toggle in both overlay and push modes
- Verified terminals redraw correctly when sidecar opens/closes
- Confirmed behavior matches main sidebar toggle (immediate redraw, correct dimensions)