### PR TITLE
Add confirmation dialog before removing project from project list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -859,6 +859,10 @@ function App() {
         onAddProject={projectSwitcherPalette.addProject}
         onStopProject={(projectId) => projectSwitcherPalette.stopProject(projectId)}
         onCloseProject={(projectId) => projectSwitcherPalette.removeProject(projectId)}
+        removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
+        onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
+        onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
+        isRemovingProject={projectSwitcherPalette.isRemovingProject}
       />
       <ConfirmDialog
         isOpen={projectSwitcherPalette.stopConfirmProjectId != null}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -703,6 +703,10 @@ export function Toolbar({
             onCloseProject={handleCloseProject}
             onOpenProjectSettings={currentProject ? handleOpenProjectSettings : undefined}
             dropdownAlign="center"
+            removeConfirmProject={projectSwitcher.removeConfirmProject}
+            onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
+            onConfirmRemove={projectSwitcher.confirmRemoveProject}
+            isRemovingProject={projectSwitcher.isRemovingProject}
           >
             <button
               className={cn(

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -94,6 +94,10 @@ export function ProjectSwitcher() {
             onAddProject={projectSwitcher.addProject}
             onStopProject={handleStopProject}
             onCloseProject={handleCloseProject}
+            removeConfirmProject={projectSwitcher.removeConfirmProject}
+            onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
+            onConfirmRemove={projectSwitcher.confirmRemoveProject}
+            isRemovingProject={projectSwitcher.isRemovingProject}
           >
             <Button
               variant="outline"
@@ -143,6 +147,10 @@ export function ProjectSwitcher() {
         onStopProject={handleStopProject}
         onCloseProject={handleCloseProject}
         onOpenProjectSettings={handleOpenSettings}
+        removeConfirmProject={projectSwitcher.removeConfirmProject}
+        onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
+        onConfirmRemove={projectSwitcher.confirmRemoveProject}
+        isRemovingProject={projectSwitcher.isRemovingProject}
       >
         <TooltipProvider>
           <Tooltip>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -3,9 +3,10 @@ import { AppDialog, type DialogZIndex } from "@/components/ui/AppDialog";
 
 export interface ConfirmDialogProps {
   isOpen: boolean;
-  onClose: () => void;
+  onClose?: () => void;
   title: React.ReactNode;
   description?: React.ReactNode;
+  children?: React.ReactNode;
   confirmLabel?: string;
   cancelLabel?: string;
   onConfirm: () => void | Promise<void>;
@@ -19,6 +20,7 @@ export function ConfirmDialog({
   onClose,
   title,
   description,
+  children,
   confirmLabel = "Confirm",
   cancelLabel = "Cancel",
   onConfirm,
@@ -26,22 +28,25 @@ export function ConfirmDialog({
   variant = "destructive",
   zIndex,
 }: ConfirmDialogProps) {
+  const handleClose = onClose ?? (() => {});
+
   return (
-    <AppDialog isOpen={isOpen} onClose={onClose} size="sm" variant={variant} zIndex={zIndex}>
+    <AppDialog isOpen={isOpen} onClose={handleClose} size="sm" variant={variant} zIndex={zIndex}>
       <AppDialog.Header>
         <AppDialog.Title>{title}</AppDialog.Title>
-        <AppDialog.CloseButton />
+        {onClose && <AppDialog.CloseButton />}
       </AppDialog.Header>
 
       <AppDialog.Body className="space-y-3">
         {description && <AppDialog.Description>{description}</AppDialog.Description>}
+        {children}
       </AppDialog.Body>
 
       <AppDialog.Footer
         secondaryAction={{
           label: cancelLabel,
-          onClick: onClose,
-          disabled: isConfirmLoading,
+          onClick: handleClose,
+          disabled: isConfirmLoading || !onClose,
         }}
         primaryAction={{
           label: confirmLabel,


### PR DESCRIPTION
## Summary
Adds a destructive confirmation dialog when users attempt to remove a project from the project switcher to prevent accidental removal of projects with running processes or active sessions.

Closes #2196

## Changes Made
- Add confirmation state and handlers to useProjectSwitcherPalette hook
- Integrate ConfirmDialog with nested z-index for dropdown compatibility
- Display warnings for active processes, agents, and sessions
- Validate active project status at confirmation time to prevent removal
- Block dialog dismissal during removal operation
- Extend ConfirmDialog to support children and optional onClose
- Wire confirmation props through App, Toolbar, and ProjectSwitcher