### PR TITLE
Update system prompt to recommend autoResume over await_listener

### DIFF
--- a/electron/services/assistant/examples.txt
+++ b/electron/services/assistant/examples.txt
@@ -108,7 +108,7 @@ agent_launch({
 })
 ```
 
-**Example: Monitor agent completion**
+**Example: Monitor agent completion with autoResume (RECOMMENDED)**
 
 User: "Run the tests and let me know when they finish"
 
@@ -118,40 +118,63 @@ agent_launch({ agentId: "claude", prompt: "Run the test suite and fix any failur
 ```
 Result: `{ terminalId: "xyz-789" }`
 
-Step 2 - Register listeners for completion and failure:
+Step 2 - Register ONE listener with autoResume:
 ```
 register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "xyz-789", toState: "completed" }
-})
-register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "xyz-789", toState: "failed" }
+  eventType: "agent:completed",
+  filter: { terminalId: "xyz-789" },
+  once: true,
+  autoResume: {
+    prompt: "The test agent has completed. Get the output and summarize the results.",
+    context: { metadata: { terminalId: "xyz-789", task: "test-run" } }
+  }
 })
 ```
-Result: `{ listenerId: "listener-abc" }` and `{ listenerId: "listener-def" }`
+Result: `{ listenerId: "listener-abc" }`
 
-Step 3 - Inform user:
-"Running tests. I'll notify you when complete."
+Note: autoResume triggers once when the listener fires, then the continuation is removed.
 
-Step 4 - When listener triggers (you receive notification chunk):
-Payload: `{ type: "listener_triggered", listenerData: { listenerId: "listener-abc", eventType: "terminal:state-changed", data: { terminalId: "xyz-789", toState: "completed", ... } } }`
+Step 3 - Respond immediately to user:
+"Launched test runner. I'll summarize the results when complete."
 
-Step 5 - Check results:
+**[Conversation ends - user is not blocked]**
+
+**[Later, when agent completes, system auto-resumes with the prompt]**
+
+Step 4 - Check results (in resumed conversation):
 ```
 terminal_getOutput({ terminalId: "xyz-789", maxLines: 100 })
 ```
 
-Step 6 - Report to user:
+Step 5 - Report to user:
 "Tests completed. All 47 tests passed."
 
-Step 7 - Clean up listeners:
-```
-remove_listener({ listenerId: "listener-abc" })
-remove_listener({ listenerId: "listener-def" })
-```
+**Why autoResume is better:**
+- User gets immediate response, not a frozen conversation
+- No multi-minute blocking waits
+- System handles continuation automatically
+- One listener instead of multiple
 
 ### Event Listener Patterns
+
+**IMPORTANT: Use autoResume for agent tasks**
+
+For any agent task that may take more than 30 seconds, use `autoResume` instead of blocking waits:
+
+```
+// RECOMMENDED: autoResume for agent tasks
+register_listener({
+  eventType: "agent:completed",
+  filter: { terminalId: "xyz-789" },
+  once: true,
+  autoResume: {
+    prompt: "Agent finished. Summarize the results.",
+    context: { task: "my-task" }
+  }
+})
+```
+
+**DO NOT launch multiple agents in a loop with blocking waits.** Launch ONE agent, register ONE listener with autoResume, respond immediately.
 
 **Monitor all terminals for waiting state:**
 When any agent enters waiting state (may need user input), you'll be notified.
@@ -160,41 +183,51 @@ IMPORTANT: Only `terminal:state-changed` events are currently bridged to the ass
 ```
 register_listener({
   eventType: "terminal:state-changed",
-  filter: { toState: "waiting" }
+  filter: { toState: "waiting" },
+  autoResume: {
+    prompt: "An agent is waiting for input. Check what it needs."
+  }
 })
 ```
 Result: `{ success: true, listenerId: "abc-123", ... }`
 Use the listenerId to remove the listener later.
 
