### PR TITLE
feat(assistant): add enable/disable toggle in settings

### DIFF
--- a/shared/types/appAgent.ts
+++ b/shared/types/appAgent.ts
@@ -13,6 +13,7 @@ export const AppAgentConfigSchema = z.object({
   model: z.string(),
   apiKey: z.string().optional(),
   baseUrl: z.string().optional(),
+  enabled: z.boolean().optional(),
 });
 
 export type AppAgentConfig = z.infer<typeof AppAgentConfigSchema>;

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -44,8 +44,16 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const { showMenu } = useNativeContextMenu();
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
-  const { hasApiKey, isInitialized: agentStoreReady } = useAppAgentStore(
-    useShallow((s) => ({ hasApiKey: s.hasApiKey, isInitialized: s.isInitialized }))
+  const {
+    hasApiKey,
+    enabled,
+    isInitialized: agentStoreReady,
+  } = useAppAgentStore(
+    useShallow((s) => ({
+      hasApiKey: s.hasApiKey,
+      enabled: s.enabled,
+      isInitialized: s.isInitialized,
+    }))
   );
   const initializeAgentStore = useAppAgentStore((s) => s.initialize);
   const closeAssistant = useAssistantChatStore((s) => s.close);
@@ -55,12 +63,12 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   }, [initializeAgentStore]);
 
   useEffect(() => {
-    if (agentStoreReady && !hasApiKey) {
+    if (agentStoreReady && (!hasApiKey || !enabled)) {
       closeAssistant();
     }
-  }, [agentStoreReady, hasApiKey, closeAssistant]);
+  }, [agentStoreReady, hasApiKey, enabled, closeAssistant]);
 
-  const showAssistant = agentStoreReady && hasApiKey;
+  const showAssistant = agentStoreReady && hasApiKey && enabled;
 
   const trashedTerminals = useTerminalStore(useShallow((state) => state.trashedTerminals));
   const terminals = useTerminalStore((state) => state.terminals);

--- a/src/components/Settings/AssistantSettingsTab.tsx
+++ b/src/components/Settings/AssistantSettingsTab.tsx
@@ -13,12 +13,14 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { DEFAULT_APP_AGENT_CONFIG } from "@shared/types";
+import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 
 type ValidationResult = "success" | "error" | "test-success" | "test-error" | null;
 
 export function AssistantSettingsTab() {
-  const { hasApiKey, config, initialize, setApiKey, setModel } = useAppAgentStore();
+  const { hasApiKey, config, enabled, initialize, setApiKey, setModel, setEnabled } =
+    useAppAgentStore();
   const [apiKeyInput, setApiKeyInput] = useState("");
   const [modelInput, setModelInput] = useState("");
   const [showApiKey, setShowApiKey] = useState(false);
@@ -173,6 +175,33 @@ export function AssistantSettingsTab() {
       </div>
 
       <div className="rounded-[var(--radius-lg)] border border-canopy-border bg-surface p-4 space-y-4">
+        <div className="flex items-center justify-between pb-3 border-b border-canopy-border">
+          <div>
+            <div className="text-sm font-medium text-canopy-text">Enable Canopy Assistant</div>
+            <div className="text-xs text-canopy-text/50">
+              When disabled, the assistant icon is hidden from the dock
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={enabled}
+            aria-label="Enable Canopy Assistant"
+            onClick={() => void setEnabled(!enabled).catch(() => {})}
+            className={cn(
+              "relative w-11 h-6 rounded-full transition-colors shrink-0",
+              enabled ? "bg-canopy-accent" : "bg-canopy-border"
+            )}
+          >
+            <span
+              className={cn(
+                "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                enabled && "translate-x-5"
+              )}
+            />
+          </button>
+        </div>
+
         <div className="flex items-center gap-3 pb-3 border-b border-canopy-border">
           <div className="w-10 h-10 rounded-[var(--radius-md)] bg-gradient-to-br from-orange-500/20 to-red-500/20 flex items-center justify-center">
             <Sparkles className="w-5 h-5 text-orange-400" />

--- a/src/services/actions/definitions/assistantActions.ts
+++ b/src/services/actions/definitions/assistantActions.ts
@@ -1,5 +1,6 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { useAssistantChatStore } from "@/store/assistantChatStore";
+import { useAppAgentStore } from "@/store/appAgentStore";
 
 export function registerAssistantActions(
   actions: ActionRegistry,
@@ -14,6 +15,8 @@ export function registerAssistantActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
+      const { hasApiKey, enabled } = useAppAgentStore.getState();
+      if (!hasApiKey || !enabled) return;
       useAssistantChatStore.getState().toggle();
     },
   }));


### PR DESCRIPTION
## Summary

Adds an **Enable Canopy Assistant** toggle to the Settings > Canopy Assistant tab, allowing users to hide the dock button without removing their stored API key.

Closes #2491

## Changes Made

- Add `enabled?: boolean` to `AppAgentConfigSchema` — optional field, absent treated as `true` for backward compatibility
- Expose `enabled` state and `setEnabled()` action in `useAppAgentStore`; sync `enabled` from config on all config updates to prevent state drift
- Gate `showAssistant` in `ContentDock` on `enabled !== false`; close assistant popover immediately when disabled
- Gate `assistant.open` keyboard action when disabled or no API key configured
- Add "Enable Canopy Assistant" toggle switch to `AssistantSettingsTab` — mirrors the CLI agent toggle pattern from `AgentSettings.tsx`