### PR TITLE
feat(quickrun): auto-restart terminal command on exit

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -705,6 +705,8 @@ export interface TerminalSnapshot {
   scope?: "worktree" | "project";
   /** Note creation timestamp (kind === 'notes') */
   createdAt?: number;
+  /** Behavior when terminal exits */
+  exitBehavior?: PanelExitBehavior;
   // Note: Tab membership is now stored in ProjectState.tabGroups, not on terminals
 }
 
@@ -760,7 +762,7 @@ export interface ProjectState {
 export type RecipeTerminalType = AgentId | "terminal" | "dev-preview";
 
 /** Exit behavior for panels/terminals after process exits */
-export type PanelExitBehavior = "keep" | "trash" | "remove";
+export type PanelExitBehavior = "keep" | "trash" | "remove" | "restart";
 
 /** A single terminal definition within a recipe */
 export interface RecipeTerminal {

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -84,6 +84,8 @@ export interface TerminalState {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Behavior when terminal exits */
+  exitBehavior?: import("../domain.js").PanelExitBehavior;
 }
 
 /** Terminal data payload for IPC */

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -12,7 +12,8 @@ function cloneTerminal(t: RecipeTerminal): RecipeTerminal {
 
 function normalizeExitBehavior(t: RecipeTerminal): "" | "keep" | "trash" | "remove" {
   const value = t.exitBehavior ?? "";
-  if (!value) return "";
+  // "restart" is QuickRun-only and not exposed in recipe UI — treat as default
+  if (!value || value === "restart") return "";
   const defaultBehavior = t.type === "terminal" || t.type === "dev-preview" ? "trash" : "keep";
   return value === defaultBehavior ? "" : value;
 }

--- a/src/store/persistence/terminalPersistence.ts
+++ b/src/store/persistence/terminalPersistence.ts
@@ -36,6 +36,7 @@ export function terminalToSnapshot(t: TerminalInstance): TerminalSnapshot {
       ...(t.devPreviewConsoleOpen !== undefined && {
         devPreviewConsoleOpen: t.devPreviewConsoleOpen,
       }),
+      ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
     };
   }
 
@@ -46,6 +47,7 @@ export function terminalToSnapshot(t: TerminalInstance): TerminalSnapshot {
       agentId: t.agentId,
       cwd: t.cwd,
       command: t.command?.trim() || undefined,
+      ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
     };
   } else if (t.kind === "notes") {
     return {

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -655,8 +655,10 @@ export function setupTerminalStoreListeners() {
       return;
     }
 
-    if (terminal.exitBehavior === "keep") {
-      // Explicit keep - preserve terminal regardless of type
+    if (terminal.exitBehavior === "keep" || terminal.exitBehavior === "restart") {
+      // "keep": preserve terminal for review
+      // "restart": preserve terminal; TerminalPane triggers the restart via its exit effect
+      // Note: non-zero exits are already preserved above, so this only matters for exit code 0
       return;
     }
 

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -199,6 +199,7 @@ export interface HydrationOptions {
     devServerError?: { type: string; message: string } | null;
     devServerTerminalId?: string | null;
     devPreviewConsoleOpen?: boolean;
+    exitBehavior?: import("@shared/types/domain").PanelExitBehavior;
   }) => Promise<string>;
   setActiveWorktree: (id: string | null) => void;
   loadRecipes: (projectId: string) => Promise<void>;
@@ -428,6 +429,7 @@ export async function hydrateAppState(
                   browserHistory: isDevPreview ? saved.browserHistory : undefined,
                   browserZoom: isDevPreview ? saved.browserZoom : undefined,
                   devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+                  exitBehavior: saved.exitBehavior,
                 });
 
                 // Initialize frontend tier state from backend to ensure proper wake behavior
@@ -613,6 +615,7 @@ export async function hydrateAppState(
                       browserHistory: isDevPreview ? saved.browserHistory : undefined,
                       browserZoom: isDevPreview ? saved.browserZoom : undefined,
                       devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+                      exitBehavior: saved.exitBehavior,
                     });
 
                     // Initialize frontend tier state from backend
@@ -729,7 +732,7 @@ export async function hydrateAppState(
                       location,
                       // Don't reuse ID on timeout - could kill a slow-to-respond live session
                       requestedId: reconnectTimedOut ? undefined : saved.id,
-                      command: isAgentPanel ? command : undefined,
+                      command: isAgentPanel ? command : saved.command?.trim() || undefined,
                       // Execute command at spawn for all agents (grid and dock)
                       // Docked agents just run in background - same behavior, different location
                       isInputLocked: saved.isInputLocked,
@@ -738,6 +741,7 @@ export async function hydrateAppState(
                       browserHistory: isDevPreview ? saved.browserHistory : undefined,
                       browserZoom: isDevPreview ? saved.browserZoom : undefined,
                       devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
+                      exitBehavior: isAgentPanel ? undefined : saved.exitBehavior,
                     });
 
                     // Restore terminal dimensions if available
@@ -786,6 +790,7 @@ export async function hydrateAppState(
                     devCommand,
                     devPreviewConsoleOpen:
                       kind === "dev-preview" ? saved.devPreviewConsoleOpen : undefined,
+                    exitBehavior: saved.exitBehavior,
                   });
                 }
               }


### PR DESCRIPTION
## Summary

Implements auto-restart for QuickRun-spawned terminals. When the toggle is enabled, the same command automatically re-runs whenever the process exits — no manual click required. Includes exponential backoff to handle rapid crash loops, and correctly ignores Ctrl+C interrupts.

Closes #2410

## Changes Made

- **`shared/types/domain.ts`** — Added `"restart"` to `PanelExitBehavior`; added `exitBehavior` field to `TerminalSnapshot`
- **`shared/types/ipc/terminal.ts`** — Added `exitBehavior` to `TerminalState` for IPC persistence
- **`src/components/Project/QuickRun.tsx`** — Added auto-restart toggle button (with `RefreshCw` icon) next to the grid/dock toggle; persists per-project to `localStorage`; reloads on project switch
- **`src/components/Terminal/TerminalPane.tsx`** — On exit with `exitBehavior === "restart"`: schedules `restartTerminal` with exponential backoff (250ms → 5s cap); skips auto-restart for exit code 130; shows "Auto-restarting…" spinner; suppresses manual restart banner; cancels on trash/unmount
- **`src/store/terminalStore.ts`** — Treats `exitBehavior === "restart"` as preserved on clean exit (no auto-trash)
- **`src/store/persistence/terminalPersistence.ts`** — Persists `exitBehavior` in both PTY and dev-preview snapshots
- **`src/utils/stateHydration.ts`** — Threads `exitBehavior` through all `addTerminal` restore paths (reconnect, reconnect-fallback, respawn, non-PTY recreate)
- **`src/components/TerminalRecipe/RecipeEditor.tsx`** — Filters `"restart"` from recipe editor UI (QuickRun-only behavior)