### PR TITLE
Close toolbar dropdowns when modals or dialogs open

### DIFF
--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -2,6 +2,7 @@ import React, { useState, useLayoutEffect, useEffect, useCallback, useRef } from
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
+import { useUIStore } from "@/store/uiStore";
 
 interface FixedDropdownProps {
   open: boolean;
@@ -24,6 +25,8 @@ export function FixedDropdown({
   const [position, setPosition] = useState<{ top: number; right: string } | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const { isVisible, shouldRender } = useAnimatedPresence({ isOpen: open });
+  const overlayCount = useUIStore((state) => state.overlayCount);
+  const prevOverlayCountRef = useRef<number>(overlayCount);
 
   useEffect(() => setMounted(true), []);
 
@@ -69,6 +72,13 @@ export function FixedDropdown({
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [open, onOpenChange, anchorRef]);
+
+  useEffect(() => {
+    if (open && overlayCount > prevOverlayCountRef.current && overlayCount > 0) {
+      onOpenChange(false);
+    }
+    prevOverlayCountRef.current = overlayCount;
+  }, [open, overlayCount, onOpenChange]);
 
   if (!shouldRender || !mounted || !position) return null;
 


### PR DESCRIPTION
## Summary
Toolbar dropdowns (issues, PRs, commits) and the project switcher now automatically close when modals or dialogs open, preventing visual clutter and improving UX consistency.

Closes #2247

## Changes Made
- Subscribe to overlay count in FixedDropdown and ProjectSwitcherPalette
- Close dropdowns on overlay count increase (edge-triggered detection)
- Initialize prevOverlayCountRef from current overlayCount to prevent false closes on mount
- Add requestAnimationFrame cleanup in ProjectSwitcherPalette to prevent focus race conditions

## Implementation Details
- Uses Zustand `useUIStore` overlay count subscription
- Edge-triggered close (only on overlay increase, not decrease)
- Maintains existing close behavior (click outside, Escape key)
- Proper React lifecycle cleanup for RAF and refs