### PR TITLE
Fix Codex resize corruption during project/worktree switch

### DIFF
--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -352,12 +352,16 @@ export const createTerminalRegistrySlice =
                 heightPx,
               });
 
-              // Also set initial PTY geometry for agent TUI initialization
-              const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
-              const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
-              const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));
-              const rows = Math.max(10, Math.min(200, Math.floor(heightPx / cellHeight)));
-              terminalClient.resize(id, cols, rows);
+              // For offscreen/inactive agents, prewarmTerminal's fit() already handles
+              // initial PTY resize through settled strategy. Only send explicit resize
+              // for active grid spawns where fit() is skipped.
+              if (!offscreenOrInactive) {
+                const cellWidth = Math.max(6, Math.floor(fontSize * 0.6));
+                const cellHeight = Math.max(10, Math.floor(fontSize * 1.1));
+                const cols = Math.max(20, Math.min(500, Math.floor(widthPx / cellWidth)));
+                const rows = Math.max(10, Math.min(200, Math.floor(heightPx / cellHeight)));
+                terminalInstanceService.sendPtyResize(id, cols, rows);
+              }
             }
           } catch (error) {
             console.warn(`[TerminalStore] Failed to prewarm terminal ${id}:`, error);


### PR DESCRIPTION
## Summary
Fixes Codex terminal corruption during project/worktree switches by preventing rapid resize events from reaching Ratatui-based TUIs.

Closes #2331

## Changes Made
- Skip post-wake resize bounce for settled agents (Codex, Gemini)
- Defer xterm.js resize to fire atomically with PTY resize for settled agents
- Fix clear-screen injection to use xterm.js instead of PTY stdin
- Clear settled timer on project-switch detach to prevent stale resize
- Skip duplicate prewarm resize for offscreen agents (fit() already handles it)
- Route all agent prewarm resizes through settled-aware sendPtyResize()