### PR TITLE
feat(assistant): implement multi-step tool calling with AI SDK

### DIFF
--- a/electron/ipc/handlers/assistant.ts
+++ b/electron/ipc/handlers/assistant.ts
@@ -2,10 +2,10 @@ import { ipcMain, type BrowserWindow, type WebContents } from "electron";
 import { CHANNELS } from "../channels.js";
 import { assistantService } from "../../services/AssistantService.js";
 import {
-  type AssistantMessage,
   type AssistantChunkPayload,
   SendMessageRequestSchema,
 } from "../../../shared/types/assistant.js";
+import type { ActionManifestEntry, ActionContext } from "../../../shared/types/actions.js";
 
 const MAX_MESSAGES = 100;
 const MAX_MESSAGE_LENGTH = 50000;
@@ -33,47 +33,54 @@ export function registerAssistantHandlers(mainWindow: BrowserWindow): () => void
     assistantService.cancelAll();
   };
 
-  ipcMain.handle(
-    CHANNELS.ASSISTANT_SEND_MESSAGE,
-    async (
-      event,
-      payload: {
-        sessionId: string;
-        messages: AssistantMessage[];
-        context?: {
-          projectId?: string;
-          activeWorktreeId?: string;
-          focusedTerminalId?: string;
-        };
-      }
-    ) => {
-      // Validate payload
-      const validation = SendMessageRequestSchema.safeParse(payload);
-      if (!validation.success) {
-        console.error("[AssistantHandlers] Invalid payload:", validation.error);
-        sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
-          sessionId: payload.sessionId || "unknown",
-          chunk: {
-            type: "error",
-            error: "Invalid request: " + validation.error.message,
-          },
-        });
-        sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
-          sessionId: payload.sessionId || "unknown",
-          chunk: { type: "done" },
-        });
-        return;
-      }
+  ipcMain.handle(CHANNELS.ASSISTANT_SEND_MESSAGE, async (event, payload: unknown) => {
+    // Validate payload
+    const validation = SendMessageRequestSchema.safeParse(payload);
+    if (!validation.success) {
+      console.error("[AssistantHandlers] Invalid payload:", validation.error);
+      const sessionId =
+        typeof payload === "object" && payload !== null && "sessionId" in payload
+          ? String((payload as Record<string, unknown>).sessionId)
+          : "unknown";
+      sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
+        sessionId,
+        chunk: {
+          type: "error",
+          error: "Invalid request: " + validation.error.message,
+        },
+      });
+      sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
+        sessionId,
+        chunk: { type: "done" },
+      });
+      return;
+    }
 
-      const { sessionId, messages } = validation.data;
+    const { sessionId, messages, actions, context } = validation.data;
 
-      // Size limits to prevent DoS
-      if (messages.length > MAX_MESSAGES) {
+    // Size limits to prevent DoS
+    if (messages.length > MAX_MESSAGES) {
+      sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
+        sessionId,
+        chunk: {
+          type: "error",
+          error: `Too many messages (max ${MAX_MESSAGES})`,
+        },
+      });
+      sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
+        sessionId,
+        chunk: { type: "done" },
+      });
+      return;
+    }
+
+    for (const msg of messages) {
+      if (msg.content.length > MAX_MESSAGE_LENGTH) {
         sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
           sessionId,
           chunk: {
             type: "error",
-            error: `Too many messages (max ${MAX_MESSAGES})`,
+            error: `Message too long (max ${MAX_MESSAGE_LENGTH} chars)`,
           },
         });
         sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
@@ -82,43 +89,32 @@ export function registerAssistantHandlers(mainWindow: BrowserWindow): () => void
         });
         return;
       }
+    }
 
