### PR TITLE
Fix assistant AI_MissingToolResultsError on follow-up messages

### DIFF
--- a/electron/services/AssistantService.ts
+++ b/electron/services/AssistantService.ts
@@ -97,6 +97,9 @@ export class AssistantService {
         : SYSTEM_PROMPT;
 
       // Convert messages to ModelMessage format with proper tool call/result interleaving
+      // AI SDK requires that every tool call has a corresponding tool result.
+      // If tool results are missing for any tool call, we exclude those tool calls
+      // from the history to prevent AI_MissingToolResultsError.
       const modelMessages: ModelMessage[] = [];
 
       for (const msg of messages) {
@@ -104,34 +107,67 @@ export class AssistantService {
           modelMessages.push({ role: "user", content: msg.content });
         } else {
           // Assistant message - may have tool calls
-          if (msg.toolCalls && msg.toolCalls.length > 0) {
-            modelMessages.push({
-              role: "assistant",
-              content: [
-                ...(msg.content ? [{ type: "text" as const, text: msg.content }] : []),
-                ...msg.toolCalls.map((tc) => ({
-                  type: "tool-call" as const,
-                  toolCallId: tc.id,
-                  toolName: sanitizeToolName(tc.name),
-                  input: tc.args,
-                })),
-              ],
-            });
-          } else {
-            modelMessages.push({ role: "assistant", content: msg.content });
-          }
+          const hasToolCalls = msg.toolCalls && msg.toolCalls.length > 0;
+          const hasToolResults = msg.toolResults && msg.toolResults.length > 0;
 
-          // Add tool results immediately after their assistant message (proper interleaving)
-          if (msg.toolResults && msg.toolResults.length > 0) {
-            modelMessages.push({
-              role: "tool",
-              content: msg.toolResults.map((tr) => ({
-                type: "tool-result" as const,
-                toolCallId: tr.toolCallId,
-                toolName: sanitizeToolName(tr.toolName),
-                output: { type: "json" as const, value: tr.result as JSONValue },
-              })),
-            });
+          if (hasToolCalls && hasToolResults) {
+            // TypeScript needs explicit narrowing - these are guaranteed non-null by the boolean checks
+            const toolCalls = msg.toolCalls!;
+            const toolResults = msg.toolResults!;
+
+            // Build a set of tool call IDs that have results
+            const resultIds = new Set(toolResults.map((tr) => tr.toolCallId));
+
+            // Only include tool calls that have corresponding results
+            const pairedToolCalls = toolCalls.filter((tc) => resultIds.has(tc.id));
+
+            if (pairedToolCalls.length > 0) {
+              // Build a set of paired call IDs for efficient filtering
+              const pairedCallIds = new Set(pairedToolCalls.map((tc) => tc.id));
+
+              // Add assistant message with only the paired tool calls
+              modelMessages.push({
+                role: "assistant",
+                content: [
+                  ...(msg.content ? [{ type: "text" as const, text: msg.content }] : []),
+                  ...pairedToolCalls.map((tc) => ({
+                    type: "tool-call" as const,
+                    toolCallId: tc.id,
+                    toolName: sanitizeToolName(tc.name),
+                    input: tc.args,
+                  })),
+                ],
+              });
+
+              // Add tool results for the paired tool calls (filter efficiently using Set)
+              const pairedResults = toolResults.filter((tr) => pairedCallIds.has(tr.toolCallId));
+              modelMessages.push({
+                role: "tool",
+                content: pairedResults.map((tr) => ({
+                  type: "tool-result" as const,
+                  toolCallId: tr.toolCallId,
+                  toolName: sanitizeToolName(tr.toolName),
+                  // Normalize result to JSON-safe value (null if undefined)
+                  output: {
+                    type: "json" as const,
+                    value: (tr.result ?? null) as JSONValue,
+                  },
+                })),
+              });
+            } else if (msg.content) {
+              // No paired tool calls, but have content - add as text-only message
+              modelMessages.push({ role: "assistant", content: msg.content });
+            }
+          } else if (hasToolCalls && !hasToolResults) {
+            // Tool calls without results - this indicates incomplete tool execution
+            // Include only the text content to avoid AI_MissingToolResultsError
+            if (msg.content) {
+              modelMessages.push({ role: "assistant", content: msg.content });
+            }
+            // Note: Tool calls are intentionally omitted to prevent validation errors
+          } else {
+            // No tool calls - just add the text content
+            modelMessages.push({ role: "assistant", content: msg.content });
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes the `AI_MissingToolResultsError` that occurred when sending follow-up messages to the assistant after tool calls. The issue was caused by tool calls being sent to the AI SDK without their corresponding results, which violates the SDK's requirement that every tool call must have a matching result.

Closes #1999

## Changes Made

- Exclude tool calls without corresponding results from conversation history
- Normalize undefined results to null for IPC transport to handle void/undefined results
- Fix duplicate tool call handling from out-of-order streaming events
- Improve terminal status check to handle all non-pending statuses (not just success/error)
- Optimize pairing logic with Set-based filtering for better performance
- Handle void/undefined results and error-only tool outcomes correctly