### PR TITLE
Add detailed request/response logging for assistant

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -92,6 +92,7 @@ import { AgentUpdateHandler } from "./services/AgentUpdateHandler.js";
 import { SidecarManager } from "./services/SidecarManager.js";
 import { createWindowWithState } from "./windowState.js";
 import { setLoggerWindow, initializeLogger } from "./utils/logger.js";
+import { initializeAssistantLogger } from "./utils/assistantLogger.js";
 import { openExternalUrl } from "./utils/openExternal.js";
 import { EventBuffer } from "./services/EventBuffer.js";
 import { CHANNELS } from "./ipc/channels.js";
@@ -125,6 +126,7 @@ import { workflowLoader } from "./services/WorkflowLoader.js";
 
 // Initialize logger early with userData path
 initializeLogger(app.getPath("userData"));
+initializeAssistantLogger();
 
 // Register commands early so they're available when IPC handlers start
 registerCommands();

--- a/electron/utils/assistantLogger.ts
+++ b/electron/utils/assistantLogger.ts
@@ -1,0 +1,293 @@
+import { appendFileSync, mkdirSync, existsSync, writeFileSync } from "fs";
+import { join } from "path";
+import { app } from "electron";
+import type { AssistantMessage, StreamChunk } from "../../shared/types/assistant.js";
+import type { ActionManifestEntry, ActionContext } from "../../shared/types/actions.js";
+
+const IS_TEST = process.env.NODE_ENV === "test";
+
+type AssistantLogType = "request" | "stream" | "complete" | "error" | "cancelled";
+
+interface BaseLogEntry {
+  ts: string;
+  type: AssistantLogType;
+  sessionId: string;
+}
+
+interface RequestLogEntry extends BaseLogEntry {
+  type: "request";
+  messages: AssistantMessage[];
+  tools: string[];
+  listenerToolCount: number;
+  context: Partial<ActionContext> | null;
+  model: string;
+  systemPromptLength: number;
+}
+
+interface StreamLogEntry extends BaseLogEntry {
+  type: "stream";
+  event: "text-delta" | "tool-call" | "tool-result" | "error" | "other";
+  content?: string;
+  toolName?: string;
+  toolCallId?: string;
+  args?: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  partType?: string;
+  data?: unknown;
+}
+
+interface CompleteLogEntry extends BaseLogEntry {
+  type: "complete";
+  finishReason: string | undefined;
+  durationMs: number;
+}
+
+interface ErrorLogEntry extends BaseLogEntry {
+  type: "error";
+  error: string;
+  durationMs?: number;
+}
+
+interface CancelledLogEntry extends BaseLogEntry {
+  type: "cancelled";
+  durationMs: number;
+}
+
+type AssistantLogEntry =
+  | RequestLogEntry
+  | StreamLogEntry
+  | CompleteLogEntry
+  | ErrorLogEntry
+  | CancelledLogEntry;
+
+let logFilePath: string | null = null;
+let isInitialized = false;
+
+function isDevelopmentMode(): boolean {
+  if (IS_TEST || process.env.CANOPY_DISABLE_FILE_LOGGING === "1") {
+    return false;
+  }
+  try {
+    return !app.isPackaged || process.env.NODE_ENV === "development";
+  } catch {
+    return process.env.NODE_ENV === "development";
+  }
+}
+
+function getLogFilePath(): string {
+  if (logFilePath) {
+    return logFilePath;
+  }
+
+  let basePath: string;
+  if (process.env.CANOPY_USER_DATA) {
+    basePath = process.env.CANOPY_USER_DATA;
+  } else {
+    try {
+      basePath = app.getPath("userData");
+    } catch {
+      basePath = process.cwd();
+    }
+  }
+
+  const logsDir = join(basePath, "logs");
+  if (!existsSync(logsDir)) {
+    mkdirSync(logsDir, { recursive: true });
+  }
+
+  logFilePath = join(logsDir, "assistant.log");
+  return logFilePath;
+}
+
+export function initializeAssistantLogger(): void {
+  if (isInitialized || !isDevelopmentMode()) {
+    return;
+  }
+
+  try {
+    const filePath = getLogFilePath();
+    writeFileSync(filePath, "", "utf8");
+    isInitialized = true;
+  } catch {
+    // Silently fail - logging is optional
+  }
+}
+
+function safeJSONStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (_key, val) => {
+      if (typeof val === "bigint") {
+        return val.toString();
+      }
+      if (val && typeof val === "object") {
+        if (seen.has(val as object)) {
+          return "[Circular]";
+        }
+        seen.add(val as object);
+      }
+      return val;
+    });
+  } catch {
+    return JSON.stringify({ error: "Failed to serialize" });
+  }
+}
+
+function writeLogEntry(entry: AssistantLogEntry): void {
+  if (!isDevelopmentMode()) {
+    return;
+  }
+
+  if (!isInitialized) {
+    initializeAssistantLogger();
+  }
+
+  try {
+    const filePath = getLogFilePath();
+    const line = safeJSONStringify(entry) + "\n";
+    appendFileSync(filePath, line, "utf8");
+  } catch {
+    // Silently fail - logging should not break functionality
+  }
+}
+
+export function logAssistantRequest(
+  sessionId: string,
+  messages: AssistantMessage[],
+  tools: ActionManifestEntry[] | undefined,
+  listenerToolCount: number,
+  context: ActionContext | undefined,
+  model: string,
+  systemPromptLength: number
+): void {
+  const entry: RequestLogEntry = {
+    ts: new Date().toISOString(),
+    type: "request",
+    sessionId,
+    messages,
+    tools: tools?.map((t) => t.id) ?? [],
+    listenerToolCount,
+    context: context
+      ? {
+          projectId: context.projectId,
+          projectName: context.projectName,
+          activeWorktreeId: context.activeWorktreeId,
+          activeWorktreeName: context.activeWorktreeName,
+          focusedTerminalId: context.focusedTerminalId,
+        }
+      : null,
+    model,
+    systemPromptLength,
+  };
+  writeLogEntry(entry);
+}
+
+export function logAssistantStreamEvent(sessionId: string, chunk: StreamChunk): void {
+  let entry: StreamLogEntry;
+
+  switch (chunk.type) {
+    case "text":
+      entry = {
+        ts: new Date().toISOString(),
+        type: "stream",
+        sessionId,
+        event: "text-delta",
+        content: chunk.content,
+      };
+      break;
+
+    case "tool_call":
+      if (!chunk.toolCall) return;
+      entry = {
+        ts: new Date().toISOString(),
+        type: "stream",
+        sessionId,
+        event: "tool-call",
+        toolName: chunk.toolCall.name,
+        toolCallId: chunk.toolCall.id,
+        args: chunk.toolCall.args,
+      };
+      break;
+
+    case "tool_result":
+      if (!chunk.toolResult) return;
+      entry = {
+        ts: new Date().toISOString(),
+        type: "stream",
+        sessionId,
+        event: "tool-result",
+        toolName: chunk.toolResult.toolName,
+        toolCallId: chunk.toolResult.toolCallId,
+        result: chunk.toolResult.result,
+      };
+      break;
+
+    case "error":
+      entry = {
+        ts: new Date().toISOString(),
+        type: "stream",
+        sessionId,
+        event: "error",
+        error: chunk.error,
+      };
+      break;
+
+    default:
+      return;
+  }
+
+  writeLogEntry(entry);
+}
+
+export function logAssistantComplete(
+  sessionId: string,
+  finishReason: string | undefined,
+  durationMs: number
+): void {
+  const entry: CompleteLogEntry = {
+    ts: new Date().toISOString(),
+    type: "complete",
+    sessionId,
+    finishReason,
+    durationMs,
+  };
+  writeLogEntry(entry);
+}
+
+export function logAssistantError(sessionId: string, error: string, durationMs?: number): void {
+  const entry: ErrorLogEntry = {
+    ts: new Date().toISOString(),
+    type: "error",
+    sessionId,
+    error,
+    durationMs,
+  };
+  writeLogEntry(entry);
+}
+
+export function logAssistantCancelled(sessionId: string, durationMs: number): void {
+  const entry: CancelledLogEntry = {
+    ts: new Date().toISOString(),
+    type: "cancelled",
+    sessionId,
+    durationMs,
+  };
+  writeLogEntry(entry);
+}
+
+export function logAssistantStreamPart(
+  sessionId: string,
+  partType: string,
+  partData?: unknown
+): void {
+  const entry: StreamLogEntry = {
+    ts: new Date().toISOString(),
+    type: "stream",
+    sessionId,
+    event: "other",
+    partType,
+    data: partData,
+  };
+  writeLogEntry(entry);
+}


