### PR TITLE
Fix docked terminal popup alignment when sidebar is hidden

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -20,6 +20,7 @@ import {
   useTerminalInputStore,
   useTerminalStore,
   useSidecarStore,
+  useFocusStore,
   type TerminalInstance,
 } from "@/store";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
@@ -95,15 +96,17 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     useShallow((s) => ({ isOpen: s.isOpen, width: s.width }))
   );
 
+  const isFocusMode = useFocusStore((s) => s.isFocusMode);
+
   const collisionPadding = useMemo(() => {
     const basePadding = 32;
     return {
       top: basePadding,
-      left: basePadding,
+      left: isFocusMode ? 8 : basePadding,
       bottom: basePadding,
       right: sidecarOpen ? sidecarWidth + basePadding : basePadding,
     };
-  }, [sidecarOpen, sidecarWidth]);
+  }, [isFocusMode, sidecarOpen, sidecarWidth]);
 
   // Toggle buffering based on popover open state
   useEffect(() => {

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -8,6 +8,7 @@ import {
   useTerminalInputStore,
   useTerminalStore,
   useSidecarStore,
+  useFocusStore,
   type TerminalInstance,
 } from "@/store";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
@@ -55,15 +56,17 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     useShallow((s) => ({ isOpen: s.isOpen, width: s.width }))
   );
 
+  const isFocusMode = useFocusStore((s) => s.isFocusMode);
+
   const collisionPadding = useMemo(() => {
     const basePadding = 32;
     return {
       top: basePadding,
-      left: basePadding,
+      left: isFocusMode ? 8 : basePadding,
       bottom: basePadding,
       right: sidecarOpen ? sidecarWidth + basePadding : basePadding,
     };
-  }, [sidecarOpen, sidecarWidth]);
+  }, [isFocusMode, sidecarOpen, sidecarWidth]);
 
   // Toggle buffering based on popover open state
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes the docked terminal popup misalignment that occurs when the left sidebar is hidden (focus mode). The popup was shifting ~30-40px to the right of the dock button instead of aligning with it.

Closes #2285

## Changes Made

- Reduce left collision padding to 8px in focus mode (sidebar hidden)
- Apply fix to both single terminals and grouped terminals
- Add isFocusMode dependency to collision padding calculation

## Technical Details

The root cause was a hardcoded `left: 32px` collision padding in Radix UI's PopoverContent. When the sidebar is hidden, the dock button sits near the left viewport edge (~10-20px), and Radix's collision avoidance would shift the popup right to satisfy the 32px padding constraint.

The fix makes the collision padding focus-mode-aware:
- Focus mode ON (sidebar hidden): `left: 8px` (allows popup near left edge)
- Focus mode OFF (sidebar visible): `left: 32px` (original behavior)

This fix was applied to both `DockedTerminalItem` and `DockedTabGroup` to ensure consistency across all docked terminal variants.