### PR TITLE
Add await_listener tool for blocking event waits

### DIFF
--- a/electron/services/assistant/ListenerManager.ts
+++ b/electron/services/assistant/ListenerManager.ts
@@ -2,6 +2,94 @@ import { randomUUID } from "node:crypto";
 import type { Listener, ListenerFilter } from "../../../shared/types/listener.js";
 import { RegisterListenerOptionsSchema } from "../../../shared/types/listener.js";
 
+export interface ListenerEvent {
+  listenerId: string;
+  eventType: string;
+  data: Record<string, unknown>;
+  timestamp: number;
+}
+
+interface Waiter {
+  resolve: (event: ListenerEvent) => void;
+  reject: (error: Error) => void;
+  timeout: NodeJS.Timeout;
+  startTime: number;
+}
+
+export class ListenerWaiter {
+  private waiters = new Map<string, Waiter & { sessionId: string }>();
+
+  wait(listenerId: string, timeoutMs: number, sessionId: string): Promise<ListenerEvent> {
+    if (this.waiters.has(listenerId)) {
+      return Promise.reject(new Error("already_awaiting"));
+    }
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.waiters.delete(listenerId);
+        reject(new Error("timeout"));
+      }, timeoutMs);
+
+      this.waiters.set(listenerId, {
+        resolve,
+        reject,
+        timeout,
+        startTime: Date.now(),
+        sessionId,
+      });
+    });
+  }
+
+  notify(listenerId: string, event: ListenerEvent): boolean {
+    const waiter = this.waiters.get(listenerId);
+    if (waiter) {
+      clearTimeout(waiter.timeout);
+      waiter.resolve(event);
+      this.waiters.delete(listenerId);
+      return true;
+    }
+    return false;
+  }
+
+  cancel(listenerId: string, reason: string): void {
+    const waiter = this.waiters.get(listenerId);
+    if (waiter) {
+      clearTimeout(waiter.timeout);
+      waiter.reject(new Error(reason));
+      this.waiters.delete(listenerId);
+    }
+  }
+
+  cancelAll(reason: string): void {
+    for (const [listenerId] of this.waiters) {
+      this.cancel(listenerId, reason);
+    }
+  }
+
+  cancelForSession(sessionId: string, reason: string): number {
+    let count = 0;
+    for (const [listenerId, waiter] of this.waiters) {
+      if (waiter.sessionId === sessionId) {
+        this.cancel(listenerId, reason);
+        count++;
+      }
+    }
+    return count;
+  }
+
+  isAwaiting(listenerId: string): boolean {
+    return this.waiters.has(listenerId);
+  }
+
+  getWaitedMs(listenerId: string): number {
+    const waiter = this.waiters.get(listenerId);
+    if (!waiter) {
+      return 0;
+    }
+    return Date.now() - waiter.startTime;
+  }
+}
+
 export class ListenerManager {
   private listeners = new Map<string, Listener>();
 
@@ -31,7 +119,11 @@ export class ListenerManager {
   }
 
   unregister(listenerId: string): boolean {
-    return this.listeners.delete(listenerId);
+    const deleted = this.listeners.delete(listenerId);
+    if (deleted) {
+      listenerWaiter.cancel(listenerId, "listener_removed");
+    }
+    return deleted;
   }
 
   get(listenerId: string): Listener | undefined {
@@ -68,6 +160,7 @@ export class ListenerManager {
     for (const id of toRemove) {
       this.listeners.delete(id);
     }
+    listenerWaiter.cancelForSession(sessionId, "session_cleared");
     if (toRemove.length > 0) {
       console.log(
         `[ListenerManager] Cleared ${toRemove.length} listener(s) for session ${sessionId}`
@@ -79,6 +172,7 @@ export class ListenerManager {
   clearAllSessions(): number {
     const count = this.listeners.size;
     this.listeners.clear();
+    listenerWaiter.cancelAll("all_sessions_cleared");
     if (count > 0) {
       console.log(`[ListenerManager] Cleared all ${count} listener(s) across all sessions`);
     }
@@ -129,3 +223,4 @@ export class ListenerManager {
 }
 
 export const listenerManager = new ListenerManager();
+export const listenerWaiter = new ListenerWaiter();

--- a/electron/services/assistant/__tests__/ListenerManager.test.ts
+++ b/electron/services/assistant/__tests__/ListenerManager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { ListenerManager } from "../ListenerManager.js";
+import { ListenerManager, ListenerWaiter } from "../ListenerManager.js";
 
 describe("ListenerManager", () => {
   let manager: ListenerManager;
@@ -529,6 +529,235 @@ describe("ListenerManager", () => {
       manager.clear();
 
       expect(manager.size()).toBe(0);
+    });
+  });
+});
+
+describe("ListenerWaiter", () => {
+  let waiter: ListenerWaiter;
+
+  beforeEach(() => {
+    waiter = new ListenerWaiter();
+  });
+
+  describe("wait and notify", () => {
+    it("resolves when notify is called with event data", async () => {
+      const waitPromise = waiter.wait("listener-1", 5000, "session-1");
+
+      // Notify immediately
+      waiter.notify("listener-1", {
+        listenerId: "listener-1",
+        eventType: "terminal:state-changed",
+        data: { terminalId: "term-1", toState: "completed" },
+        timestamp: Date.now(),
+      });
+
+      const result = await waitPromise;
+
+      expect(result.listenerId).toBe("listener-1");
+      expect(result.eventType).toBe("terminal:state-changed");
+      expect(result.data).toEqual({ terminalId: "term-1", toState: "completed" });
+    });
+
+    it("rejects with timeout error when timeout expires", async () => {
+      const waitPromise = waiter.wait("listener-1", 50, "session-1");
+
+      await expect(waitPromise).rejects.toThrow("timeout");
+    });
+
+    it("rejects with already_awaiting error when awaiting same listener twice", async () => {
+      const firstWait = waiter.wait("listener-1", 5000, "session-1");
+
+      await expect(waiter.wait("listener-1", 5000, "session-1")).rejects.toThrow("already_awaiting");
+
+      // Clean up first wait
+      waiter.cancel("listener-1", "cleanup");
+      await firstWait.catch(() => {});
+    });
+
+    it("notify returns true when waiter exists", () => {
+      waiter.wait("listener-1", 5000, "session-1");
+
+      const result = waiter.notify("listener-1", {
+        listenerId: "listener-1",
+        eventType: "test",
+        data: {},
+        timestamp: Date.now(),
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it("notify returns false when no waiter exists", () => {
+      const result = waiter.notify("non-existent", {
+        listenerId: "non-existent",
+        eventType: "test",
+        data: {},
+        timestamp: Date.now(),
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("cancel", () => {
+    it("rejects the waiting promise with cancel reason", async () => {
+      const waitPromise = waiter.wait("listener-1", 5000, "session-1");
+
+      waiter.cancel("listener-1", "stream cancelled");
+
+      await expect(waitPromise).rejects.toThrow("stream cancelled");
+    });
+
+    it("does nothing when cancelling non-existent waiter", () => {
+      expect(() => waiter.cancel("non-existent", "reason")).not.toThrow();
+    });
+
+    it("clears the timeout when cancelled", async () => {
+      const waitPromise = waiter.wait("listener-1", 50, "session-1");
+
+      waiter.cancel("listener-1", "early cancel");
+
+      await expect(waitPromise).rejects.toThrow("early cancel");
+      // Wait longer than timeout to ensure it doesn't trigger
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+  });
+
+  describe("cancelAll", () => {
+    it("cancels all waiting promises", async () => {
+      const wait1 = waiter.wait("listener-1", 5000, "session-1");
+      const wait2 = waiter.wait("listener-2", 5000, "session-1");
+      const wait3 = waiter.wait("listener-3", 5000, "session-1");
+
+      waiter.cancelAll("session ended");
+
+      await expect(wait1).rejects.toThrow("session ended");
+      await expect(wait2).rejects.toThrow("session ended");
+      await expect(wait3).rejects.toThrow("session ended");
+    });
+
+    it("does nothing when no waiters exist", () => {
+      expect(() => waiter.cancelAll("reason")).not.toThrow();
+    });
+  });
+
+  describe("isAwaiting", () => {
+    it("returns true when waiter exists", async () => {
+      const waitPromise = waiter.wait("listener-1", 5000, "session-1");
+
+      expect(waiter.isAwaiting("listener-1")).toBe(true);
+
+      // Cleanup
+      waiter.cancel("listener-1", "cleanup");
+      await waitPromise.catch(() => {});
+    });
+
+    it("returns false when no waiter exists", () => {
+      expect(waiter.isAwaiting("non-existent")).toBe(false);
+    });
+
+    it("returns false after notify", async () => {
+      const waitPromise = waiter.wait("listener-1", 5000, "session-1");
+
+      waiter.notify("listener-1", {
+        listenerId: "listener-1",
+        eventType: "test",
+        data: {},
+        timestamp: Date.now(),
+      });
+
+      await waitPromise;
+
+      expect(waiter.isAwaiting("listener-1")).toBe(false);
+    });
+
+    it("returns false after cancel", async () => {
+      const waitPromise = waiter.wait("listener-1", 5000, "session-1");
+
+      waiter.cancel("listener-1", "cancelled");
+
+      await waitPromise.catch(() => {});
+
+      expect(waiter.isAwaiting("listener-1")).toBe(false);
+    });
+
+    it("returns false after timeout", async () => {
+      const waitPromise = waiter.wait("listener-1", 50, "session-1");
+
+      await waitPromise.catch(() => {});
+
+      expect(waiter.isAwaiting("listener-1")).toBe(false);
+    });
+  });
+
+  describe("getWaitedMs", () => {
+    it("returns 0 when no waiter exists", () => {
+      expect(waiter.getWaitedMs("non-existent")).toBe(0);
+    });
+
+    it("returns elapsed time when waiter is active", async () => {
+      const waitPromise = waiter.wait("listener-1", 5000, "session-1");
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const elapsed = waiter.getWaitedMs("listener-1");
+      expect(elapsed).toBeGreaterThanOrEqual(40);
+      expect(elapsed).toBeLessThan(200);
+
+      // Cleanup
+      waiter.cancel("listener-1", "cleanup");
+      await waitPromise.catch(() => {});
+    });
+  });
+
+  describe("multiple concurrent waiters", () => {
+    it("handles multiple independent waiters correctly", async () => {
+      const wait1 = waiter.wait("listener-1", 5000, "session-1");
+      const wait2 = waiter.wait("listener-2", 5000, "session-1");
+
+      // Notify second waiter first
+      waiter.notify("listener-2", {
+        listenerId: "listener-2",
+        eventType: "event-2",
+        data: { id: 2 },
+        timestamp: Date.now(),
+      });
+
+      // Then notify first waiter
+      waiter.notify("listener-1", {
+        listenerId: "listener-1",
+        eventType: "event-1",
+        data: { id: 1 },
+        timestamp: Date.now(),
+      });
+
+      const [result1, result2] = await Promise.all([wait1, wait2]);
+
+      expect(result1.data).toEqual({ id: 1 });
+      expect(result2.data).toEqual({ id: 2 });
+    });
+
+    it("cancelling one waiter does not affect others", async () => {
+      const wait1 = waiter.wait("listener-1", 5000, "session-1");
+      const wait2 = waiter.wait("listener-2", 5000, "session-1");
+
+      waiter.cancel("listener-1", "cancelled");
+
+      await expect(wait1).rejects.toThrow("cancelled");
+
+      // Second waiter should still be active
+      expect(waiter.isAwaiting("listener-2")).toBe(true);
+
+      waiter.notify("listener-2", {
+        listenerId: "listener-2",
+        eventType: "test",
+        data: {},
+        timestamp: Date.now(),
+      });
+
+      const result2 = await wait2;
+      expect(result2.listenerId).toBe("listener-2");
     });
   });
 });


### PR DESCRIPTION
## Summary
Implements the `await_listener` tool that enables the assistant to pause execution while waiting for registered listener events. This is the key enabler for autonomous agent workflows, allowing the assistant to block until an agent completes, a terminal state changes, or another subscribed event fires.

Closes #2093

## Changes Made
- Add `ListenerWaiter` class to manage promise-based waiting with timeouts and session tracking
- Add `await_listener` tool with timeout validation (1ms-5min range) and abort signal handling
- Integrate waiter notifications in `TerminalStateListenerBridge` while maintaining pending event queue
- Track sessionId in waiters for proper session isolation and cleanup
- Cancel waiters automatically when listeners are removed or sessions cleared
- Validate timeout values including NaN guard for robustness
- Handle pre-aborted abort signals immediately to prevent unnecessary waits
- Maintain backward compatibility with pending event queue for reliable delivery
- Add comprehensive test coverage (137 new tests) including unit, integration, and edge case tests

## Implementation Details
- **Timeout management**: Default 30s, max 5min, validates against NaN/Infinity
- **Session isolation**: Waiters track sessionId for proper cleanup on session end
- **Memory safety**: No orphaned promises - waiters cancelled on listener removal
- **Abort handling**: Checks `abortSignal.aborted` before waiting starts
- **Backward compatible**: Always pushes to pending queue regardless of waiter presence

## Testing
- All 176 tests pass (137 new tests added)
- Type checking passes
- Test coverage includes: success paths, timeout handling, cancellation, abort signals, session isolation, integration flows, edge cases