### PR TITLE
Fix: permanently kill terminals when worktree is deleted

### DIFF
--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -602,6 +602,15 @@ export async function hydrateAppState(
       }
     }
 
+    // Cleanup orphaned terminals after terminal hydration completes
+    // This must run after terminals are restored to ensure we're checking the full terminal list
+    try {
+      const { cleanupOrphanedTerminals } = await import("@/store/worktreeDataStore");
+      cleanupOrphanedTerminals();
+    } catch (error) {
+      logWarn("Failed to cleanup orphaned terminals", { error });
+    }
+
     // Restore active worktree with validation
     // Fetch worktrees to validate the saved activeWorktreeId still exists
     try {


### PR DESCRIPTION
## Summary
This PR fixes the issue where terminals persist in the UI after their associated worktrees are deleted. The fix changes the behavior from moving terminals to trash to permanently killing them when their worktree is deleted.

Closes #2119

## Changes Made
- Changed `onRemove` handler to call `removeTerminal()` instead of `trashTerminal()`
- Removed `location !== "trash"` filter to kill all terminals for the deleted worktree
- Fixed critical timing race: moved orphan cleanup from worktree initialization to after terminal hydration
- Added `cleanupOrphanedTerminals()` exported function
- Call cleanup in `stateHydration.ts` after terminals are restored from disk

## Key Bug Fixed
The orphan cleanup was running before terminal hydration completed, allowing orphaned terminals to be restored from disk after cleanup ran. The fix ensures cleanup runs **after** terminal hydration completes, so orphaned terminals are properly detected and removed.

## Testing
- Type checking passes
- Linting passes
- Format checking passes