-      for (const msg of messages) {
-        if (msg.content.length > MAX_MESSAGE_LENGTH) {
-          sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
-            sessionId,
-            chunk: {
-              type: "error",
-              error: `Message too long (max ${MAX_MESSAGE_LENGTH} chars)`,
-            },
-          });
-          sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
-            sessionId,
-            chunk: { type: "done" },
-          });
-          return;
-        }
-      }
+    // Cancel stream if sender is destroyed
+    const senderDestroyedListener = () => {
+      assistantService.cancel(sessionId);
+    };
+    event.sender.once("destroyed", senderDestroyedListener);
 
-      // Cancel stream if sender is destroyed
-      const senderDestroyedListener = () => {
-        assistantService.cancel(sessionId);
-      };
-      event.sender.once("destroyed", senderDestroyedListener);
-
-      await assistantService.streamMessage(sessionId, messages, (chunk) => {
+    await assistantService.streamMessage(
+      sessionId,
+      messages,
+      (chunk) => {
         sendToWebContents(event.sender, CHANNELS.ASSISTANT_CHUNK, {
           sessionId,
           chunk,
         });
-      });
+      },
+      actions as ActionManifestEntry[] | undefined,
+      context as ActionContext | undefined
+    );
 
-      // Cleanup listener if stream completed normally
-      if (!event.sender.isDestroyed()) {
-        event.sender.removeListener("destroyed", senderDestroyedListener);
-      }
+    // Cleanup listener if stream completed normally
+    if (!event.sender.isDestroyed()) {
+      event.sender.removeListener("destroyed", senderDestroyedListener);
     }
-  );
+  });
 
   ipcMain.handle(CHANNELS.ASSISTANT_CANCEL, (_event, sessionId: string) => {
     assistantService.cancel(sessionId);

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1291,10 +1291,26 @@ const api: ElectronAPI = {
         toolResults?: Array<{ toolCallId: string; result: unknown; error?: string }>;
         createdAt: string;
       }>;
+      actions?: Array<{
+        id: string;
+        name: string;
+        title: string;
+        description: string;
+        category: string;
+        kind: "query" | "command";
+        danger: "safe" | "confirm" | "restricted";
+        inputSchema?: Record<string, unknown>;
+        outputSchema?: Record<string, unknown>;
+        enabled: boolean;
+        disabledReason?: string;
+      }>;
       context?: {
         projectId?: string;
         activeWorktreeId?: string;
+        focusedWorktreeId?: string;
         focusedTerminalId?: string;
+        isTerminalPaletteOpen?: boolean;
+        isSettingsOpen?: boolean;
       };
     }) => ipcRenderer.invoke(CHANNELS.ASSISTANT_SEND_MESSAGE, payload),
 
@@ -1309,7 +1325,7 @@ const api: ElectronAPI = {
           type: "text" | "tool_call" | "tool_result" | "error" | "done";
           content?: string;
           toolCall?: { id: string; name: string; args: Record<string, unknown> };
-          toolResult?: { toolCallId: string; result: unknown; error?: string };
+          toolResult?: { toolCallId: string; toolName: string; result: unknown; error?: string };
           error?: string;
           finishReason?: string;
         };
@@ -1323,7 +1339,7 @@ const api: ElectronAPI = {
             type: "text" | "tool_call" | "tool_result" | "error" | "done";
             content?: string;
             toolCall?: { id: string; name: string; args: Record<string, unknown> };
-            toolResult?: { toolCallId: string; result: unknown; error?: string };
+            toolResult?: { toolCallId: string; toolName: string; result: unknown; error?: string };
             error?: string;
             finishReason?: string;
           };

