### PR TITLE
Add worktree orchestration API for task isolation

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -11,6 +11,9 @@ export const CHANNELS = {
   WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
   WORKTREE_GET_AVAILABLE_BRANCH: "worktree:get-available-branch",
   WORKTREE_DELETE: "worktree:delete",
+  WORKTREE_CREATE_FOR_TASK: "worktree:create-for-task",
+  WORKTREE_GET_BY_TASK_ID: "worktree:get-by-task-id",
+  WORKTREE_CLEANUP_TASK: "worktree:cleanup-task",
 
   TERMINAL_SPAWN: "terminal:spawn",
   TERMINAL_SPAWN_RESULT: "terminal:spawn-result",

--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -4,12 +4,60 @@ import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
 import type { WorktreeSetActivePayload, WorktreeDeletePayload } from "../../types/index.js";
 import type { PulseRangeDays, ProjectPulse } from "../../../shared/types/pulse.js";
+import type {
+  CreateForTaskPayload,
+  CleanupTaskOptions,
+} from "../../../shared/types/ipc/worktree.js";
+import type { WorktreeState } from "../../../shared/types/domain.js";
 import {
   generateWorktreePath,
   DEFAULT_WORKTREE_PATH_PATTERN,
   validatePathPattern,
 } from "../../../shared/utils/pathPattern.js";
 import { GitService } from "../../services/GitService.js";
+import { logDebug, logError } from "../../utils/logger.js";
+
+// In-memory map to track taskId -> worktreeIds for orchestration
+// Scoped by projectId to avoid cross-project collisions
+// This is stored in-process since taskId is transient orchestration metadata
+const taskWorktreeMap = new Map<string, Map<string, Set<string>>>();
+
+function getProjectTaskMap(projectId: string): Map<string, Set<string>> {
+  if (!taskWorktreeMap.has(projectId)) {
+    taskWorktreeMap.set(projectId, new Map());
+  }
+  return taskWorktreeMap.get(projectId)!;
+}
+
+function addTaskWorktreeMapping(projectId: string, taskId: string, worktreeId: string): void {
+  const projectMap = getProjectTaskMap(projectId);
+  if (!projectMap.has(taskId)) {
+    projectMap.set(taskId, new Set());
+  }
+  projectMap.get(taskId)!.add(worktreeId);
+}
+
+function removeTaskWorktreeMapping(projectId: string, taskId: string, worktreeId: string): void {
+  const projectMap = getProjectTaskMap(projectId);
+  const worktrees = projectMap.get(taskId);
+  if (worktrees) {
+    worktrees.delete(worktreeId);
+    if (worktrees.size === 0) {
+      projectMap.delete(taskId);
+    }
+  }
+}
+
+function getWorktreeIdsForTask(projectId: string, taskId: string): string[] {
+  const projectMap = getProjectTaskMap(projectId);
+  const worktrees = projectMap.get(taskId);
+  return worktrees ? Array.from(worktrees) : [];
+}
+
+// Commented out for now - will be needed when implementing project switch cleanup
+// function clearProjectMappings(projectId: string): void {
+//   taskWorktreeMap.delete(projectId);
+// }
 
 export function registerWorktreeHandlers(deps: HandlerDependencies): () => void {
   const { worktreeService: workspaceClient } = deps;
@@ -297,6 +345,330 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
   };
   ipcMain.handle(CHANNELS.GIT_LIST_COMMITS, handleGitListCommits);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_LIST_COMMITS));
