### PR TITLE
Panel close button closes entire tab group

### DIFF
--- a/src/components/Terminal/DockedPanel.tsx
+++ b/src/components/Terminal/DockedPanel.tsx
@@ -13,7 +13,7 @@ export interface DockedPanelProps {
 
 export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
-  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+  const trashPanelGroup = useTerminalStore((state) => state.trashPanelGroup);
   const removeTerminal = useTerminalStore((state) => state.removeTerminal);
   const updateTitle = useTerminalStore((state) => state.updateTitle);
   const moveTerminalToGrid = useTerminalStore((state) => state.moveTerminalToGrid);
@@ -46,7 +46,8 @@ export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelP
         setIsTrashing(true);
         timeoutRef.current = setTimeout(() => {
           try {
-            trashTerminal(terminal.id);
+            // trashPanelGroup handles both grouped and ungrouped panels
+            trashPanelGroup(terminal.id);
           } catch (error) {
             console.error("Failed to trash terminal:", error);
           } finally {
@@ -58,7 +59,7 @@ export function DockedPanel({ terminal, onPopoverClose, onAddTab }: DockedPanelP
         }, duration);
       }
     },
-    [removeTerminal, trashTerminal, terminal.id, onPopoverClose]
+    [removeTerminal, trashPanelGroup, terminal.id, onPopoverClose]
   );
 
   const handleRestore = useCallback(() => {

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -37,7 +37,7 @@ export function GridPanel({
   onTabReorder,
 }: GridPanelProps) {
   const setFocused = useTerminalStore((state) => state.setFocused);
-  const trashTerminal = useTerminalStore((state) => state.trashTerminal);
+  const trashPanelGroup = useTerminalStore((state) => state.trashPanelGroup);
   const removeTerminal = useTerminalStore((state) => state.removeTerminal);
   const toggleMaximize = useTerminalStore((state) => state.toggleMaximize);
   const getPanelGroup = useTerminalStore((state) => state.getPanelGroup);
@@ -73,7 +73,8 @@ export function GridPanel({
         setIsTrashing(true);
         timeoutRef.current = setTimeout(() => {
           try {
-            trashTerminal(terminal.id);
+            // trashPanelGroup handles both grouped and ungrouped panels
+            trashPanelGroup(terminal.id);
           } catch (error) {
             console.error("Failed to trash terminal:", error);
           } finally {
@@ -84,7 +85,7 @@ export function GridPanel({
         }, duration);
       }
     },
-    [removeTerminal, trashTerminal, terminal.id]
+    [removeTerminal, trashPanelGroup, terminal.id]
   );
 
   const handleToggleMaximize = useCallback(() => {

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -57,10 +57,21 @@ export interface AddTerminalOptions {
   // Note: Tab membership is now managed via createTabGroup/addPanelToGroup, not on terminals
 }
 
+export interface TrashedTerminalGroupMetadata {
+  panelIds: string[];
+  activeTabId: string;
+  location: TabGroupLocation;
+  worktreeId: string | null;
+}
+
 export interface TrashedTerminal {
   id: string;
   expiresAt: number;
   originalLocation: "dock" | "grid";
+  /** Shared ID for panels trashed together as a group */
+  groupRestoreId?: string;
+  /** Present on the "anchor" panel of a trashed group, holds metadata for recreation */
+  groupMetadata?: TrashedTerminalGroupMetadata;
 }
 
 export interface TerminalRegistrySlice {
@@ -97,6 +108,8 @@ export interface TerminalRegistrySlice {
   toggleTerminalLocation: (id: string) => void;
 
   trashTerminal: (id: string) => void;
+  /** Trash all panels in a group together, storing group metadata for restoration */
+  trashPanelGroup: (panelId: string) => void;
   restoreTerminal: (id: string, targetWorktreeId?: string) => void;
   markAsTrashed: (id: string, expiresAt: number, originalLocation: "dock" | "grid") => void;
   markAsRestored: (id: string) => void;


### PR DESCRIPTION
## Summary
Implements functionality to close entire tab groups when clicking the panel header close button (X), and restore all panels together when using "Reopen Last Closed".

Closes #1878

## Changes Made
- Add trashPanelGroup method to trash all panels in a group with shared restore ID
- Extend TrashedTerminal type with groupRestoreId and groupMetadata fields
- Preserve group metadata across IPC markAsTrashed updates to prevent data loss
- Add terminalStore wrapper to handle focus/dock state cleanup for groups
- Update restoreLastTrashed to detect and restore panel groups together
- Recreate tab groups with proper activeTabByGroup state seeding
- Use group location/worktreeId as canonical source instead of first panel
- Filter to existing panels when trashing to handle missing panel edge cases
- Update GridPanel and DockedPanel to use trashPanelGroup for all closures

## Key Features
- Panel header X button now closes all tabs in a group
- Individual tab × buttons continue closing just that tab (no regression)
- "Reopen Last Closed" restores entire groups with tab order and active tab preserved
- Proper cleanup of focus, maximize, and dock state when groups are closed