### PR TITLE
Fix: Dock→Grid drag placeholder index breaks with tab groups

### DIFF
--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -572,8 +572,9 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
     isDraggingRef.current = isDragging;
   }, [isDragging]);
 
+  // placeholderIndex is now group-based (from DndProvider), so bound by tabGroups.length
   const placeholderInGrid =
-    placeholderIndex !== null && placeholderIndex >= 0 && placeholderIndex <= gridTerminals.length;
+    placeholderIndex !== null && placeholderIndex >= 0 && placeholderIndex <= tabGroups.length;
 
   // Show placeholder when dragging from dock to grid (only if grid not full)
   const showPlaceholder = placeholderInGrid && sourceContainer === "dock" && !isGridFull;


### PR DESCRIPTION
## Summary
Fixes incorrect placeholder rendering when dragging docked panels into the grid with multi-panel tab groups. The placeholder index was computed using panel indices but ContentGrid expected group indices, causing the placeholder to appear in the wrong position or not at all.

Closes #1881

## Changes Made
- Compute placeholder index from tab groups instead of terminal list
- Prioritize over.id lookup to avoid SortableContext circular dependency
- Handle GRID_PLACEHOLDER_ID case to prevent oscillation during drag
- Bound placeholder index to [0, tabGroups.length] range
- Update ContentGrid validation to use tabGroups.length