### PR TITLE
Sync pull request data between toolbar and worktree sidebar

### DIFF
--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useMemo } from "react";
 import type { WorktreeState } from "../types";
 import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import { useGitHubDataStore } from "@/store/githubDataStore";
 import { worktreeClient } from "@/clients";
 
 export interface UseWorktreesReturn {
@@ -24,6 +25,7 @@ export function useWorktrees(): UseWorktreesReturn {
   useEffect(() => {
     if (!isInitialized) {
       initialize();
+      useGitHubDataStore.getState().initialize();
     }
   }, [isInitialized, initialize]);
 

--- a/src/store/__tests__/githubDataStore.test.ts
+++ b/src/store/__tests__/githubDataStore.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PRDetectedPayload, PRClearedPayload, IssueDetectedPayload } from "../../types";
+
+let mockOnPRDetectedCallback: ((data: PRDetectedPayload) => void) | null = null;
+let mockOnPRClearedCallback: ((data: PRClearedPayload) => void) | null = null;
+let mockOnIssueDetectedCallback: ((data: IssueDetectedPayload) => void) | null = null;
+
+vi.mock("@/clients", () => ({
+  githubClient: {
+    onPRDetected: vi.fn((callback) => {
+      mockOnPRDetectedCallback = callback;
+      return () => {
+        mockOnPRDetectedCallback = null;
+      };
+    }),
+    onPRCleared: vi.fn((callback) => {
+      mockOnPRClearedCallback = callback;
+      return () => {
+        mockOnPRClearedCallback = null;
+      };
+    }),
+    onIssueDetected: vi.fn((callback) => {
+      mockOnIssueDetectedCallback = callback;
+      return () => {
+        mockOnIssueDetectedCallback = null;
+      };
+    }),
+  },
+}));
+
+const { useGitHubDataStore, cleanupGitHubDataStore } = await import("../githubDataStore");
+
+describe("githubDataStore", () => {
+  beforeEach(() => {
+    cleanupGitHubDataStore();
+    mockOnPRDetectedCallback = null;
+    mockOnPRClearedCallback = null;
+    mockOnIssueDetectedCallback = null;
+  });
+
+  describe("initialization", () => {
+    it("subscribes to PR events on initialize", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      expect(mockOnPRDetectedCallback).toBeTypeOf("function");
+      expect(mockOnPRClearedCallback).toBeTypeOf("function");
+      expect(mockOnIssueDetectedCallback).toBeTypeOf("function");
+      expect(store.getState().isInitialized).toBe(true);
+    });
+
+    it("does not re-initialize if already initialized", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      const firstPRCallback = mockOnPRDetectedCallback;
+      store.getState().initialize();
+
+      expect(mockOnPRDetectedCallback).toBe(firstPRCallback);
+    });
+
+    it("unsubscribes from events on reset", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      expect(mockOnPRDetectedCallback).toBeTruthy();
+      cleanupGitHubDataStore();
+
+      expect(mockOnPRDetectedCallback).toBeNull();
+      expect(mockOnPRClearedCallback).toBeNull();
+      expect(mockOnIssueDetectedCallback).toBeNull();
+      expect(store.getState().isInitialized).toBe(false);
+    });
+  });
+
+  describe("PR events", () => {
+    it("stores PR data when PR detected event fires", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-1",
+        prNumber: 123,
+        prUrl: "https://github.com/test/repo/pull/123",
+        prState: "open",
+        prTitle: "Add new feature",
+        issueNumber: 456,
+        issueTitle: "Implement new feature",
+        timestamp: Date.now(),
+      });
+
+      const pr = store.getState().getPRForWorktree("wt-1");
+      expect(pr).toBeDefined();
+      expect(pr?.prNumber).toBe(123);
+      expect(pr?.prUrl).toBe("https://github.com/test/repo/pull/123");
+      expect(pr?.prState).toBe("open");
+      expect(pr?.prTitle).toBe("Add new feature");
+      expect(pr?.issueNumber).toBe(456);
+      expect(pr?.issueTitle).toBe("Implement new feature");
+    });
+
+    it("removes PR data when PR cleared event fires", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-2",
+        prNumber: 789,
+        prUrl: "https://github.com/test/repo/pull/789",
+        prState: "open",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState().getPRForWorktree("wt-2")).toBeDefined();
+
+      mockOnPRClearedCallback!({
+        worktreeId: "wt-2",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState().getPRForWorktree("wt-2")).toBeUndefined();
+    });
+
+    it("handles merged PR state", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-3",
+        prNumber: 999,
+        prUrl: "https://github.com/test/repo/pull/999",
+        prState: "merged",
+        prTitle: "Merged feature",
+        timestamp: Date.now(),
+      });
+
+      const pr = store.getState().getPRForWorktree("wt-3");
+      expect(pr?.prState).toBe("merged");
+    });
+
+    it("handles closed PR state", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-4",
+        prNumber: 888,
+        prUrl: "https://github.com/test/repo/pull/888",
+        prState: "closed",
+        prTitle: "Closed PR",
+        timestamp: Date.now(),
+      });
+
+      const pr = store.getState().getPRForWorktree("wt-4");
+      expect(pr?.prState).toBe("closed");
+    });
+
+    it("overwrites existing PR with new PR", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-5",
+        prNumber: 100,
+        prUrl: "https://github.com/test/repo/pull/100",
+        prState: "open",
+        prTitle: "First PR",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState().getPRForWorktree("wt-5")?.prNumber).toBe(100);
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-5",
+        prNumber: 200,
+        prUrl: "https://github.com/test/repo/pull/200",
+        prState: "open",
+        prTitle: "Updated PR",
+        timestamp: Date.now(),
+      });
+
+      const pr = store.getState().getPRForWorktree("wt-5");
+      expect(pr?.prNumber).toBe(200);
+      expect(pr?.prTitle).toBe("Updated PR");
+    });
+  });
+
+  describe("issue events", () => {
+    it("stores issue data when issue detected event fires", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnIssueDetectedCallback!({
+        worktreeId: "wt-6",
+        issueNumber: 555,
+        issueTitle: "Bug report",
+      });
+
+      const issue = store.getState().getIssueForWorktree("wt-6");
+      expect(issue).toBeDefined();
+      expect(issue?.issueNumber).toBe(555);
+      expect(issue?.issueTitle).toBe("Bug report");
+    });
+
+    it("stores issue data from PR detected event", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-7",
+        prNumber: 111,
+        prUrl: "https://github.com/test/repo/pull/111",
+        prState: "open",
+        issueNumber: 222,
+        issueTitle: "Feature request",
+        timestamp: Date.now(),
+      });
+
+      const issue = store.getState().getIssueForWorktree("wt-7");
+      expect(issue).toBeDefined();
+      expect(issue?.issueNumber).toBe(222);
+      expect(issue?.issueTitle).toBe("Feature request");
+    });
+  });
+
+  describe("aggregate counts", () => {
+    it("counts only open PRs", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-a",
+        prNumber: 1,
+        prUrl: "https://github.com/test/repo/pull/1",
+        prState: "open",
+        timestamp: Date.now(),
+      });
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-b",
+        prNumber: 2,
+        prUrl: "https://github.com/test/repo/pull/2",
+        prState: "open",
+        timestamp: Date.now(),
+      });
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-c",
+        prNumber: 3,
+        prUrl: "https://github.com/test/repo/pull/3",
+        prState: "merged",
+        timestamp: Date.now(),
+      });
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-d",
+        prNumber: 4,
+        prUrl: "https://github.com/test/repo/pull/4",
+        prState: "closed",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState().getOpenPRCount()).toBe(2);
+    });
+
+    it("counts unique issues by worktree", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnIssueDetectedCallback!({
+        worktreeId: "wt-x",
+        issueNumber: 10,
+        issueTitle: "Issue 1",
+      });
+
+      mockOnIssueDetectedCallback!({
+        worktreeId: "wt-y",
+        issueNumber: 20,
+        issueTitle: "Issue 2",
+      });
+
+      mockOnIssueDetectedCallback!({
+        worktreeId: "wt-z",
+        issueNumber: 30,
+        issueTitle: "Issue 3",
+      });
+
+      expect(store.getState().getOpenIssueCount()).toBe(3);
+    });
+
+    it("updates count when PR is cleared", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-1",
+        prNumber: 1,
+        prUrl: "https://github.com/test/repo/pull/1",
+        prState: "open",
+        timestamp: Date.now(),
+      });
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-2",
+        prNumber: 2,
+        prUrl: "https://github.com/test/repo/pull/2",
+        prState: "open",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState().getOpenPRCount()).toBe(2);
+
+      mockOnPRClearedCallback!({
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState().getOpenPRCount()).toBe(1);
+    });
+
+    it("clears all data on reset", () => {
+      const store = useGitHubDataStore;
+      store.getState().initialize();
+
+      mockOnPRDetectedCallback!({
+        worktreeId: "wt-1",
+        prNumber: 1,
+        prUrl: "https://github.com/test/repo/pull/1",
+        prState: "open",
+        timestamp: Date.now(),
+      });
+
+      mockOnIssueDetectedCallback!({
+        worktreeId: "wt-1",
+        issueNumber: 10,
+        issueTitle: "Issue",
+      });
+
+      expect(store.getState().getOpenPRCount()).toBe(1);
+      expect(store.getState().getOpenIssueCount()).toBe(1);
+
+      cleanupGitHubDataStore();
+
+      expect(store.getState().getOpenPRCount()).toBe(0);
+      expect(store.getState().getOpenIssueCount()).toBe(0);
+      expect(store.getState().prsByWorktree.size).toBe(0);
+      expect(store.getState().issuesByWorktree.size).toBe(0);
+    });
+  });
+});

