### PR TITLE
Dock context menu should open new panels immediately

### DIFF
--- a/src/components/Layout/CompactDock.tsx
+++ b/src/components/Layout/CompactDock.tsx
@@ -102,8 +102,8 @@ export function CompactDock({
   );
 
   const handleAddTerminal = useCallback(
-    (agentId: string) => {
-      void actionService.dispatch(
+    async (agentId: string) => {
+      const result = await actionService.dispatch<{ terminalId: string | null }>(
         "agent.launch",
         {
           agentId: agentId as any,
@@ -113,8 +113,12 @@ export function CompactDock({
         },
         { source: "context-menu" }
       );
+
+      if (result.ok && result.result?.terminalId) {
+        openDockTerminal(result.result.terminalId);
+      }
     },
-    [activeWorktreeId, cwd]
+    [activeWorktreeId, cwd, openDockTerminal]
   );
 
   const handleContextMenu = useCallback(
@@ -128,7 +132,7 @@ export function CompactDock({
       if (!actionId) return;
 
       if (actionId.startsWith("new:")) {
-        handleAddTerminal(actionId.slice("new:".length));
+        void handleAddTerminal(actionId.slice("new:".length));
       }
     },
     [handleAddTerminal, showMenu]


### PR DESCRIPTION
## Summary
When users right-click the dock and create a new panel (terminal, agent, browser), the panel is now immediately opened in visible/preview state instead of remaining collapsed.

Closes #2136

## Changes Made
- Make handleAddTerminal async to await agent.launch result
- Call openDockTerminal with returned terminalId on success
- Update type to handle null terminalId from failed launches
- Add void operator to prevent unhandled promise rejection
- Add openDockTerminal to useCallback dependency array