### PR TITLE
Improve assistant guidance for choosing listener event types

### DIFF
--- a/electron/services/assistant/__tests__/combinedTools.test.ts
+++ b/electron/services/assistant/__tests__/combinedTools.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// Mock electron modules
+vi.mock("electron", () => ({
+  BrowserWindow: {
+    getAllWindows: vi.fn(() => []),
+  },
+  ipcMain: {
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+// Mock the listenerManager module
+vi.mock("../ListenerManager.js", async () => {
+  const { ListenerManager } =
+    await vi.importActual<typeof import("../ListenerManager.js")>("../ListenerManager.js");
+  const instance = new ListenerManager();
+  return {
+    ListenerManager,
+    listenerManager: instance,
+  };
+});
+
+import { createCombinedTools, type CombinedToolContext } from "../combinedTools.js";
+import { listenerManager } from "../ListenerManager.js";
+import { BrowserWindow, ipcMain } from "electron";
+
+describe("combinedTools", () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let tools: any;
+  let context: CombinedToolContext;
+
+  beforeEach(() => {
+    listenerManager.clear();
+    context = {
+      sessionId: "test-session-1",
+      actionContext: {},
+    };
+    tools = createCombinedTools(context);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    listenerManager.clear();
+  });
+
+  describe("agent_launchWithAutoResume", () => {
+    describe("tool metadata", () => {
+      it("has description mentioning event type decision guidance", () => {
+        const description = tools.agent_launchWithAutoResume.description as string;
+        expect(description).toContain("terminal:state-changed");
+        expect(description).toContain("agent:completed");
+        expect(description).toContain("INTERACTIVE agents");
+        expect(description).toContain("ONE-SHOT agents");
+        expect(description).toContain("Claude");
+        expect(description).toContain("Codex");
+      });
+
+      it("has description recommending terminal:state-changed as safer default", () => {
+        const description = tools.agent_launchWithAutoResume.description as string;
+        expect(description).toContain("safer default");
+        expect(description).toContain("waiting");
+      });
+
+      it("schema includes correct eventType enum values", () => {
+        const schema = (
+          tools.agent_launchWithAutoResume as unknown as {
+            inputSchema: {
+              jsonSchema: {
+                properties: { eventType: { enum: string[]; description: string } };
+              };
+            };
+          }
+        ).inputSchema.jsonSchema;
+        expect(schema.properties.eventType.enum).toEqual([
+          "agent:completed",
+          "agent:failed",
+          "agent:killed",
+          "terminal:state-changed",
+        ]);
+      });
+
+      it("eventType parameter description includes decision guidance", () => {
+        const schema = (
+          tools.agent_launchWithAutoResume as unknown as {
+            inputSchema: {
+              jsonSchema: {
+                properties: { eventType: { enum: string[]; description: string } };
+              };
+            };
+          }
+        ).inputSchema.jsonSchema;
+        const eventTypeDesc = schema.properties.eventType.description;
+        expect(eventTypeDesc).toContain("INTERACTIVE agents");
+        expect(eventTypeDesc).toContain("ONE-SHOT agents");
+        expect(eventTypeDesc).toContain("Claude");
+        expect(eventTypeDesc).toContain("Codex");
+      });
+    });
+
+    describe("validation", () => {
+      it("returns error when no window available", async () => {
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([]);
+
+        const result = await tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "claude",
+            prompt: "Test prompt",
+            autoResumePrompt: "Continue after completion",
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        expect(result).toEqual({
+          success: false,
+          error: "Main window not available",
+          code: "NO_WINDOW",
+        });
+      });
+
+      it("requires stateFilter for terminal:state-changed event type", async () => {
+        // Mock window available
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+          {
+            isDestroyed: () => false,
+            webContents: { send: vi.fn() },
+          } as unknown as Electron.BrowserWindow,
+        ]);
+
+        const result = await tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "claude",
+            prompt: "Test prompt",
+            autoResumePrompt: "Continue after completion",
+            eventType: "terminal:state-changed",
+            // stateFilter intentionally missing
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        expect(result).toEqual({
+          success: false,
+          error:
+            "stateFilter is required for terminal:state-changed events. Specify the target state (e.g., 'completed', 'waiting', 'failed').",
+          code: "VALIDATION_ERROR",
+        });
+      });
+
+      it("rejects invalid event type at runtime", async () => {
+        // Mock window available
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+          {
+            isDestroyed: () => false,
+            webContents: { send: vi.fn() },
+          } as unknown as Electron.BrowserWindow,
+        ]);
+
+        const result = await tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "claude",
+            prompt: "Test prompt",
+            autoResumePrompt: "Continue after completion",
+            eventType: "invalid:event",
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        expect(result).toEqual({
+          success: false,
+          error: expect.stringContaining("Invalid event type"),
+          code: "VALIDATION_ERROR",
+        });
+      });
+
+      it("rejects empty stateFilter for terminal:state-changed", async () => {
+        // Mock window available
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+          {
+            isDestroyed: () => false,
+            webContents: { send: vi.fn() },
+          } as unknown as Electron.BrowserWindow,
+        ]);
+
+        const result = await tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "claude",
+            prompt: "Test prompt",
+            autoResumePrompt: "Continue after completion",
+            eventType: "terminal:state-changed",
+            stateFilter: "  ",
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        expect(result).toEqual({
+          success: false,
+          error: expect.stringContaining("stateFilter is required"),
+          code: "VALIDATION_ERROR",
+        });
+      });
+
+      it("rejects invalid stateFilter value", async () => {
+        // Mock window available
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+          {
+            isDestroyed: () => false,
+            webContents: { send: vi.fn() },
+          } as unknown as Electron.BrowserWindow,
+        ]);
+
+        const result = await tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "claude",
+            prompt: "Test prompt",
+            autoResumePrompt: "Continue after completion",
+            eventType: "terminal:state-changed",
+            stateFilter: "invalid-state",
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        expect(result).toEqual({
+          success: false,
+          error: expect.stringContaining("Invalid stateFilter"),
+          code: "VALIDATION_ERROR",
+        });
+      });
+    });
+
+    describe("successful launch with terminal:state-changed", () => {
+      it("accepts terminal:state-changed with stateFilter", async () => {
+        // Mock window and IPC
+        const mockSend = vi.fn();
+        const mockWindow = {
+          isDestroyed: () => false,
+          webContents: { send: mockSend },
+        } as unknown as Electron.BrowserWindow;
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([mockWindow]);
+
+        // Need to actually trigger the handler when on() is called
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const handlers: { response?: any } = {};
+        vi.mocked(ipcMain.on).mockImplementation((channel, handler) => {
+          if (channel === "app-agent:dispatch-action-response") {
+            handlers.response = handler;
+          }
+          return ipcMain;
+        });
+
+        const resultPromise = tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "claude",
+            prompt: "Analyze the project",
+            autoResumePrompt: "Summarize the results",
+            eventType: "terminal:state-changed",
+            stateFilter: "waiting",
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        // Wait for handler to be captured
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // Simulate response
+        const sendCall = mockSend.mock.calls[0];
+        const requestId = sendCall?.[1]?.requestId;
+        if (handlers.response && requestId) {
+          handlers.response(
+            {},
+            {
+              requestId,
+              result: { ok: true, result: { terminalId: "term-123" } },
+            }
+          );
+        }
+
+        const result = await resultPromise;
+
+        expect(result).toEqual({
+          success: true,
+          terminalId: "term-123",
+          listenerId: expect.any(String),
+          eventType: "terminal:state-changed",
+          agentId: "claude",
+          message: expect.stringContaining("END YOUR TURN NOW"),
+        });
+
+        // Verify listener was registered with correct filter
+        const listeners = listenerManager.listForSession("test-session-1");
+        expect(listeners.length).toBe(1);
+        expect(listeners[0].eventType).toBe("terminal:state-changed");
+        expect(listeners[0].filter).toEqual({
+          terminalId: "term-123",
+          toState: "waiting",
+        });
+      });
+    });
+
+    describe("successful launch with agent:completed", () => {
+      it("accepts agent:completed without stateFilter", async () => {
+        // Mock window and IPC
+        const mockSend = vi.fn();
+        const mockWindow = {
+          isDestroyed: () => false,
+          webContents: { send: mockSend },
+        } as unknown as Electron.BrowserWindow;
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([mockWindow]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const handlers: { response?: any } = {};
+        vi.mocked(ipcMain.on).mockImplementation((channel, handler) => {
+          if (channel === "app-agent:dispatch-action-response") {
+            handlers.response = handler;
+          }
+          return ipcMain;
+        });
+
+        const resultPromise = tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "codex",
+            prompt: "Run the build script",
+            autoResumePrompt: "Report the build results",
+            eventType: "agent:completed",
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        // Wait for handler to be captured
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        // Simulate response
+        const sendCall = mockSend.mock.calls[0];
+        const requestId = sendCall?.[1]?.requestId;
+        if (handlers.response && requestId) {
+          handlers.response(
+            {},
+            {
+              requestId,
+              result: { ok: true, result: { terminalId: "term-456" } },
+            }
+          );
+        }
+
+        const result = await resultPromise;
+
+        expect(result).toEqual({
+          success: true,
+          terminalId: "term-456",
+          listenerId: expect.any(String),
+          eventType: "agent:completed",
+          agentId: "codex",
+          message: expect.stringContaining("END YOUR TURN NOW"),
+        });
+
+        // Verify listener was registered without toState filter
+        const listeners = listenerManager.listForSession("test-session-1");
+        expect(listeners.length).toBe(1);
+        expect(listeners[0].eventType).toBe("agent:completed");
+        expect(listeners[0].filter).toEqual({
+          terminalId: "term-456",
+        });
+        expect(listeners[0].filter).not.toHaveProperty("toState");
+      });
+
+      it("defaults to agent:completed when eventType not specified", async () => {
+        // Mock window and IPC
+        const mockSend = vi.fn();
+        const mockWindow = {
+          isDestroyed: () => false,
+          webContents: { send: mockSend },
+        } as unknown as Electron.BrowserWindow;
+        vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([mockWindow]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const handlers: { response?: any } = {};
+        vi.mocked(ipcMain.on).mockImplementation((channel, handler) => {
+          if (channel === "app-agent:dispatch-action-response") {
+            handlers.response = handler;
+          }
+          return ipcMain;
+        });
+
+        const resultPromise = tools.agent_launchWithAutoResume.execute!(
+          {
+            agentId: "codex",
+            prompt: "Run tests",
+            autoResumePrompt: "Report results",
+            // eventType not specified - should default to agent:completed
+          },
+          { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal }
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        const sendCall = mockSend.mock.calls[0];
+        const requestId = sendCall?.[1]?.requestId;
+        if (handlers.response && requestId) {
+          handlers.response(
+            {},
+            {
+              requestId,
+              result: { ok: true, result: { terminalId: "term-789" } },
+            }
+          );
+        }
+
+        const result = await resultPromise;
+
+        expect((result as { success: boolean }).success).toBe(true);
+        expect((result as { eventType: string }).eventType).toBe("agent:completed");
+      });
+    });
+  });
+});

