### PR TITLE
Improve visual hierarchy between Assistant header and user messages

### DIFF
--- a/src/components/Assistant/InteractionBlock.tsx
+++ b/src/components/Assistant/InteractionBlock.tsx
@@ -17,7 +17,7 @@ function UserInputBlock({ content, className }: { content: string; className?: s
     <div
       className={cn(
         "group relative flex gap-4 px-6 py-5",
-        "bg-white/[0.02] border-b border-white/[0.05]",
+        "bg-white/[0.03] border-b border-white/[0.05]",
         className
       )}
       role="article"


### PR DESCRIPTION
## Summary
Improves visual hierarchy in the Assistant by darkening the user message background to create better distinction from the header bar.

Closes #2042

## Changes Made
- Darken user message background from bg-white/[0.02] to bg-white/[0.03]
- Creates clearer distinction between header and message content
- Maintains color progression: responses < header < user messages