### PR TITLE
Dev preview panels persist server state across project switches

### DIFF
--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -60,6 +60,15 @@ export const AppStateTerminalEntrySchema = z
     scope: z.enum(["worktree", "project"]).optional(),
     createdAt: z.number().optional(),
     devCommand: z.string().optional(),
+    devServerStatus: z.enum(["stopped", "starting", "installing", "running", "error"]).optional(),
+    devServerUrl: z.string().optional(),
+    devServerError: z
+      .object({
+        type: z.string(),
+        message: z.string(),
+      })
+      .optional(),
+    devServerTerminalId: z.string().optional(),
   })
   .passthrough()
   .refine(
@@ -116,6 +125,15 @@ export const TerminalSnapshotSchema = z
     scope: z.enum(["worktree", "project"]).optional(),
     createdAt: z.number().optional(),
     devCommand: z.string().optional(),
+    devServerStatus: z.enum(["stopped", "starting", "installing", "running", "error"]).optional(),
+    devServerUrl: z.string().optional(),
+    devServerError: z
+      .object({
+        type: z.string(),
+        message: z.string(),
+      })
+      .optional(),
+    devServerTerminalId: z.string().optional(),
   })
   .passthrough()
   .refine(

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -451,6 +451,14 @@ interface PtyPanelData extends BasePanelData {
   browserZoom?: number;
   /** Dev command override for dev-preview panels */
   devCommand?: string;
+  /** Dev server status for dev-preview panels */
+  devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server URL for dev-preview panels */
+  devServerUrl?: string;
+  /** Dev server error for dev-preview panels */
+  devServerError?: { type: string; message: string };
+  /** Terminal ID associated with dev server for dev-preview panels */
+  devServerTerminalId?: string;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
 }
@@ -552,6 +560,14 @@ export interface TerminalInstance {
   createdAt?: number;
   /** Dev command override for dev-preview panels */
   devCommand?: string;
+  /** Dev server status for dev-preview panels */
+  devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server URL for dev-preview panels */
+  devServerUrl?: string;
+  /** Dev server error for dev-preview panels */
+  devServerError?: { type: string; message: string };
+  /** Terminal ID associated with dev server for dev-preview panels */
+  devServerTerminalId?: string;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
   /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */
@@ -640,6 +656,14 @@ export interface TerminalSnapshot {
   browserHistory?: BrowserHistory;
   /** Zoom factor for browser/dev-preview panes */
   browserZoom?: number;
+  /** Dev server status for dev-preview panels */
+  devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server URL for dev-preview panels */
+  devServerUrl?: string;
+  /** Dev server error for dev-preview panels */
+  devServerError?: { type: string; message: string };
+  /** Terminal ID associated with dev server for dev-preview panels */
+  devServerTerminalId?: string;
   /** Path to note file (kind === 'notes') */
   notePath?: string;
   /** Note ID (kind === 'notes') */

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -41,7 +41,7 @@ export function DevPreviewPane({
   const terminal = useTerminalStore((state) => state.getTerminal(id));
   const devCommand = terminal?.devCommand || "";
 
-  const { status, url, terminalId, error, start, stop } = useDevServer({
+  const { status, url, terminalId, error, start } = useDevServer({
     panelId: id,
     devCommand,
     cwd,
@@ -112,12 +112,6 @@ export function DevPreviewPane({
       start();
     }
   }, [devCommand, status, start]);
-
-  useEffect(() => {
-    return () => {
-      stop();
-    };
-  }, [stop]);
 
   const handleNavigate = useCallback((rawUrl: string) => {
     const normalized = normalizeBrowserUrl(rawUrl);

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { terminalClient } from "../clients/terminalClient";
+import { useTerminalStore } from "../store/terminalStore";
 import type { DevServerErrorType } from "../../shared/utils/devServerErrors";
 
 export type DevPreviewStatus = "stopped" | "starting" | "installing" | "running" | "error";
@@ -31,20 +32,31 @@ export function useDevServer({
   worktreeId,
   env,
 }: UseDevServerOptions): UseDevServerReturn {
-  const [status, setStatus] = useState<DevPreviewStatus>("stopped");
-  const [url, setUrl] = useState<string | null>(null);
-  const [terminalId, setTerminalId] = useState<string | null>(null);
-  const [error, setError] = useState<{ type: DevServerErrorType; message: string } | null>(null);
+  const terminalStore = useTerminalStore();
+  const panel = terminalStore.getTerminal(panelId);
+
+  // Initialize from persisted state or default to stopped
+  const [status, setStatus] = useState<DevPreviewStatus>(panel?.devServerStatus ?? "stopped");
+  const [url, setUrl] = useState<string | null>(panel?.devServerUrl ?? null);
+  const [terminalId, setTerminalId] = useState<string | null>(panel?.devServerTerminalId ?? null);
+  const [error, setError] = useState<{ type: DevServerErrorType; message: string } | null>(
+    panel?.devServerError ?? null
+  );
 
   const cleanupRef = useRef<(() => void) | null>(null);
-  const terminalIdRef = useRef<string | null>(null);
+  const terminalIdRef = useRef<string | null>(panel?.devServerTerminalId ?? null);
   const isStartingRef = useRef(false);
+  const isMountedRef = useRef(true);
 
-  const stop = useCallback(() => {
+  const disconnect = useCallback(() => {
     if (cleanupRef.current) {
       cleanupRef.current();
       cleanupRef.current = null;
     }
+  }, []);
+
+  const stop = useCallback(() => {
+    disconnect();
 
     if (terminalIdRef.current) {
       terminalClient.kill(terminalIdRef.current).catch((err) => {
@@ -57,7 +69,10 @@ export function useDevServer({
     setTerminalId(null);
     terminalIdRef.current = null;
     setError(null);
-  }, []);
+
+    // Clear persisted state
+    terminalStore.setDevServerState(panelId, "stopped", null, null, null);
+  }, [disconnect, panelId, terminalStore]);
 
   const start = useCallback(async () => {
     if (isStartingRef.current) {
@@ -65,92 +80,95 @@ export function useDevServer({
     }
 
     isStartingRef.current = true;
+    const sessionId = Date.now();
+    const sessionIdRef = { current: sessionId };
 
+    // Clean up any existing listeners
     if (cleanupRef.current) {
       cleanupRef.current();
       cleanupRef.current = null;
     }
 
-    if (terminalIdRef.current) {
-      terminalClient.kill(terminalIdRef.current).catch(() => {});
-      terminalIdRef.current = null;
+    if (!devCommand.trim()) {
+      const errorObj = { type: "unknown" as const, message: "No dev command configured" };
+      setError(errorObj);
+      setStatus("error");
+      terminalStore.setDevServerState(panelId, "error", null, errorObj, null);
+      isStartingRef.current = false;
+      return;
     }
 
-    if (!devCommand.trim()) {
-      setError({ type: "unknown", message: "No dev command configured" });
-      setStatus("error");
+    // Try to reconnect to existing terminal first
+    const persistedTerminalId = panel?.devServerTerminalId;
+    let id: string | null = null;
+    let reconnected = false;
+
+    if (persistedTerminalId && persistedTerminalId === terminalIdRef.current) {
+      try {
+        const reconnectResult = await terminalClient.reconnect(persistedTerminalId);
+        if (reconnectResult?.id && reconnectResult.exists && reconnectResult.hasPty) {
+          id = reconnectResult.id;
+          reconnected = true;
+          console.log(`[useDevServer] Reconnected to existing terminal: ${id}`);
+        }
+      } catch (err) {
+        console.log(`[useDevServer] Reconnect failed, will spawn new terminal:`, err);
+      }
+    }
+
+    // Check if still mounted after reconnect attempt
+    if (!isMountedRef.current || sessionIdRef.current !== sessionId) {
       isStartingRef.current = false;
       return;
     }
 
     setStatus("starting");
     setError(null);
-    setUrl(null);
-    setTerminalId(null);
 
-    let id: string | null = null;
     const listeners: Array<() => void> = [];
 
     try {
-      id = await terminalClient.spawn({
-        id: panelId,
-        command: devCommand,
-        cwd,
-        worktreeId,
-        kind: "dev-preview",
-        cols: 80,
-        rows: 30,
-        restore: false,
-        isEphemeral: true,
-        env,
-      });
+      // If reconnection failed or no persisted terminal, spawn a new one
+      if (!reconnected) {
+        // Kill any orphaned terminal
+        if (terminalIdRef.current) {
+          terminalClient.kill(terminalIdRef.current).catch(() => {});
+          terminalIdRef.current = null;
+        }
+
+        setUrl(null);
+        setTerminalId(null);
+
+        id = await terminalClient.spawn({
+          id: panelId,
+          command: devCommand,
+          cwd,
+          worktreeId,
+          kind: "dev-preview",
+          cols: 80,
+          rows: 30,
+          restore: false,
+          env,
+        });
+
+        console.log(`[useDevServer] Spawned new terminal: ${id}`);
+      }
+
+      // Check if still mounted after spawn
+      if (!isMountedRef.current || sessionIdRef.current !== sessionId) {
+        if (id && !reconnected) {
+          terminalClient.kill(id).catch(() => {});
+        }
+        isStartingRef.current = false;
+        return;
+      }
 
       setTerminalId(id);
       terminalIdRef.current = id;
 
       const statusRef = { current: "starting" as DevPreviewStatus };
 
-      const unsubscribeUrl = window.electron.devPreview.onUrlDetected((payload) => {
-        if (payload.terminalId === id) {
-          setUrl(payload.url);
-          setStatus("running");
-          statusRef.current = "running";
-          setError(null);
-        }
-      });
-      listeners.push(unsubscribeUrl);
-
-      const unsubscribeError = window.electron.devPreview.onErrorDetected((payload) => {
-        if (payload.terminalId === id) {
-          const newStatus = payload.error.type === "missing-dependencies" ? "installing" : "error";
-          setError({ type: payload.error.type, message: payload.error.message });
-          setStatus(newStatus);
-          statusRef.current = newStatus;
-        }
-      });
-      listeners.push(unsubscribeError);
-
-      const unsubscribeExit = window.electron.terminal.onExit(
-        (termId: string, exitCode: number) => {
-          if (termId === id) {
-            if (statusRef.current === "starting" || statusRef.current === "installing") {
-              setError({
-                type: "unknown",
-                message: `Dev server exited with code ${exitCode}`,
-              });
-              setStatus("error");
-              statusRef.current = "error";
-            } else {
-              setStatus("stopped");
-              statusRef.current = "stopped";
-            }
-          }
-        }
-      );
-      listeners.push(unsubscribeExit);
-
-      await window.electron.devPreview.subscribe(id);
-
+      // Assign cleanup early to prevent leak if unmount happens during listener setup
       cleanupRef.current = () => {
         window.electron.devPreview.unsubscribe(id!).catch((err) => {
           console.error("[useDevServer] Failed to unsubscribe:", err);
@@ -158,32 +176,105 @@ export function useDevServer({
         listeners.forEach((unsub) => unsub());
       };
 
+      const unsubscribeUrl = window.electron.devPreview.onUrlDetected((payload) => {
+        if (payload.terminalId === id && isMountedRef.current && sessionIdRef.current === sessionId) {
+          setUrl(payload.url);
+          setStatus("running");
+          statusRef.current = "running";
+          setError(null);
+          terminalStore.setDevServerState(panelId, "running", payload.url, null, id);
+        }
+      });
+      listeners.push(unsubscribeUrl);
+
+      const unsubscribeError = window.electron.devPreview.onErrorDetected((payload) => {
+        if (payload.terminalId === id && isMountedRef.current && sessionIdRef.current === sessionId) {
+          const newStatus = payload.error.type === "missing-dependencies" ? "installing" : "error";
+          const errorObj = { type: payload.error.type, message: payload.error.message };
+          setError(errorObj);
+          setStatus(newStatus);
+          statusRef.current = newStatus;
+          terminalStore.setDevServerState(panelId, newStatus, null, errorObj, id);
+        }
+      });
+      listeners.push(unsubscribeError);
+
+      const unsubscribeExit = window.electron.terminal.onExit(
+        (termId: string, exitCode: number) => {
+          if (termId === id && isMountedRef.current && sessionIdRef.current === sessionId) {
+            if (statusRef.current === "starting" || statusRef.current === "installing") {
+              const errorObj = {
+                type: "unknown" as const,
+                message: `Dev server exited with code ${exitCode}`,
+              };
+              setError(errorObj);
+              setStatus("error");
+              statusRef.current = "error";
+              setTerminalId(null);
+              terminalIdRef.current = null;
+              terminalStore.setDevServerState(panelId, "error", null, errorObj, null);
+            } else {
+              setStatus("stopped");
+              statusRef.current = "stopped";
+              setTerminalId(null);
+              terminalIdRef.current = null;
+              terminalStore.setDevServerState(panelId, "stopped", null, null, null);
+            }
+          }
+        }
+      );
+      listeners.push(unsubscribeExit);
+
+      // Check if still mounted before subscribe
+      if (!isMountedRef.current || sessionIdRef.current !== sessionId) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+        isStartingRef.current = false;
+        return;
+      }
+
+      await window.electron.devPreview.subscribe(id);
+
+      // Persist initial state
+      if (isMountedRef.current && sessionIdRef.current === sessionId) {
+        terminalStore.setDevServerState(panelId, "starting", null, null, id);
+      }
+
       isStartingRef.current = false;
     } catch (err) {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
+      }
       listeners.forEach((unsub) => unsub());
 
-      if (id) {
+      if (id && !reconnected) {
         terminalClient.kill(id).catch(() => {});
       }
 
-      setError({
-        type: "unknown",
-        message: err instanceof Error ? err.message : String(err),
-      });
-      setStatus("error");
-      setTerminalId(null);
-      terminalIdRef.current = null;
+      if (isMountedRef.current && sessionIdRef.current === sessionId) {
+        const errorObj = {
+          type: "unknown" as const,
+          message: err instanceof Error ? err.message : String(err),
+        };
+        setError(errorObj);
+        setStatus("error");
+        setTerminalId(null);
+        terminalIdRef.current = null;
+        terminalStore.setDevServerState(panelId, "error", null, errorObj, null);
+      }
       isStartingRef.current = false;
     }
-  }, [panelId, devCommand, cwd, worktreeId, env]);
+  }, [panelId, devCommand, cwd, worktreeId, env, panel, terminalStore]);
 
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
-      if (cleanupRef.current) {
-        cleanupRef.current();
-      }
+      isMountedRef.current = false;
+      // Only disconnect listeners, don't kill the terminal
+      disconnect();
     };
-  }, []);
+  }, [disconnect]);
 
   return {
     status,

--- a/src/store/persistence/terminalPersistence.ts
+++ b/src/store/persistence/terminalPersistence.ts
@@ -36,6 +36,10 @@ const DEFAULT_OPTIONS: Required<Omit<TerminalPersistenceOptions, "getProjectId">
         ...(t.browserUrl && { browserUrl: t.browserUrl }),
         ...(t.browserHistory && { browserHistory: t.browserHistory }),
         ...(t.browserZoom != null && { browserZoom: t.browserZoom }),
+        ...(t.devServerStatus && { devServerStatus: t.devServerStatus }),
+        ...(t.devServerUrl && { devServerUrl: t.devServerUrl }),
+        ...(t.devServerError && { devServerError: t.devServerError }),
+        ...(t.devServerTerminalId && { devServerTerminalId: t.devServerTerminalId }),
       };
     }
 

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -365,6 +365,10 @@ export const createTerminalRegistrySlice =
               browserUrl: options.browserUrl,
               browserHistory: options.browserHistory,
               browserZoom: options.browserZoom,
+              devServerStatus: options.devServerStatus,
+              devServerUrl: options.devServerUrl,
+              devServerError: options.devServerError,
+              devServerTerminalId: options.devServerTerminalId,
             }),
           };
 
@@ -1912,6 +1916,29 @@ export const createTerminalRegistrySlice =
 
           const newTerminals = state.terminals.map((t) =>
             t.id === id ? { ...t, browserZoom: zoom } : t
+          );
+
+          saveTerminals(newTerminals);
+          return { terminals: newTerminals };
+        });
+      },
+
+      setDevServerState: (id, status, url, error, terminalId) => {
+        set((state) => {
+          const terminal = state.terminals.find((t) => t.id === id);
+          if (!terminal) return state;
+          if (terminal.kind !== "dev-preview") return state;
+
+          const newTerminals = state.terminals.map((t) =>
+            t.id === id
+              ? {
+                  ...t,
+                  devServerStatus: status,
+                  devServerUrl: url,
+                  devServerError: error,
+                  devServerTerminalId: terminalId,
+                }
+              : t
           );
 
           saveTerminals(newTerminals);

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -56,6 +56,14 @@ export interface AddTerminalOptions {
   createdAt?: number;
   /** Dev server command override for dev-preview panels (kind === 'dev-preview') */
   devCommand?: string;
+  /** Dev server status for dev-preview panels (kind === 'dev-preview') */
+  devServerStatus?: "stopped" | "starting" | "installing" | "running" | "error";
+  /** Dev server URL for dev-preview panels (kind === 'dev-preview') */
+  devServerUrl?: string;
+  /** Dev server error for dev-preview panels (kind === 'dev-preview') */
+  devServerError?: { type: string; message: string };
+  /** Terminal ID associated with dev server for dev-preview panels (kind === 'dev-preview') */
+  devServerTerminalId?: string;
   /** Environment variables to set for this terminal */
   env?: Record<string, string>;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
@@ -148,6 +156,13 @@ export interface TerminalRegistrySlice {
   setBrowserUrl: (id: string, url: string) => void;
   setBrowserHistory: (id: string, history: BrowserHistory) => void;
   setBrowserZoom: (id: string, zoom: number) => void;
+  setDevServerState: (
+    id: string,
+    status: "stopped" | "starting" | "installing" | "running" | "error",
+    url: string | null,
+    error: { type: string; message: string } | null,
+    terminalId: string | null
+  ) => void;
   setSpawnError: (id: string, error: SpawnError) => void;
   clearSpawnError: (id: string) => void;
   setReconnectError: (id: string, error: TerminalReconnectError) => void;

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -211,6 +211,8 @@ export async function hydrateAppState(
                   title: backendTerminal.title,
                 });
 
+                const isDevPreview = backendTerminal.kind === "dev-preview";
+                const devCommand = isDevPreview ? saved.command?.trim() : undefined;
                 await addTerminal({
                   kind: backendTerminal.kind ?? (agentId ? "agent" : "terminal"),
                   type: backendTerminal.type,
@@ -222,6 +224,14 @@ export async function hydrateAppState(
                   existingId: backendTerminal.id,
                   agentState: currentAgentState,
                   lastStateChange: backendLastStateChange,
+                  devCommand,
+                  browserUrl: isDevPreview ? saved.browserUrl : undefined,
+                  browserHistory: isDevPreview ? saved.browserHistory : undefined,
+                  browserZoom: isDevPreview ? saved.browserZoom : undefined,
+                  devServerStatus: isDevPreview ? saved.devServerStatus : undefined,
+                  devServerUrl: isDevPreview ? saved.devServerUrl : undefined,
+                  devServerError: isDevPreview ? saved.devServerError : undefined,
+                  devServerTerminalId: isDevPreview ? saved.devServerTerminalId : undefined,
                 });
 
                 // Initialize frontend tier state from backend to ensure proper wake behavior
@@ -382,6 +392,10 @@ export async function hydrateAppState(
                       browserUrl: isDevPreview ? saved.browserUrl : undefined,
                       browserHistory: isDevPreview ? saved.browserHistory : undefined,
                       browserZoom: isDevPreview ? saved.browserZoom : undefined,
+                      devServerStatus: isDevPreview ? saved.devServerStatus : undefined,
+                      devServerUrl: isDevPreview ? saved.devServerUrl : undefined,
+                      devServerError: isDevPreview ? saved.devServerError : undefined,
+                      devServerTerminalId: isDevPreview ? saved.devServerTerminalId : undefined,
                     });
 
                     // Initialize frontend tier state from backend
@@ -482,6 +496,10 @@ export async function hydrateAppState(
                       browserUrl: isDevPreview ? saved.browserUrl : undefined,
                       browserHistory: isDevPreview ? saved.browserHistory : undefined,
                       browserZoom: isDevPreview ? saved.browserZoom : undefined,
+                      devServerStatus: isDevPreview ? saved.devServerStatus : undefined,
+                      devServerUrl: isDevPreview ? saved.devServerUrl : undefined,
+                      devServerError: isDevPreview ? saved.devServerError : undefined,
+                      devServerTerminalId: isDevPreview ? saved.devServerTerminalId : undefined,
                     });
                   }
                 } else {
@@ -494,6 +512,7 @@ export async function hydrateAppState(
                       ? devCommandCandidate || saved.command?.trim() || undefined
                       : undefined;
 
+                  const isDevPreview = kind === "dev-preview";
                   await addTerminal({
                     kind,
                     title: saved.title,
@@ -509,6 +528,10 @@ export async function hydrateAppState(
                     scope: saved.scope as "worktree" | "project" | undefined,
                     createdAt: saved.createdAt,
                     devCommand,
+                    devServerStatus: isDevPreview ? saved.devServerStatus : undefined,
+                    devServerUrl: isDevPreview ? saved.devServerUrl : undefined,
+                    devServerError: isDevPreview ? saved.devServerError : undefined,
+                    devServerTerminalId: isDevPreview ? saved.devServerTerminalId : undefined,
                   });
                 }
               }


### PR DESCRIPTION
## Summary
This PR implements persistent dev server state for dev-preview panels, preventing unnecessary restarts when switching between projects. Dev server terminals now remain alive in the background and reconnect when switching back to their project.

Closes #2210

## Changes Made
- Add devServerStatus, devServerUrl, devServerError, devServerTerminalId fields to TerminalInstance and TerminalSnapshot types
- Implement setDevServerState() store method for state persistence
- Update useDevServer hook with reconnection logic and session-based lifecycle management
- Fix listener leak race condition with early cleanup assignment
- Add mount guards and session ID tracking to prevent post-unmount state updates
- Synchronize terminalIdRef with persisted state on all exit/error paths
- Strengthen reconnect validation to require exists && hasPty
- Pass dev server state through all stateHydration paths (backend-terminal, reconnect, respawn)
- Update persistence transform to include dev server state fields
- Add validation schemas for dev server state fields

## Technical Details
- **Architecture change:** Dev preview terminals no longer use `isEphemeral: true` and persist like regular terminals
- **Reconnection logic:** On mount, attempts to reconnect to existing terminal before spawning new one
- **State persistence:** All status transitions (URL detected, errors, exits) are persisted to the store
- **Lifecycle safety:** Session ID tracking and mount guards prevent state updates after unmount
- **Code review fixes:** Addressed listener leaks, stale state issues, and weak reconnection validation

## Testing
- Manual test: Start dev server, switch projects, switch back - should reconnect quickly (< 1s)
- Verify no memory leaks from accumulated background terminals
- Verify terminals are cleaned up when panels are permanently closed