### PR TITLE
Strengthen Content Security Policy across all sessions

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7,6 +7,7 @@ import {
   MessageChannelMain,
   protocol,
   net,
+  session,
 } from "electron";
 import path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -102,6 +103,12 @@ import { createWindowWithState } from "./windowState.js";
 import { setLoggerWindow, initializeLogger } from "./utils/logger.js";
 import { initializeAssistantLogger } from "./utils/assistantLogger.js";
 import { openExternalUrl } from "./utils/openExternal.js";
+import {
+  classifyPartition,
+  getLocalhostDevCSP,
+  mergeCspHeaders,
+  isDevPreviewPartition,
+} from "./utils/webviewCsp.js";
 import { EventBuffer } from "./services/EventBuffer.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { createApplicationMenu } from "./menu.js";
@@ -184,9 +191,15 @@ if (!gotTheLock) {
     }
   });
 
-  app.whenReady().then(() => {
-    registerAppProtocol();
-    createWindow();
+  app.whenReady().then(async () => {
+    try {
+      registerAppProtocol();
+      setupWebviewCSP();
+      await createWindow();
+    } catch (error) {
+      console.error("[MAIN] Startup failed:", error);
+      app.exit(1);
+    }
   });
 
   app.on("window-all-closed", () => {
@@ -259,6 +272,54 @@ if (!gotTheLock) {
         console.error("[MAIN] Error during cleanup:", error);
         app.exit(1);
       });
+  });
+}
+
+/**
+ * Configures CSP headers for webview partitions.
+ * Applies idempotent CSP injection to prevent multiple registrations.
+ * Sidecar is excluded to preserve origin CSP from external sites.
+ */
+function setupWebviewCSP(): void {
+  const configuredPartitions = new Set<string>();
+
+  const applyCSP = (partition: string): void => {
+    if (configuredPartitions.has(partition)) {
+      return;
+    }
+
+    const partitionType = classifyPartition(partition);
+    if (partitionType === "unknown" || partitionType === "sidecar") {
+      // Skip unknown partitions and sidecar (external sites keep their own CSP)
+      return;
+    }
+
+    const ses = session.fromPartition(partition);
+    const cspPolicy = getLocalhostDevCSP();
+
+    ses.webRequest.onHeadersReceived((details, callback) => {
+      callback({
+        responseHeaders: mergeCspHeaders(details, cspPolicy),
+      });
+    });
+
+    configuredPartitions.add(partition);
+    console.log(`[MAIN] CSP configured for partition: ${partition} (${partitionType})`);
+  };
+
+  // Configure static partitions (browser only - sidecar excluded)
+  applyCSP("persist:browser");
+
+  // Monitor for dynamic dev-preview partitions
+  // Dev preview uses dynamic partitions like "persist:dev-preview-project-worktree-panel"
+  // We intercept will-attach-webview to detect and configure them
+  app.on("web-contents-created", (_event, contents) => {
+    contents.on("will-attach-webview", (_event, _webPreferences, params) => {
+      const partition = params.partition;
+      if (partition && isDevPreviewPartition(partition)) {
+        applyCSP(partition);
+      }
+    });
   });
 }
 

