### PR TITLE
Fix: Dev preview error detection and automatic recovery

### DIFF
--- a/shared/utils/__tests__/devServerErrors.test.ts
+++ b/shared/utils/__tests__/devServerErrors.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectDevServerError,
+  isRecoverableError,
+  type DevServerError,
+} from "../devServerErrors.js";
+
+describe("devServerErrors", () => {
+  describe("detectDevServerError", () => {
+    describe("port conflicts", () => {
+      it("detects EADDRINUSE error", () => {
+        const output = "Error: listen EADDRINUSE: address already in use :::3000";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "port-conflict",
+          message: "Port 3000 is already in use. Stop the other server or use a different port.",
+          port: "3000",
+        });
+      });
+
+      it("detects 'port already in use' message", () => {
+        const output = "Error: port 5173 is already in use";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "port-conflict",
+          message: "Port 5173 is already in use. Stop the other server or use a different port.",
+          port: "5173",
+        });
+      });
+
+      it("detects 'Something is already running' message", () => {
+        const output = "Something is already running on port 8080";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "port-conflict",
+          message: "Port 8080 is already in use. Stop the other server or use a different port.",
+          port: "8080",
+        });
+      });
+
+      it("detects Vite port in use message", () => {
+        const output = "Port 5173 is in use, trying another one...";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "port-conflict",
+          message: "Port 5173 is already in use. Stop the other server or use a different port.",
+          port: "5173",
+        });
+      });
+    });
+
+    describe("missing dependencies", () => {
+      it("detects Cannot find module error", () => {
+        const output = "Error: Cannot find module 'vite'";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependency: vite. Installing dependencies...",
+          module: "vite",
+        });
+      });
+
+      it("detects MODULE_NOT_FOUND error", () => {
+        const output = "Error [MODULE_NOT_FOUND]: Cannot locate module";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependencies detected. Installing...",
+          module: undefined,
+        });
+      });
+
+      it("detects ERR_MODULE_NOT_FOUND error", () => {
+        const output = "Error [ERR_MODULE_NOT_FOUND]: Cannot find package";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependencies detected. Installing...",
+          module: undefined,
+        });
+      });
+
+      it("detects Cannot find package error", () => {
+        const output = "Error: Cannot find package 'react' imported from";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependency: react. Installing dependencies...",
+          module: "react",
+        });
+      });
+
+      it("detects npm missing error", () => {
+        const output = "npm ERR! missing: webpack@5.0.0";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependencies detected. Installing...",
+          module: undefined,
+        });
+      });
+
+      it("detects native module compilation error", () => {
+        const output = "The module 'node-pty' was compiled against a different Node.js version";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependency: node-pty. Installing dependencies...",
+          module: "node-pty",
+        });
+      });
+
+      it("detects ENOENT node_modules error", () => {
+        const output =
+          "Error: ENOENT: no such file or directory, open 'node_modules/vite/package.json'";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "missing-dependencies",
+          message: "Missing dependencies detected. Installing...",
+          module: undefined,
+        });
+      });
+    });
+
+    describe("permission errors", () => {
+      it("detects EACCES error", () => {
+        const output = "Error: EACCES: permission denied, open '/etc/passwd'";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "permission",
+          message: "Permission denied. Check file permissions or run with elevated privileges.",
+        });
+      });
+
+      it("detects permission denied message", () => {
+        const output = "Error: permission denied trying to access file";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "permission",
+          message: "Permission denied. Check file permissions or run with elevated privileges.",
+        });
+      });
+
+      it("detects EPERM error", () => {
+        const output = "Error: EPERM: operation not permitted";
+        const error = detectDevServerError(output);
+        expect(error).toEqual({
+          type: "permission",
+          message: "Permission denied. Check file permissions or run with elevated privileges.",
+        });
+      });
+    });
+
+    describe("no error", () => {
+      it("returns null for normal output", () => {
+        const output = "Server started successfully at http://localhost:3000";
+        const error = detectDevServerError(output);
+        expect(error).toBeNull();
+      });
+
+      it("returns null for empty output", () => {
+        const error = detectDevServerError("");
+        expect(error).toBeNull();
+      });
+
+      it("returns null for generic errors without matching patterns", () => {
+        const output = "Error: Something went wrong";
+        const error = detectDevServerError(output);
+        expect(error).toBeNull();
+      });
+    });
+  });
+
+  describe("isRecoverableError", () => {
+    it("returns true for missing-dependencies errors", () => {
+      const error: DevServerError = {
+        type: "missing-dependencies",
+        message: "Missing dependencies",
+      };
+      expect(isRecoverableError(error)).toBe(true);
+    });
+
+    it("returns false for port-conflict errors", () => {
+      const error: DevServerError = {
+        type: "port-conflict",
+        message: "Port in use",
+        port: "3000",
+      };
+      expect(isRecoverableError(error)).toBe(false);
+    });
+
+    it("returns false for permission errors", () => {
+      const error: DevServerError = {
+        type: "permission",
+        message: "Permission denied",
+      };
+      expect(isRecoverableError(error)).toBe(false);
+    });
+
+    it("returns false for unknown errors", () => {
+      const error: DevServerError = {
+        type: "unknown",
+        message: "Unknown error",
+      };
+      expect(isRecoverableError(error)).toBe(false);
+    });
+  });
+});

