### PR TITLE
feat(quick-switcher): add MRU ranking to Quick Switcher results

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -365,6 +365,25 @@ export function registerAppStateHandlers(): () => void {
         }
       }
 
+      if ("mruList" in partialState && Array.isArray(partialState.mruList)) {
+        // Sanitize: dense array, string items with valid prefix, per-item length cap, dedupe
+        const MRU_ID_PATTERN = /^(terminal|worktree):[a-zA-Z0-9_-]{1,128}$/;
+        const seen = new Set<string>();
+        const sanitized: string[] = [];
+        for (const id of partialState.mruList) {
+          if (
+            typeof id === "string" &&
+            MRU_ID_PATTERN.test(id) &&
+            !seen.has(id) &&
+            sanitized.length < 50
+          ) {
+            seen.add(id);
+            sanitized.push(id);
+          }
+        }
+        updates.mruList = sanitized;
+      }
+
       store.set("appState", { ...currentState, ...updates });
 
       // Note: We intentionally do NOT save per-project terminal state.

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -83,6 +83,7 @@ export interface StoreSchema {
       lastUsedAt?: number;
     }>;
     panelGridConfig?: PanelGridConfig;
+    mruList?: string[];
   };
   projects: {
     list: Project[];

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -76,6 +76,8 @@ export interface AppState {
   };
   /** Panel grid layout configuration */
   panelGridConfig?: import("../config.js").PanelGridConfig;
+  /** Most-recently-used ordered list of quick-switcher item IDs ("terminal:<id>" | "worktree:<id>") */
+  mruList?: string[];
 }
 
 /** Result from app hydration */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -569,14 +569,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 }
 
 function App() {
-  const { focusedId, addTerminal, setReconnectError, hydrateTabGroups } = useTerminalStore(
-    useShallow((state) => ({
-      focusedId: state.focusedId,
-      addTerminal: state.addTerminal,
-      setReconnectError: state.setReconnectError,
-      hydrateTabGroups: state.hydrateTabGroups,
-    }))
-  );
+  const { focusedId, addTerminal, setReconnectError, hydrateTabGroups, hydrateMru } =
+    useTerminalStore(
+      useShallow((state) => ({
+        focusedId: state.focusedId,
+        addTerminal: state.addTerminal,
+        setReconnectError: state.setReconnectError,
+        hydrateTabGroups: state.hydrateTabGroups,
+        hydrateMru: state.hydrateMru,
+      }))
+    );
 
   useEffect(() => {
     const handleBeforeUnload = () => {
@@ -785,6 +787,7 @@ function App() {
       setFocusMode,
       setReconnectError,
       hydrateTabGroups,
+      hydrateMru,
     }),
     [
       addTerminal,
@@ -794,6 +797,7 @@ function App() {
       setFocusMode,
       setReconnectError,
       hydrateTabGroups,
+      hydrateMru,
     ]
   );
 

--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -25,6 +25,7 @@ export interface HydrationCallbacks {
   ) => void;
   setReconnectError?: (id: string, error: TerminalReconnectError) => void;
   hydrateTabGroups?: (tabGroups: TabGroup[], options?: { skipPersist?: boolean }) => void;
+  hydrateMru?: (list: string[]) => void;
 }
 
 export function useAppHydration(callbacks: HydrationCallbacks) {
@@ -57,6 +58,7 @@ export function useAppHydration(callbacks: HydrationCallbacks) {
     callbacks.setFocusMode,
     callbacks.setReconnectError,
     callbacks.hydrateTabGroups,
+    callbacks.hydrateMru,
   ]);
 
   return { isStateLoaded };

--- a/src/hooks/app/useProjectSwitchRehydration.ts
+++ b/src/hooks/app/useProjectSwitchRehydration.ts
@@ -129,5 +129,6 @@ export function useProjectSwitchRehydration(callbacks: HydrationCallbacks) {
     callbacks.setFocusMode,
     callbacks.setReconnectError,
     callbacks.hydrateTabGroups,
+    callbacks.hydrateMru,
   ]);
 }

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -27,3 +27,5 @@ export {
   type TerminalBulkActionsSlice,
   type BulkRestartValidation,
 } from "./terminalBulkActionsSlice";
+
+export { createTerminalMruSlice, type TerminalMruSlice } from "./terminalMruSlice";

