### PR TITLE
fix(menu): align menu accelerators with canonical keybinding assignments

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -181,14 +181,14 @@ export function createApplicationMenu(
             ]
           : [{ type: "separator" as const }]),
         {
-          label: "Terminal Palette...",
+          label: "Quick Switcher...",
           accelerator: "CommandOrControl+P",
-          click: () => sendAction("open-agent-palette"),
+          click: () => sendAction("open-quick-switcher"),
         },
         {
-          label: "Panel Palette...",
+          label: "Command Palette...",
           accelerator: "CommandOrControl+Shift+P",
-          click: () => sendAction("open-panel-palette"),
+          click: () => sendAction("open-action-palette"),
         },
         { type: "separator" },
         {

--- a/src/hooks/__tests__/useMenuActions.test.tsx
+++ b/src/hooks/__tests__/useMenuActions.test.tsx
@@ -56,6 +56,64 @@ describe("useMenuActions", () => {
     expect(dispatchMock).not.toHaveBeenCalled();
   });
 
+  it("dispatches nav.quickSwitcher when open-quick-switcher action is received", async () => {
+    let handler: ((action: string) => Promise<void>) | undefined;
+    Object.defineProperty(window, "electron", {
+      value: {
+        app: {
+          onMenuAction: (cb: (action: string) => Promise<void>) => {
+            handler = cb;
+            return () => {};
+          },
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    renderHook(() =>
+      useMenuActions({
+        onOpenSettings: vi.fn(),
+        onToggleSidebar: vi.fn(),
+        onOpenAgentPalette: vi.fn(),
+        onLaunchAgent: vi.fn(),
+        defaultCwd: "/tmp",
+      })
+    );
+
+    await handler?.("open-quick-switcher");
+    expect(dispatchMock).toHaveBeenCalledWith("nav.quickSwitcher", undefined, { source: "menu" });
+  });
+
+  it("dispatches action.palette.open when open-action-palette action is received", async () => {
+    let handler: ((action: string) => Promise<void>) | undefined;
+    Object.defineProperty(window, "electron", {
+      value: {
+        app: {
+          onMenuAction: (cb: (action: string) => Promise<void>) => {
+            handler = cb;
+            return () => {};
+          },
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    renderHook(() =>
+      useMenuActions({
+        onOpenSettings: vi.fn(),
+        onToggleSidebar: vi.fn(),
+        onOpenAgentPalette: vi.fn(),
+        onLaunchAgent: vi.fn(),
+        defaultCwd: "/tmp",
+      })
+    );
+
+    await handler?.("open-action-palette");
+    expect(dispatchMock).toHaveBeenCalledWith("action.palette.open", undefined, { source: "menu" });
+  });
+
   it("does not leak unhandled rejection when action dispatch throws", async () => {
     let handler: ((action: string) => Promise<void>) | undefined;
     Object.defineProperty(window, "electron", {

--- a/src/hooks/useMenuActions.ts
+++ b/src/hooks/useMenuActions.ts
@@ -80,8 +80,8 @@ export function useMenuActions(options: UseMenuActionsOptions): void {
           "new-worktree": "worktree.createDialog.open",
           "open-settings": "app.settings",
           "toggle-sidebar": "nav.toggleSidebar",
-          "open-agent-palette": "terminal.palette",
-          "open-panel-palette": "panel.palette",
+          "open-quick-switcher": "nav.quickSwitcher",
+          "open-action-palette": "action.palette.open",
           "open-assistant": "assistant.open",
         };
 


### PR DESCRIPTION
## Summary

Resolves the mismatch between native menu accelerators and the canonical keybindings registered in `KeybindingService`. Users pressing `Cmd+P` or `Cmd+Shift+P` now get consistent behaviour regardless of whether they use the menu or the keyboard shortcut.

Closes #2467

## Changes Made

- Rename "Terminal Palette..." → "Quick Switcher..." in `electron/menu.ts` (Cmd+P now sends `open-quick-switcher`)
- Rename "Panel Palette..." → "Command Palette..." in `electron/menu.ts` (Cmd+Shift+P now sends `open-action-palette`)
- Update `menuToActionMap` in `useMenuActions.ts`: `open-quick-switcher` → `nav.quickSwitcher`, `open-action-palette` → `action.palette.open`
- Add tests covering the new menu-to-action dispatch for both renamed items