### PR TITLE
Display detailed error messages from AI provider API responses

### DIFF
--- a/scripts/dump-assistant-tools.ts
+++ b/scripts/dump-assistant-tools.ts
@@ -389,7 +389,10 @@ interface ActionInfo {
  * Extract a balanced brace block starting from a given position.
  * Returns the content inside the braces (excluding the outer braces).
  */
-function extractBalancedBlock(content: string, startIndex: number): { block: string; endIndex: number } | null {
+function extractBalancedBlock(
+  content: string,
+  startIndex: number
+): { block: string; endIndex: number } | null {
   if (content[startIndex] !== "{" && content[startIndex] !== "(") return null;
 
   const openChar = content[startIndex];
@@ -457,7 +460,9 @@ function extractActionsFromSource(): ActionInfo[] {
   const actions: ActionInfo[] = [];
   const definitionsDir = path.join(ROOT, "src/services/actions/definitions");
 
-  const files = fs.readdirSync(definitionsDir).filter((f) => f.endsWith(".ts") && f !== "schemas.ts");
+  const files = fs
+    .readdirSync(definitionsDir)
+    .filter((f) => f.endsWith(".ts") && f !== "schemas.ts");
 
   for (const file of files) {
     const content = fs.readFileSync(path.join(definitionsDir, file), "utf-8");
@@ -490,7 +495,9 @@ function extractActionsFromSource(): ActionInfo[] {
       let description = descMatch?.[1]?.replace(/\s+/g, " ").trim() || "";
       if (!description) {
         // Try to match multi-line description with string concatenation
-        const multiLineDesc = bodyRaw.match(/description:\s*\n?\s*["']([^"']+)["']\s*\+?\s*\n?\s*["']?([^"']*)?["']?/s);
+        const multiLineDesc = bodyRaw.match(
+          /description:\s*\n?\s*["']([^"']+)["']\s*\+?\s*\n?\s*["']?([^"']*)?["']?/s
+        );
         if (multiLineDesc) {
           description = (multiLineDesc[1] + (multiLineDesc[2] || "")).replace(/\s+/g, " ").trim();
         }
@@ -680,7 +687,9 @@ Output:
   // Filter and process actions
   const actionsToInclude = showAll
     ? extractedActions
-    : extractedActions.filter((a) => allowlistSet.has(a.id as (typeof AGENT_ACCESSIBLE_ACTIONS)[number]));
+    : extractedActions.filter((a) =>
+        allowlistSet.has(a.id as (typeof AGENT_ACCESSIBLE_ACTIONS)[number])
+      );
 
   for (const action of actionsToInclude) {
     const sanitizedSchema = sanitizeSchema(action.inputSchema);

--- a/scripts/test-assistant-api.ts
+++ b/scripts/test-assistant-api.ts
@@ -42,7 +42,10 @@ function loadEnv(): Record<string, string> {
     if (trimmed && !trimmed.startsWith("#")) {
       const [key, ...valueParts] = trimmed.split("=");
       if (key && valueParts.length > 0) {
-        env[key.trim()] = valueParts.join("=").trim().replace(/^["']|["']$/g, "");
+        env[key.trim()] = valueParts
+          .join("=")
+          .trim()
+          .replace(/^["']|["']$/g, "");
       }
     }
   }
@@ -201,7 +204,7 @@ interface ApiResponse {
 
 async function testApi(apiKey: string, useFullTools: boolean = true) {
   const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
-  const MODEL = "accounts/fireworks/models/kimi-k2p5";  // Kimi K2
+  const MODEL = "accounts/fireworks/models/kimi-k2p5"; // Kimi K2
 
   console.log("Testing Fireworks AI API...");
   console.log("Model:", MODEL);
@@ -276,7 +279,6 @@ async function testApi(apiKey: string, useFullTools: boolean = true) {
 
       console.log("Finish reason:", data.choices[0].finish_reason);
     }
-
   } catch (err) {
     console.error("\n=== FETCH ERROR ===");
     console.error(err);
@@ -289,7 +291,7 @@ async function testApi(apiKey: string, useFullTools: boolean = true) {
 
 async function main() {
   const args = process.argv.slice(2);
-  const useFullTools = !args.includes("--simple");  // Full tools by default
+  const useFullTools = !args.includes("--simple"); // Full tools by default
   const showHelp = args.includes("--help") || args.includes("-h");
 
   if (showHelp) {


### PR DESCRIPTION
## Summary
Enhance the Canopy assistant to display comprehensive error details from AI provider API responses (Fireworks.ai, Kimi K2). Previously, errors were silently logged or shown as generic messages, making debugging impossible. Now the assistant extracts and displays full error details including HTTP status codes, error codes, and formatted messages, while sanitizing sensitive data to prevent security issues.

Closes #2048

## Changes Made
- Add `extractDetailedError()` function to parse `APICallError` from Vercel AI SDK and extract detailed error information
- Support multiple error response formats: Fireworks.ai (`{error: {message, type, code}}`), generic (`{message, code}`), detail field, and errors array
- Implement comprehensive sanitization to remove API keys, JWTs, Bearer tokens, credentials from URLs/headers/JSON, file paths, ANSI escape sequences, control characters, and bidirectional override characters
- Add size limits (64KB max) for response body parsing to prevent memory/CPU issues
- Implement safe JSON stringification with circular reference handling and sensitive field filtering (headers, config, request, response, stack)
- Add support for numeric string status codes with coercion to number
- Enforce 2000 character maximum error length to prevent UI overflow
- Update stream part error handling to use detailed extraction
- Add HTTP status text mapping for common status codes (401, 429, 500, etc.)