-**Monitor specific terminal for multiple outcomes:**
-Register separate listeners for completion and failure.
+**Monitor specific terminal for completion (with autoResume):**
 ```
-// Listen for success
 register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "xyz-789", toState: "completed" }
-})
-
-// Listen for failure
-register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "xyz-789", toState: "failed" }
+  eventType: "agent:completed",
+  filter: { terminalId: "xyz-789" },
+  once: true,
+  autoResume: {
+    prompt: "The agent completed. Get output and report results.",
+    context: { metadata: { terminalId: "xyz-789" } }
+  }
 })
 ```
 
-**Handle waiting state with user notification:**
-When a listener triggers for waiting state:
-1. The notification chunk arrives with payload: `{ type: "listener_triggered", listenerData: { listenerId, eventType: "terminal:state-changed", data: { terminalId, agentId, toState: "waiting", ... } } }`
-2. Query the terminal output to see what the agent is asking:
+**Handle waiting state (with autoResume):**
+Register with autoResume so you're automatically invoked when the agent needs input:
+```
+register_listener({
+  eventType: "terminal:state-changed",
+  filter: { terminalId: "xyz-789", toState: "waiting" },
+  autoResume: {
+    prompt: "The agent is waiting for input. Check what it needs and respond appropriately."
+  }
+})
+```
+
+When auto-resumed:
+1. Query the terminal output to see what the agent is asking:
 ```
 terminal_getOutput({ terminalId: "xyz-789", maxLines: 20 })
 ```
-3. Check output to determine if agent truly needs input (waiting can be silence-based)
-4. Either respond programmatically:
+2. Check output to determine if agent truly needs input (waiting can be silence-based)
+3. Either respond programmatically:
 ```
 terminal_sendCommand({ terminalId: "xyz-789", command: "y" })
 ```
-5. Or describe the situation to the user and wait for their decision.
+4. Or describe the situation to the user and wait for their decision.
 
 **Cleanup listeners after workflow completes:**
 Always remove listeners when no longer needed.
@@ -209,8 +242,8 @@ list_listeners()
 remove_listener({ listenerId: "abc-123" })
 ```
 
-**Launch, listen, and react workflow:**
-Complete example: launch agent, monitor for waiting/completion/failure, handle prompt.
+**Launch, listen, and react workflow (using autoResume):**
+Complete example: launch ONE agent, register with autoResume, respond immediately.
 
 Step 1 - Launch agent with task that may need input:
 ```
