### PR TITLE
Consolidate input protocol configuration into agent registry

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1035,7 +1035,8 @@ export class TerminalProcess {
     const effectiveAgentId =
       this.terminalInfo.agentId ??
       (this.terminalInfo.type !== "terminal" ? this.terminalInfo.type : undefined);
-    const ignoredInputSequences = effectiveAgentId === "codex" ? ["\n", "\x1b\r"] : ["\x1b\r"];
+    const agentConfig = effectiveAgentId ? getEffectiveAgentConfig(effectiveAgentId) : undefined;
+    const ignoredInputSequences = agentConfig?.capabilities?.ignoredInputSequences ?? ["\x1b\r"];
 
     const detection = effectiveAgentId
       ? getEffectiveAgentConfig(effectiveAgentId)?.detection

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -109,6 +109,12 @@ export interface AgentConfig {
     resizeStrategy?: "default" | "settled";
     /** CLI flag to disable alt-screen and use inline rendering (e.g., "--no-alt-screen") */
     inlineModeFlag?: string;
+    /** Whether the agent CLI supports bracketed paste input (default: true) */
+    supportsBracketedPaste?: boolean;
+    /** Escape sequence sent for Shift+Enter / soft newline (default: "\x1b\r") */
+    softNewlineSequence?: string;
+    /** Input sequences the activity monitor should ignore (default: ["\x1b\r"]) */
+    ignoredInputSequences?: string[];
   };
   /**
    * Configuration for pattern-based working state detection.
@@ -209,6 +215,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     },
     capabilities: {
       scrollback: 10000,
+      supportsBracketedPaste: true,
+      softNewlineSequence: "\x1b\r",
+      ignoredInputSequences: ["\x1b\r"],
     },
     detection: {
       primaryPatterns: [
@@ -307,6 +316,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       blockAltScreen: true,
       blockMouseReporting: true,
       resizeStrategy: "settled",
+      supportsBracketedPaste: false,
+      softNewlineSequence: "\x1b\r",
+      ignoredInputSequences: ["\x1b\r"],
     },
     detection: {
       primaryPatterns: [
@@ -404,6 +416,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       blockMouseReporting: true,
       resizeStrategy: "settled",
       inlineModeFlag: "--no-alt-screen",
+      supportsBracketedPaste: true,
+      softNewlineSequence: "\n",
+      ignoredInputSequences: ["\n", "\x1b\r"],
     },
     detection: {
       primaryPatterns: [
@@ -528,6 +543,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     capabilities: {
       scrollback: 10000,
       blockAltScreen: true,
+      supportsBracketedPaste: true,
+      softNewlineSequence: "\n",
+      ignoredInputSequences: ["\n", "\x1b\r"],
     },
     detection: {
       primaryPatterns: [

--- a/shared/utils/terminalInputProtocol.ts
+++ b/shared/utils/terminalInputProtocol.ts
@@ -1,3 +1,5 @@
+import { getEffectiveAgentConfig } from "../config/agentRegistry.js";
+
 // Bracketed paste escape sequences
 export const BRACKETED_PASTE_START = "\x1b[200~";
 export const BRACKETED_PASTE_END = "\x1b[201~";
@@ -7,20 +9,16 @@ export const PASTE_THRESHOLD_CHARS = 200;
 
 /**
  * Get the soft-newline sequence for a given agent type.
- * Shift+Enter behavior differs by agent CLI.
- * For normal terminal types, returns plain LF (standard newline).
+ * Reads from agent registry capabilities. For normal terminals (undefined or "terminal"),
+ * returns plain LF. For unknown agent IDs, defaults to ESC+CR (most agent CLIs use this).
  */
 export function getSoftNewlineSequence(agentType?: string): string {
-  // Codex uses plain LF (\n / Ctrl+J)
-  if (agentType === "codex") {
-    return "\n";
+  if (!agentType || agentType === "terminal") return "\n";
+  const config = getEffectiveAgentConfig(agentType);
+  if (config) {
+    return config.capabilities?.softNewlineSequence ?? "\x1b\r";
   }
-  // Claude and Gemini agents use ESC+CR
-  if (agentType === "claude" || agentType === "gemini") {
-    return "\x1b\r";
-  }
-  // Normal terminals (type "terminal" or undefined) use plain LF
-  return "\n";
+  return "\x1b\r";
 }
 
 /**


### PR DESCRIPTION
## Summary

Refactors input protocol configuration from hardcoded agent type checks into the agent registry capabilities system, making the system data-driven and extensible for user-defined agents.

Closes #2326

## Changes Made

- Add `supportsBracketedPaste`, `softNewlineSequence`, and `ignoredInputSequences` to agent capabilities schema
- Replace hardcoded agent type checks with registry lookups in `terminalInput`, `terminalInputProtocol`, and `TerminalProcess`
- Fix `opencode` `ignoredInputSequences` to include LF (matching its `softNewlineSequence`)
- Fix unknown agent soft newline default to ESC+CR (most agent CLIs use this)
- Add test coverage for registry integration and fallback behaviors

## Testing

- ✅ All existing tests pass
- ✅ Added tests for unknown agents, custom agents with missing capabilities, and registry integration
- ✅ Verified behavior preserves existing functionality for all built-in agents