### PR TITLE
fix(worktree): protect main worktree from deletion during cleanup

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -82,7 +82,12 @@ export interface Worktree {
   /** Whether this is the currently active worktree based on cwd */
   isCurrent: boolean;
 
-  /** Whether this is the main worktree (not a linked worktree) */
+  /**
+   * Whether this is the main worktree (project permanent worktree).
+   * Determined by canonical path match with project root, not git primary status.
+   * Main worktrees are protected from deletion and cleanup operations.
+   * False when project root path is unavailable (no protection applied).
+   */
   isMainWorktree?: boolean;
 
   /** Path to the .git directory */

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -60,6 +60,12 @@ export interface WorktreeSnapshot {
   name: string;
   branch?: string;
   isCurrent: boolean;
+  /**
+   * Whether this is the main worktree (project permanent worktree).
+   * Determined by canonical path match with project root, not git primary status.
+   * Main worktrees are protected from deletion and cleanup operations.
+   * False when project root path is unavailable (no protection applied).
+   */
   isMainWorktree?: boolean;
   gitDir?: string;
   summary?: string;


### PR DESCRIPTION
## Summary
Fixes issue where main worktree terminals were being closed during PR review workflows by implementing robust path-based main worktree identification instead of relying on git-order heuristics.

Closes #2249

## Changes Made
- Use canonical path matching instead of git-order for main worktree identification
- Add path canonicalization helper with symlink resolution and Windows case-insensitivity
- Fix cleanup handler to use correct API (getAllStatesAsync) and optimize performance
- Update monitor sync to maintain isMainWorktree flag consistency
- Clarify type definitions for main worktree protection semantics
- Remove fallback to git-order logic when project root path is unavailable

## Technical Details
The issue occurred because `isMainWorktree` was determined by `worktrees.length === 0` (first in git's output), which is unreliable. The fix:
1. Compares normalized canonical paths with project root to determine main worktree
2. Handles symlinks via `realpathSync`
3. Applies case-insensitive comparison on Windows
4. Updates existing monitor flags during sync to prevent stale state
5. Optimizes cleanup handler by fetching states once outside loop

## Testing
- Path canonicalization logic tested with symlinks and case variations
- TypeScript compilation passes
- Existing safeguards at multiple layers now correctly protected