### PR TITLE
feat(panels): implement tab group support for grid panels

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, forwardRef, useMemo, useEffect, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
-import { PanelHeader } from "./PanelHeader";
+import { PanelHeader, type TabInfo } from "./PanelHeader";
 import { useIsDragging } from "@/components/DragDrop";
 import { TitleEditingProvider, useTitleEditing } from "./TitleEditingContext";
 import { TerminalHeaderContent } from "@/components/Terminal/TerminalHeaderContent";
@@ -44,6 +44,12 @@ export interface ContentPanelProps extends BasePanelProps {
   tabIndex?: number;
   role?: string;
   "aria-label"?: string;
+
+  // Tab support (for multi-panel groups)
+  tabs?: TabInfo[];
+  onTabClick?: (tabId: string) => void;
+  onTabClose?: (tabId: string) => void;
+  onAddTab?: () => void;
 
   // Terminal-specific header props (optional, only used for terminal/agent panels)
   type?: TerminalType;
@@ -89,6 +95,10 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     tabIndex,
     role,
     "aria-label": ariaLabel,
+    tabs,
+    onTabClick,
+    onTabClose,
+    onAddTab,
     type,
     agentId,
     isExited = false,
@@ -262,6 +272,10 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         wasJustSelected={wasJustSelected}
         headerContent={resolvedHeaderContent}
         headerActions={headerActions}
+        tabs={tabs}
+        onTabClick={onTabClick}
+        onTabClose={onTabClose}
+        onAddTab={onAddTab}
       />
 
       {toolbar}

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -4,6 +4,7 @@ import { getTerminalAnimationDuration } from "@/lib/animationUtils";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { getPanelComponent, type PanelComponentProps } from "@/registry";
 import { ContentPanel, triggerPanelTransition } from "@/components/Panel";
+import type { TabInfo } from "@/components/Panel/PanelHeader";
 
 export interface GridPanelProps {
   terminal: TerminalInstance;
@@ -11,6 +12,14 @@ export interface GridPanelProps {
   isMaximized?: boolean;
   gridPanelCount?: number;
   gridCols?: number;
+  /** Tab data for multi-panel groups */
+  tabs?: TabInfo[];
+  /** Callback when a tab is clicked */
+  onTabClick?: (tabId: string) => void;
+  /** Callback when a tab close button is clicked */
+  onTabClose?: (tabId: string) => void;
+  /** Callback when the add tab button is clicked */
+  onAddTab?: () => void;
 }
 
 export function GridPanel({
@@ -19,6 +28,10 @@ export function GridPanel({
   isMaximized = false,
   gridPanelCount,
   gridCols,
+  tabs,
+  onTabClick,
+  onTabClose,
+  onAddTab,
 }: GridPanelProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
   const trashTerminal = useTerminalStore((state) => state.trashTerminal);
@@ -143,6 +156,12 @@ export function GridPanel({
       onTitleChange: handleTitleChange,
       onMinimize: handleMinimize,
 
+      // Tab support (for multi-panel groups)
+      tabs,
+      onTabClick,
+      onTabClose,
+      onAddTab,
+
       // Terminal-specific
       type: terminal.type,
       agentId: terminal.agentId,
@@ -182,6 +201,10 @@ export function GridPanel({
       handleToggleMaximize,
       handleTitleChange,
       handleMinimize,
+      tabs,
+      onTabClick,
+      onTabClose,
+      onAddTab,
     ]
   );
 

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useEffect } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import { GridPanel } from "./GridPanel";
+import type { TabGroup } from "@/types";
+import type { TabInfo } from "@/components/Panel/PanelHeader";
+
+export interface GridTabGroupProps {
+  group: TabGroup;
+  panels: TerminalInstance[];
+  focusedId: string | null;
+  gridPanelCount?: number;
+  gridCols?: number;
+  /** Whether this group item is disabled for drag-drop (e.g., when in trash) */
+  disabled?: boolean;
+}
+
+export function GridTabGroup({
+  group,
+  panels,
+  focusedId,
+  gridPanelCount,
+  gridCols,
+  disabled = false,
+}: GridTabGroupProps) {
+  const setFocused = useTerminalStore((state) => state.setFocused);
+  const setActiveTab = useTerminalStore((state) => state.setActiveTab);
+  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+
+  // CRITICAL: Subscribe to activeTabByGroup to get reactive updates
+  const storedActiveTabId = useTerminalStore(
+    (state) => state.activeTabByGroup.get(group.id) ?? null
+  );
+
+  // Reconcile active tab - ensure it's valid and in this group
+  const activeTabId = useMemo(() => {
+    // If stored ID is valid and in this group, use it
+    if (storedActiveTabId && panels.some((p) => p.id === storedActiveTabId)) {
+      return storedActiveTabId;
+    }
+    // If focused panel is in this group, prefer it
+    if (focusedId && panels.some((p) => p.id === focusedId)) {
+      return focusedId;
+    }
+    // Default to first panel
+    return panels[0]?.id ?? "";
+  }, [storedActiveTabId, focusedId, panels]);
+
+  // Sync active tab when it changes or when focused panel in this group changes
+  useEffect(() => {
+    if (activeTabId && activeTabId !== storedActiveTabId) {
+      setActiveTab(group.id, activeTabId);
+    }
+  }, [activeTabId, storedActiveTabId, group.id, setActiveTab]);
+
+  // Find the active panel to render
+  const activePanel = useMemo(() => {
+    return panels.find((p) => p.id === activeTabId) ?? panels[0];
+  }, [panels, activeTabId]);
+
+  // Build tabs array for PanelHeader
+  const tabs: TabInfo[] = useMemo(() => {
+    return panels.map((p) => ({
+      id: p.id,
+      title: p.title,
+      type: p.type,
+      agentId: p.agentId,
+      kind: p.kind ?? "terminal",
+      agentState: p.agentState,
+      isActive: p.id === activeTabId,
+    }));
+  }, [panels, activeTabId]);
+
+  // Handle tab click - switch to that tab and focus it
+  const handleTabClick = useCallback(
+    (tabId: string) => {
+      setActiveTab(group.id, tabId);
+      setFocused(tabId);
+    },
+    [group.id, setActiveTab, setFocused]
+  );
+
+  // Handle tab close - move to trash (not destructive delete)
+  const handleTabClose = useCallback(
+    (tabId: string) => {
+      // If closing the active tab, switch to another tab first
+      if (tabId === activeTabId) {
+        const currentIndex = panels.findIndex((p) => p.id === tabId);
+        // Try to switch to the next tab, or previous if last
+        const nextPanel = panels[currentIndex + 1] ?? panels[currentIndex - 1];
+        if (nextPanel) {
+          setActiveTab(group.id, nextPanel.id);
+          setFocused(nextPanel.id);
+        }
+      }
+      // Move to trash (allows restore/undo)
+      trashTerminal(tabId);
+    },
+    [activeTabId, panels, group.id, setActiveTab, setFocused, trashTerminal]
+  );
+
+  // Set up sortable for dragging the entire group as a unit
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: group.id,
+    disabled,
+    data: {
+      type: "tab-group",
+      groupId: group.id,
+      container: "grid",
+    },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  // If there's no active panel (shouldn't happen), return null
+  if (!activePanel) {
+    return null;
+  }
+
+  // Check if this group's active panel is focused
+  const isFocused = activePanel.id === focusedId;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="h-full"
+      data-tab-group-id={group.id}
+    >
+      <GridPanel
+        terminal={activePanel}
+        isFocused={isFocused}
+        gridPanelCount={gridPanelCount}
+        gridCols={gridCols}
+        tabs={tabs}
+        onTabClick={handleTabClick}
+        onTabClose={handleTabClose}
+      />
+    </div>
+  );
+}

--- a/src/components/Terminal/index.ts
+++ b/src/components/Terminal/index.ts
@@ -19,5 +19,7 @@ export { ReconnectErrorBanner } from "./ReconnectErrorBanner";
 export type { ReconnectErrorBannerProps } from "./ReconnectErrorBanner";
 export { GridPanel } from "./GridPanel";
 export type { GridPanelProps } from "./GridPanel";
+export { GridTabGroup } from "./GridTabGroup";
+export type { GridTabGroupProps } from "./GridTabGroup";
 export { DockedPanel } from "./DockedPanel";
 export type { DockedPanelProps } from "./DockedPanel";


### PR DESCRIPTION
## Summary
Implements tab group support for grid panels, allowing multiple panels to share a single grid cell with VS Code-style tabs in the panel header.

Closes #1831

## Changes Made
- Add GridTabGroup component for multi-panel groups with tabs
- Update ContentGrid to render tab groups instead of flat panels
- Make tab groups reactive to terminal changes
- Forward tab props through ContentPanel to PanelHeader
- Use trash flow for tab close (allows restore/undo)
- Track active tab reactively with store subscription
- Calculate grid capacity based on groups, not individual panels