### PR TITLE
fix(ipc): register handlers before renderer load to prevent startup race

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -137,7 +137,7 @@ describe("registerIpcHandlers", () => {
   }
 
   it("registers every handler module exactly once", () => {
-    registerIpcHandlers({} as never, {} as never);
+    registerIpcHandlers({} as never);
 
     for (const register of allRegisterMocks) {
       expect(register).toHaveBeenCalledTimes(1);
@@ -150,9 +150,7 @@ describe("registerIpcHandlers", () => {
       throw new Error("github registration failed");
     });
 
-    expect(() => registerIpcHandlers({} as never, {} as never)).toThrow(
-      "github registration failed"
-    );
+    expect(() => registerIpcHandlers({} as never)).toThrow("github registration failed");
 
     expect(cleanups.length).toBeGreaterThan(0);
     for (const cleanup of cleanups) {
@@ -162,7 +160,7 @@ describe("registerIpcHandlers", () => {
 
   it("attempts every cleanup even if one throws", () => {
     const cleanups = registerWithTrackedCleanups();
-    const cleanupAll = registerIpcHandlers({} as never, {} as never);
+    const cleanupAll = registerIpcHandlers({} as never);
 
     cleanups[0].mockImplementation(() => {
       throw new Error("cleanup failed");

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -1,11 +1,3 @@
-import { BrowserWindow } from "electron";
-import type { CliAvailabilityService } from "../services/CliAvailabilityService.js";
-import type { AgentVersionService } from "../services/AgentVersionService.js";
-import type { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
-import type { EventBuffer } from "../services/EventBuffer.js";
-import type { SidecarManager } from "../services/SidecarManager.js";
-import type { PtyClient } from "../services/PtyClient.js";
-import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import type { HandlerDependencies } from "./types.js";
 import { registerWorktreeHandlers } from "./handlers/worktree.js";
 import { registerTerminalHandlers } from "./handlers/terminal.js";
@@ -49,27 +41,10 @@ function runCleanups(cleanupFunctions: CleanupFn[]): void {
   }
 }
 
-export function registerIpcHandlers(
-  mainWindow: BrowserWindow,
-  ptyClient: PtyClient,
-  worktreeService?: WorkspaceClient,
-  eventBuffer?: EventBuffer,
-  cliAvailabilityService?: CliAvailabilityService,
-  agentVersionService?: AgentVersionService,
-  agentUpdateHandler?: AgentUpdateHandler,
-  sidecarManager?: SidecarManager
-): () => void {
-  const deps: HandlerDependencies = {
-    mainWindow,
-    ptyClient,
-    worktreeService,
-    eventBuffer,
-    cliAvailabilityService,
-    agentVersionService,
-    agentUpdateHandler,
-    sidecarManager,
-    events,
-  };
+export function registerIpcHandlers(deps: HandlerDependencies): () => void {
+  if (!deps.events) {
+    deps.events = events;
+  }
 
   const cleanupFunctions: CleanupFn[] = [];
 

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -145,7 +145,7 @@ async function getCurrentProjectSettings(): Promise<
 }
 
 export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void {
-  const { mainWindow, worktreeService: workspaceClient, ptyClient } = deps;
+  const { mainWindow } = deps;
   const handlers: Array<() => void> = [];
 
   const injectionsInProgress = new Set<string>();
@@ -173,7 +173,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     const validated = parseResult.data;
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return {
         content: "",
         fileCount: 0,
@@ -181,7 +181,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
-    const states = await workspaceClient.getAllStatesAsync();
+    const states = await deps.worktreeService.getAllStatesAsync();
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
     if (!worktree) {
@@ -200,7 +200,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     const projectSettings = await getCurrentProjectSettings();
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
-    return workspaceClient.generateContext(worktree.path, mergedOptions, onProgress);
+    return deps.worktreeService.generateContext(worktree.path, mergedOptions, onProgress);
   };
   ipcMain.handle(CHANNELS.COPYTREE_GENERATE, handleCopyTreeGenerate);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GENERATE));
@@ -231,7 +231,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     const validated = parseResult.data;
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return {
         content: "",
         fileCount: 0,
@@ -239,7 +239,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
-    const states = await workspaceClient.getAllStatesAsync();
+    const states = await deps.worktreeService.getAllStatesAsync();
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
     if (!worktree) {
@@ -258,7 +258,11 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     const projectSettings = await getCurrentProjectSettings();
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
-    const result = await workspaceClient.generateContext(worktree.path, mergedOptions, onProgress);
+    const result = await deps.worktreeService.generateContext(
+      worktree.path,
+      mergedOptions,
+      onProgress
+    );
 
     if (result.error) {
       return result;
@@ -359,7 +363,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return {
         content: "",
         fileCount: 0,
@@ -371,7 +375,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     activeInjectionIds.set(validated.terminalId, injectionId);
 
     try {
-      const states = await workspaceClient.getAllStatesAsync();
+      const states = await deps.worktreeService.getAllStatesAsync();
       const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
       if (!worktree) {
@@ -382,7 +386,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
         };
       }
 
-      if (!ptyClient.hasTerminal(validated.terminalId)) {
+      if (!deps.ptyClient!.hasTerminal(validated.terminalId)) {
         return {
           content: "",
           fileCount: 0,
@@ -398,7 +402,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       const projectSettings = await getCurrentProjectSettings();
       const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options || {});
 
-      const result = await workspaceClient.generateContext(
+      const result = await deps.worktreeService.generateContext(
         worktree.path,
         mergedOptions,
         onProgress
@@ -422,7 +426,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
           };
         }
 
-        if (!ptyClient.hasTerminal(validated.terminalId)) {
+        if (!deps.ptyClient!.hasTerminal(validated.terminalId)) {
           return {
             content: "",
             fileCount: 0,
@@ -431,7 +435,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
         }
 
         const chunk = content.slice(i, i + CHUNK_SIZE);
-        ptyClient.write(validated.terminalId, chunk, traceId);
+        deps.ptyClient!.write(validated.terminalId, chunk, traceId);
         if (i + CHUNK_SIZE < content.length) {
           await new Promise((resolve) => setTimeout(resolve, 1));
         }
@@ -449,7 +453,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_INJECT));
 
   const handleCopyTreeAvailable = async (): Promise<boolean> => {
-    return !!workspaceClient && workspaceClient.isReady();
+    return !!deps.worktreeService && deps.worktreeService.isReady();
   };
   ipcMain.handle(CHANNELS.COPYTREE_AVAILABLE, handleCopyTreeAvailable);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_AVAILABLE));
@@ -482,8 +486,8 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       Array.from(activeInjectionIds.values()).forEach((id) => {
         cancelledInjections.add(id);
       });
-      if (workspaceClient) {
-        workspaceClient.cancelAllContext();
+      if (deps.worktreeService) {
+        deps.worktreeService.cancelAllContext();
       }
       console.log(
         `[cancel] Marked all ${activeInjectionIds.size} active injections for cancellation`
@@ -515,17 +519,17 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       }
     }
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Worktree service not available");
     }
 
-    const monitor = await workspaceClient.getMonitorAsync(validated.worktreeId);
+    const monitor = await deps.worktreeService.getMonitorAsync(validated.worktreeId);
 
     if (!monitor) {
       throw new Error(`Worktree not found: ${validated.worktreeId}`);
     }
 
-    return workspaceClient.getFileTree(monitor.path, validated.dirPath);
+    return deps.worktreeService.getFileTree(monitor.path, validated.dirPath);
   };
   ipcMain.handle(CHANNELS.COPYTREE_GET_FILE_TREE, handleCopyTreeGetFileTree);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GET_FILE_TREE));
@@ -556,7 +560,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     const validated = parseResult.data;
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return {
         includedFiles: 0,
         includedSize: 0,
@@ -565,7 +569,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
-    const states = await workspaceClient.getAllStatesAsync();
+    const states = await deps.worktreeService.getAllStatesAsync();
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
     if (!worktree) {
@@ -581,7 +585,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
     const projectSettings = await getCurrentProjectSettings();
     const mergedOptions = mergeCopyTreeOptions(projectSettings, validated.options);
 
-    return workspaceClient.testConfig(worktree.path, mergedOptions);
+    return deps.worktreeService.testConfig(worktree.path, mergedOptions);
   };
   ipcMain.handle(CHANNELS.COPYTREE_TEST_CONFIG, handleCopyTreeTestConfig);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_TEST_CONFIG));

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -26,7 +26,7 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     }
   };
 
-  const sessionService = new DevPreviewSessionService(deps.ptyClient, (state) => {
+  const sessionService = new DevPreviewSessionService(deps.ptyClient!, (state) => {
     const payload: DevPreviewStateChangedPayload = { state };
     sendToRenderer(CHANNELS.DEV_PREVIEW_STATE_CHANGED, payload);
   });

--- a/electron/ipc/handlers/eventInspector.ts
+++ b/electron/ipc/handlers/eventInspector.ts
@@ -8,14 +8,13 @@ const subscribedWebContents = new Map<WebContents, () => void>();
 let eventBufferUnsubscribe: (() => void) | null = null;
 
 export function registerEventInspectorHandlers(deps: HandlerDependencies): () => void {
-  const { eventBuffer } = deps;
   const handlers: Array<() => void> = [];
 
   const handleEventInspectorGetEvents = async () => {
-    if (!eventBuffer) {
+    if (!deps.eventBuffer) {
       return [];
     }
-    return eventBuffer.getAll();
+    return deps.eventBuffer.getAll();
   };
   ipcMain.handle(CHANNELS.EVENT_INSPECTOR_GET_EVENTS, handleEventInspectorGetEvents);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENT_INSPECTOR_GET_EVENTS));
@@ -24,19 +23,19 @@ export function registerEventInspectorHandlers(deps: HandlerDependencies): () =>
     _event: Electron.IpcMainInvokeEvent,
     filters: EventFilterOptions
   ) => {
-    if (!eventBuffer) {
+    if (!deps.eventBuffer) {
       return [];
     }
-    return eventBuffer.getFiltered(filters);
+    return deps.eventBuffer.getFiltered(filters);
   };
   ipcMain.handle(CHANNELS.EVENT_INSPECTOR_GET_FILTERED, handleEventInspectorGetFiltered);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENT_INSPECTOR_GET_FILTERED));
 
   const handleEventInspectorClear = async () => {
-    if (!eventBuffer) {
+    if (!deps.eventBuffer) {
       return;
     }
-    eventBuffer.clear();
+    deps.eventBuffer.clear();
   };
   ipcMain.handle(CHANNELS.EVENT_INSPECTOR_CLEAR, handleEventInspectorClear);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENT_INSPECTOR_CLEAR));
@@ -83,8 +82,8 @@ export function registerEventInspectorHandlers(deps: HandlerDependencies): () =>
     subscribedWebContents.set(sender, destroyListener);
     sender.once("destroyed", destroyListener);
 
-    if (!eventBufferUnsubscribe && eventBuffer) {
-      eventBufferUnsubscribe = eventBuffer.onRecord(broadcastEvent);
+    if (!eventBufferUnsubscribe && deps.eventBuffer) {
+      eventBufferUnsubscribe = deps.eventBuffer.onRecord(broadcastEvent);
     }
   };
   ipcMain.on(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, handleSubscribe);

--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -7,6 +7,8 @@ import { openExternalUrl } from "../../utils/openExternal.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { runCommandDetector } from "../../services/RunCommandDetector.js";
 import { ProjectSwitchService } from "../../services/ProjectSwitchService.js";
+import { sendToRenderer } from "../utils.js";
+import { randomUUID } from "crypto";
 import type { HandlerDependencies } from "../types.js";
 import type { Project, ProjectSettings, TerminalRecipe, TabGroup } from "../../types/index.js";
 import type {
@@ -25,21 +27,12 @@ import {
 import type { TerminalSnapshot } from "../../types/index.js";
 
 export function registerProjectHandlers(deps: HandlerDependencies): () => void {
-  const {
-    mainWindow,
-    worktreeService,
-    cliAvailabilityService,
-    agentVersionService,
-    agentUpdateHandler,
-  } = deps;
+  const { mainWindow, cliAvailabilityService, agentVersionService, agentUpdateHandler } = deps;
   const handlers: Array<() => void> = [];
 
-  const projectSwitchService = new ProjectSwitchService({
-    mainWindow: deps.mainWindow,
-    ptyClient: deps.ptyClient,
-    worktreeService: deps.worktreeService,
-    eventBuffer: deps.eventBuffer,
-  });
+  // Pass deps directly so ProjectSwitchService sees late-init services
+  // (worktreeService, eventBuffer) when they become available.
+  const projectSwitchService = new ProjectSwitchService(deps);
 
   const handleSystemOpenExternal = async (
     _event: Electron.IpcMainInvokeEvent,
@@ -325,9 +318,9 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
   const handleProjectGetCurrent = async () => {
     const currentProject = projectStore.getCurrentProject();
 
-    if (currentProject && worktreeService) {
+    if (currentProject && deps.worktreeService) {
       try {
-        await worktreeService.loadProject(currentProject.path);
+        await deps.worktreeService.loadProject(currentProject.path);
       } catch (err) {
         console.error("Failed to load worktrees for current project:", err);
       }
@@ -480,11 +473,11 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
     }
 
     try {
-      const ptyStats = await deps.ptyClient.getProjectStats(projectId);
+      const ptyStats = await deps.ptyClient!.getProjectStats(projectId);
 
       if (killTerminals) {
         // Kill terminals when explicitly requested (freeing resources completely)
-        const terminalsKilled = await deps.ptyClient.killByProject(projectId);
+        const terminalsKilled = await deps.ptyClient!.killByProject(projectId);
 
         // Clear persisted state
         await projectStore.clearProjectState(projectId);
@@ -544,6 +537,19 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
       throw new Error(`Project not found: ${projectId}`);
     }
 
+    // Idempotent: if already active, emit switch event and return current state
+    if (project.status === "active") {
+      console.log(
+        `[IPC] project:reopen: Project ${projectId} already active, emitting switch event`
+      );
+      const switchId = randomUUID();
+      sendToRenderer(mainWindow, CHANNELS.PROJECT_ON_SWITCH, {
+        project,
+        switchId,
+      });
+      return project;
+    }
+
     // Reopen is only meaningful for background projects
     if (project.status !== "background") {
       throw new Error(
@@ -562,7 +568,7 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
       throw new Error("Invalid project ID");
     }
 
-    const ptyStats = await deps.ptyClient.getProjectStats(projectId);
+    const ptyStats = await deps.ptyClient!.getProjectStats(projectId);
 
     // Estimate memory (rough approximation)
     const MEMORY_PER_TERMINAL_MB = 50;

--- a/electron/ipc/handlers/sidecar.ts
+++ b/electron/ipc/handlers/sidecar.ts
@@ -12,7 +12,6 @@ import type {
 } from "../../../shared/types/sidecar.js";
 
 export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
-  const { sidecarManager } = deps;
   const handlers: Array<() => void> = [];
 
   const handleSidecarCreate = async (
@@ -20,14 +19,14 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     payload: SidecarCreatePayload
   ) => {
     try {
-      if (!sidecarManager) return;
+      if (!deps.sidecarManager) return;
       if (!payload?.tabId || typeof payload.tabId !== "string") {
         throw new Error("Invalid tabId");
       }
       if (!payload?.url || typeof payload.url !== "string") {
         throw new Error("Invalid url");
       }
-      sidecarManager.createTab(payload.tabId, payload.url);
+      deps.sidecarManager.createTab(payload.tabId, payload.url);
     } catch (error) {
       console.error("[SidecarHandler] Error in create:", error);
       throw error;
@@ -41,14 +40,14 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     payload: SidecarShowPayload
   ) => {
     try {
-      if (!sidecarManager) return;
+      if (!deps.sidecarManager) return;
       if (!payload?.tabId || typeof payload.tabId !== "string") {
         throw new Error("Invalid tabId");
       }
       if (!payload?.bounds || typeof payload.bounds !== "object") {
         throw new Error("Invalid bounds");
       }
-      sidecarManager.showTab(payload.tabId, payload.bounds);
+      deps.sidecarManager.showTab(payload.tabId, payload.bounds);
     } catch (error) {
       console.error("[SidecarHandler] Error in show:", error);
       throw error;
@@ -58,8 +57,8 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_SHOW));
 
   const handleSidecarHide = async () => {
-    if (!sidecarManager) return;
-    sidecarManager.hideAll();
+    if (!deps.sidecarManager) return;
+    deps.sidecarManager.hideAll();
   };
   ipcMain.handle(CHANNELS.SIDECAR_HIDE, handleSidecarHide);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_HIDE));
@@ -69,11 +68,11 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     bounds: SidecarBounds
   ) => {
     try {
-      if (!sidecarManager) return;
+      if (!deps.sidecarManager) return;
       if (!bounds || typeof bounds !== "object") {
         throw new Error("Invalid bounds");
       }
-      sidecarManager.updateBounds(bounds);
+      deps.sidecarManager.updateBounds(bounds);
     } catch (error) {
       console.error("[SidecarHandler] Error in resize:", error);
       throw error;
@@ -86,11 +85,11 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: SidecarCloseTabPayload
   ) => {
-    if (!sidecarManager) return;
+    if (!deps.sidecarManager) return;
     if (!payload || typeof payload !== "object" || typeof payload.tabId !== "string") {
       return;
     }
-    sidecarManager.closeTab(payload.tabId);
+    deps.sidecarManager.closeTab(payload.tabId);
   };
   ipcMain.handle(CHANNELS.SIDECAR_CLOSE_TAB, handleSidecarCloseTab);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_CLOSE_TAB));
@@ -99,7 +98,7 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: SidecarNavigatePayload
   ) => {
-    if (!sidecarManager) return;
+    if (!deps.sidecarManager) return;
     if (
       !payload ||
       typeof payload !== "object" ||
@@ -108,7 +107,7 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     ) {
       return;
     }
-    sidecarManager.navigate(payload.tabId, payload.url);
+    deps.sidecarManager.navigate(payload.tabId, payload.url);
   };
   ipcMain.handle(CHANNELS.SIDECAR_NAVIGATE, handleSidecarNavigate);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_NAVIGATE));
@@ -117,9 +116,9 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     tabId: string
   ): Promise<boolean> => {
-    if (!sidecarManager) return false;
+    if (!deps.sidecarManager) return false;
     if (typeof tabId !== "string") return false;
-    return sidecarManager.goBack(tabId);
+    return deps.sidecarManager.goBack(tabId);
   };
   ipcMain.handle(CHANNELS.SIDECAR_GO_BACK, handleSidecarGoBack);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_GO_BACK));
@@ -128,17 +127,17 @@ export function registerSidecarHandlers(deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     tabId: string
   ): Promise<boolean> => {
-    if (!sidecarManager) return false;
+    if (!deps.sidecarManager) return false;
     if (typeof tabId !== "string") return false;
-    return sidecarManager.goForward(tabId);
+    return deps.sidecarManager.goForward(tabId);
   };
   ipcMain.handle(CHANNELS.SIDECAR_GO_FORWARD, handleSidecarGoForward);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_GO_FORWARD));
 
   const handleSidecarReload = async (_event: Electron.IpcMainInvokeEvent, tabId: string) => {
-    if (!sidecarManager) return;
+    if (!deps.sidecarManager) return;
     if (typeof tabId !== "string") return;
-    sidecarManager.reload(tabId);
+    deps.sidecarManager.reload(tabId);
   };
   ipcMain.handle(CHANNELS.SIDECAR_RELOAD, handleSidecarReload);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.SIDECAR_RELOAD));

--- a/electron/ipc/handlers/terminal/artifacts.ts
+++ b/electron/ipc/handlers/terminal/artifacts.ts
@@ -9,7 +9,7 @@ import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 
 export function registerArtifactHandlers(deps: HandlerDependencies): () => void {
-  const { mainWindow, worktreeService: workspaceClient } = deps;
+  const { mainWindow } = deps;
   const handlers: Array<() => void> = [];
 
   const handleArtifactSaveToFile = async (
@@ -123,8 +123,8 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
           };
         }
 
-        if (workspaceClient) {
-          const states = await workspaceClient.getAllStatesAsync();
+        if (deps.worktreeService) {
+          const states = await deps.worktreeService.getAllStatesAsync();
           const isValidWorktree = states.some(
             (wt: { path: string }) => path.resolve(wt.path) === resolvedCwd
           );

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -9,6 +9,9 @@ import type { HandlerDependencies } from "../../types.js";
 
 export function registerTerminalEventHandlers(deps: HandlerDependencies): () => void {
   const { mainWindow, ptyClient } = deps;
+  if (!ptyClient) {
+    return () => {};
+  }
   const handlers: Array<() => void> = [];
 
   // PTY data/exit/error events

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -11,6 +11,9 @@ import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 
 export function registerTerminalIOHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
+  if (!ptyClient) {
+    return () => {};
+  }
   const handlers: Array<() => void> = [];
 
   const handleTerminalInput = (_event: Electron.IpcMainEvent, id: string, data: string) => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -15,6 +15,9 @@ import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 
 export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
+  if (!ptyClient) {
+    return () => {};
+  }
   const handlers: Array<() => void> = [];
 
   const handleTerminalSpawn = async (

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -10,6 +10,9 @@ import { logDebug, logInfo, logWarn, logError } from "../../../utils/logger.js";
 
 export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
+  if (!ptyClient) {
+    return () => {};
+  }
   const handlers: Array<() => void> = [];
 
   const handleTerminalWake = async (

--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -65,42 +65,40 @@ function getWorktreeIdsForTask(projectId: string, taskId: string): string[] {
 // }
 
 export function registerWorktreeHandlers(deps: HandlerDependencies): () => void {
-  const { worktreeService: workspaceClient } = deps;
-
   const handlers: Array<() => void> = [];
 
   const handleWorktreeGetAll = async () => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return [];
     }
-    return await workspaceClient.getAllStatesAsync();
+    return await deps.worktreeService.getAllStatesAsync();
   };
   ipcMain.handle(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_ALL));
 
   const handleWorktreeRefresh = async () => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return;
     }
-    await workspaceClient.refresh();
+    await deps.worktreeService.refresh();
   };
   ipcMain.handle(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_REFRESH));
 
   const handleWorktreePRRefresh = async () => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return;
     }
-    await workspaceClient.refreshPullRequests();
+    await deps.worktreeService.refreshPullRequests();
   };
   ipcMain.handle(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_REFRESH));
 
   const handleWorktreePRStatus = async () => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return null;
     }
