### PR TITLE
Implement terminal state change listener for assistant

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -260,6 +260,7 @@ export const CHANNELS = {
   ASSISTANT_CANCEL: "assistant:cancel",
   ASSISTANT_CHUNK: "assistant:chunk",
   ASSISTANT_HAS_API_KEY: "assistant:has-api-key",
+  ASSISTANT_CLEAR_SESSION: "assistant:clear-session",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -412,6 +412,7 @@ const CHANNELS = {
   ASSISTANT_CANCEL: "assistant:cancel",
   ASSISTANT_CHUNK: "assistant:chunk",
   ASSISTANT_HAS_API_KEY: "assistant:has-api-key",
+  ASSISTANT_CLEAR_SESSION: "assistant:clear-session",
 } as const;
 
 const api: ElectronAPI = {
@@ -1285,18 +1286,26 @@ const api: ElectronAPI = {
 
     cancel: (sessionId: string) => ipcRenderer.invoke(CHANNELS.ASSISTANT_CANCEL, sessionId),
 
+    clearSession: (sessionId: string) =>
+      ipcRenderer.invoke(CHANNELS.ASSISTANT_CLEAR_SESSION, sessionId),
+
     hasApiKey: () => ipcRenderer.invoke(CHANNELS.ASSISTANT_HAS_API_KEY),
 
     onChunk: (
       callback: (data: {
         sessionId: string;
         chunk: {
-          type: "text" | "tool_call" | "tool_result" | "error" | "done";
+          type: "text" | "tool_call" | "tool_result" | "error" | "done" | "listener_triggered";
           content?: string;
           toolCall?: { id: string; name: string; args: Record<string, unknown> };
           toolResult?: { toolCallId: string; toolName: string; result: unknown; error?: string };
           error?: string;
           finishReason?: string;
+          listenerData?: {
+            listenerId: string;
+            eventType: string;
+            data: Record<string, unknown>;
+          };
         };
       }) => void
     ) => {
@@ -1305,12 +1314,17 @@ const api: ElectronAPI = {
         data: {
           sessionId: string;
           chunk: {
-            type: "text" | "tool_call" | "tool_result" | "error" | "done";
+            type: "text" | "tool_call" | "tool_result" | "error" | "done" | "listener_triggered";
             content?: string;
             toolCall?: { id: string; name: string; args: Record<string, unknown> };
             toolResult?: { toolCallId: string; toolName: string; result: unknown; error?: string };
             error?: string;
             finishReason?: string;
+            listenerData?: {
+              listenerId: string;
+              eventType: string;
+              data: Record<string, unknown>;
+            };
           };
         }
       ) => callback(data);

--- a/electron/services/assistant/TerminalStateListenerBridge.ts
+++ b/electron/services/assistant/TerminalStateListenerBridge.ts
@@ -1,0 +1,66 @@
+import { events } from "../events.js";
+import { listenerManager } from "./ListenerManager.js";
+
+export type ChunkEmitter = (sessionId: string, chunk: {
+  type: "listener_triggered";
+  listenerData: {
+    listenerId: string;
+    eventType: string;
+    data: Record<string, unknown>;
+  };
+}) => void;
+
+let chunkEmitter: ChunkEmitter | null = null;
+let unsubscribe: (() => void) | null = null;
+
+export function initTerminalStateListenerBridge(emitter: ChunkEmitter): void {
+  if (unsubscribe) {
+    destroyTerminalStateListenerBridge();
+  }
+
+  chunkEmitter = emitter;
+
+  unsubscribe = events.on("agent:state-changed", (payload) => {
+    if (!chunkEmitter) {
+      return;
+    }
+
+    const eventData = {
+      terminalId: payload.terminalId,
+      agentId: payload.agentId,
+      oldState: payload.previousState,
+      newState: payload.state,
+      toState: payload.state,
+      worktreeId: payload.worktreeId,
+      timestamp: payload.timestamp,
+    };
+
+    const listeners = listenerManager.getMatchingListeners("terminal:state-changed", eventData);
+
+    for (const listener of listeners) {
+      try {
+        chunkEmitter(listener.sessionId, {
+          type: "listener_triggered",
+          listenerData: {
+            listenerId: listener.id,
+            eventType: "terminal:state-changed",
+            data: eventData,
+          },
+        });
+      } catch (error) {
+        console.error(
+          "[TerminalStateListenerBridge] Failed to emit listener chunk:",
+          error instanceof Error ? error.message : error
+        );
+      }
+    }
+  });
+}
+
+export function destroyTerminalStateListenerBridge(): void {
+  if (unsubscribe) {
+    unsubscribe();
+    unsubscribe = null;
+  }
+  chunkEmitter = null;
+}

--- a/electron/services/assistant/listenerTools.ts
+++ b/electron/services/assistant/listenerTools.ts
@@ -26,7 +26,8 @@ export function createListenerTools(context: ListenerToolContext): ToolSet {
     register_listener: tool({
       description:
         "Subscribe to Canopy events. Returns a listener ID for later removal. " +
-        "Use this to monitor terminal activity, agent state changes, worktree updates, and more.",
+        "Use this to monitor terminal activity, agent state changes, worktree updates, and more. " +
+        "For terminal:state-changed, you can filter by terminalId and toState (e.g., 'completed').",
       inputSchema: jsonSchema({
         type: "object",
         properties: {

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -277,6 +277,12 @@ export const EVENT_META: Record<keyof CanopyEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Terminal reliability metric (pause/suspend/wake timing)",
   },
+  "terminal:state-changed": {
+    category: "agent",
+    requiresContext: true,
+    requiresTimestamp: true,
+    description: "Terminal agent state changed (idle, working, completed, etc.)",
+  },
 
   // Task events
   "task:created": {
@@ -653,6 +659,19 @@ export type CanopyEventMap = {
    */
   "terminal:reliability-metric": TerminalReliabilityMetricPayload;
 
+  /**
+   * Emitted when a terminal's agent state changes.
+   * This is a listener-friendly variant of agent:state-changed focused on terminals.
+   */
+  "terminal:state-changed": WithContext<{
+    terminalId: string;
+    agentId?: string;
+    oldState: AgentState;
+    newState: AgentState;
+    toState: AgentState;
+    worktreeId?: string;
+  }>;
+
   // Task Lifecycle Events (Future-proof for task management)
 
   /**
@@ -748,6 +767,7 @@ export const ALL_EVENT_TYPES: Array<keyof CanopyEventMap> = [
   "terminal:backgrounded",
   "terminal:foregrounded",
   "terminal:reliability-metric",
+  "terminal:state-changed",
   "task:created",
   "task:assigned",
   "task:state-changed",

--- a/shared/types/assistant.ts
+++ b/shared/types/assistant.ts
@@ -28,8 +28,22 @@ export const AssistantMessageSchema = z.object({
 });
 export type AssistantMessage = z.infer<typeof AssistantMessageSchema>;
 
-export const StreamChunkTypeSchema = z.enum(["text", "tool_call", "tool_result", "error", "done"]);
+export const StreamChunkTypeSchema = z.enum([
+  "text",
+  "tool_call",
+  "tool_result",
+  "error",
+  "done",
+  "listener_triggered",
+]);
 export type StreamChunkType = z.infer<typeof StreamChunkTypeSchema>;
+
+export const ListenerTriggeredDataSchema = z.object({
+  listenerId: z.string(),
+  eventType: z.string(),
+  data: z.record(z.string(), z.unknown()),
+});
+export type ListenerTriggeredData = z.infer<typeof ListenerTriggeredDataSchema>;
 
 export const StreamChunkSchema = z.object({
   type: StreamChunkTypeSchema,
@@ -38,6 +52,7 @@ export const StreamChunkSchema = z.object({
   toolResult: ToolResultSchema.optional(),
   error: z.string().optional(),
   finishReason: z.string().optional(),
+  listenerData: ListenerTriggeredDataSchema.optional(),
 });
 export type StreamChunk = z.infer<typeof StreamChunkSchema>;
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -605,6 +605,8 @@ export interface ElectronAPI {
     }): Promise<void>;
     /** Cancel an active streaming session */
     cancel(sessionId: string): Promise<void>;
+    /** Clear session and remove all listeners associated with it */
+    clearSession(sessionId: string): Promise<void>;
     /** Check if API key is configured (uses appAgentConfig) */
     hasApiKey(): Promise<boolean>;
     /** Subscribe to streaming chunks from the assistant */

--- a/src/store/assistantChatStore.ts
+++ b/src/store/assistantChatStore.ts
@@ -147,6 +147,13 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
   },
 
   clearConversation: (panelId) => {
+    const existing = get().conversations[panelId];
+    if (existing?.sessionId) {
+      window.electron.assistant.clearSession(existing.sessionId).catch((err) => {
+        console.error("[AssistantChatStore] Failed to clear session:", err);
+      });
+    }
+
     set((s) => {
       const existing = s.conversations[panelId];
       if (!existing) return s;
@@ -166,6 +173,13 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
   },
 
   removeConversation: (panelId) => {
+    const existing = get().conversations[panelId];
+    if (existing?.sessionId) {
+      window.electron.assistant.clearSession(existing.sessionId).catch((err) => {
+        console.error("[AssistantChatStore] Failed to clear session:", err);
+      });
+    }
+
     set((s) => {
       const { [panelId]: _, ...rest } = s.conversations;
       return { conversations: rest };


### PR DESCRIPTION
## Summary
Implements the first concrete listener type for the assistant: terminal state changes. This allows the assistant to monitor terminal agent state transitions (idle → working → completed) and receive notifications when registered listeners match the event.

Closes #1950

## Changes Made
- Add TerminalStateListenerBridge to connect agent state changes to listeners
- Add terminal:state-changed event type with terminalId and toState filters
- Add listener_triggered chunk type for async event notifications
- Add mount-level chunk subscription for persistent notifications
- Add clearSession IPC method for proper listener cleanup
- Improve notification formatting with state emoji and worktree context