### PR TITLE
fix(build): disable source maps in production to prevent source exposure

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "concurrently -k \"npm run watch:main\" \"vite\" \"wait-on dist-electron/electron/main.js && npm run dev:electron\"",
     "dev:vite": "vite",
     "dev:electron": "nodemon --delay 500ms --watch dist-electron --ext js --exec \"cross-env NODE_ENV=development electron .\"",
-    "build:main": "node scripts/build-main.mjs",
+    "build:main": "cross-env NODE_ENV=production node scripts/build-main.mjs",
     "watch:main": "node scripts/build-main.mjs --watch",
     "build": "tsc && vite build && npm run build:main",
     "package": "npm run build && electron-builder",

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -31,6 +31,13 @@ const common = {
 async function run() {
   console.log(`[Build] Starting build in ${isWatch ? "watch" : "single"} mode...`);
 
+  if (isProd && !isWatch) {
+    const electronOutDir = path.join(root, "dist-electron/electron");
+    if (fs.existsSync(electronOutDir)) {
+      fs.rmSync(electronOutDir, { recursive: true, force: true });
+    }
+  }
+
   // Config for ESM files (Main, Hosts)
   const esmConfig = {
     ...common,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,7 +89,7 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
-    sourcemap: true,
+    sourcemap: false,
     rollupOptions: {
       output: {
         manualChunks(id) {


### PR DESCRIPTION
## Summary

Prevents full TypeScript source code from being recoverable from distributed production builds by disabling JavaScript source maps. Without this fix, anyone who extracted the app ASAR could recover the complete readable source.

Closes #2373

## Changes Made

- **`vite.config.ts`**: Changed `sourcemap: true` → `sourcemap: false` in the renderer (Vite) build config
- **`package.json`**: Added `cross-env NODE_ENV=production` to the `build:main` script so esbuild's existing `sourcemap: !isProd` guard correctly activates
- **`scripts/build-main.mjs`**: Added a clean step that removes `dist-electron/electron` before production builds, preventing stale `.map` artifacts from a prior dev build being packaged