### PR TITLE
Focus assistant input when opening via keybinding or dock button

### DIFF
--- a/src/components/Assistant/AssistantPane.tsx
+++ b/src/components/Assistant/AssistantPane.tsx
@@ -9,7 +9,7 @@ import { useAssistantChat } from "./useAssistantChat";
 
 export function AssistantPane() {
   const { hasApiKey, isInitialized, initialize } = useAppAgentStore();
-  const { close } = useAssistantChatStore();
+  const { isOpen, close } = useAssistantChatStore();
   const inputRef = useRef<AssistantInputHandle>(null);
 
   const {
@@ -24,9 +24,24 @@ export function AssistantPane() {
     clearMessages,
   } = useAssistantChat();
 
+  const showLoading = !isInitialized;
+  const showNoApiKey = isInitialized && !hasApiKey;
+  const showChat = isInitialized && hasApiKey;
+  const hasMessages = messages.length > 0;
+
   useEffect(() => {
     initialize();
   }, [initialize]);
+
+  // Focus input when assistant opens and chat UI is ready
+  useEffect(() => {
+    if (!isOpen || !showChat || isLoading) return;
+
+    const rafId = requestAnimationFrame(() => {
+      inputRef.current?.focus();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [isOpen, showChat, isLoading]);
 
   const handleSubmit = useCallback(
     (value: string) => {
@@ -43,11 +58,6 @@ export function AssistantPane() {
     }
     clearMessages();
   }, [clearMessages, messages.length, isLoading]);
-
-  const showLoading = !isInitialized;
-  const showNoApiKey = isInitialized && !hasApiKey;
-  const showChat = isInitialized && hasApiKey;
-  const hasMessages = messages.length > 0;
 
   return (
     <div className="flex flex-col h-full bg-canopy-bg">


### PR DESCRIPTION
## Summary

Implements auto-focus for the assistant input field when the panel is opened via `Cmd+Shift+K` keybinding or by clicking the dock button. Previously, users had to manually click the input field after opening the assistant, which was inefficient for keyboard-driven workflows.

Closes #2038

## Changes Made

- Subscribe to `isOpen` state from `assistantChatStore` to detect when panel opens
- Add `useEffect` to auto-focus input when panel opens
- Guard focus with `showChat` and `!isLoading` to ensure UI is ready and input is rendered
- Use `requestAnimationFrame` for proper timing after popover animation completes
- Add cleanup to cancel pending animation frame on unmount to prevent focus on hidden input
- Move derived state variables before dependent `useEffect` to fix TypeScript ordering issues

## Implementation Details

The implementation waits for three conditions before focusing:
1. `isOpen` - Panel is open
2. `showChat` - Chat UI is rendered (API key is configured)
3. `!isLoading` - Input is not disabled

This ensures the input element exists and is ready to receive focus, preventing race conditions with component mounting and popover animations.