### PR TITLE
Enable tab renaming via double-click in tab groups

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -14,6 +14,7 @@ export interface BrowserPaneProps extends BasePanelProps {
   tabs?: import("@/components/Panel/TabButton").TabInfo[];
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
+  onTabRename?: (tabId: string, newTitle: string) => void;
   onAddTab?: () => void;
 }
 
@@ -35,6 +36,7 @@ export function BrowserPane({
   tabs,
   onTabClick,
   onTabClose,
+  onTabRename,
   onAddTab,
 }: BrowserPaneProps) {
   const webviewRef = useRef<Electron.WebviewTag>(null);
@@ -390,6 +392,7 @@ export function BrowserPane({
       tabs={tabs}
       onTabClick={onTabClick}
       onTabClose={onTabClose}
+      onTabRename={onTabRename}
       onAddTab={onAddTab}
     >
       <div className="relative flex-1 min-h-0 bg-white">

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -35,6 +35,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const setFocused = useTerminalStore((s) => s.setFocused);
   const trashTerminal = useTerminalStore((s) => s.trashTerminal);
   const removePanelFromGroup = useTerminalStore((s) => s.removePanelFromGroup);
+  const updateTitle = useTerminalStore((s) => s.updateTitle);
   const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
   const hybridInputAutoFocus = useTerminalInputStore((s) => s.hybridInputAutoFocus);
 
@@ -220,6 +221,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     [activeTabId, panels, group.id, setActiveTab, setFocused, removePanelFromGroup, trashTerminal]
   );
 
+  const handleTabRename = useCallback(
+    (tabId: string, newTitle: string) => {
+      updateTitle(tabId, newTitle);
+    },
+    [updateTitle]
+  );
+
   if (!activePanel || panels.length === 0) {
     return null;
   }
@@ -354,6 +362,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
               isActive={panel.id === activeTabId}
               onClick={() => handleTabClick(panel.id)}
               onClose={() => handleTabClose(panel.id)}
+              onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
             />
           ))}
         </div>

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -67,6 +67,7 @@ export interface ContentPanelProps extends BasePanelProps {
   tabs?: TabInfo[];
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
+  onTabRename?: (tabId: string, newTitle: string) => void;
   onAddTab?: () => void;
 }
 
@@ -114,6 +115,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     tabs,
     onTabClick,
     onTabClose,
+    onTabRename,
     onAddTab,
   },
   ref
@@ -276,6 +278,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         tabs={tabs}
         onTabClick={onTabClick}
         onTabClose={onTabClose}
+        onTabRename={onTabRename}
         onAddTab={onAddTab}
       />
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -59,6 +59,7 @@ export interface PanelHeaderProps {
   tabs?: TabInfo[];
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
+  onTabRename?: (tabId: string, newTitle: string) => void;
   onAddTab?: () => void;
 }
 
