### PR TITLE
feat(project-settings): add unsaved changes confirmation dialog

### DIFF
--- a/src/components/Project/__tests__/projectSettingsDirty.test.ts
+++ b/src/components/Project/__tests__/projectSettingsDirty.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect } from "vitest";
+import { createProjectSettingsSnapshot, areSnapshotsEqual } from "../projectSettingsDirty";
+import type { CommandOverride } from "@shared/types/commands";
+
+describe("projectSettingsDirty", () => {
+  describe("createProjectSettingsSnapshot", () => {
+    it("should create a normalized snapshot", () => {
+      const snapshot = createProjectSettingsSnapshot(
+        "  My Project  ",
+        "🌲",
+        "  npm run dev  ",
+        undefined,
+        ["  node_modules/**  ", "", "  dist/**  "],
+        [
+          { id: "1", key: "  API_KEY  ", value: "secret123" },
+          { id: "2", key: "  PORT  ", value: "3000" },
+        ],
+        [
+          {
+            id: "cmd1",
+            name: "  Build  ",
+            command: "  npm run build  ",
+            icon: "🔨",
+            description: "Build the app",
+          },
+          { id: "cmd2", name: "", command: "test", icon: undefined },
+        ],
+        "recipe-123",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(snapshot.name).toBe("My Project");
+      expect(snapshot.devServerCommand).toBe("npm run dev");
+      expect(snapshot.excludedPaths).toEqual(["node_modules/**", "dist/**"]);
+      expect(snapshot.environmentVariables).toEqual({
+        API_KEY: "secret123",
+        PORT: "3000",
+      });
+      expect(snapshot.runCommands).toHaveLength(2);
+      expect(snapshot.runCommands[0]).toEqual({
+        id: "cmd1",
+        name: "Build",
+        command: "npm run build",
+      });
+      expect(snapshot.runCommands[1]).toEqual({
+        id: "cmd2",
+        name: "",
+        command: "test",
+      });
+      expect(snapshot.defaultWorktreeRecipeId).toBe("recipe-123");
+    });
+
+    it("should keep partial environment variables with values", () => {
+      const snapshot = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "",
+        undefined,
+        [],
+        [
+          { id: "1", key: "  ", value: "value1" },
+          { id: "2", key: "KEY", value: "value2" },
+        ],
+        [],
+        undefined,
+        []
+      );
+
+      expect(Object.keys(snapshot.environmentVariables).length).toBe(2);
+      expect(snapshot.environmentVariables["KEY"]).toBe("value2");
+      expect(snapshot.environmentVariables["__partial_1"]).toBe("value1");
+    });
+
+    it("should keep duplicate environment variable keys for dirty tracking", () => {
+      const snapshot = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "",
+        undefined,
+        [],
+        [
+          { id: "1", key: "KEY", value: "value1" },
+          { id: "2", key: "KEY", value: "value2" },
+        ],
+        [],
+        undefined,
+        []
+      );
+
+      expect(Object.keys(snapshot.environmentVariables).length).toBe(2);
+      expect(snapshot.environmentVariables["KEY"]).toBeDefined();
+    });
+
+    it("should sort environment variables by key", () => {
+      const snapshot = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "",
+        undefined,
+        [],
+        [
+          { id: "1", key: "ZEBRA", value: "z" },
+          { id: "2", key: "ALPHA", value: "a" },
+          { id: "3", key: "BETA", value: "b" },
+        ],
+        [],
+        undefined,
+        []
+      );
+
+      expect(Object.keys(snapshot.environmentVariables)).toEqual(["ALPHA", "BETA", "ZEBRA"]);
+    });
+
+    it("should preserve excluded paths order", () => {
+      const snapshot = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "",
+        undefined,
+        ["z/**", "a/**", "m/**"],
+        [],
+        [],
+        undefined,
+        []
+      );
+
+      expect(snapshot.excludedPaths).toEqual(["z/**", "a/**", "m/**"]);
+    });
+
+    it("should preserve command overrides order", () => {
+      const overrides: CommandOverride[] = [
+        { commandId: "z", disabled: false },
+        { commandId: "a", disabled: true },
+      ];
+
+      const snapshot = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "",
+        undefined,
+        [],
+        [],
+        [],
+        undefined,
+        overrides
+      );
+
+      expect(snapshot.commandOverrides[0].commandId).toBe("z");
+      expect(snapshot.commandOverrides[1].commandId).toBe("a");
+    });
+  });
+
+  describe("areSnapshotsEqual", () => {
+    const baseSnapshot = createProjectSettingsSnapshot(
+      "Project",
+      "🌲",
+      "npm run dev",
+      undefined,
+      ["node_modules/**"],
+      [{ id: "1", key: "KEY", value: "value" }],
+      [{ id: "cmd1", name: "Build", command: "npm run build" }],
+      "recipe-1",
+      [{ commandId: "test", disabled: false }]
+    );
+
+    it("should return true for identical snapshots", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(true);
+    });
+
+    it("should detect changed name", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Different Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed emoji", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🚀",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed devServerCommand", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm start",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed projectIconSvg", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        "<svg></svg>",
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed excludedPaths", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**", "dist/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed environment variables", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "different-value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed runCommands", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Test", command: "npm test" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed defaultWorktreeRecipeId", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-2",
+        [{ commandId: "test", disabled: false }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+
+    it("should detect changed commandOverrides", () => {
+      const snapshot2 = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        ["node_modules/**"],
+        [{ id: "1", key: "KEY", value: "value" }],
+        [{ id: "cmd1", name: "Build", command: "npm run build" }],
+        "recipe-1",
+        [{ commandId: "test", disabled: true }]
+      );
+
+      expect(areSnapshotsEqual(baseSnapshot, snapshot2)).toBe(false);
+    });
+  });
+});

