### PR TITLE
Enable Electron Fuses and enforce code signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,21 +53,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libarchive-tools
 
-      # macOS code signing (configure secrets when certificates are available)
-      # - name: Import macOS Certificates
-      #   if: startsWith(matrix.os, 'macos')
-      #   uses: apple-actions/import-codesign-certs@v3
-      #   with:
-      #     p12-file-base64: ${{ secrets.MAC_CERTS }}
-      #     p12-password: ${{ secrets.MAC_CERTS_PASSWORD }}
+      - name: Import macOS Certificates
+        if: startsWith(matrix.os, 'macos')
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MAC_CERTS }}
+          p12-password: ${{ secrets.MAC_CERTS_PASSWORD }}
 
       - name: Build
         env:
-          # macOS notarization (configure when Apple Developer account is set up)
-          # APPLE_ID: ${{ secrets.APPLE_ID }}
-          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.MAC_CERTS }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
+          WIN_CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
+          WIN_CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
         run: npm run build && npx electron-builder --publish never
 
       - name: Validate Update Metadata (Windows)

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@electron/fuses": "^2.0.0",
         "@electron/rebuild": "^3.7.1",
         "@eslint/js": "^9.39.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -1296,6 +1297,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@electron/fuses": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-2.0.0.tgz",
+      "integrity": "sha512-lyb1zK3YHeWUjaz7yiK0GnxSPduwASKMyiDbCtbn3spP6EEt+UWtktggWehG0icFrXAk3GwvcJ4nCrJO0N9IhQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "electron-fuses": "dist/bin.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/get": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "node-gyp": "^10.3.1"
   },
   "devDependencies": {
+    "@electron/fuses": "^2.0.0",
     "@electron/rebuild": "^3.7.1",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/typography": "^0.5.19",
@@ -145,6 +146,7 @@
     "wait-on": "^8.0.1"
   },
   "build": {
+    "asar": true,
     "appId": "com.canopy.commandcenter",
     "publish": [
       {
@@ -152,7 +154,6 @@
         "url": "https://updates.canopy.dev/releases/"
       }
     ],
-    "forceCodeSigning": false,
     "electronUpdaterCompatibility": ">=2.16",
     "productName": "Canopy",
     "npmRebuild": false,
@@ -179,6 +180,7 @@
     ],
     "afterPack": "./scripts/afterPack.cjs",
     "mac": {
+      "forceCodeSigning": true,
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",
       "extendInfo": {
@@ -218,6 +220,7 @@
       ]
     },
     "win": {
+      "forceCodeSigning": true,
       "icon": "build/icon.ico",
       "target": [
         {

--- a/scripts/afterPack.test.ts
+++ b/scripts/afterPack.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import path from "path";
+import Module from "module";
+
+const mockFlipFuses = vi.fn();
+const mockExistsSync = vi.fn();
+
+const originalRequire = Module.prototype.require;
+
+describe("afterPack", () => {
+  let afterPack: (context: any) => Promise<void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlipFuses.mockResolvedValue(undefined);
+
+    Module.prototype.require = function (id: string) {
+      if (id === "@electron/fuses") {
+        return {
+          flipFuses: mockFlipFuses,
+          FuseVersion: { V1: "V1" },
+          FuseV1Options: {
+            RunAsNode: "RunAsNode",
+            EnableCookieEncryption: "EnableCookieEncryption",
+            EnableNodeOptionsEnvironmentVariable: "EnableNodeOptionsEnvironmentVariable",
+            EnableNodeCliInspectArguments: "EnableNodeCliInspectArguments",
+            EnableEmbeddedAsarIntegrityValidation: "EnableEmbeddedAsarIntegrityValidation",
+            OnlyLoadAppFromAsar: "OnlyLoadAppFromAsar",
+            LoadBrowserProcessSpecificV8Snapshot: "LoadBrowserProcessSpecificV8Snapshot",
+            GrantFileProtocolExtraPrivileges: "GrantFileProtocolExtraPrivileges",
+          },
+        };
+      }
+      if (id === "fs") {
+        return {
+          existsSync: mockExistsSync,
+        };
+      }
+      return originalRequire.apply(this, [id]);
+    };
+
+    delete require.cache[require.resolve("./afterPack.cjs")];
+    const module = require("./afterPack.cjs");
+    afterPack = module.default;
+
+    Module.prototype.require = originalRequire;
+  });
+
+  describe("macOS", () => {
+    it("should validate node-pty and flip fuses successfully", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      const context = {
+        appOutDir: "/build/mac",
+        electronPlatformName: "darwin",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await afterPack(context);
+
+      const expectedNodePtyPath = path.join(
+        "/build/mac/Canopy.app/Contents/Resources/app.asar.unpacked",
+        "node_modules/node-pty"
+      );
+      expect(mockExistsSync).toHaveBeenCalledWith(expectedNodePtyPath);
+
+      const expectedBinaryPath = path.join(
+        "/build/mac/Canopy.app/Contents/Resources/app.asar.unpacked",
+        "node_modules/node-pty/build/Release/pty.node"
+      );
+      expect(mockExistsSync).toHaveBeenCalledWith(expectedBinaryPath);
+
+      const expectedElectronPath = "/build/mac/Canopy.app/Contents/MacOS/Canopy";
+      expect(mockFlipFuses).toHaveBeenCalledWith(expectedElectronPath, {
+        version: "V1",
+        strictlyRequireAllFuses: true,
+        resetAdHocDarwinSignature: true,
+        RunAsNode: false,
+        EnableCookieEncryption: true,
+        EnableNodeOptionsEnvironmentVariable: false,
+        EnableNodeCliInspectArguments: false,
+        EnableEmbeddedAsarIntegrityValidation: true,
+        OnlyLoadAppFromAsar: true,
+        LoadBrowserProcessSpecificV8Snapshot: true,
+        GrantFileProtocolExtraPrivileges: false,
+      });
+    });
+
+    it("should throw error when node-pty is missing", async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      const context = {
+        appOutDir: "/build/mac",
+        electronPlatformName: "darwin",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await expect(afterPack(context)).rejects.toThrow(/node-pty not found/);
+      expect(mockFlipFuses).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when node-pty native binary is missing", async () => {
+      mockExistsSync.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+      const context = {
+        appOutDir: "/build/mac",
+        electronPlatformName: "darwin",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await expect(afterPack(context)).rejects.toThrow(/native binary not found/);
+      expect(mockFlipFuses).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Windows", () => {
+    it("should validate node-pty and flip fuses successfully", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      const context = {
+        appOutDir: "/build/win",
+        electronPlatformName: "win32",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await afterPack(context);
+
+      const expectedElectronPath = "/build/win/Canopy.exe";
+      expect(mockFlipFuses).toHaveBeenCalledWith(
+        expectedElectronPath,
+        expect.objectContaining({
+          version: "V1",
+          strictlyRequireAllFuses: true,
+          resetAdHocDarwinSignature: false,
+        })
+      );
+    });
+  });
+
+  describe("Linux", () => {
+    it("should validate node-pty and flip fuses successfully", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      const context = {
+        appOutDir: "/build/linux",
+        electronPlatformName: "linux",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await afterPack(context);
+
+      const expectedElectronPath = "/build/linux/canopy-app";
+      expect(mockFlipFuses).toHaveBeenCalledWith(
+        expectedElectronPath,
+        expect.objectContaining({
+          version: "V1",
+          strictlyRequireAllFuses: true,
+          resetAdHocDarwinSignature: false,
+        })
+      );
+    });
+  });
+
+  describe("Fuse configuration", () => {
+    it("should configure all security fuses correctly", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      const context = {
+        appOutDir: "/build/mac",
+        electronPlatformName: "darwin",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await afterPack(context);
+
+      const fuseConfig = mockFlipFuses.mock.calls[0][1];
+
+      expect(fuseConfig.RunAsNode).toBe(false);
+      expect(fuseConfig.EnableCookieEncryption).toBe(true);
+      expect(fuseConfig.EnableNodeOptionsEnvironmentVariable).toBe(false);
+      expect(fuseConfig.EnableNodeCliInspectArguments).toBe(false);
+      expect(fuseConfig.EnableEmbeddedAsarIntegrityValidation).toBe(true);
+      expect(fuseConfig.OnlyLoadAppFromAsar).toBe(true);
+      expect(fuseConfig.LoadBrowserProcessSpecificV8Snapshot).toBe(true);
+      expect(fuseConfig.GrantFileProtocolExtraPrivileges).toBe(false);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should throw error for unsupported platforms", async () => {
+      mockExistsSync.mockReturnValue(true);
+
+      const context = {
+        appOutDir: "/build/freebsd",
+        electronPlatformName: "freebsd",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await expect(afterPack(context)).rejects.toThrow(/Unsupported platform: freebsd/);
+      expect(mockFlipFuses).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when Electron binary is missing", async () => {
+      mockExistsSync
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      const context = {
+        appOutDir: "/build/mac",
+        electronPlatformName: "darwin",
+        packager: {
+          appInfo: {
+            productFilename: "Canopy",
+          },
+          executableName: "canopy-app",
+        },
+      };
+
+      await expect(afterPack(context)).rejects.toThrow(/Electron binary not found/);
+      expect(mockFlipFuses).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements foundational security measures for Electron app hardening by configuring Electron fuses and enforcing code signing for all macOS and Windows builds.

Closes #2303

## Changes Made
- Add @electron/fuses dependency for security hardening
- Configure all V1 fuses in afterPack.cjs with production-ready settings
- Enforce code signing for macOS and Windows builds (platform-specific)
- Enable macOS certificate import and notarization in release workflow
- Add Windows code signing credentials to CI/CD pipeline
- Implement comprehensive afterPack tests with platform-specific coverage
- Fix Linux binary path resolution to use executableName
- Add explicit asar configuration and platform validation
- Validate Electron binary existence before fuse flipping