### PR TITLE
fix(tooltip): add missing tooltips to copy and menu buttons

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -600,7 +600,7 @@ export function Toolbar({
       "copy-tree": {
         render: () => (
           <TooltipProvider key="copy-tree">
-            <Tooltip open={treeCopied} delayDuration={0}>
+            <Tooltip open={treeCopied || undefined} delayDuration={treeCopied ? 0 : 300}>
               <TooltipTrigger asChild>
                 <Button
                   variant="ghost"
@@ -615,7 +615,7 @@ export function Toolbar({
                     isCopyingTree && "cursor-wait opacity-70",
                     !activeWorktree && "opacity-50"
                   )}
-                  aria-label={treeCopied ? "Context Copied" : "Copy Context"}
+                  aria-label={isCopyingTree ? "Copying…" : treeCopied ? "Context Copied" : "Copy Context"}
                 >
                   {isCopyingTree ? (
                     <Loader2 className="animate-spin motion-reduce:animate-none" />
@@ -627,9 +627,15 @@ export function Toolbar({
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="font-medium">
-                <span role="status" aria-live="polite">
-                  {copyFeedback}
-                </span>
+                {isCopyingTree ? (
+                  "Copying…"
+                ) : treeCopied ? (
+                  <span role="status" aria-live="polite">
+                    {copyFeedback}
+                  </span>
+                ) : (
+                  "Copy Context"
+                )}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -318,7 +318,7 @@ export function WorktreeHeader({
           )}
         >
           <TooltipProvider>
-            <Tooltip open={copy.treeCopied} delayDuration={0}>
+            <Tooltip open={copy.treeCopied || undefined} delayDuration={copy.treeCopied ? 0 : 300}>
               <TooltipTrigger asChild>
                 <button
                   onClick={copy.onCopyTreeClick}
@@ -331,7 +331,13 @@ export function WorktreeHeader({
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
                     copy.isCopyingTree && "cursor-wait opacity-70"
                   )}
-                  aria-label={copy.treeCopied ? "Context Copied" : "Copy Context"}
+                  aria-label={
+                    copy.isCopyingTree
+                      ? "Copying…"
+                      : copy.treeCopied
+                        ? "Context Copied"
+                        : "Copy Context"
+                  }
                 >
                   {copy.isCopyingTree ? (
                     <Loader2 className="w-3.5 h-3.5 animate-spin motion-reduce:animate-none text-canopy-text" />
@@ -343,23 +349,36 @@ export function WorktreeHeader({
                 </button>
               </TooltipTrigger>
               <TooltipContent side="top" className="font-medium">
-                <span role="status" aria-live="polite">
-                  {copy.copyFeedback}
-                </span>
+                {copy.isCopyingTree ? (
+                  "Copying…"
+                ) : copy.treeCopied ? (
+                  <span role="status" aria-live="polite">
+                    {copy.copyFeedback}
+                  </span>
+                ) : (
+                  "Copy Context"
+                )}
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
 
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                onClick={(e) => e.stopPropagation()}
-                className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/5 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-                aria-label="More actions"
-              >
-                <MoreHorizontal className="w-3.5 h-3.5" />
-              </button>
-            </DropdownMenuTrigger>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      onClick={(e) => e.stopPropagation()}
+                      className="p-1 text-canopy-text/60 hover:text-white hover:bg-white/5 rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+                      aria-label="More actions"
+                    >
+                      <MoreHorizontal className="w-3.5 h-3.5" />
+                    </button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="top">More actions</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <DropdownMenuContent
               align="end"
               side="bottom"


### PR DESCRIPTION
## Summary

Fixes missing tooltips on the Copy Context and More Actions (⋯) buttons in the worktree card header and the toolbar copy button.

Closes #2504

## Changes Made

- **WorktreeHeader**: Copy button tooltip now shows on hover (previously only appeared after a successful copy). Added tooltip to the `MoreHorizontal` menu trigger using Radix `TooltipTrigger` + `DropdownMenuTrigger` composition.
- **Toolbar**: Same fix applied to the copy-tree button — tooltip is now hover-accessible and not gated behind the copy success state.
- **Copy states**: Tooltip and `aria-label` now reflect all three states — "Copy Context" (idle), "Copying…" (in-progress), and the success feedback message (complete).
- **Delay tuning**: Tooltip `delayDuration` set to 300ms for normal hover (was 0, but only triggered on success), and 0ms for forced-open success state.