### PR TITLE
feat(dnd): implement group-aware drag and drop for tab groups

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -43,6 +43,10 @@ interface DndPlaceholderContextValue {
   sourceContainer: "grid" | "dock" | null;
   activeTerminal: TerminalInstance | null;
   isDragging: boolean;
+  /** If dragging a tab group, the group ID */
+  activeGroupId: string | null;
+  /** If dragging a tab group, the panel IDs in the group */
+  activeGroupPanelIds: string[] | null;
 }
 
 const DndPlaceholderContext = createContext<DndPlaceholderContextValue>({
@@ -50,6 +54,8 @@ const DndPlaceholderContext = createContext<DndPlaceholderContextValue>({
   sourceContainer: null,
   activeTerminal: null,
   isDragging: false,
+  activeGroupId: null,
+  activeGroupPanelIds: null,
 });
 
 export function useDndPlaceholder() {
@@ -75,6 +81,10 @@ export interface DragData {
   terminal: TerminalInstance;
   sourceLocation: "grid" | "dock";
   sourceIndex: number;
+  /** If panel is part of a tab group, the group ID */
+  groupId?: string;
+  /** If panel is part of a tab group, all panel IDs in the group */
+  groupPanelIds?: string[];
 }
 
 export interface WorktreeDragData extends DragData {
@@ -103,8 +113,10 @@ function getEventCoordinates(event: Event): { x: number; y: number } {
 // Inner component that uses useDndMonitor to track cursor position (must be inside DndContext)
 function DragOverlayWithCursorTracking({
   activeTerminal,
+  groupTabCount,
 }: {
   activeTerminal: TerminalInstance | null;
+  groupTabCount?: number;
 }) {
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
   const pointerPositionRef = useRef<{ x: number; y: number } | null>(null);
@@ -149,7 +161,7 @@ function DragOverlayWithCursorTracking({
 
   return (
     <DragOverlay dropAnimation={null} modifiers={[cursorOverlayModifier]}>
-      {activeTerminal ? <TerminalDragPreview terminal={activeTerminal} /> : null}
+      {activeTerminal ? <TerminalDragPreview terminal={activeTerminal} groupTabCount={groupTabCount} /> : null}
     </DragOverlay>
   );
 }
@@ -182,7 +194,9 @@ export function DndProvider({ children }: DndProviderProps) {
 
   const terminals = useTerminalStore((state) => state.terminals);
   const reorderTerminals = useTerminalStore((s) => s.reorderTerminals);
+  const reorderTabGroups = useTerminalStore((s) => s.reorderTabGroups);
   const moveTerminalToPosition = useTerminalStore((s) => s.moveTerminalToPosition);
+  const moveTabGroupToLocation = useTerminalStore((s) => s.moveTabGroupToLocation);
   const moveTerminalToWorktree = useTerminalStore((s) => s.moveTerminalToWorktree);
   const setFocused = useTerminalStore((s) => s.setFocused);
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
@@ -359,17 +373,27 @@ export function DndProvider({ children }: DndProviderProps) {
         return;
       }
 
+      // Check if this is a group drag (before processing worktree drops)
+      const isGroupDrag = activeData.groupId && activeData.groupPanelIds && activeData.groupPanelIds.length > 1;
+
       // Track if this is a worktree drop (skip reorder logic, but still run stabilization)
       const isWorktreeDrop = overData?.type === "worktree" && !!overData.worktreeId;
       if (isWorktreeDrop) {
         console.log(`[DND_DEBUG] Worktree drop detected: ${overData.worktreeId}`);
-        const currentTerminal = terminals.find((t) => t.id === draggedId);
-        if (currentTerminal && currentTerminal.worktreeId !== overData.worktreeId) {
-          console.log(
-            `[DND_DEBUG] Moving terminal ${draggedId} to worktree ${overData.worktreeId}`
-          );
-          moveTerminalToWorktree(draggedId, overData.worktreeId!);
-          setFocused(null);
+
+        // Block worktree drops for multi-panel groups (would split the group)
+        if (isGroupDrag) {
+          console.log(`[DND_DEBUG] Blocking worktree drop for multi-panel group ${activeData.groupId}`);
+          // Cancel the drop - fall through to stabilization only
+        } else {
+          const currentTerminal = terminals.find((t) => t.id === draggedId);
+          if (currentTerminal && currentTerminal.worktreeId !== overData.worktreeId) {
+            console.log(
+              `[DND_DEBUG] Moving terminal ${draggedId} to worktree ${overData.worktreeId}`
+            );
+            moveTerminalToWorktree(draggedId, overData.worktreeId!);
+            setFocused(null);
+          }
         }
         // Don't return - fall through to stabilization
       }
@@ -460,9 +484,76 @@ export function DndProvider({ children }: DndProviderProps) {
           }
         }
         const isGridFull = explicitGroupCount + ungroupedCount >= getMaxGridCapacity();
+
         if (sourceLocation === "dock" && targetContainer === "grid" && isGridFull) {
           // Grid is full, cancel the drop - still run stabilization below
+        } else if (isGroupDrag) {
+          // Group-aware drag: move the entire tab group
+          if (sourceLocation === targetContainer) {
+            // Same container: reorder groups
+            // The sourceIndex from DragData is the group index (set by ContentGrid/ContentDock)
+            // targetIndex needs to be computed as the group index at drop location
+            const fromGroupIndex = activeData.sourceIndex;
+
+            // Find which group we're dropping over
+            const tabGroupsAtLocation = useTerminalStore.getState().getTabGroups(
+              targetContainer,
+              activeWorktreeId ?? undefined
+            );
+
+            // Find target group index by looking at which group contains the overId terminal
+            let toGroupIndex = tabGroupsAtLocation.length - 1;
+            for (let i = 0; i < tabGroupsAtLocation.length; i++) {
+              if (tabGroupsAtLocation[i].panelIds.includes(overId)) {
+                toGroupIndex = i;
+                break;
+              }
+            }
+
+            if (fromGroupIndex !== toGroupIndex) {
+              reorderTabGroups(fromGroupIndex, toGroupIndex, targetContainer, activeWorktreeId);
+            }
+          } else {
+            // Cross-container: move entire group to new location
+            const moveSuccess = moveTabGroupToLocation(activeData.groupId!, targetContainer);
+
+            if (moveSuccess) {
+              // After moving, reorder to the drop position
+              // The group is now at the end, move it to targetIndex
+              const tabGroupsAtLocation = useTerminalStore.getState().getTabGroups(
+                targetContainer,
+                activeWorktreeId ?? undefined
+              );
+
+              // Find the moved group's current index (should be last)
+              const movedGroupIndex = tabGroupsAtLocation.findIndex((g) => g.id === activeData.groupId);
+
+              if (movedGroupIndex !== -1) {
+                // Find target group index by looking at which group contains the overId terminal
+                let toGroupIndex = tabGroupsAtLocation.length - 1;
+                for (let i = 0; i < tabGroupsAtLocation.length; i++) {
+                  if (tabGroupsAtLocation[i].panelIds.includes(overId)) {
+                    toGroupIndex = i;
+                    break;
+                  }
+                }
+
+                // If we're not already at the target position, reorder
+                if (movedGroupIndex !== toGroupIndex) {
+                  reorderTabGroups(movedGroupIndex, toGroupIndex, targetContainer, activeWorktreeId);
+                }
+              }
+
+              // Set focus to first panel in group when moving to grid
+              if (targetContainer === "grid") {
+                setFocused(activeData.groupPanelIds![0] ?? draggedId);
+              } else {
+                setFocused(null);
+              }
+            }
+          }
         } else {
+          // Single panel drag (not part of a multi-panel group)
           // Same container reorder
           if (sourceLocation === targetContainer) {
             if (draggedId !== overId) {
@@ -606,7 +697,9 @@ export function DndProvider({ children }: DndProviderProps) {
       overContainer,
       terminals,
       reorderTerminals,
+      reorderTabGroups,
       moveTerminalToPosition,
+      moveTabGroupToLocation,
       moveTerminalToWorktree,
       setFocused,
       activeWorktreeId,
@@ -663,8 +756,10 @@ export function DndProvider({ children }: DndProviderProps) {
       sourceContainer: activeData?.sourceLocation ?? null,
       activeTerminal,
       isDragging: activeId !== null,
+      activeGroupId: activeData?.groupId ?? null,
+      activeGroupPanelIds: activeData?.groupPanelIds ?? null,
     }),
-    [placeholderIndex, activeData?.sourceLocation, activeTerminal, activeId]
+    [placeholderIndex, activeData?.sourceLocation, activeData?.groupId, activeData?.groupPanelIds, activeTerminal, activeId]
   );
 
   useEffect(() => {
@@ -689,7 +784,10 @@ export function DndProvider({ children }: DndProviderProps) {
       <DndPlaceholderContext.Provider value={placeholderContextValue}>
         {children}
       </DndPlaceholderContext.Provider>
-      <DragOverlayWithCursorTracking activeTerminal={activeTerminal} />
+      <DragOverlayWithCursorTracking
+        activeTerminal={activeTerminal}
+        groupTabCount={activeData?.groupPanelIds?.length}
+      />
     </DndContext>
   );
 }

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -9,13 +9,25 @@ interface SortableDockItemProps {
   terminal: TerminalInstance;
   sourceIndex: number;
   children: React.ReactNode;
+  /** If this panel is part of a tab group, the group ID */
+  groupId?: string;
+  /** If this panel is part of a tab group, all panel IDs in the group */
+  groupPanelIds?: string[];
 }
 
-export function SortableDockItem({ terminal, sourceIndex, children }: SortableDockItemProps) {
+export function SortableDockItem({
+  terminal,
+  sourceIndex,
+  children,
+  groupId,
+  groupPanelIds,
+}: SortableDockItemProps) {
   const dragData: DragData = {
     terminal,
     sourceLocation: "dock",
     sourceIndex,
+    groupId,
+    groupPanelIds,
   };
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -11,6 +11,10 @@ interface SortableTerminalProps {
   sourceIndex: number;
   children: React.ReactNode;
   disabled?: boolean;
+  /** If this panel is part of a tab group, the group ID */
+  groupId?: string;
+  /** If this panel is part of a tab group, all panel IDs in the group */
+  groupPanelIds?: string[];
 }
 
 export function SortableTerminal({
@@ -19,11 +23,15 @@ export function SortableTerminal({
   sourceIndex,
   children,
   disabled = false,
+  groupId,
+  groupPanelIds,
 }: SortableTerminalProps) {
   const dragData: DragData = {
     terminal,
     sourceLocation,
     sourceIndex,
+    groupId,
+    groupPanelIds,
   };
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -1,15 +1,18 @@
-import { Loader2 } from "lucide-react";
+import { Loader2, Layers } from "lucide-react";
 import type { TerminalInstance } from "@/store";
 import { PlaceholderContent } from "./PlaceholderContent";
 import { getPanelKindColor } from "@shared/config/panelKindRegistry";
 
 interface TerminalDragPreviewProps {
   terminal: TerminalInstance;
+  /** Number of tabs if dragging a multi-tab group */
+  groupTabCount?: number;
 }
 
-export function TerminalDragPreview({ terminal }: TerminalDragPreviewProps) {
+export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPreviewProps) {
   const brandColor = getPanelKindColor(terminal.kind ?? "terminal", terminal.agentId);
   const isWorking = terminal.agentState === "working";
+  const isGroupDrag = (groupTabCount ?? 0) > 1;
 
   return (
     <div
@@ -21,11 +24,36 @@ export function TerminalDragPreview({ terminal }: TerminalDragPreviewProps) {
         border: "1px solid var(--color-canopy-border)",
         borderRadius: "var(--radius-lg)",
         boxShadow: "0 8px 24px rgba(0, 0, 0, 0.6)",
-        overflow: "hidden",
+        overflow: "visible",
         display: "flex",
         flexDirection: "column",
+        position: "relative",
       }}
     >
+      {/* Group tab count badge */}
+      {isGroupDrag && (
+        <div
+          style={{
+            position: "absolute",
+            top: -8,
+            right: -8,
+            backgroundColor: "var(--color-canopy-accent)",
+            color: "var(--color-canopy-bg)",
+            borderRadius: "9999px",
+            padding: "2px 6px",
+            fontSize: 10,
+            fontWeight: 600,
+            display: "flex",
+            alignItems: "center",
+            gap: 3,
+            boxShadow: "0 2px 8px rgba(0, 0, 0, 0.4)",
+            zIndex: 10,
+          }}
+        >
+          <Layers style={{ width: 10, height: 10 }} aria-hidden="true" />
+          <span>{groupTabCount}</span>
+        </div>
+      )}
       {/* Title bar */}
       <div
         style={{

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -185,7 +185,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                   const groupPanels = getTabGroupPanels(group.id, "dock");
                   if (groupPanels.length === 0) return null;
 
-                  // Single-panel group: render DockedTerminalItem directly
+                  // Single-panel group: render DockedTerminalItem directly (no group context)
                   if (groupPanels.length === 1) {
                     const terminal = groupPanels[0];
                     return (
@@ -195,10 +195,16 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                     );
                   }
 
-                  // Multi-panel group: wrap in SortableDockItem using first panel
+                  // Multi-panel group: pass group context for group-aware DnD
                   const firstPanel = groupPanels[0];
                   return (
-                    <SortableDockItem key={group.id} terminal={firstPanel} sourceIndex={index}>
+                    <SortableDockItem
+                      key={group.id}
+                      terminal={firstPanel}
+                      sourceIndex={index}
+                      groupId={group.id}
+                      groupPanelIds={group.panelIds}
+                    >
                       <DockedTabGroup group={group} panels={groupPanels} />
                     </SortableDockItem>
                   );

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -899,7 +899,7 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
                   // Check if any panel in the group is trashed
                   const isGroupDisabled = groupPanels.some((p) => isInTrash(p.id));
 
-                  // Single-panel group: render GridPanel directly
+                  // Single-panel group: render GridPanel directly (no group context for single panel)
                   if (groupPanels.length === 1) {
                     const terminal = groupPanels[0];
                     elements.push(
@@ -920,7 +920,7 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
                       </SortableTerminal>
                     );
                   } else {
-                    // Multi-panel group: wrap in SortableTerminal using first panel for DnD
+                    // Multi-panel group: pass group context for group-aware DnD
                     const firstPanel = groupPanels[0];
                     elements.push(
                       <SortableTerminal
@@ -929,6 +929,8 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
                         sourceLocation="grid"
                         sourceIndex={index}
                         disabled={isGroupDisabled}
+                        groupId={group.id}
+                        groupPanelIds={group.panelIds}
                       >
                         <GridTabGroup
                           group={group}

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -154,6 +154,13 @@ export interface TerminalRegistrySlice {
   deleteTabGroup: (groupId: string) => void;
   /** Move an entire tab group to a new location (grid/dock), updating all member panels */
   moveTabGroupToLocation: (groupId: string, location: TabGroupLocation) => boolean;
+  /** Reorder tab groups within a location. Moves all panels in each group together. */
+  reorderTabGroups: (
+    fromGroupIndex: number,
+    toGroupIndex: number,
+    location: TabGroupLocation,
+    worktreeId?: string | null
+  ) => void;
   /** Hydrate tab groups from persisted state, sanitizing invalid data */
   hydrateTabGroups: (tabGroups: TabGroup[]) => void;
   /** @deprecated Use createTabGroup/addPanelToGroup instead */


### PR DESCRIPTION
## Summary
Implements group-aware drag and drop for multi-panel tab groups, allowing entire tab groups to be moved together when dragging. When a tab group contains multiple panels, dragging any tab now moves all panels in the group as a single unit, maintaining tab organization.

Closes #1849

## Changes Made
- Add groupId and groupPanelIds to DragData interface for multi-panel groups
- Implement reorderTabGroups store function to reorder groups by moving all panels together
- Update getTabGroups to sort explicit groups by terminal array order (enables visual reordering)
- Add group-aware logic in handleDragEnd for same-container and cross-container group moves
- Block worktree drops for multi-panel groups to prevent group splitting
- Add cross-container group positioning to insert groups at drop location
- Add visual indicator badge showing tab count when dragging multi-panel groups
- Filter by location in reorderTabGroups to prevent panel duplication

## Technical Details
- Single-panel groups continue to behave like ungrouped panels
- Multi-panel groups (2+ tabs) trigger group-aware drag logic
- Visual badge displays tab count during group drags
- Worktree drops are blocked for multi-panel groups to prevent splitting
- Cross-container moves preserve drop position