### PR TITLE
Extract assistant from panel system into standalone global component

### DIFF
--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -94,18 +94,6 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
   },
-  assistant: {
-    id: "assistant",
-    name: "Assistant",
-    iconId: "canopy",
-    color: "#a855f7", // purple-500 (distinct from other purples)
-    hasPty: false,
-    canRestart: false,
-    canConvert: false,
-    usesTerminalUi: false,
-    keepAliveOnProjectSwitch: true,
-    showInPalette: true,
-  },
 };
 
 /**
@@ -227,5 +215,5 @@ export function panelKindKeepsAliveOnProjectSwitch(kind: PanelKind): boolean {
  * Get all built-in panel kinds.
  */
 export function getBuiltInPanelKinds(): BuiltInPanelKind[] {
-  return ["terminal", "agent", "browser", "notes", "dev-preview", "assistant"];
+  return ["terminal", "agent", "browser", "notes", "dev-preview"];
 }

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -208,8 +208,7 @@ export type ActionId =
   | "notes.create"
   | "notes.delete"
   | "notes.reveal"
-  | "devServer.start"
-  | "assistant.restart";
+  | "devServer.start";
 
 export interface ActionContext {
   projectId?: string;

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -204,13 +204,7 @@ export type AgentId = string;
 export type LegacyAgentType = "claude" | "gemini" | "codex" | "opencode";
 
 /** Built-in panel kinds */
-export type BuiltInPanelKind =
-  | "terminal"
-  | "agent"
-  | "browser"
-  | "notes"
-  | "dev-preview"
-  | "assistant";
+export type BuiltInPanelKind = "terminal" | "agent" | "browser" | "notes" | "dev-preview";
 
 /**
  * Panel kind: distinguishes between default terminals, agent-driven terminals, browser panels,
@@ -297,8 +291,7 @@ export function isBuiltInPanelKind(kind: PanelKind): kind is BuiltInPanelKind {
     kind === "agent" ||
     kind === "browser" ||
     kind === "notes" ||
-    kind === "dev-preview" ||
-    kind === "assistant"
+    kind === "dev-preview"
   );
 }
 
@@ -481,11 +474,7 @@ interface NotesPanelData extends BasePanelData {
   createdAt: number;
 }
 
-interface AssistantPanelData extends BasePanelData {
-  kind: "assistant";
-}
-
-export type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData | AssistantPanelData;
+export type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData;
 
 export function isPtyPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
@@ -501,10 +490,6 @@ export function isNotesPanel(panel: PanelInstance): panel is NotesPanelData {
   return panel.kind === "notes";
 }
 
-export function isAssistantPanel(panel: PanelInstance): panel is AssistantPanelData {
-  return panel.kind === "assistant";
-}
-
 export function isDevPreviewPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
   return kind === "dev-preview";
@@ -515,7 +500,7 @@ export function isDevPreviewPanel(panel: PanelInstance | TerminalInstance): pane
  * New code should use the PanelInstance discriminated union.
  *
  * Note: PTY-specific fields (cwd, cols, rows) are optional to support
- * non-PTY panels like assistant, browser, and notes.
+ * non-PTY panels like browser and notes.
  */
 export interface TerminalInstance {
   id: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import { RecipeEditor } from "./components/TerminalRecipe/RecipeEditor";
 import { NotesPalette } from "./components/Notes";
 import { SettingsDialog, type SettingsTab } from "./components/Settings";
 import { ShortcutReferenceDialog } from "./components/KeyboardShortcuts";
+import { AssistantHost } from "./components/Assistant/AssistantHost";
 import { Toaster } from "./components/ui/toaster";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { DndProvider } from "./components/DragDrop";
@@ -938,6 +939,8 @@ function App() {
       <TerminalInfoDialogHost />
 
       <PanelTransitionOverlay />
+
+      <AssistantHost />
 
       <Toaster />
     </ErrorBoundary>

--- a/src/components/Assistant/AssistantHost.tsx
+++ b/src/components/Assistant/AssistantHost.tsx
@@ -1,0 +1,22 @@
+import { useAssistantUiStore } from "@/store/assistantUiStore";
+import { AssistantPane } from "./AssistantPane";
+
+export function AssistantHost() {
+  const isOpen = useAssistantUiStore((s) => s.isOpen);
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/50 transition-opacity ${
+        isOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+      }`}
+    >
+      <div
+        className={`w-full max-w-3xl h-[80vh] bg-canopy-bg rounded-lg shadow-2xl overflow-hidden flex flex-col transition-transform ${
+          isOpen ? "scale-100" : "scale-95"
+        }`}
+      >
+        <AssistantPane />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Assistant/useAssistantChat.ts
+++ b/src/components/Assistant/useAssistantChat.ts
@@ -4,7 +4,7 @@ import { actionService } from "@/services/ActionService";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useProjectStore } from "@/store/projectStore";
-import { useAssistantChatStore, type ConversationState } from "@/store/assistantChatStore";
+import { useAssistantChatStore } from "@/store/assistantChatStore";
 import type { AssistantMessage as IPCAssistantMessage } from "@shared/types/assistant";
 
 function generateId(): string {
@@ -34,31 +34,15 @@ function formatListenerNotification(eventType: string, data: Record<string, unkn
   return `🔔 Event triggered: ${eventType}`;
 }
 
-// Stable default to avoid infinite loops - must be module-level constant
-const EMPTY_CONVERSATION: ConversationState = Object.freeze({
-  messages: [],
-  sessionId: "",
-  isLoading: false,
-  error: null,
-});
-
 interface UseAssistantChatOptions {
-  panelId: string;
   onError?: (error: string) => void;
 }
 
-export function useAssistantChat(options: UseAssistantChatOptions) {
-  const { panelId, onError } = options;
+export function useAssistantChat(options?: UseAssistantChatOptions) {
+  const { onError } = options ?? {};
 
-  // Ensure conversation exists on mount - this creates it in the store
-  const ensureConversation = useAssistantChatStore((s) => s.ensureConversation);
-  useEffect(() => {
-    ensureConversation(panelId);
-  }, [panelId, ensureConversation]);
-
-  // Get conversation state from global store - access directly to avoid infinite loop
-  // The selector must return a stable reference when conversation doesn't exist
-  const conversation = useAssistantChatStore((s) => s.conversations[panelId]) ?? EMPTY_CONVERSATION;
+  // Get conversation state from global store
+  const conversation = useAssistantChatStore((s) => s.conversation);
   const storeAddMessage = useAssistantChatStore((s) => s.addMessage);
   const storeUpdateMessage = useAssistantChatStore((s) => s.updateMessage);
   const storeUpdateLastMessage = useAssistantChatStore((s) => s.updateLastMessage);
@@ -92,7 +76,7 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
       if (chunk.type === "listener_triggered" && chunk.listenerData) {
         const { eventType, data: eventData } = chunk.listenerData;
         const notificationText = formatListenerNotification(eventType, eventData);
-        storeAddMessage(panelId, {
+        storeAddMessage({
           id: `listener-${Date.now()}-${Math.random()}`,
           role: "assistant",
           content: notificationText,
@@ -102,7 +86,7 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
     });
 
     return cleanup;
-  }, [panelId, storeAddMessage]);
+  }, [storeAddMessage]);
 
   const addMessage = useCallback(
     (role: AssistantMessage["role"], content: string) => {
@@ -112,17 +96,17 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
         content,
         timestamp: Date.now(),
       };
-      storeAddMessage(panelId, message);
+      storeAddMessage(message);
       return message;
     },
-    [panelId, storeAddMessage]
+    [storeAddMessage]
   );
 
   const updateLastMessage = useCallback(
     (updates: Partial<AssistantMessage>) => {
-      storeUpdateLastMessage(panelId, updates);
+      storeUpdateLastMessage(updates);
     },
-    [panelId, storeUpdateLastMessage]
+    [storeUpdateLastMessage]
   );
 
   const setStreamingStateSync = useCallback(
@@ -139,7 +123,7 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
       const id = generateId();
       streamingMessageIdRef.current = id;
       setStreamingMessageId(id);
-      storeAddMessage(panelId, {
+      storeAddMessage({
         id,
         role: "assistant",
         content: state.content,
@@ -147,7 +131,7 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
         toolCalls: state.toolCalls.length > 0 ? state.toolCalls : undefined,
       });
     },
-    [panelId, storeAddMessage]
+    [storeAddMessage]
   );
 
   const syncStreamingMessage = useCallback(
@@ -156,12 +140,12 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
       ensureStreamingMessage(state);
       const messageId = streamingMessageIdRef.current;
       if (!messageId) return;
-      storeUpdateMessage(panelId, messageId, {
+      storeUpdateMessage(messageId, {
         content: state.content,
         toolCalls: state.toolCalls.length > 0 ? state.toolCalls : undefined,
       });
     },
-    [ensureStreamingMessage, panelId, storeUpdateMessage]
+    [ensureStreamingMessage, storeUpdateMessage]
   );
 
   const startStreaming = useCallback(() => {
@@ -223,23 +207,20 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
   }, [streamingState]);
 
   const finalizeStreaming = useCallback(() => {
-    // Capture streaming state from ref (kept in sync by all update functions)
     const currentStreaming = streamingStateRef.current;
     if (!currentStreaming) return;
 
-    // Clear ref first to prevent double-finalization
     streamingStateRef.current = null;
 
-    // Add the finalized message to the store
     if (currentStreaming.content || currentStreaming.toolCalls.length > 0) {
       const messageId = streamingMessageIdRef.current;
       if (messageId) {
-        storeUpdateMessage(panelId, messageId, {
+        storeUpdateMessage(messageId, {
           content: currentStreaming.content,
           toolCalls: currentStreaming.toolCalls.length > 0 ? currentStreaming.toolCalls : undefined,
         });
       } else {
-        storeAddMessage(panelId, {
+        storeAddMessage({
           id: generateId(),
           role: "assistant",
           content: currentStreaming.content,
@@ -248,15 +229,12 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
         });
       }
     }
-    // Defer clearing the streaming state to ensure the store update is processed first.
-    // This prevents a race condition where the streaming item is removed before
-    // the finalized message appears in the messages array.
     setTimeout(() => {
       setStreamingStateSync(null);
       streamingMessageIdRef.current = null;
       setStreamingMessageId(null);
     }, 0);
-  }, [panelId, storeAddMessage, storeUpdateMessage, setStreamingStateSync]);
+  }, [storeAddMessage, storeUpdateMessage, setStreamingStateSync]);
 
   const cancelStreaming = useCallback(() => {
     window.electron.assistant.cancel(sessionIdRef.current);
@@ -273,85 +251,70 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
       streamingMessageIdRef.current = null;
       setStreamingMessageId(null);
     }, 0);
-    storeSetLoading(panelId, false);
-  }, [panelId, storeSetLoading, setStreamingStateSync, syncStreamingMessage]);
+    storeSetLoading(false);
+  }, [storeSetLoading, setStreamingStateSync, syncStreamingMessage]);
 
   const clearError = useCallback(() => {
-    storeSetError(panelId, null);
-  }, [panelId, storeSetError]);
+    storeSetError(null);
+  }, [storeSetError]);
 
   const clearMessages = useCallback(() => {
     window.electron.assistant.cancel(sessionIdRef.current);
     cleanupRef.current?.();
     cleanupRef.current = null;
-    // Invalidate any in-flight requests to prevent race conditions
     currentRequestIdRef.current++;
-    storeClearConversation(panelId);
+    storeClearConversation();
     streamingMessageIdRef.current = null;
     setStreamingMessageId(null);
     setStreamingStateSync(null);
-    // Session ID is already regenerated by clearConversation, sync the ref
-    sessionIdRef.current = useAssistantChatStore.getState().getConversation(panelId).sessionId;
-  }, [panelId, storeClearConversation, setStreamingStateSync]);
+    sessionIdRef.current = useAssistantChatStore.getState().conversation.sessionId;
+  }, [storeClearConversation, setStreamingStateSync]);
 
   // Cleanup on unmount only - cancel streaming and clear loading state
   useEffect(() => {
     return () => {
       cleanupRef.current?.();
       cleanupRef.current = null;
-      // Cancel if there's an active stream
       if (streamingStateRef.current) {
         window.electron.assistant.cancel(sessionIdRef.current);
       }
-      // Always clear loading state on unmount to prevent stuck state
-      storeSetLoading(panelId, false);
+      storeSetLoading(false);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on unmount
-  }, [panelId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const sendMessage = useCallback(
     async (content: string) => {
       if (!content.trim()) return;
 
-      storeSetError(panelId, null);
+      storeSetError(null);
       addMessage("user", content);
-      storeSetLoading(panelId, true);
+      storeSetLoading(true);
 
       const requestId = ++currentRequestIdRef.current;
       const sessionId = sessionIdRef.current;
 
-      // Clean up previous listener
       cleanupRef.current?.();
 
-      // Reset streaming state to ensure clean slate for new message
       streamingStateRef.current = null;
       setStreamingStateSync(null);
       streamingMessageIdRef.current = null;
       setStreamingMessageId(null);
 
       try {
-        // Don't call startStreaming() here - let it be created when first chunk arrives
-        // Get current context
         const projectId = useProjectStore.getState().currentProject?.id;
         const worktreeSelection = useWorktreeSelectionStore.getState();
         const activeWorktreeId = worktreeSelection.activeWorktreeId ?? undefined;
         const focusedWorktreeId = worktreeSelection.focusedWorktreeId ?? undefined;
         const focusedTerminalId = useTerminalStore.getState().focusedId ?? undefined;
 
-        // Get available actions
         const actions = actionService.list();
 
-        // Get current messages from store for the IPC call (includes the message we just added)
-        const currentMessages = useAssistantChatStore.getState().getConversation(panelId).messages;
+        const currentMessages = useAssistantChatStore.getState().conversation.messages;
 
-        // Convert messages to IPC format including tool results
-        // Tool results are derived from tool calls that have completed (status is success/error)
         const ipcMessages: IPCAssistantMessage[] = currentMessages.map((msg) => {
-          // For messages with tool calls, extract completed results
           const completedToolResults = msg.toolCalls
             ?.filter((tc) => {
-              // Include tool call if it has a terminal status (not pending) and has a result or error
-              // This handles both successful results and errors, including void/undefined results
               const hasTerminalStatus = tc.status !== "pending";
               const hasResultOrError = tc.result !== undefined || tc.error !== undefined;
               return hasTerminalStatus && hasResultOrError;
@@ -359,7 +322,6 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
             .map((tc) => ({
               toolCallId: tc.id,
               toolName: tc.name,
-              // Normalize undefined to null for IPC transport
               result: tc.result ?? null,
               error: tc.error,
             }));
@@ -373,8 +335,6 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
               name: tc.name,
               args: tc.args,
             })),
-            // Only include toolResults if there are completed results
-            // This ensures the backend receives properly paired tool calls and results
             toolResults:
               completedToolResults && completedToolResults.length > 0
                 ? completedToolResults
@@ -383,11 +343,8 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
           };
         });
 
-        // Subscribe to chunks
         const cleanup = window.electron.assistant.onChunk((data) => {
-          // Only process chunks for this session
           if (data.sessionId !== sessionId) return;
-          // Ignore if request was superseded
           if (currentRequestIdRef.current !== requestId) return;
 
           const { chunk } = data;
@@ -401,19 +358,16 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
 
             case "tool_call":
               if (chunk.toolCall) {
-                // Check if tool call already exists (can happen if tool_result arrived first)
                 const existingToolCall = streamingStateRef.current?.toolCalls.find(
                   (tc) => tc.id === chunk.toolCall!.id
                 );
 
                 if (existingToolCall) {
-                  // Update existing tool call with proper name and args
                   updateStreamingToolCall(chunk.toolCall.id, {
                     name: chunk.toolCall.name,
                     args: chunk.toolCall.args,
                   });
                 } else {
-                  // Add new tool call
                   addStreamingToolCall({
                     id: chunk.toolCall.id,
                     name: chunk.toolCall.name,
@@ -427,7 +381,6 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
             case "tool_result":
               if (chunk.toolResult) {
                 const toolResult = chunk.toolResult;
-                // Check if tool call exists before updating
                 const toolCallExists = streamingStateRef.current?.toolCalls.some(
                   (tc) => tc.id === toolResult.toolCallId
                 );
@@ -439,7 +392,6 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
                     error: toolResult.error,
                   });
                 } else {
-                  // Tool result arrived before tool call - create placeholder
                   addStreamingToolCall({
                     id: toolResult.toolCallId,
                     name: toolResult.toolName,
@@ -454,12 +406,11 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
 
             case "error":
               if (chunk.error) {
-                storeSetError(panelId, chunk.error);
+                storeSetError(chunk.error);
                 onError?.(chunk.error);
               }
-              // Finalize and cleanup on error to prevent stuck loading state
               finalizeStreaming();
-              storeSetLoading(panelId, false);
+              storeSetLoading(false);
               cleanupRef.current?.();
               cleanupRef.current = null;
               break;
@@ -469,7 +420,7 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
 
             case "done":
               finalizeStreaming();
-              storeSetLoading(panelId, false);
+              storeSetLoading(false);
               cleanupRef.current?.();
               cleanupRef.current = null;
               break;
@@ -478,7 +429,6 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
 
         cleanupRef.current = cleanup;
 
-        // Send the message
         await window.electron.assistant.sendMessage({
           sessionId,
           messages: ipcMessages,
@@ -493,20 +443,17 @@ export function useAssistantChat(options: UseAssistantChatOptions) {
       } catch (err) {
         if (currentRequestIdRef.current === requestId) {
           const errorMessage = err instanceof Error ? err.message : "An error occurred";
-          storeSetError(panelId, errorMessage);
+          storeSetError(errorMessage);
           onError?.(errorMessage);
           setStreamingStateSync(null);
-          storeSetLoading(panelId, false);
-          // Clean up listener on error
+          storeSetLoading(false);
           cleanupRef.current?.();
           cleanupRef.current = null;
-          // Cancel the session to avoid dangling stream
           window.electron.assistant.cancel(sessionId);
         }
       }
     },
     [
-      panelId,
       addMessage,
       startStreaming,
       appendStreamingContent,

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -1,6 +1,5 @@
 import { Terminal, Globe, StickyNote, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { CanopyIcon } from "@/components/icons";
 import type { TerminalType, TerminalKind } from "@/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 
@@ -31,13 +30,6 @@ export function TerminalIcon({ type, kind, agentId, className, brandColor }: Ter
   // Dev preview panes get a monitor icon
   if (kind === "dev-preview") {
     return <Monitor {...finalProps} className={cn(finalProps.className, "text-violet-400")} />;
-  }
-
-  // Assistant panes get the Canopy icon
-  if (kind === "assistant") {
-    return (
-      <CanopyIcon {...finalProps} className={cn(finalProps.className, "text-canopy-accent")} />
-    );
   }
 
   // Get effective agent ID - either from explicit agentId prop or from type (backward compat)

--- a/src/registry/builtInPanelRegistrations.ts
+++ b/src/registry/builtInPanelRegistrations.ts
@@ -1,13 +1,12 @@
 /**
  * Built-in panel component registrations.
- * Called once at app startup to register terminal, agent, browser, notes, and assistant panels.
+ * Called once at app startup to register terminal, agent, browser, and notes panels.
  */
 import { registerPanelComponent } from "./panelComponentRegistry";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { BrowserPane } from "@/components/Browser/BrowserPane";
 import { NotesPane } from "@/components/Notes/NotesPane";
 import { DevPreviewPane } from "@/components/DevPreview/DevPreviewPane";
-import { AssistantPane } from "@/components/Assistant/AssistantPane";
 
 // Registration flag to prevent double registration
 let registered = false;
@@ -44,10 +43,5 @@ export function registerBuiltInPanelComponents(): void {
   // Dev Preview panel - auto-starts dev server and shows iframe
   registerPanelComponent("dev-preview", {
     component: DevPreviewPane,
-  });
-
-  // Assistant panel - Canopy AI assistant interface
-  registerPanelComponent("assistant", {
-    component: AssistantPane,
   });
 }

--- a/src/services/actions/definitions/assistantActions.ts
+++ b/src/services/actions/definitions/assistantActions.ts
@@ -1,8 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import { z } from "zod";
-import { useTerminalStore } from "@/store/terminalStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
-import { useAssistantChatStore } from "@/store/assistantChatStore";
+import { useAssistantUiStore } from "@/store/assistantUiStore";
 
 export function registerAssistantActions(
   actions: ActionRegistry,
@@ -10,41 +7,14 @@ export function registerAssistantActions(
 ): void {
   actions.set("assistant.open", () => ({
     id: "assistant.open",
-    title: "Open Assistant",
-    description: "Open or focus the Canopy Assistant panel",
+    title: "Toggle Assistant",
+    description: "Open or close the Canopy Assistant",
     category: "assistant",
     kind: "command",
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-      await useTerminalStore.getState().addTerminal({
-        kind: "assistant",
-        title: "Assistant",
-        location: "grid",
-        worktreeId: activeWorktreeId ?? undefined,
-      });
-    },
-  }));
-
-  actions.set("assistant.restart", () => ({
-    id: "assistant.restart",
-    title: "Restart Assistant",
-    description: "Clear conversation and start a new session",
-    category: "assistant",
-    kind: "command",
-    danger: "safe",
-    scope: "renderer",
-    argsSchema: z.object({ panelId: z.string().optional() }).optional(),
-    run: async (args: unknown) => {
-      const { panelId } = (args as { panelId?: string } | undefined) ?? {};
-      const chatStore = useAssistantChatStore.getState();
-      const terminalStore = useTerminalStore.getState();
-      const targetId = panelId ?? terminalStore.focusedId;
-
-      if (targetId) {
-        chatStore.clearConversation(targetId);
-      }
+      useAssistantUiStore.getState().toggle();
     },
   }));
 }

--- a/src/store/assistantUiStore.ts
+++ b/src/store/assistantUiStore.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface AssistantUiState {
+  isOpen: boolean;
+}
+
+interface AssistantUiActions {
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+export const useAssistantUiStore = create<AssistantUiState & AssistantUiActions>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+}));

--- a/src/store/persistence/terminalPersistence.ts
+++ b/src/store/persistence/terminalPersistence.ts
@@ -15,7 +15,7 @@ export interface TerminalPersistenceOptions {
 const DEFAULT_OPTIONS: Required<Omit<TerminalPersistenceOptions, "getProjectId">> &
   Pick<TerminalPersistenceOptions, "getProjectId"> = {
   debounceMs: 500,
-  filter: (t) => t.location !== "trash",
+  filter: (t) => t.location !== "trash" && t.kind !== "assistant",
   transform: (t) => {
     // Note: tabGroupId and orderInGroup are NOT saved on terminals anymore
     // Tab groups are stored separately in ProjectState.tabGroups

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -133,16 +133,6 @@ export const createTerminalRegistrySlice =
               browserUrl: options.browserUrl,
               exitBehavior: options.exitBehavior,
             };
-          } else if (requestedKind === "assistant") {
-            terminal = {
-              id,
-              kind: "assistant",
-              title,
-              worktreeId: options.worktreeId,
-              location,
-              isVisible: location === "grid",
-              runtimeStatus,
-            };
           } else {
             // Generic non-PTY panel fallback for extensions
             terminal = {

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -104,13 +104,6 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
           }
         });
       }
-
-      // Clean up assistant chat conversation when assistant panel is permanently removed
-      if (removedTerminal?.kind === "assistant") {
-        void import("@/store/assistantChatStore").then(({ useAssistantChatStore }) => {
-          useAssistantChatStore.getState().removeConversation(id);
-        });
-      }
     },
   })(set, get, api);
 

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -254,12 +254,22 @@ export async function hydrateAppState(
                     kind = "browser";
                   } else if (saved.notePath !== undefined || saved.noteId !== undefined) {
                     kind = "notes";
-                  } else if (saved.title === "Assistant") {
-                    // Legacy assistant panels from before kind was always set
+                  } else if (saved.title === "Assistant" || saved.title?.startsWith("Assistant")) {
+                    // Legacy assistant panels from before kind was always set - skip these
+                    // Match "Assistant", "Assistant (renamed)", etc.
+                    kind = "assistant";
+                  } else if (!saved.cwd && !saved.command) {
+                    // Non-PTY panel with no PTY markers and not browser/notes - likely legacy assistant
                     kind = "assistant";
                   }
                   // Note: dev-preview detection removed since 'devCommand' isn't in TerminalSnapshot.
                   // Dev-preview panels should always have 'kind' set during persistence.
+                }
+
+                // Skip assistant panels (they're now global, not panel-based)
+                if (kind === "assistant") {
+                  console.log(`[StateHydration] Skipping legacy assistant panel: ${saved.id}`);
+                  continue;
                 }
 
                 const location = (saved.location === "dock" ? "dock" : "grid") as "grid" | "dock";


### PR DESCRIPTION
## Summary
Converts the Canopy assistant from a panel-based component to a standalone global component, decoupling it from the panel system while maintaining all current functionality.

Closes #2026

## Changes Made
- Removed "assistant" from BuiltInPanelKind and panel type system
- Created global assistantUiStore for UI visibility state (isOpen, toggle)
- Simplified assistantChatStore to single global conversation (no per-panel state)
- Converted AssistantPane to standalone component without BasePanelProps
- Added AssistantHost modal overlay, keeps mounted when hidden to preserve streaming
- Updated assistant.open action to toggle global UI instead of spawning panels
- Removed assistant.restart action (replaced by inline clear button)
- Filtered assistant panels from persistence and hydration
- Improved legacy assistant panel detection for migration safety

## Technical Details
The assistant now renders as a global modal overlay that persists across the app, similar to how settings or diagnostics work. The component remains mounted when hidden (via CSS) to preserve active streaming sessions and listener notifications.

Migration safety: Legacy assistant panels are automatically filtered during state hydration and persistence, preventing ghost panels in saved layouts.