### PR TITLE
Include trigger and confidence in listener event payloads

### DIFF
--- a/electron/services/assistant/TerminalStateListenerBridge.ts
+++ b/electron/services/assistant/TerminalStateListenerBridge.ts
@@ -73,6 +73,8 @@ export function initTerminalStateListenerBridge(emitter: ChunkEmitter): void {
         worktreeId: payload.worktreeId,
         timestamp: payload.timestamp,
         traceId: payload.traceId,
+        trigger: payload.trigger,
+        confidence: payload.confidence,
       };
 
       emitToListeners("terminal:state-changed", eventData);

--- a/electron/services/assistant/__tests__/TerminalStateListenerBridge.test.ts
+++ b/electron/services/assistant/__tests__/TerminalStateListenerBridge.test.ts
@@ -201,6 +201,8 @@ describe("TerminalStateListenerBridge", () => {
           toState: payload.state,
           worktreeId: payload.worktreeId,
           timestamp: payload.timestamp,
+          trigger: payload.trigger,
+          confidence: payload.confidence,
         }),
       });
     });

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -690,6 +690,8 @@ export type CanopyEventMap = {
     newState: AgentState;
     toState: AgentState;
     worktreeId?: string;
+    trigger: AgentStateChangeTrigger;
+    confidence: number;
   }>;
 
   // Task Lifecycle Events (Future-proof for task management)

--- a/src/components/Assistant/types.ts
+++ b/src/components/Assistant/types.ts
@@ -1,5 +1,14 @@
 export type MessageRole = "user" | "assistant" | "event";
 
+export type AgentStateChangeTrigger =
+  | "input"
+  | "output"
+  | "heuristic"
+  | "ai-classification"
+  | "timeout"
+  | "exit"
+  | "activity";
+
 export interface ToolCall {
   id: string;
   name: string;
@@ -16,6 +25,8 @@ export interface EventMetadata {
   worktreeId?: string;
   oldState?: string;
   newState?: string;
+  trigger?: AgentStateChangeTrigger;
+  confidence?: number;
 }
 
 export interface AssistantMessage {


### PR DESCRIPTION
## Summary
Enriches listener event payloads with trigger and confidence metadata from agent state changes. This enables assistants to distinguish reliable state changes from heuristic guesses and make better decisions about when to intervene.

Closes #2088

## Changes Made
- Add trigger and confidence fields to terminal:state-changed event type
- Forward trigger/confidence from agent:state-changed in TerminalStateListenerBridge
- Display confidence percentage and trigger type in UI notifications
- Add AgentStateChangeTrigger type to frontend for type safety
- Validate confidence is finite number in [0,1] range before display
- Update bridge test to assert new fields are preserved