### PR TITLE
feat(github): hide issue badge when GitHub confirms issue not on repo

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -89,6 +89,7 @@ export const CHANNELS = {
   PR_DETECTED: "pr:detected",
   PR_CLEARED: "pr:cleared",
   ISSUE_DETECTED: "issue:detected",
+  ISSUE_NOT_FOUND: "issue:not-found",
 
   GITHUB_GET_REPO_STATS: "github:get-repo-stats",
   GITHUB_OPEN_ISSUES: "github:open-issues",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -28,6 +28,7 @@ import type {
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
+  IssueNotFoundPayload,
   GitStatus,
   KeyAction,
   TerminalRecipe,
@@ -224,6 +225,7 @@ const CHANNELS = {
   PR_DETECTED: "pr:detected",
   PR_CLEARED: "pr:cleared",
   ISSUE_DETECTED: "issue:detected",
+  ISSUE_NOT_FOUND: "issue:not-found",
 
   // GitHub channels
   GITHUB_GET_REPO_STATS: "github:get-repo-stats",
@@ -1028,6 +1030,9 @@ const api: ElectronAPI = {
 
     onIssueDetected: (callback: (data: IssueDetectedPayload) => void) =>
       _typedOn(CHANNELS.ISSUE_DETECTED, callback),
+
+    onIssueNotFound: (callback: (data: IssueNotFoundPayload) => void) =>
+      _typedOn(CHANNELS.ISSUE_NOT_FOUND, callback),
   },
 
   // Notes API

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -413,6 +413,12 @@ class PullRequestService {
             issueTitle: checkResult.issueTitle,
             timestamp: Date.now(),
           });
+        } else if (issueNumber && !checkResult.issueTitle) {
+          events.emit("sys:issue:not-found", {
+            worktreeId,
+            issueNumber,
+            timestamp: Date.now(),
+          });
         }
 
         if (checkResult.pr) {

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -459,6 +459,20 @@ export class WorkspaceClient extends EventEmitter {
         break;
       }
 
+      case "issue-not-found": {
+        if (!this.isCurrentProjectEvent(event.projectScopeId)) {
+          return;
+        }
+        const notFoundPayload = {
+          worktreeId: event.worktreeId,
+          issueNumber: event.issueNumber,
+          timestamp: Date.now(),
+        };
+        events.emit("sys:issue:not-found", notFoundPayload);
+        this.sendToRenderer(CHANNELS.ISSUE_NOT_FOUND, notFoundPayload);
+        break;
+      }
+
       // CopyTree events
       case "copytree:progress": {
         const callback = this.copyTreeProgressCallbacks.get(event.operationId);

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -107,6 +107,12 @@ export const EVENT_META: Record<keyof CanopyEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Issue metadata detected for worktree branch",
   },
+  "sys:issue:not-found": {
+    category: "system",
+    requiresContext: true,
+    requiresTimestamp: true,
+    description: "GitHub confirmed issue does not exist on current repo",
+  },
 
   // File events
   "file:open": {
@@ -489,6 +495,12 @@ export type CanopyEventMap = {
     timestamp: number;
   };
 
+  "sys:issue:not-found": {
+    worktreeId: string;
+    issueNumber: number;
+    timestamp: number;
+  };
+
   /**
    * Emitted when a new AI agent (Claude, Gemini, etc.) is spawned in a terminal.
    * Use this to track agent creation and associate agents with worktrees.
@@ -822,6 +834,7 @@ export const ALL_EVENT_TYPES: Array<keyof CanopyEventMap> = [
   "sys:pr:detected",
   "sys:pr:cleared",
   "sys:issue:detected",
+  "sys:issue:not-found",
   "agent:spawned",
   "agent:state-changed",
   "agent:detected",

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1514,6 +1514,28 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     );
 
     this.prEventUnsubscribers.push(
+      events.on("sys:issue:not-found", (data) => {
+        const monitor = this.monitors.get(data.worktreeId);
+        if (monitor && monitor.issueNumber === data.issueNumber) {
+          monitor.issueNumber = undefined;
+          monitor.issueTitle = undefined;
+          if (monitor.hasInitialStatus) {
+            this.emitUpdate(monitor);
+          }
+        }
+
+        if (this.projectScopeId) {
+          this.sendEvent({
+            type: "issue-not-found",
+            worktreeId: data.worktreeId,
+            issueNumber: data.issueNumber,
+            projectScopeId: this.projectScopeId,
+          });
+        }
+      })
+    );
+
+    this.prEventUnsubscribers.push(
       events.on("sys:pr:cleared", (data: any) => {
         const monitor = this.monitors.get(data.worktreeId);
         if (monitor) {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -125,6 +125,7 @@ export type {
   PRClearedPayload,
   // Issue detection IPC types
   IssueDetectedPayload,
+  IssueNotFoundPayload,
   // Project close IPC types
   ProjectCloseResult,
   ProjectStats,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -67,6 +67,7 @@ import type {
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
+  IssueNotFoundPayload,
 } from "./github.js";
 import type { TerminalConfig } from "./config.js";
 import type { HibernationConfig } from "./hibernation.js";
@@ -418,6 +419,7 @@ export interface ElectronAPI {
     onPRDetected(callback: (data: PRDetectedPayload) => void): () => void;
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;
     onIssueDetected(callback: (data: IssueDetectedPayload) => void): () => void;
+    onIssueNotFound(callback: (data: IssueNotFoundPayload) => void): () => void;
   };
   notes: {
     create(

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -74,3 +74,10 @@ export interface IssueDetectedPayload {
   issueNumber: number;
   issueTitle: string;
 }
+
+/** Issue not found payload - emitted when GitHub confirms issue doesn't exist on current repo */
+export interface IssueNotFoundPayload {
+  worktreeId: string;
+  issueNumber: number;
+  timestamp: number;
+}

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -79,6 +79,7 @@ import type {
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
+  IssueNotFoundPayload,
 } from "./github.js";
 import type { GitGetFileDiffPayload } from "./git.js";
 import type { TerminalConfig } from "./config.js";
@@ -1050,6 +1051,7 @@ export interface IpcEventMap {
 
   // Issue detection events
   "issue:detected": IssueDetectedPayload;
+  "issue:not-found": IssueNotFoundPayload;
 
   // Error events
   "error:notify": AppError;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -251,6 +251,12 @@ export type WorkspaceHostEvent =
       issueTitle: string;
       projectScopeId: string;
     }
+  | {
+      type: "issue-not-found";
+      worktreeId: string;
+      issueNumber: number;
+      projectScopeId: string;
+    }
   // CopyTree events
   | { type: "copytree:progress"; operationId: string; progress: CopyTreeProgress }
   | {

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -6,6 +6,7 @@ import type {
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
+  IssueNotFoundPayload,
 } from "../types";
 import type {
   GitHubIssue,
@@ -81,6 +82,10 @@ export const githubClient = {
 
   onIssueDetected: (callback: (data: IssueDetectedPayload) => void): (() => void) => {
     return window.electron.github.onIssueDetected(callback);
+  },
+
+  onIssueNotFound: (callback: (data: IssueNotFoundPayload) => void): (() => void) => {
+    return window.electron.github.onIssueNotFound(callback);
   },
 
   getIssueUrl: (cwd: string, issueNumber: number): Promise<string | null> => {

--- a/src/store/worktreeDataStore.ts
+++ b/src/store/worktreeDataStore.ts
@@ -186,7 +186,24 @@ export const useWorktreeDataStore = create<WorktreeDataStore>()((set, get) => ({
           const next = new Map(prev.worktrees);
           next.set(data.worktreeId, {
             ...worktree,
+            issueNumber: data.issueNumber,
             issueTitle: data.issueTitle,
+          });
+          return { worktrees: next };
+        });
+      });
+
+      const unsubIssueNotFound = githubClient.onIssueNotFound((data) => {
+        set((prev) => {
+          const worktree = prev.worktrees.get(data.worktreeId);
+          if (!worktree) return prev;
+          if (worktree.issueNumber !== data.issueNumber) return prev;
+
+          const next = new Map(prev.worktrees);
+          next.set(data.worktreeId, {
+            ...worktree,
+            issueNumber: undefined,
+            issueTitle: undefined,
           });
           return { worktrees: next };
         });
@@ -198,6 +215,7 @@ export const useWorktreeDataStore = create<WorktreeDataStore>()((set, get) => ({
         unsubPRDetected();
         unsubPRCleared();
         unsubIssueDetected();
+        unsubIssueNotFound();
       };
     }
 


### PR DESCRIPTION
## Summary

When a worktree branch contains an issue number (e.g. `feature/issue-2348-foo`) but the GitHub API confirms that issue doesn't exist on the current repository, the issue badge is now hidden. Previously the badge would show indefinitely with just the issue number and no title, even when GitHub had confirmed the issue didn't belong to the repo.

Closes #2348

## Changes Made

- Add `IssueNotFoundPayload` type to shared IPC types
- Add `sys:issue:not-found` event to `CanopyEventMap`, `EVENT_META`, and `ALL_EVENT_TYPES` in `events.ts`
- Emit `sys:issue:not-found` from `PullRequestService` when an issue number is present but GitHub returns no title (confirmed absence, not network error)
- Add `issue-not-found` workspace-host message type and `ISSUE_NOT_FOUND` IPC channel
- Handle `sys:issue:not-found` in `WorkspaceService` — guards by `issueNumber` match to prevent stale events, clears monitor `issueNumber`/`issueTitle`, forwards via IPC
- Handle `issue-not-found` in `WorkspaceClient` — forwards to renderer via `ISSUE_NOT_FOUND` channel
- Expose `onIssueNotFound` in preload and `ElectronAPI` type
- Add `onIssueNotFound` to `githubClient` and wire into `worktreeDataStore`
- Guard `onIssueNotFound` handler to only clear when `issueNumber` matches current worktree (prevents stale/out-of-order events from clearing a different, valid issue)
- Also set `issueNumber` in `onIssueDetected` handler for consistency (previously only updated `issueTitle`)
- Add 2 new tests: mismatched `issueNumber` is ignored, `issue-detected` now sets `issueNumber`