### PR TITLE
Fix project dropdown incorrectly counting dev-preview panels as waiting terminals

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -16,10 +16,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { projectClient, terminalClient } from "@/clients";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { Project, ProjectStats } from "@shared/types";
-import { isAgentTerminal } from "@/utils/terminalType";
 import { groupProjects } from "./projectGrouping";
+import { isAgentTerminal } from "@/utils/terminalType";
 import { ProjectActionRow } from "./ProjectActionRow";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 
@@ -74,13 +73,16 @@ export function ProjectSwitcher() {
         let waitingAgentCount = 0;
 
         for (const terminal of terminalsResult.value) {
-          if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
-          if (terminal.kind === "dev-preview") continue;
+          // Only count agent terminals - excludes dev-preview, browser, notes, etc.
+          // Use explicit kind check first (fast path), fall back to isAgentTerminal for legacy terminals
+          const isAgent =
+            terminal.kind === "agent" ||
+            (terminal.kind == null && isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId));
+
+          if (!isAgent) continue;
           if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
           const agentState = terminal.agentState;
-          const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
-          if (!isAgent) continue;
 
           if (agentState === "waiting") {
             waitingAgentCount += 1;
@@ -173,14 +175,16 @@ export function ProjectSwitcher() {
         let waitingAgentCount = 0;
 
         for (const terminal of result.value) {
-          if (!panelKindHasPty(terminal.kind ?? "terminal")) continue;
-          if (terminal.kind === "dev-preview") continue;
+          // Only count agent terminals - excludes dev-preview, browser, notes, etc.
+          // Use explicit kind check first (fast path), fall back to isAgentTerminal for legacy terminals
+          const isAgent =
+            terminal.kind === "agent" ||
+            (terminal.kind == null && isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId));
+
+          if (!isAgent) continue;
           if (terminal.hasPty === false) continue; // Skip orphaned terminals without active PTY
 
           const agentState = terminal.agentState;
-          const isAgent = isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId);
-
-          if (!isAgent) continue;
 
           if (agentState === "waiting") {
             waitingAgentCount += 1;


### PR DESCRIPTION
## Summary
Fixes a bug where dev-preview panels were incorrectly counted as waiting agent terminals in the project dropdown selector. Previously, a project with 1 agent terminal (waiting) + 1 dev-preview panel would show "2 waiting terminals" instead of the correct count of "1 waiting terminal".

Closes #2103

## Changes Made
- Add explicit `kind === "agent"` check to filter only agent terminals
- Preserve backwards compatibility for legacy terminals without kind field
- Remove redundant `panelKindHasPty` check
- Apply consistent filtering in both `refreshStopCandidateCounts` and `fetchProjectTerminalCounts`
- Exclude dev-preview, browser, notes, and terminal panels from agent counts

## Technical Details
The fix prioritizes checking `terminal.kind === "agent"` explicitly, which correctly excludes all non-agent panel types (dev-preview, browser, notes, terminal). For backwards compatibility with persisted terminals from older versions that may lack the `kind` field, the code falls back to the `isAgentTerminal()` helper function that checks `type` and `agentId`.