### PR TITLE
Fix: Prevent agent_launch/register_listener race condition

### DIFF
--- a/electron/services/AssistantService.ts
+++ b/electron/services/AssistantService.ts
@@ -7,6 +7,7 @@ import { createActionTools, sanitizeToolName } from "./assistant/actionTools.js"
 import { SYSTEM_PROMPT, buildContextBlock } from "./assistant/index.js";
 import { listenerManager } from "./assistant/ListenerManager.js";
 import { createListenerTools } from "./assistant/listenerTools.js";
+import { createCombinedTools } from "./assistant/combinedTools.js";
 import { pendingEventQueue, type PendingEvent } from "./assistant/PendingEventQueue.js";
 import {
   logAssistantRequest,
@@ -671,11 +672,14 @@ export class AssistantService {
           }
         }
 
-        // Build tools from filtered actions and listener management
+        // Build tools from filtered actions, listener management, and combined tools
         const actionTools =
           filteredActions && context ? createActionTools(filteredActions, context) : {};
         const listenerTools = createListenerTools({ sessionId });
-        const tools = { ...actionTools, ...listenerTools };
+        const combinedTools = context
+          ? createCombinedTools({ sessionId, actionContext: context })
+          : {};
+        const tools = { ...actionTools, ...listenerTools, ...combinedTools };
         const hasTools = Object.keys(tools).length > 0;
 
         // Log request (include attempt number for retries)

