### PR TITLE
Add AI SDK tools for listener management

### DIFF
--- a/electron/services/AssistantService.ts
+++ b/electron/services/AssistantService.ts
@@ -6,6 +6,7 @@ import type { ActionManifestEntry, ActionContext } from "../../shared/types/acti
 import { createActionTools, sanitizeToolName } from "./assistant/actionTools.js";
 import { SYSTEM_PROMPT, buildContextBlock } from "./assistant/index.js";
 import { listenerManager } from "./assistant/ListenerManager.js";
+import { createListenerTools } from "./assistant/listenerTools.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 const MAX_STEPS = 10;
@@ -128,9 +129,11 @@ export class AssistantService {
         }
       }
 
-      // Build tools from actions if provided
-      const tools = actions && context ? createActionTools(actions, context) : undefined;
-      const hasTools = tools && Object.keys(tools).length > 0;
+      // Build tools from actions and listener management
+      const actionTools = actions && context ? createActionTools(actions, context) : {};
+      const listenerTools = createListenerTools({ sessionId });
+      const tools = { ...actionTools, ...listenerTools };
+      const hasTools = Object.keys(tools).length > 0;
 
       const result = streamText({
         model: this.fireworks(config.model),

--- a/electron/services/assistant/__tests__/listenerTools.test.ts
+++ b/electron/services/assistant/__tests__/listenerTools.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { createListenerTools, type ListenerToolContext } from "../listenerTools.js";
+import { ListenerManager } from "../ListenerManager.js";
+
+// Mock the listenerManager module
+vi.mock("../ListenerManager.js", async () => {
+  const { ListenerManager } = await vi.importActual<typeof import("../ListenerManager.js")>(
+    "../ListenerManager.js"
+  );
+  const instance = new ListenerManager();
+  return {
+    ListenerManager,
+    listenerManager: instance,
+  };
+});
+
+// Import mocked instance after mock setup
+import { listenerManager } from "../ListenerManager.js";
+
+describe("listenerTools", () => {
+  let tools: ReturnType<typeof createListenerTools>;
+  let context: ListenerToolContext;
+
+  beforeEach(() => {
+    listenerManager.clear();
+    context = { sessionId: "test-session-1" };
+    tools = createListenerTools(context);
+  });
+
+  afterEach(() => {
+    listenerManager.clear();
+  });
+
+  describe("register_listener", () => {
+    it("registers a listener and returns success", async () => {
+      const result = await tools.register_listener.execute(
+        { eventType: "agent:state-changed", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: true,
+        listenerId: expect.any(String),
+        eventType: "agent:state-changed",
+        message: "Successfully subscribed to agent:state-changed events",
+      });
+      expect(listenerManager.size()).toBe(1);
+    });
+
+    it("registers a listener with filter", async () => {
+      const result = await tools.register_listener.execute(
+        {
+          eventType: "terminal:activity",
+          filter: { terminalId: "term-123" },
+        },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: true,
+        listenerId: expect.any(String),
+        eventType: "terminal:activity",
+        filter: { terminalId: "term-123" },
+        message: "Successfully subscribed to terminal:activity events",
+      });
+
+      const listeners = listenerManager.listForSession("test-session-1");
+      expect(listeners.length).toBe(1);
+      expect(listeners[0].filter).toEqual({ terminalId: "term-123" });
+    });
+
+    it("creates listeners scoped to the session", async () => {
+      await tools.register_listener.execute(
+        { eventType: "agent:spawned", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      const session1Listeners = listenerManager.listForSession("test-session-1");
+      const session2Listeners = listenerManager.listForSession("other-session");
+
+      expect(session1Listeners.length).toBe(1);
+      expect(session2Listeners.length).toBe(0);
+    });
+
+    it("handles registration errors gracefully with empty eventType", async () => {
+      const result = await tools.register_listener.execute(
+        { eventType: "", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining("Invalid listener registration"),
+      });
+    });
+
+    it("validates schema and rejects invalid event types", () => {
+      const invalidEventType = "invalid:event:type";
+      const parseResult = tools.register_listener.parameters.safeParse({
+        eventType: invalidEventType,
+        filter: undefined,
+      });
+
+      expect(parseResult.success).toBe(false);
+    });
+
+    it("validates schema and rejects nested filter values", () => {
+      const parseResult = tools.register_listener.parameters.safeParse({
+        eventType: "agent:spawned",
+        filter: { nested: { value: 123 } },
+      });
+
+      expect(parseResult.success).toBe(false);
+    });
+  });
+
+  describe("list_listeners", () => {
+    it("returns empty list when no listeners registered", async () => {
+      const result = await tools.list_listeners.execute(
+        {},
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: true,
+        count: 0,
+        listeners: [],
+      });
+    });
+
+    it("returns all listeners for the session", async () => {
+      // Register multiple listeners
+      await tools.register_listener.execute(
+        { eventType: "agent:state-changed", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+      await tools.register_listener.execute(
+        { eventType: "terminal:activity", filter: { terminalId: "term-1" } },
+        { toolCallId: "tc-2", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      const result = await tools.list_listeners.execute(
+        {},
+        { toolCallId: "tc-3", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: true,
+        count: 2,
+        listeners: expect.arrayContaining([
+          {
+            listenerId: expect.any(String),
+            eventType: "agent:state-changed",
+            createdAt: expect.any(Number),
+          },
+          {
+            listenerId: expect.any(String),
+            eventType: "terminal:activity",
+            filter: { terminalId: "term-1" },
+            createdAt: expect.any(Number),
+          },
+        ]),
+      });
+    });
+
+    it("only returns listeners for the current session", async () => {
+      // Register listener in our session
+      await tools.register_listener.execute(
+        { eventType: "agent:state-changed", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      // Register listener in another session directly
+      listenerManager.register("other-session", "terminal:activity");
+
+      const result = await tools.list_listeners.execute(
+        {},
+        { toolCallId: "tc-2", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result.count).toBe(1);
+      expect(result.listeners[0].eventType).toBe("agent:state-changed");
+    });
+  });
+
+  describe("remove_listener", () => {
+    it("removes a registered listener", async () => {
+      const registerResult = await tools.register_listener.execute(
+        { eventType: "agent:state-changed", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+      expect(registerResult.success).toBe(true);
+      const listenerId = (registerResult as { success: true; listenerId: string }).listenerId;
+
+      const result = await tools.remove_listener.execute(
+        { listenerId },
+        { toolCallId: "tc-2", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: true,
+        removed: true,
+        listenerId,
+        message: "Listener removed successfully",
+      });
+      expect(listenerManager.size()).toBe(0);
+    });
+
+    it("returns error for non-existent listener", async () => {
+      const result = await tools.remove_listener.execute(
+        { listenerId: "non-existent-id" },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: false,
+        removed: false,
+        error: "Listener not found",
+      });
+    });
+
+    it("prevents removing listeners from other sessions without leaking session info", async () => {
+      // Register listener in another session directly
+      const otherSessionListenerId = listenerManager.register("other-session", "terminal:activity");
+
+      const result = await tools.remove_listener.execute(
+        { listenerId: otherSessionListenerId },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      // Should return generic "not found" error without revealing it belongs to another session
+      expect(result).toEqual({
+        success: false,
+        removed: false,
+        error: "Listener not found",
+      });
+
+      // Verify listener still exists
+      expect(listenerManager.get(otherSessionListenerId)).toBeDefined();
+    });
+
+    it("validates schema and rejects empty listenerId", () => {
+      const parseResult = tools.remove_listener.parameters.safeParse({
+        listenerId: "",
+      });
+
+      expect(parseResult.success).toBe(false);
+    });
+
+    it("handles already removed listener gracefully", async () => {
+      const registerResult = await tools.register_listener.execute(
+        { eventType: "agent:state-changed", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+      const listenerId = (registerResult as { success: true; listenerId: string }).listenerId;
+
+      // Remove the listener directly
+      listenerManager.unregister(listenerId);
+
+      // Try to remove again via tool
+      const result = await tools.remove_listener.execute(
+        { listenerId },
+        { toolCallId: "tc-2", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        success: false,
+        removed: false,
+        error: "Listener not found",
+      });
+    });
+  });
+
+  describe("tool metadata", () => {
+    it("register_listener has correct description", () => {
+      expect(tools.register_listener.description).toContain("Subscribe to Canopy events");
+    });
+
+    it("list_listeners has correct description", () => {
+      expect(tools.list_listeners.description).toContain("List all active event listeners");
+    });
+
+    it("remove_listener has correct description", () => {
+      expect(tools.remove_listener.description).toContain("Unsubscribe from events");
+    });
+  });
+
+  describe("cross-session isolation", () => {
+    it("tools from different sessions operate independently", async () => {
+      const context1: ListenerToolContext = { sessionId: "session-1" };
+      const context2: ListenerToolContext = { sessionId: "session-2" };
+      const tools1 = createListenerTools(context1);
+      const tools2 = createListenerTools(context2);
+
+      // Register listeners in both sessions
+      await tools1.register_listener.execute(
+        { eventType: "agent:state-changed", filter: undefined },
+        { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+      );
+      await tools2.register_listener.execute(
+        { eventType: "terminal:activity", filter: undefined },
+        { toolCallId: "tc-2", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      // Verify each session sees only its own listeners
+      const list1 = await tools1.list_listeners.execute(
+        {},
+        { toolCallId: "tc-3", messages: [], abortSignal: new AbortController().signal }
+      );
+      const list2 = await tools2.list_listeners.execute(
+        {},
+        { toolCallId: "tc-4", messages: [], abortSignal: new AbortController().signal }
+      );
+
+      expect(list1.count).toBe(1);
+      expect(list1.listeners[0].eventType).toBe("agent:state-changed");
+      expect(list2.count).toBe(1);
+      expect(list2.listeners[0].eventType).toBe("terminal:activity");
+    });
+  });
+});

--- a/electron/services/assistant/index.ts
+++ b/electron/services/assistant/index.ts
@@ -25,3 +25,5 @@ export {
 } from "./actionTools.js";
 
 export { ListenerManager, listenerManager } from "./ListenerManager.js";
+
+export { createListenerTools, type ListenerToolContext } from "./listenerTools.js";

--- a/electron/services/assistant/listenerTools.ts
+++ b/electron/services/assistant/listenerTools.ts
@@ -1,0 +1,134 @@
+/**
+ * Listener Management Tools for Assistant Service
+ *
+ * Provides AI SDK tools for the assistant to manage event listeners.
+ * These tools allow the assistant to subscribe to, list, and unsubscribe from
+ * Canopy events during a conversation.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import type { ToolSet } from "ai";
+import { listenerManager } from "./ListenerManager.js";
+import { ALL_EVENT_TYPES } from "../events.js";
+
+/**
+ * Event types that the assistant can subscribe to.
+ * Derived from ALL_EVENT_TYPES in the events module.
+ */
+const ListenableEventTypeSchema = z.enum(ALL_EVENT_TYPES as [string, ...string[]]);
+
+/**
+ * Filter schema for narrowing event subscriptions.
+ * Allows filtering by any field value (string, number, boolean, or null).
+ * Accepts both undefined and null, normalizing to undefined internally.
+ */
+const ListenerFilterSchema = z
+  .record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null()]))
+  .nullable()
+  .optional()
+  .transform((val) => (val === null ? undefined : val))
+  .describe("Optional filter to narrow events by field values (e.g., { terminalId: 'abc' })");
+
+/**
+ * Context provided to listener tools containing the session ID.
+ */
+export interface ListenerToolContext {
+  sessionId: string;
+}
+
+/**
+ * Create listener management tools for the assistant.
+ *
+ * @param context - Context containing the session ID for scoping listeners
+ * @returns ToolSet containing register_listener, list_listeners, and remove_listener tools
+ */
+export function createListenerTools(context: ListenerToolContext): ToolSet {
+  return {
+    register_listener: tool({
+      description:
+        "Subscribe to Canopy events. Returns a listener ID for later removal. " +
+        "Use this to monitor terminal activity, agent state changes, worktree updates, and more.",
+      parameters: z.object({
+        eventType: ListenableEventTypeSchema.describe(
+          "The event type to subscribe to (e.g., 'agent:state-changed', 'terminal:activity')"
+        ),
+        filter: ListenerFilterSchema,
+      }),
+      execute: async ({ eventType, filter }) => {
+        try {
+          const listenerId = listenerManager.register(context.sessionId, eventType, filter);
+          return {
+            success: true,
+            listenerId,
+            eventType,
+            ...(filter ? { filter } : {}),
+            message: `Successfully subscribed to ${eventType} events`,
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : "Failed to register listener",
+          };
+        }
+      },
+    }),
+
+    list_listeners: tool({
+      description:
+        "List all active event listeners for this conversation. " +
+        "Shows what events you are currently subscribed to.",
+      parameters: z.object({}),
+      execute: async () => {
+        const listeners = listenerManager.listForSession(context.sessionId);
+        return {
+          success: true,
+          count: listeners.length,
+          listeners: listeners.map((l) => ({
+            listenerId: l.id,
+            eventType: l.eventType,
+            ...(l.filter ? { filter: l.filter } : {}),
+            createdAt: l.createdAt,
+          })),
+        };
+      },
+    }),
+
+    remove_listener: tool({
+      description:
+        "Unsubscribe from events by listener ID. " +
+        "Use the listener ID returned from register_listener or list_listeners.",
+      parameters: z.object({
+        listenerId: z.string().min(1).describe("The listener ID to remove"),
+      }),
+      execute: async ({ listenerId }) => {
+        // Verify the listener belongs to this session before removing
+        const listener = listenerManager.get(listenerId);
+
+        if (!listener) {
+          return {
+            success: false,
+            removed: false,
+            error: "Listener not found",
+          };
+        }
+
+        if (listener.sessionId !== context.sessionId) {
+          return {
+            success: false,
+            removed: false,
+            error: "Listener not found",
+          };
+        }
+
+        const removed = listenerManager.unregister(listenerId);
+        return {
+          success: true,
+          removed,
+          listenerId,
+          message: removed ? "Listener removed successfully" : "Listener was already removed",
+        };
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
Implements AI SDK tools that allow the assistant to manage event listeners during conversations. The assistant can now subscribe to Canopy events (like terminal activity, agent state changes, worktree updates), list active subscriptions, and unsubscribe when needed.

Closes #1949

## Changes Made
- Add `register_listener` tool: Subscribe to Canopy events with optional filters
- Add `list_listeners` tool: List all active listeners for current session
- Add `remove_listener` tool: Unsubscribe from events by listener ID
- Implement session-scoped listener isolation to prevent cross-session access
- Add filter nullability normalization (null→undefined) for input/output consistency
- Implement security hardening to prevent session boundary information leaks
- Add comprehensive test coverage (18 tests) with schema validation and edge cases
- Integrate listener tools with AssistantService alongside existing action tools