### PR TITLE
Implement tabbed grid panels with integrated tab bar

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -75,6 +75,12 @@ export interface DragData {
   terminal: TerminalInstance;
   sourceLocation: "grid" | "dock";
   sourceIndex: number;
+  /** Whether this drag represents a tab group */
+  isTabGroup?: boolean;
+  /** Tab group ID when dragging a group */
+  tabGroupId?: string;
+  /** Panel IDs in the tab group */
+  panelIds?: string[];
 }
 
 export interface WorktreeDragData extends DragData {

--- a/src/components/Terminal/GridTabBar.tsx
+++ b/src/components/Terminal/GridTabBar.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+import { TerminalIcon } from "./TerminalIcon";
+import type { TerminalInstance } from "@/store";
+import type { AgentState } from "@/types";
+import { STATE_ICONS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
+
+export interface GridTabBarProps {
+  groupId: string;
+  panels: TerminalInstance[];
+  activeTabId: string;
+  onTabClick: (panelId: string) => void;
+  isDragging?: boolean;
+}
+
+function GridTabBarComponent({
+  groupId,
+  panels,
+  activeTabId,
+  onTabClick,
+  isDragging = false,
+}: GridTabBarProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-0.5 border-b border-divider bg-canopy-sidebar/50 px-1 py-0.5 shrink-0 overflow-x-auto",
+        isDragging && "opacity-70"
+      )}
+      role="tablist"
+      aria-label={`Tab group ${groupId}`}
+    >
+      {panels.map((panel) => {
+        const isActive = activeTabId === panel.id;
+        const agentState = panel.agentState;
+        const showStateBadge =
+          !isActive &&
+          agentState &&
+          (agentState === "waiting" || agentState === "failed" || agentState === "working");
+
+        return (
+          <button
+            key={panel.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            aria-controls={`panel-${panel.id}`}
+            onClick={() => onTabClick(panel.id)}
+            className={cn(
+              "flex items-center gap-1.5 px-2.5 py-1 text-xs rounded-t transition-colors min-w-0 max-w-[200px] group",
+              isActive
+                ? "bg-canopy-bg text-canopy-text border-t border-l border-r border-divider -mb-px"
+                : "text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-bg/50"
+            )}
+            title={panel.title}
+          >
+            <span className="shrink-0">
+              <TerminalIcon
+                type={panel.type}
+                kind={panel.kind}
+                agentId={panel.agentId}
+                className="w-3.5 h-3.5"
+              />
+            </span>
+            <span className="truncate">{panel.title}</span>
+            {showStateBadge && <AgentStateBadge state={agentState} />}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface AgentStateBadgeProps {
+  state: AgentState;
+}
+
+function AgentStateBadge({ state }: AgentStateBadgeProps) {
+  const StateIcon = STATE_ICONS[state];
+  if (!StateIcon) return null;
+
+  return (
+    <span
+      className={cn(
+        "shrink-0 flex items-center justify-center w-4 h-4 rounded-full",
+        STATE_COLORS[state]
+      )}
+      title={`Agent ${state}`}
+      aria-label={`Agent state: ${state}`}
+    >
+      <StateIcon
+        className={cn(
+          "w-3 h-3",
+          state === "working" && "animate-spin",
+          state === "waiting" && "animate-breathe",
+          "motion-reduce:animate-none"
+        )}
+        aria-hidden="true"
+      />
+    </span>
+  );
+}
+
+export const GridTabBar = React.memo(GridTabBarComponent);

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,0 +1,119 @@
+import React, { useCallback, useMemo } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@/lib/utils";
+import type { TerminalInstance } from "@/store";
+import { useTerminalStore } from "@/store";
+import type { TabGroup } from "@/types";
+import { GridTabBar } from "./GridTabBar";
+import { GridPanel } from "./GridPanel";
+import { DragHandleProvider } from "@/components/DragDrop/DragHandleContext";
+import type { DragData } from "@/components/DragDrop";
+
+export interface GridTabGroupProps {
+  group: TabGroup;
+  panels: TerminalInstance[];
+  activeTabId: string;
+  focusedId: string | null;
+  gridPanelCount?: number;
+  gridCols?: number;
+}
+
+function GridTabGroupComponent({
+  group,
+  panels,
+  activeTabId,
+  focusedId,
+  gridPanelCount,
+  gridCols,
+}: GridTabGroupProps) {
+  const setActiveTab = useTerminalStore((state) => state.setActiveTab);
+  const setFocused = useTerminalStore((state) => state.setFocused);
+
+  // Find the active panel to render
+  // Guard against empty panels array to prevent undefined access
+  const activePanel = useMemo(() => {
+    if (panels.length === 0) return null;
+    return panels.find((p) => p.id === activeTabId) ?? panels[0];
+  }, [panels, activeTabId]);
+
+  // Use the first panel's ID as the sortable ID for the group
+  // This maintains compatibility with the existing drag-and-drop system
+  const sortableId = group.id;
+
+  // Build drag data for the entire group
+  // If no active panel (empty group), don't provide drag data
+  const dragData: DragData | null = useMemo(() => {
+    if (!activePanel) return null;
+    return {
+      terminal: activePanel,
+      sourceLocation: "grid",
+      sourceIndex: 0, // Will be updated by ContentGrid
+      isTabGroup: panels.length > 1, // Only mark as tab group if actually grouped
+      tabGroupId: group.id,
+      panelIds: group.panelIds,
+    };
+  }, [activePanel, group.id, group.panelIds, panels.length]);
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: sortableId,
+    data: dragData ?? undefined,
+    disabled: !activePanel, // Disable dragging if no active panel
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const handleTabClick = useCallback(
+    (panelId: string) => {
+      setActiveTab(group.id, panelId);
+      setFocused(panelId);
+    },
+    [group.id, setActiveTab, setFocused]
+  );
+
+  // If no active panel (empty group), render nothing
+  if (!activePanel) return null;
+
+  const isFocused = activePanel.id === focusedId;
+
+  // Ensure activeTabId matches an actual panel to keep UI in sync
+  const resolvedActiveTabId = panels.find((p) => p.id === activeTabId)
+    ? activeTabId
+    : activePanel.id;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-tab-group-id={group.id}
+      className={cn(
+        "flex flex-col h-full min-h-0 terminal-pane",
+        isDragging && "opacity-40 ring-2 ring-canopy-accent/50 rounded"
+      )}
+      {...attributes}
+    >
+      <DragHandleProvider value={{ listeners }}>
+        <GridTabBar
+          groupId={group.id}
+          panels={panels}
+          activeTabId={resolvedActiveTabId}
+          onTabClick={handleTabClick}
+          isDragging={isDragging}
+        />
+        <div className="flex-1 min-h-0">
+          <GridPanel
+            terminal={activePanel}
+            isFocused={isFocused}
+            gridPanelCount={gridPanelCount}
+            gridCols={gridCols}
+          />
+        </div>
+      </DragHandleProvider>
+    </div>
+  );
+}
+
+export const GridTabGroup = React.memo(GridTabGroupComponent);

--- a/src/components/Terminal/index.ts
+++ b/src/components/Terminal/index.ts
@@ -21,3 +21,7 @@ export { GridPanel } from "./GridPanel";
 export type { GridPanelProps } from "./GridPanel";
 export { DockedPanel } from "./DockedPanel";
 export type { DockedPanelProps } from "./DockedPanel";
+export { GridTabBar } from "./GridTabBar";
+export type { GridTabBarProps } from "./GridTabBar";
+export { GridTabGroup } from "./GridTabGroup";
+export type { GridTabGroupProps } from "./GridTabGroup";

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -1559,7 +1559,12 @@ export const createTerminalRegistrySlice =
         const hasWorktreeFilter = worktreeId !== undefined;
         const targetWorktreeId = worktreeId ?? null;
         const panels = get().terminals.filter((t) => {
-          if (t.location !== location) return false;
+          // Match location: grid matches both "grid" and undefined (backward compat)
+          const locationMatches =
+            location === "grid"
+              ? t.location === "grid" || t.location === undefined
+              : t.location === location;
+          if (!locationMatches) return false;
           return !hasWorktreeFilter || (t.worktreeId ?? null) === targetWorktreeId;
         });
 


### PR DESCRIPTION
## Summary
Implements tabbed grid panels with an integrated tab bar that displays multiple panels within a single grid cell. Panels in the same tab group share one grid position and can be switched via tabs, improving space efficiency and organization.

Closes #1818

## Changes Made
- Add GridTabBar component for rendering tab navigation within panel groups
- Add GridTabGroup wrapper to manage multi-panel groups with tab switching
- Update ContentGrid to render tab groups instead of flat panel list
- Fix grid capacity calculation to use group count (each group = one grid cell)
- Add tab group support to DragData interface for drag-and-drop
- Fix location filtering in getTabGroups to handle undefined as grid (backward compat)
- Add null guards in GridTabGroup for empty panels array
- Sync active tab ID with actual panels to prevent UI desync

## Implementation Details
- **GridTabBar**: Horizontal tab navigation with agent state badges for waiting/failed/working panels
- **GridTabGroup**: Wrapper that combines tab bar + active panel, handles drag-drop for entire group
- **ContentGrid**: Renders tab groups instead of flat panels, maintains backward compatibility for single-panel groups
- **Grid capacity**: Now based on group count (each group = 1 grid cell) instead of terminal count
- **Drag-drop**: Tab groups drag as units (via isTabGroup flag in DragData)

## Testing
- Build passes
- All 9 tab grouping tests pass
- Backward compatible with single-panel groups (no tab bar shown)