### PR TITLE
feat(HybridInputBar): support pasting arbitrary files as inline file chips

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -45,6 +45,10 @@ import {
   imageChipField,
   addImageChip,
   createImageChipTooltip,
+  fileDropChipField,
+  addFileDropChip,
+  createFileDropChipTooltip,
+  createFilePasteHandler,
 } from "./inputEditorExtensions";
 
 export interface HybridInputBarHandle {
@@ -130,6 +134,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
     const tooltipCompartmentRef = useRef(new Compartment());
     const fileChipTooltipCompartmentRef = useRef(new Compartment());
     const imageChipTooltipCompartmentRef = useRef(new Compartment());
+    const fileDropChipTooltipCompartmentRef = useRef(new Compartment());
     const isApplyingExternalValueRef = useRef(false);
     const lastEnterKeydownNewlineRef = useRef(false);
     const handledEnterRef = useRef(false);
@@ -181,6 +186,36 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           } catch {
             // Editor may have been destroyed before IPC returned
           }
+        }),
+      []
+    );
+
+    const filePasteExtension = useMemo(
+      () =>
+        createFilePasteHandler((view, files) => {
+          const cursor = view.state.selection.main.head;
+          const effects: ReturnType<typeof addFileDropChip.of>[] = [];
+
+          let insertText = "";
+          for (const file of files) {
+            const token = formatAtFileToken(file.path);
+            const from = cursor + insertText.length;
+            insertText += token + " ";
+            effects.push(
+              addFileDropChip.of({
+                from,
+                to: from + token.length,
+                filePath: file.path,
+                fileName: file.name,
+              })
+            );
+          }
+
+          view.dispatch({
+            changes: { from: cursor, insert: insertText },
+            effects,
+            selection: { anchor: cursor + insertText.length },
+          });
         }),
       []
     );
@@ -980,10 +1015,15 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
           fileChipTooltipCompartmentRef.current.of(!disabled ? createFileChipTooltip() : []),
           imageChipField,
           imageChipTooltipCompartmentRef.current.of(!disabled ? createImageChipTooltip() : []),
+          fileDropChipField,
+          fileDropChipTooltipCompartmentRef.current.of(
+            !disabled ? createFileDropChipTooltip() : []
+          ),
           keymapCompartmentRef.current.of(keymapExtension),
           editorUpdateListener,
           domEventHandlers,
           imagePasteExtension,
+          filePasteExtension,
         ],
       });
 
@@ -1057,6 +1097,17 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       view.dispatch({
         effects: imageChipTooltipCompartmentRef.current.reconfigure(
           !disabled ? createImageChipTooltip() : []
+        ),
+      });
+    }, [disabled]);
+
+    useEffect(() => {
+      const view = editorViewRef.current;
+      if (!view) return;
+
+      view.dispatch({
+        effects: fileDropChipTooltipCompartmentRef.current.reconfigure(
+          !disabled ? createFileDropChipTooltip() : []
         ),
       });
     }, [disabled]);

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -4,7 +4,14 @@
 import { describe, it, expect, vi } from "vitest";
 import { EditorState } from "@codemirror/state";
 import { EditorView, runScopeHandlers } from "@codemirror/view";
