### PR TITLE
Add event listener documentation and context integration

### DIFF
--- a/electron/services/AssistantService.ts
+++ b/electron/services/AssistantService.ts
@@ -86,7 +86,12 @@ export class AssistantService {
 
     try {
       // Build context block for the system prompt
-      const contextBlock = context ? buildContextBlock(context) : "";
+      const activeListenerCount = listenerManager.countForSession(sessionId);
+      const contextBlock = context
+        ? buildContextBlock({ ...context, activeListenerCount })
+        : activeListenerCount > 0
+          ? buildContextBlock({ activeListenerCount })
+          : "";
       const systemPromptWithContext = contextBlock
         ? `${SYSTEM_PROMPT}\n\n${contextBlock}`
         : SYSTEM_PROMPT;

--- a/electron/services/assistant/ListenerManager.ts
+++ b/electron/services/assistant/ListenerManager.ts
@@ -46,6 +46,16 @@ export class ListenerManager {
     return result;
   }
 
+  countForSession(sessionId: string): number {
+    let count = 0;
+    for (const listener of this.listeners.values()) {
+      if (listener.sessionId === sessionId) {
+        count++;
+      }
+    }
+    return count;
+  }
+
   clearSession(sessionId: string): void {
     const toRemove: string[] = [];
     for (const listener of this.listeners.values()) {

--- a/electron/services/assistant/systemPrompt.ts
+++ b/electron/services/assistant/systemPrompt.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app } from "electron";
+import type { ActionContext } from "../../../shared/types/actions.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -40,14 +41,9 @@ export const SYSTEM_PROMPT = loadSystemPrompt();
  * Template for constructing the context block in user messages
  * Only includes fields that are useful for agent decision-making
  */
-export function buildContextBlock(context: {
-  projectId?: string;
-  activeWorktreeId?: string;
-  focusedWorktreeId?: string;
-  focusedTerminalId?: string;
-  isTerminalPaletteOpen?: boolean;
-  isSettingsOpen?: boolean;
-}): string {
+export function buildContextBlock(
+  context: ActionContext & { activeListenerCount?: number }
+): string {
   const lines: string[] = [];
 
   if (context.projectId) {
@@ -67,6 +63,9 @@ export function buildContextBlock(context: {
   }
   if (context.isSettingsOpen) {
     lines.push(`Settings: open`);
+  }
+  if (context.activeListenerCount && context.activeListenerCount > 0) {
+    lines.push(`Active listeners: ${context.activeListenerCount}`);
   }
 
   return lines.length > 0 ? `Context:\n${lines.join("\n")}` : "";

--- a/electron/services/assistant/systemPrompt.txt
+++ b/electron/services/assistant/systemPrompt.txt
@@ -230,6 +230,54 @@ Never claim success unless `success: true`.
 - Redact sensitive values in responses
 - Never echo tokens or keys
 
+## Event Listeners
+
+You can subscribe to events to be notified when things happen in the application.
+
+### Available Events
+
+**Currently supported:**
+- `terminal:state-changed` - Notified when a terminal's agent state changes
+  - Filter by `terminalId` for a specific terminal
+  - Filter by `toState` for specific transitions (e.g., `"completed"`, `"failed"`, `"working"`)
+  - Filter by `oldState`, `newState`, `worktreeId`, or `agentId`
+  - States: `idle`, `working`, `running`, `waiting`, `completed`, `failed`
+  - **Note:** Filters use exact match (no arrays or regex)
+
+### Listener Tools
+
+- `register_listener` - Subscribe to an event type with optional filters
+- `list_listeners` - List your active listeners
+- `remove_listener` - Unsubscribe by listener ID
+
+### Best Practices
+
+- Register listeners when monitoring ongoing processes (e.g., agent task completion)
+- Always clean up listeners when no longer needed to avoid noise
+- Use filters to narrow events—don't subscribe to everything
+- When a listener triggers, you'll see a notification message in the chat with a summary (state change, terminal, and worktree info)
+- To monitor both success and failure, register two listeners (one for `toState: "completed"`, one for `toState: "failed"`)
+
+### Example Usage
+
+When a user asks to run a long task and wants to be notified when done:
+
+1. Run the command in the terminal
+2. Register a listener and save the ID:
+   ```
+   const result = register_listener({
+     eventType: "terminal:state-changed",
+     filter: { terminalId: "<id>", toState: "completed" }
+   })
+   // result.listenerId contains the ID for later removal
+   ```
+3. When the terminal completes, you'll receive a notification message
+4. Inform the user the task is done
+5. Remove the listener: `remove_listener({ listenerId: "<saved-id>" })`
+   - Or use `list_listeners` to find active listeners if you didn't save the ID
+
+**Note:** Listeners are scoped to your conversation session and automatically cleared when the session ends.
+
 ## Stop Conditions
 
 Stop when:


### PR DESCRIPTION
## Summary

This PR implements issue #1951, adding comprehensive documentation for event listener capabilities to the assistant's system prompt and integrating active listener count into the context block.

The assistant can now use event listeners to monitor ongoing processes (like agent task completion) and be notified when terminal states change. The system prompt provides clear guidance on:
- Available events (currently `terminal:state-changed`)
- Filter options and exact-match behavior
- Best practices for listener management
- Example usage with proper listener ID handling

Closes #1951

## Changes Made

- Add Event Listeners section to system prompt with detailed guidance
- Document terminal:state-changed event with filter options and best practices
- Include example usage showing listener ID handling and cleanup
- Integrate active listener count into assistant context block
- Add countForSession() method to ListenerManager for performance
- Use ActionContext type for buildContextBlock parameter to ensure type safety