### PR TITLE
Implement sticky-bottom auto-scroll for Assistant panel

### DIFF
--- a/src/components/Assistant/MessageList.tsx
+++ b/src/components/Assistant/MessageList.tsx
@@ -8,6 +8,7 @@ import { AssistantThinkingIndicator } from "./AssistantThinkingIndicator";
 import type { AssistantMessage, StreamingState } from "./types";
 
 const LOADING_INDICATOR_DELAY_MS = 150;
+const AT_BOTTOM_THRESHOLD_PX = 100;
 
 interface MessageListProps {
   messages: AssistantMessage[];
@@ -137,7 +138,8 @@ export function MessageList({
       <Virtuoso
         ref={virtuosoRef}
         data={allItems}
-        followOutput="smooth"
+        followOutput={(isAtBottom) => (isAtBottom ? "smooth" : false)}
+        atBottomThreshold={AT_BOTTOM_THRESHOLD_PX}
         atBottomStateChange={setAtBottom}
         itemContent={renderMessage}
         computeItemKey={computeItemKey}


### PR DESCRIPTION
## Summary
Replaces the always-on auto-scroll behavior with a "sticky bottom" system that automatically scrolls to the bottom when new content arrives, but only if the user is already at or near the bottom (within 100px threshold).

Closes #2063

## Changes Made
- Add AT_BOTTOM_THRESHOLD_PX constant (100px tolerance)
- Replace static followOutput="smooth" with conditional callback
- Add atBottomThreshold prop to Virtuoso component
- Auto-scroll only occurs when user is at or near bottom