### PR TITLE
Fix keyboard shortcut tooltips for cross-platform display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import { useWorktreePalette } from "./hooks/useWorktreePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useAssistantContextSync } from "./hooks/useAssistantContextSync";
 import { actionService } from "./services/ActionService";
+import { createTooltipWithShortcut } from "./lib/platform";
 import { getAssistantContext } from "./components/Assistant/assistantContext";
 import {
   useAppHydration,
@@ -398,7 +399,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           <button
             onClick={onOpenOverview}
             className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-white/[0.06] rounded transition-colors"
-            title="Toggle worktrees overview (⌘⇧O)"
+            title={createTooltipWithShortcut("Toggle worktrees overview", "Cmd+Shift+O")}
             aria-label="Open worktrees overview"
           >
             <Maximize2 className="w-3.5 h-3.5" />

--- a/src/components/Commands/CommandPickerButton.tsx
+++ b/src/components/Commands/CommandPickerButton.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from "react";
 import { cn } from "@/lib/utils";
+import { createTooltipWithShortcut } from "@/lib/platform";
 import { Terminal } from "lucide-react";
 
 interface CommandPickerButtonProps {
@@ -25,7 +26,7 @@ export const CommandPickerButton = forwardRef<HTMLButtonElement, CommandPickerBu
           disabled && "opacity-50 cursor-not-allowed",
           className
         )}
