### PR TITLE
feat(actions): filter args-required actions from palette and surface errors

### DIFF
--- a/electron/services/assistant/__tests__/actionTools.test.ts
+++ b/electron/services/assistant/__tests__/actionTools.test.ts
@@ -78,6 +78,7 @@ function createAction(overrides: Partial<ActionManifestEntry> = {}): ActionManif
     kind: "query",
     danger: "safe",
     enabled: true,
+    requiresArgs: false,
     inputSchema: { type: "object", properties: {} },
     ...overrides,
   };

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -265,6 +265,7 @@ export interface ActionManifestEntry {
   outputSchema?: Record<string, unknown>;
   enabled: boolean;
   disabledReason?: string;
+  requiresArgs: boolean;
 }
 
 export interface ActionDispatchSuccess<Result = unknown> {

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -174,6 +174,10 @@ export class ActionService {
         : undefined,
       enabled,
       disabledReason,
+      requiresArgs: definition.argsSchema
+        ? !definition.argsSchema.safeParse(undefined).success &&
+          !definition.argsSchema.safeParse({}).success
+        : false,
     };
   }
 


### PR DESCRIPTION
## Summary

Actions whose `argsSchema` has required fields were silently failing when dispatched from the Action Palette (which always called `dispatch(id, undefined)`). This PR excludes those actions from the palette and ensures any dispatch failure is surfaced as a visible error toast.

Closes #2470

## Changes Made

- Add `requiresArgs: boolean` to `ActionManifestEntry` type (`shared/types/actions.ts`)
- Compute `requiresArgs` in `ActionService.toManifestEntry` via `!(safeParse(undefined).success || safeParse({}).success)` — correctly includes actions with all-optional object schemas (e.g. `z.object({ terminalId: z.string().optional() })`) while excluding those with required fields
- Filter `requiresArgs` actions out of the Action Palette (`useActionPalette.ts`)
- Dispatch palette actions with `{}` instead of `undefined` so schemas with all-optional fields pass Zod validation
- Surface `{ok: false}` dispatch results as error toasts via `useNotificationStore`
- Add `.catch()` to handle unexpected promise rejections (previously silent)
- Update `actionTools.test.ts` fixture with the new required `requiresArgs` field