### PR TITLE
feat(setup): add first-run CLI agent setup wizard with embedded terminal

### DIFF
--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -8,7 +8,7 @@ import {
   getAgentSettingsEntry,
   DEFAULT_DANGEROUS_ARGS,
 } from "@shared/types";
-import { RotateCcw, ExternalLink, RefreshCw, Copy, Check } from "lucide-react";
+import { RotateCcw, ExternalLink, RefreshCw, Copy, Check, Sparkles } from "lucide-react";
 import { actionService } from "@/services/ActionService";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { AgentHelpOutput } from "./AgentHelpOutput";
@@ -201,11 +201,24 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        <div>
-          <h3 className="text-sm font-medium mb-1">Agent Runtime Settings</h3>
-          <p className="text-xs text-canopy-text/50">
-            Configure CLI flags and options for each agent
-          </p>
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-sm font-medium mb-1">Agent Runtime Settings</h3>
+            <p className="text-xs text-canopy-text/50">
+              Configure CLI flags and options for each agent
+            </p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              window.dispatchEvent(new CustomEvent("canopy:open-agent-setup-wizard"));
+            }}
+            className="text-canopy-text/60 hover:text-canopy-text shrink-0"
+          >
+            <Sparkles className="w-3.5 h-3.5" />
+            Run Setup Wizard
+          </Button>
         </div>
 
         {/* Agent Selector - Horizontal scrolling pills */}