-    return await workspaceClient.getPRStatus();
+    return await deps.worktreeService.getPRStatus();
   };
   ipcMain.handle(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_STATUS));
@@ -109,10 +107,10 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     _event: Electron.IpcMainInvokeEvent,
     payload: WorktreeSetActivePayload
   ) => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       return;
     }
-    await workspaceClient.setActiveWorktree(payload.worktreeId);
+    await deps.worktreeService.setActiveWorktree(payload.worktreeId);
   };
   ipcMain.handle(CHANNELS.WORKTREE_SET_ACTIVE, handleWorktreeSetActive);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_SET_ACTIVE));
@@ -125,10 +123,10 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     }
   ): Promise<string> => {
     checkRateLimit(CHANNELS.WORKTREE_CREATE, 10, 10_000);
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
-    const worktreeId = await workspaceClient.createWorktree(payload.rootPath, payload.options);
+    const worktreeId = await deps.worktreeService.createWorktree(payload.rootPath, payload.options);
     try {
       fileSearchService.invalidate(payload.options.path);
     } catch (error) {
@@ -143,10 +141,10 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     _event: Electron.IpcMainInvokeEvent,
     payload: { rootPath: string }
   ) => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
-    return await workspaceClient.listBranches(payload.rootPath);
+    return await deps.worktreeService.listBranches(payload.rootPath);
   };
   ipcMain.handle(CHANNELS.WORKTREE_LIST_BRANCHES, handleWorktreeListBranches);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_LIST_BRANCHES));
