### PR TITLE
refactor(sidecar): remove layout mode preference and reduce default width

### DIFF
--- a/electron/services/assistant/actionTools.ts
+++ b/electron/services/assistant/actionTools.ts
@@ -187,7 +187,6 @@ export const AGENT_ACCESSIBLE_ACTIONS = [
   // Sidecar layout
   "sidecar.width.set",
   "sidecar.resetWidth",
-  "sidecar.setLayoutMode",
   "sidecar.setDefaultNewTab",
   "sidecar.tabs.reorder",
 

--- a/scripts/dump-assistant-tools.ts
+++ b/scripts/dump-assistant-tools.ts
@@ -182,7 +182,6 @@ const AGENT_ACCESSIBLE_ACTIONS = [
   // Sidecar layout
   "sidecar.width.set",
   "sidecar.resetWidth",
-  "sidecar.setLayoutMode",
   "sidecar.setDefaultNewTab",
   "sidecar.tabs.reorder",
 

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -193,7 +193,6 @@ export type ActionId =
   | "sidecar.openTabExternal"
   | "sidecar.closeOthers"
   | "sidecar.closeToRight"
-  | "sidecar.setLayoutMode"
   | "sidecar.resetWidth"
   | "sidecar.width.set"
   | "sidecar.setDefaultNewTab"

--- a/shared/types/sidecar.ts
+++ b/shared/types/sidecar.ts
@@ -115,5 +115,5 @@ export const DEFAULT_SIDECAR_TABS: SidecarTab[] = [];
 
 export const SIDECAR_MIN_WIDTH = 480;
 export const SIDECAR_MAX_WIDTH = 1200;
-export const SIDECAR_DEFAULT_WIDTH = 640;
+export const SIDECAR_DEFAULT_WIDTH = 480;
 export const MIN_GRID_WIDTH = 400;

--- a/src/components/Settings/SidecarSettingsTab.tsx
+++ b/src/components/Settings/SidecarSettingsTab.tsx
@@ -1,17 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import {
-  RefreshCw,
-  Plus,
-  Trash2,
-  Globe,
-  Check,
-  X,
-  Search,
-  Layers,
-  ArrowRightToLine,
-  SquareStack,
-  AlertTriangle,
-} from "lucide-react";
+import { RefreshCw, Plus, Trash2, Globe, Check, X, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { useSidecarStore } from "@/store/sidecarStore";
@@ -21,9 +9,7 @@ import {
   SIDECAR_MIN_WIDTH,
   SIDECAR_MAX_WIDTH,
   SIDECAR_DEFAULT_WIDTH,
-  MIN_GRID_WIDTH,
 } from "@shared/types";
-import type { SidecarLayoutModePreference } from "@shared/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
 
@@ -67,35 +53,8 @@ function FaviconIcon({ url }: { url: string }) {
   }
 }
 
-const LAYOUT_MODE_OPTIONS: Array<{
-  id: SidecarLayoutModePreference;
-  label: string;
-  description: string;
-  icon: typeof Layers;
-}> = [
-  {
-    id: "auto",
-    label: "Auto",
-    description: "Adapts to window size",
-    icon: Layers,
-  },
-  {
-    id: "push",
-    label: "Push",
-    description: "Always pushes content",
-    icon: ArrowRightToLine,
-  },
-  {
-    id: "overlay",
-    label: "Overlay",
-    description: "Always overlays content",
-    icon: SquareStack,
-  },
-];
-
 export function SidecarSettingsTab() {
   const links = useSidecarStore((s) => s.links);
-  const layoutModePreference = useSidecarStore((s) => s.layoutModePreference);
   const width = useSidecarStore((s) => s.width);
   const defaultNewTabUrl = useSidecarStore((s) => s.defaultNewTabUrl);
   const { rescan, isScanning } = useLinkDiscovery();
@@ -602,67 +561,6 @@ export function SidecarSettingsTab() {
           </div>
           {urlError && <p className="text-xs text-red-500 mt-1">{urlError}</p>}
         </div>
-      </section>
-
-      <section className="pt-4 border-t border-canopy-border">
-        <h4 className="text-sm font-medium text-canopy-text mb-2">Layout Mode</h4>
-        <p className="text-xs text-canopy-text/50 mb-4">
-          Control how the sidecar panel interacts with the main content area.
-        </p>
-
-        <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Layout mode">
-          {LAYOUT_MODE_OPTIONS.map(({ id, label, description, icon: Icon }) => (
-            <button
-              key={id}
-              type="button"
-              onClick={() =>
-                void actionService.dispatch(
-                  "sidecar.setLayoutMode",
-                  { mode: id },
-                  { source: "user" }
-                )
-              }
-              role="radio"
-              aria-checked={layoutModePreference === id}
-              aria-label={`${label} - ${description}`}
-              className={cn(
-                "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-all",
-                layoutModePreference === id
-                  ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
-                  : "border-canopy-border hover:bg-white/5 text-canopy-text/70"
-              )}
-            >
-              <Icon className="w-5 h-5 mb-1.5" />
-              <span className="text-xs font-medium">{label}</span>
-              <span className="text-[11px] mt-0.5 opacity-60">{description}</span>
-            </button>
-          ))}
-        </div>
-
-        <div className="text-xs text-canopy-text/50 space-y-1.5 bg-canopy-bg/50 rounded-[var(--radius-md)] p-3 mt-3">
-          <div className="font-medium text-canopy-text/70 mb-2">Mode behavior:</div>
-          <div className="flex justify-between">
-            <span>Auto</span>
-            <span className="text-canopy-text/70">
-              Switches to overlay when grid width &lt; {MIN_GRID_WIDTH}px
-            </span>
-          </div>
-          <div className="flex justify-between">
-            <span>Push</span>
-            <span className="text-canopy-text/70">Always pushes content aside</span>
-          </div>
-          <div className="flex justify-between">
-            <span>Overlay</span>
-            <span className="text-canopy-text/70">Always overlays on top of content</span>
-          </div>
-        </div>
-
-        {layoutModePreference === "push" && (
-          <p className="text-xs text-amber-500/80 flex items-center gap-1.5 mt-3">
-            <AlertTriangle className="w-3 h-3" />
-            Forcing push mode on small windows may make the panel grid unusable.
-          </p>
-        )}
       </section>
 
       <section className="pt-4 border-t border-canopy-border">

--- a/src/components/Sidecar/SidecarDock.tsx
+++ b/src/components/Sidecar/SidecarDock.tsx
@@ -13,16 +13,8 @@ import { actionService } from "@/services/ActionService";
 
 export function SidecarDock() {
   const { showMenu } = useNativeContextMenu();
-  const {
-    width,
-    activeTabId,
-    tabs,
-    links,
-    setWidth,
-    setOpen,
-    defaultNewTabUrl,
-    layoutModePreference,
-  } = useSidecarStore();
+  const { width, activeTabId, tabs, links, setWidth, setOpen, defaultNewTabUrl } =
+    useSidecarStore();
   const contentRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);
@@ -76,30 +68,6 @@ export function SidecarDock() {
         { id: "sidecar:close-tab", label: "Close Tab", enabled: activeTabId !== null },
         { id: "sidecar:close-all", label: "Close All Tabs", enabled: tabs.length > 0 },
         { type: "separator" },
-        {
-          id: "sidecar:layout-mode",
-          label: "Layout Mode",
-          submenu: [
-            {
-              id: "sidecar:layout-mode:auto",
-              label: "Auto",
-              type: "checkbox",
-              checked: layoutModePreference === "auto",
-            },
-            {
-              id: "sidecar:layout-mode:push",
-              label: "Push",
-              type: "checkbox",
-              checked: layoutModePreference === "push",
-            },
-            {
-              id: "sidecar:layout-mode:overlay",
-              label: "Overlay",
-              type: "checkbox",
-              checked: layoutModePreference === "overlay",
-            },
-          ],
-        },
         { id: "sidecar:reset-width", label: "Reset Width" },
         { type: "separator" },
         { id: "sidecar:default-new-tab", label: "Default New Tab", submenu: defaultNewTabItems },
@@ -132,27 +100,6 @@ export function SidecarDock() {
             source: "context-menu",
           });
           break;
-        case "sidecar:layout-mode:auto":
-          void actionService.dispatch(
-            "sidecar.setLayoutMode",
-            { mode: "auto" },
-            { source: "context-menu" }
-          );
-          break;
-        case "sidecar:layout-mode:push":
-          void actionService.dispatch(
-            "sidecar.setLayoutMode",
-            { mode: "push" },
-            { source: "context-menu" }
-          );
-          break;
-        case "sidecar:layout-mode:overlay":
-          void actionService.dispatch(
-            "sidecar.setLayoutMode",
-            { mode: "overlay" },
-            { source: "context-menu" }
-          );
-          break;
         case "sidecar:reset-width":
           void actionService.dispatch("sidecar.resetWidth", undefined, { source: "context-menu" });
           break;
@@ -172,7 +119,7 @@ export function SidecarDock() {
           break;
       }
     },
-    [activeTabId, defaultNewTabUrl, enabledLinks, layoutModePreference, showMenu, tabs.length]
+    [activeTabId, defaultNewTabUrl, enabledLinks, showMenu, tabs.length]
   );
 
   const syncBounds = useCallback(() => {

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -1,5 +1,4 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import { SidecarLayoutModeSchema } from "./schemas";
 import { z } from "zod";
 import { cliAvailabilityClient, systemClient } from "@/clients";
 import { getAIAgentInfo } from "@/lib/aiAgentDetection";
@@ -779,21 +778,6 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
         return;
       }
       await activateSidecarTab(next.activeTabId);
-    },
-  }));
-
-  actions.set("sidecar.setLayoutMode", () => ({
-    id: "sidecar.setLayoutMode",
-    title: "Set Sidecar Layout Mode",
-    description: "Set sidecar layout mode preference",
-    category: "sidecar",
-    kind: "command",
-    danger: "safe",
-    scope: "renderer",
-    argsSchema: z.object({ mode: SidecarLayoutModeSchema }),
-    run: async (args: unknown) => {
-      const { mode } = args as { mode: "auto" | "push" | "overlay" };
-      useSidecarStore.getState().setLayoutModePreference(mode);
     },
   }));
 

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -27,8 +27,6 @@ export const SettingsTabSchema = z.enum([
 
 export const TerminalTypeSchema = z.enum(["terminal", "claude", "gemini", "codex", "opencode"]);
 
-export const SidecarLayoutModeSchema = z.enum(["auto", "push", "overlay"]);
-
 export const LegacyAgentTypeSchema = z.enum(["claude", "gemini", "codex", "opencode"]);
 
 export const GitStatusSchema = z.enum([

--- a/src/store/sidecarStore.ts
+++ b/src/store/sidecarStore.ts
@@ -48,7 +48,6 @@ interface SidecarActions {
   updateTabUrl: (id: string, url: string) => void;
   updateTabIcon: (id: string, icon: string | undefined) => void;
   updateLayoutMode: (windowWidth: number, sidebarWidth: number) => void;
-  setLayoutModePreference: (preference: SidecarLayoutModePreference) => void;
   markTabCreated: (id: string) => void;
   isTabCreated: (id: string) => boolean;
   reset: () => void;
@@ -282,13 +281,6 @@ const createSidecarStore: StateCreator<SidecarState & SidecarActions> = (set, ge
     set({ layoutMode: remainingSpace < MIN_GRID_WIDTH ? "overlay" : "push" });
   },
 
-  setLayoutModePreference: (preference) => {
-    set({
-      layoutModePreference: preference,
-      ...(preference !== "auto" ? { layoutMode: preference } : {}),
-    });
-  },
-
   markTabCreated: (id) =>
     set((s) => {
       const newSet = new Set(s.createdTabs);
@@ -450,7 +442,6 @@ const sidecarStoreCreator: StateCreator<
     links: state.links,
     width: state.width,
     tabs: state.tabs,
-    layoutModePreference: state.layoutModePreference,
     defaultNewTabUrl: state.defaultNewTabUrl,
   }),
   merge: (persistedState: unknown, currentState) => {
@@ -462,12 +453,7 @@ const sidecarStoreCreator: StateCreator<
         typeof persisted.width === "number"
           ? Math.min(Math.max(persisted.width, SIDECAR_MIN_WIDTH), SIDECAR_MAX_WIDTH)
           : currentState.width,
-      layoutModePreference:
-        persisted.layoutModePreference === "auto" ||
-        persisted.layoutModePreference === "push" ||
-        persisted.layoutModePreference === "overlay"
-          ? persisted.layoutModePreference
-          : currentState.layoutModePreference,
+      layoutModePreference: "auto",
       defaultNewTabUrl:
         typeof persisted.defaultNewTabUrl === "string" && persisted.defaultNewTabUrl.trim()
           ? persisted.defaultNewTabUrl.trim()


### PR DESCRIPTION
## Summary

Removes the user-facing Layout Mode preference from the sidecar (the three-way Auto/Push/Overlay picker) and reduces the default sidecar width from 640px to 480px. The internal auto-switching logic that dynamically picks push vs overlay based on available grid space is preserved unchanged.

Closes #2456

## Changes Made

- Change `SIDECAR_DEFAULT_WIDTH` from `640` to `480` in `shared/types/sidecar.ts`
- Remove the Layout Mode section (three-button picker, description box, warning) from `SidecarSettingsTab`
- Remove the Layout Mode submenu from the `SidecarDock` context menu
- Remove `setLayoutModePreference` from the store actions interface and implementation
- Remove `sidecar.setLayoutMode` from the `ActionId` union, action registry, assistant allowlist, and dump-tools script
- Remove `layoutModePreference` from the persist `partialize` config so it is no longer written to storage
- Force `layoutModePreference: "auto"` in the store merge function to clear any legacy persisted value on next load
- Remove unused icon imports (`Layers`, `ArrowRightToLine`, `SquareStack`, `AlertTriangle`) from `SidecarSettingsTab`
- Remove dead `SidecarLayoutModeSchema` export from action schemas