--- a/src/components/Setup/AgentSetupStep.tsx
+++ b/src/components/Setup/AgentSetupStep.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Copy, ExternalLink, CircleCheck, CircleDashed } from "lucide-react";
+import type { AgentConfig, AgentIconProps } from "@/config/agents";
+import type { AgentInstallBlock } from "@shared/config/agentRegistry";
+import { getInstallBlocksForCurrentOS } from "@/lib/agentInstall";
+import { systemClient } from "@/clients";
+import type { ComponentType } from "react";
+
+interface AgentSetupStepProps {
+  agent: AgentConfig;
+  isAvailable: boolean;
+  icon: ComponentType<AgentIconProps>;
+}
+
+export function AgentSetupStep({ agent, isAvailable, icon: Icon }: AgentSetupStepProps) {
+  const installBlocks = getInstallBlocksForCurrentOS(agent);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <div
+          className="w-10 h-10 rounded-[var(--radius-md)] flex items-center justify-center"
+          style={{ backgroundColor: `${agent.color}15` }}
+        >
+          <Icon size={22} brandColor={agent.color} />
+        </div>
+        <div className="flex-1">
+          <h3 className="text-sm font-semibold text-canopy-text">{agent.name}</h3>
+          {agent.tooltip && <p className="text-xs text-canopy-text/50">{agent.tooltip}</p>}
+        </div>
+        <StatusBadge isAvailable={isAvailable} />
+      </div>
+
+      {!isAvailable && installBlocks && (
+        <div className="space-y-2">
+          {installBlocks.map((block, i) => (
+            <InstallBlock key={i} block={block} />
+          ))}
+        </div>
+      )}
+
+      {!isAvailable && agent.install?.docsUrl && (
+        <a
+          href={agent.install.docsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs text-canopy-accent hover:underline"
+          onClick={(e) => {
+            e.preventDefault();
+            systemClient.openExternal(agent.install!.docsUrl!);
+          }}
+        >
+          <ExternalLink className="w-3 h-3" />
+          View documentation
+        </a>
+      )}
+
+      {isAvailable && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-emerald-500/10 border border-emerald-500/20">
+          <CircleCheck className="w-4 h-4 text-emerald-400" />
+          <span className="text-sm text-emerald-400">{agent.name} is installed and ready</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusBadge({ isAvailable }: { isAvailable: boolean }) {
+  if (isAvailable) {
+    return (
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-emerald-500/15 text-emerald-400">
+        <CircleCheck className="w-3 h-3" />
+        Installed
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-canopy-text/5 text-canopy-text/50">
+      <CircleDashed className="w-3 h-3" />
+      Not installed
+    </span>
+  );
+}
+
+function InstallBlock({ block }: { block: AgentInstallBlock }) {
+  return (
+    <div className="rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/50 p-3">
+      {block.label && (
+        <div className="text-xs font-medium text-canopy-text/60 mb-2">{block.label}</div>
+      )}
+      {block.steps && block.steps.length > 0 && (
+        <ol className="list-decimal list-inside text-xs text-canopy-text/60 space-y-1 mb-2">
+          {block.steps.map((step, i) => (
+            <li key={i}>{step}</li>
+          ))}
+        </ol>
+      )}
+      {block.commands && block.commands.length > 0 && (
+        <div className="space-y-1.5">
+          {block.commands.map((cmd, i) => (
+            <CopyableCommand key={i} command={cmd} />
+          ))}
+        </div>
+      )}
+      {block.notes && block.notes.length > 0 && (
+        <div className="mt-2 text-[11px] text-canopy-text/40 space-y-0.5">
+          {block.notes.map((note, i) => (
+            <p key={i}>{note}</p>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CopyableCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(command).then(() => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      setCopied(true);
+      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    });
+  }, [command]);
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 rounded-[var(--radius-sm)] bg-canopy-bg border border-canopy-border">
+      <code className="flex-1 text-xs text-canopy-text font-mono select-all">{command}</code>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="shrink-0 p-1 text-canopy-text/40 hover:text-canopy-text transition-colors rounded"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <Check className="w-3.5 h-3.5 text-emerald-400" />
+        ) : (
+          <Copy className="w-3.5 h-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { Button } from "@/components/ui/button";
+import { AgentSetupStep } from "./AgentSetupStep";
+import { EmbeddedTerminal } from "./EmbeddedTerminal";
+import { AGENT_REGISTRY, getAgentConfig } from "@/config/agents";
+import { cliAvailabilityClient } from "@/clients";
+import type { CliAvailability } from "@shared/types";
+import { Sparkles, ChevronLeft, ChevronRight, ArrowRight, SkipForward } from "lucide-react";
+
+const STORAGE_KEY = "canopy:agent-setup-complete";
+const AGENT_ORDER = ["claude", "gemini", "codex", "opencode"] as const;
+const POLL_INTERVAL = 3000;
+
+let sessionGuard = false;
+
+export function shouldShowAgentSetupWizard(availability: CliAvailability): boolean {
+  if (sessionGuard) return false;
+
+  try {
+    if (localStorage.getItem(STORAGE_KEY)) return false;
+  } catch {
+    return false;
+  }
+
+  const anyInstalled = Object.values(availability).some((v) => v === true);
+  return !anyInstalled;
+}
+
+export function markAgentSetupComplete(): void {
+  sessionGuard = true;
+  try {
+    localStorage.setItem(STORAGE_KEY, "true");
+  } catch {
+    // silently fail
+  }
+}
+
+export function resetAgentSetupFlag(): void {
+  sessionGuard = false;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // silently fail
+  }
+}
+
+interface AgentSetupWizardProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialAvailability?: CliAvailability;
+}
+
+type WizardStep = "welcome" | "agent" | "complete";
+
+export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: AgentSetupWizardProps) {
+  const [step, setStep] = useState<WizardStep>("welcome");
+  const [agentIndex, setAgentIndex] = useState(0);
+  const [availability, setAvailability] = useState<CliAvailability>(
+    initialAvailability ?? ({} as CliAvailability)
+  );
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const currentAgentId = AGENT_ORDER[agentIndex];
+  const currentAgent = useMemo(
+    () => (currentAgentId ? getAgentConfig(currentAgentId) : undefined),
+    [currentAgentId]
+  );
+  const isCurrentAvailable = currentAgentId ? availability[currentAgentId] === true : false;
+
+  const installedAgents = useMemo(
+    () => AGENT_ORDER.filter((id) => availability[id] === true),
+    [availability]
+  );
+
+  // Reset wizard state when reopened
+  const prevIsOpenRef = useRef(false);
+  useEffect(() => {
+    if (isOpen && !prevIsOpenRef.current) {
+      setStep("welcome");
+      setAgentIndex(0);
+    }
+    prevIsOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const poll = () => {
+      cliAvailabilityClient
+        .refresh()
+        .then((result) => {
+          if (isOpenRef.current) setAvailability(result);
+        })
+        .catch(console.error);
+    };
+
+    poll();
+    pollRef.current = setInterval(poll, POLL_INTERVAL);
+
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [isOpen]);
+
+  const handleNext = useCallback(() => {
+    if (step === "welcome") {
+      setStep("agent");
+      setAgentIndex(0);
+    } else if (step === "agent") {
+      if (agentIndex < AGENT_ORDER.length - 1) {
+        setAgentIndex((i) => i + 1);
+      } else {
+        setStep("complete");
+      }
+    }
+  }, [step, agentIndex]);
+
+  const handleBack = useCallback(() => {
+    if (step === "agent") {
+      if (agentIndex > 0) {
+        setAgentIndex((i) => i - 1);
+      } else {
+        setStep("welcome");
+      }
+    } else if (step === "complete") {
+      setStep("agent");
+      setAgentIndex(AGENT_ORDER.length - 1);
+    }
+  }, [step, agentIndex]);
+
+  const handleSkip = useCallback(() => {
+    handleNext();
+  }, [handleNext]);
+
+  const handleFinish = useCallback(() => {
+    markAgentSetupComplete();
+    onClose();
+  }, [onClose]);
+
+  const stepNumber =
+    step === "welcome" ? 0 : step === "agent" ? agentIndex + 1 : AGENT_ORDER.length + 1;
+  const totalSteps = AGENT_ORDER.length + 2;
+
+  return (
+    <AppDialog isOpen={isOpen} onClose={handleFinish} size="lg" dismissible={true}>
+      <AppDialog.Header>
+        <AppDialog.Title icon={<Sparkles className="w-5 h-5 text-canopy-accent" />}>
+          Agent Setup
+        </AppDialog.Title>
+        <div className="flex items-center gap-3">
+          <span className="text-xs text-canopy-text/40">
+            {stepNumber + 1} of {totalSteps}
+          </span>
+          <AppDialog.CloseButton />
+        </div>
+      </AppDialog.Header>
+
+      <AppDialog.Body>
+        {step === "welcome" && <WelcomeStep availability={availability} />}
+        {step === "agent" && currentAgent && (
+          <div className="space-y-5">
+            <AgentSetupStep
+              agent={currentAgent}
+              isAvailable={isCurrentAvailable}
+              icon={currentAgent.icon}
+            />
+            <div className="border-t border-canopy-border pt-4">
+              <div className="flex items-center gap-2 mb-3">
+                <div className="text-xs font-medium text-canopy-text/60">Terminal</div>
+                <div className="text-[11px] text-canopy-text/30">
+                  Run installation commands here
+                </div>
+              </div>
+              <EmbeddedTerminal />
+            </div>
+          </div>
+        )}
+        {step === "complete" && <CompleteStep installedAgents={installedAgents} />}
+      </AppDialog.Body>
+
+      <AppDialog.Footer>
+        <div className="flex items-center justify-between w-full">
+          <div className="flex items-center gap-1.5">
+            {Array.from({ length: totalSteps }).map((_, i) => (
+              <div
+                key={i}
+                className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                  i === stepNumber
+                    ? "bg-canopy-accent"
+                    : i < stepNumber
+                      ? "bg-canopy-accent/40"
+                      : "bg-canopy-text/15"
+                }`}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            {step !== "welcome" && (
+              <Button variant="ghost" onClick={handleBack} className="text-canopy-text/70">
+                <ChevronLeft className="w-4 h-4" />
+                Back
+              </Button>
+            )}
+            {step === "welcome" && (
+              <Button onClick={handleNext}>
+                Get Started
+                <ArrowRight className="w-4 h-4 ml-1" />
+              </Button>
+            )}
+            {step === "agent" && !isCurrentAvailable && (
+              <Button variant="ghost" onClick={handleSkip} className="text-canopy-text/60">
+                <SkipForward className="w-4 h-4" />
+                Skip
+              </Button>
+            )}
+            {step === "agent" && (
+              <Button onClick={handleNext}>
+                {isCurrentAvailable ? "Continue" : "Next"}
+                <ChevronRight className="w-4 h-4 ml-1" />
+              </Button>
+            )}
+            {step === "complete" && <Button onClick={handleFinish}>Finish Setup</Button>}
+          </div>
+        </div>
+      </AppDialog.Footer>
+    </AppDialog>
+  );
+}
+
+function WelcomeStep({ availability }: { availability: CliAvailability }) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-semibold text-canopy-text mb-2">
+          Get started with AI agents
+        </h3>
+        <p className="text-sm text-canopy-text/60">
+          Canopy orchestrates multiple AI coding agents. This wizard will help you install the CLI
+          tools you need. Each agent is optional — install the ones you want to use.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {AGENT_ORDER.map((id) => {
+          const agent = AGENT_REGISTRY[id];
+          if (!agent) return null;
+          const isInstalled = availability[id] === true;
+          const Icon = agent.icon;
+
+          return (
+            <div
+              key={id}
+              className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30"
+            >
+              <div
+                className="w-8 h-8 rounded-[var(--radius-sm)] flex items-center justify-center"
+                style={{ backgroundColor: `${agent.color}15` }}
+              >
+                <Icon size={18} brandColor={agent.color} />
+              </div>
+              <div className="flex-1">
+                <div className="text-sm font-medium text-canopy-text">{agent.name}</div>
+                {agent.tooltip && (
+                  <div className="text-[11px] text-canopy-text/40">{agent.tooltip}</div>
+                )}
+              </div>
+              {isInstalled ? (
+                <span className="text-[11px] text-emerald-400 font-medium">Installed</span>
+              ) : (
+                <span className="text-[11px] text-canopy-text/30">Not installed</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function CompleteStep({ installedAgents }: { installedAgents: string[] }) {
+  return (
+    <div className="space-y-6 text-center py-4">
+      <div>
+        <div className="w-12 h-12 rounded-full bg-emerald-500/15 flex items-center justify-center mx-auto mb-4">
+          <Sparkles className="w-6 h-6 text-emerald-400" />
+        </div>
+        <h3 className="text-base font-semibold text-canopy-text mb-2">Setup Complete</h3>
+        <p className="text-sm text-canopy-text/60">
+          {installedAgents.length > 0
+            ? `You have ${installedAgents.length} agent${installedAgents.length === 1 ? "" : "s"} ready to use. Launch them from the toolbar or with keyboard shortcuts.`
+            : "No agents were installed. You can install them later from Settings > Agents."}
+        </p>
+      </div>
+
+      {installedAgents.length > 0 && (
+        <div className="space-y-2">
+          {installedAgents.map((id) => {
+            const agent = AGENT_REGISTRY[id];
+            if (!agent) return null;
+            const Icon = agent.icon;
+
+            return (
+              <div
+                key={id}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border border-emerald-500/20 bg-emerald-500/5"
+              >
+                <Icon size={18} brandColor={agent.color} />
+                <span className="text-sm text-canopy-text font-medium">{agent.name}</span>
+                {agent.shortcut && (
+                  <span className="text-[11px] text-canopy-text/40 ml-auto">{agent.shortcut}</span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="text-xs text-canopy-text/40">
+        You can re-run this wizard from Settings &gt; Agents
+      </p>
+    </div>
+  );
+}

--- a/src/components/Setup/EmbeddedTerminal.tsx
+++ b/src/components/Setup/EmbeddedTerminal.tsx
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
+import { terminalClient } from "@/clients";
+
+interface EmbeddedTerminalProps {
+  className?: string;
+}
+
+export function EmbeddedTerminal({ className }: EmbeddedTerminalProps) {
+  const [terminalId, setTerminalId] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const pendingIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    const id = `setup-terminal-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    pendingIdRef.current = id;
+
+    terminalClient
+      .spawn({
+        id,
+        kind: "terminal",
+        cols: 80,
+        rows: 12,
+        isEphemeral: true,
+      })
+      .then(() => {
+        if (mountedRef.current) {
+          setTerminalId(id);
+        } else {
+          terminalClient.kill(id).catch(() => {});
+        }
+        pendingIdRef.current = null;
+      })
+      .catch((err) => {
+        console.error("[EmbeddedTerminal] Failed to spawn:", err);
+        pendingIdRef.current = null;
+      });
+
+    return () => {
+      mountedRef.current = false;
+      if (pendingIdRef.current) {
+        terminalClient.kill(pendingIdRef.current).catch(() => {});
+        pendingIdRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const id = terminalId;
+    if (!id) return;
+    return () => {
+      terminalClient.kill(id).catch(() => {});
+    };
+  }, [terminalId]);
+
+  const handleExit = useCallback(() => {
+    setTerminalId(null);
+  }, []);
+
+  if (!terminalId) {
+    return (
+      <div
+        className={`flex items-center justify-center bg-canopy-bg rounded-[var(--radius-md)] border border-canopy-border ${className ?? ""}`}
+        style={{ height: 280 }}
+      >
+        <span className="text-sm text-canopy-text/40">Starting terminal...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`overflow-hidden rounded-[var(--radius-md)] border border-canopy-border ${className ?? ""}`}
+      style={{ height: 280 }}
+    >
+      <XtermAdapter terminalId={terminalId} terminalType="terminal" onExit={handleExit} />
+    </div>
+  );
+}

--- a/src/components/Setup/index.ts
+++ b/src/components/Setup/index.ts
@@ -1,0 +1,6 @@
+export {
+  AgentSetupWizard,
+  shouldShowAgentSetupWizard,
+  markAgentSetupComplete,
+  resetAgentSetupFlag,
+} from "./AgentSetupWizard";


### PR DESCRIPTION
## Summary

Adds a guided first-run setup wizard that appears when Canopy is launched without any CLI agents installed. The wizard walks through each agent (Claude, Gemini, Codex, OpenCode) with an embedded terminal for running installation commands and auto-detects when a CLI becomes available.

Closes #2433

## Changes Made

- **`src/components/Setup/AgentSetupWizard.tsx`** — Main wizard modal with welcome, per-agent installation, and complete steps; polls CLI availability every 3s; resets state on reopen; mounted guard prevents stale updates after close
- **`src/components/Setup/AgentSetupStep.tsx`** — Individual agent step showing OS-specific install commands with copy buttons and installed/not-installed status badge
- **`src/components/Setup/EmbeddedTerminal.tsx`** — Compact embedded terminal (ephemeral PTY, 280px height) with spawn/kill race protection via `pendingIdRef`
- **`src/App.tsx`** — Integrates wizard into render tree; first-run detection gated on `isCheckingAvailability === false` to avoid false positives; wires `canopy:open-agent-setup-wizard` custom event
- **`src/components/Settings/AgentSettings.tsx`** — Adds "Run Setup Wizard" button to re-trigger the wizard from Settings → Agents