### PR TITLE
Add completion pattern detection for task finish feedback

### DIFF
--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -5,6 +5,7 @@ export type AgentEvent =
   | { type: "output"; data: string }
   | { type: "busy" } // Agent is actively receiving data
   | { type: "prompt" } // Agent has been idle (no data for debounce period)
+  | { type: "completion" } // Agent completed a task (pattern-detected)
   | { type: "input" } // User input received
   | { type: "exit"; code: number }
   | { type: "error"; error: string };
@@ -14,7 +15,7 @@ const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
   working: ["waiting", "completed", "failed"],
   running: ["idle"], // Shell process state - managed by TerminalProcess, not this state machine
   waiting: ["working", "failed"],
-  completed: ["failed"], // Allow error events to override completed state
+  completed: ["working", "waiting", "failed"], // Allow resuming work, prompt, or error override
   failed: ["failed"],
 };
 
@@ -35,8 +36,8 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
       break;
 
     case "busy":
-      // Handles re-entry to working from waiting state when agent resumes activity
-      if (current === "waiting" || current === "idle") {
+      // Handles re-entry to working from waiting/idle/completed states when agent resumes activity
+      if (current === "waiting" || current === "idle" || current === "completed") {
         return "working";
       }
       break;
@@ -45,21 +46,31 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
       // Output events no longer trigger state changes - activity is handled by ActivityMonitor
       break;
 
+    case "completion":
+      if (current === "working") {
+        return "completed";
+      }
+      break;
+
     case "prompt":
       // Activity monitor detected silence - transition to waiting
-      if (current === "working") {
+      if (current === "working" || current === "completed") {
         return "waiting";
       }
       break;
 
     case "input":
-      if (current === "waiting" || current === "idle") {
+      if (current === "waiting" || current === "idle" || current === "completed") {
         return "working";
       }
       break;
 
     case "exit":
       if (current === "working" || current === "waiting") {
+        return event.code === 0 ? "completed" : "failed";
+      }
+      if (current === "completed") {
+        // Exit from completed state (e.g., early completion detection before exit)
         return event.code === 0 ? "completed" : "failed";
       }
       break;

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -268,17 +268,21 @@ export class AgentStateService {
    */
   handleActivityState(
     terminal: TerminalInfo,
-    activity: "busy" | "idle",
+    activity: "busy" | "idle" | "completed",
     metadata?: { trigger: "input" | "output" | "pattern"; patternConfidence?: number }
   ): void {
     if (!terminal.agentId) {
       return;
     }
 
-    const event: AgentEvent = activity === "busy" ? { type: "busy" } : { type: "prompt" };
+    const event: AgentEvent =
+      activity === "busy"
+        ? { type: "busy" }
+        : activity === "completed"
+          ? { type: "completion" }
+          : { type: "prompt" };
 
     if (metadata?.trigger === "pattern") {
-      // Pattern-based detection has its own confidence
       const confidence = metadata.patternConfidence ?? 0.9;
       this.updateAgentState(terminal, event, "heuristic", confidence);
     } else if (metadata?.trigger === "output") {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -62,6 +62,7 @@ import {
   buildBootCompletePatterns,
   buildPromptPatterns,
   buildPromptHintPatterns,
+  buildCompletionPatterns,
   createProcessStateValidator,
 } from "./terminalActivityPatterns.js";
 import { TerminalForensicsBuffer } from "./TerminalForensicsBuffer.js";
@@ -1044,6 +1045,7 @@ export class TerminalProcess {
     const bootCompletePatterns = buildBootCompletePatterns(detection, effectiveAgentId);
     const promptPatterns = buildPromptPatterns(detection, effectiveAgentId);
     const promptHintPatterns = buildPromptHintPatterns(detection, effectiveAgentId);
+    const completionPatterns = buildCompletionPatterns(detection, effectiveAgentId);
 
     const outputActivityDetection = {
       enabled: true,
@@ -1065,6 +1067,8 @@ export class TerminalProcess {
       bootCompletePatterns,
       promptPatterns,
       promptHintPatterns,
+      completionPatterns,
+      completionConfidence: detection?.completionConfidence,
       promptScanLineCount: detection?.promptScanLineCount,
       promptConfidence: detection?.promptConfidence,
       idleDebounceMs: effectiveAgentId ? (detection?.debounceMs ?? 2000) : undefined,

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -68,6 +68,19 @@ export function buildPromptHintPatterns(
   return promptHintPatterns.length ? promptHintPatterns : undefined;
 }
 
+export function buildCompletionPatterns(
+  detection: AgentDetectionConfig | undefined,
+  agentId: string | undefined
+): RegExp[] | undefined {
+  if (!detection?.completionPatterns || detection.completionPatterns.length === 0) {
+    return undefined;
+  }
+
+  const completionPatterns = compilePatterns(detection.completionPatterns, agentId, "completion");
+
+  return completionPatterns.length ? completionPatterns : undefined;
+}
+
 export function compilePatterns(
   patterns: string[],
   agentId: string | undefined,

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -86,6 +86,18 @@ export interface AgentDetectionConfig {
    * Confidence level when prompt pattern matches (default: 0.85).
    */
   promptConfidence?: number;
+
+  /**
+   * Patterns that indicate the agent successfully completed a task.
+   * When detected, briefly transition to "completed" state before settling to "waiting".
+   * Use strings that will be converted to RegExp with case-insensitive flag.
+   */
+  completionPatterns?: string[];
+
+  /**
+   * Confidence level when completion pattern matches (default: 0.90).
+   */
+  completionConfidence?: number;
 }
 
 export interface AgentConfig {
@@ -222,6 +234,11 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       bootCompletePatterns: ["claude\\s+code\\s+v?\\d"],
       promptPatterns: ["^\\s*>\\s*", "^\\s*❯\\s*"],
       promptHintPatterns: ["bypass permissions", "^\\s*>\\s+Try\\b"],
+      completionPatterns: [
+        "\\$\\d+\\.\\d+\\s*·\\s*\\d+\\s*tokens",
+        "Task\\s+completed",
+      ],
+      completionConfidence: 0.9,
       scanLineCount: 10,
       primaryConfidence: 0.95,
       fallbackConfidence: 0.75,
@@ -318,6 +335,11 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       bootCompletePatterns: ["type\\s+your\\s+message"],
       promptPatterns: ["^\\s*>\\s*", "type\\s+your\\s+message"],
       promptHintPatterns: ["type\\s+your\\s+message"],
+      completionPatterns: [
+        "Response\\s+complete",
+        "Finished\\s+processing",
+      ],
+      completionConfidence: 0.9,
       scanLineCount: 10,
       primaryConfidence: 0.95,
       fallbackConfidence: 0.7,
@@ -415,6 +437,12 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       bootCompletePatterns: ["openai[-\\s]+codex", "codex\\s+v"],
       promptPatterns: ["^\\s*[›❯>]\\s*", "^\\s*codex\\s*>\\s*"],
       promptHintPatterns: ["context\\s+left"],
+      completionPatterns: [
+        "Task\\s+completed\\s+successfully",
+        "\\d+\\s+files?\\s+changed",
+        "Created\\s+\\d+\\s+files?",
+      ],
+      completionConfidence: 0.9,
       scanLineCount: 10,
       primaryConfidence: 0.95,
       fallbackConfidence: 0.75,
@@ -539,6 +567,11 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       bootCompletePatterns: ["Ask anything", "Build\\s+OpenCode"],
       promptPatterns: ["^\\s*[›❯>]\\s*", "Ask anything"],
       promptHintPatterns: ["Ask anything"],
+      completionPatterns: [
+        "Task\\s+completed",
+        "\\d+\\s+files?\\s+changed",
+      ],
+      completionConfidence: 0.9,
       scanLineCount: 10,
       primaryConfidence: 0.95,
       fallbackConfidence: 0.7,


### PR DESCRIPTION
## Summary

Add completion pattern detection to agent state machine, providing better UI feedback when agents finish tasks. When completion patterns are detected (e.g., cost summaries, "Task completed"), the agent briefly shows a "completed" state before settling to "waiting".

Closes #2329

## Changes Made

- Add completionPatterns and completionConfidence to AgentDetectionConfig
- Add completion patterns for Claude, Gemini, Codex, and OpenCode agents
- Implement completion detection in ActivityMonitor with 500ms hold timer
- Add completion event type to AgentStateMachine
- Allow completed → working/waiting transitions for work resumption
- Handle exit events from completed state
- Add timer guards to prevent duplicate idle emissions
- Wire completion patterns through TerminalProcess and AgentStateService
- Add comprehensive test coverage for new transitions