--- a/electron/services/assistant/combinedTools.ts
+++ b/electron/services/assistant/combinedTools.ts
@@ -1,0 +1,284 @@
+/**
+ * Combined Tools for Assistant Service
+ *
+ * Provides convenience tools that combine multiple operations atomically.
+ * These tools prevent race conditions and ensure correct data dependencies.
+ */
+
+import { tool, jsonSchema } from "ai";
+import type { ToolSet } from "ai";
+import { BrowserWindow, ipcMain } from "electron";
+import type { ActionContext } from "../../../shared/types/actions.js";
+import type { AutoResumeOptions, AutoResumeContext } from "../../../shared/types/listener.js";
+import { listenerManager } from "./ListenerManager.js";
+
+/**
+ * Context provided to combined tools.
+ */
+export interface CombinedToolContext {
+  sessionId: string;
+  actionContext: ActionContext;
+}
+
+/**
+ * Dispatch an action to the renderer via IPC and wait for the result.
+ */
+async function dispatchAction(
+  actionId: string,
+  args: Record<string, unknown> | undefined,
+  context: ActionContext
+): Promise<{ ok: boolean; result?: unknown; error?: { code: string; message: string } }> {
+  const mainWindow = BrowserWindow.getAllWindows()[0];
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return { ok: false, error: { code: "NO_WINDOW", message: "Main window not available" } };
+  }
+
+  const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      ipcMain.removeListener("app-agent:dispatch-action-response", handler);
+      resolve({ ok: false, error: { code: "TIMEOUT", message: "Action dispatch timed out" } });
+    }, 30000);
+
+    const handler = (
+      _event: Electron.IpcMainEvent,
+      payload: {
+        requestId: string;
+        result: { ok: boolean; result?: unknown; error?: { code: string; message: string } };
+      }
+    ) => {
+      if (payload.requestId === requestId) {
+        clearTimeout(timeout);
+        ipcMain.removeListener("app-agent:dispatch-action-response", handler);
+        resolve(payload.result);
+      }
+    };
+
+    ipcMain.on("app-agent:dispatch-action-response", handler);
+
+    mainWindow.webContents.send("app-agent:dispatch-action-request", {
+      requestId,
+      actionId,
+      args,
+      context,
+    });
+  });
+}
+
+/**
+ * Create combined tools for the assistant.
+ * These tools combine multiple operations to ensure correct execution order.
+ */
+export function createCombinedTools(context: CombinedToolContext): ToolSet {
+  return {
+    agent_launchWithAutoResume: tool({
+      description:
+        "Launch an agent AND register an autoResume listener in a single atomic operation. " +
+        "This is the RECOMMENDED way to launch an agent and wait for completion, as it guarantees " +
+        "the listener is registered with the correct terminal ID. " +
+        "Returns both the terminalId and listenerId. " +
+        "After calling this tool, END YOUR TURN IMMEDIATELY - the conversation will automatically " +
+        "continue when the agent completes.",
+      inputSchema: jsonSchema({
+        type: "object",
+        properties: {
+          agentId: {
+            type: "string",
+            description:
+              "The agent to launch: claude, codex, gemini, opencode, or terminal",
+            enum: ["claude", "codex", "gemini", "opencode", "terminal"],
+          },
+          prompt: {
+            type: "string",
+            description: "The prompt/task to give the agent",
+          },
+          autoResumePrompt: {
+            type: "string",
+            description:
+              "The message to inject when the agent completes (e.g., 'Summarize the results.')",
+            minLength: 1,
+          },
+          autoResumeContext: {
+            type: "object",
+            description: "Optional context to preserve for the resumed conversation",
+            properties: {
+              plan: {
+                type: "string",
+                description: "A plan or checklist of steps to continue from",
+              },
+              metadata: {
+                type: "object",
+                description: "Any additional metadata to preserve",
+                additionalProperties: true,
+              },
+            },
+          },
+          location: {
+            type: "string",
+            description: "Where to launch the agent: grid (default) or dock",
+            enum: ["grid", "dock"],
+          },
+          cwd: {
+            type: "string",
+            description: "Working directory for the agent (optional)",
+          },
+          worktreeId: {
+            type: "string",
+            description: "Worktree to associate the agent with (optional)",
+          },
+          interactive: {
+            type: "boolean",
+            description: "Whether the agent should run in interactive mode (optional)",
+          },
+          eventType: {
+            type: "string",
+            description:
+              "Event type to listen for: agent:completed (default), agent:failed, agent:killed, or terminal:state-changed",
+            enum: ["agent:completed", "agent:failed", "agent:killed", "terminal:state-changed"],
+          },
+          stateFilter: {
+            type: "string",
+            description:
+              "For terminal:state-changed events, the state to filter for (e.g., 'completed', 'waiting')",
+          },
+        },
+        required: ["agentId", "prompt", "autoResumePrompt"],
+      }),
+      execute: async ({
+        agentId,
+        prompt,
+        autoResumePrompt,
+        autoResumeContext,
+        location,
+        cwd,
+        worktreeId,
+        interactive,
+        eventType = "agent:completed",
+        stateFilter,
+      }: {
+        agentId: string;
+        prompt: string;
+        autoResumePrompt: string;
+        autoResumeContext?: AutoResumeContext;
+        location?: "grid" | "dock";
+        cwd?: string;
+        worktreeId?: string;
+        interactive?: boolean;
+        eventType?: "agent:completed" | "agent:failed" | "agent:killed" | "terminal:state-changed";
+        stateFilter?: string;
+      }) => {
+        try {
+          // Validate eventType at runtime
+          const validEventTypes = ["agent:completed", "agent:failed", "agent:killed", "terminal:state-changed"];
+          if (!validEventTypes.includes(eventType)) {
+            return {
+              success: false,
+              error: `Invalid event type '${eventType}'. Must be one of: ${validEventTypes.join(", ")}`,
+              code: "VALIDATION_ERROR",
+            };
+          }
+
+          // For terminal:state-changed, require stateFilter to avoid premature resume
+          if (eventType === "terminal:state-changed") {
+            if (!stateFilter) {
+              return {
+                success: false,
+                error: "stateFilter is required for terminal:state-changed events. Specify the target state (e.g., 'completed', 'waiting', 'failed').",
+                code: "VALIDATION_ERROR",
+              };
+            }
+          }
+          // Step 1: Launch the agent
+          const launchResult = await dispatchAction(
+            "agent.launch",
+            {
+              agentId,
+              prompt,
+              location,
+              cwd,
+              worktreeId,
+              interactive,
+            },
+            context.actionContext
+          );
+
+          if (!launchResult.ok) {
+            return {
+              success: false,
+              error: launchResult.error?.message || "Failed to launch agent",
+              code: launchResult.error?.code,
+            };
+          }
+
+          // Extract terminal ID from result
+          const result = launchResult.result as { terminalId?: string } | undefined;
+          const terminalId = result?.terminalId;
+
+          if (!terminalId) {
+            return {
+              success: false,
+              error: "Agent launched but no terminal ID returned",
+              code: "NO_TERMINAL_ID",
+            };
+          }
+
+          // Step 2: Register the listener with the correct terminal ID
+          const autoResumeOptions: AutoResumeOptions = {
+            prompt: autoResumePrompt,
+            context: autoResumeContext,
+          };
+
+          // Build filter based on event type
+          const filter: Record<string, string | number | boolean | null> = {
+            terminalId,
+          };
+
+          // Add state filter for terminal:state-changed events
+          if (eventType === "terminal:state-changed" && stateFilter) {
+            filter.toState = stateFilter;
+          }
+
+          let listenerId: string;
+          try {
+            listenerId = listenerManager.register(
+              context.sessionId,
+              eventType,
+              filter,
+              true, // once: true for completion events
+              autoResumeOptions
+            );
+          } catch (error) {
+            // If listener registration fails after successful launch, return terminalId for recovery
+            return {
+              success: false,
+              error: error instanceof Error ? error.message : "Failed to register listener",
+              code: "LISTENER_REGISTRATION_ERROR",
+              terminalId, // Include terminalId so assistant can retry listener registration
+              eventType,
+            };
+          }
+
+          return {
+            success: true,
+            terminalId,
+            listenerId,
+            eventType,
+            agentId,
+            message:
+              "Agent launched with auto-resume listener. END YOUR TURN NOW - " +
+              "the conversation will automatically continue when the agent finishes. " +
+              "Do not poll, check status, or make additional tool calls. " +
+              "Simply inform the user you're waiting.",
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : "Failed to launch agent with listener",
+            code: "EXECUTION_ERROR",
+          };
+        }
+      },
+    }),
+  };
+}

