### PR TITLE
fix(project-store): resolve variable shadowing causing non-absolute path in git init dialog

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -181,10 +181,12 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       if (errorMessage.includes("Not a git repository")) {
-        const resolvedPath = path.trim() || errorMessage.match(/Not a git repository: (.+)/)?.[1];
-        if (resolvedPath) {
+        const gitInitPath =
+          resolvedPath || path.trim() || errorMessage.match(/Not a git repository: (.+)/)?.[1];
+        const isAbsolutePath = (p: string) => p.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(p);
+        if (gitInitPath && isAbsolutePath(gitInitPath)) {
           set({ isLoading: false });
-          get().openGitInitDialog(resolvedPath);
+          get().openGitInitDialog(gitInitPath);
           return;
         }
       }


### PR DESCRIPTION
## Summary

Fixes a variable shadowing bug in `addProjectByPath` where the git init dialog received a non-absolute (or undefined) path when opening a project via the folder picker.

Closes #2403

## Changes Made

- **`src/store/projectStore.ts`**: Rename inner `const resolvedPath` to `gitInitPath` in the "Not a git repository" catch block to eliminate shadowing of the outer `let resolvedPath` that holds the dialog-selected absolute path. Prioritize `resolvedPath` (outer, absolute) first, then `path.trim()`, then regex fallback. Add an absolute-path guard before calling `openGitInitDialog` to prevent IPC failure with a non-absolute path.
- **`src/store/__tests__/projectStore.addProject.test.ts`**: Add regression test covering the dialog-based open flow with a bare "Not a git repository" error message (no path embedded) — verifies `openGitInitDialog` receives the dialog-selected absolute path. Add test verifying that a non-absolute `gitInitPath` falls through to the error notification rather than opening the dialog.