### PR TITLE
Add update notification UI for auto-updates

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -233,6 +233,13 @@ export const CHANNELS = {
 
   NOTIFICATION_UPDATE: "notification:update",
 
+  // Auto-update channels
+  UPDATE_AVAILABLE: "update:available",
+  UPDATE_DOWNLOAD_PROGRESS: "update:download-progress",
+  UPDATE_DOWNLOADED: "update:downloaded",
+  UPDATE_ERROR: "update:error",
+  UPDATE_QUIT_AND_INSTALL: "update:quit-and-install",
+
   SLASH_COMMANDS_LIST: "slash-commands:list",
 
   GEMINI_GET_STATUS: "gemini:get-status",

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -858,7 +858,7 @@ async function createWindow(): Promise<void> {
   });
 
   // Initialize auto-updater (checks for updates on startup and periodically)
-  autoUpdaterService.initialize();
+  autoUpdaterService.initialize(mainWindow);
 
   // Initialize Deferred Services
   initializeDeferredServices(mainWindow, cliAvailabilityService!, eventBuffer!).catch((error) => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -401,6 +401,13 @@ const CHANNELS = {
   // Notification channels
   NOTIFICATION_UPDATE: "notification:update",
 
+  // Auto-update channels
+  UPDATE_AVAILABLE: "update:available",
+  UPDATE_DOWNLOAD_PROGRESS: "update:download-progress",
+  UPDATE_DOWNLOADED: "update:downloaded",
+  UPDATE_ERROR: "update:error",
+  UPDATE_QUIT_AND_INSTALL: "update:quit-and-install",
+
   // Slash command channels
   SLASH_COMMANDS_LIST: "slash-commands:list",
 
@@ -1199,6 +1206,23 @@ const api: ElectronAPI = {
   notification: {
     updateBadge: (state: { waitingCount: number; failedCount: number }) =>
       ipcRenderer.send(CHANNELS.NOTIFICATION_UPDATE, state),
+  },
+
+  // Auto-Update API
+  update: {
+    onUpdateAvailable: (callback: (info: { version: string }) => void) =>
+      _typedOn(CHANNELS.UPDATE_AVAILABLE, callback),
+
+    onDownloadProgress: (callback: (info: { percent: number }) => void) =>
+      _typedOn(CHANNELS.UPDATE_DOWNLOAD_PROGRESS, callback),
+
+    onUpdateDownloaded: (callback: (info: { version: string }) => void) =>
+      _typedOn(CHANNELS.UPDATE_DOWNLOADED, callback),
+
+    onUpdateError: (callback: (info: { message: string }) => void) =>
+      _typedOn(CHANNELS.UPDATE_ERROR, callback),
+
+    quitAndInstall: () => _typedInvoke(CHANNELS.UPDATE_QUIT_AND_INSTALL),
   },
 
   // Gemini API

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -1,18 +1,31 @@
-import { app } from "electron";
+import { app, BrowserWindow, ipcMain } from "electron";
 import { autoUpdater } from "electron-updater";
 import type { UpdateInfo, ProgressInfo } from "electron-updater";
+import { CHANNELS } from "../ipc/channels.js";
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
 class AutoUpdaterService {
   private checkInterval: NodeJS.Timeout | null = null;
   private initialized = false;
+  private window: BrowserWindow | null = null;
+  private updateDownloaded = false;
   private checkingHandler: (() => void) | null = null;
   private availableHandler: ((info: UpdateInfo) => void) | null = null;
   private notAvailableHandler: ((info: UpdateInfo) => void) | null = null;
   private errorHandler: ((err: Error) => void) | null = null;
   private progressHandler: ((progress: ProgressInfo) => void) | null = null;
   private downloadedHandler: ((info: UpdateInfo) => void) | null = null;
+
+  private sendToWindow(channel: string, payload: unknown): void {
+    if (this.window && !this.window.isDestroyed() && !this.window.webContents.isDestroyed()) {
+      try {
+        this.window.webContents.send(channel, payload);
+      } catch {
+        // Silently ignore send failures during window disposal.
+      }
+    }
+  }
 
   private runUpdateCheck(context: "Initial" | "Periodic"): void {
     try {
@@ -25,11 +38,18 @@ class AutoUpdaterService {
     }
   }
 
-  initialize(): void {
+  initialize(window?: BrowserWindow): void {
     if (this.initialized) {
       console.log("[MAIN] Auto-updater already initialized, skipping");
       return;
     }
+
+    if (!window) {
+      console.warn("[MAIN] Auto-updater requires a window, skipping initialization");
+      return;
+    }
+
+    this.window = window;
 
     if (!app.isPackaged) {
       console.log("[MAIN] Auto-updater disabled in non-packaged mode");
@@ -52,6 +72,7 @@ class AutoUpdaterService {
 
       this.availableHandler = (info: UpdateInfo) => {
         console.log("[MAIN] Update available:", info.version);
+        this.sendToWindow(CHANNELS.UPDATE_AVAILABLE, { version: info.version });
       };
       autoUpdater.on("update-available", this.availableHandler);
 
@@ -62,18 +83,31 @@ class AutoUpdaterService {
 
       this.errorHandler = (err: Error) => {
         console.error("[MAIN] Auto-updater error:", err);
+        this.sendToWindow(CHANNELS.UPDATE_ERROR, { message: err.message });
       };
       autoUpdater.on("error", this.errorHandler);
 
       this.progressHandler = (progress: ProgressInfo) => {
         console.log(`[MAIN] Download progress: ${Math.round(progress.percent)}%`);
+        this.sendToWindow(CHANNELS.UPDATE_DOWNLOAD_PROGRESS, { percent: progress.percent });
       };
       autoUpdater.on("download-progress", this.progressHandler);
 
       this.downloadedHandler = (info: UpdateInfo) => {
         console.log("[MAIN] Update downloaded:", info.version);
+        this.updateDownloaded = true;
+        this.sendToWindow(CHANNELS.UPDATE_DOWNLOADED, { version: info.version });
       };
       autoUpdater.on("update-downloaded", this.downloadedHandler);
+
+      // Handle quit-and-install request from renderer
+      ipcMain.handle(CHANNELS.UPDATE_QUIT_AND_INSTALL, () => {
+        if (!this.updateDownloaded) {
+          console.warn("[MAIN] Quit-and-install called before download completed");
+          return;
+        }
+        autoUpdater.quitAndInstall();
+      });
 
       this.runUpdateCheck("Initial");
 
@@ -120,6 +154,14 @@ class AutoUpdaterService {
       this.downloadedHandler = null;
     }
 
+    try {
+      ipcMain.removeHandler(CHANNELS.UPDATE_QUIT_AND_INSTALL);
+    } catch {
+      // Handler may not have been registered
+    }
+
+    this.window = null;
+    this.updateDownloaded = false;
     this.initialized = false;
   }
 }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -586,6 +586,13 @@ export interface ElectronAPI {
     /** Update window title and dock badge based on terminal attention state */
     updateBadge(state: { waitingCount: number; failedCount: number }): void;
   };
+  update: {
+    onUpdateAvailable(callback: (info: { version: string }) => void): () => void;
+    onDownloadProgress(callback: (info: { percent: number }) => void): () => void;
+    onUpdateDownloaded(callback: (info: { version: string }) => void): () => void;
+    onUpdateError(callback: (info: { message: string }) => void): () => void;
+    quitAndInstall(): Promise<void>;
+  };
   gemini: {
     /** Get Gemini config status (exists, alternate buffer enabled) */
     getStatus(): Promise<{ exists: boolean; alternateBufferEnabled: boolean; error?: string }>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -958,6 +958,12 @@ export interface IpcInvokeMap {
     result: DevPreviewSessionState;
   };
 
+  // Auto-update channels
+  "update:quit-and-install": {
+    args: [];
+    result: void;
+  };
+
   // Agent Capabilities channels
   "agent-capabilities:get-registry": {
     args: [];
@@ -1056,6 +1062,12 @@ export interface IpcEventMap {
 
   // Notification events
   "notification:update": { waitingCount: number; failedCount: number };
+
+  // Auto-update events
+  "update:available": { version: string };
+  "update:download-progress": { percent: number };
+  "update:downloaded": { version: string };
+  "update:error": { message: string };
 
   // Dev Preview events
   "dev-preview:state-changed": DevPreviewStateChangedPayload;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import {
   useAssistantStreamProcessor,
 } from "./hooks";
 import { useActionRegistry } from "./hooks/useActionRegistry";
+import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useActionPalette } from "./hooks/useActionPalette";
 import { useWorktreePalette } from "./hooks/useWorktreePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
@@ -59,6 +60,7 @@ import { NotesPalette } from "./components/Notes";
 import { SettingsDialog, type SettingsTab } from "./components/Settings";
 import { ShortcutReferenceDialog } from "./components/KeyboardShortcuts";
 import { Toaster } from "./components/ui/toaster";
+import { UpdateNotification } from "./components/UpdateNotification";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { DndProvider } from "./components/DragDrop";
 import {
@@ -482,6 +484,7 @@ function App() {
   const loadRecipes = useRecipeStore((state) => state.loadRecipes);
   useTerminalConfig();
   useWindowNotifications();
+  useUpdateListener();
   useAppAgentDispatcher(); // Enable Assistant tool calling via action dispatch
   useAssistantStreamProcessor(); // Process Assistant chunks even when pane is closed
 
@@ -924,6 +927,7 @@ function App() {
       <PanelTransitionOverlay />
 
       <Toaster />
+      <UpdateNotification />
     </ErrorBoundary>
   );
 }

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useState, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Download, RefreshCw, X, AlertCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useUpdateStore } from "@/store/updateStore";
+
+export function UpdateNotification() {
+  const { status, version, progress, dismissed, dismiss } = useUpdateStore();
+  const [isVisible, setIsVisible] = useState(false);
+  const dismissTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const shouldShow =
+    !dismissed && (status === "available" || status === "downloading" || status === "downloaded" || status === "error");
+
+  useEffect(() => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+
+    if (shouldShow) {
+      const rafId = requestAnimationFrame(() => setIsVisible(true));
+      return () => cancelAnimationFrame(rafId);
+    } else {
+      setIsVisible(false);
+      return undefined;
+    }
+  }, [shouldShow]);
+
+  const handleDismiss = useCallback(() => {
+    setIsVisible(false);
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+    }
+    dismissTimerRef.current = setTimeout(() => {
+      dismiss();
+      dismissTimerRef.current = null;
+    }, 300);
+  }, [dismiss]);
+
+  const handleRestart = useCallback(() => {
+    window.electron?.update?.quitAndInstall();
+  }, []);
+
+  if (!shouldShow) return null;
+
+  return createPortal(
+    <div
+      className={cn(
+        "fixed bottom-20 z-[var(--z-toast)] pointer-events-none p-4",
+        "flex justify-end w-full max-w-[420px]"
+      )}
+      style={{ right: "calc(var(--sidecar-right-offset, 0px))" }}
+    >
+      <div
+        className={cn(
+          "pointer-events-auto relative flex w-full items-start gap-2.5",
+          "rounded-[var(--radius-sm)] border",
+          "px-3 py-2.5 pr-10",
+          "text-sm text-canopy-text",
+          "shadow-[0_4px_12px_rgba(0,0,0,0.2)]",
+          "transition-[transform,opacity] duration-300 ease-out",
+          isVisible ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0",
+          "bg-[color-mix(in_oklab,var(--color-canopy-accent)_12%,transparent)]",
+          "border-[color:color-mix(in_oklab,var(--color-canopy-accent)_25%,transparent)]",
+          "backdrop-blur-sm"
+        )}
+      >
+        <div className={cn("mt-0.5 shrink-0", status === "error" ? "text-[var(--color-status-error)]" : "text-canopy-accent")}>
+          {status === "downloaded" ? (
+            <RefreshCw className="h-4 w-4" />
+          ) : status === "error" ? (
+            <AlertCircle className="h-4 w-4" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+        </div>
+
+        <div className="flex-1 space-y-1.5 min-w-0">
+          {status === "available" && (
+            <>
+              <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-canopy-accent">
+                Update Available
+              </h4>
+              <div className="text-xs text-canopy-text/90 leading-snug">
+                Version {version} is downloading...
+              </div>
+            </>
+          )}
+
+          {status === "downloading" && (
+            <>
+              <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-canopy-accent">
+                Downloading Update
+              </h4>
+              <div className="text-xs text-canopy-text/90 leading-snug">
+                {Math.round(progress)}% complete
+              </div>
+              <div className="h-1 w-full rounded-full bg-white/10 overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-canopy-accent transition-[width] duration-300 ease-out"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </>
+          )}
+
+          {status === "downloaded" && (
+            <>
+              <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-canopy-accent">
+                Update Ready
+              </h4>
+              <div className="text-xs text-canopy-text/90 leading-snug">
+                Version {version} is ready to install.
+              </div>
+              <button
+                type="button"
+                onClick={handleRestart}
+                className={cn(
+                  "mt-1 px-2.5 py-1 rounded-[var(--radius-xs)]",
+                  "text-xs font-medium",
+                  "bg-canopy-accent/15 text-canopy-accent",
+                  "hover:bg-canopy-accent/25 transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
+                )}
+              >
+                Restart to Update
+              </button>
+            </>
+          )}
+
+          {status === "error" && (
+            <>
+              <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-[var(--color-status-error)]">
+                Update Failed
+              </h4>
+              <div className="text-xs text-canopy-text/90 leading-snug">
+                Unable to check for updates. Please try again later.
+              </div>
+            </>
+          )}
+        </div>
+
+        {status !== "downloading" && (
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss notification"
+            className={cn(
+              "absolute right-1.5 top-1.5 rounded-[var(--radius-xs)]",
+              "h-6 w-6 flex items-center justify-center",
+              "text-canopy-text/60 transition-colors",
+              "hover:text-canopy-text/90 hover:bg-white/10",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
+            )}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -71,6 +71,8 @@ export type { ActionPaletteItem, UseActionPaletteReturn } from "./useActionPalet
 
 export { useDoubleShift } from "./useDoubleShift";
 
+export { useUpdateListener } from "./useUpdateListener";
+
 export { useAnimatedPresence } from "./useAnimatedPresence";
 export type { UseAnimatedPresenceOptions, UseAnimatedPresenceReturn } from "./useAnimatedPresence";
 

--- a/src/hooks/useUpdateListener.ts
+++ b/src/hooks/useUpdateListener.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useUpdateStore } from "@/store/updateStore";
+
+export function useUpdateListener(): void {
+  const setAvailable = useUpdateStore((state) => state.setAvailable);
+  const setDownloading = useUpdateStore((state) => state.setDownloading);
+  const setDownloaded = useUpdateStore((state) => state.setDownloaded);
+  const setError = useUpdateStore((state) => state.setError);
+
+  useEffect(() => {
+    if (!window.electron?.update) return;
+
+    const cleanupAvailable = window.electron.update.onUpdateAvailable((info) => {
+      setAvailable(info.version);
+    });
+
+    const cleanupProgress = window.electron.update.onDownloadProgress((info) => {
+      setDownloading(info.percent);
+    });
+
+    const cleanupDownloaded = window.electron.update.onUpdateDownloaded((info) => {
+      setDownloaded(info.version);
+    });
+
+    const cleanupError = window.electron.update.onUpdateError((info) => {
+      setError(info.message);
+    });
+
+    return () => {
+      cleanupAvailable();
+      cleanupProgress();
+      cleanupDownloaded();
+      cleanupError();
+    };
+  }, [setAvailable, setDownloading, setDownloaded, setError]);
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -33,6 +33,9 @@ export type { PanelState } from "./focusStore";
 export { useNotificationStore } from "./notificationStore";
 export type { Notification, NotificationType } from "./notificationStore";
 
+export { useUpdateStore } from "./updateStore";
+export type { UpdateStatus } from "./updateStore";
+
 export { useDiagnosticsStore } from "./diagnosticsStore";
 export type { DiagnosticsTab } from "./diagnosticsStore";
 export {

--- a/src/store/updateStore.ts
+++ b/src/store/updateStore.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+export type UpdateStatus = "idle" | "available" | "downloading" | "downloaded" | "error";
+
+interface UpdateStore {
+  status: UpdateStatus;
+  version: string | null;
+  progress: number;
+  error: string | null;
+  dismissed: boolean;
+  setAvailable: (version: string) => void;
+  setDownloading: (percent: number) => void;
+  setDownloaded: (version: string) => void;
+  setError: (message: string) => void;
+  dismiss: () => void;
+  reset: () => void;
+}
+
+export const useUpdateStore = create<UpdateStore>((set) => ({
+  status: "idle",
+  version: null,
+  progress: 0,
+  error: null,
+  dismissed: false,
+  setAvailable: (version) => set({ status: "available", version, progress: 0, error: null, dismissed: false }),
+  setDownloading: (percent) => set({ status: "downloading", progress: Math.min(Math.max(percent, 0), 100) }),
+  setDownloaded: (version) =>
+    set({ status: "downloaded", version, progress: 100, error: null, dismissed: false }),
+  setError: (message) => set({ status: "error", error: message, progress: 0 }),
+  dismiss: () => set({ dismissed: true }),
+  reset: () => set({ status: "idle", version: null, progress: 0, error: null, dismissed: false }),
+}));


### PR DESCRIPTION
## Summary
Implements user-facing notification system for electron-updater with toast-style UI that displays update status, download progress, and restart prompt.

Closes #2230

## Changes Made

**Backend:**
- Added IPC channels and types for update events (available, progress, downloaded, error)
- Forward autoUpdater events from main process to renderer via IPC
- Added quit-and-install handler with download state gating
- Required window reference for AutoUpdaterService initialization
- Track update downloaded state to prevent premature quit-and-install

**Frontend:**
- Created Zustand store for update state management with normalized transitions
- Added useUpdateListener hook with selective store subscriptions to prevent app rerenders
- Built UpdateNotification component with progress bar and restart CTA
- Display error state with appropriate UI feedback
- Added dismiss functionality with timer cleanup and race condition prevention
- Clamped progress values to 0-100 range

**Code Review Fixes:**
- Fixed app-wide rerender issue by selecting only actions from store
- Added cleanup for animation frames and dismiss timers
- Normalized state transitions to clear stale fields
- Added error UI that was missing from initial implementation
- Bounded progress values to prevent rendering issues