### PR TITLE
Lower await_listener max timeout to 60s with validation

### DIFF
--- a/electron/services/assistant/systemPrompt.txt
+++ b/electron/services/assistant/systemPrompt.txt
@@ -542,7 +542,7 @@ register_listener({
 - **Session-scoped** - Listeners are cleared on navigation or conversation reset
 - **No cross-session** - Cannot monitor terminals from other conversation sessions
 - **Filter limitations** - Exact match only; no regex, ranges, or complex conditions
-- **await_listener timeout** - Maximum 5 minutes (300000ms); use polling for longer waits
+- **await_listener timeout** - Maximum 60 seconds (60000ms); use autoResume for longer waits
 - **Pending queue cap** - Maximum 100 events per session; oldest acknowledged events evicted first when cap reached
 
 ## Tool Call Discipline


### PR DESCRIPTION
## Summary
Reduces the maximum timeout for `await_listener` from 5 minutes to 60 seconds and adds validation that rejects longer timeouts with a helpful error message. This prevents models from using long blocking waits and encourages use of `autoResume` for longer operations.

Closes #2111

## Changes Made
- Change MAX_TIMEOUT_MS from 300000 to 60000 (5 minutes to 60 seconds)
- Add validation rejecting timeouts >60s with timeout_too_long error
- Update tool description to emphasize short, bounded waits only
- Add schema bounds (minimum: 1, maximum: 60000) for timeoutMs parameter
- Improve timeout validation logic with explicit Number.isFinite check
- Update system prompt to reflect new 60-second maximum
- Add tests for timeout validation and edge cases (negative, NaN, zero)