### PR TITLE
Add tab grouping data model to panel system

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -225,6 +225,23 @@ export type TerminalType = "terminal" | LegacyAgentType;
 /** Location of a panel instance in the UI */
 export type PanelLocation = "grid" | "dock" | "trash";
 
+/** Tab group location (subset of PanelLocation, excludes trash) */
+export type TabGroupLocation = "grid" | "dock";
+
+/** Tab group - a collection of panels displayed as tabs */
+export interface TabGroup {
+  /** Unique identifier for this tab group */
+  id: string;
+  /** Location of the tab group in the UI */
+  location: TabGroupLocation;
+  /** Worktree this tab group is associated with (undefined for global) */
+  worktreeId?: string;
+  /** ID of the currently active/visible panel in this group */
+  activeTabId: string;
+  /** Ordered list of panel IDs in this group (sorted by orderInGroup) */
+  panelIds: string[];
+}
+
 /**
  * @deprecated Use PanelLocation instead. Kept for backward compatibility.
  */
@@ -364,6 +381,10 @@ interface BasePanelData {
   worktreeId?: string;
   /** Whether the panel pane is currently visible in the viewport */
   isVisible?: boolean;
+  /** Tab group identifier - panels with the same tabGroupId are grouped together */
+  tabGroupId?: string;
+  /** Order within the tab group (0-based) */
+  orderInGroup?: number;
 }
 
 interface PtyPanelData extends BasePanelData {
@@ -519,6 +540,10 @@ export interface TerminalInstance {
   exitBehavior?: PanelExitBehavior;
   /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
   hasPty?: boolean;
+  /** Tab group identifier - panels with the same tabGroupId are grouped together */
+  tabGroupId?: string;
+  /** Order within the tab group (0-based) */
+  orderInGroup?: number;
 }
 
 /** Options for spawning a new PTY process */
@@ -606,6 +631,10 @@ export interface TerminalSnapshot {
   scope?: "worktree" | "project";
   /** Note creation timestamp (kind === 'notes') */
   createdAt?: number;
+  /** Tab group identifier - panels with the same tabGroupId are grouped together */
+  tabGroupId?: string;
+  /** Order within the tab group (0-based) */
+  orderInGroup?: number;
 }
 
 /** Type alias for TerminalSnapshot. Use this in new code. */

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -36,6 +36,9 @@ export type {
   PanelLocation,
   PanelInstance,
   PanelSnapshot,
+  // Tab group types
+  TabGroupLocation,
+  TabGroup,
   // Terminal types (deprecated aliases for backward compat)
   TerminalKind,
   TerminalType,

--- a/src/store/persistence/terminalPersistence.ts
+++ b/src/store/persistence/terminalPersistence.ts
@@ -24,6 +24,12 @@ const DEFAULT_OPTIONS: Required<Omit<TerminalPersistenceOptions, "getProjectId">
       worktreeId: t.worktreeId,
       location: t.location === "trash" ? "grid" : t.location,
       cwd: t.cwd,
+      // Tab grouping fields (persist both or neither to maintain consistency)
+      ...(t.tabGroupId !== undefined &&
+        t.tabGroupId !== "" && {
+          tabGroupId: t.tabGroupId,
+          ...(t.orderInGroup !== undefined && { orderInGroup: t.orderInGroup }),
+        }),
     };
 
     if (t.kind === "dev-preview") {

--- a/src/store/slices/terminalRegistry/__tests__/tabGrouping.test.ts
+++ b/src/store/slices/terminalRegistry/__tests__/tabGrouping.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTerminalRegistrySlice, type TerminalInstance } from "../index";
+import type { TerminalRegistrySlice } from "../types";
+
+// Mock dependencies
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn().mockResolvedValue("mock-id"),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: { get: vi.fn() },
+  projectClient: { getCurrent: vi.fn(), getSettings: vi.fn() },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    prewarmTerminal: vi.fn(),
+    destroy: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    setInputLocked: vi.fn(),
+    get: vi.fn(),
+    fit: vi.fn(),
+    suppressNextExit: vi.fn(),
+    wake: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: {
+    getState: vi.fn(() => ({
+      activeWorktreeId: "worktree-1",
+    })),
+  },
+}));
+
+vi.mock("@/store/layoutConfigStore", () => ({
+  useLayoutConfigStore: {
+    getState: vi.fn(() => ({
+      getMaxGridCapacity: vi.fn().mockReturnValue(6),
+    })),
+  },
+}));
+
+vi.mock("@/store/scrollbackStore", () => ({
+  useScrollbackStore: { getState: vi.fn(() => ({ scrollbackLines: 10000 })) },
+}));
+
+vi.mock("@/store/performanceModeStore", () => ({
+  usePerformanceModeStore: { getState: vi.fn(() => ({ performanceMode: false })) },
+}));
+
+vi.mock("@/store/terminalFontStore", () => ({
+  useTerminalFontStore: { getState: vi.fn(() => ({ fontSize: 14, fontFamily: "monospace" })) },
+}));
+
+vi.mock("@/utils/scrollbackConfig", () => ({
+  getScrollbackForType: vi.fn().mockReturnValue(10000),
+  PERFORMANCE_MODE_SCROLLBACK: 1000,
+}));
+
+vi.mock("@/utils/terminalTheme", () => ({
+  getTerminalThemeFromCSS: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@/config/terminalFont", () => ({
+  DEFAULT_TERMINAL_FONT_FAMILY: "monospace",
+}));
+
+vi.mock("@/config/agents", () => ({
+  isRegisteredAgent: vi.fn().mockReturnValue(false),
+  getAgentConfig: vi.fn(),
+}));
+
+vi.mock("@shared/config/panelKindRegistry", () => ({
+  panelKindHasPty: vi.fn((kind: string) => kind === "terminal" || kind === "agent"),
+  panelKindUsesTerminalUi: vi.fn((kind: string) => kind === "terminal" || kind === "agent"),
+}));
+
+vi.mock("@/utils/terminalValidation", () => ({
+  validateTerminalConfig: vi.fn().mockResolvedValue({ valid: true, errors: [] }),
+}));
+
+vi.mock("@/store/restartExitSuppression", () => ({
+  markTerminalRestarting: vi.fn(),
+  unmarkTerminalRestarting: vi.fn(),
+}));
+
+vi.mock("@shared/types", () => ({
+  generateAgentFlags: vi.fn().mockReturnValue([]),
+}));
+
+describe("Tab Grouping - getTabGroupPanels", () => {
+  let state: TerminalRegistrySlice;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let setState: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let getState: any;
+
+  const createMockTerminals = (): TerminalInstance[] =>
+    [
+      {
+        id: "term-1",
+        title: "Terminal 1",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 1,
+      },
+      {
+        id: "term-2",
+        title: "Terminal 2",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 0,
+      },
+      {
+        id: "term-3",
+        title: "Terminal 3",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 2,
+      },
+      {
+        id: "term-4",
+        title: "Terminal 4 (ungrouped)",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+      },
+      {
+        id: "term-5",
+        title: "Terminal 5 (trashed)",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "trash",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 3,
+      },
+    ] as TerminalInstance[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setState = vi.fn((updater) => {
+      const currentState = getState();
+      const updates = typeof updater === "function" ? updater(currentState) : updater;
+      state = { ...currentState, ...updates };
+    });
+    getState = vi.fn(() => state);
+    state = createTerminalRegistrySlice()(setState, getState, {} as never);
+    state.terminals = createMockTerminals();
+    state.trashedTerminals = new Map();
+  });
+
+  it("should return panels sorted by orderInGroup", () => {
+    const panels = state.getTabGroupPanels("group-a");
+
+    expect(panels).toHaveLength(3);
+    expect(panels[0].id).toBe("term-2"); // orderInGroup: 0
+    expect(panels[1].id).toBe("term-1"); // orderInGroup: 1
+    expect(panels[2].id).toBe("term-3"); // orderInGroup: 2
+  });
+
+  it("should exclude trashed panels from groups", () => {
+    const panels = state.getTabGroupPanels("group-a");
+
+    expect(panels.find((p) => p.id === "term-5")).toBeUndefined();
+  });
+
+  it("should treat ungrouped panels as single-panel groups", () => {
+    const panels = state.getTabGroupPanels("term-4");
+
+    expect(panels).toHaveLength(1);
+    expect(panels[0].id).toBe("term-4");
+  });
+
+  it("should return empty array for non-existent group", () => {
+    const panels = state.getTabGroupPanels("non-existent-group");
+
+    expect(panels).toHaveLength(0);
+  });
+
+  it("should exclude panels marked in trashedTerminals map", () => {
+    state.trashedTerminals.set("term-2", {
+      id: "term-2",
+      expiresAt: Date.now() + 120000,
+      originalLocation: "grid",
+    });
+
+    const panels = state.getTabGroupPanels("group-a");
+
+    expect(panels).toHaveLength(2);
+    expect(panels.find((p) => p.id === "term-2")).toBeUndefined();
+  });
+});
+
+describe("Tab Grouping - getTabGroups", () => {
+  let state: TerminalRegistrySlice;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let setState: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let getState: any;
+
+  const createMockTerminals = (): TerminalInstance[] =>
+    [
+      {
+        id: "term-1",
+        title: "Terminal 1",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 0,
+      },
+      {
+        id: "term-2",
+        title: "Terminal 2",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 1,
+      },
+      {
+        id: "term-3",
+        title: "Terminal 3",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "dock",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-b",
+        orderInGroup: 0,
+      },
+      {
+        id: "term-4",
+        title: "Terminal 4 (ungrouped)",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+      },
+      {
+        id: "term-5",
+        title: "Terminal 5 (different worktree)",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "grid",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-2",
+        tabGroupId: "group-c",
+        orderInGroup: 0,
+      },
+      {
+        id: "term-6",
+        title: "Terminal 6 (trashed)",
+        type: "terminal",
+        kind: "terminal",
+        cwd: "/test",
+        location: "trash",
+        cols: 80,
+        rows: 24,
+        worktreeId: "worktree-1",
+        tabGroupId: "group-a",
+        orderInGroup: 2,
+      },
+    ] as TerminalInstance[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setState = vi.fn((updater) => {
+      const currentState = getState();
+      const updates = typeof updater === "function" ? updater(currentState) : updater;
+      state = { ...currentState, ...updates };
+    });
+    getState = vi.fn(() => state);
+    state = createTerminalRegistrySlice()(setState, getState, {} as never);
+    state.terminals = createMockTerminals();
+    state.trashedTerminals = new Map();
+  });
+
+  it("should group panels correctly by location and worktree", () => {
+    const gridGroups = state.getTabGroups("grid", "worktree-1");
+
+    expect(gridGroups).toHaveLength(2);
+
+    const groupA = gridGroups.find((g) => g.id === "group-a");
+    expect(groupA).toBeDefined();
+    expect(groupA?.panelIds).toEqual(["term-1", "term-2"]);
+    expect(groupA?.activeTabId).toBe("term-1");
+
+    const ungroupedPanel = gridGroups.find((g) => g.id === "term-4");
+    expect(ungroupedPanel).toBeDefined();
+    expect(ungroupedPanel?.panelIds).toEqual(["term-4"]);
+  });
+
+  it("should filter by location correctly", () => {
+    const dockGroups = state.getTabGroups("dock", "worktree-1");
+
+    expect(dockGroups).toHaveLength(1);
+    expect(dockGroups[0].id).toBe("group-b");
+    expect(dockGroups[0].location).toBe("dock");
+  });
+
+  it("should filter by worktree correctly", () => {
+    const worktree2Groups = state.getTabGroups("grid", "worktree-2");
+
+    expect(worktree2Groups).toHaveLength(1);
+    expect(worktree2Groups[0].id).toBe("group-c");
+    expect(worktree2Groups[0].worktreeId).toBe("worktree-2");
+  });
+
+  it("should exclude trashed panels from groups", () => {
+    const gridGroups = state.getTabGroups("grid", "worktree-1");
+    const groupA = gridGroups.find((g) => g.id === "group-a");
+
+    expect(groupA?.panelIds).not.toContain("term-6");
+    expect(groupA?.panelIds).toHaveLength(2);
+  });
+
+  it("should return panels sorted by orderInGroup within each group", () => {
+    const gridGroups = state.getTabGroups("grid", "worktree-1");
+    const groupA = gridGroups.find((g) => g.id === "group-a");
+
+    expect(groupA?.panelIds[0]).toBe("term-1"); // orderInGroup: 0
+    expect(groupA?.panelIds[1]).toBe("term-2"); // orderInGroup: 1
+  });
+
+  it("should handle undefined worktree filter", () => {
+    // Add a global terminal (no worktreeId)
+    state.terminals.push({
+      id: "term-global",
+      title: "Global Terminal",
+      type: "terminal",
+      kind: "terminal",
+      cwd: "/test",
+      location: "grid",
+      cols: 80,
+      rows: 24,
+    } as TerminalInstance);
+
+    const globalGroups = state.getTabGroups("grid", undefined);
+
+    expect(globalGroups).toHaveLength(1);
+    expect(globalGroups[0].id).toBe("term-global");
+    expect(globalGroups[0].worktreeId).toBeUndefined();
+  });
+
+  it("should return empty array for location with no panels", () => {
+    const groups = state.getTabGroups("grid", "non-existent-worktree");
+
+    expect(groups).toHaveLength(0);
+  });
+});
+
+describe("Tab Grouping - activeTabByGroup (Focus Slice)", () => {
+  // These tests verify the focus slice tab tracking
+  // Import and test the focus slice separately
+  let focusSlice: import("../../terminalFocusSlice").TerminalFocusSlice;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let setState: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let getState: any;
+  let createTerminalFocusSlice: typeof import("../../terminalFocusSlice").createTerminalFocusSlice;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const focusModule = await import("../../terminalFocusSlice");
+    createTerminalFocusSlice = focusModule.createTerminalFocusSlice;
+
+    setState = vi.fn((updater) => {
+      const currentState = getState();
+      const updates = typeof updater === "function" ? updater(currentState) : updater;
+      focusSlice = { ...currentState, ...updates };
+    });
+    getState = vi.fn(() => focusSlice);
+    focusSlice = createTerminalFocusSlice(() => [])(setState, getState, {} as never);
+  });
+
+  it("should set active tab for a group", () => {
+    focusSlice.setActiveTab("group-a", "term-1");
+
+    expect(focusSlice.activeTabByGroup.get("group-a")).toBe("term-1");
+  });
+
+  it("should update active tab for existing group", () => {
+    focusSlice.setActiveTab("group-a", "term-1");
+    focusSlice.setActiveTab("group-a", "term-2");
+
+    expect(focusSlice.activeTabByGroup.get("group-a")).toBe("term-2");
+  });
+
+  it("should get active tab ID for a group", () => {
+    focusSlice.activeTabByGroup = new Map([["group-a", "term-1"]]);
+
+    const activeTabId = focusSlice.getActiveTabId("group-a");
+
+    expect(activeTabId).toBe("term-1");
+  });
+
+  it("should return null for untracked group", () => {
+    const activeTabId = focusSlice.getActiveTabId("non-existent-group");
+
+    expect(activeTabId).toBeNull();
+  });
+
+  it("should cleanup stale tabs when panels are removed", () => {
+    focusSlice.activeTabByGroup = new Map([
+      ["group-a", "term-1"],
+      ["group-b", "term-2"],
+      ["group-c", "term-3"],
+    ]);
+
+    const validPanelIds = new Set(["term-1", "term-3"]);
+    focusSlice.cleanupStaleTabs(validPanelIds);
+
+    expect(focusSlice.activeTabByGroup.has("group-a")).toBe(true);
+    expect(focusSlice.activeTabByGroup.has("group-b")).toBe(false);
+    expect(focusSlice.activeTabByGroup.has("group-c")).toBe(true);
+  });
+
+  it("should not modify state if no stale entries", () => {
+    const originalMap = new Map([["group-a", "term-1"]]);
+    focusSlice.activeTabByGroup = originalMap;
+
+    const validPanelIds = new Set(["term-1"]);
+    focusSlice.cleanupStaleTabs(validPanelIds);
+
+    // State should be unchanged (same reference)
+    expect(focusSlice.activeTabByGroup).toBe(originalMap);
+  });
+});

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -10,6 +10,8 @@ import type {
   SpawnError,
   PanelExitBehavior,
   TerminalReconnectError,
+  TabGroup,
+  TabGroupLocation,
 } from "@/types";
 import type { PanelKind } from "@/types";
 
