### PR TITLE
fix(quick-run): improve placeholder and icon contrast for WCAG compliance

### DIFF
--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -377,7 +377,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                 placeholder="Execute command..."
                 aria-label="Command input"
                 className={cn(
-                  "flex-1 bg-transparent py-2.5 text-xs text-canopy-text font-mono placeholder:text-white/20",
+                  "flex-1 bg-transparent py-2.5 text-xs text-canopy-text font-mono placeholder:text-white/35",
                   "focus:outline-none min-w-0"
                 )}
                 autoComplete="off"
@@ -395,7 +395,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                           "p-1.5 rounded-[var(--radius-sm)] transition-all",
                           autoRestart
                             ? "bg-canopy-accent/20 text-canopy-accent"
-                            : "text-white/30 hover:text-white/60 hover:bg-white/10"
+                            : "text-white/40 hover:text-white/60 hover:bg-white/10"
                         )}
                         aria-label={autoRestart ? "Disable auto-restart" : "Enable auto-restart"}
                         aria-pressed={autoRestart}
@@ -419,7 +419,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                           "p-1.5 rounded-[var(--radius-sm)] transition-all",
                           runAsDocked
                             ? "bg-canopy-accent/20 text-canopy-accent"
-                            : "text-white/30 hover:text-white/60 hover:bg-white/10"
+                            : "text-white/40 hover:text-white/60 hover:bg-white/10"
                         )}
                         aria-label={
                           runAsDocked
@@ -454,7 +454,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                             "p-1.5 rounded-[var(--radius-sm)] transition-all",
                             input.trim()
                               ? "text-white hover:bg-white/10"
-                              : "text-white/10 cursor-not-allowed"
+                              : "text-white/20 cursor-not-allowed"
                           )}
                           aria-label="Run command"
                         >


### PR DESCRIPTION
## Summary

Improves contrast ratios in the QuickRun command input panel to meet WCAG AA requirements. Previously, placeholder text, inactive icon buttons, and the disabled run button were rendered with critically low contrast against the dark sidebar background.

Closes #2483

## Changes Made

- Placeholder text opacity: `text-white/20` → `text-white/35` — improves readability as a hint colour
- Inactive auto-restart and location-toggle icon buttons: `text-white/30` → `text-white/40` — makes icons discernible without straining
- Disabled enter button: `text-white/10` → `text-white/20` — remains muted but visually distinct from background
- Hover state (`text-white/60`) and active states are unchanged, preserving visual hierarchy