--- a/src/store/slices/terminalMruSlice.ts
+++ b/src/store/slices/terminalMruSlice.ts
@@ -1,0 +1,41 @@
+import type { StateCreator } from "zustand";
+
+const MRU_MAX_SIZE = 50;
+
+export interface TerminalMruSlice {
+  mruList: string[];
+  recordMru: (id: string) => void;
+  pruneMru: (validIds: Set<string>) => void;
+  hydrateMru: (list: string[]) => void;
+  clearMru: () => void;
+}
+
+export const createTerminalMruSlice: StateCreator<TerminalMruSlice, [], [], TerminalMruSlice> = (
+  set
+) => ({
+  mruList: [],
+
+  recordMru: (id) => {
+    set((state) => {
+      const next = [id, ...state.mruList.filter((x) => x !== id)].slice(0, MRU_MAX_SIZE);
+      if (next[0] === state.mruList[0] && next.length === state.mruList.length) return state;
+      return { mruList: next };
+    });
+  },
+
+  pruneMru: (validIds) => {
+    set((state) => {
+      const next = state.mruList.filter((id) => validIds.has(id));
+      if (next.length === state.mruList.length) return state;
+      return { mruList: next };
+    });
+  },
+
+  hydrateMru: (list) => {
+    set({ mruList: list.slice(0, MRU_MAX_SIZE) });
+  },
+
+  clearMru: () => {
+    set({ mruList: [] });
+  },
+});

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -9,11 +9,13 @@ import {
   createTerminalFocusSlice,
   createTerminalCommandQueueSlice,
   createTerminalBulkActionsSlice,
+  createTerminalMruSlice,
   flushTerminalPersistence,
   type TerminalRegistrySlice,
   type TerminalFocusSlice,
   type TerminalCommandQueueSlice,
   type TerminalBulkActionsSlice,
+  type TerminalMruSlice,
   type AddTerminalOptions,
   type QueuedCommand,
   isAgentReady,
@@ -35,6 +37,7 @@ import { logInfo, logWarn, logError } from "@/utils/logger";
 
 export type { TerminalInstance, AddTerminalOptions, QueuedCommand, CrashType };
 export { isAgentReady };
+export type { TerminalMruSlice };
 
 const PROJECT_SWITCH_RESIZE_SUPPRESSION_MS = 10_000;
 
@@ -77,7 +80,8 @@ export interface PanelGridState
     TerminalRegistrySlice,
     TerminalFocusSlice,
     TerminalCommandQueueSlice,
-    TerminalBulkActionsSlice {
+    TerminalBulkActionsSlice,
+    TerminalMruSlice {
   backendStatus: BackendStatus;
   lastCrashType: CrashType | null;
   setBackendStatus: (status: BackendStatus) => void;
@@ -122,6 +126,7 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
 
   const focusSlice = createTerminalFocusSlice(getTerminals)(set, get, api);
   const commandQueueSlice = createTerminalCommandQueueSlice(getTerminal)(set, get, api);
+  const mruSlice = createTerminalMruSlice(set, get, api);
   const bulkActionsSlice = createTerminalBulkActionsSlice(
     getTerminals,
     (id) => get().removeTerminal(id),
@@ -138,6 +143,7 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
     ...focusSlice,
     ...commandQueueSlice,
     ...bulkActionsSlice,
+    ...mruSlice,
 
     backendStatus: "connected" as BackendStatus,
     lastCrashType: null as CrashType | null,
@@ -416,6 +422,7 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
         commandQueue: [],
         backendStatus: "connected",
         lastCrashType: null,
+        mruList: [],
       });
     },
 
@@ -457,6 +464,7 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
         commandQueue: [],
         backendStatus: "connected",
         lastCrashType: null,
+        mruList: [],
       });
     },
   };


### PR DESCRIPTION
## Summary

Adds most-recently-used (MRU) ranking to the Quick Switcher (`Cmd+P`) so frequently visited terminals and worktrees surface at the top of results without any typing.

Closes #2471

## Changes Made

- **New `TerminalMruSlice`** (`src/store/slices/terminalMruSlice.ts`): Zustand slice managing `mruList: string[]` (capped at 50) with `recordMru`, `pruneMru`, `hydrateMru`, and `clearMru` actions
- **Focus wiring** (`src/store/worktreeStore.ts`): `setupWorktreeFocusTracking` subscriber records `terminal:<id>` MRU on every focus change; `selectWorktree` records `worktree:<id>` MRU on explicit worktree selection
- **Persistence** (`src/store/worktreeStore.ts`): `persistMruList` sends `mruList` via `appClient.setState` with full-array equality check to skip no-op writes
- **Hydration guard** (`src/utils/stateHydration.ts`): `suppressMruRecording(true)` during hydration prevents restore-order focus events from corrupting the persisted MRU list; `hydrateMru` is called at the end of hydration to restore persisted order
- **IPC validation** (`electron/ipc/handlers/app/state.ts`): hardened validation with strict ID format regex (`terminal:|worktree:` prefix), per-item length cap, deduplication, and dense-array sanitization
- **Electron store** (`electron/store.ts`, `shared/types/ipc/app.ts`): `mruList?: string[]` added to schema and `AppState` type
- **MRU-aware filtering** (`src/hooks/useQuickSwitcher.ts`): replaced `fuseOptions` with a `filterFn` — empty query returns items sorted by MRU rank; non-empty query runs Fuse search then applies `MRU_BOOST_FACTOR=0.05` score reduction for recency, preserving strong fuzzy matches
- **Stale-entry pruning**: `pruneMru` called when item set or MRU list changes, evicting IDs for removed/trashed panels