### PR TITLE
Panel tab duplication: "+" button creates same-type instance

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -167,34 +167,37 @@ function PanelHeaderComponent({
       >
         {/* Tab bar mode: show tabs when there are 2+ tabs */}
         {tabs && tabs.length > 1 ? (
-          <div
-            className="flex items-center min-w-0 overflow-x-auto scrollbar-none -ml-3"
-            role="tablist"
-            aria-label="Panel tabs"
-          >
-            {tabs.map((tab) => (
-              <TabButton
-                key={tab.id}
-                id={tab.id}
-                title={tab.title}
-                type={tab.type}
-                agentId={tab.agentId}
-                kind={tab.kind}
-                agentState={tab.agentState}
-                isActive={tab.isActive}
-                onClick={() => onTabClick?.(tab.id)}
-                onClose={() => onTabClose?.(tab.id)}
-              />
-            ))}
+          <div className="flex items-center min-w-0 -ml-3">
+            <div
+              className="flex items-center min-w-0 overflow-x-auto scrollbar-none"
+              role="tablist"
+              aria-label="Panel tabs"
+            >
+              {tabs.map((tab) => (
+                <TabButton
+                  key={tab.id}
+                  id={tab.id}
+                  title={tab.title}
+                  type={tab.type}
+                  agentId={tab.agentId}
+                  kind={tab.kind}
+                  agentState={tab.agentState}
+                  isActive={tab.isActive}
+                  onClick={() => onTabClick?.(tab.id)}
+                  onClose={() => onTabClose?.(tab.id)}
+                />
+              ))}
+            </div>
             {onAddTab && (
               <button
                 onClick={(e) => {
                   e.stopPropagation();
                   onAddTab();
                 }}
+                onPointerDown={(e) => e.stopPropagation()}
                 className="shrink-0 p-1.5 hover:bg-canopy-text/10 text-canopy-text/40 hover:text-canopy-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1"
-                title="Add tab"
-                aria-label="Add new tab"
+                title="Duplicate panel as new tab"
+                aria-label="Duplicate panel as new tab"
                 type="button"
               >
                 <Plus className="w-3.5 h-3.5" aria-hidden="true" />
@@ -202,7 +205,7 @@ function PanelHeaderComponent({
             )}
           </div>
         ) : (
-          /* Single-tab mode: show icon + title (unchanged) */
+          /* Single-tab mode: show icon + title + add button */
           <div className="flex items-center gap-2 min-w-0">
             <span className="shrink-0 flex items-center justify-center w-3.5 h-3.5 text-canopy-text">
               <TerminalIcon
@@ -246,6 +249,23 @@ function PanelHeaderComponent({
                   {displayTitle}
                 </span>
               </div>
+            )}
+
+            {/* Add tab button for single panels */}
+            {onAddTab && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onAddTab();
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-canopy-text/10 text-canopy-text/40 hover:text-canopy-text transition-all focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1"
+                title="Duplicate panel as new tab"
+                aria-label="Duplicate panel as new tab"
+                type="button"
+              >
+                <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
             )}
           </div>
         )}

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -1555,6 +1555,19 @@ export const createTerminalRegistrySlice =
         });
       },
 
+      setTabGroupInfo: (id, tabGroupId, orderInGroup) => {
+        set((state) => {
+          const terminal = state.terminals.find((t) => t.id === id);
+          if (!terminal) return state;
+
+          const newTerminals = state.terminals.map((t) =>
+            t.id === id ? { ...t, tabGroupId, orderInGroup } : t
+          );
+          saveTerminals(newTerminals);
+          return { terminals: newTerminals };
+        });
+      },
+
       getTabGroupPanels: (groupId) => {
         const terminals = get().terminals;
         const trashedTerminals = get().trashedTerminals;

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -136,6 +136,8 @@ export interface TerminalRegistrySlice {
   getTabGroupPanels: (groupId: string) => TerminalInstance[];
   /** Get all tab groups for a location/worktree */
   getTabGroups: (location: TabGroupLocation, worktreeId?: string) => TabGroup[];
+  /** Set a panel's tab group info */
+  setTabGroupInfo: (id: string, tabGroupId: string | undefined, orderInGroup: number | undefined) => void;
 }
 
 export type TerminalRegistryMiddleware = {


### PR DESCRIPTION
## Summary
Implements a "+" button on panel headers that allows users to duplicate panels as new tabs within the same panel group. Clicking the button on a single panel converts it to a tabbed group and creates a duplicate. On existing tab groups, it adds a new tab of the same type (terminal, agent, browser, notes, or dev-preview).

Closes #1842

## Changes Made
- Add "+" button to PanelHeader for both single-panel and multi-tab modes
- Implement handleAddTab callbacks in GridTabGroup and DockedTabGroup components
- Add setTabGroupInfo method to terminal registry for managing tab group assignments
- Copy all panel properties when duplicating, including kind-specific fields (browser URLs, note paths, dev-preview commands)
- Use timestamp-based orderInGroup values to prevent race conditions during concurrent tab additions
- Add error handling with automatic rollback if panel creation fails
- Fix ARIA violations by separating the add button from the tablist element
- Prevent drag interference by adding onPointerDown event handler to stop propagation
- Improve accessibility with descriptive aria-labels and keyboard support

## Implementation Details
- New tabs inherit: kind, type, agentId, cwd, worktreeId, location, exitBehavior, isInputLocked
- Browser panels copy browserUrl
- Notes panels copy notePath, noteId, scope (with new createdAt timestamp)
- Dev-preview panels copy devCommand and browserUrl
- Single panels are automatically assigned a tabGroupId when duplicated
- Tab ordering is deterministic using timestamps to avoid conflicts
- Failed panel creation triggers rollback of any state changes

## Testing
Verified tab duplication works correctly for:
- Single terminals becoming tab groups
- Existing tab groups adding new tabs
- Grid panels and dock panels
- All panel types (terminal, agent, browser, notes, dev-preview)