-        title="Open command picker (⌘K)"
+        title={createTooltipWithShortcut("Open command picker", "Cmd+K")}
         aria-label="Open command picker"
       >
         <Terminal className="h-3.5 w-3.5" />

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -22,6 +22,7 @@ import {
   Monitor,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { createTooltipWithShortcut, formatShortcutForTooltip } from "@/lib/platform";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { GitHubResourceList, CommitList } from "@/components/GitHub";
 import { AgentButton } from "./AgentButton";
@@ -257,7 +258,7 @@ export function Toolbar({
             size="icon"
             onClick={onToggleFocusMode}
             className="text-canopy-text hover:bg-white/[0.06] hover:text-canopy-accent transition-colors"
-            title={isFocusMode ? "Show Sidebar (Cmd+B)" : "Hide Sidebar (Cmd+B)"}
+            title={createTooltipWithShortcut(isFocusMode ? "Show Sidebar" : "Hide Sidebar", "Cmd+B")}
             aria-label="Toggle Sidebar"
             aria-pressed={!isFocusMode}
           >
@@ -322,7 +323,7 @@ export function Toolbar({
             size="icon"
             onClick={() => onLaunchAgent("terminal")}
             className="text-canopy-text hover:bg-white/[0.06] transition-colors hover:text-canopy-accent focus-visible:text-canopy-accent"
-            title="Open Terminal (⌘T for palette)"
+            title={formatShortcutForTooltip("Open Terminal (Cmd+T for palette)")}
             aria-label="Open Terminal"
           >
             <Terminal />
@@ -590,7 +591,7 @@ export function Toolbar({
               "text-canopy-text hover:bg-white/[0.06] hover:text-canopy-accent relative transition-colors",
               errorCount > 0 && "text-[var(--color-status-error)]"
             )}
-            title="Show Problems Panel (Ctrl+Shift+M)"
+            title={createTooltipWithShortcut("Show Problems Panel", "Ctrl+Shift+M")}
             aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
           >
             <AlertCircle />

--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
+import { createTooltipWithShortcut } from "@/lib/platform";
+import { keybindingService } from "@/services/KeybindingService";
 import { useOverlayState } from "@/hooks";
 import { useNotesStore } from "@/store/notesStore";
 import { useTerminalStore } from "@/store/terminalStore";
@@ -689,14 +691,16 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
             <div className="px-3 py-2 border-b border-canopy-border flex items-center justify-between shrink-0">
               <div className="flex items-center gap-3">
                 <span className="text-[11px] text-canopy-text/50">Notes</span>
-                <span className="text-[11px] text-canopy-text/50 font-mono">⌘⇧N</span>
+                <span className="text-[11px] text-canopy-text/50 font-mono">
+                  {keybindingService.getDisplayCombo("notes.openPalette") || "⌘⇧N"}
+                </span>
               </div>
               <div className="flex items-center gap-2">
                 <button
                   type="button"
                   onClick={() => handleCreateNote()}
                   className="px-2.5 py-1 rounded-[var(--radius-md)] bg-canopy-accent hover:bg-canopy-accent/90 text-canopy-bg font-medium text-xs transition-colors flex items-center gap-1 active:scale-[0.98]"
-                  title="Create new note (Cmd+N)"
+                  title={createTooltipWithShortcut("Create new note", "Cmd+N")}
                 >
                   <Plus size={14} />
                   New

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -22,6 +22,7 @@ import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import type { PanelKind, TerminalType } from "@/types";
 import { cn, getBaseTitle } from "@/lib/utils";
+import { createTooltipWithShortcut, formatShortcutForTooltip } from "@/lib/platform";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -600,7 +601,7 @@ function PanelHeaderComponent({
                   onToggleMaximize();
                 }}
                 className="flex items-center gap-1.5 px-2 py-1 bg-canopy-accent/10 text-canopy-accent hover:bg-canopy-accent/20 rounded transition-colors mr-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
-                title="Restore Grid View (Ctrl+Shift+F)"
+                title={createTooltipWithShortcut("Restore Grid View", "Ctrl+Shift+F")}
                 aria-label="Exit Focus mode and restore grid view"
               >
                 <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" />
@@ -615,7 +616,7 @@ function PanelHeaderComponent({
                     onToggleMaximize();
                   }}
                   className="p-1.5 hover:bg-canopy-text/10 focus-visible:bg-canopy-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2 text-canopy-text/60 hover:text-canopy-text transition-colors"
-                  title="Maximize (Ctrl+Shift+F)"
+                  title={createTooltipWithShortcut("Maximize", "Ctrl+Shift+F")}
                   aria-label="Maximize"
                 >
                   <Maximize2 className="w-3 h-3" aria-hidden="true" />
@@ -635,8 +636,8 @@ function PanelHeaderComponent({
                 }
               }}
               className="p-1.5 hover:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:bg-[color-mix(in_oklab,var(--color-status-error)_15%,transparent)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-status-error)] focus-visible:outline-offset-2 text-canopy-text/60 hover:text-[var(--color-status-error)] transition-colors"
-              title="Close Session (Alt+Click to force close)"
-              aria-label="Close session. Hold Alt and click to force close without recovery."
+              title={formatShortcutForTooltip("Close Session (Alt+Click to force close)")}
+              aria-label={formatShortcutForTooltip("Close session. Hold Alt and click to force close without recovery.")}
             >
               <X className="w-3 h-3" aria-hidden="true" />
             </button>

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,51 @@
+let _isMac: boolean | undefined;
+
+export function isMac(): boolean {
+  if (_isMac === undefined) {
+    _isMac =
+      typeof navigator !== "undefined" &&
+      !!navigator.platform &&
+      navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+  }
+  return _isMac;
+}
+
+/**
+ * Format a keyboard shortcut string for tooltip display using OS-appropriate modifier names.
+ * Uses text labels (not symbols) for clarity in tooltips.
+ *
+ * On macOS: Alt+ becomes Option+
+ * On Windows/Linux: Cmd+ becomes Ctrl+, Option+ becomes Alt+
+ *
+ * Note: Ctrl+ is NOT converted on macOS because some shortcuts intentionally use
+ * the physical Control key on all platforms (e.g., Ctrl+Shift+F).
+ */
+export function formatShortcutForTooltip(shortcut: string): string {
+  if (!shortcut) return "";
+
+  let formatted = shortcut;
+
+  if (isMac()) {
+    formatted = formatted.replace(/\bAlt\+/gi, "Option+");
+    formatted = formatted.replace(/\bAlt\b/gi, "Option");
+  } else {
+    formatted = formatted.replace(/\bCmd\+/gi, "Ctrl+");
+    formatted = formatted.replace(/\bOption\+/gi, "Alt+");
+    formatted = formatted.replace(/\bOption\b/gi, "Alt");
+  }
+
+  return formatted;
+}
+
+/**
+ * Create a tooltip string with an OS-appropriate keyboard shortcut appended.
+ *
+ * @example
+ * createTooltipWithShortcut("Show Sidebar", "Cmd+B")
+ * // macOS:  "Show Sidebar (Cmd+B)"
+ * // Windows: "Show Sidebar (Ctrl+B)"
+ */
+export function createTooltipWithShortcut(label: string, shortcut: string): string {
+  const formatted = formatShortcutForTooltip(shortcut);
+  return formatted ? `${label} (${formatted})` : label;
+}


### PR DESCRIPTION
## Summary
Fixes keyboard shortcut tooltips to display OS-appropriate modifier key names (e.g., "Option+Click" on Mac vs "Alt+Click" on Windows/Linux).

Closes #2324

## Changes Made
- Created `platform.ts` utility with OS detection and modifier key formatting functions
- Updated PanelHeader tooltips (close, maximize, restore) to use platform-aware formatting
- Updated Toolbar tooltips (sidebar toggle, terminal, problems panel) for cross-platform display
- Replaced hardcoded Mac-only shortcut (`⌘⇧N`) in NotesPalette with keybinding service
- Fixed empty shortcut edge case in `createTooltipWithShortcut`
- Corrected modifier key logic to only convert Alt↔Option (preserves Ctrl on all platforms for intentional Control key shortcuts)

## Testing
- Verified tooltips display correctly on macOS and Windows/Linux
- Ensured shortcuts that intentionally use physical Ctrl key (like Ctrl+Shift+F) are not incorrectly converted to Cmd on Mac
- Validated all tooltip strings are platform-aware