### PR TITLE
feat(gemini): inject --include-directories for clipboard image access

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -80,6 +80,7 @@ export const CHANNELS = {
   SYSTEM_CHECK_COMMAND: "system:check-command",
   SYSTEM_CHECK_DIRECTORY: "system:check-directory",
   SYSTEM_GET_HOME_DIR: "system:get-home-dir",
+  SYSTEM_GET_TMP_DIR: "system:get-tmp-dir",
   SYSTEM_GET_CLI_AVAILABILITY: "system:get-cli-availability",
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",
   SYSTEM_WAKE: "system:wake",

--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -205,6 +205,12 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
   ipcMain.handle(CHANNELS.SYSTEM_GET_HOME_DIR, handleSystemGetHomeDir);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_HOME_DIR));
 
+  const handleSystemGetTmpDir = async () => {
+    return os.tmpdir();
+  };
+  ipcMain.handle(CHANNELS.SYSTEM_GET_TMP_DIR, handleSystemGetTmpDir);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_TMP_DIR));
+
   const handleSystemGetCliAvailability = async () => {
     if (!cliAvailabilityService) {
       console.warn("[IPC] CliAvailabilityService not available");

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -215,6 +215,7 @@ const CHANNELS = {
   SYSTEM_CHECK_COMMAND: "system:check-command",
   SYSTEM_CHECK_DIRECTORY: "system:check-directory",
   SYSTEM_GET_HOME_DIR: "system:get-home-dir",
+  SYSTEM_GET_TMP_DIR: "system:get-tmp-dir",
   SYSTEM_GET_CLI_AVAILABILITY: "system:get-cli-availability",
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",
   SYSTEM_GET_AGENT_VERSIONS: "system:get-agent-versions",
@@ -722,6 +723,8 @@ const api: ElectronAPI = {
     checkDirectory: (path: string) => _typedInvoke(CHANNELS.SYSTEM_CHECK_DIRECTORY, path),
 
     getHomeDir: () => _typedInvoke(CHANNELS.SYSTEM_GET_HOME_DIR),
+
+    getTmpDir: () => _typedInvoke(CHANNELS.SYSTEM_GET_TMP_DIR),
 
     getCliAvailability: () => _typedInvoke(CHANNELS.SYSTEM_GET_CLI_AVAILABILITY),
 

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -83,6 +83,8 @@ export interface AgentSettingsEntry {
   dangerousEnabled?: boolean;
   /** Use inline rendering instead of fullscreen alt-screen TUI */
   inlineMode?: boolean;
+  /** When true, inject --include-directories for the clipboard temp directory (Gemini only) */
+  shareClipboardDirectory?: boolean;
   [key: string]: unknown;
 }
 
@@ -118,7 +120,16 @@ export function getAgentSettingsEntry(
   return settings.agents[agentId] ?? {};
 }
 
-export function generateAgentFlags(entry: AgentSettingsEntry, agentId?: string): string[] {
+export interface GenerateAgentFlagsOptions {
+  /** Absolute path to the clipboard temp directory (e.g. /tmp/canopy-clipboard) */
+  clipboardDirectory?: string;
+}
+
+export function generateAgentFlags(
+  entry: AgentSettingsEntry,
+  agentId?: string,
+  options?: GenerateAgentFlagsOptions
+): string[] {
   const flags: string[] = [];
   if (entry.dangerousEnabled) {
     // Use entry.dangerousArgs if set, otherwise fall back to default for this agent
@@ -134,6 +145,23 @@ export function generateAgentFlags(entry: AgentSettingsEntry, agentId?: string):
       flags.push(...trimmed.split(/\s+/));
     }
   }
+
+  // Inject --include-directories for Gemini clipboard image access
+  if (
+    agentId === "gemini" &&
+    entry.shareClipboardDirectory !== false &&
+    options?.clipboardDirectory
+  ) {
+    const dir = options.clipboardDirectory;
+    // Deduplicate: skip if user already added this exact directory in custom flags
+    const alreadyIncluded = flags.some(
+      (f, i) => f === "--include-directories" && flags[i + 1] === dir
+    );
+    if (!alreadyIncluded) {
+      flags.push("--include-directories", dir);
+    }
+  }
+
   return flags;
 }
 
@@ -142,6 +170,8 @@ export interface GenerateAgentCommandOptions {
   initialPrompt?: string;
   /** If true, agent runs in interactive mode (default). If false, runs one-shot/print mode. */
   interactive?: boolean;
+  /** Absolute path to the clipboard temp directory for --include-directories injection */
+  clipboardDirectory?: string;
 }
 
 /**
@@ -168,7 +198,9 @@ export function generateAgentCommand(
   agentId?: string,
   options?: GenerateAgentCommandOptions
 ): string {
-  const flags = generateAgentFlags(entry, agentId);
+  const flags = generateAgentFlags(entry, agentId, {
+    clipboardDirectory: options?.clipboardDirectory,
+  });
   const parts: string[] = [baseCommand];
 
   // Add default args from agent registry (before user flags)

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -229,6 +229,7 @@ export type {
   AgentSettingsEntry,
   AgentSettings,
   GenerateAgentCommandOptions,
+  GenerateAgentFlagsOptions,
 } from "./agentSettings.js";
 
 // Agent settings helpers

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -227,6 +227,7 @@ export interface ElectronAPI {
     checkCommand(command: string): Promise<boolean>;
     checkDirectory(path: string): Promise<boolean>;
     getHomeDir(): Promise<string>;
+    getTmpDir(): Promise<string>;
     getCliAvailability(): Promise<CliAvailability>;
     refreshCliAvailability(): Promise<CliAvailability>;
     getAgentVersions(): Promise<AgentVersionInfo[]>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -338,6 +338,10 @@ export interface IpcInvokeMap {
     args: [];
     result: string;
   };
+  "system:get-tmp-dir": {
+    args: [];
+    result: string;
+  };
   "system:get-cli-availability": {
     args: [];
     result: CliAvailability;

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -32,6 +32,10 @@ export const systemClient = {
     return window.electron.system.getHomeDir();
   },
 
+  getTmpDir: (): Promise<string> => {
+    return window.electron.system.getTmpDir();
+  },
+
   onWake: (
     callback: (data: { sleepDuration: number; timestamp: number }) => void
   ): (() => void) => {

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -417,6 +417,43 @@ export function AgentSettings({ onSettingsChange }: AgentSettingsProps) {
               );
             })()}
 
+            {/* Share Clipboard Directory Toggle - Gemini only */}
+            {activeAgent.id === "gemini" && (
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-medium text-canopy-text">
+                    Share Clipboard Directory
+                  </div>
+                  <div className="text-xs text-canopy-text/50">
+                    Allow Gemini to read pasted clipboard images via --include-directories
+                  </div>
+                </div>
+                <button
+                  role="switch"
+                  aria-checked={activeEntry.shareClipboardDirectory !== false}
+                  aria-label="Share clipboard directory with Gemini"
+                  onClick={async () => {
+                    const current = activeEntry.shareClipboardDirectory !== false;
+                    await updateAgent(activeAgent.id, { shareClipboardDirectory: !current });
+                    onSettingsChange?.();
+                  }}
+                  className={cn(
+                    "relative w-11 h-6 rounded-full transition-colors shrink-0",
+                    activeEntry.shareClipboardDirectory !== false
+                      ? "bg-canopy-accent"
+                      : "bg-canopy-border"
+                  )}
+                >
+                  <span
+                    className={cn(
+                      "absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform",
+                      activeEntry.shareClipboardDirectory !== false && "translate-x-5"
+                    )}
+                  />
+                </button>
+              </div>
+            )}
+
             {/* Custom Arguments */}
             <div className="space-y-2 pt-2 border-t border-canopy-border">
               <label className="text-sm font-medium text-canopy-text">Custom Arguments</label>

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -5,10 +5,12 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useWorktrees } from "./useWorktrees";
 import { isElectronAvailable } from "./useElectron";
-import { agentSettingsClient } from "@/clients";
+import { agentSettingsClient, systemClient } from "@/clients";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 import { generateAgentCommand } from "@shared/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
+
+const CLIPBOARD_DIR_NAME = "canopy-clipboard";
 
 export interface LaunchAgentOptions {
   location?: AddTerminalOptions["location"];
@@ -114,9 +116,22 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
       let command: string | undefined;
       if (agentConfig) {
         const entry = agentSettings?.agents?.[agentId] ?? {};
+
+        // Resolve clipboard directory for agents that need it (e.g. Gemini)
+        let clipboardDirectory: string | undefined;
+        if (agentId === "gemini" && entry.shareClipboardDirectory !== false) {
+          try {
+            const tmpDir = await systemClient.getTmpDir();
+            clipboardDirectory = `${tmpDir}/${CLIPBOARD_DIR_NAME}`;
+          } catch {
+            // Non-critical: Gemini will work without clipboard access
+          }
+        }
+
         command = generateAgentCommand(agentConfig.command, entry, agentId, {
           initialPrompt: launchOptions?.prompt,
           interactive: launchOptions?.interactive ?? true,
+          clipboardDirectory,
         });
       }
 

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -3,7 +3,7 @@ import type { AddTerminalOptions } from "@/store/slices/terminalRegistry/types";
 import type { TabGroupLocation } from "@/types";
 import { generateAgentCommand } from "@shared/types";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
-import { agentSettingsClient } from "@/clients";
+import { agentSettingsClient, systemClient } from "@/clients";
 
 /**
  * Generate the startup command for a panel being duplicated.
@@ -15,10 +15,15 @@ async function resolveCommandForPanel(panel: TerminalInstance): Promise<string |
     const agentConfig = getAgentConfig(panel.agentId);
     if (agentConfig) {
       try {
-        const agentSettings = await agentSettingsClient.get();
+        const [agentSettings, tmpDir] = await Promise.all([
+          agentSettingsClient.get(),
+          systemClient.getTmpDir().catch(() => ""),
+        ]);
         const entry = agentSettings?.agents?.[panel.agentId] ?? {};
+        const clipboardDirectory = tmpDir ? `${tmpDir}/canopy-clipboard` : undefined;
         return generateAgentCommand(agentConfig.command, entry, panel.agentId, {
           interactive: true,
+          clipboardDirectory,
         });
       } catch (error) {
         console.warn(

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -1,7 +1,7 @@
 import { create, type StateCreator } from "zustand";
 import type { TerminalRecipe, RecipeTerminal, RecipeTerminalType } from "@/types";
 import { useTerminalStore, type TerminalInstance } from "./terminalStore";
-import { projectClient, agentSettingsClient } from "@/clients";
+import { projectClient, agentSettingsClient, systemClient } from "@/clients";
 import { getAgentConfig } from "@/config/agents";
 import { generateAgentCommand } from "@shared/types";
 
@@ -227,12 +227,18 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     // Pre-fetch agent settings once for all agent terminals
     let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
+    let clipboardDirectory: string | undefined;
     const hasAgent = recipe.terminals.some(
       (t) => t.type !== "terminal" && t.type !== "dev-preview"
     );
     if (hasAgent) {
       try {
-        agentSettings = await agentSettingsClient.get();
+        const [settings, tmpDir] = await Promise.all([
+          agentSettingsClient.get(),
+          systemClient.getTmpDir().catch(() => ""),
+        ]);
+        agentSettings = settings;
+        clipboardDirectory = tmpDir ? `${tmpDir}/canopy-clipboard` : undefined;
       } catch (error) {
         console.warn("Failed to fetch agent settings for recipe:", error);
       }
@@ -265,6 +271,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           const entry = agentSettings?.agents?.[terminal.type] ?? {};
           command = generateAgentCommand(baseCommand, entry, terminal.type, {
             initialPrompt,
+            clipboardDirectory,
           });
         }
 

--- a/src/store/slices/terminalRegistry/index.ts
+++ b/src/store/slices/terminalRegistry/index.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { TerminalRuntimeStatus, TerminalLocation, TabGroup, TabGroupLocation } from "@/types";
-import { terminalClient, agentSettingsClient, projectClient } from "@/clients";
+import { terminalClient, agentSettingsClient, projectClient, systemClient } from "@/clients";
 import { generateAgentCommand } from "@shared/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -1364,14 +1364,19 @@ export const createTerminalRegistrySlice =
 
         if (isAgent && effectiveAgentId) {
           try {
-            const agentSettings = await agentSettingsClient.get();
+            const [agentSettings, tmpDir] = await Promise.all([
+              agentSettingsClient.get(),
+              systemClient.getTmpDir().catch(() => ""),
+            ]);
             if (agentSettings) {
               const agentConfig = getAgentConfig(effectiveAgentId);
               const baseCommand = agentConfig?.command || effectiveAgentId;
+              const clipboardDirectory = tmpDir ? `${tmpDir}/canopy-clipboard` : undefined;
               commandToRun = generateAgentCommand(
                 baseCommand,
                 agentSettings.agents?.[effectiveAgentId] ?? {},
-                effectiveAgentId
+                effectiveAgentId,
+                { clipboardDirectory }
               );
             }
           } catch (error) {
@@ -1741,14 +1746,19 @@ export const createTerminalRegistrySlice =
         let commandToRun: string | undefined;
         if (effectiveAgentId) {
           try {
-            const agentSettings = await agentSettingsClient.get();
+            const [agentSettings, tmpDir] = await Promise.all([
+              agentSettingsClient.get(),
+              systemClient.getTmpDir().catch(() => ""),
+            ]);
             if (agentSettings) {
               const agentConfig = getAgentConfig(effectiveAgentId);
               const baseCommand = agentConfig?.command || effectiveAgentId;
+              const clipboardDirectory = tmpDir ? `${tmpDir}/canopy-clipboard` : undefined;
               commandToRun = generateAgentCommand(
                 baseCommand,
                 agentSettings.agents?.[effectiveAgentId] ?? {},
-                effectiveAgentId
+                effectiveAgentId,
+                { clipboardDirectory }
               );
             }
           } catch (error) {

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -58,6 +58,7 @@ vi.mock("@/clients", () => ({
   terminalClient: terminalClientMock,
   worktreeClient: worktreeClientMock,
   projectClient: projectClientMock,
+  systemClient: { getTmpDir: vi.fn().mockResolvedValue("/tmp") },
 }));
 
 vi.mock("@/clients/terminalConfigClient", () => ({
@@ -442,7 +443,8 @@ describe("hydrateAppState", () => {
     expect(callArgs).not.toHaveProperty("existingId");
 
     // Verify command is regenerated from settings (doesn't include old prompt)
-    expect(callArgs.command).toBe("claude --model sonnet-4");
+    // Non-flag values are shell-escaped by generateAgentCommand, hence the quotes
+    expect(callArgs.command).toBe("claude --model 'sonnet-4'");
     expect(callArgs.command).not.toContain("-p");
     expect(callArgs.command).not.toContain("Old prompt");
 

--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -1,4 +1,4 @@
-import { appClient, terminalClient, worktreeClient, projectClient } from "@/clients";
+import { appClient, terminalClient, worktreeClient, projectClient, systemClient } from "@/clients";
 import { suppressMruRecording } from "@/store/worktreeStore";
 import { terminalConfigClient } from "@/clients/terminalConfigClient";
 import {
@@ -17,7 +17,7 @@ import type {
 } from "@/types";
 import { keybindingService } from "@/services/KeybindingService";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
-import { generateAgentFlags } from "@shared/types";
+import { generateAgentCommand } from "@shared/types";
 import { normalizeScrollbackLines } from "@shared/config/scrollback";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isTerminalWarmInProjectSwitchCache } from "@/services/projectSwitchRendererCache";
@@ -30,6 +30,7 @@ const RECONNECT_TIMEOUT_MS = 10000;
 const RESTORE_CONCURRENCY = 8;
 const DEFERRED_RESTORE_IDLE_TIMEOUT_MS = 1200;
 const DEFERRED_RESTORE_FALLBACK_DELAY_MS = 32;
+const CLIPBOARD_DIR_NAME = "canopy-clipboard";
 
 let hydrationBootstrapPromise: Promise<void> | null = null;
 
@@ -242,12 +243,12 @@ export async function hydrateAppState(
     if (!checkCurrent()) return;
 
     // Batch fetch initial state
-    const {
-      appState,
-      terminalConfig,
-      project: currentProject,
-      agentSettings,
-    } = await appClient.hydrate();
+    const [hydrateResult, tmpDir] = await Promise.all([
+      appClient.hydrate(),
+      systemClient.getTmpDir().catch(() => ""),
+    ]);
+    const { appState, terminalConfig, project: currentProject, agentSettings } = hydrateResult;
+    const clipboardDirectory = tmpDir ? `${tmpDir}/${CLIPBOARD_DIR_NAME}` : undefined;
     if (!checkCurrent()) return;
 
     // Hydrate terminal config (scrollback, performance mode) BEFORE restoring terminals
@@ -697,12 +698,12 @@ export async function hydrateAppState(
                     if (agentId && agentSettings) {
                       const agentConfig = getAgentConfig(agentId);
                       const baseCommand = agentConfig?.command || agentId;
-                      const flags = generateAgentFlags(
+                      command = generateAgentCommand(
+                        baseCommand,
                         agentSettings.agents?.[agentId] ?? {},
-                        agentId
+                        agentId,
+                        { clipboardDirectory }
                       );
-                      command =
-                        flags.length > 0 ? `${baseCommand} ${flags.join(" ")}` : baseCommand;
                     }
 
                     // Preserve the original kind (dev-preview, terminal, etc.) unless it's an agent


### PR DESCRIPTION
## Summary

When a user pastes a clipboard image into the hybrid input bar, Canopy saves it to `os.tmpdir()/canopy-clipboard/` and inserts the absolute path into the editor. Claude and Codex read absolute paths natively, but Gemini CLI restricts file access to the workspace and rejects paths outside it with `Path not in workspace`.

This PR fixes the issue by injecting `--include-directories <tmpdir>/canopy-clipboard` into the Gemini spawn command at launch time, bypassing the workspace sandbox for clipboard images.

Closes #2503

## Changes Made

- Add `shareClipboardDirectory` boolean setting to `AgentSettingsEntry` (defaults to `true`)
- Inject `--include-directories <tmpdir>/canopy-clipboard` into Gemini commands via `generateAgentFlags` when the setting is enabled, with deduplication guard
- Add `system:get-tmp-dir` IPC channel (mirrors `system:get-home-dir` pattern) across channels, handler, preload, type maps, API interface, and client
- Pass `clipboardDirectory` through all Gemini spawn paths: `useAgentLauncher`, hydration/respawn (`stateHydration`), terminal restart/convert (`terminalRegistry`), recipe execution (`recipeStore`), and panel duplication (`panelDuplicationService`)
- Switch hydration respawn command build from raw `flags.join(" ")` to `generateAgentCommand` for correct shell escaping (also picks up registry args and inline mode flags)
- Add "Share Clipboard Directory" toggle in the Gemini agent settings UI
- Fix `stateHydration` test mock to include `systemClient`, update command expectation to reflect shell-escaped output