### PR TITLE
Security: enforce trusted renderer origins (preload + navigation + IPC)

### DIFF
--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -76,7 +76,11 @@ describe("project:close handler", () => {
       options?: { killTerminals?: boolean }
     ) => Promise<{ success: boolean; terminalsKilled: number; processesKilled: number }>;
 
-    const result = await handler({}, "project-active", { killTerminals: true });
+    const result = await handler(
+      { senderFrame: { url: "http://localhost:5173" } },
+      "project-active",
+      { killTerminals: true }
+    );
 
     expect(result.success).toBe(true);
     expect(result.terminalsKilled).toBe(2);
@@ -121,8 +125,16 @@ describe("project:close handler", () => {
       options?: { killTerminals?: boolean }
     ) => Promise<unknown>;
 
-    await expect(handler({}, "project-active", { killTerminals: false })).rejects.toThrow(
-      "Cannot close the active project"
-    );
+    await expect(
+      handler(
+        { senderFrame: { url: "http://localhost:5173" } },
+        "project-active",
+        { killTerminals: false }
+      )
+    ).rejects.toThrow("Cannot close the active project");
   });
+
+  // Note: IPC sender validation is enforced globally via monkey-patch in main.ts,
+  // which doesn't apply to mocked ipcMain in unit tests. Integration/E2E tests
+  // should verify the actual runtime enforcement.
 });

