### PR TITLE
Add agent routing capabilities to registry

### DIFF
--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -23,10 +23,12 @@ function toAgentMetadata(config: AgentConfig, agentId: string): AgentMetadata {
     tooltip: config.tooltip,
     usageUrl: config.usageUrl,
     capabilities: config.capabilities,
+    routing: config.routing,
     hasDetection: !!config.detection,
     hasVersionConfig: !!config.version,
     hasUpdateConfig: !!config.update,
     hasInstallHelp: !!config.install,
+    hasRoutingConfig: !!config.routing,
     isBuiltIn,
     isUserDefined: !isBuiltIn,
   };

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getAgentIds,
+  getAgentConfig,
+  isRegisteredAgent,
+  setUserRegistry,
+  getEffectiveAgentIds,
+  getEffectiveAgentConfig,
+  isEffectivelyRegisteredAgent,
+  isBuiltInAgent,
+  isUserDefinedAgent,
+  type AgentConfig,
+} from "../agentRegistry.js";
+import {
+  AgentRoutingConfigSchema,
+  AgentDomainWeightsSchema,
+  DEFAULT_ROUTING_CONFIG,
+} from "../../types/agentSettings.js";
+
+describe("agentRegistry", () => {
+  beforeEach(() => {
+    setUserRegistry({});
+  });
+
+  describe("built-in agents", () => {
+    it("has all expected built-in agents", () => {
+      const ids = getAgentIds();
+      expect(ids).toContain("claude");
+      expect(ids).toContain("gemini");
+      expect(ids).toContain("codex");
+      expect(ids).toContain("opencode");
+    });
+
+    it("returns agent config for built-in agents", () => {
+      const claude = getAgentConfig("claude");
+      expect(claude).toBeDefined();
+      expect(claude?.name).toBe("Claude");
+      expect(claude?.command).toBe("claude");
+    });
+
+    it("returns undefined for non-existent agents", () => {
+      expect(getAgentConfig("nonexistent")).toBeUndefined();
+    });
+
+    it("correctly identifies registered agents", () => {
+      expect(isRegisteredAgent("claude")).toBe(true);
+      expect(isRegisteredAgent("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("routing configuration", () => {
+    it("all built-in agents have routing config", () => {
+      const ids = getAgentIds();
+      for (const id of ids) {
+        const config = getAgentConfig(id);
+        expect(config?.routing).toBeDefined();
+        expect(config?.routing?.enabled).toBe(true);
+      }
+    });
+
+    it("all built-in routing configs are valid per schema", () => {
+      const ids = getAgentIds();
+      for (const id of ids) {
+        const config = getAgentConfig(id);
+        if (config?.routing) {
+          const result = AgentRoutingConfigSchema.safeParse(config.routing);
+          expect(result.success).toBe(true);
+          if (!result.success) {
+            console.error(`Invalid routing config for ${id}:`, result.error);
+          }
+        }
+      }
+    });
+
+    it("claude has expected routing capabilities", () => {
+      const claude = getAgentConfig("claude");
+      expect(claude?.routing?.capabilities).toContain("javascript");
+      expect(claude?.routing?.capabilities).toContain("typescript");
+      expect(claude?.routing?.capabilities).toContain("debugging");
+      expect(claude?.routing?.capabilities).toContain("refactoring");
+    });
+
+    it("claude has high refactoring and debugging weights", () => {
+      const claude = getAgentConfig("claude");
+      expect(claude?.routing?.domains?.refactoring).toBeGreaterThanOrEqual(0.9);
+      expect(claude?.routing?.domains?.debugging).toBeGreaterThanOrEqual(0.85);
+    });
+
+    it("codex has high frontend and testing weights", () => {
+      const codex = getAgentConfig("codex");
+      expect(codex?.routing?.domains?.frontend).toBeGreaterThanOrEqual(0.85);
+      expect(codex?.routing?.domains?.testing).toBeGreaterThanOrEqual(0.8);
+    });
+
+    it("gemini has high architecture weight", () => {
+      const gemini = getAgentConfig("gemini");
+      expect(gemini?.routing?.domains?.architecture).toBeGreaterThanOrEqual(0.85);
+    });
+
+    it("routing config has maxConcurrent set", () => {
+      const ids = getAgentIds();
+      for (const id of ids) {
+        const config = getAgentConfig(id);
+        expect(config?.routing?.maxConcurrent).toBeGreaterThanOrEqual(1);
+      }
+    });
+  });
+
+  describe("user registry", () => {
+    const customAgent: AgentConfig = {
+      id: "custom-agent",
+      name: "Custom Agent",
+      command: "custom",
+      color: "#FF0000",
+      iconId: "custom",
+      supportsContextInjection: true,
+      routing: {
+        capabilities: ["custom-task", "specialized"],
+        domains: {
+          frontend: 0.5,
+          backend: 0.8,
+        },
+        maxConcurrent: 3,
+        enabled: true,
+      },
+    };
+
+    it("user-defined agents appear in effective registry", () => {
+      setUserRegistry({ "custom-agent": customAgent });
+
+      expect(getEffectiveAgentIds()).toContain("custom-agent");
+      expect(isEffectivelyRegisteredAgent("custom-agent")).toBe(true);
+    });
+
+    it("user-defined agents are not built-in", () => {
+      setUserRegistry({ "custom-agent": customAgent });
+
+      expect(isBuiltInAgent("custom-agent")).toBe(false);
+      expect(isUserDefinedAgent("custom-agent")).toBe(true);
+    });
+
+    it("built-in agents are not user-defined", () => {
+      expect(isBuiltInAgent("claude")).toBe(true);
+      expect(isUserDefinedAgent("claude")).toBe(false);
+    });
+
+    it("user-defined agents can have custom routing config", () => {
+      setUserRegistry({ "custom-agent": customAgent });
+
+      const config = getEffectiveAgentConfig("custom-agent");
+      expect(config?.routing?.capabilities).toContain("custom-task");
+      expect(config?.routing?.domains?.backend).toBe(0.8);
+      expect(config?.routing?.maxConcurrent).toBe(3);
+    });
+
+    it("built-in agents take precedence over user agents with same ID", () => {
+      const fakeClaudeConfig: AgentConfig = {
+        id: "claude",
+        name: "Fake Claude",
+        command: "fake-claude",
+        color: "#000000",
+        iconId: "fake",
+        supportsContextInjection: false,
+      };
+
+      setUserRegistry({ claude: fakeClaudeConfig });
+
+      const effective = getEffectiveAgentConfig("claude");
+      expect(effective?.name).toBe("Claude");
+      expect(effective?.command).toBe("claude");
+    });
+  });
+});
+
+describe("AgentRoutingConfigSchema", () => {
+  it("validates valid routing config", () => {
+    const validConfig = {
+      capabilities: ["javascript", "react"],
+      domains: {
+        frontend: 0.9,
+        backend: 0.5,
+      },
+      maxConcurrent: 2,
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(validConfig);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid domain weight (> 1)", () => {
+    const invalidConfig = {
+      capabilities: ["javascript"],
+      domains: {
+        frontend: 1.5,
+      },
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(invalidConfig);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid domain weight (< 0)", () => {
+    const invalidConfig = {
+      capabilities: ["javascript"],
+      domains: {
+        frontend: -0.5,
+      },
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(invalidConfig);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects maxConcurrent < 1", () => {
+    const invalidConfig = {
+      capabilities: ["javascript"],
+      maxConcurrent: 0,
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(invalidConfig);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer maxConcurrent", () => {
+    const invalidConfig = {
+      capabilities: ["javascript"],
+      maxConcurrent: 1.5,
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(invalidConfig);
+    expect(result.success).toBe(false);
+  });
+
+  it("provides defaults for missing fields", () => {
+    const minimalConfig = {
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(minimalConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities).toEqual([]);
+    }
+  });
+
+  it("rejects empty capability strings", () => {
+    const invalidConfig = {
+      capabilities: ["valid", ""],
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(invalidConfig);
+    expect(result.success).toBe(false);
+  });
+
+  it("trims and lowercases capability strings", () => {
+    const config = {
+      capabilities: ["  JavaScript  ", "REACT", "TypeScript"],
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities).toEqual(["javascript", "react", "typescript"]);
+    }
+  });
+
+  it("removes duplicate capabilities", () => {
+    const config = {
+      capabilities: ["javascript", "react", "JavaScript", "REACT"],
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities).toEqual(["javascript", "react"]);
+    }
+  });
+
+  it("applies maxConcurrent default of 1", () => {
+    const config = {
+      capabilities: ["javascript"],
+      enabled: true,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxConcurrent).toBe(1);
+    }
+  });
+
+  it("handles enabled: false", () => {
+    const config = {
+      capabilities: ["javascript"],
+      enabled: false,
+    };
+
+    const result = AgentRoutingConfigSchema.safeParse(config);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(false);
+    }
+  });
+});
+
+describe("AgentDomainWeightsSchema", () => {
+  it("validates all domain fields", () => {
+    const validWeights = {
+      frontend: 0.9,
+      backend: 0.8,
+      testing: 0.7,
+      refactoring: 0.85,
+      debugging: 0.95,
+      architecture: 0.6,
+      devops: 0.5,
+    };
+
+    const result = AgentDomainWeightsSchema.safeParse(validWeights);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows partial domain weights", () => {
+    const partialWeights = {
+      frontend: 0.9,
+    };
+
+    const result = AgentDomainWeightsSchema.safeParse(partialWeights);
+    expect(result.success).toBe(true);
+  });
+
+  it("allows empty domain weights", () => {
+    const emptyWeights = {};
+
+    const result = AgentDomainWeightsSchema.safeParse(emptyWeights);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("DEFAULT_ROUTING_CONFIG", () => {
+  it("has empty capabilities", () => {
+    expect(DEFAULT_ROUTING_CONFIG.capabilities).toEqual([]);
+  });
+
+  it("is enabled by default", () => {
+    expect(DEFAULT_ROUTING_CONFIG.enabled).toBe(true);
+  });
+
+  it("has maxConcurrent of 1", () => {
+    expect(DEFAULT_ROUTING_CONFIG.maxConcurrent).toBe(1);
+  });
+});

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -1,3 +1,5 @@
+import type { AgentRoutingConfig } from "../types/agentSettings.js";
+
 export interface AgentHelpConfig {
   args: string[];
   title?: string;
@@ -135,6 +137,11 @@ export interface AgentConfig {
     /** Update command for other package managers or scripts */
     other?: Record<string, string>;
   };
+  /**
+   * Routing configuration for intelligent agent dispatch.
+   * Used by orchestrators to select the best agent for a given task.
+   */
+  routing?: AgentRoutingConfig;
 }
 
 export const AGENT_REGISTRY: Record<string, AgentConfig> = {
@@ -211,6 +218,30 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       promptConfidence: 0.85,
       debounceMs: 2000,
     },
+    routing: {
+      capabilities: [
+        "javascript",
+        "typescript",
+        "python",
+        "rust",
+        "go",
+        "react",
+        "node",
+        "debugging",
+        "refactoring",
+        "code-review",
+      ],
+      domains: {
+        frontend: 0.85,
+        backend: 0.85,
+        testing: 0.8,
+        refactoring: 0.95,
+        debugging: 0.9,
+        architecture: 0.8,
+      },
+      maxConcurrent: 2,
+      enabled: true,
+    },
   },
   gemini: {
     id: "gemini",
@@ -281,6 +312,29 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       fallbackConfidence: 0.7,
       promptConfidence: 0.85,
       debounceMs: 2000,
+    },
+    routing: {
+      capabilities: [
+        "javascript",
+        "typescript",
+        "python",
+        "go",
+        "java",
+        "kotlin",
+        "system-design",
+        "architecture",
+        "exploration",
+      ],
+      domains: {
+        frontend: 0.7,
+        backend: 0.85,
+        testing: 0.7,
+        refactoring: 0.75,
+        debugging: 0.75,
+        architecture: 0.9,
+      },
+      maxConcurrent: 2,
+      enabled: true,
     },
   },
   codex: {
@@ -353,6 +407,28 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       fallbackConfidence: 0.75,
       promptConfidence: 0.85,
       debounceMs: 2000,
+    },
+    routing: {
+      capabilities: [
+        "javascript",
+        "typescript",
+        "react",
+        "node",
+        "testing",
+        "frontend",
+        "css",
+        "html",
+      ],
+      domains: {
+        frontend: 0.9,
+        backend: 0.7,
+        testing: 0.85,
+        refactoring: 0.8,
+        debugging: 0.75,
+        architecture: 0.65,
+      },
+      maxConcurrent: 2,
+      enabled: true,
     },
   },
   opencode: {
@@ -459,6 +535,27 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       fallbackConfidence: 0.7,
       promptConfidence: 0.85,
       debounceMs: 2000,
+    },
+    routing: {
+      capabilities: [
+        "javascript",
+        "typescript",
+        "python",
+        "go",
+        "rust",
+        "multi-provider",
+        "general-purpose",
+      ],
+      domains: {
+        frontend: 0.75,
+        backend: 0.75,
+        testing: 0.7,
+        refactoring: 0.7,
+        debugging: 0.7,
+        architecture: 0.7,
+      },
+      maxConcurrent: 1,
+      enabled: true,
     },
   },
 };

--- a/shared/types/ipc/agentCapabilities.ts
+++ b/shared/types/ipc/agentCapabilities.ts
@@ -1,4 +1,5 @@
 import type { AgentConfig } from "../../config/agentRegistry.js";
+import type { AgentRoutingConfig } from "../agentSettings.js";
 
 export type AgentRegistry = Record<string, AgentConfig>;
 
@@ -20,10 +21,14 @@ export interface AgentMetadata {
     blockClearScreen?: boolean;
     blockCursorToTop?: boolean;
   };
+  /** Routing configuration for intelligent agent dispatch */
+  routing?: AgentRoutingConfig;
   hasDetection: boolean;
   hasVersionConfig: boolean;
   hasUpdateConfig: boolean;
   hasInstallHelp: boolean;
+  /** Whether the agent has routing configuration */
+  hasRoutingConfig: boolean;
   isBuiltIn: boolean;
   isUserDefined: boolean;
 }

--- a/shared/types/userAgentRegistry.ts
+++ b/shared/types/userAgentRegistry.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AgentRoutingConfigSchema } from "./agentSettings.js";
 
 const RESERVED_KEYS = ["__proto__", "constructor", "prototype"];
 
@@ -13,6 +14,7 @@ export const UserAgentConfigSchema = z
     shortcut: z.string().nullable().optional(),
     tooltip: z.string().optional(),
     usageUrl: z.string().url().optional(),
+    routing: AgentRoutingConfigSchema.optional(),
   })
   .refine((data) => !RESERVED_KEYS.includes(data.id), {
     message: "Agent ID cannot be a reserved key (__proto__, constructor, prototype)",


### PR DESCRIPTION
## Summary
Extend the agent registry with routing-specific metadata (task domains, capability tags, performance weights) to enable intelligent capability-based agent dispatch.

Closes #1988

## Changes Made
- Add `AgentRoutingConfig` type with capabilities, domain weights, maxConcurrent, and enabled fields
- Add Zod schemas with validation: trim/lowercase capabilities, enforce uniqueness, apply defaults
- Extend all built-in agents (Claude, Gemini, Codex, OpenCode) with routing configurations:
  - **Claude**: High refactoring/debugging weights, broad language support
  - **Codex**: Frontend/testing focus with React/TypeScript emphasis
  - **Gemini**: Architecture-heavy bias for system design work
  - **OpenCode**: General-purpose with conservative concurrency limits
- Expose routing config via IPC `AgentMetadata` interface with `hasRoutingConfig` flag
- Support routing config in user-defined agents via `UserAgentConfigSchema`
- Add comprehensive test suite (33 tests) validating schemas, built-in configs, and edge cases

## Technical Details
- Schema applies sensible defaults: `maxConcurrent: 1`, `enabled: true`, empty capabilities array
- Capability strings are normalized (trimmed, lowercased) and deduplicated automatically
- Domain weights validated to 0-1 scale
- All built-in routing configs validated against schema in tests
- Full backward compatibility maintained - routing is optional