### PR TITLE
refactor(wizard): simplify project setup wizard and remove re-open button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -647,7 +647,6 @@ function App() {
   const onboardingProjectId = useProjectStore((state) => state.onboardingProjectId);
   const closeOnboardingWizard = useProjectStore((state) => state.closeOnboardingWizard);
 
-  const openOnboardingWizard = useProjectStore((state) => state.openOnboardingWizard);
   const agentSettingsInitialized = useAgentSettingsStore((state) => state.isInitialized);
 
   // Intercept onboarding to show agent selection on first run.
@@ -832,13 +831,6 @@ function App() {
       }).catch(() => {});
     }
   }, [launchAgent, activeWorktreeId, availability, agentSettings]);
-
-  const handleOpenSetupWizard = useCallback(() => {
-    const currentProject = useProjectStore.getState().currentProject;
-    if (!currentProject) return;
-    setIsSettingsOpen(false);
-    openOnboardingWizard(currentProject.id);
-  }, [openOnboardingWizard]);
 
   const handleOpenAgentSettings = useCallback(() => {
     setSettingsTab("agents");
@@ -1207,7 +1199,6 @@ function App() {
         onClose={() => setIsSettingsOpen(false)}
         defaultTab={settingsTab}
         onSettingsChange={refreshSettings}
-        onOpenSetupWizard={currentProject ? handleOpenSetupWizard : undefined}
       />
 
       <ShortcutReferenceDialog isOpen={isShortcutsOpen} onClose={() => setIsShortcutsOpen(false)} />

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -22,7 +22,6 @@ import { actionService } from "@/services/ActionService";
 interface GeneralTabProps {
   appVersion: string;
   onNavigateToAgents?: () => void;
-  onOpenSetupWizard?: () => void;
 }
 
 const CURATED_SHORTCUTS = [
@@ -66,7 +65,7 @@ interface ShortcutCategory {
   shortcuts: ShortcutDisplay[];
 }
 
-export function GeneralTab({ appVersion, onNavigateToAgents, onOpenSetupWizard }: GeneralTabProps) {
+export function GeneralTab({ appVersion, onNavigateToAgents }: GeneralTabProps) {
   const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
   const [hibernationConfig, setHibernationConfig] = useState<HibernationConfig | null>(null);
   const [isSaving, setIsSaving] = useState(false);
@@ -257,25 +256,6 @@ export function GeneralTab({ appVersion, onNavigateToAgents, onOpenSetupWizard }
           progress, and inject context to help them understand your codebase.
         </p>
       </div>
-
-      {onOpenSetupWizard && (
-        <div className="space-y-2">
-          <h4 className="text-sm font-medium text-canopy-text">Project Setup</h4>
-          <div className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] p-4">
-            <p className="text-sm text-canopy-text/60 mb-3">
-              Re-open the project setup wizard to update your project name, AI rules (CLAUDE.md),
-              and advanced configuration.
-            </p>
-            <button
-              type="button"
-              onClick={onOpenSetupWizard}
-              className="text-sm px-3 py-1.5 rounded-[var(--radius-md)] border border-canopy-border hover:bg-canopy-border/30 text-canopy-text transition-colors"
-            >
-              Re-open Setup Wizard
-            </button>
-          </div>
-        </div>
-      )}
 
       <div className="space-y-2">
         <h4 className="text-sm font-medium text-canopy-text">System Status</h4>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -32,7 +32,6 @@ interface SettingsDialogProps {
   onClose: () => void;
   defaultTab?: SettingsTab;
   onSettingsChange?: () => void;
-  onOpenSetupWizard?: () => void;
 }
 
 export type SettingsTab =
@@ -53,7 +52,6 @@ export function SettingsDialog({
   onClose,
   defaultTab,
   onSettingsChange,
-  onOpenSetupWizard,
 }: SettingsDialogProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>(defaultTab ?? "general");
   const setSidecarOpen = useSidecarStore((state) => state.setOpen);
@@ -201,7 +199,6 @@ export function SettingsDialog({
               <GeneralTab
                 appVersion={appVersion}
                 onNavigateToAgents={() => setActiveTab("agents")}
-                onOpenSetupWizard={onOpenSetupWizard}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Removes the "Re-open Setup Wizard" button from General Settings and strips the AI Rules (CLAUDE.md) editing step from the project onboarding wizard, leaving it focused solely on project identity and dev command configuration.

Closes #2453

## Changes Made

- Remove "Project Setup" section and "Re-open Setup Wizard" button from `GeneralTab`
- Remove `onOpenSetupWizard` prop from `GeneralTabProps`, `SettingsDialogProps`, and the `App.tsx` render
- Remove `handleOpenSetupWizard` callback and the `openOnboardingWizard` store hook from `App.tsx`
- Strip the "AI Rules (CLAUDE.md)" section (textarea, template toggle) from `ProjectOnboardingWizard`
- Remove `claudeMdContent`, `useTemplate`, `templateContent` state and `handleUseTemplateToggle`
- Remove `projectClient.readClaudeMd` / `writeClaudeMd` calls from the wizard
- Remove `detectProjectType` and `generateClaudeMdTemplate` imports
- Simplify wizard init effect to synchronous initialization (no async CLAUDE.md loading)