### PR TITLE
fix(worktree): prevent cross-project worktree pollution with scope filtering

### DIFF
--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -72,7 +72,16 @@ port.on("message", async (rawMsg: any) => {
 
     switch (request.type) {
       case "load-project":
-        await workspaceService.loadProject(request.requestId, request.rootPath);
+        if (!request.projectScopeId || typeof request.projectScopeId !== "string") {
+          sendEvent({
+            type: "load-project-result",
+            requestId: request.requestId,
+            success: false,
+            error: "Invalid projectScopeId: must be a non-empty string",
+          });
+          break;
+        }
+        await workspaceService.loadProject(request.requestId, request.rootPath, request.projectScopeId);
         break;
 
       case "sync":

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -107,7 +107,7 @@ export interface MonitorConfig {
  */
 export type WorkspaceHostRequest =
   // Project lifecycle
-  | { type: "load-project"; requestId: string; rootPath: string }
+  | { type: "load-project"; requestId: string; rootPath: string; projectScopeId: string }
   | {
       type: "sync";
       requestId: string;
@@ -227,8 +227,9 @@ export type WorkspaceHostEvent =
   // Git operation responses
   | { type: "get-file-diff-result"; requestId: string; diff: string; error?: string }
   // Spontaneous updates (no requestId - these are pushed events)
-  | { type: "worktree-update"; worktree: WorktreeSnapshot }
-  | { type: "worktree-removed"; worktreeId: string }
+  // Project scope filtering: events include projectScopeId to prevent cross-project pollution
+  | { type: "worktree-update"; worktree: WorktreeSnapshot; projectScopeId: string }
+  | { type: "worktree-removed"; worktreeId: string; projectScopeId: string }
   // PR events
   | {
       type: "pr-detected";
@@ -239,14 +240,16 @@ export type WorkspaceHostEvent =
       prTitle?: string;
       issueNumber?: number;
       issueTitle?: string;
+      projectScopeId: string;
     }
-  | { type: "pr-cleared"; worktreeId: string }
+  | { type: "pr-cleared"; worktreeId: string; projectScopeId: string }
   // Issue events
   | {
       type: "issue-detected";
       worktreeId: string;
       issueNumber: number;
       issueTitle: string;
+      projectScopeId: string;
     }
   // CopyTree events
   | { type: "copytree:progress"; operationId: string; progress: CopyTreeProgress }


### PR DESCRIPTION
## Summary

Fixes duplicate worktrees appearing in sidebar when switching between projects by implementing project scope filtering on IPC events. This prevents race condition where in-flight events from Project A's monitors leak into Project B after switching.

Closes #2315

## Changes Made

- Add projectScopeId to load-project request and all spontaneous IPC events (worktree-update, worktree-removed, pr-detected, pr-cleared, issue-detected)
- Implement event filtering in WorkspaceClient to drop stale cross-project events
- Add null-scope guards in WorkspaceService to prevent events during project switch
- Add input validation for projectScopeId parameter in load-project handler
- Centralize filter logic with isCurrentProjectEvent helper method
- Fix empty-scope bypass vulnerability by requiring non-null scopes on both sides
- Move currentRootPath clearing to start of onProjectSwitch to prevent stale autoreload on host crash

## Technical Approach

**Hybrid Option 2 + Option 3 (from issue analysis):**
- Opaque UUID scope IDs generated per project load
- Scope barrier created by clearing to null during switch
- Client-side filtering drops events with mismatched/null scopes
- Host-side guards prevent emission of events with null scope

**Key improvements from code review:**
- Changed scope type from `string` to `string | null` for explicit invalid state
- Added runtime validation to reject invalid scope IDs
- Centralized filter logic to prevent future inconsistencies
- Added guards to prevent event emission during switch window