### PR TITLE
Enhance worktree overview with agent activity statistics and main worktree distinction

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -271,7 +271,9 @@ export function WorktreeHeader({
     <div className="space-y-1">
       <div className="flex items-center gap-2 min-h-[22px]">
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          {isMainWorktree && <Shield className="w-3.5 h-3.5 text-canopy-text/30 shrink-0" />}
+          {isMainWorktree && (
+            <Shield className="w-3.5 h-3.5 text-canopy-text/30 shrink-0" aria-label="Main worktree" />
+          )}
           {isPinned && !isMainWorktree && (
             <Pin className="w-3 h-3 text-canopy-text/40 shrink-0" aria-label="Pinned" />
           )}

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -60,6 +60,7 @@ interface WorktreeFilterState {
   sessionFilters: Set<SessionFilter>;
   activityFilters: Set<ActivityFilter>;
   alwaysShowActive: boolean;
+  hideMainWorktree: boolean;
   pinnedWorktrees: string[];
 }
 
@@ -73,6 +74,7 @@ interface WorktreeFilterActions {
   toggleSessionFilter: (filter: SessionFilter) => void;
   toggleActivityFilter: (filter: ActivityFilter) => void;
   setAlwaysShowActive: (enabled: boolean) => void;
+  setHideMainWorktree: (enabled: boolean) => void;
   pinWorktree: (id: string) => void;
   unpinWorktree: (id: string) => void;
   isWorktreePinned: (id: string) => boolean;
@@ -93,6 +95,7 @@ interface PersistedState {
   sessionFilters: SessionFilter[];
   activityFilters: ActivityFilter[];
   alwaysShowActive: boolean;
+  hideMainWorktree: boolean;
   pinnedWorktrees: string[];
 }
 
@@ -108,6 +111,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
       sessionFilters: new Set<SessionFilter>(),
       activityFilters: new Set<ActivityFilter>(),
       alwaysShowActive: true,
+      hideMainWorktree: true,
       pinnedWorktrees: [],
 
       setQuery: (query) => set({ query }),
@@ -170,6 +174,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
         }),
 
       setAlwaysShowActive: (enabled) => set({ alwaysShowActive: enabled }),
+      setHideMainWorktree: (enabled) => set({ hideMainWorktree: enabled }),
 
       pinWorktree: (id) =>
         set((state) => {
@@ -194,6 +199,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
           githubFilters: new Set(),
           sessionFilters: new Set(),
           activityFilters: new Set(),
+          hideMainWorktree: true,
         }),
 
       getActiveFilterCount: () => {
@@ -233,6 +239,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
         sessionFilters: Array.from(state.sessionFilters),
         activityFilters: Array.from(state.activityFilters),
         alwaysShowActive: state.alwaysShowActive,
+        hideMainWorktree: state.hideMainWorktree,
         pinnedWorktrees: state.pinnedWorktrees,
       }),
       merge: (persisted, current) => {
@@ -248,6 +255,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
           sessionFilters: new Set(p?.sessionFilters ?? []),
           activityFilters: new Set(p?.activityFilters ?? []),
           alwaysShowActive: p?.alwaysShowActive ?? true,
+          hideMainWorktree: p?.hideMainWorktree ?? true,
           pinnedWorktrees: p?.pinnedWorktrees ?? [],
         };
       },


### PR DESCRIPTION
## Summary
Enhances the worktree overview modal header to display meaningful agent activity statistics and provides visual distinction for the main worktree, improving at-a-glance understanding of feature development progress.

Closes #1867

## Changes Made
- Add aggregate statistics in header showing worktrees with working/waiting/failed agents
- Add toggle to hide/show main worktree (defaults to hidden, persists to localStorage)
- Sync statistics with filtered list visibility to prevent stat/display mismatch
- Prevent unrecoverable empty state by keeping toggle visible when filter is active
- Add aria-label to Shield icon for screen reader accessibility
- Add reduced-motion support for pulsing working indicator
- Include hideMainWorktree in clearAll to allow filter recovery