### PR TITLE
Fix agent CLI status inconsistency and infinite spinner (issue #2333)

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -3,6 +3,8 @@ import type { CliAvailability } from "../../shared/types/ipc.js";
 import { getEffectiveRegistry } from "../../shared/config/agentRegistry.js";
 
 export class CliAvailabilityService {
+  private static readonly CHECK_TIMEOUT_MS = 10_000;
+
   private availability: CliAvailability | null = null;
   private inFlightCheck: Promise<CliAvailability> | null = null;
   private checkId = 0;
@@ -17,9 +19,42 @@ export class CliAvailabilityService {
     this.inFlightCheck = (async () => {
       try {
         const entries = Object.entries(getEffectiveRegistry());
-        const availabilityEntries = await Promise.all(
-          entries.map(async ([id, config]) => [id, await this.checkCommand(config.command)])
+
+        const checksPromise = Promise.allSettled(
+          entries.map(async ([id, config]) => {
+            const available = await this.checkCommand(config.command);
+            return [id, available] as [string, boolean];
+          })
         );
+
+        let timeoutHandle: NodeJS.Timeout;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutHandle = setTimeout(
+            () => reject(new Error("CLI availability check timed out")),
+            CliAvailabilityService.CHECK_TIMEOUT_MS
+          );
+        });
+
+        let availabilityEntries: [string, boolean][];
+        try {
+          const results = await Promise.race([checksPromise, timeoutPromise]);
+          availabilityEntries = results.map((result, index) => {
+            if (result.status === "fulfilled") {
+              return result.value;
+            } else {
+              console.warn(
+                `[CliAvailabilityService] Check failed for ${entries[index][0]}:`,
+                result.reason
+              );
+              return [entries[index][0], false] as [string, boolean];
+            }
+          });
+        } catch (error) {
+          console.warn("[CliAvailabilityService]", error instanceof Error ? error.message : error);
+          availabilityEntries = entries.map(([id]) => [id, false]);
+        } finally {
+          clearTimeout(timeoutHandle);
+        }
 
         const result: CliAvailability = Object.fromEntries(availabilityEntries);
 
@@ -65,7 +100,7 @@ export class CliAvailabilityService {
       setImmediate(() => {
         try {
           const checkCmd = process.platform === "win32" ? "where" : "which";
-          execFileSync(checkCmd, [command], { stdio: "ignore" });
+          execFileSync(checkCmd, [command], { stdio: "ignore", timeout: 5000 });
           resolve(true);
         } catch {
           resolve(false);


### PR DESCRIPTION
## Summary
Fixes the agent CLI status inconsistency between General and individual settings pages, and resolves the infinite spinner issue when clicking the Re-check button.

Closes #2333

## Root Causes Fixed
1. **Infinite spinner**: `CliAvailabilityService.checkCommand()` used `execFileSync` with no timeout - if `which`/`where` hung, the promise never resolved
2. **State inconsistency**: Both settings pages loaded CLI availability independently with `null` → `{}` initialization causing "CLI not found" to display before data loaded
3. **Error swallowing**: Errors in `AgentSettings` were caught silently with no logging or user feedback

## Changes Made
- **CliAvailabilityService.ts**:
  - Added 5-second timeout to `execFileSync` per-command check
  - Added 10-second overall timeout with `Promise.race`
  - Fixed timeout timer leak by storing handle and calling `clearTimeout`
  - Switched to `Promise.allSettled` to preserve partial results instead of all-false fallback
- **AgentSettings.tsx**:
  - Changed `cliAvailability` initialization from `{}` to `null` to distinguish loading vs not-found
  - Added loading state UI: "Checking CLI availability..." while `null`
  - Added error state with user-friendly messages on check/refresh failures
  - Added console logging for all errors
  - Added request sequencing to prevent race conditions on rapid refresh clicks
- **GeneralTab.tsx**:
  - Added unmount safety guards (`isMountedRef`) to all async handlers
  - Added error state for failed CLI checks
  - Added console logging for all errors

## Testing
- Both General and individual agent settings now show consistent CLI status
- Re-check button completes within 10 seconds or shows timeout error
- Errors are logged to console and displayed to users
- No state updates occur after component unmount