### PR TITLE
feat(toolbar): hide unselected agents and add agent-setup wizard button

### DIFF
--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -884,6 +884,7 @@ export interface ProjectSettings {
 /** Unique identifier for toolbar buttons */
 export type ToolbarButtonId =
   | "sidebar-toggle"
+  | "agent-setup"
   | "claude"
   | "gemini"
   | "codex"

--- a/src/components/Layout/AgentSetupButton.tsx
+++ b/src/components/Layout/AgentSetupButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Sparkles } from "lucide-react";
+
+export function AgentSetupButton() {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              window.dispatchEvent(new CustomEvent("canopy:open-agent-setup-wizard"));
+            }}
+            className="text-canopy-text hover:bg-white/[0.06] hover:text-canopy-accent focus-visible:text-canopy-accent transition-colors"
+            aria-label="Install AI Agents"
+          >
+            <Sparkles className="text-canopy-accent" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Install AI Agents</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -26,6 +26,7 @@ import { isMac, createTooltipWithShortcut } from "@/lib/platform";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { GitHubResourceList, CommitList } from "@/components/GitHub";
 import { AgentButton } from "./AgentButton";
+import { AgentSetupButton } from "./AgentSetupButton";
 import { GitHubStatusIndicator, type GitHubStatusIndicatorStatus } from "./GitHubStatusIndicator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useWorktreeActions } from "@/hooks/useWorktreeActions";
@@ -248,6 +249,11 @@ export function Toolbar({
     void actionService.dispatch("app.settings.openTab", { tab }, { source: "context-menu" });
   };
 
+  const hasAnySelectedAgent = useMemo(() => {
+    if (!agentSettings?.agents) return false;
+    return Object.values(agentSettings.agents).some((entry) => entry.selected === true);
+  }, [agentSettings]);
+
   const buttonRegistry = useMemo<
     Record<ToolbarButtonId, { render: () => React.ReactNode; isAvailable: boolean }>
   >(
@@ -276,6 +282,10 @@ export function Toolbar({
         ),
         isAvailable: true,
       },
+      "agent-setup": {
+        render: () => <AgentSetupButton key="agent-setup" />,
+        isAvailable: agentSettings != null && !hasAnySelectedAgent,
+      },
       claude: {
         render: () => (
           <AgentButton
@@ -286,7 +296,7 @@ export function Toolbar({
             onOpenSettings={openAgentSettings}
           />
         ),
-        isAvailable: true,
+        isAvailable: agentSettings?.agents?.claude?.selected ?? true,
       },
       gemini: {
         render: () => (
@@ -298,7 +308,7 @@ export function Toolbar({
             onOpenSettings={openAgentSettings}
           />
         ),
-        isAvailable: true,
+        isAvailable: agentSettings?.agents?.gemini?.selected ?? true,
       },
       codex: {
         render: () => (
@@ -310,7 +320,7 @@ export function Toolbar({
             onOpenSettings={openAgentSettings}
           />
         ),
-        isAvailable: true,
+        isAvailable: agentSettings?.agents?.codex?.selected ?? true,
       },
       opencode: {
         render: () => (
@@ -322,7 +332,7 @@ export function Toolbar({
             onOpenSettings={openAgentSettings}
           />
         ),
-        isAvailable: true,
+        isAvailable: agentSettings?.agents?.opencode?.selected ?? true,
       },
       terminal: {
         render: () => (
@@ -714,6 +724,7 @@ export function Toolbar({
       onToggleFocusMode,
       agentAvailability,
       agentSettings,
+      hasAnySelectedAgent,
       openAgentSettings,
       onLaunchAgent,
       terminalShortcut,

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -26,6 +26,7 @@ import {
   Settings,
   AlertCircle,
   Bot,
+  Sparkles,
 } from "lucide-react";
 import { useToolbarPreferencesStore } from "@/store";
 import type { ToolbarButtonId } from "@/../../shared/types/domain";
@@ -34,6 +35,11 @@ import { CanopyIcon } from "@/components/icons";
 type ButtonMetadata = { label: string; icon: React.ReactNode; description: string };
 
 const BUTTON_METADATA: Partial<Record<ToolbarButtonId, ButtonMetadata>> = {
+  "agent-setup": {
+    label: "Agent Setup",
+    icon: <Sparkles className="h-4 w-4" />,
+    description: "Shown only when no agents are selected in Agent Settings",
+  },
   claude: {
     label: "Claude Agent",
     icon: <Bot className="h-4 w-4" />,

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -23,6 +23,7 @@ function getSafeStorage(): StateStorage {
 }
 
 const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
+  "agent-setup",
   "claude",
   "gemini",
   "codex",


### PR DESCRIPTION
## Summary

Hides unselected AI agent buttons from the toolbar and shows a single "Agent Setup" button (Sparkles icon) when no agents are selected. This improves the first-run experience by reducing clutter and providing a clear entry point to the setup wizard.

Closes #2434

## Changes Made

- **`shared/types/domain.ts`**: Added `"agent-setup"` to the `ToolbarButtonId` union type
- **`src/components/Layout/AgentSetupButton.tsx`**: New button component that dispatches `canopy:open-agent-setup-wizard` custom event to open the setup wizard modal
- **`src/components/Layout/Toolbar.tsx`**: Agent buttons now check `agentSettings?.agents?.[id]?.selected ?? true` (fallback to visible during loading/pre-migration); setup button visible only when `agentSettings` is loaded and no agents are selected
- **`src/store/toolbarPreferencesStore.ts`**: Added `"agent-setup"` at position 0 of `DEFAULT_LEFT_BUTTONS`; existing users get it injected automatically via `mergeButtonList` on upgrade
- **`src/components/Settings/ToolbarSettingsTab.tsx`**: Registered metadata for `"agent-setup"` so it appears in the toolbar customization UI