### PR TITLE
build(mac): add spawn-helper to mac.binaries for explicit code signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,9 @@
     "mac": {
       "forceCodeSigning": true,
       "notarize": false,
+      "binaries": [
+        "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper"
+      ],
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",
       "extendInfo": {


### PR DESCRIPTION
## Summary

Adds `spawn-helper` to the `mac.binaries` array in `package.json` so electron-builder explicitly code-signs this extensionless Mach-O binary during the macOS signing pass.

Closes #2369

## Changes Made

- Add `binaries` array to `build.mac` in `package.json` with the bundle-root-relative path `Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper`

## Why this matters

electron-builder's auto-signer detects binaries by extension (`.node`, `.dylib`, `.so`). `spawn-helper` has no extension, so it is silently skipped. Apple's notarization service inspects every Mach-O binary in the bundle and rejects submissions that contain any unsigned binary. Without this fix, re-enabling notarization would fail with a "binary is not signed with a valid Developer ID certificate" error for `spawn-helper`.

The path is relative to the app bundle root (not the project root), which is the format required by electron-builder's `mac.binaries` field.