### PR TITLE
Add debounce grace period for auto-resume to prevent interrupting user input

### DIFF
--- a/src/components/Assistant/AutoResumePrompt.tsx
+++ b/src/components/Assistant/AutoResumePrompt.tsx
@@ -1,0 +1,130 @@
+import React, { useEffect, useState, useCallback, useRef } from "react";
+import { Play, X, Clock } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const AUTO_RESUME_GRACE_PERIOD_MS = 15000;
+
+export interface AutoResumePromptProps {
+  eventSummary: string;
+  queuedAt: number;
+  onResume: () => void;
+  onCancel: () => void;
+  className?: string;
+}
+
+function AutoResumePromptComponent({
+  eventSummary,
+  queuedAt,
+  onResume,
+  onCancel,
+  className,
+}: AutoResumePromptProps) {
+  const deadline = queuedAt + AUTO_RESUME_GRACE_PERIOD_MS;
+  const [remainingSeconds, setRemainingSeconds] = useState(() =>
+    Math.ceil((deadline - Date.now()) / 1000)
+  );
+  const hasTriggeredRef = useRef(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      const remaining = Math.ceil((deadline - Date.now()) / 1000);
+      setRemainingSeconds(remaining);
+      if (remaining <= 0) {
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+      }
+    }, 1000);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [deadline]);
+
+  useEffect(() => {
+    if (remainingSeconds <= 0 && !hasTriggeredRef.current) {
+      hasTriggeredRef.current = true;
+      onResume();
+    }
+  }, [remainingSeconds, onResume]);
+
+  const handleResume = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (hasTriggeredRef.current) return;
+      hasTriggeredRef.current = true;
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      onResume();
+    },
+    [onResume]
+  );
+
+  const handleCancel = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (hasTriggeredRef.current) return;
+      hasTriggeredRef.current = true;
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      onCancel();
+    },
+    [onCancel]
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 px-3 py-2 shrink-0",
+        "bg-[color-mix(in_oklab,var(--color-canopy-accent)_10%,transparent)]",
+        "border-b border-[var(--color-canopy-accent)]/20",
+        className
+      )}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <Clock className="w-4 h-4 shrink-0 text-[var(--color-canopy-accent)]" aria-hidden="true" />
+        <span className="text-sm text-canopy-text truncate">
+          Agent event: <span className="font-medium">{eventSummary}</span>
+        </span>
+        <span className="text-xs text-canopy-text/60 shrink-0" aria-hidden="true">
+          Auto-resuming in {remainingSeconds}s
+        </span>
+      </div>
+
+      <div className="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onClick={handleResume}
+          className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium bg-[var(--color-canopy-accent)]/10 text-[var(--color-canopy-accent)] hover:bg-[var(--color-canopy-accent)]/20 rounded transition-colors"
+          title="Resume now"
+          aria-label="Resume conversation now"
+        >
+          <Play className="w-3 h-3" aria-hidden="true" />
+          Resume now
+        </button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="p-1 text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-text/10 rounded transition-colors"
+          title="Cancel"
+          aria-label="Cancel auto-resume"
+        >
+          <X className="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export const AutoResumePrompt = React.memo(AutoResumePromptComponent);

--- a/src/store/assistantChatStore.ts
+++ b/src/store/assistantChatStore.ts
@@ -40,6 +40,21 @@ interface RetryState {
   isRetrying: boolean;
 }
 
