### PR TITLE
Fix dock-to-grid expansion animation distortion

### DIFF
--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -448,7 +448,7 @@ export const createTerminalRegistrySlice =
               } else {
                 // Update group without this panel
                 const newActiveTabId =
-                  group.activeTabId === id ? filteredPanelIds[0] ?? "" : group.activeTabId;
+                  group.activeTabId === id ? (filteredPanelIds[0] ?? "") : group.activeTabId;
                 newTabGroups.set(groupId, {
                   ...group,
                   panelIds: filteredPanelIds,
@@ -1658,7 +1658,7 @@ export const createTerminalRegistrySlice =
           }
 
           // CRITICAL: Enforce unique membership - remove from any existing group first
-          let newTabGroups = new Map(state.tabGroups);
+          const newTabGroups = new Map(state.tabGroups);
           for (const [existingGroupId, existingGroup] of newTabGroups) {
             if (existingGroup.panelIds.includes(panelId)) {
               const filteredPanelIds = existingGroup.panelIds.filter((id) => id !== panelId);
@@ -1669,7 +1669,7 @@ export const createTerminalRegistrySlice =
                 // Update group without this panel
                 const newActiveTabId =
                   existingGroup.activeTabId === panelId
-                    ? filteredPanelIds[0] ?? ""
+                    ? (filteredPanelIds[0] ?? "")
                     : existingGroup.activeTabId;
                 newTabGroups.set(existingGroupId, {
                   ...existingGroup,


### PR DESCRIPTION
## Summary

Eliminates visual distortion in the dock-to-grid panel expansion animation by replacing the scale-based transform with position/size-based transitions. The previous implementation used non-uniform scaling (8x horizontal, 25x vertical) which created a "weird shape" effect with rounded corners.

Closes #1852

## Changes Made

- Replace scale-based animation with position/size transitions (left, top, width, height)
- Reduce animation duration from 250ms to 180ms to minimize visual artifacts
- Use expo ease-out timing (cubic-bezier) for snappier, more natural feel
- Apply fixed 6px border-radius instead of class-based rounded to prevent scaling distortion
- Fix ID parsing bug in transition completion callback
- Remove unused transformOrigin code
- Change minimize fade to full opacity 0 for smoother transition