### PR TITLE
Add terminal content query action for multi-step agents

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -13,6 +13,7 @@ export type ActionId =
   | KeyAction
   // Query actions for App Agent
   | "terminal.list"
+  | "terminal.getOutput"
   | "panel.list"
   | "worktree.list"
   | "worktree.getCurrent"

--- a/shared/types/appAgent.ts
+++ b/shared/types/appAgent.ts
@@ -74,6 +74,7 @@ export interface OneShotRunResult {
 export const AGENT_ACCESSIBLE_ACTIONS = [
   // Query actions - return system state
   "terminal.list",
+  "terminal.getOutput",
   "panel.list",
   "worktree.list",
   "worktree.getCurrent",

--- a/shared/utils/artifactParser.ts
+++ b/shared/utils/artifactParser.ts
@@ -120,6 +120,11 @@ export function suggestFilename(language: string, content: string): string | und
 }
 
 export function stripAnsiCodes(text: string): string {
+  // More comprehensive ANSI escape code stripping
+  // Handles CSI, OSC, DCS, and other control sequences
   // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+  return text.replace(
+    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+    ""
+  );
 }

--- a/src/services/actions/__tests__/terminalGetOutputAction.test.ts
+++ b/src/services/actions/__tests__/terminalGetOutputAction.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import { stripAnsiCodes } from "@shared/utils/artifactParser";
+
+// Mock window.electron and window event listeners before any imports
+const mockGetSerializedState = vi.fn();
+const mockAddEventListener = vi.fn();
+const mockRemoveEventListener = vi.fn();
+const mockDispatchEvent = vi.fn();
+
+beforeAll(() => {
+  // Provide a complete window mock before module imports
+  vi.stubGlobal("window", {
+    electron: {
+      terminal: {
+        getSerializedState: mockGetSerializedState,
+      },
+    },
+    addEventListener: mockAddEventListener,
+    removeEventListener: mockRemoveEventListener,
+    dispatchEvent: mockDispatchEvent,
+    location: {
+      origin: "http://localhost:5173",
+      protocol: "http:",
+      href: "http://localhost:5173/",
+    },
+    top: null, // Will be set to self
+  });
+  // Make window.top reference itself
+  (window as any).top = window;
+});
+
+// Helper to create the action registry
+async function createRegistry() {
+  (globalThis as any).self = globalThis;
+
+  // Reset module cache to ensure fresh imports with mocks
+  vi.resetModules();
+
+  const { createActionDefinitions } = await import("../actionDefinitions");
+  return createActionDefinitions({
+    onOpenSettings: () => {},
+    onOpenSettingsTab: () => {},
+    onToggleSidebar: () => {},
+    onToggleFocusMode: () => {},
+    onOpenAgentPalette: () => {},
+    onOpenWorktreePalette: () => {},
+    onToggleWorktreeOverview: () => {},
+    onOpenWorktreeOverview: () => {},
+    onCloseWorktreeOverview: () => {},
+    onOpenNewTerminalPalette: () => {},
+    onOpenPanelPalette: () => {},
+    onOpenProjectSwitcherPalette: () => {},
+    onOpenShortcuts: () => {},
+    onLaunchAgent: async () => {},
+    onInject: () => {},
+    getDefaultCwd: () => "/",
+    getActiveWorktreeId: () => undefined,
+    getWorktrees: () => [],
+    getFocusedId: () => null,
+    getGridNavigation: () => ({
+      findNearest: () => null,
+      findByIndex: () => null,
+      findDockByIndex: () => null,
+      getCurrentLocation: () => null,
+    }),
+  });
+}
+
+describe("terminal.getOutput action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is registered in the action registry", async () => {
+    const actions = await createRegistry();
+    expect(actions.has("terminal.getOutput")).toBe(true);
+  });
+
+  it("has correct metadata", async () => {
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    expect(actionFn).toBeDefined();
+
+    const action = actionFn!();
+    expect(action.id).toBe("terminal.getOutput");
+    expect(action.kind).toBe("query");
+    expect(action.danger).toBe("safe");
+    expect(action.category).toBe("terminal");
+  });
+
+  it("returns last N lines from terminal buffer", async () => {
+    const mockBuffer = "line1\nline2\nline3\nline4\nline5";
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal", maxLines: 3 }, {});
+
+    expect(result.terminalId).toBe("test-terminal");
+    expect(result.content).toBe("line3\nline4\nline5");
+    expect(result.lineCount).toBe(3);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("returns all lines when buffer has fewer than maxLines", async () => {
+    const mockBuffer = "line1\nline2\nline3";
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal", maxLines: 100 }, {});
+
+    expect(result.content).toBe("line1\nline2\nline3");
+    expect(result.lineCount).toBe(3);
+    expect(result.truncated).toBe(false);
+  });
+
+  it("defaults to 100 lines when maxLines not specified", async () => {
+    // Generate 150 lines
+    const lines = Array.from({ length: 150 }, (_, i) => `line${i + 1}`);
+    const mockBuffer = lines.join("\n");
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal" }, {});
+
+    expect(result.lineCount).toBe(100);
+    expect(result.truncated).toBe(true);
+    // Should have last 100 lines (line51-line150)
+    expect(result.content).toContain("line51");
+    expect(result.content).toContain("line150");
+  });
+
+  it("strips ANSI codes by default", async () => {
+    const mockBuffer = "\x1b[32mgreen text\x1b[0m\n\x1b[31mred text\x1b[0m";
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal" }, {});
+
+    expect(result.content).toBe("green text\nred text");
+    expect(result.content).not.toContain("\x1b");
+  });
+
+  it("preserves ANSI codes when stripAnsi is false", async () => {
+    const mockBuffer = "\x1b[32mgreen text\x1b[0m";
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal", stripAnsi: false }, {});
+
+    expect(result.content).toBe("\x1b[32mgreen text\x1b[0m");
+    expect(result.content).toContain("\x1b");
+  });
+
+  it("returns null content for non-existent terminal", async () => {
+    mockGetSerializedState.mockResolvedValue(null);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "non-existent" }, {});
+
+    expect(result.terminalId).toBe("non-existent");
+    expect(result.content).toBeNull();
+    expect(result.lineCount).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it("handles empty terminal buffer", async () => {
+    mockGetSerializedState.mockResolvedValue("");
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "empty-terminal" }, {});
+
+    expect(result.content).toBe("");
+    expect(result.lineCount).toBe(1); // Empty string splits into one empty line
+    expect(result.truncated).toBe(false);
+  });
+
+  it("enforces maxLines upper bound of 1000", async () => {
+    // Generate 1500 lines
+    const lines = Array.from({ length: 1500 }, (_, i) => `line${i + 1}`);
+    const mockBuffer = lines.join("\n");
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal", maxLines: 5000 }, {});
+
+    // Should cap at 1000 lines
+    expect(result.lineCount).toBe(1000);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("enforces maxLines lower bound of 1", async () => {
+    const mockBuffer = "line1\nline2\nline3";
+    mockGetSerializedState.mockResolvedValue(mockBuffer);
+
+    const actions = await createRegistry();
+    const actionFn = actions.get("terminal.getOutput");
+    const action = actionFn!();
+
+    const result = await action.run({ terminalId: "test-terminal", maxLines: 0 }, {});
+
+    // Should get at least 1 line
+    expect(result.lineCount).toBe(1);
+  });
+});
+
+describe("stripAnsiCodes utility", () => {
+  it("strips common color codes", () => {
+    const input = "\x1b[32mgreen\x1b[0m \x1b[31mred\x1b[0m";
+    expect(stripAnsiCodes(input)).toBe("green red");
+  });
+
+  it("strips cursor positioning codes", () => {
+    const input = "\x1b[2Jcleared\x1b[H";
+    expect(stripAnsiCodes(input)).toBe("cleared");
+  });
+
+  it("handles text with no ANSI codes", () => {
+    const input = "plain text";
+    expect(stripAnsiCodes(input)).toBe("plain text");
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new `terminal.getOutput` action that enables multi-step agents to query terminal output content. This allows agents to read terminal buffer content to analyze command results, debug failures, and make informed decisions during automated workflows.

Closes #1929

## Changes Made
- Add `terminal.getOutput` action with configurable `maxLines` and `stripAnsi` parameters
- Improve `stripAnsiCodes` regex to handle CSI, OSC, DCS, and 8-bit control sequences
- Add `terminal.getOutput` to agent-accessible actions list
- Fix Zod schema defaults (remove `.optional()` when using `.default()`)
- Add comprehensive test coverage with 14 test cases
- Document that output includes terminal control sequences and alternate buffer content

## Implementation Details
The action uses the existing `window.electron.terminal.getSerializedState()` IPC method and provides:
- Configurable line limit (default 100, max 1000)
- Optional ANSI code stripping (enabled by default)
- Graceful handling of non-existent terminals
- Proper truncation indicators

## Testing
All 14 test cases pass, covering:
- Action registration and metadata
- Line limiting and truncation
- ANSI code stripping
- Edge cases (empty buffers, non-existent terminals, boundary conditions)