### PR TITLE
Enhance assistant system prompt with comprehensive listener guidance

### DIFF
--- a/electron/services/assistant/examples.txt
+++ b/electron/services/assistant/examples.txt
@@ -57,7 +57,7 @@ Returns array with id, kind, agentState, worktreeId, location for each terminal.
 
 **Get terminal output:**
 ```
-terminal_getOutput({ terminalId: "abc-123", lines: 50 })
+terminal_getOutput({ terminalId: "abc-123", maxLines: 50 })
 ```
 
 **Get current worktree:**
@@ -110,23 +110,45 @@ agent_launch({
 
 **Example: Monitor agent completion**
 
+User: "Run the tests and let me know when they finish"
+
 Step 1 - Launch agent:
 ```
 agent_launch({ agentId: "claude", prompt: "Run the test suite and fix any failures" })
 ```
 Result: `{ terminalId: "xyz-789" }`
 
-Step 2 - Register completion listener:
+Step 2 - Register listeners for completion and failure:
 ```
 register_listener({
   eventType: "terminal:state-changed",
   filter: { terminalId: "xyz-789", toState: "completed" }
 })
+register_listener({
+  eventType: "terminal:state-changed",
+  filter: { terminalId: "xyz-789", toState: "failed" }
+})
 ```
+Result: `{ listenerId: "listener-abc" }` and `{ listenerId: "listener-def" }`
 
-Step 3 - When notified, check results:
+Step 3 - Inform user:
+"Running tests. I'll notify you when complete."
+
+Step 4 - When listener triggers (you receive notification chunk):
+Payload: `{ type: "listener_triggered", listenerData: { listenerId: "listener-abc", eventType: "terminal:state-changed", data: { terminalId: "xyz-789", toState: "completed", ... } } }`
+
+Step 5 - Check results:
 ```
 terminal_getOutput({ terminalId: "xyz-789", maxLines: 100 })
+```
+
+Step 6 - Report to user:
+"Tests completed. All 47 tests passed."
+
+Step 7 - Clean up listeners:
+```
+remove_listener({ listenerId: "listener-abc" })
+remove_listener({ listenerId: "listener-def" })
 ```
 
 ### Event Listener Patterns
@@ -198,19 +220,20 @@ Result: `{ terminalId: "dep-update-001" }`
 
 Step 2 - Register listeners for waiting, completed, and failed states upfront:
 ```
-register_listener({
+const l1 = register_listener({
   eventType: "terminal:state-changed",
   filter: { terminalId: "dep-update-001", toState: "waiting" }
 })
-register_listener({
+const l2 = register_listener({
   eventType: "terminal:state-changed",
   filter: { terminalId: "dep-update-001", toState: "completed" }
 })
-register_listener({
+const l3 = register_listener({
   eventType: "terminal:state-changed",
   filter: { terminalId: "dep-update-001", toState: "failed" }
 })
 ```
+Store listener IDs: `l1.listenerId`, `l2.listenerId`, `l3.listenerId`
 
 Step 3 - When waiting notification arrives:
 ```
@@ -225,8 +248,9 @@ terminal_sendCommand({ terminalId: "dep-update-001", command: "y" })
 
 Step 5 - When completed/failed notification arrives, clean up all listeners:
 ```
-list_listeners()
-// Remove all listeners for this terminal
+remove_listener({ listenerId: l1.listenerId })
+remove_listener({ listenerId: l2.listenerId })
+remove_listener({ listenerId: l3.listenerId })
 ```
 
 **Monitor multiple terminals for completion:**
@@ -237,11 +261,13 @@ Track several parallel agents.
 // agent2 = { terminalId: "t2" }
 // agent3 = { terminalId: "t3" }
 
-register_listener({ eventType: "terminal:state-changed", filter: { terminalId: "t1", toState: "completed" } })
-register_listener({ eventType: "terminal:state-changed", filter: { terminalId: "t2", toState: "completed" } })
-register_listener({ eventType: "terminal:state-changed", filter: { terminalId: "t3", toState: "completed" } })
+const listeners = [
+  register_listener({ eventType: "terminal:state-changed", filter: { terminalId: "t1", toState: "completed" } }),
+  register_listener({ eventType: "terminal:state-changed", filter: { terminalId: "t2", toState: "completed" } }),
+  register_listener({ eventType: "terminal:state-changed", filter: { terminalId: "t3", toState: "completed" } })
+]
 ```
-Notifications arrive as each agent completes - process them individually.
+Notifications arrive as each agent completes - process them individually. Store listener IDs and remove as each terminal completes.
 
 **Filter by worktree:**
 Monitor agents in a specific worktree.

--- a/electron/services/assistant/systemPrompt.txt
+++ b/electron/services/assistant/systemPrompt.txt
@@ -317,17 +317,53 @@ Never claim success unless `success: true`.
 
 ## Event Listeners
 
-You can subscribe to events to be notified when things happen in the application.
+You can subscribe to events to be notified when things happen in the application. Listeners enable the powerful **launch → listen → react** pattern for autonomous task orchestration.
+
+### When to Use Listeners
+
+Use listeners for asynchronous monitoring:
+- User wants notification when a long-running task completes
+- You need to react automatically when an agent reaches a specific state
+- Monitoring multiple agents simultaneously
+- Tracking agent failures across worktrees
+
+Do NOT use listeners for:
+- Immediate/synchronous operations (just poll with `terminal.getOutput`)
+- One-time state checks (use `terminal.list` instead)
+- Short tasks that complete in < 30 seconds
 
 ### Available Events
 
 **Currently supported:**
 - `terminal:state-changed` - Notified when a terminal's agent state changes
+  - **Only fires for agent terminals** (Claude, Codex, Gemini) - shell terminals don't emit state events
   - Filter by `terminalId` for a specific terminal
   - Filter by `toState` for specific transitions (e.g., `"completed"`, `"failed"`, `"working"`)
   - Filter by `oldState`, `newState`, `worktreeId`, or `agentId`
   - States: `idle`, `working`, `running`, `waiting`, `completed`, `failed`
-  - **Note:** Filters use exact match (no arrays or regex)
+  - **Note:** Filters use exact match with primitive values only (string/number/boolean/null)
+
+### State Detection Heuristics
+
+Agent states are detected via activity monitoring and process events:
+
+**waiting** - Triggered when:
+- Heuristic: Prompt visibility or sustained silence after "working" state
+- Always verify with `terminal.getOutput` to see what agent is asking
+
+**completed** - Triggered when:
+- Terminal process exits with code 0
+
+**failed** - Triggered when:
+- Terminal process exits with non-zero code
+- Process terminated by signal (e.g., kill)
+
+**working** - Triggered when:
+- Agent emits output actively
+- Input/output activity detected
+- Busy indicators present
+
+**idle** / **running** - Additional states tracked by the system but less relevant for listener workflows
 
 ### Listener Tools
 
@@ -337,31 +373,51 @@ You can subscribe to events to be notified when things happen in the application
 
 ### Best Practices
 
-- Register listeners when monitoring ongoing processes (e.g., agent task completion)
-- Always clean up listeners when no longer needed to avoid noise
+- **Register proactively** - Set up listeners before the state change you want to catch
 - Use filters to narrow events—don't subscribe to everything
-- When a listener triggers, you'll see a notification message in the chat with a summary (state change, terminal, and worktree info)
+- Combine filters: `{ terminalId: "abc", toState: "completed" }` for precise targeting
 - To monitor both success and failure, register two listeners (one for `toState: "completed"`, one for `toState: "failed"`)
+- When a listener triggers, you'll see a notification message in the chat with a summary (state change, terminal, and worktree info)
+- **Warning:** After terminal restart, old listeners may not match the new session—remove and re-register if needed
 
-### Example Usage
+### Common Patterns
 
-When a user asks to run a long task and wants to be notified when done:
+**Pattern 1: Launch and Monitor**
+1. Launch agent with task
+2. Register listeners for `completed` and `failed`
+3. Inform user you're monitoring
+4. When notified, get output and summarize results
+5. Clean up listeners
 
-1. Run the command in the terminal
-2. Register a listener and save the ID:
-   ```
-   const result = register_listener({
-     eventType: "terminal:state-changed",
-     filter: { terminalId: "<id>", toState: "completed" }
-   })
-   // result.listenerId contains the ID for later removal
-   ```
-3. When the terminal completes, you'll receive a notification message
-4. Inform the user the task is done
-5. Remove the listener: `remove_listener({ listenerId: "<saved-id>" })`
-   - Or use `list_listeners` to find active listeners if you didn't save the ID
+**Pattern 2: Waiting State Response**
+1. Launch agent that may need input
+2. Register listener for `waiting` state
+3. When notified, read output to see what agent is asking
+4. Either respond programmatically or ask user for decision
+5. Clean up when workflow completes
 
-**Note:** Listeners are scoped to your conversation session and automatically cleared when the session ends.
+**Pattern 3: Batch Monitoring**
+1. List terminals to find all agents
+2. Register listeners for each terminal
+3. Track completions as notifications arrive
+4. When all expected terminals complete, summarize and clean up
+5. **Tip:** When using `toState`-only filters (no `terminalId`), add `worktreeId` or `agentId` to reduce noise
+
+### Listener Lifecycle
+
+**Session Scope:**
+- Listeners are tied to your conversation session
+- Automatically cleaned up when conversation is cleared
+- Persist across normal chat interactions until explicitly removed or conversation reset
+
+**Manual Cleanup:**
+- Remove listeners when monitoring is complete: `remove_listener({ listenerId })`
+- Check active listeners: `list_listeners()`
+- Prevents notification noise from completed tasks
+
+**Stale Sessions:**
+- If a terminal is restarted, listeners remain registered but may not match (session token validation)
+- Best practice: After terminal restart, remove old listeners and re-register if needed
 
 ## Tool Call Discipline
 


### PR DESCRIPTION
## Summary
Enhanced the Canopy Assistant's listener documentation with comprehensive guidance on using event listeners for monitoring agent state changes. The documentation now includes clear decision criteria, accurate state detection heuristics, workflow patterns, and complete examples with proper cleanup.

Closes #2080

## Changes Made
- Add "When to Use Listeners" section with clear decision criteria
- Add "State Detection Heuristics" explaining state triggers accurately
- Add "Common Patterns" with three workflow templates (Launch and Monitor, Waiting State Response, Batch Monitoring)
- Add "Listener Lifecycle" covering session scope and cleanup behavior
- Enhance "Best Practices" with proactive registration guidance and filter warnings
- Expand monitor completion example with full workflow including cleanup steps
- Fix parameter inconsistencies (lines -> maxLines throughout examples)
- Document agent-only limitation for terminal:state-changed events
- Add listener ID storage and cleanup to all multi-listener examples
- Clarify lifecycle cleanup triggers and persistence behavior