### PR TITLE
perf(terminal): optimize container for xterm v6 overlay scrollbar

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -423,7 +423,7 @@ function XtermAdapterComponent({
         "w-full h-full text-white overflow-hidden bg-canopy-bg",
         // In normal buffer mode: apply padding and rounded corners
         // In alt buffer mode (TUI apps like OpenCode, vim, htop): remove padding for tight full-screen fit
-        !isAltBuffer && "pl-3 pt-3 pb-3 pr-4 rounded-b-[var(--radius-lg)]",
+        !isAltBuffer && "pl-3 pt-3 pb-3 pr-3 rounded-b-[var(--radius-lg)]",
         className
       )}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -328,6 +328,14 @@
     font-family: "JetBrains Mono", monospace;
   }
 
+  /* Hide native viewport scrollbar — xterm v6 provides its own overlay scrollbar */
+  .xterm .xterm-viewport {
+    scrollbar-width: none;
+  }
+  .xterm .xterm-viewport::-webkit-scrollbar {
+    display: none;
+  }
+
   /* Consistent monospace font stack */
   code,
   kbd,

--- a/src/utils/terminalTheme.ts
+++ b/src/utils/terminalTheme.ts
@@ -22,6 +22,9 @@ const CANOPY_TERMINAL_THEME_FALLBACK = {
   brightMagenta: "#c084fc",
   brightCyan: "#67e8f9",
   brightWhite: "#fafafa",
+  scrollbarSliderBackground: "rgba(82, 82, 91, 0.4)",
+  scrollbarSliderHoverBackground: "rgba(82, 82, 91, 0.6)",
+  scrollbarSliderActiveBackground: "rgba(82, 82, 91, 0.8)",
 };
 
 export const CANOPY_TERMINAL_THEME = CANOPY_TERMINAL_THEME_FALLBACK;
@@ -75,5 +78,8 @@ export function getTerminalThemeFromCSS(): typeof CANOPY_TERMINAL_THEME_FALLBACK
     brightMagenta: "#c084fc",
     brightCyan: "#67e8f9",
     brightWhite: "#fafafa",
+    scrollbarSliderBackground: "rgba(82, 82, 91, 0.4)",
+    scrollbarSliderHoverBackground: "rgba(82, 82, 91, 0.6)",
+    scrollbarSliderActiveBackground: "rgba(82, 82, 91, 0.8)",
   };
 }


### PR DESCRIPTION
## Summary

Fixes three related issues with the terminal container now that xterm v6 ships its own `DomScrollableElement` overlay scrollbar instead of relying on the native browser scrollbar.

Closes #2355

## Changes Made

- **Symmetric padding** (`XtermAdapter.tsx`): Changed `pr-4` (16px) to `pr-3` (12px) — the extra 4px was reserved for a layout-consuming scrollbar that no longer exists in xterm v6. All four sides now use 12px padding.
- **Hide native viewport scrollbar** (`index.css`): Added `scrollbar-width: none` and `::-webkit-scrollbar { display: none }` on `.xterm .xterm-viewport` to suppress the duplicate native scrollbar. xterm v6's overlay scrollbar renders instead.
- **Theme scrollbar colors** (`terminalTheme.ts`): Added `scrollbarSliderBackground`, `scrollbarSliderHoverBackground`, and `scrollbarSliderActiveBackground` to both `CANOPY_TERMINAL_THEME_FALLBACK` and `getTerminalThemeFromCSS()` so the custom overlay scrollbar matches the app's `--color-state-idle` color palette at 40/60/80% opacity.