### PR TITLE
Harden Electron runtime security defaults

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -145,7 +145,7 @@ export function createApplicationMenu(
             win.webContents.reloadIgnoringCache();
           },
         },
-        { role: "toggleDevTools" },
+        ...(app.isPackaged ? [] : [{ role: "toggleDevTools" as const }]),
         { type: "separator" },
         { role: "resetZoom" },
         { role: "zoomIn" },

--- a/electron/services/SidecarManager.ts
+++ b/electron/services/SidecarManager.ts
@@ -34,6 +34,8 @@ export class SidecarManager {
           contextIsolation: true,
           sandbox: true,
           partition: "persist:sidecar",
+          navigateOnDragDrop: false,
+          disableBlinkFeatures: "Auxclick",
         },
       });
 


### PR DESCRIPTION
## Summary

Implements comprehensive defense-in-depth security hardening for the Electron main process, closing gaps in the runtime security model.

Closes #2304

## Changes Made

### 1. Global Sandbox Enablement
- Called `app.enableSandbox()` globally to ensure all future windows are sandboxed by default
- Prevents security regressions from any new window creation paths

### 2. Permission Lockdown
- Implemented session-based permission controls for all sessions:
  - **Trusted app renderer**: Allowlist clipboard-sanitized-write only
  - **Untrusted sessions** (browser, dev-preview-*, sidecar): Deny all permissions
- Added `session-created` event handler to catch dynamically created dev-preview partitions
- Prevents OS permission prompts from untrusted web content

### 3. DevTools Access Restriction
- Gated DevTools menu item to development builds only (`app.isPackaged` check)
- DevTools IPC handler now no-op in production to prevent errors
- Prevents DevTools access in production builds

### 4. WebPreferences Hardening
- Added `navigateOnDragDrop: false` to prevent file:// navigation via drag-drop
- Added `disableBlinkFeatures: "Auxclick"` to prevent middle-click navigation bypass
- Applied to:
  - Main window (excluding Auxclick to preserve Sidecar launchpad UX)
  - SidecarManager WebContentsViews
  - Webview guests via `will-attach-webview` handler

## Security Review

All changes were reviewed using Codex code review, which identified and helped fix:
- Dynamic session coverage gap (persist:dev-preview-* patterns)
- Clipboard regression in trusted renderer
- Middle-click functionality preservation for Sidecar launchpad
- Webview hardening completeness