-import { computeAutoSize, createAutoSize, createCustomKeymap } from "../inputEditorExtensions";
+import {
+  computeAutoSize,
+  createAutoSize,
+  createCustomKeymap,
+  fileDropChipField,
+  addFileDropChip,
+  createFilePasteHandler,
+} from "../inputEditorExtensions";
 
 describe("computeAutoSize", () => {
   it("snaps height to line height increments with epsilon tolerance", () => {
@@ -406,6 +413,262 @@ describe("createCustomKeymap", () => {
 
     expect(onEnter).not.toHaveBeenCalled();
     expect(view.state.doc.toString()).toContain("\n");
+    view.destroy();
+  });
+});
+
+describe("fileDropChipField", () => {
+  function makeEditorWithFileChip() {
+    const parent = document.createElement("div");
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "",
+        extensions: [fileDropChipField],
+      }),
+    });
+    return view;
+  }
+
+  it("adds a file chip entry via addFileDropChip effect", () => {
+    const view = makeEditorWithFileChip();
+
+    view.dispatch({
+      changes: { from: 0, insert: "@/Users/test/file.ts " },
+      effects: addFileDropChip.of({
+        from: 0,
+        to: 20,
+        filePath: "/Users/test/file.ts",
+        fileName: "file.ts",
+      }),
+    });
+
+    const entries = view.state.field(fileDropChipField);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].filePath).toBe("/Users/test/file.ts");
+    expect(entries[0].fileName).toBe("file.ts");
+    expect(entries[0].from).toBe(0);
+    expect(entries[0].to).toBe(20);
+
+    view.destroy();
+  });
+
+  it("maps chip positions through document changes before the chip", () => {
+    const view = makeEditorWithFileChip();
+
+    view.dispatch({
+      changes: { from: 0, insert: "@/Users/test/file.ts " },
+      effects: addFileDropChip.of({
+        from: 0,
+        to: 20,
+        filePath: "/Users/test/file.ts",
+        fileName: "file.ts",
+      }),
+    });
+
+    // Insert text before the chip
+    view.dispatch({
+      changes: { from: 0, insert: "prefix " },
+    });
+
+    const entries = view.state.field(fileDropChipField);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].from).toBe(7); // shifted by "prefix " (7 chars)
+    expect(entries[0].to).toBe(27);
+
+    view.destroy();
+  });
+
+  it("discards chip when its range is edited", () => {
+    const view = makeEditorWithFileChip();
+
+    view.dispatch({
+      changes: { from: 0, insert: "@/Users/test/file.ts " },
+      effects: addFileDropChip.of({
+        from: 0,
+        to: 20,
+        filePath: "/Users/test/file.ts",
+        fileName: "file.ts",
+      }),
+    });
+
+    // Edit within the chip range
+    view.dispatch({
+      changes: { from: 5, to: 10, insert: "X" },
+    });
+
+    const entries = view.state.field(fileDropChipField);
+    expect(entries).toHaveLength(0);
+
+    view.destroy();
+  });
+
+  it("supports multiple file chip entries", () => {
+    const view = makeEditorWithFileChip();
+
+    const text = "@/Users/test/a.ts @/Users/test/b.ts ";
+    view.dispatch({
+      changes: { from: 0, insert: text },
+      effects: [
+        addFileDropChip.of({
+          from: 0,
+          to: 17,
+          filePath: "/Users/test/a.ts",
+          fileName: "a.ts",
+        }),
+        addFileDropChip.of({
+          from: 18,
+          to: 35,
+          filePath: "/Users/test/b.ts",
+          fileName: "b.ts",
+        }),
+      ],
+    });
+
+    const entries = view.state.field(fileDropChipField);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].fileName).toBe("a.ts");
+    expect(entries[1].fileName).toBe("b.ts");
+
+    view.destroy();
+  });
+
+  it("removes file chips when the entire document is cleared", () => {
+    const view = makeEditorWithFileChip();
+
+    view.dispatch({
+      changes: { from: 0, insert: "@/Users/test/file.ts " },
+      effects: addFileDropChip.of({
+        from: 0,
+        to: 20,
+        filePath: "/Users/test/file.ts",
+        fileName: "file.ts",
+      }),
+    });
+
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: "" },
+    });
+
+    expect(view.state.doc.length).toBe(0);
+    expect(view.state.field(fileDropChipField)).toHaveLength(0);
+
+    view.destroy();
+  });
+
+  it("preserves raw @path text in document for agent consumption", () => {
+    const view = makeEditorWithFileChip();
+
+    view.dispatch({
+      changes: { from: 0, insert: "@/Users/test/file.ts " },
+      effects: addFileDropChip.of({
+        from: 0,
+        to: 20,
+        filePath: "/Users/test/file.ts",
+        fileName: "file.ts",
+      }),
+    });
+
+    expect(view.state.doc.toString()).toBe("@/Users/test/file.ts ");
+
+    view.destroy();
+  });
+});
+
+describe("createFilePasteHandler", () => {
+  function makeMockClipboardData(items: { kind: string; type: string; file: File | null }[]) {
+    const mockItems = items.map((item) => ({
+      kind: item.kind,
+      type: item.type,
+      getAsFile: () => item.file,
+    }));
+    return {
+      clipboardData: {
+        items: mockItems,
+        getData: () => "",
+        types: [] as string[],
+      },
+    };
+  }
+
+  function makePasteEvent(clipboardData: unknown): ClipboardEvent {
+    const event = new Event("paste", { bubbles: true, cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", { value: clipboardData });
+    return event;
+  }
+
+  it("calls onFilePaste for non-image file items with a path", () => {
+    const onFilePaste = vi.fn();
+    const parent = document.createElement("div");
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "",
+        extensions: [createFilePasteHandler(onFilePaste)],
+      }),
+    });
+
+    const file = new File(["content"], "test.pdf", { type: "application/pdf" });
+    Object.defineProperty(file, "path", { value: "/Users/test/test.pdf" });
+
+    const mockData = makeMockClipboardData([{ kind: "file", type: "application/pdf", file }]);
+    const pasteEvent = makePasteEvent(mockData.clipboardData);
+
+    view.contentDOM.dispatchEvent(pasteEvent);
+
+    expect(onFilePaste).toHaveBeenCalledOnce();
+    expect(onFilePaste).toHaveBeenCalledWith(view, [
+      { path: "/Users/test/test.pdf", name: "test.pdf" },
+    ]);
+
+    view.destroy();
+  });
+
+  it("does not call onFilePaste for image file items", () => {
+    const onFilePaste = vi.fn();
+    const parent = document.createElement("div");
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "",
+        extensions: [createFilePasteHandler(onFilePaste)],
+      }),
+    });
+
+    const file = new File(["imagedata"], "screenshot.png", { type: "image/png" });
+    Object.defineProperty(file, "path", { value: "/Users/test/screenshot.png" });
+
+    const mockData = makeMockClipboardData([{ kind: "file", type: "image/png", file }]);
+    const pasteEvent = makePasteEvent(mockData.clipboardData);
+
+    view.contentDOM.dispatchEvent(pasteEvent);
+
+    expect(onFilePaste).not.toHaveBeenCalled();
+
+    view.destroy();
+  });
+
+  it("does not call onFilePaste for files without a path", () => {
+    const onFilePaste = vi.fn();
+    const parent = document.createElement("div");
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({
+        doc: "",
+        extensions: [createFilePasteHandler(onFilePaste)],
+      }),
+    });
+
+    const file = new File(["content"], "test.txt", { type: "text/plain" });
+    // No .path property set (non-Electron file)
+
+    const mockData = makeMockClipboardData([{ kind: "file", type: "text/plain", file }]);
+    const pasteEvent = makePasteEvent(mockData.clipboardData);
+
+    view.contentDOM.dispatchEvent(pasteEvent);
+
+    expect(onFilePaste).not.toHaveBeenCalled();
+
     view.destroy();
   });
 });

