### PR TITLE
Add comprehensive diagnostic logging for autoResume listener failures

### DIFF
--- a/electron/services/assistant/ContinuationManager.ts
+++ b/electron/services/assistant/ContinuationManager.ts
@@ -18,14 +18,18 @@ export interface Continuation {
 
 const DEFAULT_EXPIRATION_MS = 24 * 60 * 60 * 1000; // 24 hours
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const STALE_WARNING_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
+const STALE_CHECK_INTERVAL_MS = 60 * 1000; // Check every 1 minute
 
 export class ContinuationManager {
   private continuations = new Map<string, Continuation>();
   private listenerToContinuation = new Map<string, string>();
   private cleanupInterval: NodeJS.Timeout | null = null;
+  private staleCheckInterval: NodeJS.Timeout | null = null;
 
   constructor() {
     this.startCleanupInterval();
+    // Stale warning check starts lazily when first continuation is added
   }
 
   create(
@@ -57,6 +61,11 @@ export class ContinuationManager {
     this.continuations.set(id, continuation);
     this.listenerToContinuation.set(listenerId, id);
 
+    // Start stale warning check when first continuation is added
+    if (this.continuations.size === 1) {
+      this.startStaleWarningCheck();
+    }
+
     return continuation;
   }
 
@@ -82,6 +91,12 @@ export class ContinuationManager {
     if (continuation) {
       this.listenerToContinuation.delete(continuation.listenerId);
       this.continuations.delete(id);
+
+      // Stop stale warning check if no continuations remain
+      if (this.continuations.size === 0) {
+        this.stopStaleWarningCheck();
+      }
+
       return true;
     }
     return false;
@@ -115,6 +130,11 @@ export class ContinuationManager {
 
     for (const id of toRemove) {
       this.remove(id);
+    }
+
+    // Stop stale warning check if no continuations remain after session clear
+    if (this.continuations.size === 0) {
+      this.stopStaleWarningCheck();
     }
 
     if (toRemove.length > 0) {
@@ -152,6 +172,9 @@ export class ContinuationManager {
     this.continuations.clear();
     this.listenerToContinuation.clear();
 
+    // Stop stale warning check when all continuations are cleared
+    this.stopStaleWarningCheck();
+
     if (count > 0) {
       console.log(`[ContinuationManager] Cleared all ${count} continuation(s)`);
     }
@@ -179,10 +202,69 @@ export class ContinuationManager {
     this.cleanupInterval.unref();
   }
 
+  detectStaleContinuations(): void {
+    const now = Date.now();
+    const staleContinuations: Array<{
+      id: string;
+      listenerId: string;
+      ageMinutes: number;
+      sessionId: string;
+    }> = [];
+
+    for (const continuation of this.continuations.values()) {
+      const age = now - continuation.createdAt;
+      if (age > STALE_WARNING_THRESHOLD_MS) {
+        staleContinuations.push({
+          id: continuation.id.substring(0, 8),
+          listenerId: continuation.listenerId.substring(0, 8),
+          ageMinutes: Math.round(age / 60000),
+          sessionId: continuation.sessionId.substring(0, 8),
+        });
+      }
+    }
+
+    if (staleContinuations.length > 0) {
+      // Truncate list to first 10 to avoid excessive log size
+      const logContinuations = staleContinuations.slice(0, 10);
+      const truncated = staleContinuations.length > 10;
+      console.warn(
+        `[ContinuationManager] Stale autoResume continuation(s) detected (waiting >5 min)`,
+        JSON.stringify({
+          count: staleContinuations.length,
+          continuations: logContinuations,
+          ...(truncated && { truncated: `+${staleContinuations.length - 10} more` }),
+        })
+      );
+    }
+  }
+
+  private startStaleWarningCheck(): void {
+    if (this.staleCheckInterval) {
+      return;
+    }
+    this.staleCheckInterval = setInterval(() => {
+      this.detectStaleContinuations();
+    }, STALE_CHECK_INTERVAL_MS);
+
+    // Don't prevent process exit
+    this.staleCheckInterval.unref();
+  }
+
+  private stopStaleWarningCheck(): void {
+    if (this.staleCheckInterval) {
+      clearInterval(this.staleCheckInterval);
+      this.staleCheckInterval = null;
+    }
+  }
+
   destroy(): void {
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
+    }
+    if (this.staleCheckInterval) {
+      clearInterval(this.staleCheckInterval);
+      this.staleCheckInterval = null;
     }
     this.clearAll();
   }


### PR DESCRIPTION
## Summary

This PR adds comprehensive diagnostic logging to help debug autoResume listener failures caused by terminal ID mismatches. When listeners don't match events, the system now provides detailed diagnostics showing exactly why the mismatch occurred.

Closes #2127

## Changes Made

- Add diagnostic logging in ListenerManager when events don't match any listeners
- Include filter key comparisons and event data in mismatch warnings
- Implement stale listener detection with rate-limited warnings (5-minute threshold)
- Add stale continuation detection in ContinuationManager with lazy start/stop
- Reduce TerminalStateListenerBridge log verbosity (only log on mismatch)
- Enhance error logging with listener and terminal ID context
- Truncate log lists to first 10 items to prevent excessive log size
- Add lazy interval management to avoid overhead when no continuations exist

## Key Features

**Mismatch Diagnostics:**
- Logs all filter keys and their values when events don't match
- Shows which listeners exist and what filters they have
- Includes data type information for non-object events

**Stale Detection:**
- Detects autoResume listeners waiting >5 minutes
- Rate-limits warnings to avoid log spam (re-warns every 5 minutes)
- Detects stale continuations with lazy interval management

**Performance:**
- Lazy start/stop of stale detection intervals
- Truncates large log lists to first 10 items
- Only logs events when mismatches occur