### PR TITLE
feat(terminal): quit app when last panel is closed via CMD+W

### DIFF
--- a/src/services/actions/definitions/terminalActions.ts
+++ b/src/services/actions/definitions/terminalActions.ts
@@ -219,6 +219,12 @@ export function registerTerminalActions(actions: ActionRegistry, callbacks: Acti
       const targetId = state.focusedId ?? state.terminals.find((t) => t.location !== "trash")?.id;
       if (targetId) {
         state.trashTerminal(targetId);
+        const remaining = useTerminalStore
+          .getState()
+          .terminals.filter((t) => t.location !== "trash");
+        if (remaining.length === 0) {
+          await appClient.quit();
+        }
       }
     },
   }));


### PR DESCRIPTION
## Summary

Implements Sublime-style CMD+W behaviour: pressing CMD+W closes panels one at a time, and when the last panel is closed, the app quits.

Closes #2509

## Changes Made

- After `trashTerminal()`, re-reads store state to check for remaining non-trashed panels
- If no panels remain (`remaining.length === 0`), calls `await appClient.quit()` to close the app
- Uses `appClient.quit()` (the existing abstraction) rather than calling `window.electron.app.quit()` directly