--- a/electron/services/assistant/systemPrompt.txt
+++ b/electron/services/assistant/systemPrompt.txt
@@ -338,6 +338,42 @@ Do NOT use listeners for:
 - One-time state checks (use `terminal_list` instead)
 - Short tasks that complete in < 30 seconds
 
+### Choosing the Right Event Type
+
+**Use `terminal:state-changed` with `stateFilter` when:**
+- Agent is **interactive** (Claude, terminal shells)
+- You want to react to **state transitions** (working → waiting, idle → working)
+- Agent may handle multiple requests without exiting
+- Example: "Launch Claude to analyze the project and summarize"
+
+**Use `agent:completed` when:**
+- Agent is **one-shot** (runs a single task then exits)
+- You only care about **successful completion**
+- Process will terminate after completing work
+- Example: "Run a build script and report results"
+- Note: For failure handling, use `agent:failed` or `agent:killed` events
+
+**Common Patterns:**
+
+| User Request | Agent Mode | Event Type | State Filter |
+|-------------|-----------|------------|--------------|
+| "Ask Claude about the project" | Interactive (Claude) | `terminal:state-changed` | `"waiting"` |
+| "Launch Codex to fix bug" | One-shot (Codex) | `agent:completed` | N/A |
+| "Run tests in Codex agent" | One-shot (Codex) | `agent:completed` | N/A |
+| "Monitor Claude for errors" | Interactive (Claude) | `terminal:state-changed` | `"failed"` |
+
+**Agent Mode Detection:**
+- **Interactive agents:** Claude (claude), Gemini (gemini) — persist and handle multiple prompts
+- **One-shot agents:** Codex (codex), OpenCode (opencode) — run task and exit
+- **Special case:** Terminal shells can be either mode depending on usage
+
+**Choosing a Default:**
+- For interactive agents waiting for user input: use `terminal:state-changed` with `stateFilter: "waiting"`
+- For any agent completion (success): use `terminal:state-changed` with `stateFilter: "completed"` or `agent:completed`
+- When uncertain about agent mode: use `terminal:state-changed` with `stateFilter: "completed"` to catch completion reliably
+
+**Note:** `stateFilter` is the parameter name for `agent_launchWithAutoResume`. When using `register_listener` directly, specify the state in the `filter` object as `toState` or `newState`.
+
 ### Supported Events
 
 Four event types are bridged to the listener system:
