### PR TITLE
feat(agent-settings): add selected field and workflow selection model

### DIFF
--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -70,6 +70,8 @@ export const DEFAULT_ROUTING_CONFIG: AgentRoutingConfig = {
 
 export interface AgentSettingsEntry {
   enabled?: boolean;
+  /** Include this agent in the user's active workflow (toolbars, palettes, menus) */
+  selected?: boolean;
   customFlags?: string;
   /** Additional args appended when dangerous mode is enabled */
   dangerousArgs?: string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -60,7 +60,12 @@ export { useUIStore } from "./uiStore";
 
 export { useGitHubConfigStore, cleanupGitHubConfigStore } from "./githubConfigStore";
 
-export { useAgentSettingsStore, cleanupAgentSettingsStore } from "./agentSettingsStore";
+export {
+  useAgentSettingsStore,
+  cleanupAgentSettingsStore,
+  getSelectedAgents,
+  migrateAgentSelection,
+} from "./agentSettingsStore";
 
 export { useCliAvailabilityStore, cleanupCliAvailabilityStore } from "./cliAvailabilityStore";
 


### PR DESCRIPTION
## Summary

Adds a `selected` boolean field to `AgentSettingsEntry` as the data model foundation for agent workflow selection. This opt-in concept lets users control which agents appear in toolbars, palettes, and menus — separate from `enabled` (launcher visibility) and `installed` (CLI detected).

Closes #2435

## Changes Made

- Add `selected?: boolean` to `AgentSettingsEntry` interface in `shared/types/agentSettings.ts`
- Add `setAgentSelected(agentId, selected)` action to `agentSettingsStore` (delegates to `updateAgent`)
- Add `migrateAgentSelection(availability)` function with in-flight guard and full registry coverage — defaults `selected: true` for installed agents, `false` for uninstalled; only runs for agents where `selected === undefined`
- Add `getSelectedAgents()` selector returning IDs of workflow-selected agents
- Export both utilities from `src/store/index.ts`
- Add "Include in Workflow" toggle in `AgentSettings.tsx` with `role="switch"` and `aria-checked` accessibility attributes
- Gate migration on CLI `isInitialized` (not just `!isLoading`) to prevent persisting incorrect `false` defaults when CLI detection errors
- Update agent pill visual indicator in Settings to reflect `selected` state with opacity and dot indicator