### PR TITLE
Fix dev preview status bar flashing during startup

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1051,9 +1051,9 @@ export function DevPreviewPane({
     const savedUrl = currentTerminal?.browserUrl?.trim() || "";
     const savedUrlPresent = savedHistoryPresent || savedUrl;
     const hasSavedUrl = Boolean(savedUrlPresent);
-    if (isProjectSwitching && hasSavedUrl) {
-      restoredFromSwitchRef.current = true;
-    }
+
+    restoredFromSwitchRef.current = isProjectSwitching && hasSavedUrl;
+
     const shouldTreatSavedUrlAsStale =
       !hasSavedUrl && webviewStore.instances.size === 0 && !restoredFromSwitchRef.current;
 
@@ -1073,14 +1073,8 @@ export function DevPreviewPane({
             };
     setHistory(nextHistory);
     setError(undefined);
-    setStatus(shouldTreatSavedUrlAsStale ? "starting" : hasSavedUrl ? "running" : "starting");
-    setMessage(
-      shouldTreatSavedUrlAsStale
-        ? "Starting dev server..."
-        : hasSavedUrl
-          ? "Running"
-          : "Starting dev server..."
-    );
+    setStatus("starting");
+    setMessage(hasSavedUrl ? "Restoring preview..." : "Starting dev server...");
     setIsRestarting(false);
     setIsBrowserOnly(false);
     setShowTerminal(false);
@@ -1459,28 +1453,26 @@ export function DevPreviewPane({
         </div>
         <div className="flex items-center justify-between gap-3 px-3 py-1.5 border-t border-canopy-border bg-[color-mix(in_oklab,var(--color-surface)_92%,transparent)] text-xs text-canopy-text/70">
           <div className="flex items-center gap-2 min-w-0" role="status" aria-live="polite">
-            <Server className="w-3.5 h-3.5 text-canopy-text/40 shrink-0" />
-            <span className={cn("h-2 w-2 rounded-full shrink-0", statusStyle.dot)} />
-            {status === "running" && !isBrowserOnly ? (
-              <span className="flex items-center gap-2 min-w-0">
-                <span className={cn("font-medium shrink-0", statusStyle.text)}>
-                  {statusStyle.label}
+            <Server className="w-3.5 h-3.5 text-canopy-text/40 shrink-0" aria-hidden="true" />
+            <span className={cn("h-2 w-2 rounded-full shrink-0", statusStyle.dot)} aria-hidden="true" />
+            <span className="flex items-center gap-2 flex-1 min-w-0">
+              <span className={cn("font-medium shrink-0", statusStyle.text)}>
+                {statusStyle.label}
+              </span>
+              {status === "running" && !isBrowserOnly && baseUrl ? (
+                <span className="truncate text-canopy-accent" title={baseUrl}>
+                  {baseUrl}
                 </span>
-                {baseUrl && (
-                  <span className="truncate text-canopy-accent" title={baseUrl}>
-                    {baseUrl}
-                  </span>
-                )}
-              </span>
-            ) : status === "error" && error ? (
-              <span className={cn("truncate", statusStyle.text)} title={error}>
-                {error}
-              </span>
-            ) : (
-              <span className="truncate text-canopy-text/60" title={message}>
-                {message}
-              </span>
-            )}
+              ) : status === "error" && error ? (
+                <span className={cn("truncate", statusStyle.text)} title={error}>
+                  {error}
+                </span>
+              ) : message && message !== statusStyle.label ? (
+                <span className="truncate text-canopy-text/60" title={message}>
+                  {message}
+                </span>
+              ) : null}
+            </span>
           </div>
           <div className="flex items-center gap-2 min-w-0">
             {canToggleTerminal && (


### PR DESCRIPTION
## Summary
Eliminates the visual flashing in the dev preview panel status bar that occurred during startup and project switching. The flash was caused by conflicting DOM structures and frontend/backend status state conflicts.

Closes #2197

## Changes Made
- Unified status bar DOM structure across all states to prevent layout shifts
- Always initialize with "starting" status to avoid frontend/backend conflicts
- Reset restoredFromSwitchRef on each restore cycle to prevent sticky state
- Added aria-hidden to decorative icons for better screen reader experience
- Used flex-1 on text container for deterministic truncation behavior
- Suppressed duplicate label/message text to avoid redundant announcements

## Technical Details
The issue had two root causes:
1. **Layout shifts**: Status bar used different DOM structures for different states (single span vs flex container), causing visual flash when React re-rendered
2. **State conflicts**: Frontend optimistically set status to "running" during project switch restore, while backend emitted "starting", causing continuous oscillation

The fix addresses both by using a consistent DOM structure and always deferring to backend for status confirmation.