### PR TITLE
fix(linux): fix clipboard URI format and inotify ENOSPC handling

### DIFF
--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -1,6 +1,7 @@
 import { ipcMain, clipboard } from "electron";
 import crypto from "crypto";
 import path from "path";
+import { pathToFileURL } from "url";
 import { CHANNELS } from "../channels.js";
 import { sendToRenderer, checkRateLimit } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
@@ -304,7 +305,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       } else if (process.platform === "win32") {
         clipboard.writeText(filePath);
       } else {
-        clipboard.writeBuffer("text/uri-list", Buffer.from(`file://${filePath}`, "utf8"));
+        clipboard.writeBuffer(
+          "text/uri-list",
+          Buffer.from(pathToFileURL(filePath).href + "\r\n", "utf8")
+        );
       }
 
       console.log(`[${traceId}] Copied context file to clipboard: ${filePath}`);


### PR DESCRIPTION
## Summary

Fixes three Linux-specific runtime bugs: malformed clipboard file URIs, silent inotify limit exhaustion, and incomplete error guidance when file watching fails.

Closes #2389

## Changes Made

- Use `pathToFileURL()` from Node's `url` module for correct `file:///` URI format in `text/uri-list` clipboard buffer, fixing file paste into Nautilus, Dolphin, and Thunar
- Add RFC 2483-required CRLF terminator (`\r\n`) to each `text/uri-list` entry
- Detect `ENOSPC` on Linux `fs.watch` errors and emit an actionable log message with both the transient `sysctl -w` fix and the persistent `/etc/sysctl.d` approach
- Also mention `fs.inotify.max_user_instances` in the guidance (the second common inotify limit)
- Close and remove the broken watcher from the internal watchers array on `ENOSPC` to avoid dangling state
- Cover the synchronous `ENOSPC` throw path in the `startWorktreeWatcher` catch block with the same user-actionable message
- Reverted an overly broad Linux auto-updater guard — `electron-updater` 6.8.3 ships `DebUpdater` with native dpkg/apt support, so the `!APPIMAGE` guard was not needed and would have broken `.deb` auto-updates