### PR TITLE
Integrate tabs into PanelHeader component

### DIFF
--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -1,0 +1,154 @@
+import React, { useCallback } from "react";
+import { X } from "lucide-react";
+import type { PanelKind, TerminalType, AgentState } from "@/types";
+import { cn } from "@/lib/utils";
+import { getBrandColorHex } from "@/lib/colorUtils";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+
+export interface TabButtonProps {
+  id: string;
+  title: string;
+  type?: TerminalType;
+  agentId?: string;
+  kind: PanelKind;
+  agentState?: AgentState;
+  isActive: boolean;
+  onClick: () => void;
+  onClose: () => void;
+}
+
+const STATE_BADGE_CONFIG: Record<
+  "waiting" | "working" | "failed",
+  { icon: string; colorClass: string; bgClass?: string; pulseClass?: string }
+> = {
+  working: {
+    icon: "⟳",
+    colorClass: "text-[var(--color-state-working)]",
+  },
+  waiting: {
+    icon: "?",
+    colorClass: "text-canopy-bg",
+    bgClass: "bg-[var(--color-state-waiting)]",
+  },
+  failed: {
+    icon: "✗",
+    colorClass: "text-[var(--color-status-error)]",
+  },
+};
+
+function TabButtonComponent({
+  id,
+  title,
+  type,
+  agentId,
+  kind,
+  agentState,
+  isActive,
+  onClick,
+  onClose,
+}: TabButtonProps) {
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onClose();
+    },
+    [onClose]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        onClick();
+      }
+    },
+    [onClick]
+  );
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    // Stop propagation to prevent drag handle from capturing tab interactions
+    e.stopPropagation();
+  }, []);
+
+  const handleCloseKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  const showStateBadge =
+    !isActive &&
+    agentState &&
+    (agentState === "waiting" || agentState === "working" || agentState === "failed");
+
+  return (
+    <div
+      role="tab"
+      aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      onPointerDown={handlePointerDown}
+      className={cn(
+        "flex items-center gap-1.5 px-2 py-1 text-xs font-medium select-none cursor-pointer group/tab",
+        "border-r border-divider transition-colors",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-[-2px]",
+        isActive
+          ? "bg-white/[0.04] text-canopy-text"
+          : "text-canopy-text/60 hover:text-canopy-text hover:bg-white/[0.02]"
+      )}
+      title={title}
+      data-tab-id={id}
+    >
+      <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5">
+        <TerminalIcon
+          type={type}
+          kind={kind}
+          agentId={agentId}
+          className="w-3.5 h-3.5"
+          brandColor={getBrandColorHex(agentId ?? type)}
+        />
+      </span>
+
+      <span className="truncate max-w-[100px]">{title}</span>
+
+      {showStateBadge && agentState && (
+        <span
+          className={cn(
+            "shrink-0 flex items-center justify-center w-3.5 h-3.5 text-[9px] font-bold rounded-full",
+            STATE_BADGE_CONFIG[agentState as "waiting" | "working" | "failed"].colorClass,
+            STATE_BADGE_CONFIG[agentState as "waiting" | "working" | "failed"].bgClass
+          )}
+          role="status"
+          aria-label={`Agent status: ${agentState}`}
+        >
+          {STATE_BADGE_CONFIG[agentState as "waiting" | "working" | "failed"].icon}
+        </span>
+      )}
+
+      <button
+        onClick={handleClose}
+        onKeyDown={handleCloseKeyDown}
+        className={cn(
+          "shrink-0 p-0.5 -mr-1 rounded transition-colors",
+          "opacity-0 group-hover/tab:opacity-100 focus-visible:opacity-100",
+          "hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)]",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1",
+          "text-canopy-text/40 hover:text-[var(--color-status-error)]"
+        )}
+        title="Close tab"
+        aria-label={`Close ${title}`}
+        type="button"
+      >
+        <X className="w-3 h-3" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+export const TabButton = React.memo(TabButtonComponent);

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -1,7 +1,9 @@
 export { ContentPanel } from "./ContentPanel";
 export type { ContentPanelProps, BasePanelProps } from "./ContentPanel";
 export { PanelHeader } from "./PanelHeader";
-export type { PanelHeaderProps } from "./PanelHeader";
+export type { PanelHeaderProps, TabInfo } from "./PanelHeader";
+export { TabButton } from "./TabButton";
+export type { TabButtonProps } from "./TabButton";
 export {
   TitleEditingProvider,
   useTitleEditing,


### PR DESCRIPTION
## Summary
Add VS Code-style tabs to PanelHeader component. This implements Phase 2 of the tabbed panels feature, providing the UI components for rendering horizontal tab bars when panels have multiple tabs.

Closes #1830

## Changes Made
- Create TabButton component with icon, truncated title, agent state badge, and close button
- Extend PanelHeader with tabs prop to conditionally render tab bar (2+ tabs) or single-tab header
- Add TabInfo interface for tab data with id, title, type, agentId, kind, agentState, isActive
- Implement agent state badges on inactive tabs for waiting/working/failed states only
- Add Plus button for adding new tabs to a group
- Support horizontal scroll when tabs overflow
- Prevent panel drag when interacting with tabs via pointer event stopPropagation
- Use roving tabindex (only active tab in tab order) for better keyboard navigation
- Prevent header double-click maximize when clicking within tab bar
- Export TabButton and TabInfo from Panel module index

## Implementation Notes
- Single-tab panels continue to show the normal header (no visual change)
- Multi-tab panels (2+ tabs) show the horizontal tab bar
- Agent state badges only display for waiting/working/failed states (not running/completed)
- Tab close permanently deletes panels (no trash recovery)
- Accessibility improvements with roving tabindex and ARIA attributes