### PR TITLE
fix(shell): prefer PowerShell over cmd.exe on Windows

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -11,6 +11,7 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { TerminalSpawnOptions } from "../../../types/index.js";
 import { TerminalSpawnOptionsSchema } from "../../../schemas/ipc.js";
+import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 
 export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -130,12 +131,9 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           const isAgent = kind === "agent" || Boolean(agentId);
           if (isAgent) {
             if (process.platform === "win32") {
-              const shell = (
-                validatedOptions.shell ||
-                process.env.COMSPEC ||
-                "powershell.exe"
-              ).toLowerCase();
-              if (shell.includes("cmd")) {
+              const shell = (validatedOptions.shell || getDefaultShell()).toLowerCase();
+              const shellBasename = shell.split(/[\\/]/).pop() ?? shell;
+              if (shellBasename === "cmd.exe" || shellBasename === "cmd") {
                 finalCommand = `${trimmedCommand} & exit`;
               } else {
                 finalCommand = `${trimmedCommand}; exit`;

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -1,7 +1,7 @@
 import * as pty from "node-pty";
 import type { IDisposable } from "node-pty";
-import { existsSync } from "fs";
 import os from "os";
+import { getDefaultShell, getDefaultShellArgs } from "./pty/terminalShell.js";
 
 export interface PtyPoolConfig {
   poolSize?: number;
@@ -28,7 +28,7 @@ export class PtyPool {
   constructor(config: PtyPoolConfig = {}) {
     this.poolSize = this.resolvePoolSize(config.poolSize);
     this.defaultCwd = this.resolveCwd(config.defaultCwd, this.getDefaultCwd());
-    this.defaultShell = this.getDefaultShell();
+    this.defaultShell = getDefaultShell();
   }
 
   async warmPool(cwd?: string): Promise<void> {
@@ -68,7 +68,7 @@ export class PtyPool {
     try {
       const id = `pool-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
-      const ptyProcess = pty.spawn(this.defaultShell, this.getDefaultShellArgs(), {
+      const ptyProcess = pty.spawn(this.defaultShell, getDefaultShellArgs(this.defaultShell), {
         name: "xterm-256color",
         cols: 80,
         rows: 24,
@@ -222,41 +222,6 @@ export class PtyPool {
 
     this.pool.clear();
     console.log("[PtyPool] Disposed");
-  }
-
-  private getDefaultShell(): string {
-    if (process.platform === "win32") {
-      return process.env.COMSPEC || "powershell.exe";
-    }
-
-    if (process.env.SHELL) {
-      return process.env.SHELL;
-    }
-
-    const commonShells = ["/bin/zsh", "/bin/bash", "/bin/sh"];
-    for (const shell of commonShells) {
-      try {
-        if (existsSync(shell)) {
-          return shell;
-        }
-      } catch {
-        // ignore
-      }
-    }
-
-    return "/bin/sh";
-  }
-
-  private getDefaultShellArgs(): string[] {
-    const shellName = this.defaultShell.toLowerCase();
-
-    if (process.platform !== "win32") {
-      if (shellName.includes("zsh") || shellName.includes("bash")) {
-        return ["-l"];
-      }
-    }
-
-    return [];
   }
 
   private getDefaultCwd(): string {

--- a/electron/services/pty/terminalShell.ts
+++ b/electron/services/pty/terminalShell.ts
@@ -1,12 +1,25 @@
 import { existsSync } from "fs";
+import { execFileSync } from "child_process";
 
 export interface ShellArgsOptions {
   nonInteractive?: boolean;
 }
 
+export function findWindowsShell(): string {
+  for (const shell of ["pwsh.exe", "powershell.exe"]) {
+    try {
+      execFileSync("where", [shell], { stdio: "ignore", timeout: 3000 });
+      return shell;
+    } catch {
+      // not on PATH or timed out, try next
+    }
+  }
+  return process.env.COMSPEC || "cmd.exe";
+}
+
 export function getDefaultShell(): string {
   if (process.platform === "win32") {
-    return process.env.COMSPEC || "powershell.exe";
+    return findWindowsShell();
   }
 
   if (process.env.SHELL) {


### PR DESCRIPTION
## Summary

Fixes Windows shell detection so new terminals prefer modern PowerShell over `cmd.exe`. Previously `getDefaultShell()` always returned the value of `COMSPEC` (which is always `C:\Windows\System32\cmd.exe`), so the `powershell.exe` fallback was never reached.

Closes #2384

## Changes Made

- **`terminalShell.ts`**: Add `findWindowsShell()` that probes `pwsh.exe` → `powershell.exe` → `COMSPEC`/`cmd.exe` using `execFileSync("where")` with a 3-second timeout to prevent blocking the event loop on a hung PATH lookup
- **`terminalShell.ts`**: Update `getDefaultShell()` on `win32` to call `findWindowsShell()` instead of returning `COMSPEC` directly
- **`PtyPool.ts`**: Remove duplicate shell-detection methods; import shared `getDefaultShell`/`getDefaultShellArgs` from `terminalShell`
- **`lifecycle.ts`**: Fix agent exit-suffix classification to use basename exact-match (`cmd.exe`/`cmd`) instead of brittle `shell.includes("cmd")` — prevents false positives on paths with "cmd" in directory names
- **Tests**: Add probe-order coverage for `findWindowsShell()`, switch to `vi.resetAllMocks()` for proper mock isolation, update assertions to include `timeout: 3000`