### PR TITLE
feat(notifications): filter dock badge to recent post-blur completions

### DIFF
--- a/src/hooks/__tests__/useTerminalSelectors.test.tsx
+++ b/src/hooks/__tests__/useTerminalSelectors.test.tsx
@@ -17,44 +17,260 @@ vi.mock("@/store/worktreeDataStore", () => ({
 
 import { useTerminalNotificationCounts } from "../useTerminalSelectors";
 
+function setupEmptyWorktrees() {
+  useWorktreeDataStoreMock.mockImplementation(
+    (selector: (state: { worktrees: Map<string, { worktreeId?: string }> }) => unknown) =>
+      selector({ worktrees: new Map() })
+  );
+}
+
+function setupTerminals(
+  terminals: Array<{
+    id: string;
+    worktreeId?: string;
+    agentState?: string;
+    location?: string;
+    lastStateChange?: number;
+  }>
+) {
+  useTerminalStoreMock.mockImplementation(
+    (
+      selector: (state: {
+        terminals: typeof terminals;
+        isInTrash: (id: string) => boolean;
+      }) => unknown
+    ) =>
+      selector({
+        terminals,
+        isInTrash: () => false,
+      })
+  );
+}
+
 describe("useTerminalSelectors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("does not hide waiting terminals when worktree IDs are temporarily unavailable", () => {
-    useWorktreeDataStoreMock.mockImplementation(
-      (selector: (state: { worktrees: Map<string, { worktreeId?: string }> }) => unknown) =>
-        selector({ worktrees: new Map() })
-    );
-
-    useTerminalStoreMock.mockImplementation(
-      (
-        selector: (state: {
-          terminals: Array<{
-            id: string;
-            worktreeId?: string;
-            agentState?: string;
-            location?: string;
-          }>;
-          isInTrash: (id: string) => boolean;
-        }) => unknown
-      ) =>
-        selector({
-          terminals: [
-            {
-              id: "t-waiting",
-              worktreeId: "wt-1",
-              agentState: "waiting",
-              location: "grid",
-            },
-          ],
-          isInTrash: () => false,
-        })
-    );
+    setupEmptyWorktrees();
+    setupTerminals([
+      { id: "t-waiting", worktreeId: "wt-1", agentState: "waiting", location: "grid" },
+    ]);
 
     const { result } = renderHook(() => useTerminalNotificationCounts());
     expect(result.current.waitingCount).toBe(1);
     expect(result.current.failedCount).toBe(0);
+  });
+
+  describe("blurTime filtering", () => {
+    it("returns zeros when blurTime is null (window focused)", () => {
+      setupEmptyWorktrees();
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: Date.now() - 1000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(null));
+      expect(result.current.waitingCount).toBe(0);
+      expect(result.current.failedCount).toBe(0);
+    });
+
+    it("counts terminals that changed state after blurTime and within 5 minutes", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 60_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: Date.now() - 30_000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(1);
+      expect(result.current.failedCount).toBe(0);
+    });
+
+    it("excludes terminals that changed state before blurTime", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 30_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: Date.now() - 60_000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(0);
+    });
+
+    it("excludes terminals older than 5 minutes even if after blurTime", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 10 * 60_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "failed",
+          location: "grid",
+          lastStateChange: Date.now() - 6 * 60_000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.failedCount).toBe(0);
+    });
+
+    it("counts terminal at exactly the 5-minute boundary as expired", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 10 * 60_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: Date.now() - 5 * 60_000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(0);
+    });
+
+    it("excludes terminals without lastStateChange when blurTime is set", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 60_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(0);
+    });
+
+    it("counts both waiting and failed terminals with valid timestamps", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 120_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: Date.now() - 60_000,
+        },
+        {
+          id: "t2",
+          agentState: "failed",
+          location: "grid",
+          lastStateChange: Date.now() - 30_000,
+        },
+        {
+          id: "t3",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: Date.now() - 180_000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(1);
+      expect(result.current.failedCount).toBe(1);
+    });
+
+    it("uses unfiltered behavior when blurTime is undefined", () => {
+      setupEmptyWorktrees();
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+        },
+        {
+          id: "t2",
+          agentState: "failed",
+          location: "grid",
+          lastStateChange: Date.now() - 10 * 60_000,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts());
+      expect(result.current.waitingCount).toBe(1);
+      expect(result.current.failedCount).toBe(1);
+    });
+
+    it("excludes terminal whose lastStateChange equals blurTime exactly", () => {
+      setupEmptyWorktrees();
+      const blurTime = Date.now() - 30_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: blurTime,
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(0);
+    });
+
+    it("includes terminal just under the 5-minute expiry window", () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+      setupEmptyWorktrees();
+      const blurTime = now - 10 * 60_000;
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: now - (5 * 60_000 - 1),
+        },
+      ]);
+
+      const { result } = renderHook(() => useTerminalNotificationCounts(blurTime));
+      expect(result.current.waitingCount).toBe(1);
+      vi.useRealTimers();
+    });
+
+    it("does not recount a terminal from a previous blur session on re-blur", () => {
+      setupEmptyWorktrees();
+      const firstBlurTime = Date.now() - 120_000;
+      const terminalStateChange = Date.now() - 90_000;
+
+      setupTerminals([
+        {
+          id: "t1",
+          agentState: "waiting",
+          location: "grid",
+          lastStateChange: terminalStateChange,
+        },
+      ]);
+
+      // Terminal is counted during first blur
+      const { result: result1 } = renderHook(() => useTerminalNotificationCounts(firstBlurTime));
+      expect(result1.current.waitingCount).toBe(1);
+
+      // After focus, count is zero
+      const { result: result2 } = renderHook(() => useTerminalNotificationCounts(null));
+      expect(result2.current.waitingCount).toBe(0);
+
+      // After re-blur (new blurTime > terminalStateChange), terminal is not re-counted
+      const secondBlurTime = Date.now() - 30_000;
+      const { result: result3 } = renderHook(() => useTerminalNotificationCounts(secondBlurTime));
+      expect(result3.current.waitingCount).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Improves the dock badge to only signal terminals that completed work while the user was away, eliminating stale and noisy notifications.

Closes #2429

## Changes Made

- **`useTerminalNotificationCounts`**: Added optional `blurTime?: number | null` parameter with three modes:
  - `null` (window focused) → returns zeros immediately
  - `undefined` (no arg) → legacy unfiltered behaviour for the in-app dock UI
  - `number` → filters to terminals where `lastStateChange > blurTime` and within 5 minutes
- **`useWindowNotifications`**: Tracks `blurTimeRef` (set to `Date.now()` on blur, `null` on focus); starts a 30-second ticker while blurred so 5-minute expiry fires even without store changes; clears pending debounce timer on focus to prevent stale badge updates; guards against duplicate tickers on double-blur
- **Tests**: 12 unit tests covering all filtering paths, 5-minute boundary conditions, missing `lastStateChange` exclusion, and blur/focus cycle regression