--- a/shared/utils/devServerErrors.ts
+++ b/shared/utils/devServerErrors.ts
@@ -1,0 +1,86 @@
+/**
+ * Error pattern detection for dev server output.
+ * Used to identify common failure modes and enable automatic recovery.
+ */
+
+export type DevServerErrorType =
+  | "port-conflict"
+  | "missing-dependencies"
+  | "permission"
+  | "unknown";
+
+export interface DevServerError {
+  type: DevServerErrorType;
+  message: string;
+  port?: string;
+  module?: string;
+}
+
+const PORT_ERROR_PATTERNS = [
+  /EADDRINUSE.*:(\d+)/,
+  /port (\d+) is already in use/i,
+  /address already in use.*:(\d+)/i,
+  /listen EADDRINUSE.*:(\d+)/,
+  /Error: listen EADDRINUSE: address already in use :::(\d+)/,
+  /Something is already running on port (\d+)/i,
+  /Port (\d+) is in use/i,
+];
+
+const DEPENDENCY_ERROR_PATTERNS = [
+  /Cannot find module '([^']+)'/,
+  /Error: Cannot find module '([^']+)'/,
+  /MODULE_NOT_FOUND/,
+  /Cannot find package '([^']+)'/,
+  /Error \[ERR_MODULE_NOT_FOUND\]/,
+  /npm ERR! missing/i,
+  /The module '([^']+)' was compiled/,
+  /Error: ENOENT.*node_modules/,
+];
+
+const PERMISSION_ERROR_PATTERNS = [/EACCES/, /permission denied/i, /EPERM/];
+
+export function detectDevServerError(output: string): DevServerError | null {
+  // Check for port conflicts first (most specific)
+  for (const pattern of PORT_ERROR_PATTERNS) {
+    const match = output.match(pattern);
+    if (match) {
+      const port = match[1] || "unknown";
+      return {
+        type: "port-conflict",
+        message: `Port ${port} is already in use. Stop the other server or use a different port.`,
+        port,
+      };
+    }
+  }
+
+  // Check for missing dependencies
+  for (const pattern of DEPENDENCY_ERROR_PATTERNS) {
+    const match = output.match(pattern);
+    if (match) {
+      const module = match[1] || undefined;
+      return {
+        type: "missing-dependencies",
+        message: module
+          ? `Missing dependency: ${module}. Installing dependencies...`
+          : "Missing dependencies detected. Installing...",
+        module,
+      };
+    }
+  }
+
+  // Check for permission errors
+  for (const pattern of PERMISSION_ERROR_PATTERNS) {
+    if (pattern.test(output)) {
+      return {
+        type: "permission",
+        message: "Permission denied. Check file permissions or run with elevated privileges.",
+      };
+    }
+  }
+
+  return null;
+}
+
+export function isRecoverableError(error: DevServerError): boolean {
+  return error.type === "missing-dependencies";
+}


### PR DESCRIPTION
## Summary
Implements comprehensive error detection and automatic recovery for dev preview panels to handle common failure scenarios like port conflicts and missing dependencies.

Closes #2134

## Changes Made
- Add error pattern detection utilities for port conflicts, missing dependencies, and permission errors
- Implement automatic dependency installation when MODULE_NOT_FOUND errors are detected
- Add PTY lifecycle guards to prevent orphaned processes during recovery
- Support all package managers (npm, pnpm, yarn, bun) for install transitions
- Preserve specific error messages on exit instead of overwriting with generic codes
- Limit recovery attempts to prevent infinite loops (max 2 attempts)
- Add 4KB output buffer for error detection across chunked PTY data
- Enable dependency installation for both auto-detected and user-provided commands
- Add comprehensive test coverage for error detection and recovery flows

## Test Coverage
- 48 tests passing (27 service tests + 21 error detection tests)
- All critical paths tested including error detection, recovery, and edge cases