### PR TITLE
Add auto-resume policy for listener-triggered assistant continuation

### DIFF
--- a/electron/services/assistant/ContinuationManager.ts
+++ b/electron/services/assistant/ContinuationManager.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+
+export interface ContinuationContext {
+  plan?: string;
+  lastToolCalls?: unknown[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface Continuation {
+  id: string;
+  sessionId: string;
+  listenerId: string;
+  resumePrompt: string;
+  context: ContinuationContext;
+  createdAt: number;
+  expiresAt: number;
+}
+
+const DEFAULT_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+export class ContinuationManager {
+  private continuations = new Map<string, Continuation>();
+  private listenerToContinuation = new Map<string, string>();
+  private cleanupInterval: NodeJS.Timeout | null = null;
+
+  constructor() {
+    this.startCleanupInterval();
+  }
+
+  create(
+    sessionId: string,
+    listenerId: string,
+    resumePrompt: string,
+    context: ContinuationContext = {},
+    expirationMs: number = DEFAULT_EXPIRATION_MS
+  ): Continuation {
+    // Remove any existing continuation for this listener
+    const existingId = this.listenerToContinuation.get(listenerId);
+    if (existingId) {
+      this.continuations.delete(existingId);
+    }
+
+    const id = randomUUID();
+    const now = Date.now();
+
+    const continuation: Continuation = {
+      id,
+      sessionId,
+      listenerId,
+      resumePrompt,
+      context,
+      createdAt: now,
+      expiresAt: now + expirationMs,
+    };
+
+    this.continuations.set(id, continuation);
+    this.listenerToContinuation.set(listenerId, id);
+
+    return continuation;
+  }
+
+  get(id: string): Continuation | undefined {
+    const continuation = this.continuations.get(id);
+    if (continuation && this.isExpired(continuation)) {
+      this.remove(id);
+      return undefined;
+    }
+    return continuation;
+  }
+
+  getByListenerId(listenerId: string): Continuation | undefined {
+    const id = this.listenerToContinuation.get(listenerId);
+    if (!id) {
+      return undefined;
+    }
+    return this.get(id);
+  }
+
+  remove(id: string): boolean {
+    const continuation = this.continuations.get(id);
+    if (continuation) {
+      this.listenerToContinuation.delete(continuation.listenerId);
+      this.continuations.delete(id);
+      return true;
+    }
+    return false;
+  }
+
+  removeByListenerId(listenerId: string): boolean {
+    const id = this.listenerToContinuation.get(listenerId);
+    if (id) {
+      return this.remove(id);
+    }
+    return false;
+  }
+
+  listForSession(sessionId: string): Continuation[] {
+    const result: Continuation[] = [];
+    for (const continuation of this.continuations.values()) {
+      if (continuation.sessionId === sessionId && !this.isExpired(continuation)) {
+        result.push(continuation);
+      }
+    }
+    return result;
+  }
+
+  clearSession(sessionId: string): number {
+    const toRemove: string[] = [];
+    for (const continuation of this.continuations.values()) {
+      if (continuation.sessionId === sessionId) {
+        toRemove.push(continuation.id);
+      }
+    }
+
+    for (const id of toRemove) {
+      this.remove(id);
+    }
+
+    if (toRemove.length > 0) {
+      console.log(
+        `[ContinuationManager] Cleared ${toRemove.length} continuation(s) for session ${sessionId}`
+      );
+    }
+
+    return toRemove.length;
+  }
+
+  clearExpired(): number {
+    const now = Date.now();
+    const toRemove: string[] = [];
+
+    for (const continuation of this.continuations.values()) {
+      if (continuation.expiresAt <= now) {
+        toRemove.push(continuation.id);
+      }
+    }
+
+    for (const id of toRemove) {
+      this.remove(id);
+    }
+
+    if (toRemove.length > 0) {
+      console.log(`[ContinuationManager] Cleared ${toRemove.length} expired continuation(s)`);
+    }
+
+    return toRemove.length;
+  }
+
+  clearAll(): number {
+    const count = this.continuations.size;
+    this.continuations.clear();
+    this.listenerToContinuation.clear();
+
+    if (count > 0) {
+      console.log(`[ContinuationManager] Cleared all ${count} continuation(s)`);
+    }
+
+    return count;
+  }
+
+  size(): number {
+    return this.continuations.size;
+  }
+
+  private isExpired(continuation: Continuation): boolean {
+    return Date.now() >= continuation.expiresAt;
+  }
+
+  private startCleanupInterval(): void {
+    if (this.cleanupInterval) {
+      return;
+    }
+    this.cleanupInterval = setInterval(() => {
+      this.clearExpired();
+    }, CLEANUP_INTERVAL_MS);
+
+    // Don't prevent process exit
+    this.cleanupInterval.unref();
+  }
+
+  destroy(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+    this.clearAll();
+  }
+}
+
+export const continuationManager = new ContinuationManager();

--- a/electron/services/assistant/__tests__/ContinuationManager.test.ts
+++ b/electron/services/assistant/__tests__/ContinuationManager.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ContinuationManager } from "../ContinuationManager.js";
+
+describe("ContinuationManager", () => {
+  let manager: ContinuationManager;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    manager = new ContinuationManager();
+  });
+
+  afterEach(() => {
+    manager.destroy();
+    vi.useRealTimers();
+  });
+
+  describe("create", () => {
+    it("creates a continuation with all required fields", () => {
+      const continuation = manager.create("session-1", "listener-1", "Resume prompt", {
+        plan: "Step 1: Do something",
+      });
+
+      expect(continuation.id).toBeDefined();
+      expect(continuation.sessionId).toBe("session-1");
+      expect(continuation.listenerId).toBe("listener-1");
+      expect(continuation.resumePrompt).toBe("Resume prompt");
+      expect(continuation.context.plan).toBe("Step 1: Do something");
+      expect(continuation.createdAt).toBeDefined();
+      expect(continuation.expiresAt).toBeGreaterThan(continuation.createdAt);
+    });
+
+    it("creates continuation with default empty context", () => {
+      const continuation = manager.create("session-1", "listener-1", "Resume prompt");
+
+      expect(continuation.context).toEqual({});
+    });
+
+    it("replaces existing continuation for the same listener", () => {
+      const first = manager.create("session-1", "listener-1", "First prompt");
+      const second = manager.create("session-1", "listener-1", "Second prompt");
+
+      expect(manager.size()).toBe(1);
+      expect(manager.get(first.id)).toBeUndefined();
+      expect(manager.get(second.id)).toBeDefined();
+      expect(manager.getByListenerId("listener-1")?.resumePrompt).toBe("Second prompt");
+    });
+
+    it("sets custom expiration time", () => {
+      const continuation = manager.create("session-1", "listener-1", "Resume", {}, 60000); // 1 minute
+
+      expect(continuation.expiresAt - continuation.createdAt).toBe(60000);
+    });
+  });
+
+  describe("get", () => {
+    it("returns undefined for non-existent continuation", () => {
+      expect(manager.get("non-existent")).toBeUndefined();
+    });
+
+    it("returns continuation by id", () => {
+      const created = manager.create("session-1", "listener-1", "Resume");
+      const retrieved = manager.get(created.id);
+
+      expect(retrieved).toEqual(created);
+    });
+
+    it("returns undefined for expired continuation", () => {
+      const continuation = manager.create("session-1", "listener-1", "Resume", {}, 1000);
+
+      expect(manager.get(continuation.id)).toBeDefined();
+
+      vi.advanceTimersByTime(1001);
+
+      expect(manager.get(continuation.id)).toBeUndefined();
+    });
+  });
+
+  describe("getByListenerId", () => {
+    it("returns undefined for non-existent listener", () => {
+      expect(manager.getByListenerId("non-existent")).toBeUndefined();
+    });
+
+    it("returns continuation by listener id", () => {
+      const created = manager.create("session-1", "listener-1", "Resume");
+      const retrieved = manager.getByListenerId("listener-1");
+
+      expect(retrieved).toEqual(created);
+    });
+  });
+
+  describe("remove", () => {
+    it("removes continuation by id", () => {
+      const continuation = manager.create("session-1", "listener-1", "Resume");
+
+      expect(manager.remove(continuation.id)).toBe(true);
+      expect(manager.get(continuation.id)).toBeUndefined();
+      expect(manager.getByListenerId("listener-1")).toBeUndefined();
+    });
+
+    it("returns false for non-existent continuation", () => {
+      expect(manager.remove("non-existent")).toBe(false);
+    });
+  });
+
+  describe("removeByListenerId", () => {
+    it("removes continuation by listener id", () => {
+      manager.create("session-1", "listener-1", "Resume");
+
+      expect(manager.removeByListenerId("listener-1")).toBe(true);
+      expect(manager.getByListenerId("listener-1")).toBeUndefined();
+    });
+
+    it("returns false for non-existent listener", () => {
+      expect(manager.removeByListenerId("non-existent")).toBe(false);
+    });
+  });
+
+  describe("listForSession", () => {
+    it("returns empty array for session with no continuations", () => {
+      expect(manager.listForSession("session-1")).toEqual([]);
+    });
+
+    it("returns all continuations for a session", () => {
+      manager.create("session-1", "listener-1", "Resume 1");
+      manager.create("session-1", "listener-2", "Resume 2");
+      manager.create("session-2", "listener-3", "Resume 3");
+
+      const session1Continuations = manager.listForSession("session-1");
+      expect(session1Continuations.length).toBe(2);
+      expect(session1Continuations.map((c) => c.resumePrompt).sort()).toEqual([
+        "Resume 1",
+        "Resume 2",
+      ]);
+    });
+
+    it("excludes expired continuations", () => {
+      manager.create("session-1", "listener-1", "Resume 1", {}, 1000);
+      manager.create("session-1", "listener-2", "Resume 2", {}, 5000);
+
+      vi.advanceTimersByTime(2000);
+
+      const continuations = manager.listForSession("session-1");
+      expect(continuations.length).toBe(1);
+      expect(continuations[0].resumePrompt).toBe("Resume 2");
+    });
+  });
+
+  describe("clearSession", () => {
+    it("clears all continuations for a session", () => {
+      manager.create("session-1", "listener-1", "Resume 1");
+      manager.create("session-1", "listener-2", "Resume 2");
+      manager.create("session-2", "listener-3", "Resume 3");
+
+      const cleared = manager.clearSession("session-1");
+
+      expect(cleared).toBe(2);
+      expect(manager.listForSession("session-1")).toEqual([]);
+      expect(manager.listForSession("session-2").length).toBe(1);
+    });
+
+    it("returns 0 for session with no continuations", () => {
+      expect(manager.clearSession("non-existent")).toBe(0);
+    });
+  });
+
+  describe("clearExpired", () => {
+    it("clears all expired continuations", () => {
+      manager.create("session-1", "listener-1", "Resume 1", {}, 1000);
+      manager.create("session-1", "listener-2", "Resume 2", {}, 2000);
+      manager.create("session-1", "listener-3", "Resume 3", {}, 5000);
+
+      vi.advanceTimersByTime(3000);
+
+      const cleared = manager.clearExpired();
+
+      expect(cleared).toBe(2);
+      expect(manager.size()).toBe(1);
+      expect(manager.getByListenerId("listener-3")).toBeDefined();
+    });
+  });
+
+  describe("clearAll", () => {
+    it("clears all continuations", () => {
+      manager.create("session-1", "listener-1", "Resume 1");
+      manager.create("session-2", "listener-2", "Resume 2");
+
+      const cleared = manager.clearAll();
+
+      expect(cleared).toBe(2);
+      expect(manager.size()).toBe(0);
+    });
+  });
+
+  describe("context handling", () => {
+    it("preserves complex context data", () => {
+      const context = {
+        plan: "1. Run tests\n2. Review output\n3. Commit if passing",
+        lastToolCalls: [{ id: "tc-1", name: "run_command" }],
+        metadata: { worktreeId: "wt-1", iteration: 3 },
+      };
+
+      const continuation = manager.create("session-1", "listener-1", "Resume", context);
+
+      expect(continuation.context).toEqual(context);
+    });
+  });
+});