@@ -351,6 +387,8 @@ Four event types are bridged to the listener system:
 
 **terminal:state-changed** is the most versatile—use it for general state monitoring. Includes `trigger` and `confidence` fields for reliability assessment.
 **agent:completed/failed/killed** are agent lifecycle events with richer payloads for completion workflows. Do not include `trigger` or `confidence` fields.
+
+See "Choosing the Right Event Type" above for when to use each event type.
 
 ### Event Filtering
 


### PR DESCRIPTION
## Summary
Adds comprehensive guidance to help the assistant choose the correct event type when launching agents with auto-resume listeners. This improves reliability by clarifying when to use `terminal:state-changed` vs `agent:completed` based on agent behavior patterns.

Closes #2130

## Changes Made
- Add "Choosing the Right Event Type" section to system prompt with decision tree and examples
- Clarify interactive agents (Claude, Gemini) vs one-shot agents (Codex, OpenCode) patterns
- Fix agent:completed description to specify "success only" (not success/failure)
- Add stateFilter validation for non-empty and known states (idle, working, running, waiting, completed, failed)
- Improve success message to reflect chosen event type dynamically
- Update tool description with IMPORTANT section on event type selection
- Expand eventType parameter description with decision criteria
- Add note about stateFilter vs filter.toState parameter naming difference
- Add comprehensive test coverage (12 tests) for agent_launchWithAutoResume validation

## Test Coverage
- Tool metadata includes decision guidance
- Validation rejects missing/empty/invalid stateFilter
- Successful launches with both terminal:state-changed and agent:completed
- Default behavior when eventType not specified