### PR TITLE
Tab reordering: drag tabs within panel to reorder

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource/jetbrains-mono": "^5.2.8",

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -65,9 +65,11 @@ export interface ContentPanelProps extends BasePanelProps {
 
   // Tab support
   tabs?: TabInfo[];
+  groupId?: string;
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
   onAddTab?: () => void;
+  onTabReorder?: (newOrder: string[]) => void;
 }
 
 const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function ContentPanelInner(
@@ -112,9 +114,11 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     isPinged,
     wasJustSelected,
     tabs,
+    groupId,
     onTabClick,
     onTabClose,
     onAddTab,
+    onTabReorder,
   },
   ref
 ) {
@@ -274,9 +278,11 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         headerContent={resolvedHeaderContent}
         headerActions={headerActions}
         tabs={tabs}
+        groupId={groupId}
         onTabClick={onTabClick}
         onTabClose={onTabClose}
         onAddTab={onAddTab}
+        onTabReorder={onTabReorder}
       />
 
       {toolbar}

--- a/src/components/Panel/SortableTabButton.tsx
+++ b/src/components/Panel/SortableTabButton.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { cn } from "@/lib/utils";
+import { TabButton, type TabButtonProps } from "./TabButton";
+
+export interface SortableTabButtonProps extends TabButtonProps {
+  disabled?: boolean;
+}
+
+function SortableTabButtonComponent({
+  id,
+  disabled = false,
+  onClick,
+  onClose,
+  ...tabButtonProps
+}: SortableTabButtonProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging, setActivatorNodeRef } =
+    useSortable({
+      id,
+      disabled,
+    });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : undefined,
+  };
+
+  // Wrap handlers to prevent activation of sortable when clicking or closing
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onClick();
+    },
+    [onClick]
+  );
+
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onClose();
+    },
+    [onClose]
+  );
+
+  return (
+    <div ref={setNodeRef} style={style} className={cn(isDragging && "opacity-50")}>
+      <TabButton
+        ref={setActivatorNodeRef}
+        id={id}
+        onClick={handleClick}
+        onClose={handleClose}
+        sortableListeners={listeners}
+        sortableAttributes={attributes}
+        {...tabButtonProps}
+      />
+    </div>
+  );
+}
+
+export const SortableTabButton = React.memo(SortableTabButtonComponent);

--- a/src/components/Panel/index.ts
+++ b/src/components/Panel/index.ts
@@ -2,6 +2,10 @@ export { ContentPanel } from "./ContentPanel";
 export type { ContentPanelProps, BasePanelProps } from "./ContentPanel";
 export { PanelHeader } from "./PanelHeader";
 export type { PanelHeaderProps } from "./PanelHeader";
+export { TabButton } from "./TabButton";
+export type { TabInfo, TabButtonProps } from "./TabButton";
+export { SortableTabButton } from "./SortableTabButton";
+export type { SortableTabButtonProps } from "./SortableTabButton";
 export {
   TitleEditingProvider,
   useTitleEditing,

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -14,9 +14,11 @@ export interface GridPanelProps {
   gridCols?: number;
   // Tab support
   tabs?: TabInfo[];
+  groupId?: string;
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
   onAddTab?: () => void;
+  onTabReorder?: (newOrder: string[]) => void;
 }
 
 export function GridPanel({
@@ -26,9 +28,11 @@ export function GridPanel({
   gridPanelCount,
   gridCols,
   tabs,
+  groupId,
   onTabClick,
   onTabClose,
   onAddTab,
+  onTabReorder,
 }: GridPanelProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
   const trashTerminal = useTerminalStore((state) => state.trashTerminal);
@@ -183,9 +187,11 @@ export function GridPanel({
 
       // Tab support
       tabs,
+      groupId,
       onTabClick,
       onTabClose,
       onAddTab,
+      onTabReorder,
     }),
     [
       terminal,
@@ -199,9 +205,11 @@ export function GridPanel({
       handleTitleChange,
       handleMinimize,
       tabs,
+      groupId,
       onTabClick,
       onTabClose,
       onAddTab,
+      onTabReorder,
     ]
   );
 
@@ -221,9 +229,11 @@ export function GridPanel({
         onTitleChange={handleTitleChange}
         onMinimize={handleMinimize}
         tabs={tabs}
+        groupId={groupId}
         onTabClick={onTabClick}
         onTabClose={onTabClose}
         onAddTab={onAddTab}
+        onTabReorder={onTabReorder}
       >
         <div className="flex flex-1 items-center justify-center bg-canopy-bg-secondary text-canopy-text-muted">
           <div className="text-center">

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -28,6 +28,7 @@ export function GridTabGroup({
   const removePanelFromGroup = useTerminalStore((state) => state.removePanelFromGroup);
   const addTerminal = useTerminalStore((state) => state.addTerminal);
   const addPanelToGroup = useTerminalStore((state) => state.addPanelToGroup);
+  const reorderPanelsInGroup = useTerminalStore((state) => state.reorderPanelsInGroup);
 
   // Subscribe to activeTabByGroup for reactive updates
   const storedActiveTabId = useTerminalStore(
@@ -100,6 +101,14 @@ export function GridTabGroup({
       trashTerminal(tabId);
     },
     [activeTabId, panels, group.id, setActiveTab, setFocused, removePanelFromGroup, trashTerminal]
+  );
+
+  // Handle tab reorder - update group panel order
+  const handleTabReorder = useCallback(
+    (newOrder: string[]) => {
+      reorderPanelsInGroup(group.id, newOrder);
+    },
+    [group.id, reorderPanelsInGroup]
   );
 
   // Handle add tab - duplicate the current panel as a new tab
@@ -189,9 +198,11 @@ export function GridTabGroup({
       gridPanelCount={gridPanelCount}
       gridCols={gridCols}
       tabs={tabs}
+      groupId={group.id}
       onTabClick={handleTabClick}
       onTabClose={handleTabClose}
       onAddTab={handleAddTab}
+      onTabReorder={handleTabReorder}
     />
   );
 }


### PR DESCRIPTION
## Summary
Implements drag-to-reorder functionality for tabs within tab groups using @dnd-kit. Users can now drag tabs horizontally to reorder them in both grid panels and dock tab groups.

Closes #1844

## Changes Made
- Add SortableTabButton component wrapping TabButton with dnd-kit sortable
- Fix drag activation by applying listeners to TabButton via setActivatorNodeRef
- Filter conflicting role/tabIndex from sortable attributes to preserve accessibility
- Add TouchSensor support for touch device compatibility
- Thread groupId and onTabReorder props through panel component hierarchy
- Implement tab reordering in both grid and dock tab groups
- Install @dnd-kit/modifiers for drag constraints

## Implementation Details
- Uses nested DndContext for tab reordering (separate from panel drag-and-drop)
- Preserves existing keyboard navigation (arrow keys) for accessibility
- Event propagation carefully managed to avoid conflicts between tab and panel dragging
- Follows existing dnd-kit patterns used elsewhere in the codebase