### PR TITLE
Fix assistant tool calls not displaying during streaming

### DIFF
--- a/electron/services/assistant/TerminalStateListenerBridge.ts
+++ b/electron/services/assistant/TerminalStateListenerBridge.ts
@@ -1,14 +1,17 @@
 import { events } from "../events.js";
 import { listenerManager } from "./ListenerManager.js";
 
-export type ChunkEmitter = (sessionId: string, chunk: {
-  type: "listener_triggered";
-  listenerData: {
-    listenerId: string;
-    eventType: string;
-    data: Record<string, unknown>;
-  };
-}) => void;
+export type ChunkEmitter = (
+  sessionId: string,
+  chunk: {
+    type: "listener_triggered";
+    listenerData: {
+      listenerId: string;
+      eventType: string;
+      data: Record<string, unknown>;
+    };
+  }
+) => void;
 
 let chunkEmitter: ChunkEmitter | null = null;
 let unsubscribe: (() => void) | null = null;

--- a/src/components/Assistant/InteractionBlock.tsx
+++ b/src/components/Assistant/InteractionBlock.tsx
@@ -67,7 +67,7 @@ export function InteractionBlock({
           </div>
         )}
 
-        {(hasContent || isStreaming) && (
+        {(hasContent || (isStreaming && !hasToolCalls)) && (
           <div>
             <MarkdownRenderer
               content={message.content}
@@ -76,6 +76,8 @@ export function InteractionBlock({
             {isStreaming && <StreamingCursor />}
           </div>
         )}
+
+        {isStreaming && hasToolCalls && !hasContent && <StreamingCursor className="ml-0" />}
 
         {!hasContent && !hasToolCalls && !isStreaming && (
           <div className="text-canopy-text/40 text-sm italic">No response content</div>


### PR DESCRIPTION
## Summary

Fixes issue where assistant tool calls don't display during streaming when the response contains only tool calls without any text content. This caused the assistant to appear inactive, then later seem to "forget" what it did and repeat actions.

Closes #1971

## Changes Made

- Use dynamic streaming key based on tool call status to force Virtuoso re-renders when tool calls are added or updated
- Fix race condition in finalizeStreaming using functional setState to capture the most recent streaming state
- Add error chunk cleanup to prevent stuck loading state when streaming errors occur
- Handle out-of-order tool_result chunks by creating placeholder tool calls
- Show streaming cursor for tool-call-only responses without content

## Technical Details

**Root Cause:**
Virtuoso's virtualization was optimizing away re-renders for items with stable keys. When tool calls arrived during streaming, the streaming item had a static `__streaming__` key, so Virtuoso didn't detect the change and skipped re-rendering.

**Solution:**
1. Dynamic streaming key that includes tool call count and status (e.g., `__streaming__:2:pending,success`)
2. Functional setState in finalizeStreaming to avoid stale ref race conditions
3. Proper error handling and cleanup for edge cases

## Testing

- Verified tool-call-only responses now display during streaming
- Confirmed tool call status updates (pending → success/error) render correctly
- Tested error scenarios with proper cleanup