--- a/electron/services/assistant/index.ts
+++ b/electron/services/assistant/index.ts
@@ -29,3 +29,10 @@ export { ListenerManager, listenerManager } from "./ListenerManager.js";
 export { createListenerTools, type ListenerToolContext } from "./listenerTools.js";
 
 export { PendingEventQueue, pendingEventQueue, type PendingEvent } from "./PendingEventQueue.js";
+
+export {
+  ContinuationManager,
+  continuationManager,
+  type Continuation,
+  type ContinuationContext,
+} from "./ContinuationManager.js";

--- a/shared/types/assistant.ts
+++ b/shared/types/assistant.ts
@@ -36,6 +36,7 @@ export const StreamChunkTypeSchema = z.enum([
   "done",
   "listener_triggered",
   "retrying",
+  "auto_resume",
 ]);
 export type StreamChunkType = z.infer<typeof StreamChunkTypeSchema>;
 
@@ -53,6 +54,22 @@ export const RetryInfoSchema = z.object({
 });
 export type RetryInfo = z.infer<typeof RetryInfoSchema>;
 
+export const AutoResumeContextSchema = z.object({
+  plan: z.string().optional(),
+  lastToolCalls: z.array(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type AutoResumeContext = z.infer<typeof AutoResumeContextSchema>;
+
+export const AutoResumeDataSchema = z.object({
+  listenerId: z.string(),
+  eventType: z.string(),
+  eventData: z.record(z.string(), z.unknown()),
+  resumePrompt: z.string(),
+  context: AutoResumeContextSchema.optional().default({}),
+});
+export type AutoResumeData = z.infer<typeof AutoResumeDataSchema>;
+
 export const StreamChunkSchema = z.object({
   type: StreamChunkTypeSchema,
   content: z.string().optional(),
@@ -62,6 +79,7 @@ export const StreamChunkSchema = z.object({
   finishReason: z.string().optional(),
   listenerData: ListenerTriggeredDataSchema.optional(),
   retryInfo: RetryInfoSchema.optional(),
+  autoResumeData: AutoResumeDataSchema.optional(),
 });
 export type StreamChunk = z.infer<typeof StreamChunkSchema>;
 

--- a/shared/types/listener.ts
+++ b/shared/types/listener.ts
@@ -5,12 +5,26 @@ const ListenerFilterValueSchema = z.union([z.string(), z.number(), z.boolean(), 
 export const ListenerFilterSchema = z.record(z.string(), ListenerFilterValueSchema).optional();
 export type ListenerFilter = z.infer<typeof ListenerFilterSchema>;
 
+export const AutoResumeContextSchema = z.object({
+  plan: z.string().optional(),
+  lastToolCalls: z.array(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+export type AutoResumeContext = z.infer<typeof AutoResumeContextSchema>;
+
+export const AutoResumeOptionsSchema = z.object({
+  prompt: z.string().min(1),
+  context: AutoResumeContextSchema.optional(),
+});
+export type AutoResumeOptions = z.infer<typeof AutoResumeOptionsSchema>;
+
 export const ListenerSchema = z.object({
   id: z.string().min(1),
   sessionId: z.string().min(1),
   eventType: z.string().min(1),
   filter: ListenerFilterSchema,
   once: z.boolean().optional(),
+  autoResume: AutoResumeOptionsSchema.optional(),
   createdAt: z.number().finite().int(),
 });
 export type Listener = z.infer<typeof ListenerSchema>;
@@ -20,5 +34,6 @@ export const RegisterListenerOptionsSchema = z.object({
   eventType: z.string().min(1),
   filter: ListenerFilterSchema,
   once: z.boolean().optional(),
+  autoResume: AutoResumeOptionsSchema.optional(),
 });
 export type RegisterListenerOptions = z.infer<typeof RegisterListenerOptionsSchema>;

--- a/src/components/Assistant/types.ts
+++ b/src/components/Assistant/types.ts
@@ -1,4 +1,4 @@
-export type MessageRole = "user" | "assistant" | "event";
+export type MessageRole = "user" | "assistant" | "event" | "system";
 
 export type AgentStateChangeTrigger =
   | "input"


### PR DESCRIPTION
## Summary
Implements an opt-in auto-resume policy that automatically re-invokes the assistant when a listener triggers, enabling autonomous workflows where the assistant can register listeners and continue working later without user intervention.

Closes #2094

## Changes Made
- Add ContinuationManager to store auto-resume continuations with 24-hour expiration
- Extend register_listener tool with autoResume option (prompt + context)
- Emit auto_resume chunks when listeners with autoResume trigger
- Queue auto-resume when conversation is busy, process when idle to prevent dropped resumes
- Prevent await_listener on autoResume listeners to avoid race conditions
- Add comprehensive tests for continuation management and auto-resume flow (26 new tests)
- Add system message role for auto-resume notifications in UI

## Technical Implementation
- **Backend**: ContinuationManager manages continuation lifecycle with automatic cleanup
- **Event bridging**: TerminalStateListenerBridge checks for continuations and emits auto_resume chunks
- **Frontend**: useAssistantStreamProcessor queues auto-resume when busy and processes when idle
- **Type safety**: New union types for auto_resume chunks and system messages throughout the stack

## Testing
- All 2205 tests passing
- Added ContinuationManager tests covering CRUD operations, expiration, and cleanup
- Updated TerminalStateListenerBridge tests to validate auto-resume behavior
- Type checking and linting pass