### PR TITLE
Add Assistant Panel Infrastructure

### DIFF
--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -94,6 +94,18 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
   },
+  assistant: {
+    id: "assistant",
+    name: "Assistant",
+    iconId: "canopy",
+    color: "#a855f7", // purple-500 (distinct from other purples)
+    hasPty: false,
+    canRestart: false,
+    canConvert: false,
+    usesTerminalUi: false,
+    keepAliveOnProjectSwitch: true,
+    showInPalette: true,
+  },
 };
 
 /**
@@ -215,5 +227,5 @@ export function panelKindKeepsAliveOnProjectSwitch(kind: PanelKind): boolean {
  * Get all built-in panel kinds.
  */
 export function getBuiltInPanelKinds(): BuiltInPanelKind[] {
-  return ["terminal", "agent", "browser", "notes", "dev-preview"];
+  return ["terminal", "agent", "browser", "notes", "dev-preview", "assistant"];
 }

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -201,7 +201,13 @@ export type AgentId = string;
 export type LegacyAgentType = "claude" | "gemini" | "codex" | "opencode";
 
 /** Built-in panel kinds */
-export type BuiltInPanelKind = "terminal" | "agent" | "browser" | "notes" | "dev-preview";
+export type BuiltInPanelKind =
+  | "terminal"
+  | "agent"
+  | "browser"
+  | "notes"
+  | "dev-preview"
+  | "assistant";
 
 /**
  * Panel kind: distinguishes between default terminals, agent-driven terminals, browser panels,
@@ -288,7 +294,8 @@ export function isBuiltInPanelKind(kind: PanelKind): kind is BuiltInPanelKind {
     kind === "agent" ||
     kind === "browser" ||
     kind === "notes" ||
-    kind === "dev-preview"
+    kind === "dev-preview" ||
+    kind === "assistant"
   );
 }
 
@@ -798,7 +805,8 @@ export type ToolbarButtonId =
   | "copy-tree"
   | "settings"
   | "problems"
-  | "sidecar-toggle";
+  | "sidecar-toggle"
+  | "assistant";
 
 /** Configuration for which toolbar buttons are visible and their order */
 export interface ToolbarLayout {

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -102,6 +102,9 @@ export type KeyAction =
   | "agent.focusNextFailed"
   | "agent.commandBar"
 
+  // Assistant panel
+  | "assistant.open"
+
   // Panel management
   | "panel.palette"
   | "panel.toggleDock"

--- a/src/components/Assistant/AssistantPane.tsx
+++ b/src/components/Assistant/AssistantPane.tsx
@@ -1,0 +1,51 @@
+import { ContentPanel, type BasePanelProps } from "@/components/Panel";
+
+export type AssistantPaneProps = BasePanelProps;
+
+export function AssistantPane({
+  id,
+  title,
+  isFocused,
+  isMaximized = false,
+  location = "grid",
+  onFocus,
+  onClose,
+  onToggleMaximize,
+  onTitleChange,
+  onMinimize,
+  onRestore,
+  isTrashing = false,
+  gridPanelCount,
+}: AssistantPaneProps) {
+  return (
+    <ContentPanel
+      id={id}
+      title={title}
+      kind="assistant"
+      isFocused={isFocused}
+      isMaximized={isMaximized}
+      location={location}
+      isTrashing={isTrashing}
+      gridPanelCount={gridPanelCount}
+      onFocus={onFocus}
+      onClose={onClose}
+      onToggleMaximize={onToggleMaximize}
+      onTitleChange={onTitleChange}
+      onMinimize={onMinimize}
+      onRestore={onRestore}
+    >
+      <div className="flex flex-col h-full bg-canopy-bg">
+        <div className="flex-1 overflow-auto p-4">
+          <p className="text-muted-foreground">Assistant ready</p>
+        </div>
+        <div className="border-t border-divider p-2">
+          <input
+            type="text"
+            placeholder="Ask the assistant..."
+            className="w-full bg-canopy-sidebar text-canopy-text px-3 py-2 rounded focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+          />
+        </div>
+      </div>
+    </ContentPanel>
+  );
+}

--- a/src/components/Assistant/index.ts
+++ b/src/components/Assistant/index.ts
@@ -1,0 +1,2 @@
+export { AssistantPane } from "./AssistantPane";
+export type { AssistantPaneProps } from "./AssistantPane";

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -25,6 +25,7 @@ import {
   Monitor,
   Circle,
 } from "lucide-react";
+import { CanopyIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { GitHubResourceList, CommitList } from "@/components/GitHub";
@@ -939,6 +940,24 @@ export function Toolbar({
           </Button>
         ),
         isAvailable: showDeveloperTools,
+      },
+      assistant: {
+        render: () => (
+          <Button
+            key="assistant"
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              void actionService.dispatch("assistant.open", undefined, { source: "user" });
+            }}
+            className="text-canopy-text hover:bg-white/[0.06] transition-colors hover:text-purple-400 focus-visible:text-purple-400"
+            title="Open Assistant (⌘⇧K)"
+            aria-label="Open Assistant"
+          >
+            <CanopyIcon size={18} />
+          </Button>
+        ),
+        isAvailable: true,
       },
       "sidecar-toggle": {
         render: () => (

--- a/src/components/PanelPalette/PanelKindIcon.tsx
+++ b/src/components/PanelPalette/PanelKindIcon.tsx
@@ -1,12 +1,24 @@
 import { Terminal, Globe, FileText, GitBranch, Monitor, LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CanopyIcon } from "@/components/icons";
+import type { ComponentType } from "react";
 
-const ICON_MAP: Record<string, LucideIcon> = {
+const ICON_MAP: Record<
+  string,
+  | LucideIcon
+  | ComponentType<{
+      className?: string;
+      style?: Record<string, string>;
+      width?: number;
+      height?: number;
+    }>
+> = {
   terminal: Terminal,
   globe: Globe,
   "file-text": FileText,
   "git-branch": GitBranch,
   monitor: Monitor,
+  canopy: CanopyIcon,
 };
 
 export interface PanelKindIconProps {
@@ -21,7 +33,7 @@ export function PanelKindIcon({ iconId, color, size = 16, className }: PanelKind
 
   return (
     <Icon
-      style={{ color }}
+      style={color ? { color } : undefined}
       className={cn("shrink-0", className)}
       width={size}
       height={size}

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -25,10 +25,11 @@ import {
   Copy,
   Settings,
   AlertCircle,
+  Bot,
 } from "lucide-react";
 import { useToolbarPreferencesStore } from "@/store";
 import type { ToolbarButtonId } from "@/../../shared/types/domain";
-import { Bot } from "lucide-react";
+import { CanopyIcon } from "@/components/icons";
 
 type ButtonMetadata = { label: string; icon: React.ReactNode; description: string };
 
@@ -92,6 +93,11 @@ const BUTTON_METADATA: Partial<Record<ToolbarButtonId, ButtonMetadata>> = {
     label: "Problems",
     icon: <AlertCircle className="h-4 w-4" />,
     description: "Show problems panel",
+  },
+  assistant: {
+    label: "Assistant",
+    icon: <CanopyIcon size={16} />,
+    description: "Open Canopy Assistant",
   },
 };
 

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -1,5 +1,6 @@
 import { Terminal, Globe, StickyNote, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CanopyIcon } from "@/components/icons";
 import type { TerminalType, TerminalKind } from "@/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 
@@ -30,6 +31,11 @@ export function TerminalIcon({ type, kind, agentId, className, brandColor }: Ter
   // Dev preview panes get a monitor icon
   if (kind === "dev-preview") {
     return <Monitor {...finalProps} className={cn(finalProps.className, "text-violet-400")} />;
+  }
+
+  // Assistant panes get the Canopy icon
+  if (kind === "assistant") {
+    return <CanopyIcon {...finalProps} className={cn(finalProps.className, "text-purple-400")} />;
   }
 
   // Get effective agent ID - either from explicit agentId prop or from type (backward compat)

--- a/src/registry/builtInPanelRegistrations.ts
+++ b/src/registry/builtInPanelRegistrations.ts
@@ -1,12 +1,13 @@
 /**
  * Built-in panel component registrations.
- * Called once at app startup to register terminal, agent, browser, and notes panels.
+ * Called once at app startup to register terminal, agent, browser, notes, and assistant panels.
  */
 import { registerPanelComponent } from "./panelComponentRegistry";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { BrowserPane } from "@/components/Browser/BrowserPane";
 import { NotesPane } from "@/components/Notes/NotesPane";
 import { DevPreviewPane } from "@/components/DevPreview/DevPreviewPane";
+import { AssistantPane } from "@/components/Assistant/AssistantPane";
 
 // Registration flag to prevent double registration
 let registered = false;
@@ -43,5 +44,10 @@ export function registerBuiltInPanelComponents(): void {
   // Dev Preview panel - auto-starts dev server and shows iframe
   registerPanelComponent("dev-preview", {
     component: DevPreviewPane,
+  });
+
+  // Assistant panel - Canopy AI assistant interface
+  registerPanelComponent("assistant", {
+    component: AssistantPane,
   });
 }

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -227,12 +227,12 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Agents",
   },
   {
-    actionId: "agent.commandBar",
+    actionId: "assistant.open",
     combo: "Cmd+Shift+K",
     scope: "global",
     priority: 0,
-    description: "Open AI command bar",
-    category: "Agents",
+    description: "Open Assistant panel",
+    category: "Assistant",
   },
   {
     actionId: "terminal.inject",

--- a/src/services/actions/actionDefinitions.ts
+++ b/src/services/actions/actionDefinitions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "./actionTypes";
 import { registerAgentActions } from "./definitions/agentActions";
 import { registerAppActions } from "./definitions/appActions";
+import { registerAssistantActions } from "./definitions/assistantActions";
 import { registerBrowserActions } from "./definitions/browserActions";
 import { registerDevServerActions } from "./definitions/devServerActions";
 import { registerGithubActions } from "./definitions/githubActions";
@@ -25,6 +26,7 @@ export function createActionDefinitions(callbacks: ActionCallbacks): ActionRegis
 
   registerTerminalActions(actions, callbacks);
   registerAgentActions(actions, callbacks);
+  registerAssistantActions(actions, callbacks);
   registerPanelActions(actions, callbacks);
   registerWorktreeActions(actions, callbacks);
   registerWorktreeSessionActions(actions, callbacks);

--- a/src/services/actions/definitions/assistantActions.ts
+++ b/src/services/actions/definitions/assistantActions.ts
@@ -1,0 +1,39 @@
+import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import { useTerminalStore } from "@/store/terminalStore";
+
+export function registerAssistantActions(
+  actions: ActionRegistry,
+  _callbacks: ActionCallbacks
+): void {
+  actions.set("assistant.open", () => ({
+    id: "assistant.open",
+    title: "Open Assistant",
+    description: "Open or focus the Canopy Assistant panel",
+    category: "assistant",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const store = useTerminalStore.getState();
+      const terminals = store.terminals;
+
+      // Look for an existing assistant panel (excluding trashed ones)
+      const existingAssistant = terminals.find(
+        (t) => t.kind === "assistant" && t.location !== "trash"
+      );
+
+      if (existingAssistant) {
+        // Activate the existing assistant panel (handles both grid and dock)
+        store.activateTerminal(existingAssistant.id);
+      } else {
+        // Create a new assistant panel (addTerminal auto-focuses grid panels)
+        await store.addTerminal({
+          kind: "assistant",
+          title: "Assistant",
+          location: "grid",
+          cwd: "",
+        });
+      }
+    },
+  }));
+}

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -23,6 +23,7 @@ function getSafeStorage(): StateStorage {
 }
 
 const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
+  "assistant",
   "claude",
   "gemini",
   "codex",


### PR DESCRIPTION
## Summary
Adds the foundational infrastructure for the Canopy AI assistant panel, including complete integration into the panel system, toolbar, and action framework.

Closes #1917

## Changes Made
- Add assistant panel kind to type system and panel registry with proper metadata
- Create AssistantPane component with ContentPanel wrapper and placeholder UI
- Register assistant.open action with focus/activation logic for grid and dock panels
- Add toolbar button with Canopy icon and Cmd+Shift+K keyboard shortcut
- Add icon mappings for assistant in TerminalIcon and PanelKindIcon components
- Update toolbar preferences to include assistant button by default in left toolbar
- Use theme tokens for consistent styling across color schemes
- Fix panel activation to properly handle docked and trashed panels