--- a/src/components/Project/projectSettingsDirty.ts
+++ b/src/components/Project/projectSettingsDirty.ts
@@ -1,0 +1,150 @@
+import type { CommandOverride } from "@shared/types/commands";
+
+export interface ProjectSettingsSnapshot {
+  name: string;
+  emoji: string;
+  devServerCommand: string;
+  projectIconSvg: string | undefined;
+  excludedPaths: string[];
+  environmentVariables: Record<string, string>;
+  runCommands: Array<{ id: string; name: string; command: string }>;
+  defaultWorktreeRecipeId: string | undefined;
+  commandOverrides: CommandOverride[];
+}
+
+interface EnvVar {
+  id: string;
+  key: string;
+  value: string;
+}
+
+interface RunCommand {
+  id: string;
+  name: string;
+  command: string;
+  icon?: string;
+  description?: string;
+}
+
+export function createProjectSettingsSnapshot(
+  name: string,
+  emoji: string,
+  devServerCommand: string,
+  projectIconSvg: string | undefined,
+  excludedPaths: string[],
+  environmentVariables: EnvVar[],
+  runCommands: RunCommand[],
+  defaultWorktreeRecipeId: string | undefined,
+  commandOverrides: CommandOverride[]
+): ProjectSettingsSnapshot {
+  const envVarRecord: Record<string, string> = {};
+  const seenKeys = new Map<string, number>();
+
+  for (const envVar of environmentVariables) {
+    const trimmedKey = envVar.key.trim();
+    if (!trimmedKey && !envVar.value.trim()) continue;
+
+    let finalKey = trimmedKey || `__partial_${envVar.id}`;
+
+    if (trimmedKey && seenKeys.has(trimmedKey)) {
+      const count = seenKeys.get(trimmedKey)!;
+      seenKeys.set(trimmedKey, count + 1);
+      finalKey = `${trimmedKey}__dup_${count}`;
+    } else if (trimmedKey) {
+      seenKeys.set(trimmedKey, 1);
+    }
+
+    envVarRecord[finalKey] = envVar.value;
+  }
+
+  const sortedEnvKeys = Object.keys(envVarRecord).sort();
+  const sortedEnvVars: Record<string, string> = {};
+  for (const key of sortedEnvKeys) {
+    sortedEnvVars[key] = envVarRecord[key];
+  }
+
+  const sanitizedRunCommands = runCommands
+    .map((cmd) => ({
+      id: cmd.id,
+      name: cmd.name.trim(),
+      command: cmd.command.trim(),
+    }))
+    .filter((cmd) => cmd.name || cmd.command);
+
+  const sanitizedPaths = excludedPaths
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  const sortedCommandOverrides = [...commandOverrides];
+
+  return {
+    name: name.trim(),
+    emoji,
+    devServerCommand: devServerCommand.trim(),
+    projectIconSvg,
+    excludedPaths: sanitizedPaths,
+    environmentVariables: sortedEnvVars,
+    runCommands: sanitizedRunCommands,
+    defaultWorktreeRecipeId,
+    commandOverrides: sortedCommandOverrides,
+  };
+}
+
+export function areSnapshotsEqual(
+  a: ProjectSettingsSnapshot,
+  b: ProjectSettingsSnapshot
+): boolean {
+  if (a.name !== b.name) return false;
+  if (a.emoji !== b.emoji) return false;
+  if (a.devServerCommand !== b.devServerCommand) return false;
+  if (a.projectIconSvg !== b.projectIconSvg) return false;
+  if (a.defaultWorktreeRecipeId !== b.defaultWorktreeRecipeId) return false;
+
+  if (a.excludedPaths.length !== b.excludedPaths.length) return false;
+  for (let i = 0; i < a.excludedPaths.length; i++) {
+    if (a.excludedPaths[i] !== b.excludedPaths[i]) return false;
+  }
+
+  const aEnvKeys = Object.keys(a.environmentVariables);
+  const bEnvKeys = Object.keys(b.environmentVariables);
+  if (aEnvKeys.length !== bEnvKeys.length) return false;
+  for (const key of aEnvKeys) {
+    if (a.environmentVariables[key] !== b.environmentVariables[key]) return false;
+  }
+
+  if (a.runCommands.length !== b.runCommands.length) return false;
+  for (let i = 0; i < a.runCommands.length; i++) {
+    if (
+      a.runCommands[i].id !== b.runCommands[i].id ||
+      a.runCommands[i].name !== b.runCommands[i].name ||
+      a.runCommands[i].command !== b.runCommands[i].command
+    ) {
+      return false;
+    }
+  }
+
+  if (a.commandOverrides.length !== b.commandOverrides.length) return false;
+  for (let i = 0; i < a.commandOverrides.length; i++) {
+    const aOverride = a.commandOverrides[i];
+    const bOverride = b.commandOverrides[i];
+    if (aOverride.commandId !== bOverride.commandId) return false;
+    if (aOverride.disabled !== bOverride.disabled) return false;
+    if (aOverride.prompt !== bOverride.prompt) return false;
+
+    const aDefaults = aOverride.defaults || {};
+    const bDefaults = bOverride.defaults || {};
+    const aDefaultsStr = JSON.stringify(
+      Object.keys(aDefaults)
+        .sort()
+        .map((k) => [k, aDefaults[k]])
+    );
+    const bDefaultsStr = JSON.stringify(
+      Object.keys(bDefaults)
+        .sort()
+        .map((k) => [k, bDefaults[k]])
+    );
+    if (aDefaultsStr !== bDefaultsStr) return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
Implements dirty tracking and unsaved changes confirmation for the Project Settings dialog to prevent accidental data loss.

Closes #1908

## Changes Made
- Implement dirty tracking system to detect unsaved edits across all tabs (General, Context, Automation, Commands)
- Add confirmation dialog when closing with unsaved changes (X button, Cancel, Esc, backdrop click)
- Track changes to name, emoji, dev server command, project icon, excluded paths, environment variables, run commands, default recipe, and command overrides
- Preserve partial/invalid rows in dirty detection to prevent silent data loss
- Guard against stale snapshots on projectId changes and external store updates
- Add comprehensive unit tests (16 test cases) for snapshot comparison logic

## Implementation Details
- Created `projectSettingsDirty.ts` with snapshot creation and comparison utilities
- Modified `ProjectSettingsDialog.tsx` to integrate dirty tracking with all close paths
- Uses `useMemo` for efficient dirty state computation
- Handles edge cases: rapid open/close, projectId changes, external updates, partial entries