### PR TITLE
fix(dev-preview): add worktree-scoped persistence for URL isolation

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -7,7 +7,12 @@ import { useIsDragging } from "@/components/DragDrop";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
-import { useBrowserStateStore, useProjectStore, useTerminalStore } from "@/store";
+import {
+  useBrowserStateStore,
+  useProjectStore,
+  useTerminalStore,
+  useWorktreeSelectionStore,
+} from "@/store";
 import { panelKindKeepsAliveOnProjectSwitch } from "@shared/config/panelKindRegistry";
 import type { DevPreviewStatus } from "@shared/types/ipc/devPreview";
 
@@ -53,12 +58,14 @@ const AUTO_RELOAD_ERROR_CODES = new Set([-102, -105, -106, -118]);
 
 export interface DevPreviewPaneProps extends BasePanelProps {
   cwd: string;
+  worktreeId?: string;
 }
 
 export function DevPreviewPane({
   id,
   title,
   cwd,
+  worktreeId,
   isFocused,
   isMaximized = false,
   location = "grid",
@@ -84,7 +91,7 @@ export function DevPreviewPane({
     future: [],
   }));
   const [zoomFactor, setZoomFactor] = useState<number>(() => {
-    const savedState = useBrowserStateStore.getState().getState(id);
+    const savedState = useBrowserStateStore.getState().getState(id, worktreeId);
     const savedZoom = savedState?.zoomFactor ?? 1.0;
     return Number.isFinite(savedZoom) ? Math.max(0.25, Math.min(2.0, savedZoom)) : 1.0;
   });
@@ -92,6 +99,7 @@ export function DevPreviewPane({
   const [isLoading, setIsLoading] = useState(false);
   const [webviewLoadError, setWebviewLoadError] = useState<string | null>(null);
   const [isWebviewReady, setIsWebviewReady] = useState(false);
+  const [wasInactive, setWasInactive] = useState(false);
   const restartTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const webviewRef = useRef<Electron.WebviewTag>(null);
   const pendingUrlRef = useRef<string | null>(null);
@@ -104,6 +112,7 @@ export function DevPreviewPane({
   const isDragging = useIsDragging();
   const setBrowserUrl = useTerminalStore((state) => state.setBrowserUrl);
   const updateBrowserZoomFactor = useBrowserStateStore((state) => state.updateZoomFactor);
+  const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
   const currentUrl = history.present;
   const canGoBack = history.past.length > 0;
@@ -417,8 +426,37 @@ export function DevPreviewPane({
   }, [currentUrl, hasValidUrl, id, setBrowserUrl]);
 
   useEffect(() => {
-    updateBrowserZoomFactor(id, zoomFactor);
-  }, [id, updateBrowserZoomFactor, zoomFactor]);
+    updateBrowserZoomFactor(id, zoomFactor, worktreeId);
+  }, [id, updateBrowserZoomFactor, zoomFactor, worktreeId]);
+
+  // Track when this panel becomes inactive (different worktree selected)
+  useEffect(() => {
+    const isCurrentlyActive = (worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
+    if (!isCurrentlyActive) {
+      setWasInactive(true);
+    }
+  }, [worktreeId, activeWorktreeId]);
+
+  // Reload when panel becomes active after being backgrounded
+  useEffect(() => {
+    const isInActiveWorktree = (worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
+
+    if (wasInactive && isInActiveWorktree && isWebviewReady && currentUrl) {
+      setWasInactive(false);
+      setIsLoading(true);
+      setWebviewLoadError(null);
+      hasLoadedRef.current = false;
+      setHasLoaded(false);
+      autoReloadAttemptsRef.current = 0;
+      clearAutoReload();
+      lastUrlSetAtRef.current = Date.now();
+
+      const webview = webviewRef.current;
+      if (webview) {
+        webview.loadURL(currentUrl);
+      }
+    }
+  }, [wasInactive, worktreeId, activeWorktreeId, isWebviewReady, currentUrl, clearAutoReload]);
 
   useEffect(() => {
     const webview = webviewRef.current;


### PR DESCRIPTION
## Summary
Implements worktree-scoped persistence for dev preview panels to prevent URL contamination when switching between worktrees.

Closes #1811

## Changes Made
- Add worktreeId prop to DevPreviewPane component
- Implement makeScopedKey function with strict null/empty checks for proper key generation
- Update browserStateStore methods to accept optional worktreeId parameter
- Track worktree activation state with reactive activeWorktreeId selector
- Reload webview when panel becomes active after being backgrounded
- Reset loading state properly during activation reload to prevent stale UI

## Technical Details
- Store keys now use `worktreeId:panelId` format when worktreeId is provided
- Activation detection uses reactive Zustand selector to trigger reload effect
- Proper state cleanup during reload prevents auto-retry conflicts
- Backwards compatible with non-worktree panels (falls back to panelId-only keys)

## Testing
Verified the A→B→C→B worktree switching scenario:
- Dev preview in worktree B correctly loads B's URL (localhost:3002)
- No contamination from worktree A's URL (localhost:3001)
- Zoom levels are also properly isolated per worktree