### PR TITLE
Tests: add Vitest coverage for tab group persistence

### DIFF
--- a/src/store/__tests__/resetWithoutKilling.test.ts
+++ b/src/store/__tests__/resetWithoutKilling.test.ts
@@ -1,0 +1,499 @@
+/**
+ * Tests for resetWithoutKilling behavior
+ * Issue #1861: Ensure tabGroups and activeTabByGroup are cleared on project switch
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { TabGroup } from "@/types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+const { useTerminalStore } = await import("../terminalStore");
+const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+const { terminalClient } = await import("@/clients");
+
+describe("resetWithoutKilling", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    await reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+      activeTabByGroup: new Map(),
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should clear tabGroups", async () => {
+    const group1: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    const group2: TabGroup = {
+      id: "group-2",
+      panelIds: ["term-3", "term-4"],
+      activeTabId: "term-3",
+      location: "dock",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+        {
+          id: "term-4",
+          type: "terminal",
+          title: "Shell 4",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+      ],
+      tabGroups: new Map([
+        ["group-1", group1],
+        ["group-2", group2],
+      ]),
+    });
+
+    expect(useTerminalStore.getState().tabGroups.size).toBe(2);
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.size).toBe(0);
+  });
+
+  it("should clear activeTabByGroup", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["term-1", "term-2"],
+            activeTabId: "term-2",
+            location: "grid",
+          },
+        ],
+      ]),
+      activeTabByGroup: new Map([
+        ["group-1", "term-2"],
+        ["group-2", "term-4"],
+      ]),
+    });
+
+    expect(useTerminalStore.getState().activeTabByGroup.size).toBe(2);
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.activeTabByGroup.size).toBe(0);
+  });
+
+  it("should clear terminals array", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+    });
+
+    expect(useTerminalStore.getState().terminals.length).toBe(2);
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.terminals.length).toBe(0);
+  });
+
+  it("should NOT kill backend processes", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+    });
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    // Should NOT call terminalClient.kill for any terminal
+    expect(terminalClient.kill).not.toHaveBeenCalled();
+  });
+
+  it("should destroy xterm.js instances", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+    });
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    // Should destroy xterm.js instances for cleanup
+    expect(terminalInstanceService.destroy).toHaveBeenCalledWith("term-1");
+    expect(terminalInstanceService.destroy).toHaveBeenCalledWith("term-2");
+  });
+
+  it("should clear trashedTerminals", async () => {
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map([
+        [
+          "term-1",
+          {
+            id: "term-1",
+            expiresAt: Date.now() + 60000,
+            originalLocation: "grid" as const,
+          },
+        ],
+        [
+          "term-2",
+          {
+            id: "term-2",
+            expiresAt: Date.now() + 60000,
+            originalLocation: "dock" as const,
+          },
+        ],
+      ]),
+    });
+
+    expect(useTerminalStore.getState().trashedTerminals.size).toBe(2);
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.trashedTerminals.size).toBe(0);
+  });
+
+  it("should clear focus state", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+      focusedId: "term-1",
+      maximizedId: "term-1",
+      activeDockTerminalId: "term-2",
+    });
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.focusedId).toBeNull();
+    expect(state.maximizedId).toBeNull();
+    expect(state.activeDockTerminalId).toBeNull();
+  });
+
+  it("should clear command queue", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+      commandQueue: [
+        {
+          id: "cmd-1",
+          terminalId: "term-1",
+          payload: "echo hello",
+          description: "Run echo",
+          queuedAt: Date.now(),
+          origin: "user" as const,
+        },
+        {
+          id: "cmd-2",
+          terminalId: "term-1",
+          payload: "ls -la",
+          description: "List files",
+          queuedAt: Date.now(),
+          origin: "user" as const,
+        },
+      ],
+    });
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.commandQueue.length).toBe(0);
+  });
+
+  it("should reset core UI state in a single atomic operation", async () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-2",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+      activeTabByGroup: new Map([["group-1", "term-2"]]),
+      trashedTerminals: new Map([
+        [
+          "term-4",
+          {
+            id: "term-4",
+            expiresAt: Date.now() + 60000,
+            originalLocation: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "term-1",
+      maximizedId: "term-2",
+      activeDockTerminalId: "term-3",
+      commandQueue: [
+        {
+          id: "cmd-1",
+          terminalId: "term-1",
+          payload: "echo test",
+          description: "Test command",
+          queuedAt: Date.now(),
+          origin: "user" as const,
+        },
+      ],
+    });
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+
+    // All state should be reset
+    expect(state.terminals).toEqual([]);
+    expect(state.tabGroups.size).toBe(0);
+    expect(state.activeTabByGroup.size).toBe(0);
+    expect(state.trashedTerminals.size).toBe(0);
+    expect(state.focusedId).toBeNull();
+    expect(state.maximizedId).toBeNull();
+    expect(state.activeDockTerminalId).toBeNull();
+    expect(state.commandQueue).toEqual([]);
+  });
+
+  it("should reset all state fields including pingedId and preMaximizeLayout", async () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+      pingedId: "term-1",
+      preMaximizeLayout: {
+        gridTerminals: [
+          {
+            id: "term-1",
+            type: "terminal",
+            title: "Shell 1",
+            cwd: "/test",
+            cols: 80,
+            rows: 24,
+            location: "grid",
+          },
+        ],
+        dockTerminals: [],
+      },
+      backendStatus: "recovering" as const,
+      lastCrashType: "OUT_OF_MEMORY" as const,
+    });
+
+    await useTerminalStore.getState().resetWithoutKilling();
+
+    const state = useTerminalStore.getState();
+    expect(state.pingedId).toBeNull();
+    expect(state.preMaximizeLayout).toBeNull();
+    expect(state.backendStatus).toBe("connected");
+    expect(state.lastCrashType).toBeNull();
+  });
+});

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Tests for tab group persistence via saveTabGroups
+ * Issue #1861: Ensure only explicit groups (panelIds.length > 1) are persisted
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TerminalPersistence } from "../terminalPersistence";
+import type { TabGroup } from "@/types";
+
+const createMockProjectClient = () => ({
+  getAll: vi.fn().mockResolvedValue([]),
+  getCurrent: vi.fn().mockResolvedValue(null),
+  add: vi.fn().mockResolvedValue({}),
+  remove: vi.fn().mockResolvedValue(undefined),
+  update: vi.fn().mockResolvedValue({}),
+  switch: vi.fn().mockResolvedValue({}),
+  openDialog: vi.fn().mockResolvedValue(null),
+  onSwitch: vi.fn().mockReturnValue(() => {}),
+  getSettings: vi.fn().mockResolvedValue({}),
+  saveSettings: vi.fn().mockResolvedValue(undefined),
+  detectRunners: vi.fn().mockResolvedValue([]),
+  close: vi.fn().mockResolvedValue({ success: true }),
+  reopen: vi.fn().mockResolvedValue({}),
+  getStats: vi.fn().mockResolvedValue({}),
+  initGit: vi.fn().mockResolvedValue(undefined),
+  getRecipes: vi.fn().mockResolvedValue([]),
+  saveRecipes: vi.fn().mockResolvedValue(undefined),
+  addRecipe: vi.fn().mockResolvedValue(undefined),
+  updateRecipe: vi.fn().mockResolvedValue(undefined),
+  deleteRecipe: vi.fn().mockResolvedValue(undefined),
+  getTerminals: vi.fn().mockResolvedValue([]),
+  setTerminals: vi.fn().mockResolvedValue(undefined),
+  getTabGroups: vi.fn().mockResolvedValue([]),
+  setTabGroups: vi.fn().mockResolvedValue(undefined),
+});
+
+describe("TerminalPersistence.saveTabGroups", () => {
+  const projectId = "test-project-id";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("explicit group filtering", () => {
+    it("only persists groups with panelIds.length > 1", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const explicitGroup: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      const singlePanelGroup: TabGroup = {
+        id: "group-2",
+        panelIds: ["term-3"],
+        activeTabId: "term-3",
+        location: "grid",
+      };
+
+      const emptyGroup: TabGroup = {
+        id: "group-3",
+        panelIds: [],
+        activeTabId: "",
+        location: "grid",
+      };
+
+      const tabGroups = new Map<string, TabGroup>([
+        ["group-1", explicitGroup],
+        ["group-2", singlePanelGroup],
+        ["group-3", emptyGroup],
+      ]);
+
+      persistence.saveTabGroups(tabGroups, projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).toHaveBeenCalledWith(projectId, [explicitGroup]);
+    });
+
+    it("persists multiple explicit groups", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const group1: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      const group2: TabGroup = {
+        id: "group-2",
+        panelIds: ["term-3", "term-4", "term-5"],
+        activeTabId: "term-4",
+        location: "dock",
+      };
+
+      const tabGroups = new Map<string, TabGroup>([
+        ["group-1", group1],
+        ["group-2", group2],
+      ]);
+
+      persistence.saveTabGroups(tabGroups, projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).toHaveBeenCalledWith(
+        projectId,
+        expect.arrayContaining([group1, group2])
+      );
+      const savedGroups = client.setTabGroups.mock.calls[0][1] as TabGroup[];
+      expect(savedGroups).toHaveLength(2);
+    });
+
+    it("persists empty array when all groups are virtual (single panel)", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const singlePanelGroup1: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      const singlePanelGroup2: TabGroup = {
+        id: "group-2",
+        panelIds: ["term-2"],
+        activeTabId: "term-2",
+        location: "dock",
+      };
+
+      const tabGroups = new Map<string, TabGroup>([
+        ["group-1", singlePanelGroup1],
+        ["group-2", singlePanelGroup2],
+      ]);
+
+      persistence.saveTabGroups(tabGroups, projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).toHaveBeenCalledWith(projectId, []);
+    });
+  });
+
+  describe("project ID handling", () => {
+    it("skips save if no project ID is provided", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const group: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", group]])); // No project ID
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).not.toHaveBeenCalled();
+    });
+
+    it("uses getProjectId option if projectId not passed directly", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, {
+        debounceMs: 100,
+        getProjectId: () => "from-option",
+      });
+
+      const group: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", group]])); // No project ID passed directly
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).toHaveBeenCalledWith("from-option", expect.any(Array));
+    });
+  });
+
+  describe("debouncing", () => {
+    it("debounces multiple saves into single persist call", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const group1: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      const group2: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2", "term-3"],
+        activeTabId: "term-2",
+        location: "grid",
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", group1]]), projectId);
+      persistence.saveTabGroups(new Map([["group-1", group2]]), projectId);
+      persistence.saveTabGroups(new Map([["group-1", group1]]), projectId);
+
+      expect(client.setTabGroups).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).toHaveBeenCalledTimes(1);
+      expect(client.setTabGroups).toHaveBeenCalledWith(projectId, [group1]);
+    });
+  });
+
+  describe("cancel and flush", () => {
+    it("cancel prevents pending tab group save", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const group: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", group]]), projectId);
+      persistence.cancel();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTabGroups).not.toHaveBeenCalled();
+    });
+
+    it("flush immediately executes pending tab group save", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 500 });
+
+      const group: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", group]]), projectId);
+
+      expect(client.setTabGroups).not.toHaveBeenCalled();
+
+      persistence.flush();
+      await vi.runAllTicks();
+
+      expect(client.setTabGroups).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("worktree groups", () => {
+    it("preserves worktreeId in persisted groups", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const worktreeGroup: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+        worktreeId: "wt-123",
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", worktreeGroup]]), projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const savedGroups = client.setTabGroups.mock.calls[0][1] as TabGroup[];
+      expect(savedGroups[0].worktreeId).toBe("wt-123");
+    });
+
+    it("preserves undefined worktreeId for global groups", async () => {
+      const client = createMockProjectClient();
+      const persistence = new TerminalPersistence(client, { debounceMs: 100 });
+
+      const globalGroup: TabGroup = {
+        id: "group-1",
+        panelIds: ["term-1", "term-2"],
+        activeTabId: "term-1",
+        location: "grid",
+        worktreeId: undefined,
+      };
+
+      persistence.saveTabGroups(new Map([["group-1", globalGroup]]), projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const savedGroups = client.setTabGroups.mock.calls[0][1] as TabGroup[];
+      expect(savedGroups[0].worktreeId).toBeUndefined();
+    });
+  });
+});

--- a/src/store/slices/terminalRegistry/__tests__/removePanelFromGroup.test.ts
+++ b/src/store/slices/terminalRegistry/__tests__/removePanelFromGroup.test.ts
@@ -1,0 +1,585 @@
+/**
+ * Tests for removePanelFromGroup behavior
+ * Issue #1861: Ensure group is deleted when ≤1 panel remains
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { TabGroup } from "@/types";
+
+const mockProjectClient = {
+  getTerminals: vi.fn().mockResolvedValue([]),
+  setTerminals: vi.fn().mockResolvedValue(undefined),
+  setTabGroups: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: mockProjectClient,
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock("../../../persistence/terminalPersistence", () => ({
+  terminalPersistence: {
+    save: vi.fn(),
+    saveTabGroups: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+const { useTerminalStore } = await import("../../../terminalStore");
+const { terminalPersistence } = await import("../../../persistence/terminalPersistence");
+
+describe("removePanelFromGroup", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    const { reset } = useTerminalStore.getState();
+    await reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+      activeTabByGroup: new Map(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should delete group when removing leaves exactly 1 panel", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.has("group-1")).toBe(false);
+  });
+
+  it("should delete group when removing leaves 0 panels", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.has("group-1")).toBe(false);
+  });
+
+  it("should keep group when removing leaves 2+ panels", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.has("group-1")).toBe(true);
+    expect(state.tabGroups.get("group-1")?.panelIds).toEqual(["term-2", "term-3"]);
+  });
+
+  it("should update activeTabId when active panel is removed", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    const updatedGroup = state.tabGroups.get("group-1");
+    expect(updatedGroup?.activeTabId).toBe("term-2");
+  });
+
+  it("should keep activeTabId unchanged when non-active panel is removed", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-2",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    const updatedGroup = state.tabGroups.get("group-1");
+    expect(updatedGroup?.activeTabId).toBe("term-2");
+  });
+
+  it("should be a no-op when panel is not in any group", () => {
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map(),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.size).toBe(0);
+  });
+
+  it("should only affect the group containing the panel", () => {
+    const group1: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    const group2: TabGroup = {
+      id: "group-2",
+      panelIds: ["term-3", "term-4", "term-5"],
+      activeTabId: "term-3",
+      location: "dock",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+        {
+          id: "term-4",
+          type: "terminal",
+          title: "Shell 4",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+        {
+          id: "term-5",
+          type: "terminal",
+          title: "Shell 5",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+      ],
+      tabGroups: new Map([
+        ["group-1", group1],
+        ["group-2", group2],
+      ]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    // group-1 should be deleted (was 2 panels, now 1)
+    expect(state.tabGroups.has("group-1")).toBe(false);
+    // group-2 should be unchanged
+    expect(state.tabGroups.has("group-2")).toBe(true);
+    expect(state.tabGroups.get("group-2")?.panelIds).toEqual(["term-3", "term-4", "term-5"]);
+  });
+
+  it("should handle dock groups correctly", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "dock",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "dock",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-2");
+
+    const state = useTerminalStore.getState();
+    const updatedGroup = state.tabGroups.get("group-1");
+    expect(updatedGroup?.panelIds).toEqual(["term-1", "term-3"]);
+    expect(updatedGroup?.location).toBe("dock");
+  });
+
+  it("should persist changes via saveTabGroups when group is deleted", async () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    // Should call saveTabGroups (which triggers persistence)
+    expect(terminalPersistence.saveTabGroups).toHaveBeenCalled();
+  });
+
+  it("should persist changes via saveTabGroups when group is updated", async () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    // Should call saveTabGroups (which triggers persistence)
+    expect(terminalPersistence.saveTabGroups).toHaveBeenCalled();
+  });
+
+  it("should preserve worktreeId when group survives removal", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["term-1", "term-2", "term-3"],
+      activeTabId: "term-1",
+      location: "grid",
+      worktreeId: "wt-123",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        {
+          id: "term-1",
+          type: "terminal",
+          title: "Shell 1",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-123",
+        },
+        {
+          id: "term-2",
+          type: "terminal",
+          title: "Shell 2",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-123",
+        },
+        {
+          id: "term-3",
+          type: "terminal",
+          title: "Shell 3",
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+          worktreeId: "wt-123",
+        },
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    const { removePanelFromGroup } = useTerminalStore.getState();
+    removePanelFromGroup("term-1");
+
+    const state = useTerminalStore.getState();
+    const updatedGroup = state.tabGroups.get("group-1");
+    expect(updatedGroup?.worktreeId).toBe("wt-123");
+  });
+});


### PR DESCRIPTION
## Summary
Adds comprehensive Vitest test coverage for tab group persistence, hydration, and invariants to prevent regressions in the new tab group model.

Closes #1861

## Changes Made
- Add `tabGroupPersistence.test.ts` with 10 tests covering `saveTabGroups` behavior
  - Validates explicit group filtering (only persists groups with `panelIds.length > 1`)
  - Tests debouncing with payload assertions for last-write-wins semantics
  - Verifies project ID handling and `getProjectId` fallback
  - Checks worktree group persistence (preserves `worktreeId`)
  - Validates flush with proper microtask handling via `runAllTicks`
- Add `removePanelFromGroup.test.ts` with 11 tests for group cleanup
  - Confirms group deletion when ≤1 panel remains (as per spec)
  - Tests `activeTabId` updates on panel removal
  - Validates persistence side-effects via `saveTabGroups` calls
  - Ensures proper mock cleanup with `vi.clearAllMocks`
- Add `resetWithoutKilling.test.ts` with 10 tests for project switch cleanup
  - Verifies `tabGroups` and `activeTabByGroup` are cleared (as per #1856)
  - Confirms xterm.js cleanup without backend process termination
  - Tests complete state reset including `pingedId` and `preMaximizeLayout`
  - Validates focus state and command queue cleanup

## Test Coverage
All 31 new tests pass and integrate with existing test suite (141 total tests passing).