+export interface PendingAutoResumeState {
+  eventId: string;
+  eventType: string;
+  eventSummary: string;
+  sessionId: string;
+  eventData: Record<string, unknown>;
+  resumePrompt: string;
+  context: {
+    plan?: string;
+    lastToolCalls?: unknown[];
+    metadata?: Record<string, unknown>;
+  };
+  queuedAt: number;
+}
+
 interface AssistantChatState {
   conversation: ConversationState;
   isOpen: boolean;
@@ -48,6 +63,9 @@ interface AssistantChatState {
   streamingState: StreamingState | null;
   streamingMessageId: string | null;
   retryState: RetryState | null;
+  pendingAutoResume: PendingAutoResumeState | null;
+  inputHasFocus: boolean;
+  inputDraftText: string;
 }
 
 interface AssistantChatActions {
@@ -66,6 +84,9 @@ interface AssistantChatActions {
   setCurrentContext: (context: ActionContext | null) => void;
   setStreamingState: (state: StreamingState | null, messageId: string | null) => void;
   setRetryState: (state: RetryState | null) => void;
+  setPendingAutoResume: (state: PendingAutoResumeState | null) => void;
+  setInputHasFocus: (hasFocus: boolean) => void;
+  setInputDraftText: (text: string) => void;
 }
 
 const initialState: AssistantChatState = {
@@ -76,6 +97,9 @@ const initialState: AssistantChatState = {
   streamingState: null,
   streamingMessageId: null,
   retryState: null,
+  pendingAutoResume: null,
+  inputHasFocus: false,
+  inputDraftText: "",
 };
 
 const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatActions> = (
@@ -150,6 +174,9 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
       streamingState: null,
       streamingMessageId: null,
       retryState: null,
+      pendingAutoResume: null,
+      inputHasFocus: false,
+      inputDraftText: "",
     });
   },
 
@@ -159,6 +186,9 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
       streamingState: null,
       streamingMessageId: null,
       retryState: null,
+      pendingAutoResume: null,
+      inputHasFocus: false,
+      inputDraftText: "",
     }),
 
   open: () => set({ isOpen: true }),
@@ -175,6 +205,12 @@ const createAssistantChatStore: StateCreator<AssistantChatState & AssistantChatA
     set({ streamingState: state, streamingMessageId: messageId }),
 
   setRetryState: (state) => set({ retryState: state }),
+
+  setPendingAutoResume: (state) => set({ pendingAutoResume: state }),
+
+  setInputHasFocus: (hasFocus) => set({ inputHasFocus: hasFocus }),
+
+  setInputDraftText: (text) => set({ inputDraftText: text }),
 });
 
 export const useAssistantChatStore = create<AssistantChatState & AssistantChatActions>()(


### PR DESCRIPTION
## Summary
Add a 15-second grace period to prevent auto-resume from interrupting user input. When a listener triggers auto-resume and the user has input focus or draft text, the system now shows a banner with a countdown timer and Resume/Cancel actions instead of resuming immediately.

Closes #2112

## Changes Made
- Add AutoResumePrompt component with countdown timer and action buttons
- Track input focus and draft text state in assistant chat store
- Check user engagement before triggering auto-resume
- Acknowledge events on cancel to prevent re-delivery
- Clear stale engagement state on component unmount and session changes
- Use deadline-based timer for accuracy during app throttle/suspend
- Add event acknowledgment for replaced and cancelled pending resumes
- Verify session consistency before sending auto-resume messages

## Implementation Details

**User Engagement Detection:**
- Tracks input focus state (`inputHasFocus`)
- Tracks draft text in input field (`inputDraftText`)
- Auto-resume only proceeds immediately if user is not engaged

**Grace Period Banner:**
- 15-second countdown timer
- Shows event summary
- "Resume now" button to proceed immediately
- "Cancel" button to acknowledge and dismiss the event
- Timer based on deadline for accuracy during app throttle/suspend

**Event Management:**
- Events are acknowledged on cancel to prevent re-delivery
- Old pending events are acknowledged when replaced by new ones
- Pending events are acknowledged on session changes and errors
- Session consistency verified before sending auto-resume messages

## Testing
- TypeScript type checking passes
- ESLint checks pass (no new warnings)
- Code formatting verified with Prettier
- Comprehensive code review completed with Codex addressing:
  - Race conditions and timing issues
  - State cleanup and memory leaks
  - Accessibility improvements
  - Session consistency
  - Event acknowledgment flow