@@ -52,6 +54,10 @@ export interface AddTerminalOptions {
   env?: Record<string, string>;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
+  /** Tab group identifier - panels with the same tabGroupId are grouped together */
+  tabGroupId?: string;
+  /** Order within the tab group (0-based) */
+  orderInGroup?: number;
 }
 
 export interface TrashedTerminal {
@@ -124,6 +130,12 @@ export interface TerminalRegistrySlice {
   clearSpawnError: (id: string) => void;
   setReconnectError: (id: string, error: TerminalReconnectError) => void;
   clearReconnectError: (id: string) => void;
+
+  // Tab grouping methods
+  /** Get all panels in a group, sorted by orderInGroup */
+  getTabGroupPanels: (groupId: string) => TerminalInstance[];
+  /** Get all tab groups for a location/worktree */
+  getTabGroups: (location: TabGroupLocation, worktreeId?: string) => TabGroup[];
 }
 
 export type TerminalRegistryMiddleware = {

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -90,6 +90,10 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
       get().handleTerminalRemoved(id, remainingTerminals, removedIndex);
       useTerminalInputStore.getState().clearDraftInput(id);
 
+      // Clean up activeTabByGroup tracking for removed panels
+      const validPanelIds = new Set(remainingTerminals.map((t) => t.id));
+      get().cleanupStaleTabs(validPanelIds);
+
       // Clean up worktree focus tracking if this was the last focused terminal
       const terminal = get().terminals.find((t) => t.id === id);
       if (terminal?.worktreeId) {


### PR DESCRIPTION
## Summary
This PR implements Phase 1 of VS Code-style tab grouping for the panel system by adding the foundational data structures and store methods. This enables future UI implementation of tabbed panels grouped together like VS Code.

Closes #1829

## Changes Made
- Add `TabGroup` and `TabGroupLocation` types to domain.ts for representing tab groups
- Add `tabGroupId` and `orderInGroup` fields to all panel types (`BasePanelData`, `TerminalInstance`, `TerminalSnapshot`)
- Implement `getTabGroups()` and `getTabGroupPanels()` methods in terminal registry slice for querying grouped panels
- Add `activeTabByGroup` tracking Map to focus slice for tracking which tab is active in each group
- Wire `cleanupStaleTabs()` into terminal removal flow to prevent stale entries and memory leaks
- Update persistence layer to save/restore tab grouping fields with consistency validation (only persist orderInGroup when tabGroupId is present)
- Propagate grouping fields through all panel creation paths (browser, notes, dev-preview, PTY panels)
- Add comprehensive unit tests (18 tests) covering grouping logic, edge cases, and cleanup
- Treat undefined location as "grid" for backward compatibility with legacy panels
- Support ungrouped panels as single-panel groups (effective groupId = panelId)

## Implementation Notes
This is Phase 1 (data model only). Phase 2 will implement the UI components (tab bar, tab switching, drag-and-drop).

**Design decisions:**
- Ungrouped panels are represented by omitting `tabGroupId`/`orderInGroup` fields
- The store methods treat such panels as singleton groups using the panel's own ID as the group ID
- Persistence ensures consistency by only saving `orderInGroup` when `tabGroupId` is present
- All 18 unit tests pass, type checking passes with no errors