--- a/src/store/githubDataStore.ts
+++ b/src/store/githubDataStore.ts
@@ -1,0 +1,170 @@
+import { create } from "zustand";
+import { githubClient } from "@/clients";
+import type { PRDetectedPayload, PRClearedPayload, IssueDetectedPayload } from "@shared/types";
+
+export interface PRData {
+  prNumber: number;
+  prUrl: string;
+  prState: "open" | "merged" | "closed";
+  prTitle?: string;
+  issueNumber?: number;
+  issueTitle?: string;
+  timestamp: number;
+}
+
+interface GitHubDataState {
+  prsByWorktree: Map<string, PRData>;
+  issuesByWorktree: Map<string, { issueNumber: number; issueTitle: string }>;
+  isInitialized: boolean;
+}
+
+interface GitHubDataActions {
+  initialize: () => void;
+  reset: () => void;
+  getOpenPRCount: () => number;
+  getOpenIssueCount: () => number;
+  getPRForWorktree: (worktreeId: string) => PRData | undefined;
+  getIssueForWorktree: (
+    worktreeId: string
+  ) => { issueNumber: number; issueTitle: string } | undefined;
+}
+
+type GitHubDataStore = GitHubDataState & GitHubDataActions;
+
+let cleanupListeners: (() => void) | null = null;
+
+export const useGitHubDataStore = create<GitHubDataStore>()((set, get) => ({
+  prsByWorktree: new Map(),
+  issuesByWorktree: new Map(),
+  isInitialized: false,
+
+  initialize: () => {
+    if (get().isInitialized) return;
+
+    if (!cleanupListeners) {
+      const unsubPRDetected = githubClient.onPRDetected((data: PRDetectedPayload) => {
+        set((prev) => {
+          const next = new Map(prev.prsByWorktree);
+          next.set(data.worktreeId, {
+            prNumber: data.prNumber,
+            prUrl: data.prUrl,
+            prState: data.prState,
+            prTitle: data.prTitle,
+            issueNumber: data.issueNumber,
+            issueTitle: data.issueTitle,
+            timestamp: data.timestamp,
+          });
+
+          // Only clone and update issues map if there's issue data
+          if (data.issueNumber && data.issueTitle) {
+            const issuesNext = new Map(prev.issuesByWorktree);
+            issuesNext.set(data.worktreeId, {
+              issueNumber: data.issueNumber,
+              issueTitle: data.issueTitle,
+            });
+            return { prsByWorktree: next, issuesByWorktree: issuesNext };
+          }
+
+          return { prsByWorktree: next };
+        });
+      });
+
+      const unsubPRCleared = githubClient.onPRCleared((data: PRClearedPayload) => {
+        set((prev) => {
+          const next = new Map(prev.prsByWorktree);
+          const clearedPR = prev.prsByWorktree.get(data.worktreeId);
+          next.delete(data.worktreeId);
+
+          // If the issue data came only from the PR event (not a separate issue event),
+          // clear it when the PR is cleared to avoid stale issue counts
+          if (clearedPR?.issueNumber && clearedPR?.issueTitle) {
+            const issuesNext = new Map(prev.issuesByWorktree);
+            const existingIssue = issuesNext.get(data.worktreeId);
+            // Only clear if issue numbers match (issue came from this PR)
+            if (existingIssue?.issueNumber === clearedPR.issueNumber) {
+              issuesNext.delete(data.worktreeId);
+              return { prsByWorktree: next, issuesByWorktree: issuesNext };
+            }
+          }
+
+          return { prsByWorktree: next };
+        });
+      });
+
+      const unsubIssueDetected = githubClient.onIssueDetected((data: IssueDetectedPayload) => {
+        set((prev) => {
+          const issuesNext = new Map(prev.issuesByWorktree);
+          issuesNext.set(data.worktreeId, {
+            issueNumber: data.issueNumber,
+            issueTitle: data.issueTitle,
+          });
+
+          // Update PR entry if it exists, to keep issue data in sync
+          const existingPR = prev.prsByWorktree.get(data.worktreeId);
+          if (existingPR) {
+            const prsNext = new Map(prev.prsByWorktree);
+            prsNext.set(data.worktreeId, {
+              ...existingPR,
+              issueNumber: data.issueNumber,
+              issueTitle: data.issueTitle,
+            });
+            return { prsByWorktree: prsNext, issuesByWorktree: issuesNext };
+          }
+
+          return { issuesByWorktree: issuesNext };
+        });
+      });
+
+      cleanupListeners = () => {
+        unsubPRDetected();
+        unsubPRCleared();
+        unsubIssueDetected();
+      };
+    }
+
+    set({ isInitialized: true });
+  },
+
+  reset: () => {
+    if (cleanupListeners) {
+      cleanupListeners();
+      cleanupListeners = null;
+    }
+    set({
+      prsByWorktree: new Map(),
+      issuesByWorktree: new Map(),
+      isInitialized: false,
+    });
+  },
+
+  getOpenPRCount: () => {
+    const { prsByWorktree } = get();
+    let count = 0;
+    for (const pr of prsByWorktree.values()) {
+      if (pr.prState === "open") {
+        count++;
+      }
+    }
+    return count;
+  },
+
+  getOpenIssueCount: () => {
+    return get().issuesByWorktree.size;
+  },
+
+  getPRForWorktree: (worktreeId: string) => {
+    return get().prsByWorktree.get(worktreeId);
+  },
+
+  getIssueForWorktree: (worktreeId: string) => {
+    return get().issuesByWorktree.get(worktreeId);
+  },
+}));
+
+export function cleanupGitHubDataStore() {
+  useGitHubDataStore.getState().reset();
+}
+
+export function initializeGitHubDataStore() {
+  useGitHubDataStore.getState().initialize();
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -57,6 +57,13 @@ export { useUIStore } from "./uiStore";
 
 export { useGitHubConfigStore, cleanupGitHubConfigStore } from "./githubConfigStore";
 
+export {
+  useGitHubDataStore,
+  cleanupGitHubDataStore,
+  initializeGitHubDataStore,
+} from "./githubDataStore";
+export type { PRData } from "./githubDataStore";
+
 export { useAgentSettingsStore, cleanupAgentSettingsStore } from "./agentSettingsStore";
 
 export { usePulseStore } from "./pulseStore";

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -4,6 +4,7 @@ import type { Project, ProjectCloseResult, TerminalSnapshot } from "@shared/type
 import { projectClient } from "@/clients";
 import { resetAllStoresForProjectSwitch } from "./resetStores";
 import { forceReinitializeWorktreeDataStore } from "./worktreeDataStore";
+import { initializeGitHubDataStore } from "./githubDataStore";
 import { flushTerminalPersistence } from "./slices";
 import { terminalPersistence } from "./persistence/terminalPersistence";
 import { useNotificationStore } from "./notificationStore";
@@ -278,6 +279,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       // Now that backend has switched, reinitialize worktree data for the new project
       console.log("[ProjectSwitch] Reinitializing worktree data store...");
       forceReinitializeWorktreeDataStore();
+      initializeGitHubDataStore();
 
       await get().loadProjects();
 
@@ -460,6 +462,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       console.log("[ProjectStore] Pre-loading project settings...");
       useProjectSettingsStore.getState().reset();
       void useProjectSettingsStore.getState().loadSettings(projectId);
+
+      // Now that backend has reopened, reinitialize worktree data for the new project
+      console.log("[ProjectStore] Reinitializing worktree data store...");
+      forceReinitializeWorktreeDataStore();
+      initializeGitHubDataStore();
 
       await get().loadProjects();
 

--- a/src/store/resetStores.ts
+++ b/src/store/resetStores.ts
@@ -10,6 +10,7 @@ import { useNotificationStore } from "./notificationStore";
 import { cleanupNotesStore } from "./notesStore";
 import { useRecipeStore } from "./recipeStore";
 import { useBrowserStateStore } from "./browserStateStore";
+import { cleanupGitHubDataStore } from "./githubDataStore";
 
 export async function resetAllStoresForProjectSwitch(): Promise<void> {
   // Use resetWithoutKilling instead of reset
@@ -32,4 +33,6 @@ export async function resetAllStoresForProjectSwitch(): Promise<void> {
   // Reset browser state to ensure per-project URLs are restored from project persistence
   // rather than using stale localStorage state from a different project
   useBrowserStateStore.getState().reset();
+  // Reset GitHub data store to clear PR/issue mappings from previous project
+  cleanupGitHubDataStore();
 }


### PR DESCRIPTION
## Summary
Implements unified GitHub data store to synchronize PR and issue data between the toolbar and worktree sidebar, replacing separate polling and event-driven mechanisms that were causing synchronization issues.

Closes #1826

## Changes Made
- Add githubDataStore with event-driven PR/issue tracking per worktree
- Subscribe to sys:pr:detected, sys:pr:cleared, and sys:issue:detected events
- Implement aggregate counts for toolbar consumption (getOpenPRCount, getOpenIssueCount)
- Queue pending refreshes when PR events arrive during in-flight fetches
- Sync issue data between PR and issue maps to prevent divergence
- Clear stale issue data when PRs are cleared
- Integrate store initialization into app and project lifecycle
- Add reinitialization in reopenProject flow to fix missing data after reopen
- Prevent unnecessary Map cloning when no issue data present
- Add comprehensive test coverage (14 tests) for event handling and edge cases