--- a/electron/utils/__tests__/webviewCsp.test.ts
+++ b/electron/utils/__tests__/webviewCsp.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyPartition,
+  getLocalhostDevCSP,
+  mergeCspHeaders,
+  isDevPreviewPartition,
+} from "../webviewCsp.js";
+import type { OnHeadersReceivedListenerDetails } from "electron";
+
+describe("webviewCsp", () => {
+  describe("isDevPreviewPartition", () => {
+    it("identifies exact dev-preview partition", () => {
+      expect(isDevPreviewPartition("persist:dev-preview")).toBe(true);
+    });
+
+    it("identifies dynamic dev-preview partitions", () => {
+      expect(isDevPreviewPartition("persist:dev-preview-myproject-main-panel1")).toBe(true);
+      expect(isDevPreviewPartition("persist:dev-preview-foo-bar-baz")).toBe(true);
+    });
+
+    it("rejects malformed dev-preview partitions", () => {
+      expect(isDevPreviewPartition("persist:dev-previewevil")).toBe(false);
+      expect(isDevPreviewPartition("persist:dev-preview")).toBe(true);
+      expect(isDevPreviewPartition("persist:dev-preview-")).toBe(true);
+    });
+
+    it("returns false for other partitions", () => {
+      expect(isDevPreviewPartition("persist:browser")).toBe(false);
+      expect(isDevPreviewPartition("persist:sidecar")).toBe(false);
+      expect(isDevPreviewPartition("persist:unknown")).toBe(false);
+    });
+  });
+
+  describe("classifyPartition", () => {
+    it("identifies browser partition", () => {
+      expect(classifyPartition("persist:browser")).toBe("browser");
+    });
+
+    it("identifies sidecar partition", () => {
+      expect(classifyPartition("persist:sidecar")).toBe("sidecar");
+    });
+
+    it("identifies dev-preview partition", () => {
+      expect(classifyPartition("persist:dev-preview")).toBe("dev-preview");
+    });
+
+    it("identifies dynamic dev-preview partitions", () => {
+      expect(classifyPartition("persist:dev-preview-myproject-main-panel1")).toBe("dev-preview");
+      expect(classifyPartition("persist:dev-preview-foo-bar-baz")).toBe("dev-preview");
+    });
+
+    it("rejects malformed dev-preview partitions as unknown", () => {
+      expect(classifyPartition("persist:dev-previewevil")).toBe("unknown");
+    });
+
+    it("returns unknown for unrecognized partitions", () => {
+      expect(classifyPartition("persist:unknown")).toBe("unknown");
+      expect(classifyPartition("some-random-partition")).toBe("unknown");
+      expect(classifyPartition("")).toBe("unknown");
+    });
+  });
+
+  describe("getLocalhostDevCSP", () => {
+    it("returns a localhost-restricted CSP policy", () => {
+      const csp = getLocalhostDevCSP();
+
+      expect(csp).toContain("default-src 'self' http://localhost:* http://127.0.0.1:*");
+      expect(csp).toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval'");
+      expect(csp).toContain("connect-src 'self' ws://localhost:* ws://127.0.0.1:*");
+      expect(csp).toContain("object-src 'none'");
+      expect(csp).toContain("base-uri 'self'");
+    });
+
+    it("includes secure localhost support (https and wss)", () => {
+      const csp = getLocalhostDevCSP();
+
+      expect(csp).toContain("https://localhost:*");
+      expect(csp).toContain("https://127.0.0.1:*");
+      expect(csp).toContain("wss://localhost:*");
+      expect(csp).toContain("wss://127.0.0.1:*");
+    });
+
+    it("does not allow non-localhost external origins", () => {
+      const csp = getLocalhostDevCSP();
+
+      // Should have https://localhost but not https: wildcard
+      expect(csp).toContain("https://localhost:*");
+      expect(csp).not.toMatch(/https:\s/); // No bare "https:" wildcard
+      expect(csp).not.toContain("http://example.com");
+    });
+  });
+
+  describe("mergeCspHeaders", () => {
+    it("adds CSP header when none exists", () => {
+      const details = {
+        responseHeaders: {
+          "content-type": ["text/html"],
+        },
+      } as Partial<OnHeadersReceivedListenerDetails> as OnHeadersReceivedListenerDetails;
+
+      const result = mergeCspHeaders(details, "default-src 'self'");
+
+      expect(result["Content-Security-Policy"]).toEqual(["default-src 'self'"]);
+      expect(result["content-type"]).toEqual(["text/html"]);
+    });
+
+    it("replaces existing CSP header (case-sensitive)", () => {
+      const details = {
+        responseHeaders: {
+          "Content-Security-Policy": ["default-src 'none'"],
+          "content-type": ["text/html"],
+        },
+      } as Partial<OnHeadersReceivedListenerDetails> as OnHeadersReceivedListenerDetails;
+
+      const result = mergeCspHeaders(details, "default-src 'self'");
+
+      expect(result["Content-Security-Policy"]).toEqual(["default-src 'self'"]);
+      expect(result["content-type"]).toEqual(["text/html"]);
+    });
+
+    it("replaces existing CSP header (case-insensitive)", () => {
+      const details = {
+        responseHeaders: {
+          "content-security-policy": ["default-src 'none'"],
+          "content-type": ["text/html"],
+        },
+      } as Partial<OnHeadersReceivedListenerDetails> as OnHeadersReceivedListenerDetails;
+
+      const result = mergeCspHeaders(details, "default-src 'self'");
+
+      expect(result["Content-Security-Policy"]).toEqual(["default-src 'self'"]);
+      expect(result["content-type"]).toEqual(["text/html"]);
+      expect(result["content-security-policy"]).toBeUndefined();
+    });
+
+    it("removes multiple CSP headers if present", () => {
+      const details = {
+        responseHeaders: {
+          "Content-Security-Policy": ["default-src 'none'"],
+          "content-security-policy": ["script-src 'self'"],
+          "content-type": ["text/html"],
+        },
+      } as Partial<OnHeadersReceivedListenerDetails> as OnHeadersReceivedListenerDetails;
+
+      const result = mergeCspHeaders(details, "default-src 'self'");
+
+      expect(result["Content-Security-Policy"]).toEqual(["default-src 'self'"]);
+      expect(result["content-security-policy"]).toBeUndefined();
+      expect(result["content-type"]).toEqual(["text/html"]);
+    });
+
+    it("preserves other headers", () => {
+      const details = {
+        responseHeaders: {
+          "content-type": ["text/html"],
+          "x-custom-header": ["value"],
+          "cache-control": ["no-cache"],
+        },
+      } as Partial<OnHeadersReceivedListenerDetails> as OnHeadersReceivedListenerDetails;
+
+      const result = mergeCspHeaders(details, "default-src 'self'");
+
+      expect(result["content-type"]).toEqual(["text/html"]);
+      expect(result["x-custom-header"]).toEqual(["value"]);
+      expect(result["cache-control"]).toEqual(["no-cache"]);
+      expect(result["Content-Security-Policy"]).toEqual(["default-src 'self'"]);
+    });
+  });
+});

