### PR TITLE
Fix: Clear conversation dialog appears above assistant popover

### DIFF
--- a/src/components/Assistant/AssistantPane.tsx
+++ b/src/components/Assistant/AssistantPane.tsx
@@ -210,6 +210,7 @@ export function AssistantPane() {
         confirmLabel="Clear"
         variant="destructive"
         isConfirmLoading={isClearing}
+        zIndex="nested"
       />
     </div>
   );

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -10,6 +10,7 @@ import { Button } from "./button";
 
 type DialogSize = "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "6xl";
 type DialogVariant = "default" | "destructive" | "info";
+type DialogZIndex = "modal" | "nested";
 
 interface AppDialogContextValue {
   onClose: () => void;
@@ -29,9 +30,10 @@ export interface AppDialogProps {
   children: React.ReactNode;
   className?: string;
   maxHeight?: string;
+  zIndex?: DialogZIndex;
 }
 
-export type { DialogSize, DialogVariant };
+export type { DialogSize, DialogVariant, DialogZIndex };
 
 const sizeClasses: Record<DialogSize, string> = {
   sm: "max-w-md",
@@ -52,6 +54,7 @@ export function AppDialog({
   children,
   className,
   maxHeight = "max-h-[80vh]",
+  zIndex = "modal",
 }: AppDialogProps) {
   const previousActiveElement = useRef<HTMLElement | null>(null);
   const titleId = useId();
@@ -157,7 +160,8 @@ export function AppDialog({
     <AppDialogContext.Provider value={{ onClose: handleClose, titleId, descriptionId, variant }}>
       <div
         className={cn(
-          "fixed inset-0 z-[var(--z-modal)] flex items-center justify-center bg-black/50 backdrop-blur-md backdrop-saturate-[1.25]",
+          "fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-md backdrop-saturate-[1.25]",
+          zIndex === "nested" ? "z-[var(--z-nested-dialog)]" : "z-[var(--z-modal)]",
           "transition-opacity duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0",
           isVisible ? "opacity-100" : "opacity-0"

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { AppDialog } from "@/components/ui/AppDialog";
+import { AppDialog, type DialogZIndex } from "@/components/ui/AppDialog";
 
 export interface ConfirmDialogProps {
   isOpen: boolean;
@@ -11,6 +11,7 @@ export interface ConfirmDialogProps {
   onConfirm: () => void | Promise<void>;
   isConfirmLoading?: boolean;
   variant?: "default" | "destructive" | "info";
+  zIndex?: DialogZIndex;
 }
 
 export function ConfirmDialog({
@@ -23,9 +24,10 @@ export function ConfirmDialog({
   onConfirm,
   isConfirmLoading = false,
   variant = "destructive",
+  zIndex,
 }: ConfirmDialogProps) {
   return (
-    <AppDialog isOpen={isOpen} onClose={onClose} size="sm" variant={variant}>
+    <AppDialog isOpen={isOpen} onClose={onClose} size="sm" variant={variant} zIndex={zIndex}>
       <AppDialog.Header>
         <AppDialog.Title>{title}</AppDialog.Title>
         <AppDialog.CloseButton />

--- a/src/index.css
+++ b/src/index.css
@@ -98,6 +98,7 @@
    * Tier 55: Maximized content (terminals)
    * Tier 60: Modal dialogs (full-screen overlays)
    * Tier 70: Popovers, dropdowns, tooltips (can appear above modals)
+   * Tier 75: Nested dialogs (dialogs triggered from within popovers)
    * Tier 80: Toast notifications (always visible)
    */
   --z-panel: 40;
@@ -105,6 +106,7 @@
   --z-maximized: 55;
   --z-modal: 60;
   --z-popover: 70;
+  --z-nested-dialog: 75;
   --z-toast: 80;
 
   /* Overlay elevation system


### PR DESCRIPTION
## Summary
Fixes z-index stacking issue where the "Clear conversation" confirmation dialog was rendered behind the Canopy Assistant popover, making it invisible and inaccessible to users.

Closes #2065

## Changes Made
- Added `--z-nested-dialog: 75` CSS variable for dialogs triggered from within popovers
- Added `zIndex` prop to `AppDialog` and `ConfirmDialog` components with shared `DialogZIndex` type
- Applied `zIndex="nested"` to the clear conversation dialog in AssistantPane
- Updated z-index tier documentation in CSS

## Technical Details
The issue occurred because:
- Canopy Assistant renders in a `Popover` with `z-index: 70` (--z-popover)
- Confirmation dialogs used `z-index: 60` (--z-modal)
- Dialog appeared behind the popover overlay

The fix introduces a new z-index tier at 75 specifically for nested dialogs, positioned between popovers (70) and toasts (80), allowing dialogs triggered from within popovers to render correctly above their parent overlay.