### PR TITLE
Improve Gemini and Ink-based agent rendering reliability

### DIFF
--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -290,6 +290,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       scrollback: 10000,
       blockAltScreen: true,
       blockMouseReporting: true,
+      resizeStrategy: "settled",
     },
     detection: {
       primaryPatterns: [


### PR DESCRIPTION
## Summary

Fixes visual corruption in Gemini terminals during rapid resizing and prevents spurious activity state transitions from status line updates in Claude Code and other Ink-based agents.

Closes #2328

## Changes Made

- Add `resizeStrategy: "settled"` to Gemini agent capabilities (500ms debounce to prevent Ink/Yoga rendering corruption)
- Implement status line noise filter in `ActivityMonitor` to exclude CR-based progress indicators from volume-based activity detection
- Add pattern matching for common status line formats (tokens, costs, percentages, timers, counters)
- Fix chunk boundary edge case for split `\r\n` sequences
- Preserve debounce timer reset before filtering to maintain correct busy state handling

## Testing

- All 84 existing ActivityMonitor tests pass
- Code reviewed by Codex with fixes applied for:
  - Critical: Early return placement to preserve busy state debounce
  - Edge case: Chunk boundary handling for CRLF splits