### PR TITLE
Remove visual disabled state from hybrid input during agent boot

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -1041,8 +1041,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               "flex w-full items-center gap-1.5 rounded-sm border border-white/[0.06] bg-white/[0.03] py-1 shadow-[0_6px_12px_rgba(0,0,0,0.18)] transition-colors",
               "group-hover:border-white/[0.08] group-hover:bg-white/[0.04]",
               "focus-within:border-white/[0.12] focus-within:ring-1 focus-within:ring-white/[0.06] focus-within:bg-white/[0.05]",
-              disabled && "opacity-60",
-              isInitializing && "opacity-50"
+              disabled && "opacity-60"
             )}
             aria-disabled={disabled}
             aria-busy={isInitializing}

--- a/src/components/Terminal/__tests__/hybridInputAgentReadiness.test.ts
+++ b/src/components/Terminal/__tests__/hybridInputAgentReadiness.test.ts
@@ -4,7 +4,7 @@ import type { AgentState } from "@/types";
 type InitializationState = "initializing" | "initialized";
 
 // Updated: Input is now always enabled regardless of initialization state
-// The isInitializing flag is only used for visual feedback (opacity, placeholder text)
+// The isInitializing flag is only used for placeholder text and aria-busy (no visual disabled state)
 function computeHybridSubmitEnabled(_params: {
   isAgentTerminal: boolean;
   agentState?: AgentState;


### PR DESCRIPTION
## Summary
Removes the visual disabled state (opacity-50) from the hybrid input bar during agent terminal initialization. The input now maintains full opacity at all times, allowing users to decide when to submit without visual suggestions about agent readiness.

Closes #2216

## Changes Made
- Remove opacity-50 from HybridInputBar during agent initialization
- Update test documentation to reflect aria-busy and placeholder usage
- Preserve backend disconnect opacity-60 for genuine connectivity issues

## Technical Details
- `isInitializing` flag is now only used for placeholder text and `aria-busy` attribute (no visual opacity change)
- Backend connectivity issues still show `opacity-60` via the `disabled` prop
- All 19 existing tests pass