### PR TITLE
fix(navigation): Cmd+N focuses Nth panel group, not Nth individual tab

### DIFF
--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -18,10 +18,13 @@ interface UseGridNavigationOptions {
 export function useGridNavigation(options: UseGridNavigationOptions = {}) {
   const { containerSelector = "#terminal-grid" } = options;
 
-  const { terminals, focusedId } = useTerminalStore(
+  const { terminals, focusedId, tabGroups, activeTabByGroup, getTabGroups } = useTerminalStore(
     useShallow((state) => ({
       terminals: state.terminals,
       focusedId: state.focusedId,
+      tabGroups: state.tabGroups,
+      activeTabByGroup: state.activeTabByGroup,
+      getTabGroups: state.getTabGroups,
     }))
   );
 
@@ -192,12 +195,23 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
     [rowMajor, indexById, columnBuckets, positionById]
   );
 
+  // Build a group-aware ordered list matching ContentGrid's visual order.
+  // Uses getTabGroups for ordering (explicit groups first by terminal order, then virtual groups)
+  // so Cmd+N indices are consistent with what the user sees on screen.
+  const groupRowMajor = useMemo(() => {
+    const orderedGroups = getTabGroups("grid", activeWorktreeId ?? undefined);
+    return orderedGroups.flatMap((group) => {
+      const activeId = activeTabByGroup.get(group.id) ?? group.activeTabId;
+      const resolvedId = group.panelIds.includes(activeId) ? activeId : group.panelIds[0];
+      return resolvedId ? [resolvedId] : [];
+    });
+  }, [getTabGroups, activeWorktreeId, terminals, tabGroups, activeTabByGroup]);
+
   const findByIndex = useCallback(
     (index: number): string | null => {
-      const position = rowMajor[index - 1];
-      return position?.terminalId ?? null;
+      return groupRowMajor[index - 1] ?? null;
     },
-    [rowMajor]
+    [groupRowMajor]
   );
 
   const findDockByIndex = useCallback(


### PR DESCRIPTION
## Summary

`Cmd+1`, `Cmd+2`, `Cmd+3` (and higher) were counting individual tabs instead of panel groups. A panel with 3 tabs would occupy indices 1, 2, and 3 rather than counting as a single panel at index 1.

Closes #2511

## Changes Made

- Added `groupRowMajor` derived list in `useGridNavigation` that deduplicates tab groups using `getTabGroups("grid", ...)` — the same source ContentGrid uses for visual ordering
- Updated `findByIndex` to index into `groupRowMajor` instead of the flat `rowMajor` list
- `findByIndex` now resolves to the group's currently active tab (`activeTabByGroup` with fallback to `group.activeTabId`), so `Cmd+N` focuses whichever tab was last active in that group
- Subscribed to `tabGroups`, `activeTabByGroup`, and `getTabGroups` from the store to keep the list reactive when tab membership or active tab selection changes