### PR TITLE
Treat assistant panel as proper non-PTY panel type

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -478,7 +478,11 @@ interface NotesPanelData extends BasePanelData {
   createdAt: number;
 }
 
-export type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData;
+interface AssistantPanelData extends BasePanelData {
+  kind: "assistant";
+}
+
+export type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData | AssistantPanelData;
 
 export function isPtyPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
@@ -494,6 +498,10 @@ export function isNotesPanel(panel: PanelInstance): panel is NotesPanelData {
   return panel.kind === "notes";
 }
 
+export function isAssistantPanel(panel: PanelInstance): panel is AssistantPanelData {
+  return panel.kind === "assistant";
+}
+
 export function isDevPreviewPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
   return kind === "dev-preview";
@@ -502,6 +510,9 @@ export function isDevPreviewPanel(panel: PanelInstance | TerminalInstance): pane
 /**
  * Legacy interface for backward compatibility with persisted state.
  * New code should use the PanelInstance discriminated union.
+ *
+ * Note: PTY-specific fields (cwd, cols, rows) are optional to support
+ * non-PTY panels like assistant, browser, and notes.
  */
 export interface TerminalInstance {
   id: string;
@@ -510,10 +521,13 @@ export interface TerminalInstance {
   type?: TerminalType;
   agentId?: AgentId;
   title: string;
-  cwd: string;
+  /** Working directory - only present for PTY panels */
+  cwd?: string;
   pid?: number;
-  cols: number;
-  rows: number;
+  /** Terminal columns - only present for PTY panels */
+  cols?: number;
+  /** Terminal rows - only present for PTY panels */
+  rows?: number;
   agentState?: AgentState;
   lastStateChange?: number;
   error?: string;
@@ -619,8 +633,8 @@ export interface TerminalSnapshot {
   agentId?: AgentId;
   /** Display title */
   title: string;
-  /** Working directory */
-  cwd: string;
+  /** Working directory - only present for PTY panels */
+  cwd?: string;
   /** Associated worktree ID */
   worktreeId?: string;
   /** Location in the UI - grid or dock */

--- a/src/components/TerminalPalette/TerminalListItem.tsx
+++ b/src/components/TerminalPalette/TerminalListItem.tsx
@@ -10,6 +10,7 @@ export interface TerminalListItemProps {
   kind?: TerminalKind;
   agentId?: string;
   worktreeName?: string;
+  /** Working directory - always present since palette only shows PTY panels */
   cwd: string;
   isSelected: boolean;
   onClick: () => void;

--- a/src/hooks/useTerminalPalette.ts
+++ b/src/hooks/useTerminalPalette.ts
@@ -3,6 +3,7 @@ import Fuse, { type IFuseOptions } from "fuse.js";
 import { useShallow } from "zustand/react/shallow";
 import { useTerminalStore, type TerminalInstance } from "@/store";
 import { useWorktrees } from "./useWorktrees";
+import { isPtyPanel } from "@shared/types/domain";
 
 export interface SearchableTerminal {
   id: string;
@@ -12,6 +13,7 @@ export interface SearchableTerminal {
   agentId?: TerminalInstance["agentId"];
   worktreeId?: string;
   worktreeName?: string;
+  /** Working directory - always present since palette only shows PTY panels */
   cwd: string;
 }
 
@@ -77,6 +79,7 @@ export function useTerminalPalette(): UseTerminalPaletteReturn {
     return terminals
       .filter((t) => t.location !== "trash")
       .filter((t) => t.hasPty !== false) // Exclude orphaned terminals without active PTY processes
+      .filter((t) => isPtyPanel(t)) // Only include PTY panels (terminals, agents, dev-preview)
       .map((t) => ({
         id: t.id,
         title: t.title,
@@ -85,7 +88,7 @@ export function useTerminalPalette(): UseTerminalPaletteReturn {
         agentId: t.agentId,
         worktreeId: t.worktreeId,
         worktreeName: t.worktreeId ? worktreeMap.get(t.worktreeId)?.name : undefined,
-        cwd: t.cwd,
+        cwd: t.cwd ?? "", // PTY panels should always have cwd, fallback to empty string
       }));
   }, [terminals, worktreeMap]);
 

--- a/src/services/actions/definitions/assistantActions.ts
+++ b/src/services/actions/definitions/assistantActions.ts
@@ -22,7 +22,6 @@ export function registerAssistantActions(
         kind: "assistant",
         title: "Assistant",
         location: "grid",
-        cwd: "",
         worktreeId: activeWorktreeId ?? undefined,
       });
     },

--- a/src/store/persistence/terminalPersistence.ts
+++ b/src/store/persistence/terminalPersistence.ts
@@ -25,7 +25,6 @@ const DEFAULT_OPTIONS: Required<Omit<TerminalPersistenceOptions, "getProjectId">
       title: t.title,
       worktreeId: t.worktreeId,
       location: t.location === "trash" ? "grid" : t.location,
-      cwd: t.cwd,
     };
 
     if (t.kind === "dev-preview") {
@@ -55,6 +54,7 @@ const DEFAULT_OPTIONS: Required<Omit<TerminalPersistenceOptions, "getProjectId">
         createdAt: t.createdAt,
       };
     } else {
+      // Non-PTY panels: browser, assistant, etc.
       return {
         ...base,
         ...(t.browserUrl && { browserUrl: t.browserUrl }),

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -213,7 +213,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
               title: t.title,
               worktreeId: t.worktreeId,
               location: t.location === "trash" ? "grid" : t.location,
-              cwd: t.cwd,
             };
 
             if (t.kind === "dev-preview") {
@@ -230,6 +229,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                 ...base,
                 type: t.type,
                 agentId: t.agentId,
+                cwd: t.cwd,
                 command: t.command?.trim() || undefined,
               };
             } else if (t.kind === "notes") {
@@ -241,6 +241,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                 createdAt: t.createdAt,
               };
             } else {
+              // Non-PTY panels: browser, assistant, etc.
               return {
                 ...base,
                 ...(t.browserUrl && { browserUrl: t.browserUrl }),
@@ -401,7 +402,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
               title: t.title,
               worktreeId: t.worktreeId,
               location: t.location === "trash" ? "grid" : t.location,
-              cwd: t.cwd,
             };
 
             if (t.kind === "dev-preview") {
@@ -418,6 +418,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                 ...base,
                 type: t.type,
                 agentId: t.agentId,
+                cwd: t.cwd,
                 command: t.command?.trim() || undefined,
               };
             } else if (t.kind === "notes") {
@@ -429,6 +430,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                 createdAt: t.createdAt,
               };
             } else {
+              // Non-PTY panels: browser, assistant, etc.
               return {
                 ...base,
                 ...(t.browserUrl && { browserUrl: t.browserUrl }),

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -133,7 +133,18 @@ export const createTerminalRegistrySlice =
               browserUrl: options.browserUrl,
               exitBehavior: options.exitBehavior,
             };
+          } else if (requestedKind === "assistant") {
+            terminal = {
+              id,
+              kind: "assistant",
+              title,
+              worktreeId: options.worktreeId,
+              location,
+              isVisible: location === "grid",
+              runtimeStatus,
+            };
           } else {
+            // Generic non-PTY panel fallback for extensions
             terminal = {
               id,
               kind: requestedKind,
@@ -354,7 +365,7 @@ export const createTerminalRegistrySlice =
             agentId,
             title,
             worktreeId: options.worktreeId,
-            cwd: options.cwd,
+            cwd: options.cwd ?? "",
             cols: 80,
             rows: 24,
             agentState,

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -24,7 +24,8 @@ export interface AddTerminalOptions {
   agentId?: string;
   title?: string;
   worktreeId?: string;
-  cwd: string;
+  /** Working directory - required for PTY panels, optional/unused for non-PTY panels */
+  cwd?: string;
   shell?: string;
   command?: string;
   location?: TerminalLocation;

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -254,6 +254,9 @@ export async function hydrateAppState(
                     kind = "browser";
                   } else if (saved.notePath !== undefined || saved.noteId !== undefined) {
                     kind = "notes";
+                  } else if (saved.title === "Assistant") {
+                    // Legacy assistant panels from before kind was always set
+                    kind = "assistant";
                   }
                   // Note: dev-preview detection removed since 'devCommand' isn't in TerminalSnapshot.
                   // Dev-preview panels should always have 'kind' set during persistence.

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -18,14 +18,17 @@ export async function validateTerminalConfig(
 ): Promise<ValidationResult> {
   const errors: ValidationError[] = [];
 
-  const cwdExists = await systemClient.checkDirectory(terminal.cwd);
-  if (!cwdExists) {
-    errors.push({
-      type: "cwd",
-      message: `Working directory does not exist: ${terminal.cwd}`,
-      code: "ENOENT",
-      recoverable: true,
-    });
+  // Only validate cwd for PTY panels that have it
+  if (terminal.cwd) {
+    const cwdExists = await systemClient.checkDirectory(terminal.cwd);
+    if (!cwdExists) {
+      errors.push({
+        type: "cwd",
+        message: `Working directory does not exist: ${terminal.cwd}`,
+        code: "ENOENT",
+        recoverable: true,
+      });
+    }
   }
 
   // Check agent CLI availability


### PR DESCRIPTION
## Summary
Refactored the assistant panel to be treated as a proper non-PTY panel type with its own `AssistantPanelData` interface, rather than being forced into the terminal/PTY data model.

Closes #2000

## Changes Made
- Add `AssistantPanelData` interface extending `BasePanelData`
- Update `PanelInstance` discriminated union to include `AssistantPanelData`
- Add `isAssistantPanel` type guard for type narrowing
- Make PTY fields (`cwd`, `cols`, `rows`) optional in legacy `TerminalInstance`
- Create assistant panels without PTY-specific fields
- Update persistence to skip `cwd` for non-PTY panels
- Skip `cwd` validation for panels without working directory
- Add assistant detection in state migration for legacy snapshots
- Filter terminal palette to only show PTY panels

## Type System Improvements
- Assistant panel now has proper type representation consistent with browser and notes panels
- Discriminated union ensures type safety when working with different panel kinds
- Legacy `TerminalInstance` made more flexible to support both PTY and non-PTY panels during migration

## Testing
- All 1805 tests pass
- TypeScript compilation successful with no errors
- Code review completed with Codex identifying and fixing edge cases