--- a/electron/utils/webviewCsp.ts
+++ b/electron/utils/webviewCsp.ts
@@ -1,0 +1,69 @@
+import type { OnHeadersReceivedListenerDetails } from "electron";
+
+export type WebviewPartitionType = "browser" | "dev-preview" | "sidecar" | "unknown";
+
+/**
+ * Checks if a partition is a valid dev-preview partition.
+ * Matches exact "persist:dev-preview" or dynamic "persist:dev-preview-*" patterns.
+ */
+export function isDevPreviewPartition(partition: string): boolean {
+  return partition === "persist:dev-preview" || partition.startsWith("persist:dev-preview-");
+}
+
+/**
+ * Classifies a partition string into its type.
+ * Used to apply appropriate CSP policies to different webview partitions.
+ */
+export function classifyPartition(partition: string): WebviewPartitionType {
+  if (partition === "persist:browser") {
+    return "browser";
+  }
+  if (partition === "persist:sidecar") {
+    return "sidecar";
+  }
+  if (isDevPreviewPartition(partition)) {
+    return "dev-preview";
+  }
+  return "unknown";
+}
+
+/**
+ * Returns the CSP policy string for localhost-based dev server webviews.
+ * Used for browser panels and dev preview panels that load localhost content.
+ * Includes https: and wss: for secure localhost dev servers.
+ */
+export function getLocalhostDevCSP(): string {
+  return [
+    "default-src 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
+    "style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
+    "connect-src 'self' ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:* http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
+    "img-src 'self' data: blob: http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
+    "font-src 'self' data:",
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+  ].join("; ");
+}
+
+/**
+ * Merges CSP headers into response headers, replacing any existing CSP header.
+ * This prevents multiple conflicting CSP headers from accumulating.
+ */
+export function mergeCspHeaders(
+  details: OnHeadersReceivedListenerDetails,
+  cspPolicy: string
+): Record<string, string[]> {
+  const responseHeaders = { ...details.responseHeaders };
+
+  // Remove any existing CSP headers (case-insensitive)
+  const cspKeys = Object.keys(responseHeaders).filter(
+    (key) => key.toLowerCase() === "content-security-policy"
+  );
+  cspKeys.forEach((key) => delete responseHeaders[key]);
+
+  // Add the new CSP header
+  responseHeaders["Content-Security-Policy"] = [cspPolicy];
+
+  return responseHeaders;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ const DEV_CSP = [
 const PROD_CSP = [
   "default-src 'self'",
   "script-src 'self' 'wasm-unsafe-eval'",
-  "style-src 'self' 'unsafe-inline'",
+  "style-src 'self'",
   "style-src-attr 'unsafe-inline'",
   "font-src 'self' data:",
   "connect-src 'self'",


### PR DESCRIPTION
## Summary
Strengthens Content Security Policy (CSP) across renderer and webview sessions to close security gaps identified in issue #2305.

Closes #2305

## Changes Made
- **Production CSP tightening**: Removed `'unsafe-inline'` from `style-src` in production renderer (Tailwind v4 uses static extraction)
- **Webview session CSP**: Added CSP headers to browser and dev-preview webview partitions via `session.webRequest.onHeadersReceived`
- **Sidecar CSP preservation**: Skip CSP injection for sidecar partition to preserve origin site protections (Claude.ai, ChatGPT, Gemini)
- **Secure localhost support**: Added https/wss protocols for secure localhost dev servers
- **Partition classification**: Implemented consistent `isDevPreviewPartition` helper to prevent malformed partition matches
- **Startup error handling**: Added try-catch with fail-fast behavior to app startup
- **Test coverage**: Added comprehensive unit tests for CSP helpers (18 tests)

## Security Improvements
1. Blocks injected `<style>` tags in production renderer
2. Restricts webview content to localhost origins (browser/dev-preview)
3. Preserves third-party CSP defenses for external sites (sidecar)
4. Closes CSP gaps while maintaining development workflow compatibility