### PR TITLE
Fix terminal visibility in dev preview console drawer

### DIFF
--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { XtermAdapter } from "../Terminal/XtermAdapter";
 import { terminalInstanceService } from "../../services/TerminalInstanceService";
+import { TerminalRefreshTier } from "@/types";
 
 interface ConsoleDrawerProps {
   terminalId: string;
@@ -20,6 +21,10 @@ export function ConsoleDrawer({ terminalId, defaultOpen = false }: ConsoleDrawer
     terminalInstanceService.setVisible(terminalId, isOpen);
   }, [terminalId, isOpen]);
 
+  const getRefreshTier = useCallback(() => {
+    return isOpen ? TerminalRefreshTier.VISIBLE : TerminalRefreshTier.BACKGROUND;
+  }, [isOpen]);
+
   return (
     <div className="flex flex-col border-t border-overlay">
       <button
@@ -33,13 +38,15 @@ export function ConsoleDrawer({ terminalId, defaultOpen = false }: ConsoleDrawer
         <ChevronDown className={cn("w-3.5 h-3.5 transition-transform", isOpen && "rotate-180")} />
       </button>
 
-      {isOpen && (
-        <div id={`console-drawer-${terminalId}`} className="h-[300px]">
-          <div className="h-full bg-black">
-            <XtermAdapter terminalId={terminalId} />
-          </div>
+      <div
+        id={`console-drawer-${terminalId}`}
+        className={cn("overflow-hidden transition-[height]", isOpen ? "h-[300px]" : "h-0")}
+        aria-hidden={!isOpen}
+      >
+        <div className="h-[300px] bg-black">
+          <XtermAdapter terminalId={terminalId} getRefreshTier={getRefreshTier} />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsoleDrawer.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConsoleDrawer } from "../ConsoleDrawer";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { TerminalRefreshTier } from "@/types";
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    setVisible: vi.fn(),
+  },
+}));
+
+vi.mock("../../Terminal/XtermAdapter", () => ({
+  XtermAdapter: vi.fn(({ terminalId, getRefreshTier }) => (
+    <div data-testid="xterm-adapter" data-terminal-id={terminalId}>
+      {getRefreshTier && <span data-testid="refresh-tier">{getRefreshTier()}</span>}
+    </div>
+  )),
+}));
+
+describe("ConsoleDrawer", () => {
+  const mockTerminalId = "test-terminal-id";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("XtermAdapter mounting", () => {
+    it("renders XtermAdapter unconditionally even when closed", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const adapter = screen.getByTestId("xterm-adapter");
+      expect(adapter).toBeTruthy();
+      expect(adapter.getAttribute("data-terminal-id")).toBe(mockTerminalId);
+    });
+
+    it("keeps XtermAdapter mounted when drawer is open", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      const adapter = screen.getByTestId("xterm-adapter");
+      expect(adapter).toBeTruthy();
+      expect(adapter.getAttribute("data-terminal-id")).toBe(mockTerminalId);
+    });
+
+    it("keeps XtermAdapter in DOM after toggling from open to closed", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      const adapter = screen.getByTestId("xterm-adapter");
+      expect(adapter).toBeTruthy();
+    });
+  });
+
+  describe("drawer visibility", () => {
+    it("renders with h-0 class when closed by default", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+      expect(drawer?.className).toContain("h-0");
+      expect(drawer?.className).not.toContain("h-[300px]");
+    });
+
+    it("renders with h-[300px] class when open by default", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+      expect(drawer?.className).toContain("h-[300px]");
+      expect(drawer?.className).not.toContain("h-0");
+    });
+
+    it("toggles height class when button is clicked", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+
+      expect(drawer?.className).toContain("h-0");
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(drawer?.className).toContain("h-[300px]");
+      expect(drawer?.className).not.toContain("h-0");
+    });
+
+    it("inner container always has h-[300px] class", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const innerContainer = container.querySelector(".h-\\[300px\\].bg-black");
+      expect(innerContainer).toBeTruthy();
+      expect(innerContainer?.className).toContain("h-[300px]");
+    });
+  });
+
+  describe("button state", () => {
+    it("displays 'Show Logs' when closed", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      expect(screen.getByText("Show Logs")).toBeTruthy();
+    });
+
+    it("displays 'Hide Logs' when open", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      expect(screen.getByText("Hide Logs")).toBeTruthy();
+    });
+
+    it("sets aria-expanded to false when closed", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("sets aria-expanded to true when open", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("toggles aria-expanded on click", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const button = screen.getByRole("button");
+
+      expect(button.getAttribute("aria-expanded")).toBe("false");
+
+      fireEvent.click(button);
+      expect(button.getAttribute("aria-expanded")).toBe("true");
+
+      fireEvent.click(button);
+      expect(button.getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
+  describe("terminalInstanceService integration", () => {
+    it("calls setVisible with false when initially closed", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, false);
+    });
+
+    it("calls setVisible with true when initially open", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, true);
+    });
+
+    it("calls setVisible on toggle from closed to open", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+
+      vi.clearAllMocks();
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledTimes(1);
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, true);
+    });
+
+    it("calls setVisible bidirectionally (open -> closed -> open)", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+
+      vi.clearAllMocks();
+
+      const button = screen.getByRole("button");
+
+      fireEvent.click(button);
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, false);
+
+      fireEvent.click(button);
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith(mockTerminalId, true);
+
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledTimes(2);
+    });
+
+    it("handles terminalId change while closed", () => {
+      const { rerender } = render(<ConsoleDrawer terminalId="terminal-1" defaultOpen={false} />);
+
+      vi.clearAllMocks();
+
+      rerender(<ConsoleDrawer terminalId="terminal-2" defaultOpen={false} />);
+
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith("terminal-2", false);
+    });
+
+    it("handles terminalId change while open", () => {
+      const { rerender } = render(<ConsoleDrawer terminalId="terminal-1" defaultOpen={true} />);
+
+      vi.clearAllMocks();
+
+      rerender(<ConsoleDrawer terminalId="terminal-2" defaultOpen={true} />);
+
+      expect(terminalInstanceService.setVisible).toHaveBeenCalledWith("terminal-2", true);
+    });
+  });
+
+  describe("refresh tier management", () => {
+    it("provides VISIBLE refresh tier when drawer is open", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      const tierDisplay = screen.getByTestId("refresh-tier");
+      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.VISIBLE.toString());
+    });
+
+    it("provides BACKGROUND refresh tier when drawer is closed", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const tierDisplay = screen.getByTestId("refresh-tier");
+      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.BACKGROUND.toString());
+    });
+
+    it("updates refresh tier bidirectionally (closed -> open -> closed)", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+
+      let tierDisplay = screen.getByTestId("refresh-tier");
+      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.BACKGROUND.toString());
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      tierDisplay = screen.getByTestId("refresh-tier");
+      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.VISIBLE.toString());
+
+      fireEvent.click(button);
+
+      tierDisplay = screen.getByTestId("refresh-tier");
+      expect(tierDisplay.textContent).toBe(TerminalRefreshTier.BACKGROUND.toString());
+    });
+  });
+
+  describe("drawer container", () => {
+    it("has overflow-hidden class to prevent content leak", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+      expect(drawer?.className).toContain("overflow-hidden");
+    });
+
+    it("has transition-[height] for smooth animation", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+      expect(drawer?.className).toContain("transition-[height]");
+    });
+
+    it("sets correct aria-controls id", () => {
+      render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-controls")).toBe(`console-drawer-${mockTerminalId}`);
+    });
+
+    it("sets aria-hidden to true when drawer is closed", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+      expect(drawer?.getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("sets aria-hidden to false when drawer is open", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={true} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+      expect(drawer?.getAttribute("aria-hidden")).toBe("false");
+    });
+
+    it("toggles aria-hidden when drawer state changes", () => {
+      const { container } = render(<ConsoleDrawer terminalId={mockTerminalId} defaultOpen={false} />);
+      const drawer = container.querySelector('[id^="console-drawer-"]');
+
+      expect(drawer?.getAttribute("aria-hidden")).toBe("true");
+
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      expect(drawer?.getAttribute("aria-hidden")).toBe("false");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the issue where the terminal in the dev preview console drawer was not visible when expanded. The problem occurred because XtermAdapter was conditionally rendered, causing xterm.js to initialize with 0x0 dimensions during the DOM layout phase.

Closes #2221

## Changes Made
- Render XtermAdapter unconditionally to prevent 0x0 initialization
- Use CSS height transition (h-0 to h-[300px]) instead of conditional rendering
- Add refresh tier management (VISIBLE when open, BACKGROUND when closed)
- Add aria-hidden attribute for accessibility when drawer is collapsed
- Add comprehensive test suite with 27 tests covering mounting, visibility, toggle behavior, and edge cases

## Testing
- ✅ All 27 new tests pass
- ✅ TypeScript type checking passes
- ✅ Terminal is immediately visible when drawer expands
- ✅ Terminal correctly resizes when drawer or panel dimensions change
- ✅ Refresh tier properly managed (performance optimization)