### PR TITLE
Add agent-specific environment variable configuration

### DIFF
--- a/electron/services/pty/terminalShell.ts
+++ b/electron/services/pty/terminalShell.ts
@@ -49,7 +49,7 @@ export function getDefaultShellArgs(shell: string, _options?: ShellArgsOptions):
  * mode and the CLI fails to display its input prompt.
  * See: https://github.com/google-gemini/gemini-cli/issues/1563
  */
-const AGENT_ENV_EXCLUSIONS: Record<string, string[]> = {
+export const AGENT_ENV_EXCLUSIONS: Record<string, string[]> = {
   gemini: ["CI", "NONINTERACTIVE"],
 };
 

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -144,6 +144,19 @@ export interface AgentConfig {
    * Used by orchestrators to select the best agent for a given task.
    */
   routing?: AgentRoutingConfig;
+  /**
+   * Environment variables to set for this agent at spawn time.
+   *
+   * Precedence order (lowest to highest):
+   * 1. process.env (system environment)
+   * 2. options.env (passed to spawn)
+   * 3. buildNonInteractiveEnv defaults (CI=1, FORCE_COLOR=3, etc.)
+   * 4. agentConfig.env (this field - highest priority)
+   *
+   * Note: Agent-specific exclusions (e.g., CI/NONINTERACTIVE for Gemini)
+   * are enforced and cannot be overridden by this field.
+   */
+  env?: Record<string, string>;
 }
 
 export const AGENT_REGISTRY: Record<string, AgentConfig> = {
@@ -239,6 +252,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       maxConcurrent: 2,
       enabled: true,
     },
+    env: {
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+    },
   },
   gemini: {
     id: "gemini",
@@ -329,6 +345,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       },
       maxConcurrent: 2,
       enabled: true,
+    },
+    env: {
+      GEMINI_CLI_ALT_SCREEN: "false",
     },
   },
   codex: {


### PR DESCRIPTION
## Summary
Adds agent-specific environment variable configuration to allow agents (Claude, Gemini, Codex) to set custom env vars at spawn time for performance optimization and behavior control.

Closes #2327

## Changes Made
- Add env field to AgentConfig interface with precedence documentation
- Set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 for Claude to prevent Grove config fetch delay
- Set GEMINI_CLI_ALT_SCREEN=false for Gemini to control alt-screen mode
- Merge agent env at spawn time with exclusion filtering to prevent bypass of agent-specific safeguards
- Export AGENT_ENV_EXCLUSIONS for use in TerminalProcess