--- a/src/components/Terminal/inputEditorExtensions.tsx
+++ b/src/components/Terminal/inputEditorExtensions.tsx
@@ -95,6 +95,24 @@ export const inputTheme = EditorView.theme({
     borderRadius: "2px",
     flexShrink: "0",
   },
+  ".cm-file-drop-chip": {
+    display: "inline-flex",
+    alignItems: "center",
+    height: "20px",
+    verticalAlign: "bottom",
+    whiteSpace: "nowrap",
+    gap: "4px",
+    padding: "0 5px",
+    color: "var(--color-canopy-accent)",
+    fontWeight: 600,
+    background: "rgba(96, 211, 224, 0.1)",
+    borderRadius: "3px",
+  },
+  ".cm-file-drop-chip svg": {
+    height: "14px",
+    width: "14px",
+    flexShrink: "0",
+  },
 });
 
 const slashChipMark = Decoration.mark({ class: "cm-slash-command-chip" });
@@ -587,6 +605,165 @@ export function createImagePasteHandler(onImagePaste: (view: EditorView) => void
         }
       }
       return false;
+    },
+  });
+}
+
+// --- File drop chip (replace widget showing file icon + filename for pasted file paths) ---
+
+interface FileDropChipEntry {
+  from: number;
+  to: number;
+  filePath: string;
+  fileName: string;
+}
+
+const FILE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>`;
+
+class FileDropChipWidget extends WidgetType {
+  constructor(
+    readonly filePath: string,
+    readonly fileName: string
+  ) {
+    super();
+  }
+
+  eq(other: FileDropChipWidget) {
+    return this.filePath === other.filePath;
+  }
+
+  toDOM() {
+    const span = document.createElement("span");
+    span.className = "cm-file-drop-chip";
+    span.setAttribute("role", "img");
+    span.setAttribute("aria-label", `File: ${this.filePath}`);
+
+    const icon = document.createElement("span");
+    icon.innerHTML = FILE_ICON_SVG;
+    icon.style.display = "inline-flex";
+    icon.style.alignItems = "center";
+    span.appendChild(icon);
+
+    const label = document.createElement("span");
+    label.setAttribute("aria-hidden", "true");
+    label.textContent = this.fileName;
+    span.appendChild(label);
+
+    return span;
+  }
+
+  ignoreEvent() {
+    return false;
+  }
+}
+
+export const addFileDropChip = StateEffect.define<FileDropChipEntry>();
+
+export const fileDropChipField = StateField.define<FileDropChipEntry[]>({
+  create() {
+    return [];
+  },
+  update(entries, tr) {
+    if (tr.docChanged) {
+      const surviving: FileDropChipEntry[] = [];
+      for (const e of entries) {
+        let edited = false;
+        tr.changes.iterChangedRanges((fromA, toA) => {
+          if (fromA < e.to && toA > e.from) edited = true;
+        });
+        if (edited) continue;
+        const from = tr.changes.mapPos(e.from, 1);
+        const to = tr.changes.mapPos(e.to, -1);
+        if (from < to) surviving.push({ ...e, from, to });
+      }
+      entries = surviving;
+    }
+    for (const effect of tr.effects) {
+      if (effect.is(addFileDropChip)) {
+        entries = [...entries, effect.value];
+      }
+    }
+    return entries;
+  },
+  provide: (f) => [
+    EditorView.decorations.from(f, (entries) => {
+      if (entries.length === 0) return Decoration.none;
+      const ranges = entries.map((e) =>
+        Decoration.replace({ widget: new FileDropChipWidget(e.filePath, e.fileName) }).range(
+          e.from,
+          e.to
+        )
+      );
+      return Decoration.set(ranges, true);
+    }),
+    EditorView.atomicRanges.of((view) => {
+      const entries = view.state.field(f, false);
+      if (!entries || entries.length === 0) return Decoration.none;
+      const ranges = entries.map((e) => Decoration.mark({}).range(e.from, e.to));
+      return Decoration.set(ranges, true);
+    }),
+  ],
+});
+
+export function createFileDropChipTooltip() {
+  return hoverTooltip((view, pos) => {
+    const entries = view.state.field(fileDropChipField, false);
+    if (!entries || entries.length === 0) return null;
+
+    const entry = entries.find((e) => pos >= e.from && pos <= e.to);
+    if (!entry) return null;
+
+    return {
+      pos: entry.from,
+      end: entry.to,
+      above: true,
+      create() {
+        const dom = document.createElement("div");
+        dom.className = "px-2 py-1 text-xs";
+        dom.style.cssText = `
+          background: rgba(24, 24, 27, 0.95);
+          border-radius: 4px;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+        `;
+
+        const pathEl = document.createElement("p");
+        pathEl.style.cssText =
+          "font-size: 10px; color: rgba(255,255,255,0.7); word-break: break-all; max-width: 300px; font-family: var(--font-mono, monospace);";
+        pathEl.textContent = entry.filePath;
+        dom.appendChild(pathEl);
+
+        return { dom };
+      },
+    };
+  });
+}
+
+export function createFilePasteHandler(
+  onFilePaste: (view: EditorView, files: { path: string; name: string }[]) => void
+): Extension {
+  return EditorView.domEventHandlers({
+    paste(event, view) {
+      const items = event.clipboardData?.items;
+      if (!items) return false;
+
+      const files: { path: string; name: string }[] = [];
+      for (const item of items) {
+        if (item.kind === "file" && !item.type.startsWith("image/")) {
+          const file = item.getAsFile();
+          const filePath = (file as unknown as { path?: string })?.path;
+          if (file && filePath) {
+            const name =
+              file.name.trim() || filePath.split(/[/\\]/).filter(Boolean).pop() || filePath;
+            files.push({ path: filePath, name });
+          }
+        }
+      }
+
+      if (files.length === 0) return false;
+
+      event.preventDefault();
+      onFilePaste(view, files);
+      return true;
     },
   });
 }


### PR DESCRIPTION
## Summary

Extends the HybridInputBar paste handler to accept any non-image file from the clipboard, rendering it as an inline file chip that expands to a bare `@/path/to/file.ext` reference when the prompt is sent.

Closes #2522

## Changes Made

- **`inputEditorExtensions.tsx`**: Add `FileDropChipWidget` (Lucide File SVG icon + filename label), `addFileDropChip` StateEffect, `fileDropChipField` StateField with atomic range support and position mapping, `createFileDropChipTooltip` showing full absolute path on hover, `createFilePasteHandler` intercepting non-image `DataTransfer` file items (reads Electron `File.path`, falls back to path basename when `File.name` is empty), and `.cm-file-drop-chip` styles in `inputTheme`
- **`HybridInputBar.tsx`**: Wire `fileDropChipField`, tooltip compartment, and `filePasteExtension` into the editor; guard tooltip behind disabled-state compartment reconfigure
- **`inputEditorExtensions.test.tsx`**: Add 9 unit tests covering state field lifecycle (add, position mapping, discard-on-edit, multi-file, clear-all), paste handler filtering (non-image with path, image skipped, no-path skipped), and raw `@path` preservation for agent consumption