### PR TITLE
fix(dev-preview): run package manager install when missing deps detected

### DIFF
--- a/shared/utils/__tests__/devServerErrors.test.ts
+++ b/shared/utils/__tests__/devServerErrors.test.ts
@@ -51,7 +51,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependency: vite. Installing dependencies...",
+          message: "Missing dependency: vite",
           module: "vite",
         });
       });
@@ -61,7 +61,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependencies detected. Installing...",
+          message: "Missing dependencies detected",
           module: undefined,
         });
       });
@@ -71,7 +71,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependencies detected. Installing...",
+          message: "Missing dependencies detected",
           module: undefined,
         });
       });
@@ -81,7 +81,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependency: react. Installing dependencies...",
+          message: "Missing dependency: react",
           module: "react",
         });
       });
@@ -91,7 +91,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependencies detected. Installing...",
+          message: "Missing dependencies detected",
           module: undefined,
         });
       });
@@ -101,7 +101,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependency: node-pty. Installing dependencies...",
+          message: "Missing dependency: node-pty",
           module: "node-pty",
         });
       });
@@ -112,7 +112,7 @@ describe("devServerErrors", () => {
         const error = detectDevServerError(output);
         expect(error).toEqual({
           type: "missing-dependencies",
-          message: "Missing dependencies detected. Installing...",
+          message: "Missing dependencies detected",
           module: undefined,
         });
       });

--- a/shared/utils/devServerErrors.ts
+++ b/shared/utils/devServerErrors.ts
@@ -64,8 +64,8 @@ export function detectDevServerError(output: string): DevServerError | null {
       return {
         type: "missing-dependencies",
         message: module
-          ? `Missing dependency: ${module}. Installing dependencies...`
-          : "Missing dependencies detected. Installing...",
+          ? `Missing dependency: ${module}`
+          : "Missing dependencies detected",
         module,
       };
     }


### PR DESCRIPTION
## Summary

When Dev Preview detects a `ERR_MODULE_NOT_FOUND` or similar missing-dependencies error, the status changed to "Installing" but nothing was ever installed. This fix wires up the actual install: a new PTY terminal is spawned, the correct package manager install command is submitted, and the dev command is automatically restarted after a successful install.

Closes #2349

## Changes Made

- **`DevPreviewSessionService`**: Add `runInstall()` method that spawns a PTY terminal, detects the package manager from lock files, submits the install command, then restarts the dev server on success (or transitions to `error` on failure)
- **Package manager detection**: Checks for `bun.lockb` → `bun install`, `pnpm-lock.yaml` → `pnpm install`, `yarn.lock` → `yarn install`, defaults to `npm install`
- **Install loop guard**: `installAttemptedGeneration` prevents re-attempting install more than once per session generation
- **State safety**: Install flags cleared in dead-terminal recovery path and on `running` transition to prevent stale-flag misclassification
- **No false positives during install**: Error pattern scanning skipped while install terminal is active
- **Frontend**: Remove `installing` auto-recovery timeout — backend now owns the full install lifecycle; simplify `autoRecoveryAttemptsRef` to only track `starting`
- **`devServerErrors.ts`**: Remove misleading "Installing dependencies..." suffix from error messages (install was never actually running)
- **Tests**: Update `devServerErrors` test assertions and adversarial `useDevServer` test to reflect the new backend-driven install behavior