### PR TITLE
Fix: Forward skipPersist option in hydrateTabGroups to prevent data loss

### DIFF
--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -360,9 +360,10 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
 
     // Override hydrateTabGroups to also seed activeTabByGroup from persisted TabGroup.activeTabId
     // This ensures the active tab state is restored after restart
-    hydrateTabGroups: (tabGroups) => {
+    hydrateTabGroups: (tabGroups, options) => {
       // First, call the registry's hydrateTabGroups to sanitize and store the groups
-      registrySlice.hydrateTabGroups(tabGroups);
+      // Forward options to respect skipPersist flag during error recovery
+      registrySlice.hydrateTabGroups(tabGroups, options);
 
       // Then seed activeTabByGroup from the hydrated TabGroup.activeTabId values
       const hydratedGroups = get().tabGroups;


### PR DESCRIPTION
## Summary
Fixed a critical bug where the `hydrateTabGroups` override in `terminalStore.ts` was dropping the `options` parameter (including the `skipPersist` flag). This caused error recovery paths to persist empty tab group arrays, wiping user's saved tab groups.

Closes #1880

## Changes Made
- Accept and forward options parameter to registrySlice.hydrateTabGroups
- Prevents wiping persisted tab groups during error recovery
- Add comprehensive test coverage for skipPersist behavior
- Test empty groups (error recovery path) and non-empty groups
- Verify persistence is skipped when skipPersist is true
- Verify in-memory state updates correctly with skipPersist

## Testing
All tests pass (23 tests in the tab group test suite). New regression tests cover:
1. Error recovery with empty groups and skipPersist: true
2. Hydration with non-empty groups and skipPersist: true (verifies in-memory update without persistence)
3. Normal hydration without skipPersist (verifies persistence occurs correctly)