### PR TITLE
feat(panel): replace minimize-to-dock icon with custom DockToBottomIcon

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -1,14 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
-import {
-  X,
-  Maximize2,
-  Minimize2,
-  ArrowDownToLine,
-  RotateCcw,
-  Grid2X2,
-  Activity,
-  Plus,
-} from "lucide-react";
+import { X, Maximize2, Minimize2, RotateCcw, Grid2X2, Activity, Plus } from "lucide-react";
 import {
   DndContext,
   closestCenter,
@@ -27,6 +18,7 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/comp
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { DockToBottomIcon } from "@/components/icons";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { useBackgroundPanelStats } from "@/hooks";
 import { TabButton, type TabInfo } from "./TabButton";
@@ -623,7 +615,7 @@ function PanelHeaderComponent({
                       className="p-1.5 hover:bg-canopy-text/10 focus-visible:bg-canopy-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2 text-canopy-text/60 hover:text-canopy-text transition-colors"
                       aria-label={location === "dock" ? "Minimize" : "Minimize to dock"}
                     >
-                      <ArrowDownToLine className="w-3 h-3" aria-hidden="true" />
+                      <DockToBottomIcon className="w-3 h-3" />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">

--- a/src/components/icons/DockToBottomIcon.tsx
+++ b/src/components/icons/DockToBottomIcon.tsx
@@ -1,0 +1,25 @@
+interface DockToBottomIconProps {
+  className?: string;
+}
+
+export function DockToBottomIcon({ className }: DockToBottomIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <line x1="4" y1="20" x2="20" y2="20" />
+      <path d="M11 16H7v-4" />
+      <path d="M7 16L14 9" />
+    </svg>
+  );
+}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,2 +1,3 @@
 export { CanopyIcon } from "./CanopyIcon";
+export { DockToBottomIcon } from "./DockToBottomIcon";
 export * from "./brands";


### PR DESCRIPTION
## Summary

Replaces the `ArrowDownToLine` icon on the minimize-to-dock button with a custom `DockToBottomIcon` SVG that is visually unambiguous.

The existing icon (`ArrowDownToLine`) shares identical geometry with the standard download icon, causing confusion. The replacement borrows from the existing `Maximize2`/`Minimize2` icon family — a 45° diagonal arrow with an L-bracket tip pointing to the bottom-left, plus a horizontal dock bar below — making the action immediately recognisable as "send to dock" rather than "download".

Closes #2507

## Changes Made

- Add `DockToBottomIcon` component (`src/components/icons/DockToBottomIcon.tsx`) — custom SVG using the same diagonal arrow + L-bracket geometry as Lucide's `Maximize2`/`Minimize2`, with a dock bar at the bottom
- Export `DockToBottomIcon` from `src/components/icons/index.ts`
- Replace `<ArrowDownToLine>` with `<DockToBottomIcon>` in the panel header minimize-to-dock button (`src/components/Panel/PanelHeader.tsx`)