### PR TITLE
fix(terminal): restore input focus when switching tabs in focused group

### DIFF
--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo, useEffect } from "react";
+import { useCallback, useMemo, useEffect, useRef } from "react";
 import { useTerminalStore, type TerminalInstance } from "@/store";
 import { GridPanel } from "./GridPanel";
 import type { TabGroup } from "@/types";
 import type { TabInfo } from "@/components/Panel/TabButton";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import { focusPanelInput } from "./terminalFocusRegistry";
 
 export interface GridTabGroupProps {
   group: TabGroup;
@@ -78,6 +79,28 @@ export function GridTabGroup({
 
   // Check if this group is currently focused
   const isGroupFocused = panels.some((p) => p.id === focusedId);
+
+  // Restore focus to the hybrid input bar when switching tabs within a focused group.
+  // The existing TerminalPane focus effect uses double-rAF which races with
+  // HybridInputBar's CodeMirror editor reinitialization on terminalId change.
+  const prevActiveTabIdRef = useRef(activeTabId);
+  const panelIdsRef = useRef<Set<string>>(new Set(panels.map((p) => p.id)));
+  useEffect(() => {
+    panelIdsRef.current = new Set(panels.map((p) => p.id));
+  }, [panels]);
+
+  useEffect(() => {
+    if (prevActiveTabIdRef.current === activeTabId) return;
+    prevActiveTabIdRef.current = activeTabId;
+    if (!activeTabId || !isGroupFocused) return;
+    const rafId = requestAnimationFrame(() => {
+      const currentFocusedId = useTerminalStore.getState().focusedId;
+      if (!currentFocusedId || !panelIdsRef.current.has(currentFocusedId)) return;
+      focusPanelInput(activeTabId);
+    });
+    return () => cancelAnimationFrame(rafId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTabId]);
 
   // Handle tab click - switch to that tab, only focus if group already focused
   const handleTabClick = useCallback(

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -467,7 +467,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       const view = editorViewRef.current;
       if (!view) return;
       requestAnimationFrame(() => {
-        if (!editorViewRef.current) return;
+        if (editorViewRef.current !== view) return;
         view.dispatch({
           selection: EditorSelection.cursor(view.state.doc.length),
           scrollIntoView: true,

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -35,6 +35,7 @@ import { getAgentConfig } from "@/config/agents";
 import { terminalClient } from "@/clients";
 import { HybridInputBar, type HybridInputBarHandle } from "./HybridInputBar";
 import { getTerminalFocusTarget } from "./terminalFocus";
+import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 import { getCanopyCommand, isEscapedCommand, unescapeCommand } from "./canopySlashCommands";
 
 export type { TerminalType };
@@ -541,6 +542,29 @@ function TerminalPaneComponent({
     isBackendDisconnected,
     isBackendRecovering,
     isInputLocked,
+  ]);
+
+  useEffect(() => {
+    if (!showHybridInputBar) return;
+    return registerPanelFocusHandler(id, () => {
+      const focusTarget = getTerminalFocusTarget({
+        isAgentTerminal,
+        isInputDisabled: isBackendDisconnected || isBackendRecovering || isInputLocked,
+        hybridInputEnabled,
+        hybridInputAutoFocus,
+      });
+      if (focusTarget !== "hybridInput") return;
+      inputBarRef.current?.focusWithCursorAtEnd();
+    });
+  }, [
+    id,
+    showHybridInputBar,
+    isAgentTerminal,
+    isBackendDisconnected,
+    isBackendRecovering,
+    isInputLocked,
+    hybridInputEnabled,
+    hybridInputAutoFocus,
   ]);
 
   // Sync agent state to terminal service for scroll management

--- a/src/components/Terminal/terminalFocusRegistry.ts
+++ b/src/components/Terminal/terminalFocusRegistry.ts
@@ -1,0 +1,16 @@
+type FocusHandler = () => void;
+
+const registry = new Map<string, FocusHandler>();
+
+export function registerPanelFocusHandler(id: string, handler: FocusHandler): () => void {
+  registry.set(id, handler);
+  return () => {
+    if (registry.get(id) === handler) {
+      registry.delete(id);
+    }
+  };
+}
+
+export function focusPanelInput(id: string): void {
+  registry.get(id)?.();
+}


### PR DESCRIPTION
## Summary

When switching between Claude agent tabs in a focused tab group, the hybrid input bar ("Type a command for Claude") lost focus due to a timing race between `TerminalPane`'s double-rAF focus effect and `HybridInputBar`'s synchronous CodeMirror editor reinitialization on `terminalId` change.

Closes #2512

## Changes Made

- **`terminalFocusRegistry.ts`** (new): Lightweight module-level `Map` registry for imperative panel focus handles. `registerPanelFocusHandler` returns a cleanup function; `focusPanelInput` triggers the registered handler for a given terminal ID.

- **`TerminalPane.tsx`**: Registers a focus handler in the registry for each hybrid-input panel. The handler respects the same `getTerminalFocusTarget` policy as the existing focus effect (checks `hybridInputAutoFocus`, disabled state) before calling `focusWithCursorAtEnd`.

- **`GridTabGroup.tsx`**: Adds a `useEffect` on `activeTabId` changes (skips initial mount via `prevActiveTabIdRef`). When the group is focused, schedules a single `requestAnimationFrame` that re-reads `focusedId` from the store before calling `focusPanelInput`, preventing focus steal if the group loses focus before the frame fires.

- **`HybridInputBar.tsx`**: Guards `focusEditorWithCursorAtEnd`'s inner `requestAnimationFrame` with a view identity check (`editorViewRef.current !== view`) to prevent stale-view dispatch/focus under rapid tab changes.