### PR TITLE
feat(project): allow closing the currently active project

### DIFF
--- a/electron/ipc/handlers/__tests__/project.close.test.ts
+++ b/electron/ipc/handlers/__tests__/project.close.test.ts
@@ -24,6 +24,7 @@ const projectStoreMock = vi.hoisted(() => ({
   getProjectById:
     vi.fn<(projectId: string) => { id: string; name: string; status?: string } | null>(),
   clearProjectState: vi.fn<(projectId: string) => Promise<void>>(),
+  clearCurrentProject: vi.fn<() => void>(),
   updateProjectStatus:
     vi.fn<(projectId: string, status: "active" | "background" | "closed") => unknown>(),
 }));
@@ -42,7 +43,7 @@ describe("project:close handler", () => {
     vi.clearAllMocks();
   });
 
-  it("allows killing terminals for the active project without closing it", async () => {
+  it("allows killing terminals for the active project and clears it", async () => {
     projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
     projectStoreMock.getProjectById.mockReturnValue({
       id: "project-active",
@@ -91,10 +92,8 @@ describe("project:close handler", () => {
     expect(result.processesKilled).toBe(2);
     expect(ptyClient.killByProject).toHaveBeenCalledWith("project-active");
     expect(projectStoreMock.clearProjectState).toHaveBeenCalledWith("project-active");
-    expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalledWith(
-      "project-active",
-      "closed"
-    );
+    expect(projectStoreMock.clearCurrentProject).toHaveBeenCalled();
+    expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-active", "closed");
   });
 
   it("rejects closing the active project when not killing terminals", async () => {

--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -425,10 +425,11 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
         // Clear persisted state
         await projectStore.clearProjectState(projectId);
 
-        // Set status to 'closed' (no running processes) unless this is the active project
-        if (projectId !== storeActiveProjectId) {
-          projectStore.updateProjectStatus(projectId, "closed");
+        // Set status to 'closed' and clear current project ref if this was the active project
+        if (projectId === storeActiveProjectId) {
+          projectStore.clearCurrentProject();
         }
+        projectStore.updateProjectStatus(projectId, "closed");
 
         console.log(
           `[IPC] project:close: Killed ${terminalsKilled} process(es) ` +

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -53,7 +53,6 @@ function ProjectListItem({
   onCloseProject,
 }: ProjectListItemProps) {
   const showStop = project.processCount > 0;
-  const canClose = !project.isActive;
 
   return (
     <div
@@ -69,7 +68,6 @@ function ProjectListItem({
             : "text-canopy-text/70 hover:bg-white/[0.02] hover:text-canopy-text cursor-pointer"
       )}
       onClick={() => !project.isActive && onSelect(project)}
-      aria-disabled={project.isActive}
     >
       <div
         className={cn(
@@ -140,19 +138,16 @@ function ProjectListItem({
                   <button
                     type="button"
                     onClick={(e) => {
-                      if (!canClose) return;
                       e.stopPropagation();
                       onCloseProject(project.id);
                     }}
                     className={cn(
-                      "p-0.5 rounded transition-colors",
-                      canClose
-                        ? "text-canopy-text/50 hover:bg-white/[0.06] hover:text-canopy-text/80 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-                        : "text-canopy-text/20 cursor-not-allowed"
+                      "p-0.5 rounded transition-colors cursor-pointer",
+                      "text-canopy-text/50 hover:bg-white/[0.06] hover:text-canopy-text/80",
+                      "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
                     )}
-                    title={canClose ? "Close project" : "Can't close active project"}
+                    title="Close project"
                     aria-label="Close project"
-                    disabled={!canClose}
                   >
                     <X className="w-3.5 h-3.5" aria-hidden="true" />
                   </button>
@@ -417,11 +412,8 @@ function ModalContent({
         selectedIndex >= 0 &&
         selectedIndex < results.length
       ) {
-        const selectedProject = results[selectedIndex];
-        if (!selectedProject.isActive) {
-          e.preventDefault();
-          onCloseProject(selectedProject.id);
-        }
+        e.preventDefault();
+        onCloseProject(results[selectedIndex].id);
       }
     },
     [results, selectedIndex, onCloseProject]
@@ -573,12 +565,9 @@ function DropdownContent({
             selectedIndex >= 0 &&
             selectedIndex < results.length
           ) {
-            const selectedProject = results[selectedIndex];
-            if (!selectedProject.isActive) {
-              e.preventDefault();
-              e.stopPropagation();
-              onCloseProject(selectedProject.id);
-            }
+            e.preventDefault();
+            e.stopPropagation();
+            onCloseProject(results[selectedIndex].id);
           }
           break;
       }
@@ -719,9 +708,9 @@ export function ProjectSwitcherPalette({
         <ConfirmDialog
           isOpen={true}
           onClose={isRemovingProject ? undefined : onRemoveConfirmClose}
-          title="Remove Project from List?"
+          title={removeConfirmProject.isActive ? "Close Project?" : "Remove Project from List?"}
           zIndex="nested"
-          confirmLabel="Remove Project"
+          confirmLabel={removeConfirmProject.isActive ? "Close Project" : "Remove Project"}
           cancelLabel="Cancel"
           onConfirm={onConfirmRemove}
           isConfirmLoading={isRemovingProject}
@@ -734,25 +723,45 @@ export function ProjectSwitcherPalette({
                 {removeConfirmProject.path}
               </div>
             </div>
-            {hasRunningProcesses && (
-              <div className="rounded-[var(--radius-md)] bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-200">
-                <div className="font-medium">Warning: Active sessions detected</div>
-                <div className="mt-1 text-amber-200/80">
-                  {removeConfirmProject.processCount > 0 && (
-                    <div>• {removeConfirmProject.processCount} running process(es)</div>
-                  )}
-                  {removeConfirmProject.activeAgentCount > 0 && (
-                    <div>• {removeConfirmProject.activeAgentCount} active agent(s)</div>
-                  )}
-                  {removeConfirmProject.waitingAgentCount > 0 && (
-                    <div>• {removeConfirmProject.waitingAgentCount} waiting agent(s)</div>
-                  )}
-                </div>
-              </div>
-            )}
+            {removeConfirmProject.isActive
+              ? hasRunningProcesses && (
+                  <div className="rounded-[var(--radius-md)] bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-200">
+                    <div className="font-medium">
+                      Warning: All running processes will be terminated
+                    </div>
+                    <div className="mt-1 text-amber-200/80">
+                      {removeConfirmProject.processCount > 0 && (
+                        <div>• {removeConfirmProject.processCount} running process(es)</div>
+                      )}
+                      {removeConfirmProject.activeAgentCount > 0 && (
+                        <div>• {removeConfirmProject.activeAgentCount} active agent(s)</div>
+                      )}
+                      {removeConfirmProject.waitingAgentCount > 0 && (
+                        <div>• {removeConfirmProject.waitingAgentCount} waiting agent(s)</div>
+                      )}
+                    </div>
+                  </div>
+                )
+              : hasRunningProcesses && (
+                  <div className="rounded-[var(--radius-md)] bg-amber-500/10 border border-amber-500/20 px-3 py-2 text-xs text-amber-200">
+                    <div className="font-medium">Warning: Active sessions detected</div>
+                    <div className="mt-1 text-amber-200/80">
+                      {removeConfirmProject.processCount > 0 && (
+                        <div>• {removeConfirmProject.processCount} running process(es)</div>
+                      )}
+                      {removeConfirmProject.activeAgentCount > 0 && (
+                        <div>• {removeConfirmProject.activeAgentCount} active agent(s)</div>
+                      )}
+                      {removeConfirmProject.waitingAgentCount > 0 && (
+                        <div>• {removeConfirmProject.waitingAgentCount} waiting agent(s)</div>
+                      )}
+                    </div>
+                  </div>
+                )}
             <div className="text-xs text-canopy-text/60">
-              This project will be removed from your list. You can add it back later, but any
-              running terminals or processes will need to be restarted.
+              {removeConfirmProject.isActive
+                ? "The project will remain in your list and can be reopened at any time."
+                : "This project will be removed from your list. You can add it back later, but any running terminals or processes will need to be restarted."}
             </div>
           </div>
         </ConfirmDialog>


### PR DESCRIPTION
## Summary

Users can now close/remove the currently active project from the project switcher. Previously the X button was greyed out and blocked at three layers. Closing the active project kills all running terminals and processes (after confirmation) and transitions the app to the empty no-project state. The project remains in the list and can be reopened at any time.

Closes #2419

## Changes Made

- Remove `canClose = !project.isActive` guard so the X button is always enabled in the project list
- Remove `aria-disabled` from the active project row (now contains an interactive close button)
- Allow `Cmd/Ctrl+Backspace` keyboard shortcut for any project including the active one
- Show a distinct confirmation dialog for active projects: warns about process termination, different title/CTA, footer notes project stays in list
- Warning box only shown when there are running processes (avoids misleading copy for idle projects)
- Remove `if (project.isActive) return` guard from `removeProjectFromList` so active project enters the confirm flow
- Branch `confirmRemoveProject` to call `closeActiveProject` for active projects and `removeProject` for non-active
- Add `isRemovingProject` reentrancy guard to `confirmRemoveProject`
- Add `closeActiveProject` store action: kills terminals via IPC, re-validates current project post-IPC to guard against races, resets all renderer stores, sets `currentProject` to `null`, reloads project list
- Add compensating error path: if IPC succeeds but renderer reset throws, still clear `currentProject` to avoid half-closed state
- Update IPC close handler: call `clearCurrentProject()` and set project status to `closed` when killing terminals for the active project
- Add tests for active-project close flow; update IPC handler test mock and assertions