### PR TITLE
feat(ui): replace Sparkles with PackagePlus on agent setup wizard buttons

### DIFF
--- a/src/components/Layout/AgentSetupButton.tsx
+++ b/src/components/Layout/AgentSetupButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Sparkles } from "lucide-react";
+import { PackagePlus } from "lucide-react";
 
 export function AgentSetupButton() {
   return (
@@ -16,7 +16,7 @@ export function AgentSetupButton() {
             className="text-canopy-text hover:bg-white/[0.06] hover:text-canopy-accent focus-visible:text-canopy-accent transition-colors"
             aria-label="Install AI Agents"
           >
-            <Sparkles className="text-canopy-accent" />
+            <PackagePlus className="text-canopy-accent" />
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Install AI Agents</TooltipContent>

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -8,7 +8,7 @@ import {
   getAgentSettingsEntry,
   DEFAULT_DANGEROUS_ARGS,
 } from "@shared/types";
-import { RotateCcw, ExternalLink, RefreshCw, Copy, Check, Sparkles } from "lucide-react";
+import { RotateCcw, ExternalLink, RefreshCw, Copy, Check, PackagePlus } from "lucide-react";
 import { actionService } from "@/services/ActionService";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { AgentHelpOutput } from "./AgentHelpOutput";
@@ -201,7 +201,7 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
             }}
             className="text-canopy-text/60 hover:text-canopy-text shrink-0"
           >
-            <Sparkles className="w-3.5 h-3.5" />
+            <PackagePlus className="w-3.5 h-3.5" />
             Run Setup Wizard
           </Button>
         </div>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -26,7 +26,7 @@ import {
   Settings,
   AlertCircle,
   Bot,
-  Sparkles,
+  PackagePlus,
 } from "lucide-react";
 import { useToolbarPreferencesStore } from "@/store";
 import type { ToolbarButtonId } from "@/../../shared/types/domain";
@@ -37,7 +37,7 @@ type ButtonMetadata = { label: string; icon: React.ReactNode; description: strin
 const BUTTON_METADATA: Partial<Record<ToolbarButtonId, ButtonMetadata>> = {
   "agent-setup": {
     label: "Agent Setup",
-    icon: <Sparkles className="h-4 w-4" />,
+    icon: <PackagePlus className="h-4 w-4" />,
     description: "Shown only when no agents are selected in Agent Settings",
   },
   claude: {


### PR DESCRIPTION
## Summary

Replaces the `Sparkles` lucide icon with `PackagePlus` on all three entry points that trigger the agent setup wizard. `PackagePlus` better communicates "install a new CLI package/agent" — the standard IDE mental model — rather than the generative-AI/decoration connotation of `Sparkles`.

Closes #2454

## Changes Made

- Replace `Sparkles` with `PackagePlus` in `AgentSetupButton.tsx` — toolbar install-agents button
- Replace `Sparkles` with `PackagePlus` in `AgentSettings.tsx` — "Run Setup Wizard" button in Agent Settings panel
- Replace `Sparkles` with `PackagePlus` in `ToolbarSettingsTab.tsx` — `BUTTON_METADATA["agent-setup"]` icon entry