### PR TITLE
Add agent capability query API for orchestration

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -261,6 +261,12 @@ export const CHANNELS = {
   ASSISTANT_CHUNK: "assistant:chunk",
   ASSISTANT_HAS_API_KEY: "assistant:has-api-key",
   ASSISTANT_CLEAR_SESSION: "assistant:clear-session",
+
+  // Agent Capabilities channels
+  AGENT_CAPABILITIES_GET_REGISTRY: "agent-capabilities:get-registry",
+  AGENT_CAPABILITIES_GET_AGENT_IDS: "agent-capabilities:get-agent-ids",
+  AGENT_CAPABILITIES_GET_AGENT_METADATA: "agent-capabilities:get-agent-metadata",
+  AGENT_CAPABILITIES_IS_AGENT_ENABLED: "agent-capabilities:is-agent-enabled",
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -30,6 +30,7 @@ import { registerDevPreviewHandlers } from "./handlers/devPreview.js";
 import { registerCommandHandlers } from "./handlers/commands.js";
 import { registerAppAgentHandlers } from "./handlers/appAgent.js";
 import { registerAssistantHandlers } from "./handlers/assistant.js";
+import { registerAgentCapabilitiesHandlers } from "./handlers/agentCapabilities.js";
 import { events } from "../services/events.js";
 import { typedHandle, typedSend, sendToRenderer } from "./utils.js";
 
@@ -81,6 +82,7 @@ export function registerIpcHandlers(
     registerCommandHandlers(),
     registerAppAgentHandlers(deps),
     registerAssistantHandlers(mainWindow),
+    registerAgentCapabilitiesHandlers(),
   ];
 
   return () => {

--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -1,0 +1,91 @@
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import { store } from "../../store.js";
+import {
+  AGENT_REGISTRY,
+  getEffectiveRegistry,
+  getEffectiveAgentIds,
+  getEffectiveAgentConfig,
+  type AgentConfig,
+} from "../../../shared/config/agentRegistry.js";
+import type { AgentMetadata } from "../../../shared/types/ipc/agentCapabilities.js";
+
+function toAgentMetadata(config: AgentConfig, agentId: string): AgentMetadata {
+  const isBuiltIn = agentId in AGENT_REGISTRY;
+  return {
+    id: config.id,
+    name: config.name,
+    command: config.command,
+    color: config.color,
+    iconId: config.iconId,
+    supportsContextInjection: config.supportsContextInjection,
+    shortcut: config.shortcut,
+    tooltip: config.tooltip,
+    usageUrl: config.usageUrl,
+    capabilities: config.capabilities,
+    hasDetection: !!config.detection,
+    hasVersionConfig: !!config.version,
+    hasUpdateConfig: !!config.update,
+    hasInstallHelp: !!config.install,
+    isBuiltIn,
+    isUserDefined: !isBuiltIn,
+  };
+}
+
+export function registerAgentCapabilitiesHandlers(): () => void {
+  const handlers: Array<() => void> = [];
+
+  const handleGetRegistry = async () => {
+    return getEffectiveRegistry();
+  };
+  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_GET_REGISTRY, handleGetRegistry);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_GET_REGISTRY));
+
+  const handleGetAgentIds = async () => {
+    return getEffectiveAgentIds();
+  };
+  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_IDS, handleGetAgentIds);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_IDS));
+
+  const handleGetAgentMetadata = async (
+    _event: Electron.IpcMainInvokeEvent,
+    agentId: string
+  ): Promise<AgentMetadata | null> => {
+    if (!agentId || typeof agentId !== "string") {
+      throw new Error("Invalid agentId");
+    }
+    if (agentId === "__proto__" || agentId === "constructor" || agentId === "prototype") {
+      throw new Error("Invalid agentId: reserved keyword");
+    }
+    const config = getEffectiveAgentConfig(agentId);
+    if (!config) {
+      return null;
+    }
+    return toAgentMetadata(config, agentId);
+  };
+  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_METADATA, handleGetAgentMetadata);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_METADATA));
+
+  const handleIsAgentEnabled = async (
+    _event: Electron.IpcMainInvokeEvent,
+    agentId: string
+  ): Promise<boolean> => {
+    if (!agentId || typeof agentId !== "string") {
+      throw new Error("Invalid agentId");
+    }
+    if (agentId === "__proto__" || agentId === "constructor" || agentId === "prototype") {
+      throw new Error("Invalid agentId: reserved keyword");
+    }
+    const config = getEffectiveAgentConfig(agentId);
+    if (!config) {
+      return false;
+    }
+    const agentSettings = store.get("agentSettings");
+    const agentEntry = agentSettings?.agents?.[agentId];
+    return agentEntry?.enabled !== false;
+  };
+  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_IS_AGENT_ENABLED, handleIsAgentEnabled);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_IS_AGENT_ENABLED));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -413,6 +413,12 @@ const CHANNELS = {
   ASSISTANT_CHUNK: "assistant:chunk",
   ASSISTANT_HAS_API_KEY: "assistant:has-api-key",
   ASSISTANT_CLEAR_SESSION: "assistant:clear-session",
+
+  // Agent Capabilities channels
+  AGENT_CAPABILITIES_GET_REGISTRY: "agent-capabilities:get-registry",
+  AGENT_CAPABILITIES_GET_AGENT_IDS: "agent-capabilities:get-agent-ids",
+  AGENT_CAPABILITIES_GET_AGENT_METADATA: "agent-capabilities:get-agent-metadata",
+  AGENT_CAPABILITIES_IS_AGENT_ENABLED: "agent-capabilities:is-agent-enabled",
 } as const;
 
 const api: ElectronAPI = {
@@ -1331,6 +1337,19 @@ const api: ElectronAPI = {
       ipcRenderer.on(CHANNELS.ASSISTANT_CHUNK, handler);
       return () => ipcRenderer.removeListener(CHANNELS.ASSISTANT_CHUNK, handler);
     },
+  },
+
+  // Agent Capabilities API
+  agentCapabilities: {
+    getRegistry: () => _typedInvoke(CHANNELS.AGENT_CAPABILITIES_GET_REGISTRY),
+
+    getAgentIds: () => _typedInvoke(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_IDS),
+
+    getAgentMetadata: (agentId: string) =>
+      _typedInvoke(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_METADATA, agentId),
+
+    isAgentEnabled: (agentId: string) =>
+      _typedInvoke(CHANNELS.AGENT_CAPABILITIES_IS_AGENT_ENABLED, agentId),
   },
 };
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -392,3 +392,6 @@ export { AssistantMessageSchema, StreamChunkSchema, ASSISTANT_MODELS } from "./a
 // Listener types - assistant event subscription management
 export type { Listener, ListenerFilter, RegisterListenerOptions } from "./listener.js";
 export { ListenerSchema, ListenerFilterSchema, RegisterListenerOptionsSchema } from "./listener.js";