--- a/electron/services/assistant/index.ts
+++ b/electron/services/assistant/index.ts
@@ -28,6 +28,8 @@ export { ListenerManager, listenerManager } from "./ListenerManager.js";
 
 export { createListenerTools, type ListenerToolContext } from "./listenerTools.js";
 
+export { createCombinedTools, type CombinedToolContext } from "./combinedTools.js";
+
 export { PendingEventQueue, pendingEventQueue, type PendingEvent } from "./PendingEventQueue.js";
 
 export {

--- a/electron/services/assistant/listenerTools.ts
+++ b/electron/services/assistant/listenerTools.ts
@@ -57,7 +57,10 @@ export function createListenerTools(context: ListenerToolContext): ToolSet {
           filter: {
             type: "object",
             description:
-              "Optional filter to narrow events by field values (e.g., { terminalId: 'abc', toState: 'completed' })",
+              "CRITICAL: If you need the terminalId from a just-launched agent, do NOT call register_listener in the same tool batch " +
+              "(including multi_tool_use) as agent_launch. Wait for agent_launch to return, then pass the returned terminalId. " +
+              "Optional filter to narrow events by field values (e.g., { terminalId: 'abc', toState: 'completed' }). " +
+              "Consider using agent_launchWithAutoResume for the common pattern.",
             additionalProperties: true,
           },
           once: {

--- a/electron/services/assistant/systemPrompt.txt
+++ b/electron/services/assistant/systemPrompt.txt
@@ -479,13 +479,54 @@ Pending events appear in the context block as a reminder. Process them to avoid 
 
 ### Common Patterns
 
+**CRITICAL: agent_launch + register_listener Data Dependency**
+
+When launching an agent and registering a listener for it, you MUST call them SEQUENTIALLY in separate tool batches (separate assistant turns):
+
+1. Call `agent_launch` FIRST
+2. WAIT for the result (do NOT put register_listener in the same tool batch, including multi_tool_use)
+3. Extract the `terminalId` from the result
+4. Call `register_listener` with that exact terminalId
+
+These tools cannot be in the same tool batch; `register_listener` requires the terminalId that `agent_launch` returns.
+
+**WRONG (parallel calls - DO NOT DO):**
+```
+// BAD: Same tool batch/assistant message — register_listener has no returned terminalId yet
+agent_launch({ agentId: "claude", prompt: "..." })
+register_listener({ filter: { terminalId: "???" }})  // Do NOT substitute agentId/worktreeId for a just-launched agent
+```
+
+**CORRECT (sequential calls):**
+```
+// GOOD: Wait for agent_launch result, then register listener
+agent_launch({ agentId: "claude", prompt: "..." })
+// Returns: { terminalId: "abc123", ... }
+
+// THEN in next tool call batch:
+register_listener({ filter: { terminalId: "abc123" }})  // Uses correct ID
+```
+
+**Recommended: Use agent_launchWithAutoResume for the common pattern:**
+```
+// BEST: Single tool call that handles both operations correctly
+agent_launchWithAutoResume({
+  agentId: "claude",
+  prompt: "Run tests",
+  autoResumePrompt: "Summarize results"
+})
+// Returns: { terminalId: "...", listenerId: "..." } - guaranteed correct association
+```
+
 **Pattern 1: autoResume for Agent Tasks (RECOMMENDED)**
 ```
 // Launch ONE agent, register with autoResume, respond immediately
 agent_launch({ agentId: "claude", prompt: "Run tests and fix failures" })
+// WAIT for result: { terminalId: "abc123" }
+// THEN call register_listener with the returned ID:
 register_listener({
   eventType: "agent:completed",
-  filter: { terminalId: "<returned-id>" },
+  filter: { terminalId: "abc123" },  // Use the ACTUAL ID from agent_launch
   once: true,
   autoResume: {
     prompt: "The test run has completed. Check the output and summarize results.",


### PR DESCRIPTION
## Summary
Fixes the race condition where the assistant parallelizes `agent_launch` and `register_listener` calls, causing listeners to register with incorrect terminal IDs. This implements a hybrid solution combining explicit warnings with a convenience tool that guarantees correct execution order.

Closes #2126

## Changes Made
- Add `agent_launchWithAutoResume` combined tool for atomic operation that guarantees correct terminal ID association
- Add explicit sequential execution warnings in system prompt with clear examples of wrong/correct patterns
- Update `register_listener` filter description with CRITICAL warning about tool batch requirements
- Add runtime validation for `terminal:state-changed` requiring `stateFilter` to prevent premature resume
- Add error recovery path that returns `terminalId` on listener registration failure for retry capability
- Add support for `agent:killed` event type in combined tool
- Add `minLength` validation for `autoResumePrompt` parameter

## Technical Details
The combined tool executes `agent_launch` and `register_listener` sequentially within a single tool call, eliminating the possibility of parallelization. System prompt and tool descriptions reinforce that when calling these tools separately, they cannot be in the same tool batch.

## Testing
- All 2,219 existing tests pass
- Build successful
- Code reviewed by Codex MCP