### PR TITLE
Auto-acknowledge triggering event and inject into model context on autoResume

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -267,6 +267,7 @@ export const CHANNELS = {
   ASSISTANT_CHUNK: "assistant:chunk",
   ASSISTANT_HAS_API_KEY: "assistant:has-api-key",
   ASSISTANT_CLEAR_SESSION: "assistant:clear-session",
+  ASSISTANT_ACKNOWLEDGE_EVENT: "assistant:acknowledge-event",
 
   // Agent Capabilities channels
   AGENT_CAPABILITIES_GET_REGISTRY: "agent-capabilities:get-registry",

--- a/shared/types/assistant.ts
+++ b/shared/types/assistant.ts
@@ -62,6 +62,7 @@ export const AutoResumeContextSchema = z.object({
 export type AutoResumeContext = z.infer<typeof AutoResumeContextSchema>;
 
 export const AutoResumeDataSchema = z.object({
+  eventId: z.string(),
   listenerId: z.string(),
   eventType: z.string(),
   eventData: z.record(z.string(), z.unknown()),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -637,6 +637,8 @@ export interface ElectronAPI {
     clearSession(sessionId: string): Promise<void>;
     /** Check if API key is configured (uses appAgentConfig) */
     hasApiKey(): Promise<boolean>;
+    /** Acknowledge a pending event by ID */
+    acknowledgeEvent(sessionId: string, eventId: string): Promise<boolean>;
     /** Subscribe to streaming chunks from the assistant */
     onChunk(callback: (data: AssistantChunkPayload) => void): () => void;
   };


### PR DESCRIPTION
## Summary

Implements automatic event acknowledgment and model context injection when listener auto-resume is triggered. This ensures events are properly cleared from the pending queue and the model receives full event context in the conversation.

Closes #2110

## Changes Made

- Add `eventId` field to AutoResumeData schema and bridge chunk payload
- Capture `eventId` from `pendingEventQueue.push()` in TerminalStateListenerBridge
- Add `ASSISTANT_ACKNOWLEDGE_EVENT` IPC channel with Zod validation
- Track `sessionId` in queued auto-resume to prevent session mismatch
- Acknowledge events before processing and check return value with logging
- Include compact event data (capped at 500 chars) in model-visible user message
- Verify session match and drop stale queued events on session change
- Update preload types to include `auto_resume` and complete chunk payload types

## Technical Details

Previously, when a listener with `autoResume` triggered, the event would stay unacknowledged in the pending queue and the model would only see event context in system messages (which are filtered out before API calls). 

This PR fixes both issues:
1. Events are now automatically acknowledged when auto-resume is processed
2. Event context is injected into the actual user message so the model can see and act on it

The implementation includes proper session tracking to prevent cross-session event processing and comprehensive error handling throughout the acknowledgment flow.

## Testing

- All 2205 existing tests pass
- Type checks pass
- Linting passes
- Codex review completed with all findings addressed