### PR DESCRIPTION
## Summary
Implements comprehensive logging for assistant API requests and responses to aid debugging and development. Logs are written to a dedicated `assistant.log` file in JSON lines format, designed for AI diagnostic tools to analyze when issues occur.

Closes #2058

## Changes Made
- Create dedicated `assistant.log` with JSON lines format for AI diagnostic tools
- Log request start with messages, tools, context, and model configuration
- Log all stream events including text deltas, tool calls, results, and errors
- Capture unhandled stream part types for comprehensive debugging
- Track request timing and duration for performance analysis
- Log early failures (missing API key, provider initialization errors)
- Include listener tool count in request metadata
- Use safe JSON serialization to handle BigInt and circular references
- Align dev-only behavior with main logger (respect CANOPY_DISABLE_FILE_LOGGING and test mode)
- Clear log file on app startup for single-session diagnostics

## Implementation Details

### New Files
- `electron/utils/assistantLogger.ts`: Dedicated logging infrastructure for assistant requests

### Modified Files
- `electron/services/AssistantService.ts`: Integrated logging calls throughout the request lifecycle
- `electron/main.ts`: Initialize assistant logger on startup

### Log Format
Each log entry is a single JSON object per line with the following structure:
- **Request**: `{ts, type: "request", sessionId, messages, tools, listenerToolCount, context, model, systemPromptLength}`
- **Stream**: `{ts, type: "stream", sessionId, event, ...event-specific-data}`
- **Complete**: `{ts, type: "complete", sessionId, finishReason, durationMs}`
- **Error**: `{ts, type: "error", sessionId, error, durationMs?}`
- **Cancelled**: `{ts, type: "cancelled", sessionId, durationMs}`

### Key Features
- **Development-only**: Only logs when `NODE_ENV === "development"` or `!app.isPackaged`, respects `CANOPY_DISABLE_FILE_LOGGING` and test mode
- **Session-based**: Clears log file on app startup for single-session diagnostics
- **Safe serialization**: Handles BigInt, circular references, and other non-JSON-safe values
- **Complete coverage**: Logs all phases of assistant requests including early failures and all stream event types