### PR TITLE
Integrate task queue with agent state machine

### DIFF
--- a/electron/services/TaskOrchestrator.ts
+++ b/electron/services/TaskOrchestrator.ts
@@ -1,0 +1,355 @@
+/**
+ * TaskOrchestrator - Coordinates task queue with agent state machine.
+ *
+ * Subscribes to agent lifecycle events and drives task state transitions:
+ * - Assigns queued tasks to idle agents
+ * - Monitors agent execution and updates task state
+ * - Handles failures and propagates to dependents
+ * - Cancels tasks when worktrees are removed
+ */
+
+import { randomUUID } from "crypto";
+import { events } from "./events.js";
+import { taskQueueService, TaskQueueService } from "./TaskQueueService.js";
+import type { PtyClient } from "./PtyClient.js";
+import type { AgentState } from "../../shared/types/domain.js";
+import type { CanopyEventMap } from "./events.js";
+
+/**
+ * Check if an agent is available to receive a new task.
+ * An agent is available if it's idle or waiting for user input.
+ */
+function isAgentAvailable(state: AgentState | undefined): boolean {
+  return state === "idle" || state === "waiting";
+}
+
+export class TaskOrchestrator {
+  /** Map of runId -> taskId for correlating agent completions to tasks */
+  private runToTaskMap: Map<string, string> = new Map();
+
+  /** Map of agentId -> runId for tracking current runs */
+  private agentToRunMap: Map<string, string> = new Map();
+
+  /** Lock to prevent concurrent assignment operations */
+  private isAssigning = false;
+
+  /** Flag to track if orchestrator is disposed */
+  private isDisposed = false;
+
+  /** Unsubscribe functions for event listeners */
+  private unsubscribers: Array<() => void> = [];
+
+  constructor(
+    private queueService: TaskQueueService,
+    private ptyClient: PtyClient
+  ) {
+    // Subscribe to agent state changes
+    this.unsubscribers.push(
+      events.on("agent:state-changed", (payload) => {
+        void this.handleAgentStateChange(payload);
+      })
+    );
+
+    // Subscribe to agent completions
+    this.unsubscribers.push(
+      events.on("agent:completed", (payload) => {
+        void this.handleAgentComplete(payload);
+      })
+    );
+
+    // Subscribe to agent failures
+    this.unsubscribers.push(
+      events.on("agent:failed", (payload) => {
+        void this.handleAgentFailed(payload);
+      })
+    );
+
+    // Subscribe to worktree removals
+    this.unsubscribers.push(
+      events.on("sys:worktree:remove", (payload) => {
+        void this.handleWorktreeRemove(payload);
+      })
+    );
+  }
+
+  /**
+   * Attempt to assign the next queued task to an available agent.
+   * Uses check-and-set pattern to prevent race conditions.
+   * Loops until no more tasks or agents are available.
+   */
+  async assignNextTask(): Promise<void> {
+    // Prevent concurrent assignments
+    if (this.isAssigning || this.isDisposed) {
+      return;
+    }
+
+    this.isAssigning = true;
+
+    try {
+      // Loop to assign multiple tasks if multiple agents are available
+      while (true) {
+        // Get the next ready task
+        const task = await this.queueService.dequeueNext();
+        if (!task) {
+          break; // No more tasks
+        }
+
+        // Find an available agent terminal
+        const availableTerminals = await this.ptyClient.getAvailableTerminalsAsync();
+
+        // Filter to only agent-type terminals that are actually available
+        // Match worktree if task has one, otherwise allow any agent
+        const availableAgent = availableTerminals.find(
+          (t) =>
+            t.kind === "agent" &&
+            t.agentId &&
+            isAgentAvailable(t.agentState) &&
+            !this.agentToRunMap.has(t.agentId) && // Not already running a task
+            (!task.worktreeId || t.worktreeId === task.worktreeId) // Worktree match if specified
+        );
+
+        if (!availableAgent || !availableAgent.agentId) {
+          // No available agents - task will stay queued for next attempt
+          break;
+        }
+
+        // Generate a new run ID for this execution
+        const runId = randomUUID();
+
+        // Set tracking maps BEFORE marking running to avoid race with fast agent events
+        this.runToTaskMap.set(runId, task.id);
+        this.agentToRunMap.set(availableAgent.agentId, runId);
+
+        // Mark task as running (atomic state transition)
+        try {
+          await this.queueService.markRunning(task.id, availableAgent.agentId, runId);
+        } catch (error) {
+          // Task state transition failed - roll back tracking maps
+          this.runToTaskMap.delete(runId);
+          this.agentToRunMap.delete(availableAgent.agentId);
+
+          console.warn(
+            `[TaskOrchestrator] Failed to mark task ${task.id} as running:`,
+            error instanceof Error ? error.message : String(error)
+          );
+          break; // Don't try to assign more tasks if we hit an error
+        }
+
+        // TaskQueueService already emits task:assigned event, no need to duplicate
+      }
+    } finally {
+      this.isAssigning = false;
+    }
+  }
+
+  /**
+   * Handle agent state changes.
+   * When an agent becomes idle or waiting, attempt to assign a new task.
+   */
+  private async handleAgentStateChange(
+    payload: CanopyEventMap["agent:state-changed"]
+  ): Promise<void> {
+    if (this.isDisposed) return;
+
+    const { state, agentId } = payload;
+
+    // Only trigger assignment when agent becomes available
+    // Don't clear run mappings here - let completion/failure events handle that
+    // to avoid race conditions with out-of-order events
+    if (isAgentAvailable(state) && agentId) {
+      // Try to assign next task
+      await this.assignNextTask();
+    }
+  }
+
+  /**
+   * Handle agent completion.
+   * Correlate the completion to a running task and mark it as completed.
+   */
+  private async handleAgentComplete(payload: CanopyEventMap["agent:completed"]): Promise<void> {
+    if (this.isDisposed) return;
+
+    const { agentId } = payload;
+    if (!agentId) return;
+
+    // Find the run ID for this agent
+    const runId = this.agentToRunMap.get(agentId);
+    if (!runId) {
+      // Agent completed without a tracked task - that's fine
+      return;
+    }
+
+    // Find the task for this run
+    const taskId = this.runToTaskMap.get(runId);
+    if (!taskId) {
+      // Run completed without a tracked task
+      this.agentToRunMap.delete(agentId);
+      return;
+    }
+
+    // Get the task to verify it's still running with this runId
+    const task = await this.queueService.getTask(taskId);
+    if (!task || task.status !== "running" || task.runId !== runId) {
+      // Task state has changed - don't update it
+      this.runToTaskMap.delete(runId);
+      this.agentToRunMap.delete(agentId);
+      return;
+    }
+
+    // Mark task as completed
+    try {
+      await this.queueService.markCompleted(taskId, {
+        summary: `Completed by agent ${agentId}`,
+      });
+    } catch (error) {
+      console.error(
+        `[TaskOrchestrator] Failed to mark task ${taskId} as completed:`,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+
+    // Clean up tracking
+    this.runToTaskMap.delete(runId);
+    this.agentToRunMap.delete(agentId);
+
+    // Try to assign next task now that this agent is free
+    await this.assignNextTask();
+  }
+
+  /**
+   * Handle agent failure.
+   * Correlate the failure to a running task and mark it as failed.
+   */
+  private async handleAgentFailed(payload: CanopyEventMap["agent:failed"]): Promise<void> {
+    if (this.isDisposed) return;
+
+    const { agentId, error } = payload;
+    if (!agentId) return;
+
+    // Find the run ID for this agent
+    const runId = this.agentToRunMap.get(agentId);
+    if (!runId) {
+      // Agent failed without a tracked task
+      return;
+    }
+
+    // Find the task for this run
+    const taskId = this.runToTaskMap.get(runId);
+    if (!taskId) {
+      // Run failed without a tracked task
+      this.agentToRunMap.delete(agentId);
+      return;
+    }
+
+    // Get the task to verify it's still running with this runId
+    const task = await this.queueService.getTask(taskId);
+    if (!task || task.status !== "running" || task.runId !== runId) {
+      // Task state has changed - don't update it
+      this.runToTaskMap.delete(runId);
+      this.agentToRunMap.delete(agentId);
+      return;
+    }
+
+    // Mark task as failed
+    try {
+      await this.queueService.markFailed(taskId, error);
+    } catch (err) {
+      console.error(
+        `[TaskOrchestrator] Failed to mark task ${taskId} as failed:`,
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+
+    // Clean up tracking
+    this.runToTaskMap.delete(runId);
+    this.agentToRunMap.delete(agentId);
+
+    // Try to assign next task (to other available agents)
+    await this.assignNextTask();
+  }
+
+  /**
+   * Handle worktree removal.
+   * Cancel all tasks tied to the removed worktree.
+   */
+  private async handleWorktreeRemove(
+    payload: CanopyEventMap["sys:worktree:remove"]
+  ): Promise<void> {
+    if (this.isDisposed) return;
+
+    const { worktreeId } = payload;
+
+    // Find all tasks for this worktree
+    const tasks = await this.queueService.listTasks({ worktreeId });
+
+    // Cancel tasks that aren't already completed
+    for (const task of tasks) {
+      if (task.status === "completed" || task.status === "failed" || task.status === "cancelled") {
+        continue;
+      }
+
+      try {
+        await this.queueService.cancelTask(task.id);
+
+        // Clean up tracking for running tasks
+        if (task.runId && task.assignedAgentId) {
+          this.runToTaskMap.delete(task.runId);
+          this.agentToRunMap.delete(task.assignedAgentId);
+        }
+      } catch (error) {
+        // Task may already be in a terminal state
+        console.warn(
+          `[TaskOrchestrator] Failed to cancel task ${task.id} on worktree removal:`,
+          error instanceof Error ? error.message : String(error)
+        );
+      }
+    }
+  }
+
+  /**
+   * Dispose of the orchestrator and clean up event subscriptions.
+   */
+  dispose(): void {
+    this.isDisposed = true;
+
+    for (const unsubscribe of this.unsubscribers) {
+      unsubscribe();
+    }
+    this.unsubscribers = [];
+    this.runToTaskMap.clear();
+    this.agentToRunMap.clear();
+  }
+}
+
+// Singleton instance
+let orchestratorInstance: TaskOrchestrator | null = null;
+
+/**
+ * Initialize the task orchestrator with dependencies.
+ * Should be called once during app startup after ptyClient is ready.
+ */
+export function initializeTaskOrchestrator(ptyClient: PtyClient): TaskOrchestrator {
+  if (orchestratorInstance) {
+    orchestratorInstance.dispose();
+  }
+  orchestratorInstance = new TaskOrchestrator(taskQueueService, ptyClient);
+  return orchestratorInstance;
+}
+
+/**
+ * Get the task orchestrator instance.
+ * Returns null if not initialized.
+ */
+export function getTaskOrchestrator(): TaskOrchestrator | null {
+  return orchestratorInstance;
+}
+
+/**
+ * Dispose the task orchestrator.
+ */
+export function disposeTaskOrchestrator(): void {
+  if (orchestratorInstance) {
+    orchestratorInstance.dispose();
+    orchestratorInstance = null;
+  }
+}

--- a/electron/services/__tests__/TaskOrchestrator.test.ts
+++ b/electron/services/__tests__/TaskOrchestrator.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Tests for TaskOrchestrator - Coordinates task queue with agent state machine.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { TaskOrchestrator } from "../TaskOrchestrator.js";
+import { TaskQueueService } from "../TaskQueueService.js";
+import { events } from "../events.js";
+import type { PtyClient } from "../PtyClient.js";
+
+type MockPtyClient = {
+  getAvailableTerminalsAsync: ReturnType<typeof vi.fn>;
+};
+
+function createMockPtyClient(): MockPtyClient {
+  return {
+    getAvailableTerminalsAsync: vi.fn().mockResolvedValue([]),
+  };
+}
+
+describe("TaskOrchestrator", () => {
+  let orchestrator: TaskOrchestrator;
+  let queueService: TaskQueueService;
+  let mockPtyClient: MockPtyClient;
+
+  beforeEach(() => {
+    queueService = new TaskQueueService();
+    mockPtyClient = createMockPtyClient();
+    orchestrator = new TaskOrchestrator(queueService, mockPtyClient as unknown as PtyClient);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    orchestrator.dispose();
+  });
+
+  describe("assignNextTask", () => {
+    it("assigns queued task to available idle agent", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      const updatedTask = await queueService.getTask(task.id);
+      expect(updatedTask?.status).toBe("running");
+      expect(updatedTask?.assignedAgentId).toBe("agent-1");
+      expect(updatedTask?.runId).toBeDefined();
+    });
+
+    it("assigns queued task to available waiting agent", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "waiting",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      const updatedTask = await queueService.getTask(task.id);
+      expect(updatedTask?.status).toBe("running");
+      expect(updatedTask?.assignedAgentId).toBe("agent-1");
+    });
+
+    it("does not assign to working agent", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "working",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      const updatedTask = await queueService.getTask(task.id);
+      expect(updatedTask?.status).toBe("queued");
+    });
+
+    it("does not assign to non-agent terminal", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "terminal",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      const updatedTask = await queueService.getTask(task.id);
+      expect(updatedTask?.status).toBe("queued");
+    });
+
+    it("does not assign when no tasks queued", async () => {
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      // Should complete without error
+      expect(mockPtyClient.getAvailableTerminalsAsync).not.toHaveBeenCalled();
+    });
+
+    it("emits task:assigned event on assignment", async () => {
+      const emitSpy = vi.spyOn(events, "emit");
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        "task:assigned",
+        expect.objectContaining({
+          taskId: task.id,
+          agentId: "agent-1",
+        })
+      );
+    });
+
+    it("prevents concurrent assignment operations", async () => {
+      const task1 = await queueService.createTask({ title: "Task 1", priority: 10 });
+      const task2 = await queueService.createTask({ title: "Task 2", priority: 5 });
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      // Call twice simultaneously
+      await Promise.all([orchestrator.assignNextTask(), orchestrator.assignNextTask()]);
+
+      // Only one should have been assigned (the higher priority one)
+      const updated1 = await queueService.getTask(task1.id);
+      const updated2 = await queueService.getTask(task2.id);
+
+      expect(updated1?.status).toBe("running");
+      expect(updated2?.status).toBe("queued");
+    });
+  });
+
+  describe("agent state change handling", () => {
+    it("triggers assignment when agent becomes idle", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      // Emit agent state change
+      events.emit("agent:state-changed", {
+        agentId: "agent-1",
+        state: "idle",
+        previousState: "working",
+        timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
+      });
+
+      // Wait for async handler
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("running");
+    });
+
+    it("triggers assignment when agent becomes waiting", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "waiting",
+        },
+      ]);
+
+      events.emit("agent:state-changed", {
+        agentId: "agent-1",
+        state: "waiting",
+        previousState: "working",
+        timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("running");
+    });
+
+    it("does not trigger assignment when agent becomes working", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      events.emit("agent:state-changed", {
+        agentId: "agent-1",
+        state: "working",
+        previousState: "idle",
+        timestamp: Date.now(),
+        trigger: "input",
+        confidence: 1.0,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("queued");
+      expect(mockPtyClient.getAvailableTerminalsAsync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("agent completion handling", () => {
+    it("marks task as completed when agent completes", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      const runningTask = await queueService.getTask(task.id);
+      expect(runningTask?.status).toBe("running");
+      expect(runningTask?.runId).toBeDefined();
+
+      // Emit agent completed
+      events.emit("agent:completed", {
+        agentId: "agent-1",
+        exitCode: 0,
+        duration: 1000,
+        timestamp: Date.now(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const completedTask = await queueService.getTask(task.id);
+      expect(completedTask?.status).toBe("completed");
+    });
+
+    it("ignores completion for unknown agents", async () => {
+      // Emit completion for agent with no tracked task
+      events.emit("agent:completed", {
+        agentId: "unknown-agent",
+        exitCode: 0,
+        duration: 1000,
+        timestamp: Date.now(),
+      });
+
+      // Should complete without error
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    it("triggers assignment for next task after completion", async () => {
+      const task1 = await queueService.createTask({ title: "Task 1", priority: 10 });
+      const task2 = await queueService.createTask({ title: "Task 2", priority: 5 });
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      // Assign first task
+      await orchestrator.assignNextTask();
+
+      const running1 = await queueService.getTask(task1.id);
+      expect(running1?.status).toBe("running");
+
+      // Complete first task
+      events.emit("agent:completed", {
+        agentId: "agent-1",
+        exitCode: 0,
+        duration: 1000,
+        timestamp: Date.now(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Second task should now be assigned
+      const updated2 = await queueService.getTask(task2.id);
+      expect(updated2?.status).toBe("running");
+    });
+  });
+
+  describe("agent failure handling", () => {
+    it("marks task as failed when agent fails", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      // Emit agent failed
+      events.emit("agent:failed", {
+        agentId: "agent-1",
+        error: "Something went wrong",
+        timestamp: Date.now(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const failedTask = await queueService.getTask(task.id);
+      expect(failedTask?.status).toBe("failed");
+      expect(failedTask?.result?.error).toBe("Something went wrong");
+    });
+
+    it("triggers assignment for next task after failure", async () => {
+      const task1 = await queueService.createTask({ title: "Task 1", priority: 10 });
+      const task2 = await queueService.createTask({ title: "Task 2", priority: 5 });
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      // Fail first task
+      events.emit("agent:failed", {
+        agentId: "agent-1",
+        error: "Failure",
+        timestamp: Date.now(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Second task should be assigned
+      const updated2 = await queueService.getTask(task2.id);
+      expect(updated2?.status).toBe("running");
+    });
+  });
+
+  describe("worktree removal handling", () => {
+    it("cancels tasks for removed worktree", async () => {
+      const task1 = await queueService.createTask({
+        title: "Task 1",
+        worktreeId: "wt-1",
+      });
+      const task2 = await queueService.createTask({
+        title: "Task 2",
+        worktreeId: "wt-1",
+      });
+      const task3 = await queueService.createTask({
+        title: "Task 3",
+        worktreeId: "wt-2",
+      });
+
+      await queueService.enqueueTask(task1.id);
+      await queueService.enqueueTask(task2.id);
+      await queueService.enqueueTask(task3.id);
+
+      // Remove worktree 1
+      events.emit("sys:worktree:remove", {
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updated1 = await queueService.getTask(task1.id);
+      const updated2 = await queueService.getTask(task2.id);
+      const updated3 = await queueService.getTask(task3.id);
+
+      expect(updated1?.status).toBe("cancelled");
+      expect(updated2?.status).toBe("cancelled");
+      expect(updated3?.status).toBe("queued");
+    });
+
+    it("does not cancel already completed tasks", async () => {
+      const task = await queueService.createTask({
+        title: "Completed task",
+        worktreeId: "wt-1",
+      });
+
+      await queueService.enqueueTask(task.id);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+          worktreeId: "wt-1", // Match the task's worktree
+        },
+      ]);
+
+      await orchestrator.assignNextTask();
+
+      // Verify task is running
+      const runningTask = await queueService.getTask(task.id);
+      expect(runningTask?.status).toBe("running");
+
+      // Complete the task
+      await queueService.markCompleted(task.id, { summary: "Done" });
+
+      // Remove worktree
+      events.emit("sys:worktree:remove", {
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("completed");
+    });
+  });
+
+  describe("dispose", () => {
+    it("cleans up event subscriptions", async () => {
+      const task = await queueService.createTask({ title: "Test task" });
+      await queueService.enqueueTask(task.id);
+
+      orchestrator.dispose();
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValue([
+        {
+          id: "term-1",
+          kind: "agent",
+          agentId: "agent-1",
+          agentState: "idle",
+        },
+      ]);
+
+      // Emit events after dispose - should not trigger assignment
+      events.emit("agent:state-changed", {
+        agentId: "agent-1",
+        state: "idle",
+        previousState: "working",
+        timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Task should still be queued (no assignment happened)
+      const updated = await queueService.getTask(task.id);
+      expect(updated?.status).toBe("queued");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implement TaskOrchestrator to coordinate the task queue system with the agent state machine, enabling automatic task assignment to idle agents and complete lifecycle management.

Closes #1984

## Changes Made
- Assign queued tasks to idle/waiting agents automatically
- Track agent runs and correlate with task state transitions
- Handle agent completion and failure events to update task status
- Cancel tasks when worktrees are removed
- Enforce worktree matching for task-agent assignment
- Prevent race conditions with disposal guards and map cleanup
- Support concurrent task assignment with loop-based scheduling
- Dispose orchestrator before ptyClient in shutdown sequence
- Add comprehensive test suite with 18 tests covering all orchestration scenarios
- Initialize orchestrator in main.ts after ptyClient is ready

## Test Coverage
- Task assignment to available agents
- Agent state change triggers
- Completion and failure handling
- Worktree removal cascading
- Concurrent assignment prevention
- Event subscription lifecycle