### PR TITLE
fix(dock): forward agentId to TerminalIcon in docked panel components

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -345,7 +345,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const isWaiting = activePanel.agentState === "waiting";
   const isActive = isWorking || isRunning || isWaiting;
   const commandText = activePanel.activityHeadline || activePanel.lastCommand;
-  const brandColor = getBrandColorHex(activePanel.type);
+  const brandColor = getBrandColorHex(activePanel.agentId ?? activePanel.type);
   const agentState = activePanel.agentState;
   const displayTitle = getBaseTitle(activePanel.title);
   const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";
@@ -385,6 +385,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
               <TerminalIcon
                 type={activePanel.type}
                 kind={activePanel.kind}
+                agentId={activePanel.agentId}
                 detectedProcessId={activePanel.detectedProcessId}
                 className="w-3.5 h-3.5"
                 brandColor={brandColor}

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -178,7 +178,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const isWaiting = terminal.agentState === "waiting";
   const isActive = isWorking || isRunning || isWaiting;
   const commandText = terminal.activityHeadline || terminal.lastCommand;
-  const brandColor = getBrandColorHex(terminal.type);
+  const brandColor = getBrandColorHex(terminal.agentId ?? terminal.type);
   const agentState = terminal.agentState;
   // Use shortened title without command summary for dock items
   const displayTitle = getBaseTitle(terminal.title);
@@ -223,6 +223,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
               <TerminalIcon
                 type={terminal.type}
                 kind={terminal.kind}
+                agentId={terminal.agentId}
                 detectedProcessId={terminal.detectedProcessId}
                 className="w-3.5 h-3.5"
                 brandColor={brandColor}


### PR DESCRIPTION
## Summary

Dock items were showing process icons (npm, vite, python, etc.) instead of agent brand icons (Claude, Gemini, Codex) when a detected running process was present. This caused the dock icon to fall out of sync with the panel header icon.

Closes #2498

## Changes Made

- Add `agentId={terminal.agentId}` to `TerminalIcon` in `DockedTerminalItem` so agent panels always show their brand icon in the dock regardless of detected processes
- Add `agentId={activePanel.agentId}` to `TerminalIcon` in `DockedTabGroup` for the same reason
- Update `brandColor` derivation in both components to use `agentId ?? type` (matching `PanelHeader`'s existing behavior) so icon color stays in sync with the icon