### PR TITLE
feat(project): add WelcomeScreen shown when no project is open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ import { NewWorktreeDialog } from "./components/Worktree/NewWorktreeDialog";
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { TerminalPalette, NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
-import { GitInitDialog, ProjectOnboardingWizard } from "./components/Project";
+import { GitInitDialog, ProjectOnboardingWizard, WelcomeScreen } from "./components/Project";
 import { CreateProjectFolderDialog } from "./components/Project/CreateProjectFolderDialog";
 import { ProjectSwitcherPalette } from "./components/Project/ProjectSwitcherPalette";
 import { ActionPalette } from "./components/ActionPalette";
@@ -927,12 +927,16 @@ function App() {
             projectSwitcherPalette={projectSwitcherPalette}
           >
             <Profiler id="content-grid" onRender={onContentGridRender}>
-              <ContentGrid
-                key={currentProject?.id ?? "no-project"}
-                className="h-full w-full"
-                agentAvailability={availability}
-                defaultCwd={defaultTerminalCwd}
-              />
+              {currentProject === null ? (
+                <WelcomeScreen />
+              ) : (
+                <ContentGrid
+                  key={currentProject.id}
+                  className="h-full w-full"
+                  agentAvailability={availability}
+                  defaultCwd={defaultTerminalCwd}
+                />
+              )}
             </Profiler>
           </AppLayout>
         </Profiler>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -1,0 +1,55 @@
+import { FolderOpen, FolderPlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CanopyIcon } from "@/components/icons";
+import { useProjectStore } from "@/store/projectStore";
+
+export function WelcomeScreen() {
+  const addProject = useProjectStore((state) => state.addProject);
+  const openCreateFolderDialog = useProjectStore((state) => state.openCreateFolderDialog);
+  const isLoading = useProjectStore((state) => state.isLoading);
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full p-8 animate-in fade-in duration-500">
+      <div className="max-w-sm w-full flex flex-col items-center text-center">
+        <div className="mb-8">
+          <CanopyIcon className="h-20 w-20 text-white/80" />
+        </div>
+
+        <h1 className="text-2xl font-semibold text-canopy-text tracking-tight mb-3">
+          Welcome to Canopy
+        </h1>
+
+        <p className="text-sm text-canopy-text/60 leading-relaxed font-medium mb-2">
+          Canopy is a habitat for your AI agents.
+        </p>
+
+        <p className="text-xs text-canopy-text/40 leading-relaxed mb-10 max-w-xs">
+          Open an existing folder or create a new project to get started.
+        </p>
+
+        <div className="flex flex-col gap-3 w-full max-w-xs">
+          <Button
+            size="lg"
+            onClick={() => void addProject()}
+            disabled={isLoading}
+            className="w-full"
+          >
+            <FolderOpen />
+            Open Folder
+          </Button>
+
+          <Button
+            size="lg"
+            variant="outline"
+            onClick={openCreateFolderDialog}
+            disabled={isLoading}
+            className="w-full"
+          >
+            <FolderPlus />
+            Create Project
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Project/index.ts
+++ b/src/components/Project/index.ts
@@ -5,3 +5,4 @@ export { ProjectSwitchOverlay } from "./ProjectSwitchOverlay";
 export { QuickRun } from "./QuickRun";
 export { GitInitDialog } from "./GitInitDialog";
 export { ProjectOnboardingWizard } from "./ProjectOnboardingWizard";
+export { WelcomeScreen } from "./WelcomeScreen";


### PR DESCRIPTION
## Summary

Replaces the broken `ContentGrid` empty state (which renders oddly without an active project) with a dedicated `WelcomeScreen` shown whenever `currentProject === null`.

Closes #2420

## Changes Made

- Create `src/components/Project/WelcomeScreen.tsx` — centered welcome UI with Canopy icon, tagline ("Canopy is a habitat for your AI agents."), and two primary CTAs
- Wire **Open Folder** CTA to `addProject` (opens OS directory picker)
- Wire **Create Project** CTA to `openCreateFolderDialog` (opens create-folder dialog)
- Disable both CTAs while `isLoading` to prevent duplicate project-open attempts on rapid clicks
- Update `App.tsx` to conditionally render `WelcomeScreen` when `currentProject === null` and `ContentGrid` when a project is active
- Export `WelcomeScreen` from the `Project` component barrel (`src/components/Project/index.ts`)