+
+// Agent Capabilities types - query agent registry and metadata
+export type { AgentRegistry, AgentMetadata } from "./ipc/agentCapabilities.js";

--- a/shared/types/ipc/agentCapabilities.ts
+++ b/shared/types/ipc/agentCapabilities.ts
@@ -1,0 +1,29 @@
+import type { AgentConfig } from "../../config/agentRegistry.js";
+
+export type AgentRegistry = Record<string, AgentConfig>;
+
+export interface AgentMetadata {
+  id: string;
+  name: string;
+  command: string;
+  color: string;
+  iconId: string;
+  supportsContextInjection: boolean;
+  shortcut?: string | null;
+  tooltip?: string;
+  usageUrl?: string;
+  capabilities?: {
+    scrollback?: number;
+    blockAltScreen?: boolean;
+    blockMouseReporting?: boolean;
+    blockScrollRegion?: boolean;
+    blockClearScreen?: boolean;
+    blockCursorToTop?: boolean;
+  };
+  hasDetection: boolean;
+  hasVersionConfig: boolean;
+  hasUpdateConfig: boolean;
+  hasInstallHelp: boolean;
+  isBuiltIn: boolean;
+  isUserDefined: boolean;
+}

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -79,6 +79,7 @@ import type {
 import type { AppAgentConfig } from "../appAgent.js";
 import type { ActionManifestEntry, ActionContext } from "../actions.js";
 import type { AssistantMessage, AssistantChunkPayload } from "../assistant.js";
+import type { AgentRegistry, AgentMetadata } from "./agentCapabilities.js";
 
 // ElectronAPI Type (exposed via preload)
 
@@ -611,5 +612,15 @@ export interface ElectronAPI {
     hasApiKey(): Promise<boolean>;
     /** Subscribe to streaming chunks from the assistant */
     onChunk(callback: (data: AssistantChunkPayload) => void): () => void;
+  };
+  agentCapabilities: {
+    /** Get effective registry (built-in + user overrides) */
+    getRegistry(): Promise<AgentRegistry>;
+    /** Get list of effective agent IDs */
+    getAgentIds(): Promise<string[]>;
+    /** Get metadata for specific agent */
+    getAgentMetadata(agentId: string): Promise<AgentMetadata | null>;
+    /** Check if agent is enabled/available */
+    isAgentEnabled(agentId: string): Promise<boolean>;
   };
 }

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -11,6 +11,7 @@ export * from "./logs.js";
 export * from "./events.js";
 export * from "./errors.js";
 export * from "./agent.js";
