### PR TITLE
fix(build): add x64ArchFiles to prevent lipo errors on node-pty universal builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,7 @@
     },
     "afterPack": "./scripts/afterPack.cjs",
     "mac": {
+      "x64ArchFiles": "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/**",
       "forceCodeSigning": true,
       "notarize": false,
       "category": "public.app-category.developer-tools",


### PR DESCRIPTION
## Summary

Adds `x64ArchFiles` to `build.mac` in `package.json` to prevent `@electron/universal` from attempting to re-merge node-pty's already-universal Mach-O binaries during the universal macOS build.

Closes #2370

## Changes Made

- Add `x64ArchFiles` glob (`Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/**`) to `build.mac`
- This covers both `pty.node` and `spawn-helper` — the two native binaries electron-rebuild compiles as universal Mach-O
- Without this, `lipo` fails with "fat file already has ARM64 architecture" when attempting to merge two universal slices