### PR TITLE
fix(worktree): default base branch to current checked-out branch

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1314,7 +1314,7 @@ export class WorkspaceService {
       const branches: BranchInfo[] = [];
 
       for (const [branchName, branchDetail] of Object.entries(summary.branches)) {
-        if (branchName.includes("HEAD ->") || branchName.endsWith("/HEAD")) {
+        if (branchName.includes("HEAD ->") || branchName.endsWith("/HEAD") || branchName.startsWith("(")) {
           continue;
         }
 

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -367,7 +367,7 @@ export function NewWorktreeDialog({
         const mainBranch =
           branchList.find((b) => b.name === "main") || branchList.find((b) => b.name === "master");
 
-        const initialBranch = mainBranch?.name || currentBranch?.name || branchList[0]?.name || "";
+        const initialBranch = currentBranch?.name || mainBranch?.name || branchList[0]?.name || "";
         setBaseBranch(initialBranch);
 
         // Auto-set fromRemote based on the initial branch type


### PR DESCRIPTION
## Summary

When opening the "New Worktree" dialog, the base branch selector now defaults to the currently checked-out branch instead of always defaulting to `main`/`master`.

Closes #2421

## Changes Made

- **`NewWorktreeDialog.tsx`**: Swapped the `initialBranch` priority so `currentBranch` is selected first, with `main`/`master` as a fallback, then the first available branch as a last resort.
- **`WorkspaceService.ts`**: Extended the branch-list filter to skip detached-HEAD pseudo-branch entries (names beginning with `(`, e.g. `(HEAD detached at abc1234)`), preventing an invalid branch name from being selected as the default.