@@ -93,6 +94,7 @@ function PanelHeaderComponent({
   tabs,
   onTabClick,
   onTabClose,
+  onTabRename,
   onAddTab,
 }: PanelHeaderProps) {
   const isBrowser = kind === "browser";
@@ -214,6 +216,7 @@ function PanelHeaderComponent({
                 isActive={tab.isActive}
                 onClick={() => onTabClick?.(tab.id)}
                 onClose={() => onTabClose?.(tab.id)}
+                onRename={onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined}
               />
             ))}
             {onAddTab && (

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState, useRef, useEffect } from "react";
 import { X } from "lucide-react";
 import type { PanelKind, TerminalType, AgentState } from "@/types";
 import { cn } from "@/lib/utils";
@@ -26,6 +26,7 @@ export interface TabButtonProps {
   isActive: boolean;
   onClick: () => void;
   onClose: () => void;
+  onRename?: (newTitle: string) => void;
 }
 
 function TabButtonComponent({
@@ -38,7 +39,49 @@ function TabButtonComponent({
   isActive,
   onClick,
   onClose,
+  onRename,
 }: TabButtonProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const didCommitOrCancelRef = useRef(false);
+
+  // Focus input when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  // Sync edit value when title changes externally
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(title);
+    }
+  }, [title, isEditing]);
+
+  // Listen for rename events from context menu
+  useEffect(() => {
+    if (!onRename) return;
+
+    const handleRenameEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        setEditValue(title);
+        setIsEditing(true);
+      }
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("canopy:rename-terminal", handleRenameEvent, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [id, title, onRename]);
+
   const handleClose = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
@@ -73,6 +116,65 @@ function TabButtonComponent({
     [onClose]
   );
 
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (onRename) {
+        setEditValue(title);
+        setIsEditing(true);
+        didCommitOrCancelRef.current = false;
+      }
+    },
+    [onRename, title]
+  );
+
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      e.stopPropagation();
+      if (e.key === "Enter") {
+        e.preventDefault();
+        const trimmed = editValue.trim();
+        if (trimmed && trimmed !== title) {
+          onRename?.(trimmed);
+        }
+        didCommitOrCancelRef.current = true;
+        setIsEditing(false);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setEditValue(title);
+        didCommitOrCancelRef.current = true;
+        setIsEditing(false);
+      }
+    },
+    [editValue, title, onRename]
+  );
+
+  const handleInputBlur = useCallback(() => {
+    // Only commit on blur if Enter/Escape didn't already handle it
+    if (!didCommitOrCancelRef.current) {
+      const trimmed = editValue.trim();
+      if (trimmed && trimmed !== title) {
+        onRename?.(trimmed);
+      }
+    }
+    setIsEditing(false);
+  }, [editValue, title, onRename]);
+
+  const handleInputClick = useCallback((e: React.MouseEvent) => {
+    // Prevent click from bubbling to tab click handler
+    e.stopPropagation();
+  }, []);
+
+  const handleInputDoubleClick = useCallback((e: React.MouseEvent) => {
+    // Prevent double-click from bubbling to header and triggering maximize
+    e.stopPropagation();
+  }, []);
+
+  const handleInputPointerDown = useCallback((e: React.PointerEvent) => {
+    // Prevent drag handle from capturing input interactions
+    e.stopPropagation();
+  }, []);
+
   const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";
   const StateIcon = showStateIcon ? STATE_ICONS[agentState] : null;
 
