### PR TITLE
fix(electron): fix critical path handling and environment bugs for Windows

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -54,7 +54,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     const projectId = currentProject?.id;
     const projectPath = currentProject?.path;
 
-    let cwd = validatedOptions.cwd || projectPath || process.env.HOME || os.homedir();
+    let cwd = validatedOptions.cwd || projectPath || os.homedir();
 
     const fs = await import("fs");
     const path = await import("path");

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -10,6 +10,7 @@ import {
   session,
 } from "electron";
 import path from "path";
+import { existsSync } from "fs";
 import { fileURLToPath, pathToFileURL } from "url";
 import os from "os";
 import { randomBytes } from "crypto";
@@ -25,6 +26,22 @@ import {
 } from "./utils/performance.js";
 
 fixPath();
+
+if (process.platform === "win32") {
+  const extraPaths = [
+    path.join(os.homedir(), "AppData", "Local", "Programs", "Git", "cmd"),
+    "C:\\Program Files\\Git\\cmd",
+    path.join(os.homedir(), ".local", "bin"),
+  ];
+  const current = process.env.PATH || "";
+  const existingEntries = current.split(path.delimiter).map((e) => e.toLowerCase());
+  const missing = extraPaths.filter(
+    (p) => !existingEntries.includes(p.toLowerCase()) && existsSync(p)
+  );
+  if (missing.length) {
+    process.env.PATH = [...missing, current].join(path.delimiter);
+  }
+}
 
 app.enableSandbox();
 
@@ -903,7 +920,7 @@ async function createWindow(): Promise<void> {
     console.log("[MAIN] Spawning default terminal...");
     try {
       ptyClient.spawn(DEFAULT_TERMINAL_ID, {
-        cwd: process.env.HOME || os.homedir(),
+        cwd: os.homedir(),
         cols: 80,
         rows: 30,
         projectId: currentProjectId ?? undefined,

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1271,7 +1271,7 @@ async function initialize(): Promise<void> {
     console.log("[PtyHost] Initialized and ready (accepting IPC)");
 
     ptyPool = getPtyPool({ poolSize: 2 });
-    const homedir = process.env.HOME || os.homedir();
+    const homedir = os.homedir();
 
     // Warm pool in background
     ptyPool

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -260,7 +260,7 @@ export class PtyPool {
   }
 
   private getDefaultCwd(): string {
-    return process.env.HOME || os.homedir();
+    return os.homedir();
   }
 
   private getFilteredEnv(): Record<string, string> {

--- a/electron/utils/gitUtils.ts
+++ b/electron/utils/gitUtils.ts
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import { join as pathJoin } from "path";
+import { isAbsolute, join as pathJoin } from "path";
 import { logWarn } from "./logger.js";
 
 const gitDirCache = new Map<string, string | null>();
@@ -26,7 +26,7 @@ export function getGitDir(worktreePath: string, options: GitDirOptions = {}): st
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
 
-    const resolved = result.startsWith("/") ? result : pathJoin(worktreePath, result);
+    const resolved = isAbsolute(result) ? result : pathJoin(worktreePath, result);
 
     if (cache) {
       gitDirCache.set(worktreePath, resolved);


### PR DESCRIPTION
## Summary

Fixes three small but critical bugs that caused Windows to misidentify paths and miss the user's home directory, breaking core functionality.

Closes #2382

## Changes Made

- **`electron/utils/gitUtils.ts`** — Replace `result.startsWith("/")` with `path.isAbsolute()` for correct absolute path detection on Windows (drive-letter `C:\...` and UNC `\\server\share` paths are now handled correctly)
- **`electron/main.ts`** — Remove `process.env.HOME` from default terminal spawn `cwd`; use `os.homedir()` directly. Add Windows PATH augmentation block after `fixPath()` that prepends known Git-for-Windows install locations (`AppData/Local/Programs/Git/cmd`, `C:\Program Files\Git\cmd`) when they exist on disk, using entry-level case-normalised dedup to avoid false matches
- **`electron/ipc/handlers/terminal/lifecycle.ts`** — Remove `process.env.HOME` fallback; use `os.homedir()` directly (cross-platform)
- **`electron/services/PtyPool.ts`** — Remove `process.env.HOME` fallback in `getDefaultCwd()`
- **`electron/pty-host.ts`** — Remove `process.env.HOME` fallback when warming the PTY pool