### PR TITLE
Add tab button in two-pane split mode

### DIFF
--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -816,6 +816,8 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
               focusedId={focusedId}
               activeWorktreeId={activeWorktreeId}
               isInTrash={isInTrash}
+              onAddTabLeft={() => handleAddTabForPanel(twoPaneTerminals[0])}
+              onAddTabRight={() => handleAddTabForPanel(twoPaneTerminals[1])}
             />
             <GridFullOverlay maxTerminals={maxGridCapacity} show={showGridFullOverlay} />
           </div>

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -15,6 +15,8 @@ interface TwoPaneSplitLayoutProps {
   focusedId: string | null;
   activeWorktreeId: string | null;
   isInTrash: (id: string) => boolean;
+  onAddTabLeft?: () => void;
+  onAddTabRight?: () => void;
 }
 
 export function TwoPaneSplitLayout({
@@ -22,6 +24,8 @@ export function TwoPaneSplitLayout({
   focusedId,
   activeWorktreeId,
   isInTrash,
+  onAddTabLeft,
+  onAddTabRight,
 }: TwoPaneSplitLayoutProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState<number>(0);
@@ -220,6 +224,7 @@ export function TwoPaneSplitLayout({
                 isFocused={terminals[0].id === focusedId}
                 gridPanelCount={2}
                 gridCols={2}
+                onAddTab={onAddTabLeft}
               />
             </SortableTerminal>
             {/* Overlay to hide terminal content during resize drag */}
@@ -259,6 +264,7 @@ export function TwoPaneSplitLayout({
                 isFocused={terminals[1].id === focusedId}
                 gridPanelCount={2}
                 gridCols={2}
+                onAddTab={onAddTabRight}
               />
             </SortableTerminal>
             {/* Overlay to hide terminal content during resize drag */}


### PR DESCRIPTION
## Summary

This PR adds the missing "add tab" button functionality to both panels when in two-pane split mode, allowing users to create additional tabs without needing to use keyboard shortcuts or spawn a third panel.

Closes #2279

## Changes Made

- Add onAddTabLeft and onAddTabRight props to TwoPaneSplitLayout component
- Pass handleAddTabForPanel callbacks from ContentGrid to both left and right panels
- Enable tab creation UI for both panels in split mode, maintaining consistency with regular grid mode