--- a/electron/ipc/handlers/terminal/__tests__/snapshots.getForProject.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.getForProject.test.ts
@@ -56,7 +56,7 @@ describe("terminal:get-for-project handler", () => {
       projectId: string
     ) => Promise<unknown[]>;
 
-    const result = await handler({}, "project-1");
+    const result = await handler({ senderFrame: { url: "http://localhost:5173" } }, "project-1");
 
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(1);
@@ -110,7 +110,10 @@ describe("terminal:get-for-project handler", () => {
       projectId: string
     ) => Promise<unknown[]>;
 
-    const result = (await handler({}, "project-1")) as any[];
+    const result = (await handler(
+      { senderFrame: { url: "http://localhost:5173" } },
+      "project-1"
+    )) as any[];
 
     expect(Array.isArray(result)).toBe(true);
     expect(result).toHaveLength(2);

--- a/shared/utils/__tests__/trustedRenderer.test.ts
+++ b/shared/utils/__tests__/trustedRenderer.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { isTrustedRendererUrl, getTrustedOrigins } from "../trustedRenderer.js";
+
+describe("trustedRenderer", () => {
+  describe("isTrustedRendererUrl", () => {
+    it("should allow production app:// origin", () => {
+      expect(isTrustedRendererUrl("app://canopy")).toBe(true);
+      expect(isTrustedRendererUrl("app://canopy/")).toBe(true);
+      expect(isTrustedRendererUrl("app://canopy/path/to/page")).toBe(true);
+    });
+
+    it("should allow localhost:5173 dev origin", () => {
+      expect(isTrustedRendererUrl("http://localhost:5173")).toBe(true);
+      expect(isTrustedRendererUrl("http://localhost:5173/")).toBe(true);
+      expect(isTrustedRendererUrl("http://localhost:5173/path")).toBe(true);
+    });
+
+    it("should allow 127.0.0.1:5173 dev origin", () => {
+      expect(isTrustedRendererUrl("http://127.0.0.1:5173")).toBe(true);
+      expect(isTrustedRendererUrl("http://127.0.0.1:5173/")).toBe(true);
+      expect(isTrustedRendererUrl("http://127.0.0.1:5173/path")).toBe(true);
+    });
+
+    it("should reject untrusted origins", () => {
+      expect(isTrustedRendererUrl("https://evil.com")).toBe(false);
+      expect(isTrustedRendererUrl("http://localhost:3000")).toBe(false);
+      expect(isTrustedRendererUrl("http://127.0.0.1:8080")).toBe(false);
+      expect(isTrustedRendererUrl("file:///etc/passwd")).toBe(false);
+      expect(isTrustedRendererUrl("app://different-app")).toBe(false);
+    });
+
+    it("should reject localhost with https protocol", () => {
+      expect(isTrustedRendererUrl("https://localhost:5173")).toBe(false);
+    });
+
+    it("should reject localhost without port", () => {
+      expect(isTrustedRendererUrl("http://localhost")).toBe(false);
+      expect(isTrustedRendererUrl("http://127.0.0.1")).toBe(false);
+    });
+
+    it("should reject app protocol with non-standard port", () => {
+      expect(isTrustedRendererUrl("app://canopy:1234")).toBe(false);
+    });
+
+    it("should reject userinfo tricks", () => {
+      expect(isTrustedRendererUrl("http://localhost:5173@evil.com")).toBe(false);
+      // Note: http://evil.com@localhost:5173 is correctly parsed as host=localhost with userinfo=evil.com
+      // This is actually a valid localhost URL per URL spec, so we accept it
+      expect(isTrustedRendererUrl("http://evil.com@localhost:5173")).toBe(true);
+    });
+
+    it("should allow query strings and hash fragments", () => {
+      expect(isTrustedRendererUrl("http://localhost:5173/?foo=bar")).toBe(true);
+      expect(isTrustedRendererUrl("http://localhost:5173/#/path")).toBe(true);
+      expect(isTrustedRendererUrl("app://canopy/index.html?v=1")).toBe(true);
+      expect(isTrustedRendererUrl("app://canopy/#/settings")).toBe(true);
+    });
+
+    it("should handle malformed URLs", () => {
+      expect(isTrustedRendererUrl("")).toBe(false);
+      expect(isTrustedRendererUrl("not-a-url")).toBe(false);
+      expect(isTrustedRendererUrl("://broken")).toBe(false);
+      expect(isTrustedRendererUrl("http://")).toBe(false);
+    });
+
+    it("should normalize protocol and hostname to lowercase per URL spec", () => {
+      expect(isTrustedRendererUrl("HTTP://localhost:5173")).toBe(true);
+      expect(isTrustedRendererUrl("http://LOCALHOST:5173")).toBe(true);
+      expect(isTrustedRendererUrl("APP://canopy")).toBe(true);
+    });
+  });
+
+  describe("getTrustedOrigins", () => {
+    it("should return all trusted origins including dev origins in development", () => {
+      const origins = getTrustedOrigins();
+      expect(origins).toContain("app://canopy");
+      expect(origins).toContain("http://localhost:5173");
+      expect(origins).toContain("http://127.0.0.1:5173");
+    });
+  });
+});

--- a/shared/utils/trustedRenderer.ts
+++ b/shared/utils/trustedRenderer.ts
@@ -1,0 +1,31 @@
+const PRODUCTION_ORIGINS = ["app://canopy"] as const;
+
+const DEV_ORIGINS = ["http://localhost:5173", "http://127.0.0.1:5173"] as const;
+
+function getTrustedRendererOrigins(): readonly string[] {
+  const isDev = process.env.NODE_ENV === "development";
+  return isDev ? [...PRODUCTION_ORIGINS, ...DEV_ORIGINS] : PRODUCTION_ORIGINS;
+}
+
+function getRendererOrigin(urlString: string): string | null {
+  try {
+    const url = new URL(urlString);
+
+    if (!url.protocol || !url.host) return null;
+
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return null;
+  }
+}
+
+export function isTrustedRendererUrl(urlString: string): boolean {
+  const origin = getRendererOrigin(urlString);
+  if (!origin) return false;
+  const trustedOrigins = getTrustedRendererOrigins();
+  return trustedOrigins.includes(origin as any);
+}
+
+export function getTrustedOrigins(): readonly string[] {
+  return getTrustedRendererOrigins();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,5 +18,8 @@ export default defineConfig({
     ],
     exclude: ["node_modules", "dist", "dist-electron", "build", "release"],
     testTimeout: 15000,
+    env: {
+      NODE_ENV: "development",
+    },
   },
 });


### PR DESCRIPTION
## Summary
Implements defense-in-depth security controls to enforce trusted renderer origins across three critical layers: preload API exposure, navigation guards, and IPC sender validation. This prevents untrusted origins from accessing privileged APIs even if the main window is compromised via XSS or navigation attacks.

Closes #1889

## Changes Made
- Add environment-aware origin allowlist (dev origins only in development mode)
- Implement preload API gating with main-frame check to prevent subframe privilege escalation
- Add global IPC sender validation via monkey-patch for comprehensive coverage
- Block same-window navigations/redirects to untrusted URLs
- Add comprehensive unit tests for origin validation with edge case coverage
- Update existing IPC handler tests with mock senderFrame for compatibility
- Configure test environment for development mode

## Security Improvements
- **Preload gating**: `window.electron` API only exposed to main frame of trusted origins
- **Navigation guards**: `will-navigate` and `will-redirect` events block untrusted destinations
- **IPC validation**: All IPC handlers validate sender origin before execution (174 handlers protected)
- **Environment-aware**: Dev origins (`localhost:5173`, `127.0.0.1:5173`) only trusted in development

## Testing
- All existing tests pass
- New unit tests cover edge cases (malformed URLs, protocol normalization, query strings, etc.)
- TypeScript compilation successful