--- a/electron/services/assistant/actionTools.ts
+++ b/electron/services/assistant/actionTools.ts
@@ -1,0 +1,225 @@
+/**
+ * Action-to-Tool Converter for Assistant Service
+ *
+ * Converts ActionManifestEntry definitions to Vercel AI SDK tool format.
+ * Uses the same IPC dispatch pattern as AppAgentService for executing actions.
+ */
+
+import { tool, jsonSchema, type ToolSet } from "ai";
+import { BrowserWindow, ipcMain } from "electron";
+import { AGENT_ACCESSIBLE_ACTIONS } from "../../../shared/types/appAgent.js";
+import type { ActionManifestEntry, ActionContext } from "../../../shared/types/actions.js";
+
+const MAX_RESULT_SIZE = 50000;
+
+/**
+ * Sanitize tool name for OpenAI/Fireworks compatibility.
+ * Replaces dots with underscores since some providers strip dots.
+ */
+export function sanitizeToolName(name: string): string {
+  return name.replace(/\./g, "_");
+}
+
+/**
+ * Restore original action ID from sanitized tool name.
+ */
+export function unsanitizeToolName(sanitizedName: string): string {
+  return sanitizedName.replace(/_/g, ".");
+}
+
+/**
+ * Sanitize JSON Schema for AI provider compatibility.
+ * Removes $schema, unwraps anyOf from Zod optionals, ensures type/properties exist.
+ */
+export function sanitizeSchema(
+  schema: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const defaultSchema = { type: "object", properties: {} };
+
+  if (!schema) {
+    return defaultSchema;
+  }
+
+  const sanitized = { ...schema };
+
+  // Remove $schema - Fireworks/OpenAI doesn't support it
+  delete sanitized["$schema"];
+
+  // Handle anyOf from .optional() - unwrap if it contains an object type
+  if (sanitized["anyOf"] && Array.isArray(sanitized["anyOf"])) {
+    const objectSchema = (sanitized["anyOf"] as Array<Record<string, unknown>>).find(
+      (s) => s.type === "object"
+    );
+    if (objectSchema) {
+      Object.assign(sanitized, objectSchema);
+      delete sanitized["anyOf"];
+    }
+  }
+
+  // Only add defaults if we don't have real structure
+  if (!sanitized["type"]) {
+    sanitized["type"] = "object";
+  }
+  if (sanitized["type"] === "object" && !sanitized["properties"]) {
+    sanitized["properties"] = {};
+  }
+
+  return sanitized;
+}
+
+/**
+ * Truncate and redact sensitive data from tool results.
+ * Safely handles circular references and BigInt values.
+ */
+function truncateResult(result: unknown): unknown {
+  try {
+    const str = JSON.stringify(result);
+    if (str.length <= MAX_RESULT_SIZE) {
+      return result;
+    }
+
+    // For large results, return a truncated summary
+    if (Array.isArray(result)) {
+      return {
+        _truncated: true,
+        _originalLength: result.length,
+        items: result.slice(0, 10),
+        _message: `Result truncated: showing first 10 of ${result.length} items`,
+      };
+    }
+
+    // For objects, try to keep the structure
+    if (typeof result === "object" && result !== null) {
+      const truncatedStr = str.slice(0, MAX_RESULT_SIZE);
+      return {
+        _truncated: true,
+        _originalSize: str.length,
+        _message: "Result truncated due to size",
+        preview: truncatedStr.slice(0, 1000) + "...",
+      };
+    }
+
+    return { _truncated: true, _message: "Result too large to display" };
+  } catch (error) {
+    // Handle circular references, BigInt, or other serialization errors
+    const errorMessage = error instanceof Error ? error.message : "Serialization failed";
+    return {
+      _error: true,
+      _message: `Could not serialize result: ${errorMessage}`,
+      _type: typeof result,
+      _isArray: Array.isArray(result),
+    };
+  }
+}
+
+/**
+ * Dispatch an action to the renderer via IPC and wait for the result.
+ * This mirrors the pattern from AppAgentService.
+ */
+async function dispatchAction(
+  actionId: string,
+  args: Record<string, unknown> | undefined,
+  context: ActionContext
+): Promise<{ ok: boolean; result?: unknown; error?: { code: string; message: string } }> {
+  const mainWindow = BrowserWindow.getAllWindows()[0];
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return { ok: false, error: { code: "NO_WINDOW", message: "Main window not available" } };
+  }
+
+  const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      ipcMain.removeListener("app-agent:dispatch-action-response", handler);
+      resolve({ ok: false, error: { code: "TIMEOUT", message: "Action dispatch timed out" } });
+    }, 30000);
+
+    const handler = (
+      _event: Electron.IpcMainEvent,
+      payload: {
+        requestId: string;
+        result: { ok: boolean; result?: unknown; error?: { code: string; message: string } };
+      }
+    ) => {
+      if (payload.requestId === requestId) {
+        clearTimeout(timeout);
+        ipcMain.removeListener("app-agent:dispatch-action-response", handler);
+        resolve(payload.result);
+      }
+    };
+
+    ipcMain.on("app-agent:dispatch-action-response", handler);
+
+    mainWindow.webContents.send("app-agent:dispatch-action-request", {
+      requestId,
+      actionId,
+      args,
+      context,
+    });
+  });
+}
+
+/**
+ * Create Vercel AI SDK tools from ActionManifestEntry definitions.
+ * Only includes actions that are in the AGENT_ACCESSIBLE_ACTIONS allowlist.
+ */
+export function createActionTools(actions: ActionManifestEntry[], context: ActionContext): ToolSet {
+  const tools: ToolSet = {};
+
+  // Filter to only agent-accessible and enabled actions
+  const agentActions = actions.filter(
+    (action) =>
+      AGENT_ACCESSIBLE_ACTIONS.includes(action.id as (typeof AGENT_ACCESSIBLE_ACTIONS)[number]) &&
+      action.enabled
+  );
+
+  for (const action of agentActions) {
+    const toolName = sanitizeToolName(action.name);
+    const sanitizedSchema = sanitizeSchema(action.inputSchema);
+
+    // Use jsonSchema() to convert JSON Schema to AI SDK format
+    tools[toolName] = tool({
+      description: `[${action.kind}] ${action.description}${action.danger !== "safe" ? ` (${action.danger})` : ""}`,
+      inputSchema: jsonSchema<Record<string, unknown>>(sanitizedSchema),
+      execute: async (args: Record<string, unknown>) => {
+        const result = await dispatchAction(action.id, args, context);
+
+        if (!result.ok) {
+          return {
+            success: false,
+            error: result.error?.message || "Action failed",
+            code: result.error?.code,
+          };
+        }
+
+        return {
+          success: true,
+          result: truncateResult(result.result),
+        };
+      },
+    });
+  }
+
+  return tools;
+}
+
+/**
+ * Map from sanitized tool name back to action ID.
+ * Used by the UI to display the original action name.
+ */
+export function createToolNameMap(actions: ActionManifestEntry[]): Map<string, string> {
+  const map = new Map<string, string>();
+
+  const agentActions = actions.filter(
+    (action) =>
+      AGENT_ACCESSIBLE_ACTIONS.includes(action.id as (typeof AGENT_ACCESSIBLE_ACTIONS)[number]) &&
+      action.enabled
+  );
+
+  for (const action of agentActions) {
+    const toolName = sanitizeToolName(action.name);
+    map.set(toolName, action.id);
+  }
+
+  return map;
+}

