### PR TITLE
Refine assistant UI execution log aesthetic

### DIFF
--- a/electron/services/assistant/TerminalStateListenerBridge.ts
+++ b/electron/services/assistant/TerminalStateListenerBridge.ts
@@ -1,14 +1,17 @@
 import { events } from "../events.js";
 import { listenerManager } from "./ListenerManager.js";
 
-export type ChunkEmitter = (sessionId: string, chunk: {
-  type: "listener_triggered";
-  listenerData: {
-    listenerId: string;
-    eventType: string;
-    data: Record<string, unknown>;
-  };
-}) => void;
+export type ChunkEmitter = (
+  sessionId: string,
+  chunk: {
+    type: "listener_triggered";
+    listenerData: {
+      listenerId: string;
+      eventType: string;
+      data: Record<string, unknown>;
+    };
+  }
+) => void;
 
 let chunkEmitter: ChunkEmitter | null = null;
 let unsubscribe: (() => void) | null = null;

--- a/src/components/Assistant/AssistantInput.tsx
+++ b/src/components/Assistant/AssistantInput.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { ArrowUp, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface AssistantInputHandle {
@@ -8,6 +9,8 @@ export interface AssistantInputHandle {
 
 interface AssistantInputProps {
   onSubmit: (value: string) => void;
+  onCancel?: () => void;
+  isStreaming?: boolean;
   disabled?: boolean;
   placeholder?: string;
   className?: string;
@@ -17,6 +20,8 @@ export const AssistantInput = forwardRef<AssistantInputHandle, AssistantInputPro
   (
     {
       onSubmit,
+      onCancel,
+      isStreaming = false,
       disabled = false,
       placeholder = "Execute a command or ask a question...",
       className,
@@ -84,22 +89,22 @@ export const AssistantInput = forwardRef<AssistantInputHandle, AssistantInputPro
       textareaRef.current?.focus();
     }, []);
 
+    const canSubmit = value.trim().length > 0 && !disabled;
+
     return (
-      <div className={cn("group shrink-0 cursor-text bg-canopy-bg px-4 pb-3 pt-3", className)}>
+      <div className={cn("shrink-0 cursor-text bg-canopy-sidebar/20", className)}>
         <div
           className={cn(
-            "relative flex w-full items-center gap-1.5 rounded-sm border border-white/[0.06] bg-white/[0.03] py-1 shadow-[0_6px_12px_rgba(0,0,0,0.18)] transition-colors",
-            "group-hover:border-white/[0.08] group-hover:bg-white/[0.04]",
-            "focus-within:border-white/[0.12] focus-within:ring-1 focus-within:ring-white/[0.06] focus-within:bg-white/[0.05]",
-            disabled && "opacity-60 pointer-events-none"
+            "flex items-start gap-2 px-3 py-2",
+            disabled && !isStreaming && "opacity-60 pointer-events-none"
           )}
           onClick={handleContainerClick}
         >
           <div
-            className="select-none pl-2 pr-1 font-mono text-xs font-semibold leading-5 text-canopy-accent/85"
+            className="shrink-0 pt-1.5 select-none font-mono text-lg text-canopy-text/40"
             aria-hidden="true"
           >
-            ❯
+            ›
           </div>
 
           <textarea
@@ -113,12 +118,44 @@ export const AssistantInput = forwardRef<AssistantInputHandle, AssistantInputPro
             disabled={disabled}
             rows={1}
             className={cn(
-              "flex-1 max-h-[200px] min-h-[24px] resize-none bg-transparent text-sm text-canopy-text",
+              "flex-1 max-h-[200px] min-h-[24px] resize-none bg-transparent text-sm text-canopy-text pt-1",
               "placeholder:text-canopy-text/30 focus:outline-none scrollbar-none font-mono"
             )}
             aria-label="Command input"
             aria-keyshortcuts="Enter Shift+Enter"
           />
+
+          {isStreaming && onCancel ? (
+            <button
+              type="button"
+              onClick={onCancel}
+              className={cn(
+                "shrink-0 mt-0.5 p-1.5 rounded transition-colors",
+                "text-red-400 hover:bg-red-500/10"
+              )}
+              aria-label="Cancel response"
+            >
+              <Square className="w-4 h-4" />
+            </button>
+          ) : (
+            canSubmit && (
+              <button
+                type="button"
+                onClick={handleSubmit}
+                className={cn(
+                  "shrink-0 mt-0.5 p-1.5 rounded transition-colors",
+                  "text-canopy-accent hover:bg-canopy-accent/10"
+                )}
+                aria-label="Submit"
+              >
+                <ArrowUp className="w-4 h-4" />
+              </button>
+            )
+          )}
+        </div>
+
+        <div className="px-3 pb-1 text-[10px] text-canopy-text/20">
+          <kbd className="font-mono">⇧⏎</kbd> newline
         </div>
       </div>
     );

--- a/src/components/Assistant/InteractionBlock.tsx
+++ b/src/components/Assistant/InteractionBlock.tsx
@@ -21,23 +21,17 @@ export function InteractionBlock({
     return (
       <div
         className={cn(
-          "group relative flex w-full gap-3 bg-canopy-sidebar/30 px-4 py-3 border-b border-divider/40",
+          "group relative flex w-full gap-3 px-4 py-2 border-l-2 border-canopy-accent/30",
           className
         )}
-        role="log"
+        role="article"
         aria-label="User input"
       >
-        <div className="shrink-0 text-canopy-accent pt-[2px]" aria-hidden="true">
+        <div className="shrink-0 text-canopy-accent/60 pt-[2px]" aria-hidden="true">
           <Terminal className="w-3.5 h-3.5" />
         </div>
         <div className="prose-sm font-mono text-sm leading-relaxed text-canopy-text/90 w-full break-words whitespace-pre-wrap">
           {message.content}
-        </div>
-        <div
-          className="absolute right-2 top-2 opacity-0 group-hover:opacity-100 text-[10px] text-canopy-text/30 transition-opacity"
-          aria-hidden="true"
-        >
-          INPUT
         </div>
       </div>
     );
@@ -52,7 +46,7 @@ export function InteractionBlock({
         "flex w-full gap-3 px-4 py-4 border-b border-divider/20 hover:bg-white/[0.01] transition-colors",
         className
       )}
-      role="log"
+      role="article"
       aria-label="Assistant response"
     >
       <div className="shrink-0 pt-[3px]" aria-hidden="true">


### PR DESCRIPTION
## Summary
Refines the Assistant UI to feel more like an integrated execution log (Jupyter notebook, CI/CD logs) and less like a consumer chat app. Implements visual cohesion improvements aligned with Canopy's "Mission Control" aesthetic.

Closes #1977

## Changes Made
- Replace "Run" badge with icon button (ArrowUp/Square) that transitions to cancel state
- Remove floating cancel button and integrate cancel functionality into input area icon
- Convert error display from floating alert box to inline log entry with left red border
- Replace user message full background with left accent border for reduced visual weight
- Simplify empty state by removing "System Ready/Configuration Required" status language
- Add suggested action pills with distinct styling (accent colors, "Suggested actions" label)
- Fix ARIA roles: use role="article" for messages instead of nested role="log"
- Add chip truncation with tooltips for long project/branch names
- Improve input area: subtle background instead of hard border, reduced padding for higher density
- Add focus management to return focus to input after suggested action submit
- Fix error text wrapping with whitespace-pre-wrap and break-words
- Guard cancel button render when onCancel is undefined
- Limit select-none to watermark only for better text selection

## Code Review Fixes
Applied recommendations from comprehensive Codex review:
- Error text wrapping and breaking for long/multiline messages
- Cancel button conditional rendering guard
- ARIA accessibility improvements
- Context chip truncation and tooltips
- Global scope logic based on activeWorktreeId presence
- Enhanced suggested actions affordance
- Focus management for keyboard navigation