### PR TITLE
feat(clipboard): garbage collect old clipboard images on startup

### DIFF
--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -6,12 +6,53 @@ import * as crypto from "node:crypto";
 import * as os from "node:os";
 
 const CLIPBOARD_DIR_NAME = "canopy-clipboard";
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 function getClipboardDir(): string {
   return path.join(os.tmpdir(), CLIPBOARD_DIR_NAME);
 }
 
+async function cleanupOldClipboardImages(): Promise<void> {
+  const dir = getClipboardDir();
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    console.warn("[clipboard] Failed to read clipboard dir for cleanup:", err);
+    return;
+  }
+
+  const now = Date.now();
+  const results = await Promise.allSettled(
+    entries
+      .filter(
+        (dirent) =>
+          dirent.isFile() && dirent.name.startsWith("clipboard-") && dirent.name.endsWith(".png")
+      )
+      .map(async (dirent) => {
+        const filePath = path.join(dir, dirent.name);
+        const stat = await fs.stat(filePath);
+        if (now - stat.mtimeMs > MAX_AGE_MS) {
+          await fs.unlink(filePath);
+        }
+      })
+  );
+
+  for (const result of results) {
+    if (result.status === "rejected") {
+      const code = (result.reason as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        console.warn("[clipboard] Unexpected error during cleanup:", result.reason);
+      }
+    }
+  }
+}
+
 export function registerClipboardHandlers(): () => void {
+  cleanupOldClipboardImages().catch((err) => {
+    console.warn("[clipboard] Cleanup failed unexpectedly:", err);
+  });
   const handleSaveImage = async (
     _event: Electron.IpcMainInvokeEvent
   ): Promise<


### PR DESCRIPTION
## Summary

Adds a startup garbage collection sweep to `registerClipboardHandlers()` that deletes clipboard images older than 24 hours from `os.tmpdir()/canopy-clipboard`. This prevents unbounded growth of pasted images across sessions while providing a reliable safety layer on top of OS-level cleanup.

Closes #2506

## Changes Made

- Add `cleanupOldClipboardImages()` that reads `os.tmpdir()/canopy-clipboard`, filters for regular `clipboard-*.png` files (using `withFileTypes` to skip symlinks/directories), checks `mtimeMs`, and deletes files older than 24 hours
- Use `Promise.allSettled` so a single deletion failure does not abort the entire sweep
- Silently swallow `ENOENT` from `readdir` (directory does not exist on first launch)
- Log warnings for unexpected per-file errors (`EACCES`, `EPERM`, etc.) while tolerating `ENOENT` races
- Call fire-and-forget with an explicit `.catch()` at the `registerClipboardHandlers` call site