### PR TITLE
feat(assistant): enable background message processing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   useWorktreeActions,
   useMenuActions,
   useAppAgentDispatcher,
+  useAssistantStreamProcessor,
 } from "./hooks";
 import { useActionRegistry } from "./hooks/useActionRegistry";
 import { useAssistantContextSync } from "./hooks/useAssistantContextSync";
@@ -490,6 +491,7 @@ function App() {
   useTerminalConfig();
   useWindowNotifications();
   useAppAgentDispatcher(); // Enable Assistant tool calling via action dispatch
+  useAssistantStreamProcessor(); // Process Assistant chunks even when pane is closed
 
   const [homeDir, setHomeDir] = useState<string | undefined>(undefined);
   useEffect(() => {

--- a/src/components/Assistant/useAssistantChat.ts
+++ b/src/components/Assistant/useAssistantChat.ts
@@ -1,5 +1,5 @@
-import { useState, useCallback, useRef, useEffect } from "react";
-import type { AssistantMessage, StreamingState, ToolCall } from "./types";
+import { useCallback, useRef, useEffect } from "react";
+import type { AssistantMessage } from "./types";
 import { actionService } from "@/services/ActionService";
 import { useAssistantChatStore } from "@/store/assistantChatStore";
 import type { AssistantMessage as IPCAssistantMessage } from "@shared/types/assistant";
@@ -7,29 +7,6 @@ import { getAssistantContext } from "./assistantContext";
 
 function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-}
-
-function formatListenerNotification(eventType: string, data: Record<string, unknown>): string {
-  if (eventType === "terminal:state-changed") {
-    const terminalId = data.terminalId as string | undefined;
-    const newState = data.newState as string | undefined;
-    const oldState = data.oldState as string | undefined;
-    const worktreeId = data.worktreeId as string | undefined;
-
-    const stateEmoji = newState === "completed" ? "✅" : newState === "failed" ? "❌" : "🔔";
-    let msg = `${stateEmoji} Terminal state: ${oldState || "unknown"} → ${newState || "unknown"}`;
-
-    if (terminalId) {
-      msg += ` (terminal: ${terminalId.slice(0, 8)})`;
-    }
-    if (worktreeId) {
-      msg += ` [${worktreeId}]`;
-    }
-
-    return msg;
-  }
-
-  return `🔔 Event triggered: ${eventType}`;
 }
 
 interface UseAssistantChatOptions {
@@ -41,50 +18,23 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
 
   // Get conversation state from global store
   const conversation = useAssistantChatStore((s) => s.conversation);
+  const streamingState = useAssistantChatStore((s) => s.streamingState);
+  const streamingMessageId = useAssistantChatStore((s) => s.streamingMessageId);
   const storeAddMessage = useAssistantChatStore((s) => s.addMessage);
-  const storeUpdateMessage = useAssistantChatStore((s) => s.updateMessage);
   const storeUpdateLastMessage = useAssistantChatStore((s) => s.updateLastMessage);
   const storeSetLoading = useAssistantChatStore((s) => s.setLoading);
   const storeSetError = useAssistantChatStore((s) => s.setError);
   const storeClearConversation = useAssistantChatStore((s) => s.clearConversation);
-
-  // Streaming state remains local since it's transient and shouldn't survive unmount
-  const [streamingState, setStreamingState] = useState<StreamingState | null>(null);
-  const streamingStateRef = useRef<StreamingState | null>(null);
-  const streamingMessageIdRef = useRef<string | null>(null);
-  const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
+  const storeSetStreamingState = useAssistantChatStore((s) => s.setStreamingState);
 
   // Use ref for session ID to maintain stability across the component lifetime
   const sessionIdRef = useRef<string>(conversation.sessionId);
   const currentRequestIdRef = useRef<number>(0);
-  const cleanupRef = useRef<(() => void) | null>(null);
 
   // Keep session ID ref in sync with store
   useEffect(() => {
     sessionIdRef.current = conversation.sessionId;
   }, [conversation.sessionId]);
-
-  // Mount-level chunk subscription for persistent listener notifications
-  useEffect(() => {
-    const cleanup = window.electron.assistant.onChunk((data) => {
-      if (data.sessionId !== sessionIdRef.current) return;
-
-      const { chunk } = data;
-
-      if (chunk.type === "listener_triggered" && chunk.listenerData) {
-        const { eventType, data: eventData } = chunk.listenerData;
-        const notificationText = formatListenerNotification(eventType, eventData);
-        storeAddMessage({
-          id: `listener-${Date.now()}-${Math.random()}`,
-          role: "assistant",
-          content: notificationText,
-          timestamp: Date.now(),
-        });
-      }
-    });
-
-    return cleanup;
-  }, [storeAddMessage]);
 
   const addMessage = useCallback(
     (role: AssistantMessage["role"], content: string) => {
@@ -107,150 +57,11 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
     [storeUpdateLastMessage]
   );
 
-  const setStreamingStateSync = useCallback(
-    (next: StreamingState | null) => {
-      streamingStateRef.current = next;
-      setStreamingState(next);
-    },
-    [setStreamingState]
-  );
-
-  const ensureStreamingMessage = useCallback(
-    (state: StreamingState) => {
-      if (streamingMessageIdRef.current) return;
-      const id = generateId();
-      streamingMessageIdRef.current = id;
-      setStreamingMessageId(id);
-      storeAddMessage({
-        id,
-        role: "assistant",
-        content: state.content,
-        timestamp: Date.now(),
-        toolCalls: state.toolCalls.length > 0 ? state.toolCalls : undefined,
-      });
-    },
-    [storeAddMessage]
-  );
-
-  const syncStreamingMessage = useCallback(
-    (state: StreamingState) => {
-      if (!state.content && state.toolCalls.length === 0) return;
-      ensureStreamingMessage(state);
-      const messageId = streamingMessageIdRef.current;
-      if (!messageId) return;
-      storeUpdateMessage(messageId, {
-        content: state.content,
-        toolCalls: state.toolCalls.length > 0 ? state.toolCalls : undefined,
-      });
-    },
-    [ensureStreamingMessage, storeUpdateMessage]
-  );
-
-  const startStreaming = useCallback(() => {
-    const newState = { content: "", toolCalls: [] };
-    setStreamingStateSync(newState);
-    streamingMessageIdRef.current = null;
-    setStreamingMessageId(null);
-  }, [setStreamingStateSync]);
-
-  const appendStreamingContent = useCallback(
-    (chunk: string) => {
-      const prev = streamingStateRef.current;
-      if (!prev) {
-        const newState = { content: chunk, toolCalls: [] };
-        setStreamingStateSync(newState);
-        syncStreamingMessage(newState);
-      } else {
-        const newState = { ...prev, content: prev.content + chunk };
-        setStreamingStateSync(newState);
-        syncStreamingMessage(newState);
-      }
-    },
-    [setStreamingStateSync, syncStreamingMessage]
-  );
-
-  const addStreamingToolCall = useCallback(
-    (toolCall: ToolCall) => {
-      const prev = streamingStateRef.current;
-      if (!prev) {
-        const newState = { content: "", toolCalls: [toolCall] };
-        setStreamingStateSync(newState);
-        syncStreamingMessage(newState);
-      } else {
-        const newState = { ...prev, toolCalls: [...prev.toolCalls, toolCall] };
-        setStreamingStateSync(newState);
-        syncStreamingMessage(newState);
-      }
-    },
-    [setStreamingStateSync, syncStreamingMessage]
-  );
-
-  const updateStreamingToolCall = useCallback(
-    (toolCallId: string, updates: Partial<ToolCall>) => {
-      const prev = streamingStateRef.current;
-      if (!prev) return;
-      const newState = {
-        ...prev,
-        toolCalls: prev.toolCalls.map((tc) => (tc.id === toolCallId ? { ...tc, ...updates } : tc)),
-      };
-      setStreamingStateSync(newState);
-      syncStreamingMessage(newState);
-    },
-    [setStreamingStateSync, syncStreamingMessage]
-  );
-
-  // Keep ref in sync with state for use in finalizeStreaming
-  useEffect(() => {
-    streamingStateRef.current = streamingState;
-  }, [streamingState]);
-
-  const finalizeStreaming = useCallback(() => {
-    const currentStreaming = streamingStateRef.current;
-    if (!currentStreaming) return;
-
-    streamingStateRef.current = null;
-
-    if (currentStreaming.content || currentStreaming.toolCalls.length > 0) {
-      const messageId = streamingMessageIdRef.current;
-      if (messageId) {
-        storeUpdateMessage(messageId, {
-          content: currentStreaming.content,
-          toolCalls: currentStreaming.toolCalls.length > 0 ? currentStreaming.toolCalls : undefined,
-        });
-      } else {
-        storeAddMessage({
-          id: generateId(),
-          role: "assistant",
-          content: currentStreaming.content,
-          timestamp: Date.now(),
-          toolCalls: currentStreaming.toolCalls.length > 0 ? currentStreaming.toolCalls : undefined,
-        });
-      }
-    }
-    setTimeout(() => {
-      setStreamingStateSync(null);
-      streamingMessageIdRef.current = null;
-      setStreamingMessageId(null);
-    }, 0);
-  }, [storeAddMessage, storeUpdateMessage, setStreamingStateSync]);
-
   const cancelStreaming = useCallback(() => {
     window.electron.assistant.cancel(sessionIdRef.current);
-    cleanupRef.current?.();
-    cleanupRef.current = null;
-    if (
-      streamingStateRef.current &&
-      (streamingStateRef.current.content || streamingStateRef.current.toolCalls.length > 0)
-    ) {
-      syncStreamingMessage(streamingStateRef.current);
-    }
-    setStreamingStateSync(null);
-    setTimeout(() => {
-      streamingMessageIdRef.current = null;
-      setStreamingMessageId(null);
-    }, 0);
+    storeSetStreamingState(null, null);
     storeSetLoading(false);
-  }, [storeSetLoading, setStreamingStateSync, syncStreamingMessage]);
+  }, [storeSetLoading, storeSetStreamingState]);
 
   const clearError = useCallback(() => {
     storeSetError(null);
@@ -258,28 +69,10 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
 
   const clearMessages = useCallback(() => {
     window.electron.assistant.cancel(sessionIdRef.current);
-    cleanupRef.current?.();
-    cleanupRef.current = null;
     currentRequestIdRef.current++;
     storeClearConversation();
-    streamingMessageIdRef.current = null;
-    setStreamingMessageId(null);
-    setStreamingStateSync(null);
     sessionIdRef.current = useAssistantChatStore.getState().conversation.sessionId;
-  }, [storeClearConversation, setStreamingStateSync]);
-
-  // Cleanup on unmount only - cancel streaming and clear loading state
-  useEffect(() => {
-    return () => {
-      cleanupRef.current?.();
-      cleanupRef.current = null;
-      if (streamingStateRef.current) {
-        window.electron.assistant.cancel(sessionIdRef.current);
-      }
-      storeSetLoading(false);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [storeClearConversation]);
 
   const sendMessage = useCallback(
     async (content: string) => {
@@ -292,12 +85,8 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
       const requestId = ++currentRequestIdRef.current;
       const sessionId = sessionIdRef.current;
 
-      cleanupRef.current?.();
-
-      streamingStateRef.current = null;
-      setStreamingStateSync(null);
-      streamingMessageIdRef.current = null;
-      setStreamingMessageId(null);
+      // Reset streaming state for new message
+      storeSetStreamingState(null, null);
 
       try {
         const context = getAssistantContext();
@@ -336,93 +125,6 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
           };
         });
 
-        const cleanup = window.electron.assistant.onChunk((data) => {
-          if (data.sessionId !== sessionId) return;
-          if (currentRequestIdRef.current !== requestId) return;
-
-          const { chunk } = data;
-
-          switch (chunk.type) {
-            case "text":
-              if (chunk.content) {
-                appendStreamingContent(chunk.content);
-              }
-              break;
-
-            case "tool_call":
-              if (chunk.toolCall) {
-                const existingToolCall = streamingStateRef.current?.toolCalls.find(
-                  (tc) => tc.id === chunk.toolCall!.id
-                );
-
-                if (existingToolCall) {
-                  updateStreamingToolCall(chunk.toolCall.id, {
-                    name: chunk.toolCall.name,
-                    args: chunk.toolCall.args,
-                  });
-                } else {
-                  addStreamingToolCall({
-                    id: chunk.toolCall.id,
-                    name: chunk.toolCall.name,
-                    args: chunk.toolCall.args,
-                    status: "pending",
-                  });
-                }
-              }
-              break;
-
-            case "tool_result":
-              if (chunk.toolResult) {
-                const toolResult = chunk.toolResult;
-                const toolCallExists = streamingStateRef.current?.toolCalls.some(
-                  (tc) => tc.id === toolResult.toolCallId
-                );
-
-                if (toolCallExists) {
-                  updateStreamingToolCall(toolResult.toolCallId, {
-                    status: toolResult.error ? "error" : "success",
-                    result: toolResult.result,
-                    error: toolResult.error,
-                  });
-                } else {
-                  addStreamingToolCall({
-                    id: toolResult.toolCallId,
-                    name: toolResult.toolName,
-                    args: {},
-                    status: toolResult.error ? "error" : "success",
-                    result: toolResult.result,
-                    error: toolResult.error,
-                  });
-                }
-              }
-              break;
-
-            case "error":
-              console.error("[AssistantChat] API Error:", chunk.error);
-              if (chunk.error) {
-                storeSetError(chunk.error);
-                onError?.(chunk.error);
-              }
-              finalizeStreaming();
-              storeSetLoading(false);
-              cleanupRef.current?.();
-              cleanupRef.current = null;
-              break;
-
-            case "listener_triggered":
-              break;
-
-            case "done":
-              finalizeStreaming();
-              storeSetLoading(false);
-              cleanupRef.current?.();
-              cleanupRef.current = null;
-              break;
-          }
-        });
-
-        cleanupRef.current = cleanup;
-
         await window.electron.assistant.sendMessage({
           sessionId,
           messages: ipcMessages,
@@ -435,26 +137,13 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
           console.error("[AssistantChat] Error:", errorMessage);
           storeSetError(errorMessage);
           onError?.(errorMessage);
-          setStreamingStateSync(null);
+          storeSetStreamingState(null, null);
           storeSetLoading(false);
-          cleanupRef.current?.();
-          cleanupRef.current = null;
           window.electron.assistant.cancel(sessionId);
         }
       }
     },
-    [
-      addMessage,
-      startStreaming,
-      appendStreamingContent,
-      addStreamingToolCall,
-      updateStreamingToolCall,
-      finalizeStreaming,
-      storeSetError,
-      storeSetLoading,
-      onError,
-      setStreamingStateSync,
-    ]
+    [addMessage, storeSetError, storeSetLoading, onError, storeSetStreamingState]
   );
 
   return {
@@ -469,9 +158,5 @@ export function useAssistantChat(options?: UseAssistantChatOptions) {
     clearMessages,
     addMessage,
     updateLastMessage,
-    appendStreamingContent,
-    addStreamingToolCall,
-    updateStreamingToolCall,
-    finalizeStreaming,
   };
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -63,3 +63,5 @@ export type { UseHorizontalScrollControlsReturn } from "./useHorizontalScrollCon
 export { useDockRenderState } from "./useDockRenderState";
 
 export { useAppAgentDispatcher } from "./useAppAgentDispatcher";
+
+export { useAssistantStreamProcessor } from "./useAssistantStreamProcessor";

--- a/src/hooks/useAssistantStreamProcessor.ts
+++ b/src/hooks/useAssistantStreamProcessor.ts
@@ -1,0 +1,297 @@
+import { useEffect, useRef } from "react";
+import { useAssistantChatStore } from "@/store/assistantChatStore";
+import type { ToolCall } from "@/components/Assistant/types";
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function formatListenerNotification(eventType: string, data: Record<string, unknown>): string {
+  if (eventType === "terminal:state-changed") {
+    const terminalId = data.terminalId as string | undefined;
+    const newState = data.newState as string | undefined;
+    const oldState = data.oldState as string | undefined;
+    const worktreeId = data.worktreeId as string | undefined;
+
+    const stateEmoji = newState === "completed" ? "✅" : newState === "failed" ? "❌" : "🔔";
+    let msg = `${stateEmoji} Terminal state: ${oldState || "unknown"} → ${newState || "unknown"}`;
+
+    if (terminalId) {
+      msg += ` (terminal: ${terminalId.slice(0, 8)})`;
+    }
+    if (worktreeId) {
+      msg += ` [${worktreeId}]`;
+    }
+
+    return msg;
+  }
+
+  return `🔔 Event triggered: ${eventType}`;
+}
+
+/**
+ * Global hook that processes assistant streaming chunks independently of UI visibility.
+ * Mount this once at the app root level to ensure messages continue processing
+ * even when the AssistantPane is closed.
+ */
+export function useAssistantStreamProcessor() {
+  const streamingStateRef = useRef<{ content: string; toolCalls: ToolCall[] } | null>(null);
+  const streamingMessageIdRef = useRef<string | null>(null);
+  const streamingSessionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!window.electron?.assistant?.onChunk) {
+      return;
+    }
+    function ensureStreamingMessage() {
+      if (streamingMessageIdRef.current) return;
+
+      const state = streamingStateRef.current;
+      if (!state) return;
+
+      const id = generateId();
+      streamingMessageIdRef.current = id;
+
+      useAssistantChatStore.getState().addMessage({
+        id,
+        role: "assistant",
+        content: state.content,
+        timestamp: Date.now(),
+        toolCalls: state.toolCalls.length > 0 ? state.toolCalls : undefined,
+      });
+    }
+
+    function syncStreamingMessage() {
+      const state = streamingStateRef.current;
+      if (!state || (!state.content && state.toolCalls.length === 0)) return;
+
+      ensureStreamingMessage();
+
+      const messageId = streamingMessageIdRef.current;
+      if (!messageId) return;
+
+      useAssistantChatStore.getState().updateMessage(messageId, {
+        content: state.content,
+        toolCalls: state.toolCalls.length > 0 ? state.toolCalls : undefined,
+      });
+
+      // Also update the streaming state in the store so the UI can reflect live streaming
+      useAssistantChatStore.getState().setStreamingState(
+        { content: state.content, toolCalls: state.toolCalls },
+        messageId
+      );
+    }
+
+    function resetStreamingState() {
+      streamingStateRef.current = null;
+      streamingMessageIdRef.current = null;
+      streamingSessionIdRef.current = null;
+      useAssistantChatStore.getState().setStreamingState(null, null);
+    }
+
+    function finalizeStreaming() {
+      const currentStreaming = streamingStateRef.current;
+      if (!currentStreaming) return;
+
+      // Finalize the message if there's content
+      if (currentStreaming.content || currentStreaming.toolCalls.length > 0) {
+        const messageId = streamingMessageIdRef.current;
+        if (messageId) {
+          useAssistantChatStore.getState().updateMessage(messageId, {
+            content: currentStreaming.content,
+            toolCalls:
+              currentStreaming.toolCalls.length > 0 ? currentStreaming.toolCalls : undefined,
+          });
+        } else {
+          // No message was created yet (very short response), create one now
+          useAssistantChatStore.getState().addMessage({
+            id: generateId(),
+            role: "assistant",
+            content: currentStreaming.content,
+            timestamp: Date.now(),
+            toolCalls:
+              currentStreaming.toolCalls.length > 0 ? currentStreaming.toolCalls : undefined,
+          });
+        }
+      }
+
+      // Reset streaming state
+      resetStreamingState();
+    }
+
+    // Subscribe to session changes to reset streaming state
+    const unsubscribe = useAssistantChatStore.subscribe((state, prev) => {
+      if (state.conversation.sessionId !== prev.conversation.sessionId) {
+        resetStreamingState();
+      }
+    });
+
+    const cleanup = window.electron.assistant.onChunk((data) => {
+      const currentState = useAssistantChatStore.getState();
+      const { sessionId: currentSessionId } = currentState.conversation;
+
+      // Reset streaming state if session changed
+      if (streamingSessionIdRef.current && streamingSessionIdRef.current !== currentSessionId) {
+        resetStreamingState();
+      }
+
+      // Ignore chunks from different sessions
+      if (data.sessionId !== currentSessionId) return;
+
+      // Track current session
+      if (!streamingSessionIdRef.current) {
+        streamingSessionIdRef.current = currentSessionId;
+      }
+
+      const { chunk } = data;
+
+      switch (chunk.type) {
+        case "text":
+          if (chunk.content) {
+            const prev = streamingStateRef.current;
+            if (!prev) {
+              streamingStateRef.current = { content: chunk.content, toolCalls: [] };
+            } else {
+              streamingStateRef.current = { ...prev, content: prev.content + chunk.content };
+            }
+            syncStreamingMessage();
+          }
+          break;
+
+        case "tool_call":
+          if (chunk.toolCall) {
+            const prev = streamingStateRef.current;
+            const existingToolCall = prev?.toolCalls.find((tc) => tc.id === chunk.toolCall!.id);
+
+            if (existingToolCall) {
+              // Update existing tool call
+              if (prev) {
+                streamingStateRef.current = {
+                  ...prev,
+                  toolCalls: prev.toolCalls.map((tc) =>
+                    tc.id === chunk.toolCall!.id
+                      ? { ...tc, name: chunk.toolCall!.name, args: chunk.toolCall!.args }
+                      : tc
+                  ),
+                };
+              }
+            } else {
+              // Add new tool call
+              const newToolCall: ToolCall = {
+                id: chunk.toolCall.id,
+                name: chunk.toolCall.name,
+                args: chunk.toolCall.args,
+                status: "pending",
+              };
+              if (!prev) {
+                streamingStateRef.current = { content: "", toolCalls: [newToolCall] };
+              } else {
+                streamingStateRef.current = { ...prev, toolCalls: [...prev.toolCalls, newToolCall] };
+              }
+            }
+            syncStreamingMessage();
+          }
+          break;
+
+        case "tool_result":
+          if (chunk.toolResult) {
+            const toolResult = chunk.toolResult;
+            const prev = streamingStateRef.current;
+
+            // Initialize streaming state if tool_result arrives before other chunks
+            if (!prev) {
+              streamingStateRef.current = {
+                content: "",
+                toolCalls: [
+                  {
+                    id: toolResult.toolCallId,
+                    name: toolResult.toolName,
+                    args: {},
+                    status: toolResult.error ? ("error" as const) : ("success" as const),
+                    result: toolResult.result,
+                    error: toolResult.error,
+                  },
+                ],
+              };
+              syncStreamingMessage();
+            } else if (prev) {
+              const toolCallExists = prev.toolCalls.some((tc) => tc.id === toolResult.toolCallId);
+
+              if (toolCallExists) {
+                streamingStateRef.current = {
+                  ...prev,
+                  toolCalls: prev.toolCalls.map((tc) =>
+                    tc.id === toolResult.toolCallId
+                      ? {
+                          ...tc,
+                          status: toolResult.error ? ("error" as const) : ("success" as const),
+                          result: toolResult.result,
+                          error: toolResult.error,
+                        }
+                      : tc
+                  ),
+                };
+              } else {
+                // Tool result arrived before tool call (race condition)
+                streamingStateRef.current = {
+                  ...prev,
+                  toolCalls: [
+                    ...prev.toolCalls,
+                    {
+                      id: toolResult.toolCallId,
+                      name: toolResult.toolName,
+                      args: {},
+                      status: toolResult.error ? ("error" as const) : ("success" as const),
+                      result: toolResult.result,
+                      error: toolResult.error,
+                    },
+                  ],
+                };
+              }
+              syncStreamingMessage();
+            }
+          }
+          break;
+
+        case "error":
+          if (chunk.error) {
+            useAssistantChatStore.getState().setError(chunk.error);
+          }
+          finalizeStreaming();
+          useAssistantChatStore.getState().setLoading(false);
+          break;
+
+        case "listener_triggered":
+          if (chunk.listenerData) {
+            const { eventType, data: eventData } = chunk.listenerData;
+            const notificationText = formatListenerNotification(eventType, eventData);
+            useAssistantChatStore.getState().addMessage({
+              id: `listener-${Date.now()}-${Math.random()}`,
+              role: "assistant",
+              content: notificationText,
+              timestamp: Date.now(),
+            });
+          }
+          break;
+
+        case "done":
+          finalizeStreaming();
+          useAssistantChatStore.getState().setLoading(false);
+          break;
+      }
+    });
+
+    return () => {
+      cleanup();
+      unsubscribe();
+    };
+  }, []);
+
+  // Expose a method to reset streaming state (called when starting a new message)
+  return {
+    resetStreaming: () => {
+      streamingStateRef.current = null;
+      streamingMessageIdRef.current = null;
+    },
+  };
+}

--- a/src/store/assistantChatStore.ts
+++ b/src/store/assistantChatStore.ts
@@ -22,11 +22,25 @@ function createInitialConversation(): ConversationState {
   };
 }
 
+interface StreamingState {
+  content: string;
+  toolCalls: Array<{
+    id: string;
+    name: string;
+    args: Record<string, unknown>;
+    status: "pending" | "success" | "error";
+    result?: unknown;
+    error?: string;
+  }>;
+}
+
 interface AssistantChatState {
   conversation: ConversationState;
   isOpen: boolean;
   displayMode: "popup" | "docked";
   currentContext: ActionContext | null;
+  streamingState: StreamingState | null;
+  streamingMessageId: string | null;
 }
 
 interface AssistantChatActions {
@@ -43,6 +57,7 @@ interface AssistantChatActions {
   toggle: () => void;
   setDisplayMode: (mode: "popup" | "docked") => void;
   setCurrentContext: (context: ActionContext | null) => void;
+  setStreamingState: (state: StreamingState | null, messageId: string | null) => void;
 }
 
 const initialState: AssistantChatState = {
@@ -50,6 +65,8 @@ const initialState: AssistantChatState = {
   isOpen: false,
   displayMode: "popup",
   currentContext: null,
+  streamingState: null,
+  streamingMessageId: null,
 };
 
 const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatActions> = (
@@ -121,10 +138,17 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
 
     set({
       conversation: createInitialConversation(),
+      streamingState: null,
+      streamingMessageId: null,
     });
   },
 
-  reset: () => set({ conversation: createInitialConversation() }),
+  reset: () =>
+    set({
+      conversation: createInitialConversation(),
+      streamingState: null,
+      streamingMessageId: null,
+    }),
 
   open: () => set({ isOpen: true }),
 
@@ -135,6 +159,9 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
   setDisplayMode: (mode) => set({ displayMode: mode }),
 
   setCurrentContext: (context) => set({ currentContext: context }),
+
+  setStreamingState: (state, messageId) =>
+    set({ streamingState: state, streamingMessageId: messageId }),
 });
 
 export const useAssistantChatStore = create<AssistantChatState & AssistantChatActions>()(


### PR DESCRIPTION
## Summary
Enables the Assistant to fully process user messages even when the Assistant pane is closed or minimized, ensuring responses are ready when users reopen it.

Closes #2040

## Changes Made
- Add useAssistantStreamProcessor hook to process streaming chunks globally
- Mount processor at app root level for continuous operation
- Move streaming state management to assistantChatStore
- Simplify useAssistantChat to be presentational layer only
- Add session-aware cleanup to prevent stale state on session/project switch
- Handle edge case where tool_result arrives before other chunks
- Add Electron environment guard for non-browser contexts

## Technical Details
**Architecture:** Implemented Option B from the issue - created a separate background service hook mounted at app root that processes streaming chunks independently of AssistantPane visibility.

**Key improvements:**
- Streaming continues when pane is closed
- Full responses available when pane is reopened
- Proper cleanup on session/project switches
- No memory leaks from persistent subscriptions

**Review:** Comprehensive Codex review completed with all critical issues addressed (session cleanup, store reset, edge cases).