### PR TITLE
Fix project emoji change not reflected in UI until dialog reopened

### DIFF
--- a/src/components/Project/ProjectSettingsDialog.tsx
+++ b/src/components/Project/ProjectSettingsDialog.tsx
@@ -357,7 +357,7 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
   };
 
   const handleSave = async () => {
-    if (!settings) return;
+    if (!settings || isSaving) return;
 
     const sanitizedRunCommands = runCommands
       .map((cmd) => ({
@@ -445,6 +445,32 @@ export function ProjectSettingsDialog({ projectId, isOpen, onClose }: ProjectSet
         insecureEnvironmentVariables: undefined,
         unresolvedSecureEnvironmentVariables: undefined,
       });
+
+      const sanitizedEnvVars = Object.entries(envVarRecord).map(([key, value]) => ({
+        id: environmentVariables.find((ev) => ev.key.trim() === key)?.id || key,
+        key,
+        value,
+      }));
+
+      const sanitizedRunCommandsWithIds = sanitizedRunCommands.map((cmd) => ({
+        id: cmd.id || "",
+        name: cmd.name,
+        command: cmd.command,
+      }));
+
+      initialSnapshotRef.current = createProjectSettingsSnapshot(
+        name.trim() || (currentProject?.name ?? ""),
+        emoji,
+        devServerCommand.trim() || "",
+        projectIconSvg,
+        sanitizedPaths,
+        sanitizedEnvVars,
+        sanitizedRunCommandsWithIds,
+        defaultWorktreeRecipeId,
+        commandOverrides.length > 0 ? commandOverrides : [],
+        hasCopyTreeSettings ? sanitizedCopyTreeSettings : {}
+      );
+
       requestClose({ bypassDirty: true });
     } catch (error) {
       console.error("Failed to save settings:", error);


### PR DESCRIPTION
## Summary
Fixes bug where changing a project's emoji in Project Settings saves successfully to the backend but doesn't update in the UI (toolbar, project switcher) until the settings dialog is closed and reopened.

Closes #2188

## Changes Made
- Add re-entrancy guard to prevent concurrent save operations
- Update `initialSnapshotRef` after successful save to reset dirty state
- Use sanitized values for snapshot to match persisted data
- Ensure emoji changes immediately reflect in toolbar and project switcher

## Technical Details
The root cause was that after saving, `initialSnapshotRef.current` wasn't updated, so `isDirty` remained `true`. This blocked the `useEffect` (line 308-313) from syncing `currentProject.emoji` to local state due to the guard: `if (isInitialized && isDirty) return;`

The fix updates the snapshot after both `updateProject` and `saveSettings` succeed, using the exact sanitized values that were persisted. This resets `isDirty` to `false` and allows the UI to sync immediately.