### PR TITLE
Remove inaccurate state transition notifier from agent panels

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -4,7 +4,7 @@ import { PanelHeader } from "./PanelHeader";
 import { useIsDragging } from "@/components/DragDrop";
 import { TitleEditingProvider, useTitleEditing } from "./TitleEditingContext";
 import { TerminalHeaderContent } from "@/components/Terminal/TerminalHeaderContent";
-import type { PanelKind, TerminalType, AgentState, AgentStateChangeTrigger } from "@/types";
+import type { PanelKind, TerminalType, AgentState } from "@/types";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import type { TabInfo } from "./TabButton";
 
@@ -57,8 +57,6 @@ export interface ContentPanelProps extends BasePanelProps {
   lastCommand?: string;
   queueCount?: number;
   flowStatus?: "running" | "paused-backpressure" | "paused-user" | "suspended";
-  stateChangeTrigger?: AgentStateChangeTrigger;
-  stateChangeConfidence?: number;
   onRestart?: () => void;
   isPinged?: boolean;
   wasJustSelected?: boolean;
@@ -109,8 +107,6 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     lastCommand,
     queueCount = 0,
     flowStatus,
-    stateChangeTrigger,
-    stateChangeConfidence,
     onRestart,
     isPinged,
     wasJustSelected,
@@ -153,8 +149,6 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
           exitCode={exitCode}
           queueCount={queueCount}
           flowStatus={flowStatus}
-          stateChangeTrigger={stateChangeTrigger}
-          stateChangeConfidence={stateChangeConfidence}
         />
       );
     }
@@ -171,8 +165,6 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
     exitCode,
     queueCount,
     flowStatus,
-    stateChangeTrigger,
-    stateChangeConfidence,
   ]);
 
   const handleTitleDoubleClick = useCallback(

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -184,13 +184,12 @@ function TerminalPaneComponent({
       return {
         isInputLocked: terminal?.isInputLocked ?? false,
         stateChangeTrigger: terminal?.stateChangeTrigger,
-        stateChangeConfidence: terminal?.stateChangeConfidence,
         isRestarting: terminal?.isRestarting ?? false,
       };
     })
   );
 
-  const { isInputLocked, stateChangeTrigger, stateChangeConfidence, isRestarting } = terminalState;
+  const { isInputLocked, stateChangeTrigger, isRestarting } = terminalState;
 
   const isBackendDisconnected = backendStatus === "disconnected";
   const isBackendRecovering = backendStatus === "recovering";
@@ -472,8 +471,6 @@ function TerminalPaneComponent({
       lastCommand={lastCommand}
       queueCount={queueCount}
       flowStatus={flowStatus}
-      stateChangeTrigger={stateChangeTrigger}
-      stateChangeConfidence={stateChangeConfidence}
       isPinged={isPinged}
       wasJustSelected={wasJustSelected}
       tabs={tabs}


### PR DESCRIPTION
## Summary
This PR removes the unreliable "Transitioned to X: new output appeared" messages and low-confidence warnings from agent panel tooltips. The state transition tracking feature frequently showed incorrect information and degraded the user experience rather than improving it.

Closes #1975

## Changes Made
- Remove formatStateTransitionReason function and transition reason display from tooltips
- Remove confidence warning display from agent panel tooltips
- Simplify tooltip to show only activity headline (when available) or agent state
- Remove stateChangeTrigger and stateChangeConfidence props from UI components
- Keep stateChangeTrigger in TerminalPane for HybridInputBar readiness check
- Improve empty headline handling with trim() check

## Testing
- All tests pass (1805 tests)
- TypeScript compilation successful
- Hybrid input tests validated (34/34 tests pass)