### PR TITLE
feat(actions): add terminal.focusDock action (Cmd+Alt+D) and focus transfer in toggleDock

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -76,6 +76,7 @@ export type KeyAction =
   | "terminal.focusDown"
   | "terminal.focusLeft"
   | "terminal.focusRight"
+  | "terminal.focusDock"
   | "terminal.focusIndex1"
   | "terminal.focusIndex2"
   | "terminal.focusIndex3"

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -89,6 +89,14 @@ const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Terminal",
   },
   {
+    actionId: "terminal.focusDock",
+    combo: "Cmd+Alt+D",
+    scope: "global",
+    priority: 0,
+    description: "Focus active dock terminal",
+    category: "Terminal",
+  },
+  {
     actionId: "terminal.toggleDockAll",
     combo: "Cmd+Alt+Shift+M",
     scope: "global",

--- a/src/services/actions/definitions/terminalActions.ts
+++ b/src/services/actions/definitions/terminalActions.ts
@@ -824,6 +824,36 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
     },
   }));
 
+  actions.set("terminal.focusDock", () => ({
+    id: "terminal.focusDock",
+    title: "Focus Dock",
+    description: "Focus the active dock terminal (or first dock terminal in the active worktree)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const state = useTerminalStore.getState();
+      const activeWorktreeId = callbacks.getActiveWorktreeId();
+      const dockTerminals = state.terminals.filter(
+        (t) =>
+          t.location === "dock" && (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
+      );
+      if (dockTerminals.length === 0) return;
+
+      const targetId =
+        (state.activeDockTerminalId &&
+          dockTerminals.some((t) => t.id === state.activeDockTerminalId) &&
+          state.activeDockTerminalId) ||
+        dockTerminals[0]!.id;
+      const group = state.getPanelGroup(targetId);
+      if (group) {
+        state.setActiveTab(group.id, targetId);
+      }
+      state.openDockTerminal(targetId);
+    },
+  }));
+
   actions.set("terminal.toggleDock", () => ({
     id: "terminal.toggleDock",
     title: "Toggle Dock",
@@ -846,6 +876,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
           state.setMaximizedId(null);
         }
         state.moveTerminalToDock(focusedId);
+        state.openDockTerminal(focusedId);
       }
     },
   }));


### PR DESCRIPTION
## Summary

Adds a `terminal.focusDock` action so users can move keyboard focus into the dock without a mouse click, and makes `terminal.toggleDock` transfer focus when sending a panel to/from the dock.

Closes #2469

## Changes Made

- Add `"terminal.focusDock"` to the `KeyAction` union in `shared/types/keymap.ts` so the action is keybinding-eligible
- Implement `terminal.focusDock` action: focuses the `activeDockTerminalId` if it belongs to the active worktree's dock, otherwise falls back to the first dock terminal; updates `setActiveTab` for tab groups before calling `openDockTerminal` to keep the visible tab in sync
- Update `terminal.toggleDock` grid→dock path to call `openDockTerminal(focusedId)` so keyboard focus follows the moved panel into the dock immediately
- Register default keybinding `Cmd+Alt+D` → `terminal.focusDock` in `KeybindingService`