@@ -218,39 +251,42 @@ agent_launch({ agentId: "claude", prompt: "Update dependencies and resolve any c
 ```
 Result: `{ terminalId: "dep-update-001" }`
 
-Step 2 - Register listeners for waiting, completed, and failed states upfront:
+Step 2 - Register ONE listener with autoResume for completion:
 ```
-const l1 = register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "dep-update-001", toState: "waiting" }
-})
-const l2 = register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "dep-update-001", toState: "completed" }
-})
-const l3 = register_listener({
-  eventType: "terminal:state-changed",
-  filter: { terminalId: "dep-update-001", toState: "failed" }
+register_listener({
+  eventType: "agent:completed",
+  filter: { terminalId: "dep-update-001" },
+  once: true,
+  autoResume: {
+    prompt: "Dependency update completed. Check the output and summarize what was updated.",
+    context: { metadata: { terminalId: "dep-update-001" } }
+  }
 })
 ```
-Store listener IDs: `l1.listenerId`, `l2.listenerId`, `l3.listenerId`
 
-Step 3 - When waiting notification arrives:
-```
-terminal_getOutput({ terminalId: "dep-update-001", maxLines: 30 })
-```
-Output shows: "Package react has breaking changes. Proceed? (y/n)"
+Step 3 - Respond immediately to user:
+"Started dependency update. I'll summarize when complete."
 
-Step 4 - Respond to prompt:
+**[User is not blocked - they can continue other work]**
+
+Step 4 - When auto-resumed after completion:
 ```
-terminal_sendCommand({ terminalId: "dep-update-001", command: "y" })
+terminal_getOutput({ terminalId: "dep-update-001", maxLines: 50 })
 ```
 
-Step 5 - When completed/failed notification arrives, clean up all listeners:
+Step 5 - Summarize results to user:
+"Dependencies updated: react 18.2→18.3, typescript 5.0→5.4. No breaking changes."
+
+**Alternative: Handle waiting state with separate listener**
+If you need to respond to prompts during execution, add a waiting listener:
 ```
-remove_listener({ listenerId: l1.listenerId })
-remove_listener({ listenerId: l2.listenerId })
-remove_listener({ listenerId: l3.listenerId })
+register_listener({
+  eventType: "terminal:state-changed",
+  filter: { terminalId: "dep-update-001", toState: "waiting" },
+  autoResume: {
+    prompt: "Agent needs input. Check what it's asking and respond."
+  }
+})
 ```
 
 **Monitor multiple terminals for completion:**

--- a/electron/services/assistant/systemPrompt.txt
+++ b/electron/services/assistant/systemPrompt.txt
@@ -479,9 +479,27 @@ Pending events appear in the context block as a reminder. Process them to avoid 
 
 ### Common Patterns
 
-**Pattern 1: One-Shot Completion**
+**Pattern 1: autoResume for Agent Tasks (RECOMMENDED)**
 ```
-// Launch and wait for completion
+// Launch ONE agent, register with autoResume, respond immediately
+agent_launch({ agentId: "claude", prompt: "Run tests and fix failures" })
+register_listener({
+  eventType: "agent:completed",
+  filter: { terminalId: "<returned-id>" },
+  once: true,
+  autoResume: {
+    prompt: "The test run has completed. Check the output and summarize results.",
+    context: { metadata: { task: "test-run" } }
+  }
+})
+// Respond to user: "Launched test runner. I'll summarize when complete."
+// System auto-resumes assistant when agent finishes
+// Note: autoResume triggers once, then the continuation is removed even if listener persists
+```
+
+**Pattern 2: One-Shot Completion (Notification Only)**
+```
+// Launch and get notified (no auto-resume)
 agent_launch({ agentId: "claude", prompt: "Run tests" })
 register_listener({
   eventType: "agent:completed",
@@ -489,31 +507,27 @@ register_listener({
   once: true
 })
 // Listener auto-removes when agent completes
+// User must send another message for assistant to process the result
 ```
 
-**Pattern 2: Launch and Monitor**
-1. Launch agent with task
-2. Register listeners for `completed` and `failed`
-3. Inform user you're monitoring
-4. When notified, get output and summarize results
-5. Clean up listeners (or use `once: true`)
-
-**Pattern 3: Blocking Wait**
-1. Launch agent with task
-2. Register one-shot listener
-3. Call `await_listener` with appropriate timeout
-4. Process result immediately when event arrives
+**Pattern 3: Short Blocking Wait**
+```
+// Only for short, predictable waits (<30s)
+register_listener({ eventType: "...", filter: {...}, once: true })
+await_listener({ listenerId: "abc", timeoutMs: 30000 })
+// Process result immediately
+```
 
 **Pattern 4: Waiting State Response**
 1. Launch agent that may need input
-2. Register listener for `waiting` state
+2. Register listener for `waiting` state with autoResume
 3. When notified, read output to see what agent is asking
 4. Either respond programmatically or ask user for decision
 5. Clean up when workflow completes
 
 **Pattern 5: Batch Monitoring**
 1. List terminals to find all agents
-2. Register listeners for each terminal
+2. Register listeners for each terminal (consider autoResume for final summary)
 3. Track completions as notifications arrive
 4. When all expected terminals complete, summarize and clean up
 5. **Tip:** When using `toState`-only filters (no `terminalId`), add `worktreeId` or `agentId` to reduce noise
@@ -535,14 +549,51 @@ register_listener({
 - If a terminal is restarted, listeners remain registered but may not match (session token validation)
 - Best practice: After terminal restart, remove old listeners and re-register if needed
 
+### Choosing Between await_listener and autoResume
+
+When you need to wait for an event, choose the right approach:
+
+**Use `autoResume` (recommended for most cases):**
+- Unknown or long duration (>30 seconds)
+- Agent tasks that may take minutes
+- You want to respond immediately and let the system continue later
+- Pattern: Launch ONE agent → register listener with `autoResume` → respond to user immediately
+
+```
+register_listener({
+  eventType: "agent:completed",
+  filter: { terminalId: "abc" },
+  once: true,
+  autoResume: {
+    prompt: "The agent has completed. Summarize the results.",
+    context: { metadata: { taskId: "issue-123" } }
+  }
+})
+```
+
+When this listener triggers, the assistant is automatically re-invoked with the provided prompt. The context metadata is available for tracking but is not directly injected into the model prompt.
+
+**Use `await_listener` (for short, bounded waits):**
+- Short waits (<30 seconds) where blocking is acceptable
+- You need the result immediately to continue
+- The timeout is predictable and reasonable
+
+```
+await_listener({ listenerId: "abc", timeoutMs: 30000 })
+```
+
+**Anti-pattern to avoid:**
+- DO NOT launch multiple agents in a loop waiting for each
+- DO NOT use await_listener for unpredictable durations
+- DO NOT block for agent tasks that may take minutes
+
 ### Limitations
 
 - **Asynchronous delivery** - Events may arrive after your response completes
-- **No auto-resume** - You won't be re-invoked when listeners trigger; events queue until next user message
 - **Session-scoped** - Listeners are cleared on navigation or conversation reset
 - **No cross-session** - Cannot monitor terminals from other conversation sessions
 - **Filter limitations** - Exact match only; no regex, ranges, or complex conditions
-- **await_listener timeout** - Maximum 5 minutes (300000ms); use polling for longer waits
+- **await_listener timeout** - Maximum 5 minutes (300000ms); use autoResume for longer waits
 - **Pending queue cap** - Maximum 100 events per session; oldest acknowledged events evicted first when cap reached
 
 ## Tool Call Discipline
@@ -570,6 +621,44 @@ terminal_sendCommand(id2, "/command") → success
 terminal_sendCommand(id3, "/command") → success
 ```
 Three calls, three DIFFERENT terminal IDs. Never the same ID twice.
+
+### Blocking Wait Workflow Guard
+
+**CRITICAL: Do NOT launch multiple agents in a blocking wait loop.**
+
+When asked to "launch an agent and wait for completion":
+1. Launch ONE agent
+2. Register ONE listener with `autoResume`
+3. Respond immediately to the user
+4. Let the system handle continuation when the agent completes
+
+**Bad pattern (DO NOT DO):**
+```
+// Loop launching agents and blocking
+for each task:
+  agent_launch(...)
+  await_listener(..., timeoutMs: 300000)  // 5 min block!
+  // This freezes the conversation for minutes
+```
+
+**Good pattern:**
+```
+// Launch once, autoResume handles continuation
+agent_launch({ agentId: "claude", prompt: "Complete the task" })
+register_listener({
+  eventType: "agent:completed",
+  filter: { terminalId: "<id>" },
+  once: true,
+  autoResume: { prompt: "Agent finished. Summarize results." }
+})
+// Respond: "Launched agent. I'll report back when complete."
+// System auto-continues when agent finishes
+```
+
+This pattern avoids:
+- Multi-minute blocking that freezes the UI
+- Repeated agent launches that waste resources
+- Poor UX where the conversation appears frozen
 
 ## Stop Conditions
 


### PR DESCRIPTION
## Summary
Updates assistant documentation to recommend `autoResume` over `await_listener` for long-running agent tasks, fixing issue where models defaulted to blocking patterns that caused 5-minute frozen conversations.

Closes #2109

## Changes Made
- Add "Choosing Between await_listener and autoResume" guidance section to systemPrompt.txt (>30s waits use autoResume, <30s use await_listener)
- Reorder Common Patterns to show autoResume as Pattern 1 (recommended approach)
- Add Blocking Wait Workflow Guard warning against multi-agent loops in Tool Call Discipline section
- Fix all autoResume context examples to use proper schema (metadata, plan, lastToolCalls instead of arbitrary keys)
- Document that autoResume triggers once, then continuation is removed
- Replace blocking workflow example with autoResume pattern in examples.txt
- Add explicit warnings against launching multiple agents in loops
- Document autoResume feature as implemented in listener-system-review.md
- Correct supported event types documentation (terminal:state-changed, agent:completed/failed/killed)
- Document pending event queue (max 100 events) and automatic injection behavior
- Update UI rendering documentation to reflect event/system roles
- Move implemented features to "Completed features" section in review doc