### PR TITLE
feat(terminal): extend Ctrl+Tab focus cycle to include dock terminals

### DIFF
--- a/src/services/actions/definitions/terminalActions.ts
+++ b/src/services/actions/definitions/terminalActions.ts
@@ -650,7 +650,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
   actions.set("terminal.focusNext", () => ({
     id: "terminal.focusNext",
     title: "Focus Next Terminal",
-    description: "Focus the next terminal in the grid",
+    description: "Focus the next terminal (cycles through grid then dock)",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -663,7 +663,7 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
   actions.set("terminal.focusPrevious", () => ({
     id: "terminal.focusPrevious",
     title: "Focus Previous Terminal",
-    description: "Focus the previous terminal in the grid",
+    description: "Focus the previous terminal (cycles through grid then dock)",
     category: "terminal",
     kind: "command",
     danger: "safe",

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -260,42 +260,40 @@ export const createTerminalFocusSlice =
 
       focusNext: () => {
         const terminals = getTerminals();
-        // Only navigate through grid terminals (not docked ones)
         const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-        const gridTerminals = terminals.filter(
-          (t) =>
-            (t.location === "grid" || !t.location) &&
-            (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
-        );
-        if (gridTerminals.length === 0) return;
+        const worktreeMatch = (t: TerminalInstance) =>
+          (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
 
-        set((state) => {
-          const currentIndex = state.focusedId
-            ? gridTerminals.findIndex((t) => t.id === state.focusedId)
-            : -1;
-          const nextIndex = (currentIndex + 1) % gridTerminals.length;
-          return { focusedId: gridTerminals[nextIndex].id };
-        });
+        const gridTerminals = terminals.filter(
+          (t) => (t.location === "grid" || !t.location) && worktreeMatch(t)
+        );
+        const dockTerminals = terminals.filter((t) => t.location === "dock" && worktreeMatch(t));
+        const cycleList = [...gridTerminals, ...dockTerminals];
+        if (cycleList.length === 0) return;
+
+        const { focusedId, activateTerminal } = get();
+        const currentIndex = focusedId ? cycleList.findIndex((t) => t.id === focusedId) : -1;
+        const nextIndex = (currentIndex + 1) % cycleList.length;
+        activateTerminal(cycleList[nextIndex].id);
       },
 
       focusPrevious: () => {
         const terminals = getTerminals();
-        // Only navigate through grid terminals (not docked ones)
         const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
-        const gridTerminals = terminals.filter(
-          (t) =>
-            (t.location === "grid" || !t.location) &&
-            (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
-        );
-        if (gridTerminals.length === 0) return;
+        const worktreeMatch = (t: TerminalInstance) =>
+          (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined);
 
-        set((state) => {
-          const currentIndex = state.focusedId
-            ? gridTerminals.findIndex((t) => t.id === state.focusedId)
-            : 0;
-          const prevIndex = currentIndex <= 0 ? gridTerminals.length - 1 : currentIndex - 1;
-          return { focusedId: gridTerminals[prevIndex].id };
-        });
+        const gridTerminals = terminals.filter(
+          (t) => (t.location === "grid" || !t.location) && worktreeMatch(t)
+        );
+        const dockTerminals = terminals.filter((t) => t.location === "dock" && worktreeMatch(t));
+        const cycleList = [...gridTerminals, ...dockTerminals];
+        if (cycleList.length === 0) return;
+
+        const { focusedId, activateTerminal } = get();
+        const currentIndex = focusedId ? cycleList.findIndex((t) => t.id === focusedId) : 0;
+        const prevIndex = currentIndex <= 0 ? cycleList.length - 1 : currentIndex - 1;
+        activateTerminal(cycleList[prevIndex].id);
       },
 
       focusDirection: (direction, findNearest) => {

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -367,6 +367,31 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
       });
     },
 
+    // Override focusNext/focusPrevious to sync activeTabByGroup when landing on a docked tab group panel
+    focusNext: () => {
+      focusSlice.focusNext();
+      const focusedId = get().focusedId;
+      if (focusedId) {
+        const terminal = get().terminals.find((t) => t.id === focusedId);
+        if (terminal?.location === "dock") {
+          const group = get().getPanelGroup(focusedId);
+          if (group) get().setActiveTab(group.id, focusedId);
+        }
+      }
+    },
+
+    focusPrevious: () => {
+      focusSlice.focusPrevious();
+      const focusedId = get().focusedId;
+      if (focusedId) {
+        const terminal = get().terminals.find((t) => t.id === focusedId);
+        if (terminal?.location === "dock") {
+          const group = get().getPanelGroup(focusedId);
+          if (group) get().setActiveTab(group.id, focusedId);
+        }
+      }
+    },
+
     // Override hydrateTabGroups to also seed activeTabByGroup from persisted TabGroup.activeTabId
     // This ensures the active tab state is restored after restart
     hydrateTabGroups: (tabGroups, options) => {


### PR DESCRIPTION
## Summary

Extends `terminal.focusNext` and `terminal.focusPrevious` (bound to `Ctrl+Tab` / `Ctrl+Shift+Tab`) to cycle through all non-trashed panels in the active worktree — grid panels first, then dock panels — instead of grid-only.

Closes #2468

## Changes Made

- **`terminalFocusSlice.ts`**: `focusNext`/`focusPrevious` now build a combined `[...gridTerminals, ...dockTerminals]` cycle list for the active worktree. Uses the existing `activateTerminal` method which correctly handles `activeDockTerminalId`, `focusedId`, and wake-on-focus for both locations.
- **`terminalStore.ts`**: Adds overrides for `focusNext`/`focusPrevious` that call `setActiveTab(group.id, panelId)` after activation, ensuring dock tab group panels display the correct tab when reached via the cycle.
- **`terminalActions.ts`**: Updated `terminal.focusNext` and `terminal.focusPrevious` action descriptions to reflect the full grid+dock cycle.