### PR TITLE
feat(agents): filter palettes and menus by selected agents

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import { NewWorktreeDialog } from "./components/Worktree/NewWorktreeDialog";
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { TerminalPalette, NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
+import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
 import { GitInitDialog, ProjectOnboardingWizard, WelcomeScreen } from "./components/Project";
 import { AgentSetupWizard, shouldShowAgentSetupWizard } from "./components/Setup";
 import { CreateProjectFolderDialog } from "./components/Project/CreateProjectFolderDialog";
@@ -1019,6 +1020,7 @@ function App() {
         onSelectNext={panelPalette.selectNext}
         onSelect={(kind) => {
           panelPalette.handleSelect(kind);
+          if (kind.id === MORE_AGENTS_PANEL_ID) return;
           if (kind.id.startsWith("agent:")) {
             const agentId = kind.id.slice("agent:".length);
             if (agentId) {
@@ -1035,7 +1037,7 @@ function App() {
         }}
         onConfirm={() => {
           const selected = panelPalette.confirmSelection();
-          if (selected) {
+          if (selected && selected.id !== MORE_AGENTS_PANEL_ID) {
             if (selected.id.startsWith("agent:")) {
               const agentId = selected.id.slice("agent:".length);
               if (agentId) {

--- a/src/components/TerminalPalette/launchOptions.tsx
+++ b/src/components/TerminalPalette/launchOptions.tsx
@@ -1,4 +1,4 @@
-import { Terminal, Globe } from "lucide-react";
+import { Terminal, Globe, Settings } from "lucide-react";
 import { ClaudeIcon, GeminiIcon, CodexIcon, OpenCodeIcon } from "@/components/icons";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import type { TerminalType, TerminalKind } from "@/types";
@@ -58,4 +58,14 @@ export function getLaunchOptions(): LaunchOption[] {
       icon: <Globe className="w-4 h-4 text-blue-400" />,
     },
   ];
+}
+
+export function getMoreAgentsOption(): LaunchOption {
+  return {
+    id: "more-agents",
+    type: "terminal",
+    label: "More agents...",
+    description: "Configure which agents appear in this menu",
+    icon: <Settings className="w-4 h-4 text-canopy-text/50" />,
+  };
 }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -278,20 +278,26 @@ export function WorktreeCard({
   }, [agentSettings]);
 
   const launchAgents = useMemo(() => {
-    return agentIds.map((agentId) => {
-      const config = getAgentConfig(agentId);
-      const entry = getAgentSettingsEntry(agentSettings, agentId);
-      const settingsEnabled = entry.enabled ?? true;
-      const available = agentAvailability?.[agentId] ?? false;
+    return agentIds
+      .filter((agentId) => {
+        const entry = getAgentSettingsEntry(agentSettings, agentId);
+        // selected === false = explicitly deselected; undefined = pre-migration, treat as visible
+        return entry.selected !== false;
+      })
+      .map((agentId) => {
+        const config = getAgentConfig(agentId);
+        const entry = getAgentSettingsEntry(agentSettings, agentId);
+        const settingsEnabled = entry.enabled ?? true;
+        const available = agentAvailability?.[agentId] ?? false;
 
-      return {
-        id: agentId,
-        name: config?.name ?? agentId,
-        icon: config?.icon,
-        shortcut: config?.shortcut ?? null,
-        isEnabled: settingsEnabled && available,
-      };
-    });
+        return {
+          id: agentId,
+          name: config?.name ?? agentId,
+          icon: config?.icon,
+          shortcut: config?.shortcut ?? null,
+          isEnabled: settingsEnabled && available,
+        };
+      });
   }, [agentAvailability, agentIds, agentSettings]);
 
   const launchAgentsForContextMenu = useMemo(

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
@@ -56,6 +56,9 @@ export function useWorktreeMenu({
         enabled: Boolean(onLaunchAgent && agent.isEnabled),
       })),
       ...(launchAgents.length > 0 ? [{ type: "separator" as const }] : []),
+      ...(launchAgents.length === 0
+        ? [{ id: "launch:configure-agents", label: "Configure agents..." }]
+        : []),
       { id: "launch:terminal", label: "Open Terminal", enabled: Boolean(onLaunchAgent) },
       { id: "launch:browser", label: "Open Browser", enabled: Boolean(onLaunchAgent) },
     ];
@@ -216,6 +219,15 @@ export function useWorktreeMenu({
     async (event: React.MouseEvent) => {
       const actionId = await showMenu(event, contextMenuTemplate);
       if (!actionId) return;
+
+      if (actionId === "launch:configure-agents") {
+        void actionService.dispatch(
+          "app.settings.openTab",
+          { tab: "agents" },
+          { source: "context-menu" }
+        );
+        return;
+      }
 
       if (actionId.startsWith("launch:")) {
         const agentId = actionId.slice("launch:".length);

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -36,6 +36,19 @@ vi.mock("@/store/userAgentRegistryStore", () => ({
   ) => selector({ registry: {} }),
 }));
 
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (
+    selector: (state: {
+      settings: { agents: Record<string, { selected?: boolean }> } | null;
+    }) => unknown
+  ) =>
+    selector({ settings: { agents: { claude: { selected: true }, gemini: { selected: true } } } }),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
 import { usePanelPalette } from "../usePanelPalette";
 
 describe("usePanelPalette", () => {

--- a/src/lib/projectExplanationPrompt.ts
+++ b/src/lib/projectExplanationPrompt.ts
@@ -28,14 +28,18 @@ Keep the summary concise but informative - aim for someone to understand the pro
 export function getDefaultAgentId(
   defaultAgent: string | undefined,
   defaultSelection: string | undefined,
-  availability: CliAvailability
+  availability: CliAvailability,
+  selectedAgents?: Set<string>
 ): "claude" | "gemini" | "codex" | "opencode" | null {
   const agentIds = ["claude", "gemini", "codex", "opencode"] as const;
+
+  const isUsable = (id: string) =>
+    availability[id as keyof CliAvailability] && (!selectedAgents || selectedAgents.has(id));
 
   if (
     defaultAgent &&
     agentIds.includes(defaultAgent as (typeof agentIds)[number]) &&
-    availability[defaultAgent as keyof CliAvailability]
+    isUsable(defaultAgent)
   ) {
     return defaultAgent as "claude" | "gemini" | "codex" | "opencode";
   }
@@ -43,13 +47,13 @@ export function getDefaultAgentId(
   if (
     defaultSelection &&
     agentIds.includes(defaultSelection as (typeof agentIds)[number]) &&
-    availability[defaultSelection as keyof CliAvailability]
+    isUsable(defaultSelection)
   ) {
     return defaultSelection as "claude" | "gemini" | "codex" | "opencode";
   }
 
   for (const agentId of agentIds) {
-    if (availability[agentId]) {
+    if (isUsable(agentId)) {
       return agentId;
     }
   }


### PR DESCRIPTION
## Summary

Filters the new-terminal palette, panel palette, worktree context menu, and grid context menu to only show agents the user has selected. Adds a "More agents..." / "Configure agents..." shortcut everywhere to open Agent Settings when an agent needs to be added.

Closes #2436

## Changes Made

- **`useNewTerminalPalette`** — Filter `getLaunchOptions()` to hide agents where `selected === false`; append a "More agents…" footer item that opens Agent Settings and closes the palette. Replace hard-coded `AGENT_IDS` with `getEffectiveAgentIds()` from the registry. Fix pre-existing `closeFnRef` bug by using the `close()` function directly.
- **`usePanelPalette`** — Apply the same `selected !== false` filter to agent kinds before building palette options; append "More agents…" item. Simplified `availableKinds` memo to inline the `isAgentHidden` predicate.
- **`WorktreeCard`** — `launchAgents` filtered to `selected !== false` agents. Worktree context menu "Launch" submenu now shows "Configure agents…" when the filtered list is empty.
- **`ContentGrid`** — Grid right-click context menu filters agent items through the selected-agents set. When settings are not yet loaded (`null`), passes `undefined` to `getDefaultAgentId` (no filter) instead of an empty Set. Uses `getEffectiveAgentConfig()` for registry-driven labels instead of a hard-coded map.
- **`getDefaultAgentId`** — Added optional `selectedAgents?: Set<string>` parameter; `undefined` = no filter, a Set = restrict to non-deselected agents.
- **`App.tsx`** — Use `MORE_AGENTS_PANEL_ID` constant; guard `onSelect`/`onConfirm` handlers to skip panel creation when "more-agents" is selected.

**Semantics:** `selected === false` = user explicitly deselected; `selected === undefined` = pre-migration (treated as visible for backward compatibility); `selected === true` = explicitly selected.