### PR TITLE
feat(worktree): restructure dropdown menu to use submenus (issue #2487)

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -167,7 +167,15 @@ export function WorktreeCard({
     allTerminalCount,
   });
 
-  const handleOpenIssue = useCallback(() => {
+  const handleOpenIssueSidecar = useCallback(() => {
+    void actionService.dispatch(
+      "worktree.openIssueInSidecar",
+      { worktreeId: worktree.id },
+      { source: "user" }
+    );
+  }, [worktree.id]);
+
+  const handleOpenIssueExternal = useCallback(() => {
     void actionService.dispatch(
       "worktree.openIssue",
       { worktreeId: worktree.id },
@@ -175,9 +183,43 @@ export function WorktreeCard({
     );
   }, [worktree.id]);
 
-  const handleOpenPR = useCallback(() => {
+  const handleOpenPRSidecar = useCallback(() => {
+    void actionService.dispatch(
+      "worktree.openPRInSidecar",
+      { worktreeId: worktree.id },
+      { source: "user" }
+    );
+  }, [worktree.id]);
+
+  const handleOpenPRExternal = useCallback(() => {
     void actionService.dispatch("worktree.openPR", { worktreeId: worktree.id }, { source: "user" });
   }, [worktree.id]);
+
+  const handleInjectContext = useCallback(() => {
+    void actionService.dispatch("worktree.inject", { worktreeId: worktree.id }, { source: "user" });
+  }, [worktree.id]);
+
+  const handleResetRenderers = useCallback(() => {
+    void actionService.dispatch(
+      "worktree.sessions.resetRenderers",
+      { worktreeId: worktree.id },
+      { source: "user" }
+    );
+  }, [worktree.id]);
+
+  const handleCopyContextFull = useCallback(() => {
+    void handleCopyTree();
+  }, [handleCopyTree]);
+
+  const handleCopyContextModified = useCallback(() => {
+    void actionService.dispatch(
+      "worktree.copyTree",
+      { worktreeId: worktree.id, modified: true },
+      { source: "user" }
+    );
+  }, [worktree.id]);
+
+  const hasFocusedTerminal = useTerminalStore((state) => state.focusedId !== null);
 
   const [showIssuePicker, setShowIssuePicker] = useState(false);
 
@@ -416,14 +458,15 @@ export function WorktreeCard({
             onCopyTreeClick: handleCopyTreeClick,
           }}
           badges={{
-            onOpenIssue: worktree.issueNumber ? handleOpenIssue : undefined,
-            onOpenPR: worktree.prNumber ? handleOpenPR : undefined,
+            onOpenIssue: worktree.issueNumber ? handleOpenIssueExternal : undefined,
+            onOpenPR: worktree.prNumber ? handleOpenPRExternal : undefined,
           }}
           menu={{
             launchAgents,
             recipes,
             runningRecipeId,
             isRestartValidating,
+            hasFocusedTerminal,
             counts: {
               grid: gridCount,
               dock: dockCount,
@@ -432,11 +475,15 @@ export function WorktreeCard({
               failed: failedCount,
               all: allTerminalCount,
             },
-            onCopyContext: () => void handleCopyTree(),
+            onCopyContextFull: handleCopyContextFull,
+            onCopyContextModified: handleCopyContextModified,
+            onInjectContext: handleInjectContext,
             onOpenEditor,
             onRevealInFinder: handlePathClick,
-            onOpenIssue: worktree.issueNumber ? handleOpenIssue : undefined,
-            onOpenPR: worktree.prNumber ? handleOpenPR : undefined,
+            onOpenIssueSidecar: worktree.issueNumber ? handleOpenIssueSidecar : undefined,
+            onOpenIssueExternal: worktree.issueNumber ? handleOpenIssueExternal : undefined,
+            onOpenPRSidecar: worktree.prUrl ? handleOpenPRSidecar : undefined,
+            onOpenPRExternal: worktree.prUrl ? handleOpenPRExternal : undefined,
             onAttachIssue: () => setShowIssuePicker(true),
             onRunRecipe: (recipeId) => void handleRunRecipe(recipeId),
             onSaveLayout,
@@ -445,6 +492,7 @@ export function WorktreeCard({
             onMinimizeAll: handleMinimizeAll,
             onMaximizeAll: handleMaximizeAll,
             onRestartAll: () => void handleRestartAll(),
+            onResetRenderers: handleResetRenderers,
             onCloseCompleted: handleCloseCompleted,
             onCloseFailed: handleCloseFailed,
             onCloseAll: handleCloseAll,

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -216,6 +216,7 @@ export interface WorktreeHeaderProps {
     recipes: TerminalRecipe[];
     runningRecipeId: string | null;
     isRestartValidating: boolean;
+    hasFocusedTerminal: boolean;
     counts: {
       grid: number;
       dock: number;
@@ -224,11 +225,15 @@ export interface WorktreeHeaderProps {
       failed: number;
       all: number;
     };
-    onCopyContext: () => void;
+    onCopyContextFull: () => void;
+    onCopyContextModified: () => void;
+    onInjectContext: () => void;
     onOpenEditor: () => void;
     onRevealInFinder: () => void;
-    onOpenIssue?: () => void;
-    onOpenPR?: () => void;
+    onOpenIssueSidecar?: () => void;
+    onOpenIssueExternal?: () => void;
+    onOpenPRSidecar?: () => void;
+    onOpenPRExternal?: () => void;
     onRunRecipe: (recipeId: string) => void;
     onSaveLayout?: () => void;
     onTogglePin?: () => void;
@@ -236,6 +241,7 @@ export interface WorktreeHeaderProps {
     onMinimizeAll: () => void;
     onMaximizeAll: () => void;
     onRestartAll: () => void;
+    onResetRenderers: () => void;
     onCloseCompleted: () => void;
     onCloseFailed: () => void;
     onCloseAll: () => void;
@@ -370,13 +376,18 @@ export function WorktreeHeader({
                 runningRecipeId={menu.runningRecipeId}
                 isRestartValidating={menu.isRestartValidating}
                 isPinned={isPinned}
+                hasFocusedTerminal={menu.hasFocusedTerminal}
                 counts={menu.counts}
                 onLaunchAgent={menu.onLaunchAgent ? handleLaunchAgent : undefined}
-                onCopyContext={menu.onCopyContext}
+                onCopyContextFull={menu.onCopyContextFull}
+                onCopyContextModified={menu.onCopyContextModified}
+                onInjectContext={menu.onInjectContext}
                 onOpenEditor={menu.onOpenEditor}
                 onRevealInFinder={menu.onRevealInFinder}
-                onOpenIssue={menu.onOpenIssue}
-                onOpenPR={menu.onOpenPR}
+                onOpenIssueSidecar={menu.onOpenIssueSidecar}
+                onOpenIssueExternal={menu.onOpenIssueExternal}
+                onOpenPRSidecar={menu.onOpenPRSidecar}
+                onOpenPRExternal={menu.onOpenPRExternal}
                 onAttachIssue={menu.onAttachIssue}
                 onRunRecipe={menu.onRunRecipe}
                 onSaveLayout={menu.onSaveLayout}
@@ -384,6 +395,7 @@ export function WorktreeHeader({
                 onMinimizeAll={menu.onMinimizeAll}
                 onMaximizeAll={menu.onMaximizeAll}
                 onRestartAll={menu.onRestartAll}
+                onResetRenderers={menu.onResetRenderers}
                 onCloseCompleted={menu.onCloseCompleted}
                 onCloseFailed={menu.onCloseFailed}
                 onCloseAll={menu.onCloseAll}

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -1,18 +1,21 @@
 import type * as React from "react";
 import type { WorktreeState } from "../../types";
 import {
-  Code,
+  ArrowDownToLine,
   CircleDot,
+  Code,
   Copy,
   Folder,
   GitPullRequest,
   Globe,
+  Layers,
   Link,
   Maximize2,
   Minimize2,
   Pin,
   PinOff,
   Play,
+  RefreshCw,
   RotateCcw,
   Save,
   Terminal,
@@ -49,6 +52,7 @@ export interface WorktreeMenuItemsProps {
   runningRecipeId: string | null;
   isRestartValidating: boolean;
   isPinned?: boolean;
+  hasFocusedTerminal: boolean;
   counts: {
     grid: number;
     dock: number;
@@ -58,11 +62,15 @@ export interface WorktreeMenuItemsProps {
     all: number;
   };
   onLaunchAgent?: (agentId: string) => void;
-  onCopyContext: () => void;
+  onCopyContextFull: () => void;
+  onCopyContextModified: () => void;
+  onInjectContext: () => void;
   onOpenEditor: () => void;
   onRevealInFinder: () => void;
-  onOpenIssue?: () => void;
-  onOpenPR?: () => void;
+  onOpenIssueSidecar?: () => void;
+  onOpenIssueExternal?: () => void;
+  onOpenPRSidecar?: () => void;
+  onOpenPRExternal?: () => void;
   onAttachIssue?: () => void;
   onRunRecipe: (recipeId: string) => void;
   onSaveLayout?: () => void;
@@ -70,6 +78,7 @@ export interface WorktreeMenuItemsProps {
   onMinimizeAll: () => void;
   onMaximizeAll: () => void;
   onRestartAll: () => void;
+  onResetRenderers: () => void;
   onCloseCompleted: () => void;
   onCloseFailed: () => void;
   onCloseAll: () => void;
@@ -85,13 +94,18 @@ export function WorktreeMenuItems({
   runningRecipeId,
   isRestartValidating,
   isPinned,
+  hasFocusedTerminal,
   counts,
   onLaunchAgent,
-  onCopyContext,
+  onCopyContextFull,
+  onCopyContextModified,
+  onInjectContext,
   onOpenEditor,
   onRevealInFinder,
-  onOpenIssue,
-  onOpenPR,
+  onOpenIssueSidecar,
+  onOpenIssueExternal,
+  onOpenPRSidecar,
+  onOpenPRExternal,
   onAttachIssue,
   onRunRecipe,
   onSaveLayout,
@@ -99,96 +113,157 @@ export function WorktreeMenuItems({
   onMinimizeAll,
   onMaximizeAll,
   onRestartAll,
+  onResetRenderers,
   onCloseCompleted,
   onCloseFailed,
   onCloseAll,
   onEndAll,
   onDeleteWorktree,
 }: WorktreeMenuItemsProps) {
-  const hasIssueOrPr = Boolean(worktree.issueNumber || worktree.prNumber);
+  const hasIssueSub = Boolean(worktree.issueNumber && (onOpenIssueSidecar || onOpenIssueExternal));
+  const hasPRSub = Boolean(worktree.prNumber && (onOpenPRSidecar || onOpenPRExternal));
+  const hasIssueOrPrSection = hasIssueSub || hasPRSub;
   const hasRecipes = recipes.length > 0;
   const hasRecipeSection = hasRecipes || (onSaveLayout && counts.active > 0);
   const hasSessions = counts.all > 0;
 
   return (
     <>
-      <C.Label>Launch</C.Label>
-      {launchAgents.map((agent) => {
-        const Icon = agent.icon;
-        return (
-          <C.Item
-            key={agent.id}
-            onSelect={() => onLaunchAgent?.(agent.id)}
-            disabled={!onLaunchAgent || !agent.isEnabled}
-          >
-            {Icon ? (
-              <Icon className="w-3.5 h-3.5 mr-2" />
-            ) : (
-              <Terminal className="w-3.5 h-3.5 mr-2" />
-            )}
-            {agent.name}
+      {/* Launch submenu */}
+      <C.Sub>
+        <C.SubTrigger>
+          <Terminal className="w-3.5 h-3.5 mr-2" />
+          Launch
+        </C.SubTrigger>
+        <C.SubContent>
+          {launchAgents.map((agent) => {
+            const Icon = agent.icon;
+            return (
+              <C.Item
+                key={agent.id}
+                onSelect={() => onLaunchAgent?.(agent.id)}
+                disabled={!onLaunchAgent || !agent.isEnabled}
+              >
+                {Icon ? (
+                  <Icon className="w-3.5 h-3.5 mr-2" />
+                ) : (
+                  <Terminal className="w-3.5 h-3.5 mr-2" />
+                )}
+                {agent.name}
+              </C.Item>
+            );
+          })}
+          {launchAgents.length > 0 && <C.Separator />}
+          <C.Item onSelect={() => onLaunchAgent?.("terminal")} disabled={!onLaunchAgent}>
+            <Terminal className="w-3.5 h-3.5 mr-2" />
+            Open Terminal
           </C.Item>
-        );
-      })}
-      <C.Item onSelect={() => onLaunchAgent?.("terminal")} disabled={!onLaunchAgent}>
-        <Terminal className="w-3.5 h-3.5 mr-2" />
-        Open Terminal
-      </C.Item>
-      <C.Item onSelect={() => onLaunchAgent?.("browser")} disabled={!onLaunchAgent}>
-        <Globe className="w-3.5 h-3.5 mr-2 text-blue-400" />
-        Open Browser
-      </C.Item>
+          <C.Item onSelect={() => onLaunchAgent?.("browser")} disabled={!onLaunchAgent}>
+            <Globe className="w-3.5 h-3.5 mr-2 text-blue-400" />
+            Open Browser
+          </C.Item>
+        </C.SubContent>
+      </C.Sub>
+
+      {/* Sessions submenu */}
+      <C.Sub>
+        <C.SubTrigger>
+          <Layers className="w-3.5 h-3.5 mr-2" />
+          Sessions
+        </C.SubTrigger>
+        <C.SubContent>
+          <C.Item onSelect={onMinimizeAll} disabled={counts.grid === 0}>
+            <Minimize2 className="w-3.5 h-3.5 mr-2" />
+            Minimize All
+            <C.Shortcut>({counts.grid})</C.Shortcut>
+          </C.Item>
+          <C.Item onSelect={onMaximizeAll} disabled={counts.dock === 0}>
+            <Maximize2 className="w-3.5 h-3.5 mr-2" />
+            Maximize All
+            <C.Shortcut>({counts.dock})</C.Shortcut>
+          </C.Item>
+
+          <C.Separator />
+
+          <C.Item onSelect={onRestartAll} disabled={counts.active === 0 || isRestartValidating}>
+            <RotateCcw
+              className={`w-3.5 h-3.5 mr-2 ${isRestartValidating ? "animate-spin" : ""}`}
+            />
+            {isRestartValidating ? "Checking..." : "Restart All"}
+            <C.Shortcut>({counts.active})</C.Shortcut>
+          </C.Item>
+          <C.Item onSelect={onResetRenderers} disabled={counts.active === 0}>
+            <RefreshCw className="w-3.5 h-3.5 mr-2" />
+            Reset All Renderers
+            <C.Shortcut>({counts.active})</C.Shortcut>
+          </C.Item>
+
+          <C.Separator />
+
+          <C.Item onSelect={onCloseCompleted} disabled={counts.completed === 0}>
+            Close Completed
+            <C.Shortcut>({counts.completed})</C.Shortcut>
+          </C.Item>
+          <C.Item onSelect={onCloseFailed} disabled={counts.failed === 0}>
+            Close Failed
+            <C.Shortcut>({counts.failed})</C.Shortcut>
+          </C.Item>
+
+          <C.Separator />
+
+          <C.Item onSelect={onCloseAll} disabled={counts.active === 0}>
+            <Trash2 className="w-3.5 h-3.5 mr-2" />
+            Close All (Trash)
+            <C.Shortcut>({counts.active})</C.Shortcut>
+          </C.Item>
+          <C.Item
+            onSelect={onEndAll}
+            disabled={!hasSessions}
+            className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
+          >
+            <X className="w-3.5 h-3.5 mr-2" />
+            End All (Kill)
+            <C.Shortcut>({counts.all})</C.Shortcut>
+          </C.Item>
+        </C.SubContent>
+      </C.Sub>
 
       <C.Separator />
 
-      <C.Label>Sessions</C.Label>
-      <C.Item onSelect={onMinimizeAll} disabled={counts.grid === 0}>
-        <Minimize2 className="w-3.5 h-3.5 mr-2" />
-        Minimize All
-        <C.Shortcut>({counts.grid})</C.Shortcut>
-      </C.Item>
-      <C.Item onSelect={onMaximizeAll} disabled={counts.dock === 0}>
-        <Maximize2 className="w-3.5 h-3.5 mr-2" />
-        Maximize All
-        <C.Shortcut>({counts.dock})</C.Shortcut>
-      </C.Item>
-      <C.Item onSelect={onRestartAll} disabled={counts.active === 0 || isRestartValidating}>
-        <RotateCcw className={`w-3.5 h-3.5 mr-2 ${isRestartValidating ? "animate-spin" : ""}`} />
-        {isRestartValidating ? "Checking..." : "Restart All"}
-        <C.Shortcut>({counts.active})</C.Shortcut>
+      {/* Worktree actions (flat) */}
+      {onAttachIssue && (
+        <C.Item onSelect={onAttachIssue}>
+          <Link className="w-3.5 h-3.5 mr-2" />
+          {worktree.issueNumber ? "Change Issue..." : "Attach to Issue..."}
+        </C.Item>
+      )}
+
+      {/* Copy Context submenu */}
+      <C.Sub>
+        <C.SubTrigger>
+          <Copy className="w-3.5 h-3.5 mr-2" />
+          Copy Context
+        </C.SubTrigger>
+        <C.SubContent>
+          <C.Item onSelect={onCopyContextFull}>Full Context</C.Item>
+          <C.Item onSelect={onCopyContextModified}>Modified Files Only</C.Item>
+        </C.SubContent>
+      </C.Sub>
+
+      <C.Item onSelect={onInjectContext} disabled={!hasFocusedTerminal}>
+        <ArrowDownToLine className="w-3.5 h-3.5 mr-2" />
+        Inject Context into Focused Terminal
       </C.Item>
 
-      <C.Separator />
-
-      <C.Item onSelect={onCloseCompleted} disabled={counts.completed === 0}>
-        Close Completed
-        <C.Shortcut>({counts.completed})</C.Shortcut>
+      <C.Item onSelect={onOpenEditor}>
+        <Code className="w-3.5 h-3.5 mr-2" />
+        Open in Editor
       </C.Item>
-      <C.Item onSelect={onCloseFailed} disabled={counts.failed === 0}>
-        Close Failed
-        <C.Shortcut>({counts.failed})</C.Shortcut>
+      <C.Item onSelect={onRevealInFinder}>
+        <Folder className="w-3.5 h-3.5 mr-2" />
+        Reveal in Finder
       </C.Item>
 
-      <C.Separator />
-
-      <C.Item onSelect={onCloseAll} disabled={counts.active === 0}>
-        <Trash2 className="w-3.5 h-3.5 mr-2" />
-        Close All (Trash)
-        <C.Shortcut>({counts.active})</C.Shortcut>
-      </C.Item>
-      <C.Item
-        onSelect={onEndAll}
-        disabled={!hasSessions}
-        className="text-[var(--color-status-error)] focus:text-[var(--color-status-error)]"
-      >
-        <X className="w-3.5 h-3.5 mr-2" />
-        End All (Kill)
-        <C.Shortcut>({counts.all})</C.Shortcut>
-      </C.Item>
-
-      <C.Separator />
-
-      <C.Label>Worktree</C.Label>
       {onTogglePin && !worktree.isMainWorktree && (
         <C.Item onSelect={onTogglePin}>
           {isPinned ? (
@@ -204,72 +279,65 @@ export function WorktreeMenuItems({
           )}
         </C.Item>
       )}
-      {onAttachIssue && (
-        <C.Item onSelect={onAttachIssue}>
-          <Link className="w-3.5 h-3.5 mr-2" />
-          {worktree.issueNumber ? "Change Issue..." : "Attach to Issue..."}
-        </C.Item>
-      )}
-      <C.Item onSelect={onCopyContext}>
-        <Copy className="w-3.5 h-3.5 mr-2" />
-        Copy Context
-      </C.Item>
-      <C.Item onSelect={onOpenEditor}>
-        <Code className="w-3.5 h-3.5 mr-2" />
-        Open in Editor
-      </C.Item>
-      <C.Item onSelect={onRevealInFinder}>
-        <Folder className="w-3.5 h-3.5 mr-2" />
-        Reveal in Finder
-      </C.Item>
 
-      {hasIssueOrPr && <C.Separator />}
-      {worktree.issueNumber && onOpenIssue && (
-        <C.Item onSelect={onOpenIssue}>
-          <CircleDot className="w-3.5 h-3.5 mr-2" />
-          Open Issue #{worktree.issueNumber}
-        </C.Item>
+      {/* Issue / PR submenus */}
+      {hasIssueOrPrSection && <C.Separator />}
+      {hasIssueSub && (
+        <C.Sub>
+          <C.SubTrigger>
+            <CircleDot className="w-3.5 h-3.5 mr-2" />
+            Open Issue #{worktree.issueNumber}
+          </C.SubTrigger>
+          <C.SubContent>
+            {onOpenIssueSidecar && <C.Item onSelect={onOpenIssueSidecar}>In Sidecar</C.Item>}
+            {onOpenIssueExternal && (
+              <C.Item onSelect={onOpenIssueExternal}>In External Browser</C.Item>
+            )}
+          </C.SubContent>
+        </C.Sub>
       )}
-      {worktree.prNumber && onOpenPR && (
-        <C.Item onSelect={onOpenPR}>
-          <GitPullRequest className="w-3.5 h-3.5 mr-2" />
-          Open PR #{worktree.prNumber}
-        </C.Item>
+      {hasPRSub && (
+        <C.Sub>
+          <C.SubTrigger>
+            <GitPullRequest className="w-3.5 h-3.5 mr-2" />
+            Open PR #{worktree.prNumber}
+          </C.SubTrigger>
+          <C.SubContent>
+            {onOpenPRSidecar && <C.Item onSelect={onOpenPRSidecar}>In Sidecar</C.Item>}
+            {onOpenPRExternal && <C.Item onSelect={onOpenPRExternal}>In External Browser</C.Item>}
+          </C.SubContent>
+        </C.Sub>
       )}
 
+      {/* Recipes */}
       {hasRecipeSection && <C.Separator />}
-
-      {hasRecipeSection && (
-        <>
-          <C.Label>Recipes</C.Label>
-          {hasRecipes && (
-            <C.Sub>
-              <C.SubTrigger>
-                <Play className="w-3.5 h-3.5 mr-2" />
-                Run Recipe
-              </C.SubTrigger>
-              <C.SubContent>
-                {recipes.map((recipe) => (
-                  <C.Item
-                    key={recipe.id}
-                    onSelect={() => onRunRecipe(recipe.id)}
-                    disabled={runningRecipeId !== null}
-                  >
-                    {recipe.name}
-                  </C.Item>
-                ))}
-              </C.SubContent>
-            </C.Sub>
-          )}
-          {onSaveLayout && counts.active > 0 && (
-            <C.Item onSelect={onSaveLayout}>
-              <Save className="w-3.5 h-3.5 mr-2" />
-              Save Layout as Recipe
-            </C.Item>
-          )}
-        </>
+      {hasRecipes && (
+        <C.Sub>
+          <C.SubTrigger>
+            <Play className="w-3.5 h-3.5 mr-2" />
+            Run Recipe
+          </C.SubTrigger>
+          <C.SubContent>
+            {recipes.map((recipe) => (
+              <C.Item
+                key={recipe.id}
+                onSelect={() => onRunRecipe(recipe.id)}
+                disabled={runningRecipeId !== null}
+              >
+                {recipe.name}
+              </C.Item>
+            ))}
+          </C.SubContent>
+        </C.Sub>
+      )}
+      {onSaveLayout && counts.active > 0 && (
+        <C.Item onSelect={onSaveLayout}>
+          <Save className="w-3.5 h-3.5 mr-2" />
+          Save Layout as Recipe
+        </C.Item>
       )}
 
+      {/* Delete */}
       {onDeleteWorktree && (
         <>
           <C.Separator />


### PR DESCRIPTION
## Summary

Restructures the worktree card's ⋯ dropdown from a flat ~20-item list into grouped submenus, matching the structure already used by the native right-click context menu. This prevents overflow on smaller displays and improves discoverability.

Closes #2487

## Changes Made

- **Launch submenu** — Claude, Gemini, Open Terminal, Open Browser collapsed into a single `Sub` trigger
- **Sessions submenu** — all session management items (Minimize/Maximize/Restart/Reset Renderers/Close/End) grouped into a single `Sub` trigger; adds the previously missing Reset All Renderers item
- **Copy Context submenu** — exposes Full Context and Modified Files Only as distinct items; Full Context preserves the treeCopied visual feedback via the existing `handleCopyTree` path
- **Inject Context into Focused Terminal** — always rendered as a standalone item; disabled when no terminal is focused (`hasFocusedTerminal` boolean prop keeps the component pure)
- **Open Issue / Open PR submenus** — each now exposes In Sidecar and In External Browser options; PR submenu gated on `worktree.prUrl` to match native menu behaviour
- **Updated `WorktreeMenuItemsProps`** — split callbacks (`onCopyContextFull`, `onCopyContextModified`, `onOpenIssueSidecar`, `onOpenIssueExternal`, `onOpenPRSidecar`, `onOpenPRExternal`, `onResetRenderers`, `onInjectContext`); removed single-action `onCopyContext`, `onOpenIssue`, `onOpenPR`
- **Updated `WorktreeHeaderProps.menu`** interface to reflect new callbacks; wired in `WorktreeCard.tsx` via `actionService.dispatch`
- Separator guards tightened so no orphan separators appear when issue/PR callbacks are absent