### PR TITLE
Redesign assistant empty state to system status monitor

### DIFF
--- a/src/components/Assistant/AssistantPane.tsx
+++ b/src/components/Assistant/AssistantPane.tsx
@@ -81,7 +81,7 @@ export function AssistantPane({
           </div>
         )}
 
-        {showEmptyState && <EmptyState onSendMessage={sendMessage} />}
+        {showEmptyState && <EmptyState />}
 
         {showChat && (
           <>

--- a/src/components/Assistant/EmptyState.tsx
+++ b/src/components/Assistant/EmptyState.tsx
@@ -1,41 +1,24 @@
 import { useCallback } from "react";
-import { Settings, Bot, Sparkles, FileCode, GitBranch, Terminal } from "lucide-react";
+import { Settings, GitBranch } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
+import { useProjectStore } from "@/store/projectStore";
+import { useAppAgentStore } from "@/store/appAgentStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useWorktreeDataStore } from "@/store/worktreeDataStore";
 
 interface EmptyStateProps {
   className?: string;
-  onSendMessage?: (message: string) => void;
 }
 
-const SUGGESTED_PROMPTS = [
-  {
-    id: "codebase-structure",
-    icon: FileCode,
-    text: "Explain this codebase structure",
-    message: "Can you help me understand the structure of this codebase?",
-  },
-  {
-    id: "review-changes",
-    icon: GitBranch,
-    text: "Review my recent changes",
-    message: "Can you review my recent code changes and provide feedback?",
-  },
-  {
-    id: "debug-terminal",
-    icon: Terminal,
-    text: "Debug this terminal output",
-    message: "I'm seeing an error in my terminal. Can you help me debug it?",
-  },
-  {
-    id: "suggest-improvements",
-    icon: Sparkles,
-    text: "Suggest improvements",
-    message: "What improvements would you suggest for my current code?",
-  },
-];
+export function EmptyState({ className }: EmptyStateProps) {
+  const currentProject = useProjectStore((s) => s.currentProject);
+  const hasApiKey = useAppAgentStore((s) => s.hasApiKey);
+  const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
+  const activeWorktree = useWorktreeDataStore((state) =>
+    activeWorktreeId ? state.worktrees.get(activeWorktreeId) : null
+  );
 
-export function EmptyState({ className, onSendMessage }: EmptyStateProps) {
   const handleOpenSettings = useCallback(async () => {
     try {
       await actionService.dispatch("app.settings.openTab", { tab: "assistant" });
@@ -44,81 +27,113 @@ export function EmptyState({ className, onSendMessage }: EmptyStateProps) {
     }
   }, []);
 
-  const handlePromptClick = useCallback(
-    (message: string) => {
-      onSendMessage?.(message);
-    },
-    [onSendMessage]
-  );
-
   return (
-    <div className={cn("flex-1 flex items-center justify-center p-8", className)}>
-      <div className="text-center max-w-lg">
-        <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-gradient-to-br from-canopy-accent/20 to-blue-500/20 mb-6">
-          <Bot className="w-8 h-8 text-canopy-accent" />
+    <div
+      className={cn(
+        "flex h-full flex-col items-center justify-center p-8 select-none",
+        className
+      )}
+    >
+      {/* Watermark - Ultra-low contrast branding */}
+      <div className="mb-8 flex flex-col items-center gap-4 opacity-5" aria-hidden="true">
+        <svg
+          className="h-16 w-16"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+
+      {/* System Status Monitor */}
+      <div className="w-full max-w-[240px] space-y-3" role="status" aria-label="Assistant status">
+        {/* Status Header */}
+        <div className="flex items-center gap-2 text-[10px] font-bold tracking-[0.15em] text-canopy-text/30 uppercase">
+          <div
+            className={cn(
+              "h-1 w-1 rounded-full",
+              hasApiKey ? "bg-green-500/50" : "bg-amber-500/50"
+            )}
+            aria-hidden="true"
+          />
+          {hasApiKey ? "System Ready" : "Configuration Required"}
         </div>
 
-        <h3 className="text-xl font-semibold text-canopy-text mb-2">Configure Canopy Assistant</h3>
+        {/* Context Grid */}
+        <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 border-l border-divider/30 pl-3 font-mono text-[11px] text-canopy-text/60">
+          <span className="text-canopy-text/30">SCOPE</span>
+          <span className="truncate">{currentProject ? "Project" : "Global"}</span>
 
-        <p className="text-sm text-canopy-text/60 mb-8 leading-relaxed">
-          Set up your Fireworks API key to start chatting with Canopy Assistant. Get help with
-          coding questions, project navigation, debugging, and more.
-        </p>
-
-        <button
-          type="button"
-          onClick={handleOpenSettings}
-          className={cn(
-            "inline-flex items-center gap-2 px-5 py-2.5",
-            "bg-canopy-accent text-white text-sm font-medium",
-            "rounded-lg",
-            "hover:bg-canopy-accent/90 transition-all duration-150",
-            "focus:outline-none focus:ring-2 focus:ring-canopy-accent/50 focus:ring-offset-2 focus:ring-offset-canopy-bg",
-            "shadow-lg shadow-canopy-accent/20"
+          {currentProject && (
+            <>
+              <span className="text-canopy-text/30">PROJECT</span>
+              <span className="truncate text-canopy-accent/80">{currentProject.name}</span>
+            </>
           )}
-        >
-          <Settings className="w-4 h-4" />
-          Open Settings
-        </button>
 
-        {onSendMessage && (
-          <div className="mt-8 pt-8 border-t border-canopy-border/50">
-            <p className="text-xs text-canopy-text/50 mb-4 uppercase tracking-wide font-semibold">
-              Try asking about
-            </p>
-            <div className="grid grid-cols-2 gap-2">
-              {SUGGESTED_PROMPTS.map((prompt) => {
-                const Icon = prompt.icon;
-                return (
-                  <button
-                    key={prompt.id}
-                    type="button"
-                    onClick={() => handlePromptClick(prompt.message)}
-                    className={cn(
-                      "flex items-center gap-2 px-3 py-2.5 text-left",
-                      "bg-canopy-sidebar/30 border border-canopy-border/50 rounded-lg",
-                      "text-xs text-canopy-text/70",
-                      "hover:bg-canopy-sidebar/50 hover:border-canopy-accent/30 hover:text-canopy-text",
-                      "transition-all duration-150",
-                      "focus:outline-none focus:ring-2 focus:ring-canopy-accent/50"
-                    )}
-                  >
-                    <Icon className="w-3.5 h-3.5 text-canopy-accent/70 shrink-0" />
-                    <span className="leading-tight">{prompt.text}</span>
-                  </button>
-                );
-              })}
-            </div>
+          {activeWorktree?.branch && (
+            <>
+              <span className="text-canopy-text/30">BRANCH</span>
+              <div className="flex items-center gap-1.5 truncate">
+                <GitBranch className="h-3 w-3" />
+                <span>{activeWorktree.branch}</span>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Configuration prompt if no API key */}
+        {!hasApiKey && (
+          <div className="mt-4 pt-4 border-t border-divider/20">
+            <button
+              type="button"
+              onClick={handleOpenSettings}
+              className={cn(
+                "w-full flex items-center justify-center gap-2 px-3 py-2",
+                "bg-canopy-sidebar/30 border border-canopy-border/50 rounded text-xs",
+                "text-canopy-text/70 hover:text-canopy-text hover:border-canopy-accent/30",
+                "transition-colors"
+              )}
+            >
+              <Settings className="w-3 h-3" />
+              Configure API Key
+            </button>
           </div>
         )}
+      </div>
 
-        <p className="text-xs text-canopy-text/40 mt-6">
-          Press{" "}
-          <kbd className="px-1.5 py-0.5 rounded bg-canopy-sidebar/60 font-mono border border-canopy-border/40">
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Keyboard Shortcuts Footer */}
+      <div className="flex gap-6 pb-4 text-[11px] text-canopy-text/40 font-medium">
+        <div className="flex items-center gap-2">
+          <span className="flex items-center justify-center min-w-[20px] h-5 rounded border border-divider/50 bg-white/[0.03] px-1 font-mono text-[10px]">
+            /
+          </span>
+          <span>Commands</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="flex items-center justify-center min-w-[20px] h-5 rounded border border-divider/50 bg-white/[0.03] px-1 font-mono text-[10px]">
+            @
+          </span>
+          <span>Context</span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <kbd className="flex items-center justify-center h-5 rounded border border-divider/50 bg-white/[0.03] px-1.5 font-mono text-[10px]">
             ⌘⇧K
-          </kbd>{" "}
-          to focus this panel
-        </p>
+          </kbd>
+          <span>Focus</span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Transform the assistant empty state from a traditional "welcome screen" to a utilitarian "system status monitor" that aligns with Canopy's mission control philosophy.

Closes #1953

## Changes Made
- Remove decorative Bot icon and suggested prompts section
- Add ultra-low contrast watermark with layered stack icon
- Display system status header with indicator dot (ready/config required)
- Show context grid with scope, project name, and active branch
- Add minimal keyboard shortcuts footer (/, @, ⌘⇧K)
- Wire dynamic hasApiKey state from useAppAgentStore
- Pull active branch from worktree selection and data stores
- Add ARIA attributes for accessibility (role, aria-label, aria-hidden)
- Conditionally render config button only when API key missing