### PR TITLE
Fix panel maximize for tab groups

### DIFF
--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -776,6 +776,30 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
   if (maximizedId) {
     const terminal = gridTerminals.find((t: TerminalInstance) => t.id === maximizedId);
     if (terminal) {
+      // Check if the maximized panel is part of a tab group
+      const group = getPanelGroup(maximizedId);
+
+      if (group) {
+        // Get filtered panels (excludes trashed, scoped to location/worktree)
+        const groupPanels = getTabGroupPanels(group.id, "grid");
+
+        if (groupPanels.length > 1) {
+          // Multi-panel group - render with tabs
+          return (
+            <div className={cn("h-full relative bg-canopy-bg", className)}>
+              <GridTabGroup
+                group={group}
+                panels={groupPanels}
+                focusedId={focusedId}
+                gridPanelCount={gridItemCount}
+                isMaximized={true}
+              />
+            </div>
+          );
+        }
+      }
+
+      // Single panel or ungrouped - render GridPanel directly
       return (
         <div className={cn("h-full relative bg-canopy-bg", className)}>
           <GridPanel

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -13,6 +13,7 @@ export interface GridTabGroupProps {
   focusedId: string | null;
   gridPanelCount?: number;
   gridCols?: number;
+  isMaximized?: boolean;
 }
 
 export function GridTabGroup({
@@ -21,9 +22,11 @@ export function GridTabGroup({
   focusedId,
   gridPanelCount,
   gridCols,
+  isMaximized = false,
 }: GridTabGroupProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
   const setActiveTab = useTerminalStore((state) => state.setActiveTab);
+  const setMaximizedId = useTerminalStore((state) => state.setMaximizedId);
   const trashTerminal = useTerminalStore((state) => state.trashTerminal);
   const addTerminal = useTerminalStore((state) => state.addTerminal);
   const addPanelToGroup = useTerminalStore((state) => state.addPanelToGroup);
@@ -86,8 +89,13 @@ export function GridTabGroup({
       if (isGroupFocused) {
         setFocused(tabId);
       }
+      // If this group is maximized, update maximizedId to the new tab
+      // so "Exit Focus" works correctly
+      if (isMaximized) {
+        setMaximizedId(tabId);
+      }
     },
-    [group.id, setActiveTab, setFocused, isGroupFocused]
+    [group.id, setActiveTab, setFocused, isGroupFocused, isMaximized, setMaximizedId]
   );
 
   // Handle tab rename
@@ -208,6 +216,7 @@ export function GridTabGroup({
     <GridPanel
       terminal={activePanel}
       isFocused={isFocused}
+      isMaximized={isMaximized}
       gridPanelCount={gridPanelCount}
       gridCols={gridCols}
       tabs={tabs}

--- a/src/services/actions/definitions/terminalActions.ts
+++ b/src/services/actions/definitions/terminalActions.ts
@@ -272,6 +272,12 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
       const state = useTerminalStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
+        // Check if moving a group that contains the maximized panel
+        const group = state.getPanelGroup(targetId);
+        if (group && state.maximizedId && group.panelIds.includes(state.maximizedId)) {
+          // Clear maximize state before moving to dock
+          state.setMaximizedId(null);
+        }
         state.moveTerminalToDock(targetId);
         // Reveal dock if hidden so the terminal is visible
         revealDockIfHidden();

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -41,6 +41,7 @@ export interface TerminalFocusSlice {
   setFocused: (id: string | null, shouldPing?: boolean) => void;
   pingTerminal: (id: string) => void;
   toggleMaximize: (id: string, currentGridCols?: number, currentGridItemCount?: number) => void;
+  setMaximizedId: (id: string | null) => void;
   clearPreMaximizeLayout: () => void;
   focusNext: () => void;
   focusPrevious: () => void;
@@ -148,6 +149,11 @@ export const createTerminalFocusSlice =
               maximizedId: null,
             };
           }
+        }),
+
+      setMaximizedId: (id) =>
+        set({
+          maximizedId: id,
         }),
 
       clearPreMaximizeLayout: () =>


### PR DESCRIPTION
## Summary
Fixes maximize functionality for panels in tab groups. When a panel within a multi-panel tab group is maximized, the entire tab group is now rendered correctly with all tabs visible and interactive.

Closes #1846

## Changes Made
- Render GridTabGroup when maximizing a multi-panel tab group
- Use filtered groupPanels to exclude trashed panels from detection
- Sync maximizedId when switching tabs in maximized group
- Clear maximize state when moving maximized group to dock
- Add setMaximizedId method for explicit state updates

## Technical Details
The fix addresses three main issues identified in code review:
1. **Multi-panel detection**: Now uses `groupPanels.length > 1` after filtering to exclude trashed panels
2. **Tab switching in maximized groups**: Added `setMaximizedId()` call to keep maximize state synced when switching tabs
3. **Stale maximize state**: Clears `maximizedId` when moving a maximized group to dock

## Testing
- All existing terminal store tests pass
- Type checking passes
- Lint passes