### PR TITLE
feat(tabs): add tab group hydration with robust error handling

### DIFF
--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -24,7 +24,7 @@ export interface HydrationCallbacks {
     focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean }
   ) => void;
   setReconnectError?: (id: string, error: TerminalReconnectError) => void;
-  hydrateTabGroups?: (tabGroups: TabGroup[]) => void;
+  hydrateTabGroups?: (tabGroups: TabGroup[], options?: { skipPersist?: boolean }) => void;
 }
 
 export function useAppHydration(callbacks: HydrationCallbacks) {

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -155,7 +155,7 @@ export interface TerminalRegistrySlice {
   /** Move an entire tab group to a new location (grid/dock), updating all member panels */
   moveTabGroupToLocation: (groupId: string, location: TabGroupLocation) => boolean;
   /** Hydrate tab groups from persisted state, sanitizing invalid data */
-  hydrateTabGroups: (tabGroups: TabGroup[]) => void;
+  hydrateTabGroups: (tabGroups: TabGroup[], options?: { skipPersist?: boolean }) => void;
   /** @deprecated Use createTabGroup/addPanelToGroup instead */
   setTabGroupInfo: (
     id: string,


### PR DESCRIPTION
## Summary
Implements loading of persisted tab groups during app hydration with comprehensive error handling and race condition protection.

Closes #1855

## Changes Made
- Add staleness check before error-path clear to prevent race conditions
- Add skipPersist flag to prevent wiping storage on transient errors
- Add shape validation to skip malformed groups before sanitation
- Add group ID deduplication to prevent panel orphaning
- Add comprehensive test coverage for tab group hydration scenarios
- Update type definitions to support skipPersist option