### PR TITLE
Add restart button to assistant panel

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -208,7 +208,8 @@ export type ActionId =
   | "notes.create"
   | "notes.delete"
   | "notes.reveal"
-  | "devServer.start";
+  | "devServer.start"
+  | "assistant.restart";
 
 export interface ActionContext {
   projectId?: string;

--- a/src/components/Assistant/AssistantPane.tsx
+++ b/src/components/Assistant/AssistantPane.tsx
@@ -28,8 +28,16 @@ export function AssistantPane({
   const { hasApiKey, isInitialized, initialize } = useAppAgentStore();
   const inputRef = useRef<AssistantInputHandle>(null);
 
-  const { messages, streamingState, isLoading, error, sendMessage, cancelStreaming, clearError } =
-    useAssistantChat({ panelId: id });
+  const {
+    messages,
+    streamingState,
+    isLoading,
+    error,
+    sendMessage,
+    cancelStreaming,
+    clearError,
+    clearMessages,
+  } = useAssistantChat({ panelId: id });
 
   useEffect(() => {
     initialize();
@@ -53,6 +61,10 @@ export function AssistantPane({
     inputRef.current?.focus();
   }, [onFocus]);
 
+  const handleRestart = useCallback(() => {
+    clearMessages();
+  }, [clearMessages]);
+
   const showLoading = !isInitialized;
   const showEmptyState = isInitialized && !hasApiKey;
   const showChat = isInitialized && hasApiKey;
@@ -73,6 +85,7 @@ export function AssistantPane({
       onTitleChange={onTitleChange}
       onMinimize={onMinimize}
       onRestore={onRestore}
+      onRestart={handleRestart}
     >
       <div className="flex flex-col h-full bg-canopy-bg">
         {showLoading && (

--- a/src/services/actions/definitions/assistantActions.ts
+++ b/src/services/actions/definitions/assistantActions.ts
@@ -1,6 +1,8 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
+import { z } from "zod";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useAssistantChatStore } from "@/store/assistantChatStore";
 
 export function registerAssistantActions(
   actions: ActionRegistry,
@@ -23,6 +25,27 @@ export function registerAssistantActions(
         cwd: "",
         worktreeId: activeWorktreeId ?? undefined,
       });
+    },
+  }));
+
+  actions.set("assistant.restart", () => ({
+    id: "assistant.restart",
+    title: "Restart Assistant",
+    description: "Clear conversation and start a new session",
+    category: "assistant",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ panelId: z.string().optional() }).optional(),
+    run: async (args: unknown) => {
+      const { panelId } = (args as { panelId?: string } | undefined) ?? {};
+      const chatStore = useAssistantChatStore.getState();
+      const terminalStore = useTerminalStore.getState();
+      const targetId = panelId ?? terminalStore.focusedId;
+
+      if (targetId) {
+        chatStore.clearConversation(targetId);
+      }
     },
   }));
 }


### PR DESCRIPTION
## Summary
Adds a restart button to the assistant panel header, matching the existing restart functionality available for terminal agents. Users can now clear the conversation state and start fresh with a new session by clicking the restart button that appears on hover.

Closes #1959

## Changes Made
- Add `assistant.restart` action to ActionId union type
- Register `assistant.restart` action with optional args schema
- Add `handleRestart` callback in AssistantPane using `clearMessages`
- Pass `onRestart` prop to ContentPanel for header button rendering
- Ensure streaming is canceled before clearing conversation

## Implementation Details
- The restart button appears on hover in the panel header with RotateCcw icon and "Restart Session" tooltip
- Clicking restart properly cancels any in-flight streaming and clears local streaming state
- Uses the hook's `clearMessages()` method which handles stream cancellation, cleanup, and session reset
- The action is also callable programmatically via the Actions System for future automation