### PR TITLE
Add conflict radar to warn when multiple agents edit the same files

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -23,6 +23,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "../../ui/tooltip";
 import {
   AlertCircle,
+  AlertTriangle,
   Check,
   CircleDot,
   Copy,
@@ -34,6 +35,9 @@ import {
   Shield,
 } from "lucide-react";
 import { useIssueTooltip, usePRTooltip } from "@/hooks/useGitHubTooltip";
+import { useWorktreeConflicts } from "@/hooks/useConflictDetector";
+import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import { getConflictingWorktreeNames } from "@/utils/conflictDetector";
 import { IssueTooltipContent, PRTooltipContent, TooltipLoading } from "./GitHubTooltipContent";
 
 const DROPDOWN_COMPONENTS: WorktreeMenuComponents = {
@@ -191,6 +195,68 @@ const PRBadge = memo(function PRBadge({
   );
 });
 
+interface ConflictBadgeProps {
+  worktreeId: string;
+}
+
+const ConflictBadge = memo(function ConflictBadge({ worktreeId }: ConflictBadgeProps) {
+  const { conflictCount, conflicts } = useWorktreeConflicts(worktreeId);
+  const worktreeMap = useWorktreeDataStore((state) => state.worktrees);
+
+  const tooltipContent = useMemo(() => {
+    const lines: { file: string; fullPath: string; worktrees: string }[] = [];
+    for (const conflict of conflicts) {
+      const otherWorktrees = getConflictingWorktreeNames(worktreeId, conflict, worktreeMap);
+      const pathSegments = conflict.filePath.split("/");
+      const fileName = pathSegments[pathSegments.length - 1] ?? conflict.filePath;
+      const parentDir = pathSegments.length > 1 ? pathSegments[pathSegments.length - 2] : "";
+      const displayPath = parentDir ? `${parentDir}/${fileName}` : fileName;
+
+      lines.push({
+        file: displayPath,
+        fullPath: conflict.filePath,
+        worktrees: otherWorktrees.join(", "),
+      });
+    }
+    return lines;
+  }, [conflicts, worktreeId, worktreeMap]);
+
+  if (conflictCount === 0) {
+    return null;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={300}>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center gap-0.5 text-amber-400 text-xs font-mono shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent rounded px-0.5 -mx-0.5"
+            aria-label={`${conflictCount} potential merge conflict${conflictCount !== 1 ? "s" : ""}`}
+          >
+            <AlertTriangle className="w-3 h-3" aria-hidden="true" />
+            <span>{conflictCount}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="start" className="max-w-sm">
+          <div className="space-y-1">
+            <div className="font-medium text-xs">
+              Potential merge conflict{conflictCount !== 1 ? "s" : ""}
+            </div>
+            <div className="text-xs text-canopy-text/70 space-y-0.5">
+              {tooltipContent.map((entry, i) => (
+                <div key={i} className="break-words" title={entry.fullPath}>
+                  {entry.file} → {entry.worktrees}
+                </div>
+              ))}
+            </div>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+});
+
 export interface WorktreeHeaderProps {
   worktree: WorktreeState;
   isActive: boolean;
@@ -285,6 +351,8 @@ export function WorktreeHeader({
             <span className="text-amber-500 text-xs font-medium shrink-0">(detached)</span>
           )}
         </div>
+
+        <ConflictBadge worktreeId={worktree.id} />
 
         {worktreeErrorCount > 0 && (
           <TooltipProvider>

--- a/src/hooks/useConflictDetector.ts
+++ b/src/hooks/useConflictDetector.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import {
+  detectConflicts,
+  getWorktreeConflicts,
+  type ConflictInfo,
+  type WorktreeConflictSummary,
+} from "@/utils/conflictDetector";
+
+const selectAllConflicts = (state: { worktrees: Map<string, unknown> }): ConflictInfo[] => {
+  const worktreeArray = Array.from(state.worktrees.values());
+  return detectConflicts(worktreeArray as Parameters<typeof detectConflicts>[0]);
+};
+
+/**
+ * Hook to detect file conflicts across all worktrees.
+ * Uses Zustand selector to compute conflicts only once per store update.
+ *
+ * @returns All detected conflicts (files modified in 2+ worktrees)
+ */
+export function useAllConflicts(): ConflictInfo[] {
+  return useWorktreeDataStore(selectAllConflicts);
+}
+
+/**
+ * Hook to get conflict summary for a specific worktree.
+ *
+ * @param worktreeId - ID of the worktree to check for conflicts
+ * @returns Conflict summary for this worktree
+ */
+export function useWorktreeConflicts(worktreeId: string): WorktreeConflictSummary {
+  const allConflicts = useAllConflicts();
+
+  return useMemo(() => {
+    return getWorktreeConflicts(worktreeId, allConflicts);
+  }, [worktreeId, allConflicts]);
+}
+
+/**
+ * Hook to check if a worktree has any conflicts.
+ *
+ * @param worktreeId - ID of the worktree to check
+ * @returns True if worktree has files conflicting with other worktrees
+ */
+export function useHasConflicts(worktreeId: string): boolean {
+  const { conflictCount } = useWorktreeConflicts(worktreeId);
+  return conflictCount > 0;
+}

--- a/src/utils/conflictDetector.ts
+++ b/src/utils/conflictDetector.ts
@@ -1,0 +1,100 @@
+import type { Worktree, WorktreeState } from "@shared/types/domain";
+
+export interface ConflictInfo {
+  /** Relative file path that has conflicts */
+  filePath: string;
+  /** IDs of worktrees that have modified this file */
+  worktreeIds: string[];
+}
+
+export interface WorktreeConflictSummary {
+  /** Number of files with conflicts in this worktree */
+  conflictCount: number;
+  /** Details about each conflicting file */
+  conflicts: ConflictInfo[];
+}
+
+/**
+ * Detects files that are modified in multiple worktrees simultaneously.
+ * This helps users identify potential merge conflicts before they occur.
+ *
+ * @param worktrees - Array of worktree states to analyze
+ * @returns Array of conflict info, one for each file modified in 2+ worktrees
+ */
+export function detectConflicts(worktrees: (Worktree | WorktreeState)[]): ConflictInfo[] {
+  const fileToWorktrees = new Map<string, Set<string>>();
+
+  for (const wt of worktrees) {
+    const worktreeRoot = wt.path;
+    const changes = wt.worktreeChanges?.changes ?? wt.changes ?? [];
+
+    for (const change of changes) {
+      let normalizedPath = change.path;
+
+      if (normalizedPath.startsWith(worktreeRoot)) {
+        normalizedPath = normalizedPath.slice(worktreeRoot.length);
+        if (normalizedPath.startsWith("/")) {
+          normalizedPath = normalizedPath.slice(1);
+        }
+      }
+
+      const worktreeSet = fileToWorktrees.get(normalizedPath) ?? new Set<string>();
+      worktreeSet.add(wt.id);
+      fileToWorktrees.set(normalizedPath, worktreeSet);
+    }
+  }
+
+  return Array.from(fileToWorktrees.entries())
+    .filter(([, wts]) => wts.size > 1)
+    .map(([path, wts]) => ({ filePath: path, worktreeIds: Array.from(wts) }));
+}
+
+/**
+ * Gets conflict summary for a specific worktree.
+ *
+ * @param worktreeId - ID of the worktree to get conflicts for
+ * @param allConflicts - All detected conflicts from detectConflicts()
+ * @returns Summary of conflicts affecting this worktree
+ */
+export function getWorktreeConflicts(
+  worktreeId: string,
+  allConflicts: ConflictInfo[]
+): WorktreeConflictSummary {
+  const relevantConflicts = allConflicts.filter((c) => c.worktreeIds.includes(worktreeId));
+  return {
+    conflictCount: relevantConflicts.length,
+    conflicts: relevantConflicts,
+  };
+}
+
+/**
+ * Gets names of other worktrees that share a conflict with the given worktree.
+ *
+ * @param worktreeId - ID of the worktree to check
+ * @param conflict - The conflict info
+ * @param worktreeMap - Map of worktree ID to worktree for name lookup
+ * @returns Array of worktree names (excluding the current worktree)
+ */
+export function getConflictingWorktreeNames(
+  worktreeId: string,
+  conflict: ConflictInfo,
+  worktreeMap: Map<string, Worktree | WorktreeState>
+): string[] {
+  const otherIds = conflict.worktreeIds.filter((id) => id !== worktreeId);
+  const branches = new Set<string>();
+
+  return otherIds.map((id) => {
+    const wt = worktreeMap.get(id);
+    if (!wt) return id;
+
+    const branch = wt.branch ?? wt.name;
+    const hasDuplicate = branches.has(branch);
+    branches.add(branch);
+
+    if (hasDuplicate && wt.name !== branch) {
+      return `${branch} (${wt.name})`;
+    }
+
+    return branch;
+  });
+}


### PR DESCRIPTION
## Summary

This PR implements a conflict radar that warns users when files are being edited in multiple worktrees simultaneously, helping prevent merge conflicts before they occur.

Closes #2071

## Changes Made

- Add conflict detection utility to identify files modified across worktrees
- Normalize absolute file paths to repo-relative for accurate matching
- Use Set-based deduplication to prevent false positives
- Prefer worktreeChanges over changes field for complete data
- Create React hooks with Zustand selector for efficient conflict detection
- Add ConflictBadge component with amber warning icon and count
- Display tooltip showing conflicting files and affected worktrees
- Improve accessibility with focusable button and ARIA labels
- Show parent directory context to disambiguate similar filenames
- Handle duplicate branch names by appending worktree name

## Implementation Details

### New Files
- `src/utils/conflictDetector.ts` - Core conflict detection logic
- `src/hooks/useConflictDetector.ts` - React hooks for conflict state

### Modified Files
- `src/components/Worktree/WorktreeCard/WorktreeHeader.tsx` - Added ConflictBadge component

### Features
- Real-time conflict detection across all active worktrees
- Visual warning badge with conflict count on affected worktree cards
- Detailed tooltip showing which files conflict and which worktrees are involved
- Parent directory context in tooltips to help disambiguate similar filenames
- Accessible UI with proper ARIA labels and keyboard focus management