### PR TITLE
fix(notifications): reset dock badge immediately on focus, remove expiry

### DIFF
--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -34,16 +34,18 @@ class NotificationService {
 
     this.focusHandler = () => {
       this.windowFocused = true;
+      this.currentState = { waitingCount: 0, failedCount: 0 };
+
+      if (this.debounceTimer) {
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = null;
+      }
+
       this.clearNotifications();
     };
 
     this.blurHandler = () => {
       this.windowFocused = false;
-      // Immediately apply notifications when window loses focus if there are any
-      const { waitingCount, failedCount } = this.currentState;
-      if (waitingCount > 0 || failedCount > 0) {
-        this.applyNotifications();
-      }
     };
 
     window.on("focus", this.focusHandler);

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -20,8 +20,6 @@ function isTerminalVisible(
   return true;
 }
 
-const NOTIFICATION_EXPIRY_MS = 5 * 60 * 1000;
-
 export function useTerminalNotificationCounts(blurTime?: number | null): {
   waitingCount: number;
   failedCount: number;
@@ -45,7 +43,6 @@ export function useTerminalNotificationCounts(blurTime?: number | null): {
 
       let waitingCount = 0;
       let failedCount = 0;
-      const now = Date.now();
 
       for (const terminal of state.terminals) {
         if (!isTerminalVisible(terminal, state.isInTrash, worktreeIds)) continue;
@@ -56,7 +53,6 @@ export function useTerminalNotificationCounts(blurTime?: number | null): {
         if (blurTime !== undefined) {
           if (terminal.lastStateChange == null) continue;
           if (terminal.lastStateChange <= blurTime) continue;
-          if (now - terminal.lastStateChange >= NOTIFICATION_EXPIRY_MS) continue;
         }
 
         if (terminal.agentState === "waiting") waitingCount += 1;


### PR DESCRIPTION
## Summary

Fixes the dock badge counter to match the intended UX: badge resets to zero immediately when the app gains focus, and only terminals that newly enter `waiting`/`failed` state *after* the blur event contribute to the count.

Closes #2481

## Changes Made

- **`useWindowNotifications.ts`**: Removed 5-minute expiry ticker (`EXPIRY_TICK_MS` / 30s interval). In `handleFocus`, cancel any pending debounce timer and reset `prevStateRef` before the immediate badge clear — ensures no stale debounced update fires after focus. Simplified `handleBlur` to just set the blur timestamp and trigger a re-render.
- **`useTerminalSelectors.ts`**: Removed `NOTIFICATION_EXPIRY_MS` (5-minute expiry) from `useTerminalNotificationCounts`. The hook now counts any terminal where `lastStateChange > blurTime` regardless of age — badge persists until the user focuses the app.
- **`NotificationService.ts`** (main process): `focusHandler` now resets `currentState` to `{0,0}` and cancels the debounce timer before clearing notifications — prevents stale pre-focus counts from flashing on rapid focus→blur cycles. `blurHandler` simplified to only set `windowFocused = false`; renderer is now the sole source of truth for counts.
- **`useTerminalSelectors.test.tsx`**: Updated 4 test descriptions, flipped 2 expectations (terminals are now counted beyond 5 minutes). Added two new tests: waiting→working→waiting re-entry scenario, and non-notifiable state (`working`/`idle`) exclusion under blur filtering. 14 tests, all passing.