+export * from "./agentCapabilities.js";
 export * from "./git.js";
 export * from "./files.js";
 export * from "./config.js";

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -90,6 +90,7 @@ import type {
 } from "../github.js";
 import type { SpawnResult, TerminalStatusPayload } from "../pty-host.js";
 import type { HibernationConfig } from "./hibernation.js";
+import type { AgentRegistry, AgentMetadata } from "./agentCapabilities.js";
 
 // IPC Contract Maps
 
@@ -916,6 +917,24 @@ export interface IpcInvokeMap {
   "dev-preview:set-url": {
     args: [panelId: string, url: string];
     result: void;
+  };
+
+  // Agent Capabilities channels
+  "agent-capabilities:get-registry": {
+    args: [];
+    result: AgentRegistry;
+  };
+  "agent-capabilities:get-agent-ids": {
+    args: [];
+    result: string[];
+  };
+  "agent-capabilities:get-agent-metadata": {
+    args: [agentId: string];
+    result: AgentMetadata | null;
+  };
+  "agent-capabilities:is-agent-enabled": {
+    args: [agentId: string];
+    result: boolean;
   };
 }
 

--- a/src/clients/agentCapabilitiesClient.ts
+++ b/src/clients/agentCapabilitiesClient.ts
@@ -1,0 +1,19 @@
+import type { AgentRegistry, AgentMetadata } from "@shared/types/ipc/agentCapabilities";
+
+export const agentCapabilitiesClient = {
+  getRegistry: (): Promise<AgentRegistry> => {
+    return window.electron.agentCapabilities.getRegistry();
+  },
+
+  getAgentIds: (): Promise<string[]> => {
+    return window.electron.agentCapabilities.getAgentIds();
+  },
+
+  getAgentMetadata: (agentId: string): Promise<AgentMetadata | null> => {
+    return window.electron.agentCapabilities.getAgentMetadata(agentId);
+  },
+
+  isAgentEnabled: (agentId: string): Promise<boolean> => {
+    return window.electron.agentCapabilities.isAgentEnabled(agentId);
+  },
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,5 +1,6 @@
 export { agentSettingsClient } from "./agentSettingsClient";
 export { agentHelpClient } from "./agentHelpClient";
+export { agentCapabilitiesClient } from "./agentCapabilitiesClient";
 export { terminalConfigClient } from "./terminalConfigClient";
 export { cliAvailabilityClient } from "./cliAvailabilityClient";
 export { appClient } from "./appClient";


### PR DESCRIPTION
## Summary
Expose the existing AgentRegistry capabilities to the assistant agent via IPC/MCP tools, enabling intelligent agent routing based on capabilities, version detection, and configuration metadata.

Closes #1978

## Changes Made
- Add agentCapabilities IPC handler with getRegistry, getAgentIds, getAgentMetadata, and isAgentEnabled methods
- Create AgentMetadata type with sanitized capability information
- Add prototype pollution protection for agentId validation
- Expose agentCapabilities namespace in preload bridge
- Add renderer client wrapper following existing patterns
- Update IPC contract maps and type exports
- Register handlers in IPC handler registry

## Implementation Details
The API provides four methods:
- `getRegistry()`: Returns effective registry (built-in + user overrides)
- `getAgentIds()`: Returns list of all available agent IDs
- `getAgentMetadata(agentId)`: Returns metadata for a specific agent
- `isAgentEnabled(agentId)`: Checks if an agent is enabled in settings

## Security
- Input validation prevents prototype pollution attacks
- Read-only API - no registry modification capabilities
- No sensitive data exposure (tokens, secrets, etc.)