@@ -105,7 +207,32 @@ function TabButtonComponent({
         />
       </span>
 
-      <span className="truncate max-w-[100px]">{title}</span>
+      {isEditing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onKeyDown={handleInputKeyDown}
+          onBlur={handleInputBlur}
+          onClick={handleInputClick}
+          onDoubleClick={handleInputDoubleClick}
+          onPointerDown={handleInputPointerDown}
+          className="text-xs bg-canopy-bg/80 border border-canopy-accent/50 px-1 h-4 min-w-[60px] max-w-[100px] text-canopy-text select-text focus-visible:outline focus-visible:outline-1 focus-visible:outline-canopy-accent"
+          aria-label={`Rename tab ${title}`}
+        />
+      ) : (
+        <span
+          className={cn(
+            "truncate max-w-[100px]",
+            onRename && "cursor-text"
+          )}
+          onDoubleClick={handleDoubleClick}
+          title={onRename ? `${title} — Double-click to rename` : title}
+        >
+          {title}
+        </span>
+      )}
 
       {showStateIcon && StateIcon && (
         <StateIcon

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -16,6 +16,7 @@ export interface GridPanelProps {
   tabs?: TabInfo[];
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
+  onTabRename?: (tabId: string, newTitle: string) => void;
   onAddTab?: () => void;
 }
 
@@ -28,6 +29,7 @@ export function GridPanel({
   tabs,
   onTabClick,
   onTabClose,
+  onTabRename,
   onAddTab,
 }: GridPanelProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
@@ -185,6 +187,7 @@ export function GridPanel({
       tabs,
       onTabClick,
       onTabClose,
+      onTabRename,
       onAddTab,
     }),
     [
@@ -201,6 +204,7 @@ export function GridPanel({
       tabs,
       onTabClick,
       onTabClose,
+      onTabRename,
       onAddTab,
     ]
   );
@@ -223,6 +227,7 @@ export function GridPanel({
         tabs={tabs}
         onTabClick={onTabClick}
         onTabClose={onTabClose}
+        onTabRename={onTabRename}
         onAddTab={onAddTab}
       >
         <div className="flex flex-1 items-center justify-center bg-canopy-bg-secondary text-canopy-text-muted">

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -28,6 +28,7 @@ export function GridTabGroup({
   const removePanelFromGroup = useTerminalStore((state) => state.removePanelFromGroup);
   const addTerminal = useTerminalStore((state) => state.addTerminal);
   const addPanelToGroup = useTerminalStore((state) => state.addPanelToGroup);
+  const updateTitle = useTerminalStore((state) => state.updateTitle);
 
   // Subscribe to activeTabByGroup for reactive updates
   const storedActiveTabId = useTerminalStore(
@@ -73,13 +74,28 @@ export function GridTabGroup({
     }));
   }, [panels, activeTabId]);
 
-  // Handle tab click - switch to that tab and focus it
+  // Check if this group is currently focused
+  const isGroupFocused = panels.some((p) => p.id === focusedId);
+
+  // Handle tab click - switch to that tab, only focus if group already focused
   const handleTabClick = useCallback(
     (tabId: string) => {
       setActiveTab(group.id, tabId);
-      setFocused(tabId);
+      // Only set focus if the group is already focused
+      // This prevents single-click from activating focus/maximize mode
+      if (isGroupFocused) {
+        setFocused(tabId);
+      }
     },
-    [group.id, setActiveTab, setFocused]
+    [group.id, setActiveTab, setFocused, isGroupFocused]
+  );
+
+  // Handle tab rename
+  const handleTabRename = useCallback(
+    (tabId: string, newTitle: string) => {
+      updateTitle(tabId, newTitle);
+    },
+    [updateTitle]
   );
 
   // Handle tab close - move to trash and remove from group
@@ -191,6 +207,7 @@ export function GridTabGroup({
       tabs={tabs}
       onTabClick={handleTabClick}
       onTabClose={handleTabClose}
+      onTabRename={handleTabRename}
       onAddTab={handleAddTab}
     />
   );

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -75,6 +75,7 @@ export interface TerminalPaneProps {
   tabs?: import("@/components/Panel/TabButton").TabInfo[];
   onTabClick?: (tabId: string) => void;
   onTabClose?: (tabId: string) => void;
+  onTabRename?: (tabId: string, newTitle: string) => void;
   onAddTab?: () => void;
 }
 
@@ -107,6 +108,7 @@ function TerminalPaneComponent({
   tabs,
   onTabClick,
   onTabClose,
+  onTabRename,
   onAddTab,
 }: TerminalPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -477,6 +479,7 @@ function TerminalPaneComponent({
       tabs={tabs}
       onTabClick={onTabClick}
       onTabClose={onTabClose}
+      onTabRename={onTabRename}
       onAddTab={onAddTab}
       className={cn(
         "terminal-pane",


### PR DESCRIPTION
## Summary
Implements double-click to rename functionality for tabs in tab groups, addressing the UX gap where grouped panels couldn't be renamed without ungrouping them first.

Closes #1851

## Changes Made
- Add inline edit mode to TabButton with double-click activation
- Implement Enter to save, Escape to cancel rename behavior
- Add ref-based commit/cancel tracking to prevent blur double-commits
- Stop event propagation to prevent unwanted maximize/focus triggers
- Separate tab click from focus mode (only focus if group already focused)
- Thread onTabRename callback through GridTabGroup, DockedTabGroup, GridPanel, ContentPanel, PanelHeader
- Add onTabRename support to TerminalPane and BrowserPane components
- Support context menu rename via canopy:rename-terminal event

## Implementation Details
- **TabButton**: Added local edit state with inline input, double-click handler, and keyboard navigation
- **Focus Mode Fix**: Single-clicking tabs now only triggers `setFocused` when the group is already focused, preventing unwanted maximize/focus activation
- **Event Handling**: Comprehensive event propagation management to prevent conflicts with header maximize and drag handlers
- **Prop Threading**: onTabRename callback properly threaded through all component layers to reach TabButton