### PR TITLE
Add scroll indicators to worktree sidebar for hidden content

### DIFF
--- a/src/components/Worktree/ScrollIndicator.tsx
+++ b/src/components/Worktree/ScrollIndicator.tsx
@@ -1,0 +1,34 @@
+import { ChevronUp, ChevronDown } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+interface ScrollIndicatorProps {
+  direction: "above" | "below";
+  count: number;
+  onClick: () => void;
+}
+
+export function ScrollIndicator({ direction, count, onClick }: ScrollIndicatorProps) {
+  if (count <= 0) return null;
+
+  const Icon = direction === "above" ? ChevronUp : ChevronDown;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "absolute left-0 right-0 z-20 py-1.5 px-4",
+        "text-xs text-canopy-text/65 hover:text-canopy-text/90",
+        "transition-colors cursor-pointer",
+        "flex items-center justify-center gap-1.5",
+        "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1",
+        direction === "above" && "top-0 bg-gradient-to-b from-[var(--color-canopy-sidebar)] via-[var(--color-canopy-sidebar)]/80 to-transparent",
+        direction === "below" && "bottom-0 bg-gradient-to-t from-[var(--color-canopy-sidebar)] via-[var(--color-canopy-sidebar)]/80 to-transparent"
+      )}
+    >
+      <Icon className="w-3 h-3" />
+      <span className="font-medium tabular-nums">{count}</span>
+      <span>more {direction === "above" ? "above" : "below"}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
Adds intelligent scroll indicators to the worktree sidebar that display when worktrees extend beyond the visible viewport, showing users how many additional worktrees are above or below.

Closes #2323

## Changes Made
- Add ScrollIndicator component with gradient overlay and click-to-scroll
- Implement scroll tracking using requestAnimationFrame throttling
- Calculate approximate hidden worktree counts above/below viewport
- Add ResizeObserver to detect dynamic content height changes
- Include keyboard focus styles and accessible contrast ratios
- Support both grouped and ungrouped worktree list modes