### PR TITLE
refactor(worktree-menu): collapse Launch and Sessions into native submenus

### DIFF
--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
@@ -49,18 +49,18 @@ export function useWorktreeMenu({
   const focusedTerminalId = useTerminalStore((state) => state.focusedId);
 
   const contextMenuTemplate = useMemo((): MenuItemOption[] => {
-    const template: MenuItemOption[] = [
-      { id: "label:launch", label: "Launch", enabled: false },
+    const launchSubmenu: MenuItemOption[] = [
       ...launchAgents.map((agent) => ({
         id: `launch:${agent.id}`,
         label: agent.label,
         enabled: Boolean(onLaunchAgent && agent.isEnabled),
       })),
+      ...(launchAgents.length > 0 ? [{ type: "separator" as const }] : []),
       { id: "launch:terminal", label: "Open Terminal", enabled: Boolean(onLaunchAgent) },
       { id: "launch:browser", label: "Open Browser", enabled: Boolean(onLaunchAgent) },
-      { type: "separator" },
+    ];
 
-      { id: "label:sessions", label: "Sessions", enabled: false },
+    const sessionsSubmenu: MenuItemOption[] = [
       {
         id: "sessions:minimize-all",
         label: `Minimize All (${counts.grid})`,
@@ -71,6 +71,7 @@ export function useWorktreeMenu({
         label: `Maximize All (${counts.dock})`,
         enabled: counts.dock > 0,
       },
+      { type: "separator" },
       {
         id: "sessions:restart-all",
         label: `${isRestartValidating ? "Checking..." : "Restart All"} (${counts.active})`,
@@ -82,7 +83,6 @@ export function useWorktreeMenu({
         enabled: counts.active > 0,
       },
       { type: "separator" },
-
       {
         id: "sessions:close-completed",
         label: `Close Completed (${counts.completed})`,
@@ -94,7 +94,6 @@ export function useWorktreeMenu({
         enabled: counts.failed > 0,
       },
       { type: "separator" },
-
       {
         id: "sessions:close-all",
         label: `Close All (Trash) (${counts.active})`,
@@ -105,9 +104,13 @@ export function useWorktreeMenu({
         label: `End All (Kill) (${counts.all})`,
         enabled: counts.all > 0,
       },
+    ];
+
+    const template: MenuItemOption[] = [
+      { id: "submenu:launch", label: "Launch", submenu: launchSubmenu },
+      { id: "submenu:sessions", label: "Sessions", submenu: sessionsSubmenu },
       { type: "separator" },
 
-      { id: "label:worktree", label: "Worktree", enabled: false },
       {
         id: "worktree:attach-issue",
         label: worktree.issueNumber ? "Change Issue..." : "Attach to Issue...",
@@ -161,7 +164,6 @@ export function useWorktreeMenu({
     const hasRecipeSection = recipes.length > 0 || (onSaveLayout && counts.active > 0);
     if (hasRecipeSection) {
       template.push({ type: "separator" });
-      template.push({ id: "label:recipes", label: "Recipes", enabled: false });
 
       if (recipes.length > 0) {
         template.push({
@@ -207,6 +209,7 @@ export function useWorktreeMenu({
     runningRecipeId,
     worktree.issueNumber,
     worktree.prNumber,
+    worktree.prUrl,
   ]);
 
   const handleContextMenu = useCallback(


### PR DESCRIPTION
## Summary

Restructures the worktree context menu to prevent it from overflowing the screen when many agents and/or recipes are configured. The flat list of 30+ items is collapsed into two native Electron submenus, keeping the top-level menu to ~12 items regardless of configuration.

Closes #2431

## Changes Made

- Wrap launch agents, terminal, and browser into a `Launch →` submenu (with conditional separator between agents and terminal/browser)
- Wrap all session management items (minimize, maximize, restart, reset, close completed, close failed, close all, end all) into a `Sessions →` submenu with existing logical separators preserved
- Remove flat section label items (`label:launch`, `label:sessions`, `label:recipes`, `label:worktree`) that were used as visual headers in the old flat list
- Fix pre-existing bug: add missing `worktree.prUrl` to `useMemo` dependency array (was causing stale PR menu visibility)

No changes required to the IPC bridge (`menu.ts`), `useNativeContextMenu`, or any other components — the bridge already resolves leaf item IDs at any submenu depth.