--- a/electron/services/assistant/index.ts
+++ b/electron/services/assistant/index.ts
@@ -1,8 +1,8 @@
 /**
  * Assistant service utilities
  *
- * This module provides the system prompt and related utilities for
- * Canopy's app-wide assistant.
+ * This module provides the system prompt, action tools, and related utilities
+ * for Canopy's app-wide assistant.
  */
 
 export {
@@ -15,3 +15,11 @@ export {
   DESTRUCTIVE_KEYWORDS,
   isLikelyDestructive,
 } from "./systemPrompt.js";
+
+export {
+  createActionTools,
+  createToolNameMap,
+  sanitizeToolName,
+  unsanitizeToolName,
+  sanitizeSchema,
+} from "./actionTools.js";

--- a/shared/types/assistant.ts
+++ b/shared/types/assistant.ts
@@ -12,6 +12,7 @@ export type ToolCall = z.infer<typeof ToolCallSchema>;
 
 export const ToolResultSchema = z.object({
   toolCallId: z.string(),
+  toolName: z.string(),
   result: z.unknown(),
   error: z.string().optional(),
 });
@@ -40,16 +41,34 @@ export const StreamChunkSchema = z.object({
 });
 export type StreamChunk = z.infer<typeof StreamChunkSchema>;
 
+export const ActionManifestEntrySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  title: z.string(),
+  description: z.string(),
+  category: z.string(),
+  kind: z.enum(["query", "command"]),
+  danger: z.enum(["safe", "confirm", "restricted"]),
+  inputSchema: z.record(z.string(), z.unknown()).optional(),
+  outputSchema: z.record(z.string(), z.unknown()).optional(),
+  enabled: z.boolean(),
+  disabledReason: z.string().optional(),
+});
+
+export const ActionContextSchema = z.object({
+  projectId: z.string().optional(),
+  activeWorktreeId: z.string().optional(),
+  focusedWorktreeId: z.string().optional(),
+  focusedTerminalId: z.string().optional(),
+  isTerminalPaletteOpen: z.boolean().optional(),
+  isSettingsOpen: z.boolean().optional(),
+});
+
 export const SendMessageRequestSchema = z.object({
   sessionId: z.string(),
   messages: z.array(AssistantMessageSchema),
-  context: z
-    .object({
-      projectId: z.string().optional(),
-      activeWorktreeId: z.string().optional(),
-      focusedTerminalId: z.string().optional(),
-    })
-    .optional(),
+  actions: z.array(ActionManifestEntrySchema).optional(),
+  context: ActionContextSchema.optional(),
 });
 export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>;
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -605,15 +605,12 @@ export interface ElectronAPI {
     }): void;
   };
   assistant: {
-    /** Send a message to the assistant and receive streaming response */
+    /** Send a message to the assistant and receive streaming response with optional tool calling */
     sendMessage(payload: {
       sessionId: string;
       messages: AssistantMessage[];
-      context?: {
-        projectId?: string;
-        activeWorktreeId?: string;
-        focusedTerminalId?: string;
-      };
+      actions?: ActionManifestEntry[];
+      context?: ActionContext;
     }): Promise<void>;
     /** Cancel an active streaming session */
     cancel(sessionId: string): Promise<void>;

--- a/src/components/Assistant/types.ts
+++ b/src/components/Assistant/types.ts
@@ -6,6 +6,7 @@ export interface ToolCall {
   args: Record<string, unknown>;
   status: "pending" | "success" | "error";
   result?: unknown;
+  error?: string;
 }
 
 export interface AssistantMessage {


### PR DESCRIPTION
## Summary
Implements multi-step tool calling for the assistant panel using Vercel AI SDK v6. The assistant can now execute actions (from ActionService) as tools during conversation, enabling powerful agentic workflows like querying terminal state, listing worktrees, and executing commands.

Closes #1920

## Changes Made
- Add tool execution via actionTools.ts using IPC dispatch pattern mirroring AppAgentService
- Implement fullStream handling for tool-call and tool-result events from AI SDK
- Fix tool-result message interleaving to maintain proper conversation flow for multi-turn tool calling
- Add toolName tracking to ToolResult schema for proper call/result association
- Include tool results in IPC messages to preserve conversation context across turns
- Add safe JSON serialization with circular reference and BigInt handling
- Capture and emit tool execution errors in stream chunks
- Update preload and shared types to support complete tool calling flow
- Add cleanup on error to prevent dangling stream listeners

## Technical Details
- Uses Vercel AI SDK v6 with `maxSteps` for automatic multi-turn execution
- Actions are filtered via AGENT_ACCESSIBLE_ACTIONS allowlist
- Tool execution happens via IPC dispatch to renderer's ActionService
- Streaming chunks properly emit tool_call and tool_result events to UI
- Tool results are now properly interleaved in message history (not appended at end)