+
+  // Task orchestration handlers
+
+  const handleWorktreeCreateForTask = async (
+    _event: Electron.IpcMainInvokeEvent,
+    payload: CreateForTaskPayload
+  ): Promise<WorktreeState> => {
+    if (!workspaceClient) {
+      throw new Error("Workspace client not initialized");
+    }
+
+    if (!payload || typeof payload !== "object") {
+      throw new Error("Invalid payload for worktree:create-for-task");
+    }
+
+    const { taskId, baseBranch, description } = payload;
+
+    if (typeof taskId !== "string" || !taskId.trim()) {
+      throw new Error("Invalid taskId: must be a non-empty string");
+    }
+
+    // Get the current project to determine root path
+    const projectsData = store.get("projects");
+    const currentProjectId = projectsData?.currentProjectId;
+    const projectsList = projectsData?.list;
+    const project = projectsList?.find((p) => p.id === currentProjectId);
+
+    if (!project || !project.path) {
+      throw new Error("No active project found");
+    }
+
+    const rootPath = project.path;
+
+    // Get all states to find the main worktree and determine base branch
+    const states = await workspaceClient.getAllStatesAsync();
+    const mainWorktree = states.find((wt) => wt.isMainWorktree);
+
+    // Use provided baseBranch, or default to main worktree's branch, or "main"
+    const effectiveBaseBranch = baseBranch || mainWorktree?.branch || "main";
+
+    // Generate collision-safe branch name: task-{taskId} with suffix if needed
+    const gitService = new GitService(rootPath);
+    const baseBranchName = `task-${taskId}`;
+    const availableBranchName = await gitService.findAvailableBranchName(baseBranchName);
+
+    // Generate path using the worktree path pattern
+    const configPattern = store.get("worktreeConfig.pathPattern");
+    const pattern =
+      typeof configPattern === "string" && configPattern.trim()
+        ? configPattern
+        : DEFAULT_WORKTREE_PATH_PATTERN;
+
+    const initialPath = generateWorktreePath(rootPath, availableBranchName, pattern);
+    const availablePath = gitService.findAvailablePath(initialPath);
+
+    logDebug("Creating worktree for task", {
+      taskId,
+      projectId: project.id,
+      branch: availableBranchName,
+      path: availablePath,
+      baseBranch: effectiveBaseBranch,
+      description,
+    });
+
+    let worktreeId: string;
+    try {
+      // Create the worktree
+      worktreeId = await workspaceClient.createWorktree(rootPath, {
+        baseBranch: effectiveBaseBranch,
+        newBranch: availableBranchName,
+        path: availablePath,
+      });
+
+      // Store the taskId mapping
+      addTaskWorktreeMapping(project.id, taskId, worktreeId);
+
+      logDebug("Worktree created for task", {
+        worktreeId,
+        taskId,
+        projectId: project.id,
+        branch: availableBranchName,
+        path: availablePath,
+      });
+    } catch (error) {
+      // Worktree creation failed, don't leave partial state
+      logError(
+        "Failed to create worktree for task",
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          taskId,
+          projectId: project.id,
+        }
+      );
+      throw error;
+    }
+
+    // Wait for the monitor to be ready and return the full state
+    // Retry a few times since the worktree might not be fully indexed yet
+    let state: WorktreeState | null = null;
+    try {
+      for (let i = 0; i < 5; i++) {
+        const monitor = await workspaceClient.getMonitorAsync(worktreeId);
+        if (monitor) {
+          state = {
+            id: monitor.id,
+            path: monitor.path,
+            name: monitor.name,
+            branch: monitor.branch,
+            isCurrent: monitor.isCurrent,
+            isMainWorktree: monitor.isMainWorktree,
+            gitDir: monitor.gitDir,
+            summary: monitor.summary,
+            modifiedCount: monitor.modifiedCount,
+            changes: monitor.changes,
+            mood: monitor.mood,
+            lastActivityTimestamp: monitor.lastActivityTimestamp ?? null,
+            createdAt: monitor.createdAt,
+            aiNote: monitor.aiNote,
+            aiNoteTimestamp: monitor.aiNoteTimestamp,
+            issueNumber: monitor.issueNumber,
+            prNumber: monitor.prNumber,
+            prUrl: monitor.prUrl,
+            prState: monitor.prState,
+            prTitle: monitor.prTitle,
+            issueTitle: monitor.issueTitle,
+            worktreeChanges: monitor.worktreeChanges ?? null,
+            worktreeId: monitor.worktreeId,
+            taskId,
+          };
+          break;
+        }
+        // Wait before retrying
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+
+      if (!state) {
+        // Worktree was created but not yet indexed, return minimal state
+        state = {
+          id: worktreeId,
+          path: availablePath,
+          name: availableBranchName,
+          branch: availableBranchName,
+          isCurrent: false,
+          lastActivityTimestamp: null,
+          worktreeId: worktreeId,
+          worktreeChanges: null,
+          taskId,
+        };
+      }
+
+      return state;
+    } catch (error) {
+      // Monitor polling failed - worktree exists but we can't get its state
+      // Return minimal state rather than failing completely
+      logError(
+        "Failed to get monitor state after creating worktree",
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          worktreeId,
+          taskId,
+          projectId: project.id,
+        }
+      );
+
+      return {
+        id: worktreeId,
+        path: availablePath,
+        name: availableBranchName,
+        branch: availableBranchName,
+        isCurrent: false,
+        lastActivityTimestamp: null,
+        worktreeId: worktreeId,
+        worktreeChanges: null,
+        taskId,
+      };
+    }
+  };
+  ipcMain.handle(CHANNELS.WORKTREE_CREATE_FOR_TASK, handleWorktreeCreateForTask);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CREATE_FOR_TASK));
+
+  const handleWorktreeGetByTaskId = async (
+    _event: Electron.IpcMainInvokeEvent,
+    taskId: string
+  ): Promise<WorktreeState[]> => {
+    if (!workspaceClient) {
+      throw new Error("Workspace client not initialized");
+    }
+
+    if (typeof taskId !== "string" || !taskId.trim()) {
+      throw new Error("Invalid taskId: must be a non-empty string");
+    }
+
+    // Get current project to scope the lookup
+    const projectsData = store.get("projects");
+    const currentProjectId = projectsData?.currentProjectId;
+    if (!currentProjectId) {
+      throw new Error("No active project found");
+    }
+
+    const worktreeIds = getWorktreeIdsForTask(currentProjectId, taskId);
+    const results: WorktreeState[] = [];
+
+    for (const worktreeId of worktreeIds) {
+      const monitor = await workspaceClient.getMonitorAsync(worktreeId);
+      if (monitor) {
+        results.push({
+          id: monitor.id,
+          path: monitor.path,
+          name: monitor.name,
+          branch: monitor.branch,
+          isCurrent: monitor.isCurrent,
+          isMainWorktree: monitor.isMainWorktree,
+          gitDir: monitor.gitDir,
+          summary: monitor.summary,
+          modifiedCount: monitor.modifiedCount,
+          changes: monitor.changes,
+          mood: monitor.mood,
+          lastActivityTimestamp: monitor.lastActivityTimestamp ?? null,
+          createdAt: monitor.createdAt,
+          aiNote: monitor.aiNote,
+          aiNoteTimestamp: monitor.aiNoteTimestamp,
+          issueNumber: monitor.issueNumber,
+          prNumber: monitor.prNumber,
+          prUrl: monitor.prUrl,
+          prState: monitor.prState,
+          prTitle: monitor.prTitle,
+          issueTitle: monitor.issueTitle,
+          worktreeChanges: monitor.worktreeChanges ?? null,
+          worktreeId: monitor.worktreeId,
+          taskId,
+        });
+      }
+    }
+
+    return results;
+  };
+  ipcMain.handle(CHANNELS.WORKTREE_GET_BY_TASK_ID, handleWorktreeGetByTaskId);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_BY_TASK_ID));
+
+  const handleWorktreeCleanupTask = async (
+    _event: Electron.IpcMainInvokeEvent,
+    taskId: string,
+    options?: CleanupTaskOptions
+  ): Promise<void> => {
+    if (!workspaceClient) {
+      throw new Error("Workspace client not initialized");
+    }
+
+    if (typeof taskId !== "string" || !taskId.trim()) {
+      throw new Error("Invalid taskId: must be a non-empty string");
+    }
+
+    // Get current project to scope the cleanup
+    const projectsData = store.get("projects");
+    const currentProjectId = projectsData?.currentProjectId;
+    if (!currentProjectId) {
+      throw new Error("No active project found");
+    }
+
+    const worktreeIds = getWorktreeIdsForTask(currentProjectId, taskId);
+
+    if (worktreeIds.length === 0) {
+      // No worktrees to clean up, return silently (idempotent)
+      return;
+    }
+
+    const force = options?.force ?? true;
+    const deleteBranch = options?.deleteBranch ?? true;
+
+    logDebug("Cleaning up worktrees for task", {
+      taskId,
+      projectId: currentProjectId,
+      worktreeIds,
+      force,
+      deleteBranch,
+    });
+
+    const errors: string[] = [];
+
+    for (const worktreeId of worktreeIds) {
+      try {
+        await workspaceClient.deleteWorktree(worktreeId, force, deleteBranch);
+
+        // Remove from tracking after successful deletion
+        removeTaskWorktreeMapping(currentProjectId, taskId, worktreeId);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+
+        // If worktree not found, treat as success and remove mapping (idempotent)
+        if (errorMessage.includes("not found") || errorMessage.includes("does not exist")) {
+          logDebug("Worktree already removed, cleaning up mapping", {
+            worktreeId,
+            taskId,
+            projectId: currentProjectId,
+          });
+          removeTaskWorktreeMapping(currentProjectId, taskId, worktreeId);
+        } else {
+          logError(
+            "Failed to cleanup worktree",
+            error instanceof Error ? error : new Error(errorMessage),
+            {
+              worktreeId,
+              taskId,
+              projectId: currentProjectId,
+            }
+          );
+          errors.push(`${worktreeId}: ${errorMessage}`);
+        }
+      }
+    }
+
+    logDebug("Task cleanup completed", {
+      taskId,
+      projectId: currentProjectId,
+      worktreeIds,
+      errors: errors.length > 0 ? errors : undefined,
+    });
+
+    if (errors.length > 0) {
+      throw new Error(`Failed to cleanup some worktrees: ${errors.join("; ")}`);
+    }
+  };
+  ipcMain.handle(CHANNELS.WORKTREE_CLEANUP_TASK, handleWorktreeCleanupTask);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CLEANUP_TASK));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -133,6 +133,9 @@ const CHANNELS = {
   WORKTREE_GET_DEFAULT_PATH: "worktree:get-default-path",
   WORKTREE_GET_AVAILABLE_BRANCH: "worktree:get-available-branch",
   WORKTREE_DELETE: "worktree:delete",
+  WORKTREE_CREATE_FOR_TASK: "worktree:create-for-task",
+  WORKTREE_GET_BY_TASK_ID: "worktree:get-by-task-id",
+  WORKTREE_CLEANUP_TASK: "worktree:cleanup-task",
 
   // Terminal channels
   TERMINAL_SPAWN: "terminal:spawn",
@@ -441,6 +444,14 @@ const api: ElectronAPI = {
 
     delete: (worktreeId: string, force?: boolean, deleteBranch?: boolean) =>
       _typedInvoke(CHANNELS.WORKTREE_DELETE, { worktreeId, force, deleteBranch }),
+
+    createForTask: (payload: { taskId: string; baseBranch?: string; description?: string }) =>
+      _typedInvoke(CHANNELS.WORKTREE_CREATE_FOR_TASK, payload),
+
+    getByTaskId: (taskId: string) => _typedInvoke(CHANNELS.WORKTREE_GET_BY_TASK_ID, taskId),
+
+    cleanupTask: (taskId: string, options?: { force?: boolean; deleteBranch?: boolean }) =>
+      _typedInvoke(CHANNELS.WORKTREE_CLEANUP_TASK, taskId, options),
 
     onUpdate: (callback: (state: WorktreeState) => void) =>
       _typedOn(CHANNELS.WORKTREE_UPDATE, callback),

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -132,6 +132,9 @@ export interface Worktree {
 
   /** Worktree changes snapshot */
   worktreeChanges?: WorktreeChanges | null;
+
+  /** Task ID for task-scoped worktree orchestration */
+  taskId?: string;
 }
 
 /** Runtime worktree state (internal to WorktreeService) */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -11,7 +11,13 @@ import type {
 } from "../domain.js";
 import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 
-import type { CreateWorktreeOptions, BranchInfo, WorktreeConfig } from "./worktree.js";
+import type {
+  CreateWorktreeOptions,
+  BranchInfo,
+  WorktreeConfig,
+  CreateForTaskPayload,
+  CleanupTaskOptions,
+} from "./worktree.js";
 import type {
   TerminalSpawnOptions,
   TerminalReconnectResult,
@@ -95,6 +101,24 @@ export interface ElectronAPI {
     getDefaultPath(rootPath: string, branchName: string): Promise<string>;
     getAvailableBranch(rootPath: string, branchName: string): Promise<string>;
     delete(worktreeId: string, force?: boolean, deleteBranch?: boolean): Promise<void>;
+    /**
+     * Create a worktree for a specific task with auto-generated collision-safe branch name.
+     * @param payload - Contains taskId, optional baseBranch, and optional description
+     * @returns The created worktree state including the assigned taskId
+     */
+    createForTask(payload: CreateForTaskPayload): Promise<WorktreeState>;
+    /**
+     * Get all worktrees linked to a specific task.
+     * @param taskId - The task ID to filter by
+     * @returns Array of worktree states matching the taskId
+     */
+    getByTaskId(taskId: string): Promise<WorktreeState[]>;
+    /**
+     * Cleanup worktrees associated with a task.
+     * @param taskId - The task ID whose worktrees should be cleaned up
+     * @param options - Optional: { force: boolean, deleteBranch: boolean } (defaults: force=true, deleteBranch=true)
+     */
+    cleanupTask(taskId: string, options?: CleanupTaskOptions): Promise<void>;
     onUpdate(callback: (state: WorktreeState) => void): () => void;
     onRemove(callback: (data: { worktreeId: string }) => void): () => void;
   };

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -18,6 +18,8 @@ import type {
   CreateWorktreeOptions,
   BranchInfo,
   WorktreeConfig,
+  CreateForTaskPayload,
+  CleanupTaskOptions,
 } from "./worktree.js";
 import type {
   TerminalSpawnOptions,
@@ -134,6 +136,18 @@ export interface IpcInvokeMap {
   };
   "worktree:delete": {
     args: [payload: WorktreeDeletePayload];
+    result: void;
+  };
+  "worktree:create-for-task": {
+    args: [payload: CreateForTaskPayload];
+    result: WorktreeState;
+  };
+  "worktree:get-by-task-id": {
+    args: [taskId: string];
+    result: WorktreeState[];
+  };
+  "worktree:cleanup-task": {
+    args: [taskId: string, options?: CleanupTaskOptions];
     result: void;
   };
 

--- a/shared/types/ipc/worktree.ts
+++ b/shared/types/ipc/worktree.ts
@@ -35,3 +35,18 @@ export interface CreateWorktreeOptions {
 export interface WorktreeConfig {
   pathPattern: string;
 }
+
+/** Payload for creating a task-scoped worktree */
+export interface CreateForTaskPayload {
+  taskId: string;
+  baseBranch?: string;
+  description?: string;
+}
+
+/** Options for cleaning up a task-scoped worktree */
+export interface CleanupTaskOptions {
+  /** Whether to force delete worktree with uncommitted changes (default: true) */
+  force?: boolean;
+  /** Whether to delete the associated git branch after removing the worktree (default: true) */
+  deleteBranch?: boolean;
+}

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -79,6 +79,8 @@ export interface WorktreeSnapshot {
   worktreeChanges?: WorktreeChanges | null;
   worktreeId: string;
   timestamp?: number;
+  /** Task ID for task-scoped worktree orchestration */
+  taskId?: string;
 }
 
 /** Monitor configuration for polling intervals */


### PR DESCRIPTION
## Summary
Adds a new IPC API for creating, tracking, and cleaning up worktrees scoped to specific tasks. This enables automated worktree lifecycle management for task-based workflows, allowing agents and automation to create isolated working environments tied to task IDs.

Closes #1980

## Changes Made
- Add `createForTask`, `getByTaskId`, and `cleanupTask` IPC handlers with full type safety
- Implement project-scoped in-memory mapping of `taskId` to `worktreeIds` to prevent cross-project collisions
- Add `taskId` field to `Worktree` and `WorktreeSnapshot` types for task-scoped tracking
- Create collision-safe branch names with `task-{taskId}` prefix using `GitService.findAvailableBranchName`
- Handle partial failures gracefully with fallback to minimal state when monitor polling fails
- Make cleanup idempotent by treating missing worktrees as success (removes stale mappings)
- Add comprehensive error handling and logging for observability throughout all handlers
- Fix cleanup options to use `force` and `deleteBranch` flags instead of unimplemented `merge` option

## Implementation Details
- **Project Scoping**: `taskWorktreeMap` is now scoped by `projectId` to prevent task ID collisions across projects
- **Error Recovery**: `createForTask` wraps worktree creation in try-catch to avoid leaving partial state
- **Idempotency**: `cleanupTask` treats "not found" errors as success and removes mappings automatically
- **Type Safety**: All new IPC channels properly typed in `IpcInvokeMap` with full payload definitions