### PR TITLE
Fix assistant panel scroll position after drag operation

### DIFF
--- a/src/components/Assistant/MessageList.tsx
+++ b/src/components/Assistant/MessageList.tsx
@@ -39,6 +39,7 @@ export function MessageList({ messages, streamingState, className }: MessageList
 
   const streamingTimestampRef = useRef<number>(Date.now());
   const isStreamingRef = useRef(false);
+  const hasScrolledOnMount = useRef(false);
 
   useEffect(() => {
     const wasStreaming = isStreamingRef.current;
@@ -50,6 +51,18 @@ export function MessageList({ messages, streamingState, className }: MessageList
 
     isStreamingRef.current = isStreaming;
   }, [streamingState]);
+
+  // Scroll to bottom on mount when messages exist (handles panel drag/remount)
+  useEffect(() => {
+    if (!hasScrolledOnMount.current && messages.length > 0) {
+      hasScrolledOnMount.current = true;
+      setAutoScroll(true);
+      virtuosoRef.current?.scrollToIndex({
+        index: "LAST",
+        behavior: "auto",
+      });
+    }
+  }, [messages.length]);
 
   const allItems = streamingState
     ? [


### PR DESCRIPTION
## Summary
Fixes the assistant panel not scrolling to bottom after drag operations within the grid layout. After dragging, the panel now correctly restores to a bottom-scrolled position, ensuring users see the most recent messages immediately.

Closes #1945

## Changes Made
- Add useEffect to scroll to bottom on mount when messages exist
- Sync autoScroll state to ensure followOutput continues working
- Use hasScrolledOnMount ref to prevent redundant scroll operations
- Fix "New output" button appearing incorrectly after drag operations

## Testing
- Drag assistant panel multiple times - verifies it's always scrolled to bottom
- "New output" button only appears for actual new messages, not after drag
- Auto-scroll continues to work correctly during active conversations