@@ -219,7 +217,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     payload: WorktreeDeletePayload
   ) => {
     checkRateLimit(CHANNELS.WORKTREE_DELETE, 10, 10_000);
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
     if (!payload || typeof payload !== "object") {
@@ -234,9 +232,13 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     if (payload.deleteBranch !== undefined && typeof payload.deleteBranch !== "boolean") {
       throw new Error("Invalid deleteBranch parameter");
     }
-    const states = await workspaceClient.getAllStatesAsync();
+    const states = await deps.worktreeService.getAllStatesAsync();
     const worktree = states.find((wt) => wt.id === payload.worktreeId);
-    await workspaceClient.deleteWorktree(payload.worktreeId, payload.force, payload.deleteBranch);
+    await deps.worktreeService.deleteWorktree(
+      payload.worktreeId,
+      payload.force,
+      payload.deleteBranch
+    );
     if (worktree) {
       try {
         fileSearchService.invalidate(worktree.path);
@@ -275,12 +277,12 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
       throw new Error("Invalid file status");
     }
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("WorkspaceClient not initialized");
     }
 
     try {
-      return await workspaceClient.getFileDiff(cwd, filePath, status);
+      return await deps.worktreeService.getFileDiff(cwd, filePath, status);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       console.error("[Git] Failed to get file diff via WorkspaceClient:", errorMessage);
@@ -327,20 +329,20 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
       throw new Error("Invalid forceRefresh: must be a boolean");
     }
 
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("WorkspaceClient not initialized");
     }
 
-    const monitor = await workspaceClient.getMonitorAsync(worktreeId);
+    const monitor = await deps.worktreeService.getMonitorAsync(worktreeId);
     if (!monitor) {
       throw new Error(`Worktree not found: ${worktreeId}`);
     }
 
-    const states = await workspaceClient.getAllStatesAsync();
+    const states = await deps.worktreeService.getAllStatesAsync();
     const mainWorktree = states.find((wt) => wt.isMainWorktree);
     const mainBranch = mainWorktree?.branch ?? "main";
 
-    return workspaceClient.getProjectPulse(monitor.path, worktreeId, mainBranch, rangeDays, {
+    return deps.worktreeService.getProjectPulse(monitor.path, worktreeId, mainBranch, rangeDays, {
       includeDelta,
       includeRecentCommits,
       forceRefresh,
@@ -384,7 +386,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     payload: CreateForTaskPayload
   ): Promise<WorktreeState> => {
     checkRateLimit(CHANNELS.WORKTREE_CREATE_FOR_TASK, 10, 10_000);
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
 
@@ -411,7 +413,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     const rootPath = project.path;
 
     // Get all states to find the main worktree and determine base branch
-    const states = await workspaceClient.getAllStatesAsync();
+    const states = await deps.worktreeService.getAllStatesAsync();
     const mainWorktree = states.find((wt) => wt.isMainWorktree);
 
     // Use provided baseBranch, or default to main worktree's branch, or "main"
@@ -444,7 +446,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     let worktreeId: string;
     try {
       // Create the worktree
-      worktreeId = await workspaceClient.createWorktree(rootPath, {
+      worktreeId = await deps.worktreeService.createWorktree(rootPath, {
         baseBranch: effectiveBaseBranch,
         newBranch: availableBranchName,
         path: availablePath,
@@ -485,7 +487,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     let state: WorktreeState | null = null;
     try {
       for (let i = 0; i < 5; i++) {
-        const monitor = await workspaceClient.getMonitorAsync(worktreeId);
+        const monitor = await deps.worktreeService.getMonitorAsync(worktreeId);
         if (monitor) {
           state = {
             id: monitor.id,
@@ -568,7 +570,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     _event: Electron.IpcMainInvokeEvent,
     taskId: string
   ): Promise<WorktreeState[]> => {
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
 
@@ -587,7 +589,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     const results: WorktreeState[] = [];
 
     for (const worktreeId of worktreeIds) {
-      const monitor = await workspaceClient.getMonitorAsync(worktreeId);
+      const monitor = await deps.worktreeService.getMonitorAsync(worktreeId);
       if (monitor) {
         results.push({
           id: monitor.id,
@@ -629,7 +631,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     options?: CleanupTaskOptions
   ): Promise<void> => {
     checkRateLimit(CHANNELS.WORKTREE_CLEANUP_TASK, 10, 10_000);
-    if (!workspaceClient) {
+    if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
 
@@ -665,9 +667,9 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
     const errors: string[] = [];
 
     // Fetch all worktree states once for efficient main-worktree checking
-    let allStates: Awaited<ReturnType<typeof workspaceClient.getAllStatesAsync>> = [];
+    let allStates: Awaited<ReturnType<typeof deps.worktreeService.getAllStatesAsync>> = [];
     try {
-      allStates = await workspaceClient.getAllStatesAsync();
+      allStates = await deps.worktreeService.getAllStatesAsync();
     } catch (error) {
       logDebug("Could not fetch worktree states for cleanup pre-check", {
         error: error instanceof Error ? error.message : String(error),
@@ -690,7 +692,7 @@ export function registerWorktreeHandlers(deps: HandlerDependencies): () => void 
           continue;
         }
 
-        await workspaceClient.deleteWorktree(worktreeId, force, deleteBranch);
+        await deps.worktreeService.deleteWorktree(worktreeId, force, deleteBranch);
         if (targetWorktree) {
           try {
             fileSearchService.invalidate(targetWorktree.path);

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -10,7 +10,7 @@ import type { AgentUpdateHandler } from "../services/AgentUpdateHandler.js";
 
 export interface HandlerDependencies {
   mainWindow: BrowserWindow;
-  ptyClient: PtyClient;
+  ptyClient?: PtyClient;
   worktreeService?: WorkspaceClient;
   eventBuffer?: EventBuffer;
   cliAvailabilityService?: CliAvailabilityService;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -245,6 +245,7 @@ protocol.registerSchemesAsPrivileged([
 app.commandLine.appendSwitch("js-flags", "--max-old-space-size=4096");
 
 import { registerIpcHandlers, sendToRenderer } from "./ipc/handlers.js";
+import type { HandlerDependencies } from "./ipc/types.js";
 import { registerErrorHandlers } from "./ipc/errorHandlers.js";
 import { PtyClient, disposePtyClient } from "./services/PtyClient.js";
 import {
@@ -751,7 +752,6 @@ async function createWindow(): Promise<void> {
     });
   }
 
-  const deferRendererLoad = process.env.CANOPY_E2E_DEFER_RENDERER_LOAD === "1" || isSmokeTest;
   let rendererLoadRequested = false;
   const loadRenderer = (reason: string): void => {
     if (!mainWindow || mainWindow.isDestroyed() || rendererLoadRequested) return;
@@ -766,12 +766,8 @@ async function createWindow(): Promise<void> {
     }
   };
 
-  if (deferRendererLoad) {
-    console.log("[MAIN] Deferring renderer load until IPC handlers are registered");
-  } else {
-    console.log("[MAIN] Window created, loading content immediately (Paint First)...");
-    loadRenderer("paint-first");
-  }
+  // Renderer load is deferred until after IPC handlers are registered to prevent
+  // race conditions where the renderer makes IPC calls before handlers exist.
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     console.log("[MAIN] setWindowOpenHandler triggered with URL:", url);
@@ -979,6 +975,25 @@ async function createWindow(): Promise<void> {
     }
   });
 
+  // Initialize synchronous services before handler registration
+  eventBuffer = new EventBuffer(1000);
+  sidecarManager = new SidecarManager(mainWindow);
+
+  // Register IPC handlers BEFORE loading the renderer so that no IPC calls
+  // arrive before handlers exist. The deps object is mutable — workspaceClient
+  // is assigned after pty-host is ready, and handlers access it lazily.
+  console.log("[MAIN] Registering IPC handlers...");
+  const handlerDeps: HandlerDependencies = {
+    mainWindow,
+    ptyClient,
+    eventBuffer,
+    sidecarManager,
+    cliAvailabilityService,
+    agentVersionService,
+    agentUpdateHandler,
+  };
+  cleanupIpcHandlers = registerIpcHandlers(handlerDeps);
+
   // Wait for pty-host to be ready before forking workspace-host.
   // Staggering prevents two utility processes from simultaneously loading
   // native modules (node-pty, simple-git) which can crash on Windows CI.
@@ -996,27 +1011,15 @@ async function createWindow(): Promise<void> {
     showCrashDialog: true,
   });
 
-  // Initialize Placeholder Services
-  eventBuffer = new EventBuffer(1000);
-  sidecarManager = new SidecarManager(mainWindow);
+  // Assign late-init workspaceClient to deps so handlers see it
+  handlerDeps.worktreeService = workspaceClient;
 
-  // Register Handlers IMMEDIATELY (so IPC doesn't fail if UI is fast)
-  console.log("[MAIN] Registering IPC handlers...");
-  cleanupIpcHandlers = registerIpcHandlers(
-    mainWindow,
-    ptyClient,
-    workspaceClient,
-    eventBuffer,
-    cliAvailabilityService,
-    agentVersionService,
-    agentUpdateHandler,
-    sidecarManager
-  );
+  // Now safe to load renderer — all handlers registered and all services ready
+  loadRenderer("after-services-ready");
+
   cleanupErrorHandlers = registerErrorHandlers(mainWindow, workspaceClient, ptyClient);
 
-  if (deferRendererLoad) {
-    loadRenderer("after-ipc-registration");
-  }
+  console.log("[MAIN] All critical services ready");
 
   function createAndDistributePorts(): void {
     // Close previous ports before creating new ones

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -1,8 +1,5 @@
-import type { BrowserWindow } from "electron";
-import type { PtyClient } from "./PtyClient.js";
-import type { WorkspaceClient } from "./WorkspaceClient.js";
-import type { EventBuffer } from "./EventBuffer.js";
 import type { Project } from "../types/index.js";
+import type { HandlerDependencies } from "../ipc/types.js";
 import { projectStore } from "./ProjectStore.js";
 import { logBuffer } from "./LogBuffer.js";
 import { taskQueueService } from "./TaskQueueService.js";
@@ -13,18 +10,11 @@ import { store } from "../store.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { markPerformance } from "../utils/performance.js";
 
-export interface ProjectSwitchDependencies {
-  mainWindow: BrowserWindow;
-  ptyClient: PtyClient;
-  worktreeService?: WorkspaceClient;
-  eventBuffer?: EventBuffer;
-}
-
 export class ProjectSwitchService {
-  private deps: ProjectSwitchDependencies;
+  private deps: HandlerDependencies;
   private switchChain: Promise<void> = Promise.resolve();
 
-  constructor(deps: ProjectSwitchDependencies) {
+  constructor(deps: HandlerDependencies) {
     this.deps = deps;
   }
 
@@ -95,9 +85,9 @@ export class ProjectSwitchService {
       console.error("[ProjectSwitch] Project switch failed, rolling back:", error);
       try {
         if (previousProjectId) {
-          this.deps.ptyClient.onProjectSwitch(previousProjectId);
+          this.deps.ptyClient!.onProjectSwitch(previousProjectId);
         } else {
-          this.deps.ptyClient.setActiveProject(null);
+          this.deps.ptyClient!.setActiveProject(null);
         }
       } catch (rollbackError) {
         console.error("[ProjectSwitch] Rollback failed:", rollbackError);
@@ -162,7 +152,7 @@ export class ProjectSwitchService {
 
     const safeCall = (fn: () => unknown): Promise<unknown> => Promise.resolve().then(fn);
     const cleanupResults = await Promise.allSettled([
-      safeCall(() => this.deps.ptyClient.onProjectSwitch(projectId)),
+      safeCall(() => this.deps.ptyClient!.onProjectSwitch(projectId)),
       safeCall(() => logBuffer.onProjectSwitch()),
       this.deps.eventBuffer?.onProjectSwitch
         ? safeCall(() => this.deps.eventBuffer!.onProjectSwitch())


### PR DESCRIPTION
## Summary
- **Reorder main process initialization** so IPC handlers are registered before the renderer loads, eliminating ~25 "No handler registered" errors on cold start
- **Make `project:reopen` idempotent** — returns the active project with a switch event instead of throwing when the project is already active
- **Convert all handlers to lazy deps access** via a shared mutable `HandlerDependencies` object so late-init services (workspaceClient) are visible when they become available

## Changes

### Initialization Order (electron/main.ts)
Previously: create window → load renderer (paint-first) → create services → register handlers
Now: create window → create sync services → register handlers → wait for pty-host → create workspaceClient → load renderer

### Handler Pattern (16 files)
- `registerIpcHandlers()` now accepts a `HandlerDependencies` object directly (not individual params)
- Handlers access `deps.worktreeService`, `deps.eventBuffer`, `deps.sidecarManager` lazily instead of destructuring at registration time
- Terminal handlers add null guards for optional `ptyClient`
- `ProjectSwitchService` accepts `HandlerDependencies` directly for shared mutable reference

### Reopen Handler (electron/ipc/handlers/project.ts)
- If project is already active, emits `PROJECT_ON_SWITCH` event and returns the project (no-op instead of error)
- Prevents the secondary startup error where renderer tries to reopen an already-active project

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] All 79 IPC handler unit tests pass
- [x] Handler registry tests updated and passing
- [x] ESLint clean (no new warnings)
- [ ] Cold start produces zero "No handler registered" errors
- [ ] Worktree list populates correctly on startup
- [ ] `project:reopen` completes successfully on startup

Closes #2545

🤖 Generated with [Claude Code](https://claude.com/claude-code)