### PR TITLE
fix(terminal): forward Enter key to agent terminal when input is empty

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -707,6 +707,12 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               return true;
             }
 
+            const text = editorViewRef.current?.state.doc.toString() ?? latest.value;
+            if (text.trim().length === 0) {
+              if (latest.onSendKey) latest.onSendKey("enter");
+              return true;
+            }
+
             queueSend();
             return true;
           },
@@ -786,6 +792,17 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             }
 
             if (latest.disabled) return true;
+
+            const text = editorViewRef.current?.state.doc.toString() ?? latest.value;
+            if (text.trim().length === 0) {
+              handledEnterRef.current = true;
+              setTimeout(() => {
+                handledEnterRef.current = false;
+              }, 0);
+
+              if (latest.onSendKey) latest.onSendKey("enter");
+              return true;
+            }
 
             handledEnterRef.current = true;
             setTimeout(() => {


### PR DESCRIPTION
## Summary

When the hybrid input bar is empty and the user presses Enter, the keystroke was silently discarded instead of being forwarded to the active agent terminal. This blocked agents waiting for confirmation prompts (e.g. `Press Enter to continue`, `y/N`, pagers like `less`).

Closes #2362

## Changes Made

- Added empty-input guard in the `onEnter` CodeMirror keymap handler: when the input is empty and `onSendKey` is available, calls `onSendKey("enter")` and returns `true` — mirroring the existing arrow-key pass-through pattern
- Added the same guard in the `beforeinput` DOM event handler to prevent double-firing across both code paths
- When input is empty, the keypress is now consumed (`return true`) even if `onSendKey` is absent, so empty Enter never falls through to the RAF send queue
- The `resolveKeySequence` in `PtyClient` already maps `"enter"` → `"\r"`, so no backend changes were needed