### PR TITLE
Add post-switch cleanup for stashed DevPreview resources

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -252,6 +252,7 @@ export const CHANNELS = {
   DEV_PREVIEW_STATUS: "dev-preview:status",
   DEV_PREVIEW_URL: "dev-preview:url",
   DEV_PREVIEW_RECOVERY: "dev-preview:recovery",
+  DEV_PREVIEW_PRUNE_SESSIONS: "dev-preview:prune-sessions",
 
   COMMANDS_LIST: "commands:list",
   COMMANDS_GET: "commands:get",

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -114,6 +114,19 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
   ipcMain.handle(CHANNELS.DEV_PREVIEW_SET_URL, handleSetUrl);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_SET_URL));
 
+  const handlePruneSessions = async (
+    _event: Electron.IpcMainInvokeEvent,
+    activePanelIds: string[]
+  ) => {
+    if (!devPreviewService) throw new Error("DevPreviewService not initialized");
+    if (!Array.isArray(activePanelIds) || activePanelIds.some((id) => typeof id !== "string")) {
+      throw new Error("activePanelIds must be an array of strings");
+    }
+    return devPreviewService.pruneInactiveSessions(new Set(activePanelIds));
+  };
+  ipcMain.handle(CHANNELS.DEV_PREVIEW_PRUNE_SESSIONS, handlePruneSessions);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_PRUNE_SESSIONS));
+
   return () => {
     handlers.forEach((dispose) => dispose());
   };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -258,6 +258,7 @@ const CHANNELS = {
   DEV_PREVIEW_STATUS: "dev-preview:status",
   DEV_PREVIEW_URL: "dev-preview:url",
   DEV_PREVIEW_RECOVERY: "dev-preview:recovery",
+  DEV_PREVIEW_PRUNE_SESSIONS: "dev-preview:prune-sessions",
 
   // App state channels
   APP_GET_STATE: "app:get-state",
@@ -1051,6 +1052,9 @@ const api: ElectronAPI = {
     onRecovery: (
       callback: (payload: { panelId: string; command: string; attempt: number }) => void
     ) => _typedOn(CHANNELS.DEV_PREVIEW_RECOVERY, callback),
+
+    pruneSessions: (activePanelIds: string[]): Promise<number> =>
+      _typedInvoke(CHANNELS.DEV_PREVIEW_PRUNE_SESSIONS, activePanelIds) as Promise<number>,
   },
 
   // Git API

--- a/electron/services/DevPreviewService.ts
+++ b/electron/services/DevPreviewService.ts
@@ -362,6 +362,25 @@ export class DevPreviewService extends EventEmitter {
     return this.sessions.get(panelId);
   }
 
+  pruneInactiveSessions(activePanelIds: Set<string>): number {
+    for (const [panelId, pending] of this.pendingAttaches) {
+      if (!activePanelIds.has(panelId)) {
+        pending.aborted = true;
+        this.pendingAttaches.delete(panelId);
+      }
+    }
+    const toRemove: string[] = [];
+    this.sessions.forEach((_, panelId) => {
+      if (!activePanelIds.has(panelId)) {
+        toRemove.push(panelId);
+      }
+    });
+    for (const panelId of toRemove) {
+      this.detach(panelId);
+    }
+    return toRemove.length;
+  }
+
   private handlePtyData(panelId: string, data: string): void {
     const session = this.sessions.get(panelId);
     if (!session) return;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -487,6 +487,7 @@ export interface ElectronAPI {
     onRecovery(
       callback: (data: { panelId: string; command: string; attempt: number }) => void
     ): () => void;
+    pruneSessions(activePanelIds: string[]): Promise<number>;
   };
   git: {
     getFileDiff(cwd: string, filePath: string, status: GitStatus): Promise<string>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -947,6 +947,10 @@ export interface IpcInvokeMap {
     args: [panelId: string, url: string];
     result: void;
   };
+  "dev-preview:prune-sessions": {
+    args: [activePanelIds: string[]];
+    result: number;
+  };
 
   // Agent Capabilities channels
   "agent-capabilities:get-registry": {

--- a/src/hooks/app/useProjectSwitchRehydration.ts
+++ b/src/hooks/app/useProjectSwitchRehydration.ts
@@ -13,6 +13,7 @@ import { useProjectStore, useTerminalStore } from "@/store";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { panelKindUsesTerminalUi } from "@shared/config/panelKindRegistry";
+import { sweepOrphanedDevPreviewStores } from "@/components/DevPreview/DevPreviewPane";
 import type { HydrationCallbacks } from "./useAppHydration";
 
 interface ProjectSwitchedEventDetail {
@@ -91,7 +92,20 @@ export function useProjectSwitchRehydration(callbacks: HydrationCallbacks) {
       } finally {
         // Only finish if this is still the current switch
         if (currentSwitchIdRef.current === switchId) {
-          useProjectStore.getState().finishProjectSwitch();
+          const activePanelIds = new Set(useTerminalStore.getState().terminals.map((t) => t.id));
+          sweepOrphanedDevPreviewStores(activePanelIds);
+          try {
+            await window.electron.devPreview.pruneSessions([...activePanelIds]);
+          } catch (error) {
+            console.error(
+              "[useProjectSwitchRehydration] Failed to prune DevPreview sessions:",
+              error
+            );
+          }
+
+          if (currentSwitchIdRef.current === switchId) {
+            useProjectStore.getState().finishProjectSwitch();
+          }
         }
       }
     };


### PR DESCRIPTION
## Summary

Implements cleanup mechanism to prevent DevPreview resource accumulation during project switches. Both frontend webview stores and backend sessions are now properly pruned after each project switch completes.

Closes #2200

## Changes Made

**Frontend (Webview Stores):**
- Add `sweepOrphanedDevPreviewStores()` to destroy webview stores not in active panel set
- Call sweep in `useProjectSwitchRehydration` after hydration completes
- Release webview stores on unmount even when empty to prevent accumulation
- Clean up stash container when all stores are removed

**Backend (Session Pruning):**
- Add `pruneInactiveSessions()` to detach backend sessions for removed panels
- Abort pending attaches during prune to prevent race condition
- Validate `activePanelIds` payload in IPC handler
- Await backend prune to prevent concurrent switch races

**Integration:**
- Coordinated sweep and prune execution in project switch pipeline
- Proper timing after hydration but before `finishProjectSwitch()`
- Race condition protection for rapid consecutive switches