### PR TITLE
feat(preferences): scope last-selected worktree recipe per project

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -74,9 +74,11 @@ export function NewWorktreeDialog({
 
   const assignWorktreeToSelf = usePreferencesStore((s) => s.assignWorktreeToSelf);
   const setAssignWorktreeToSelf = usePreferencesStore((s) => s.setAssignWorktreeToSelf);
-  const lastSelectedWorktreeRecipeId = usePreferencesStore((s) => s.lastSelectedWorktreeRecipeId);
-  const setLastSelectedWorktreeRecipeId = usePreferencesStore(
-    (s) => s.setLastSelectedWorktreeRecipeId
+  const lastSelectedWorktreeRecipeIdByProject = usePreferencesStore(
+    (s) => s.lastSelectedWorktreeRecipeIdByProject
+  );
+  const setLastSelectedWorktreeRecipeIdByProject = usePreferencesStore(
+    (s) => s.setLastSelectedWorktreeRecipeIdByProject
   );
   const githubConfig = useGitHubConfigStore((s) => s.config);
   const initializeGitHubConfig = useGitHubConfigStore((s) => s.initialize);
@@ -84,6 +86,8 @@ export function NewWorktreeDialog({
   const addNotification = useNotificationStore((s) => s.addNotification);
   const { recipes, runRecipe, loadRecipes } = useRecipeStore();
   const currentProject = useProjectStore((s) => s.currentProject);
+  const projectId = currentProject?.id ?? "";
+  const lastSelectedWorktreeRecipeId = lastSelectedWorktreeRecipeIdByProject[projectId];
 
   const currentUser = githubConfig?.username;
   const currentUserAvatar = githubConfig?.avatarUrl;
@@ -130,6 +134,7 @@ export function NewWorktreeDialog({
 
   useEffect(() => {
     if (!isOpen) return;
+    if (!projectId) return;
     if (globalRecipes.length === 0) return;
     if (recipeSelectionTouchedRef.current) return;
 
@@ -144,7 +149,7 @@ export function NewWorktreeDialog({
         setSelectedRecipeId(lastSelectedWorktreeRecipeId);
       } else {
         // Previously selected recipe no longer exists - clear it and fall back to default
-        setLastSelectedWorktreeRecipeId(undefined);
+        if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, undefined);
         if (defaultRecipeId && globalRecipes.some((r) => r.id === defaultRecipeId)) {
           setSelectedRecipeId(defaultRecipeId);
         }
@@ -158,7 +163,8 @@ export function NewWorktreeDialog({
     globalRecipes,
     lastSelectedWorktreeRecipeId,
     defaultRecipeId,
-    setLastSelectedWorktreeRecipeId,
+    projectId,
+    setLastSelectedWorktreeRecipeIdByProject,
   ]);
 
   useEffect(() => {
@@ -166,8 +172,8 @@ export function NewWorktreeDialog({
     if (globalRecipes.some((recipe) => recipe.id === selectedRecipeId)) return;
     // Selected recipe no longer exists - clear both local and persisted state
     setSelectedRecipeId(null);
-    setLastSelectedWorktreeRecipeId(undefined);
-  }, [globalRecipes, selectedRecipeId, setLastSelectedWorktreeRecipeId]);
+    if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, undefined);
+  }, [globalRecipes, selectedRecipeId, projectId, setLastSelectedWorktreeRecipeIdByProject]);
 
   const newBranchInputRef = useRef<HTMLInputElement>(null);
   const branchInputRef = useRef<HTMLInputElement>(null);
@@ -1075,14 +1081,16 @@ export function NewWorktreeDialog({
                               event.preventDefault();
                               recipeSelectionTouchedRef.current = true;
                               setSelectedRecipeId(null);
-                              setLastSelectedWorktreeRecipeId(null);
+                              if (projectId)
+                                setLastSelectedWorktreeRecipeIdByProject(projectId, null);
                               setRecipePickerOpen(false);
                             }
                           }}
                           onClick={() => {
                             recipeSelectionTouchedRef.current = true;
                             setSelectedRecipeId(null);
-                            setLastSelectedWorktreeRecipeId(null);
+                            if (projectId)
+                              setLastSelectedWorktreeRecipeIdByProject(projectId, null);
                             setRecipePickerOpen(false);
                           }}
                           className={cn(
@@ -1106,14 +1114,16 @@ export function NewWorktreeDialog({
                                 event.preventDefault();
                                 recipeSelectionTouchedRef.current = true;
                                 setSelectedRecipeId(recipe.id);
-                                setLastSelectedWorktreeRecipeId(recipe.id);
+                                if (projectId)
+                                  setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
                                 setRecipePickerOpen(false);
                               }
                             }}
                             onClick={() => {
                               recipeSelectionTouchedRef.current = true;
                               setSelectedRecipeId(recipe.id);
-                              setLastSelectedWorktreeRecipeId(recipe.id);
+                              if (projectId)
+                                setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
                               setRecipePickerOpen(false);
                             }}
                             className={cn(

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -28,8 +28,11 @@ interface PreferencesState {
   setShowDeveloperTools: (show: boolean) => void;
   assignWorktreeToSelf: boolean;
   setAssignWorktreeToSelf: (value: boolean) => void;
-  lastSelectedWorktreeRecipeId: string | null | undefined;
-  setLastSelectedWorktreeRecipeId: (id: string | null | undefined) => void;
+  lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>;
+  setLastSelectedWorktreeRecipeIdByProject: (
+    projectId: string,
+    id: string | null | undefined
+  ) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -41,12 +44,31 @@ export const usePreferencesStore = create<PreferencesState>()(
       setShowDeveloperTools: (show) => set({ showDeveloperTools: show }),
       assignWorktreeToSelf: false,
       setAssignWorktreeToSelf: (value) => set({ assignWorktreeToSelf: value }),
-      lastSelectedWorktreeRecipeId: undefined,
-      setLastSelectedWorktreeRecipeId: (id) => set({ lastSelectedWorktreeRecipeId: id }),
+      lastSelectedWorktreeRecipeIdByProject: {},
+      setLastSelectedWorktreeRecipeIdByProject: (projectId, id) =>
+        set((state) => ({
+          lastSelectedWorktreeRecipeIdByProject: {
+            ...state.lastSelectedWorktreeRecipeIdByProject,
+            [projectId]: id,
+          },
+        })),
     }),
     {
       name: "canopy-preferences",
       storage: createJSONStorage(() => getSafeStorage()),
+      version: 1,
+      migrate: (persisted, version) => {
+        if (version === 0 || version === undefined) {
+          if (persisted && typeof persisted === "object") {
+            const state = persisted as Record<string, unknown>;
+            delete state.lastSelectedWorktreeRecipeId;
+            state.lastSelectedWorktreeRecipeIdByProject = {};
+          } else {
+            return { lastSelectedWorktreeRecipeIdByProject: {} } as PreferencesState;
+          }
+        }
+        return persisted as PreferencesState;
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary

The "Run recipe" selection in the Create Worktree dialog was stored as a single global value, causing it to be lost when switching between projects with different recipe sets. This PR scopes the preference per-project so each project independently remembers its last-chosen recipe.

Closes #2359

## Changes Made

- **`src/store/preferencesStore.ts`**: Renamed `lastSelectedWorktreeRecipeId: string | null | undefined` to `lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>`. Added `setLastSelectedWorktreeRecipeIdByProject(projectId, id)` setter that merges into the record. Bumped persist `version` to `1` with a `migrate` function that handles old flat format, unversioned payloads, and null/corrupt stored state.
- **`src/components/Worktree/NewWorktreeDialog.tsx`**: Derived `projectId` from `useProjectStore` and replaced all reads/writes of the flat preference with per-project lookups. Added `if (!projectId) return` early exit in the recipe initialisation effect to prevent reads from the `""` bucket before a project loads. Added `if (projectId)` guards to all click/keydown handler persistence calls.