### PR TITLE
feat(dock): double-click pill or panel header to move to grid

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -44,6 +44,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const activeDockTerminalId = useTerminalStore((s) => s.activeDockTerminalId);
   const openDockTerminal = useTerminalStore((s) => s.openDockTerminal);
   const closeDockTerminal = useTerminalStore((s) => s.closeDockTerminal);
+  const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
   const backendStatus = useTerminalStore((s) => s.backendStatus);
   const setActiveTab = useTerminalStore((s) => s.setActiveTab);
   const setFocused = useTerminalStore((s) => s.setFocused);
@@ -374,7 +375,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 openDockTerminal(activeTabId);
               }
             }}
-            aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, drag to reorder`}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              moveTerminalToGrid(activePanel.id);
+              closeDockTerminal();
+            }}
+            aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
           >
             <div
               className={cn(

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -28,6 +28,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const activeDockTerminalId = useTerminalStore((s) => s.activeDockTerminalId);
   const openDockTerminal = useTerminalStore((s) => s.openDockTerminal);
   const closeDockTerminal = useTerminalStore((s) => s.closeDockTerminal);
+  const moveTerminalToGrid = useTerminalStore((s) => s.moveTerminalToGrid);
   const backendStatus = useTerminalStore((s) => s.backendStatus);
   const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
   const hybridInputAutoFocus = useTerminalInputStore((s) => s.hybridInputAutoFocus);
@@ -212,7 +213,13 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                 openDockTerminal(terminal.id);
               }
             }}
-            aria-label={`${terminal.title} - Click to preview, drag to reorder`}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              moveTerminalToGrid(terminal.id);
+              closeDockTerminal();
+            }}
+            aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
           >
             <div
               className={cn(

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -235,10 +235,14 @@ function PanelHeaderComponent({
 
   const handleHeaderDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement;
-    if (target.tagName === "INPUT" || target.tagName === "BUTTON") {
+    if (target.closest("button, input, [role='button']")) {
       return;
     }
-    onToggleMaximize?.();
+    if (location === "dock") {
+      onRestore?.();
+    } else {
+      onToggleMaximize?.();
+    }
   };
 
   const getAriaLabel = () => {


### PR DESCRIPTION
## Summary

Adds double-click gesture to dock pill buttons and the dock panel header so users can quickly promote a docked panel into the main grid without right-clicking or using a menu.

Closes #2495

## Changes Made

- **`DockedTerminalItem`** — added `onDoubleClick` to the dock pill button that calls `moveTerminalToGrid(terminal.id)` and `closeDockTerminal()`, closing the popover and placing the panel in the grid in one gesture
- **`DockedTabGroup`** — same treatment using `activePanel.id`; the store's `moveTerminalToGrid` automatically delegates to `moveTabGroupToLocation` when the panel belongs to a group, so the entire tab group moves
- **`PanelHeader`** — updated `handleHeaderDoubleClick` to call `onRestore?.()` when `location === "dock"` (which triggers the existing move-to-grid + animation + popover close flow) and `onToggleMaximize?.()` otherwise; this leaves grid behaviour unchanged
- **`PanelHeader`** — hardened the double-click target guard from exact `tagName` comparison to `closest("button, input, [role='button']")` so clicks on nested SVG icons or spans inside header action buttons don't accidentally trigger the move