### PR TITLE
feat(project): allow creating a new folder when adding a project

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -157,6 +157,7 @@ export const CHANNELS = {
   PROJECT_CLOSE: "project:close",
   PROJECT_REOPEN: "project:reopen",
   PROJECT_GET_STATS: "project:get-stats",
+  PROJECT_CREATE_FOLDER: "project:create-folder",
   PROJECT_INIT_GIT: "project:init-git",
   PROJECT_INIT_GIT_GUIDED: "project:init-git-guided",
   PROJECT_INIT_GIT_PROGRESS: "project:init-git-progress",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -315,6 +315,7 @@ const CHANNELS = {
   PROJECT_CLOSE: "project:close",
   PROJECT_REOPEN: "project:reopen",
   PROJECT_GET_STATS: "project:get-stats",
+  PROJECT_CREATE_FOLDER: "project:create-folder",
   PROJECT_INIT_GIT: "project:init-git",
   PROJECT_INIT_GIT_GUIDED: "project:init-git-guided",
   PROJECT_INIT_GIT_PROGRESS: "project:init-git-progress",
@@ -862,6 +863,9 @@ const api: ElectronAPI = {
     reopen: (projectId: string) => ipcRenderer.invoke(CHANNELS.PROJECT_REOPEN, projectId),
 
     getStats: (projectId: string) => ipcRenderer.invoke(CHANNELS.PROJECT_GET_STATS, projectId),
+
+    createFolder: (parentPath: string, folderName: string): Promise<string> =>
+      _typedInvoke(CHANNELS.PROJECT_CREATE_FOLDER, { parentPath, folderName }),
 
     initGit: (directoryPath: string) =>
       ipcRenderer.invoke(CHANNELS.PROJECT_INIT_GIT, directoryPath),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -295,6 +295,7 @@ export interface ElectronAPI {
      */
     reopen(projectId: string): Promise<Project>;
     getStats(projectId: string): Promise<ProjectStats>;
+    createFolder(parentPath: string, folderName: string): Promise<string>;
     initGit(directoryPath: string): Promise<void>;
     /** Initialize git repository with progress events */
     initGitGuided(options: GitInitOptions): Promise<GitInitResult>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -534,6 +534,10 @@ export interface IpcInvokeMap {
     args: [projectId: string];
     result: ProjectStats;
   };
+  "project:create-folder": {
+    args: [payload: { parentPath: string; folderName: string }];
+    result: string;
+  };
   "project:init-git": {
     args: [directoryPath: string];
     result: void;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialog
 import { TerminalPalette, NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
 import { GitInitDialog } from "./components/Project";
+import { CreateProjectFolderDialog } from "./components/Project/CreateProjectFolderDialog";
 import { ProjectSwitcherPalette } from "./components/Project/ProjectSwitcherPalette";
 import { ActionPalette } from "./components/ActionPalette";
 import { QuickSwitcher } from "./components/QuickSwitcher";
@@ -610,6 +611,9 @@ function App() {
   const gitInitDirectoryPath = useProjectStore((state) => state.gitInitDirectoryPath);
   const closeGitInitDialog = useProjectStore((state) => state.closeGitInitDialog);
   const handleGitInitSuccess = useProjectStore((state) => state.handleGitInitSuccess);
+  const createFolderDialogOpen = useProjectStore((state) => state.createFolderDialogOpen);
+  const closeCreateFolderDialog = useProjectStore((state) => state.closeCreateFolderDialog);
+  const openCreateFolderDialog = useProjectStore((state) => state.openCreateFolderDialog);
   const { setActiveWorktree, selectWorktree, activeWorktreeId, focusedWorktreeId } =
     useWorktreeSelectionStore(
       useShallow((state) => ({
@@ -1034,6 +1038,10 @@ function App() {
         onSelect={projectSwitcherPalette.selectProject}
         onClose={projectSwitcherPalette.close}
         onAddProject={projectSwitcherPalette.addProject}
+        onCreateFolder={() => {
+          projectSwitcherPalette.close();
+          openCreateFolderDialog();
+        }}
         onStopProject={(projectId) => projectSwitcherPalette.stopProject(projectId)}
         onCloseProject={(projectId) => projectSwitcherPalette.removeProject(projectId)}
         removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
@@ -1106,6 +1114,11 @@ function App() {
           onCancel={closeGitInitDialog}
         />
       )}
+
+      <CreateProjectFolderDialog
+        isOpen={createFolderDialogOpen}
+        onClose={closeCreateFolderDialog}
+      />
 
       <PanelTransitionOverlay />
 

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -83,6 +83,10 @@ export const projectClient = {
     return window.electron.project.getStats(projectId);
   },
 
+  createFolder: (parentPath: string, folderName: string): Promise<string> => {
+    return window.electron.project.createFolder(parentPath, folderName);
+  },
+
   initGit: (directoryPath: string): Promise<void> => {
     return window.electron.project.initGit(directoryPath);
   },

--- a/src/components/Project/CreateProjectFolderDialog.tsx
+++ b/src/components/Project/CreateProjectFolderDialog.tsx
@@ -1,0 +1,188 @@
+import { useState, useCallback, useEffect, useRef, useId } from "react";
+import { Button } from "@/components/ui/button";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { FolderPlus, FolderOpen } from "lucide-react";
+import { projectClient } from "@/clients";
+import { useProjectStore } from "@/store/projectStore";
+
+interface CreateProjectFolderDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function validateFolderName(name: string): string | null {
+  const trimmed = name.trim();
+  if (!trimmed) return "Folder name is required";
+  if (trimmed === ".." || trimmed === ".") return "Invalid folder name";
+  if (trimmed.includes("/") || trimmed.includes("\\"))
+    return "Folder name must not contain path separators";
+  return null;
+}
+
+export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFolderDialogProps) {
+  const [parentPath, setParentPath] = useState("");
+  const [folderName, setFolderName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const folderNameInputRef = useRef<HTMLInputElement>(null);
+  const homeDirFetchedRef = useRef(false);
+  const errorId = useId();
+
+  const createProjectFolder = useProjectStore((state) => state.createProjectFolder);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFolderName("");
+      setParentPath("");
+      setError(null);
+      setIsCreating(false);
+      homeDirFetchedRef.current = false;
+      return;
+    }
+
+    // Focus the folder name input immediately on open
+    requestAnimationFrame(() => {
+      folderNameInputRef.current?.focus();
+    });
+
+    // Pre-fill parent path with home directory, guarding against stale completion
+    homeDirFetchedRef.current = false;
+    window.electron.system
+      .getHomeDir()
+      .then((homeDir) => {
+        // Only apply if user hasn't already picked a path via Browse
+        if (!homeDirFetchedRef.current) {
+          homeDirFetchedRef.current = true;
+          setParentPath((prev) => prev || homeDir);
+        }
+      })
+      .catch(() => {
+        // Silently ignore; user can still Browse
+      });
+  }, [isOpen]);
+
+  const handleBrowseParent = useCallback(async () => {
+    try {
+      const selected = await projectClient.openDialog();
+      if (selected) {
+        homeDirFetchedRef.current = true; // Prevent homeDir overwriting user's pick
+        setParentPath(selected);
+        setError(null);
+        folderNameInputRef.current?.focus();
+      }
+    } catch {
+      setError("Could not open directory picker");
+    }
+  }, []);
+
+  const handleCreate = useCallback(async () => {
+    const validationError = validateFolderName(folderName);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    if (!parentPath.trim()) {
+      setError("Please select a parent directory");
+      return;
+    }
+
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      await createProjectFolder(parentPath, folderName.trim());
+      // Close only after the folder is created (but addProjectByPath runs in the background)
+      onClose();
+    } catch (err) {
+      // Show error inline — keep dialog open so user can retry or correct input
+      setError(err instanceof Error ? err.message : "Failed to create folder");
+    } finally {
+      setIsCreating(false);
+    }
+  }, [parentPath, folderName, createProjectFolder, onClose]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !isCreating) {
+        e.preventDefault();
+        void handleCreate();
+      }
+    },
+    [handleCreate, isCreating]
+  );
+
+  return (
+    <AppDialog isOpen={isOpen} onClose={onClose} size="md" dismissible={!isCreating}>
+      <AppDialog.Header>
+        <AppDialog.Title icon={<FolderPlus className="h-5 w-5 text-canopy-accent" />}>
+          Create New Project Folder
+        </AppDialog.Title>
+        {!isCreating && <AppDialog.CloseButton />}
+      </AppDialog.Header>
+
+      <AppDialog.Body className="space-y-4">
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-canopy-text/80" htmlFor="create-folder-parent">
+            Location
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="create-folder-parent"
+              type="text"
+              readOnly
+              value={parentPath}
+              className="flex-1 rounded-[var(--radius-md)] border border-canopy-border bg-muted/50 px-3 py-2 text-sm font-mono text-canopy-text/70 truncate"
+              placeholder="Select parent directory..."
+            />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleBrowseParent}
+              disabled={isCreating}
+              className="shrink-0 gap-1.5"
+            >
+              <FolderOpen className="h-3.5 w-3.5" />
+              Browse
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <label className="text-sm font-medium text-canopy-text/80" htmlFor="create-folder-name">
+            Folder Name
+          </label>
+          <input
+            ref={folderNameInputRef}
+            id="create-folder-name"
+            type="text"
+            value={folderName}
+            onChange={(e) => {
+              setFolderName(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={handleKeyDown}
+            aria-invalid={error != null}
+            aria-describedby={error ? errorId : undefined}
+            className="w-full rounded-[var(--radius-md)] border border-canopy-border bg-muted/50 px-3 py-2 text-sm text-canopy-text focus:outline-none focus:ring-2 focus:ring-canopy-accent/50 focus:border-canopy-accent aria-invalid:border-[var(--color-status-error)]"
+            placeholder="my-project"
+            disabled={isCreating}
+          />
+          {error && (
+            <p id={errorId} role="alert" className="text-xs text-[var(--color-status-error)]">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="outline" onClick={onClose} disabled={isCreating}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={isCreating || !parentPath || !folderName.trim()}>
+            {isCreating ? "Creating…" : "Create"}
+          </Button>
+        </div>
+      </AppDialog.Body>
+    </AppDialog>
+  );
+}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -39,6 +39,13 @@ export function ProjectSwitcher() {
     projectSwitcher.close();
   }, [projectSwitcher]);
 
+  const openCreateFolderDialog = useProjectStore((state) => state.openCreateFolderDialog);
+
+  const handleCreateFolder = useCallback(() => {
+    projectSwitcher.close();
+    openCreateFolderDialog();
+  }, [projectSwitcher, openCreateFolderDialog]);
+
   const handleOpenSettings = useCallback(() => {
     projectSwitcher.close();
     void actionService.dispatch("project.settings.open", undefined, { source: "user" });
@@ -92,6 +99,7 @@ export function ProjectSwitcher() {
             onSelect={projectSwitcher.selectProject}
             onClose={handleDropdownClose}
             onAddProject={projectSwitcher.addProject}
+            onCreateFolder={handleCreateFolder}
             onStopProject={handleStopProject}
             onCloseProject={handleCloseProject}
             removeConfirmProject={projectSwitcher.removeConfirmProject}
@@ -144,6 +152,7 @@ export function ProjectSwitcher() {
         onSelect={projectSwitcher.selectProject}
         onClose={handleDropdownClose}
         onAddProject={projectSwitcher.addProject}
+        onCreateFolder={handleCreateFolder}
         onStopProject={handleStopProject}
         onCloseProject={handleCloseProject}
         onOpenProjectSettings={handleOpenSettings}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useEffect, useRef, useCallback } from "react";
-import { Circle, Plus, Settings2, Square, X } from "lucide-react";
+import { Circle, FolderPlus, Plus, Settings2, Square, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
@@ -23,6 +23,7 @@ export interface ProjectSwitcherPaletteProps {
   onClose: () => void;
   mode?: ProjectSwitcherMode;
   onAddProject?: () => void;
+  onCreateFolder?: () => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
   onOpenProjectSettings?: () => void;
@@ -178,10 +179,12 @@ interface ProjectListContentProps {
   onSelect: (project: SearchableProject) => void;
   listRef: React.RefObject<HTMLDivElement | null>;
   onAddProject?: () => void;
+  onCreateFolder?: () => void;
   onOpenProjectSettings?: () => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
   showAddProject?: boolean;
+  showCreateFolder?: boolean;
   showProjectSettings?: boolean;
 }
 
@@ -192,15 +195,18 @@ function ProjectListContent({
   onSelect,
   listRef,
   onAddProject,
+  onCreateFolder,
   onOpenProjectSettings,
   onStopProject,
   onCloseProject,
   showAddProject = false,
+  showCreateFolder = false,
   showProjectSettings = false,
 }: ProjectListContentProps) {
   const showSettings = showProjectSettings && onOpenProjectSettings;
   const showAdd = showAddProject && onAddProject;
-  const showActions = showSettings || showAdd;
+  const showCreate = showCreateFolder && onCreateFolder;
+  const showActions = showSettings || showAdd || showCreate;
 
   const isSearching = query.trim().length > 0;
 
@@ -319,6 +325,20 @@ function ProjectListContent({
                 <span className="font-medium text-sm text-muted-foreground">Add Project...</span>
               </button>
             )}
+            {showCreate && (
+              <button
+                type="button"
+                onClick={() => onCreateFolder?.()}
+                className="w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors hover:bg-white/[0.02]"
+              >
+                <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
+                  <FolderPlus className="h-4 w-4" />
+                </div>
+                <span className="font-medium text-sm text-muted-foreground">
+                  Create New Folder...
+                </span>
+              </button>
+            )}
           </div>
         </>
       )}
@@ -369,6 +389,7 @@ function ModalContent({
   onSelect,
   onClose,
   onAddProject,
+  onCreateFolder,
   onStopProject,
   onCloseProject,
 }: Omit<ProjectSwitcherPaletteProps, "mode" | "children">) {
@@ -442,9 +463,11 @@ function ModalContent({
           onSelect={onSelect}
           listRef={listRef}
           onAddProject={onAddProject}
+          onCreateFolder={onCreateFolder}
           onStopProject={onStopProject}
           onCloseProject={onCloseProject}
           showAddProject={true}
+          showCreateFolder={true}
         />
       )}
     />
@@ -462,6 +485,7 @@ function DropdownContent({
   onSelect,
   onClose,
   onAddProject,
+  onCreateFolder,
   onStopProject,
   onOpenProjectSettings,
   onCloseProject,
@@ -604,10 +628,12 @@ function DropdownContent({
             onSelect={onSelect}
             listRef={listRef}
             onAddProject={onAddProject}
+            onCreateFolder={onCreateFolder}
             onOpenProjectSettings={onOpenProjectSettings}
             onStopProject={onStopProject}
             onCloseProject={onCloseProject}
             showAddProject={true}
+            showCreateFolder={true}
             showProjectSettings={!!onOpenProjectSettings}
           />
         </AppPaletteDialog.Body>
@@ -630,6 +656,7 @@ export function ProjectSwitcherPalette({
   onClose,
   mode = "modal",
   onAddProject,
+  onCreateFolder,
   onStopProject,
   onCloseProject,
   onOpenProjectSettings,
@@ -659,6 +686,7 @@ export function ProjectSwitcherPalette({
         onSelect={onSelect}
         onClose={onClose}
         onAddProject={onAddProject}
+        onCreateFolder={onCreateFolder}
         onStopProject={onStopProject}
         onCloseProject={onCloseProject}
         onOpenProjectSettings={onOpenProjectSettings}
@@ -678,6 +706,7 @@ export function ProjectSwitcherPalette({
         onSelect={onSelect}
         onClose={onClose}
         onAddProject={onAddProject}
+        onCreateFolder={onCreateFolder}
         onStopProject={onStopProject}
         onCloseProject={onCloseProject}
       />

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -36,6 +36,7 @@ const createMockProjectClient = () => ({
   setTabGroups: vi.fn().mockResolvedValue(undefined),
   getTerminalSizes: vi.fn().mockResolvedValue({}),
   setTerminalSizes: vi.fn().mockResolvedValue(undefined),
+  createFolder: vi.fn().mockResolvedValue(""),
 });
 
 describe("TerminalPersistence.saveTabGroups", () => {

--- a/src/store/persistence/__tests__/terminalPersistence.test.ts
+++ b/src/store/persistence/__tests__/terminalPersistence.test.ts
@@ -42,6 +42,7 @@ const createMockProjectClient = () => ({
   setTabGroups: vi.fn().mockResolvedValue(undefined),
   getTerminalSizes: vi.fn().mockResolvedValue({}),
   setTerminalSizes: vi.fn().mockResolvedValue(undefined),
+  createFolder: vi.fn().mockResolvedValue(""),
 });
 
 describe("TerminalPersistence", () => {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -38,11 +38,13 @@ interface ProjectState {
   error: string | null;
   gitInitDialogOpen: boolean;
   gitInitDirectoryPath: string | null;
+  createFolderDialogOpen: boolean;
 
   loadProjects: () => Promise<void>;
   getCurrentProject: () => Promise<void>;
   addProject: () => Promise<void>;
   addProjectByPath: (path: string) => Promise<void>;
+  createProjectFolder: (parentPath: string, folderName: string) => Promise<void>;
   switchProject: (projectId: string) => Promise<void>;
   updateProject: (id: string, updates: Partial<Project>) => Promise<void>;
   removeProject: (id: string) => Promise<void>;
@@ -55,6 +57,8 @@ interface ProjectState {
   openGitInitDialog: (directoryPath: string) => void;
   closeGitInitDialog: () => void;
   handleGitInitSuccess: () => Promise<void>;
+  openCreateFolderDialog: () => void;
+  closeCreateFolderDialog: () => void;
 }
 
 const memoryStorage: StateStorage = (() => {
@@ -156,6 +160,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   switchingToProjectName: null,
   gitInitDialogOpen: false,
   gitInitDirectoryPath: null,
+  createFolderDialogOpen: false,
   error: null,
 
   addProjectByPath: async (path) => {
@@ -679,6 +684,19 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     if (directoryPath) {
       await get().addProjectByPath(directoryPath);
     }
+  },
+
+  openCreateFolderDialog: () => {
+    set({ createFolderDialogOpen: true });
+  },
+
+  closeCreateFolderDialog: () => {
+    set({ createFolderDialogOpen: false });
+  },
+
+  createProjectFolder: async (parentPath, folderName) => {
+    const newFolderPath = await projectClient.createFolder(parentPath, folderName);
+    await get().addProjectByPath(newFolderPath);
   },
 });
 


### PR DESCRIPTION
## Summary

Adds a "Create New Folder..." option to the project switcher palette, letting users create a new directory and immediately open it as a project — without leaving Canopy.

Closes #2415

## Changes Made

- **IPC handler** (`electron/ipc/handlers/project.ts`): new `project:create-folder` channel that validates the folder name (rejects `..`/`.`/path separators), verifies the parent directory exists and is a directory, enforces path containment after `path.join`, creates the folder with `fs.mkdir`, and maps common error codes to user-friendly messages.
- **Type surface** (`shared/types/ipc/maps.ts`, `shared/types/ipc/api.ts`, `electron/preload.cts`): wired the new channel into the typed IPC map, ElectronAPI interface, and contextBridge.
- **Client** (`src/clients/projectClient.ts`): added `createFolder(parentPath, folderName)` wrapper.
- **Store** (`src/store/projectStore.ts`): added `createFolderDialogOpen` flag, `openCreateFolderDialog` / `closeCreateFolderDialog` actions, and `createProjectFolder` which calls the IPC then pipes the new path into the existing `addProjectByPath` flow.
- **Dialog** (`src/components/Project/CreateProjectFolderDialog.tsx`): new component with home-dir pre-fill, browse button, inline error display, accessibility attributes (`aria-invalid`, `aria-describedby`, `role="alert"`), and dialog closes only after a successful create.
- **Palette** (`src/components/Project/ProjectSwitcherPalette.tsx`): added `onCreateFolder` prop and "Create New Folder..." footer button alongside the existing "Add Project..." button in both modal and dropdown modes.
- **Wiring** (`src/components/Project/ProjectSwitcher.tsx`, `src/App.tsx`): connected `onCreateFolder` in all three `ProjectSwitcherPalette` call sites (two dropdown paths + the modal path).
- **Test mocks** (`tabGroupPersistence.test.ts`, `terminalPersistence.test.ts`): updated mocks to include the new `createFolder` method.