### PR TITLE
feat(FileViewer): CodeMirror syntax highlighting and smarter title display

### DIFF
--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState, useEffect, useCallback } from "react";
 import CodeMirror from "@uiw/react-codemirror";
 import { languages } from "@codemirror/language-data";
-import { EditorView } from "@codemirror/view";
-import { type Extension } from "@codemirror/state";
+import { EditorView, Decoration, type DecorationSet } from "@codemirror/view";
+import { type Extension, StateEffect, StateField } from "@codemirror/state";
 import { LanguageDescription } from "@codemirror/language";
 import { canopyTheme } from "@/components/Notes/editorTheme";
 import { cn } from "@/lib/utils";
@@ -14,11 +14,40 @@ export interface CodeViewerProps {
   className?: string;
 }
 
-const highlightLineStyle = EditorView.baseTheme({
-  "&dark .cm-highlightedLine": {
-    backgroundColor: "rgba(234, 179, 8, 0.1)",
+const setHighlightedLine = StateEffect.define<number | null>();
+
+const highlightedLineField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(deco, tr) {
+    deco = deco.map(tr.changes);
+    for (const e of tr.effects) {
+      if (e.is(setHighlightedLine)) {
+        if (e.value === null) {
+          deco = Decoration.none;
+        } else {
+          try {
+            const line = tr.state.doc.line(e.value);
+            deco = Decoration.set([
+              Decoration.line({ class: "cm-highlightedLine" }).range(line.from),
+            ]);
+          } catch {
+            deco = Decoration.none;
+          }
+        }
+      }
+    }
+    return deco;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+const highlightLineTheme = EditorView.baseTheme({
+  ".cm-highlightedLine": {
+    backgroundColor: "rgba(234, 179, 8, 0.1) !important",
   },
 });
+
+const BASE_EXTENSIONS: Extension[] = [highlightedLineField, highlightLineTheme];
 
 export function CodeViewer({ content, filePath, initialLine, className }: CodeViewerProps) {
   const [langExtension, setLangExtension] = useState<Extension | null>(null);
@@ -31,34 +60,44 @@ export function CodeViewer({ content, filePath, initialLine, className }: CodeVi
       return;
     }
     let cancelled = false;
-    desc.load().then((lang) => {
-      if (!cancelled) setLangExtension(lang);
-    });
+    desc
+      .load()
+      .then((lang) => {
+        if (!cancelled) setLangExtension(lang);
+      })
+      .catch(() => {
+        // Plain text fallback on load failure
+      });
     return () => {
       cancelled = true;
     };
   }, [filePath]);
 
-  const extensions = useMemo(() => {
-    const exts: Extension[] = [];
-    if (langExtension) exts.push(langExtension);
-    if (initialLine !== undefined) exts.push(highlightLineStyle);
-    return exts;
-  }, [langExtension, initialLine]);
+  const extensions = useMemo<Extension[]>(
+    () => (langExtension ? [...BASE_EXTENSIONS, langExtension] : BASE_EXTENSIONS),
+    [langExtension]
+  );
 
   const handleCreateEditor = useCallback(
     (view: EditorView) => {
       if (initialLine === undefined || initialLine < 1) return;
       const lineNum = Math.min(initialLine, view.state.doc.lines);
-      const line = view.state.doc.line(lineNum);
 
+      view.dispatch({ effects: setHighlightedLine.of(lineNum) });
+
+      // Use DOM scrollIntoView — outer wrapper owns scroll, not cm-scroller
       requestAnimationFrame(() => {
-        view.dispatch({
-          effects: EditorView.scrollIntoView(line.from, { y: "center" }),
-        });
-        const domLine = view.domAtPos(line.from)?.node?.parentElement;
-        const cmLine = domLine?.closest(".cm-line");
-        if (cmLine) cmLine.classList.add("cm-highlightedLine");
+        try {
+          const line = view.state.doc.line(lineNum);
+          const { node } = view.domAtPos(line.from);
+          const lineEl =
+            node instanceof Element
+              ? node.closest(".cm-line")
+              : (node as ChildNode).parentElement?.closest(".cm-line");
+          lineEl?.scrollIntoView({ block: "center" });
+        } catch {
+          // Ignore scroll errors (view may not be fully rendered)
+        }
       });
     },
     [initialLine]

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -136,11 +136,12 @@ export function FileViewerModal({
 
   const fileName = filePath.split("/").pop() || filePath;
 
-  // Compute relative path by stripping rootPath prefix
-  const normalizedRoot = rootPath.endsWith("/") ? rootPath : rootPath + "/";
-  const relativePath = filePath.startsWith(normalizedRoot)
-    ? filePath.slice(normalizedRoot.length)
-    : fileName;
+  // Compute relative path by stripping rootPath prefix; guard against empty root
+  const normalizedRoot = rootPath ? (rootPath.endsWith("/") ? rootPath : rootPath + "/") : null;
+  const relativePath =
+    normalizedRoot && filePath.startsWith(normalizedRoot)
+      ? filePath.slice(normalizedRoot.length)
+      : fileName;
   const relativeDir = relativePath.includes("/")
     ? relativePath.slice(0, relativePath.lastIndexOf("/") + 1)
     : "";
@@ -153,13 +154,15 @@ export function FileViewerModal({
         <div className="flex items-center gap-3 min-w-0">
           <TooltipProvider>
             <Tooltip>
-              <TooltipTrigger asChild>
-                <AppDialog.Title className="text-sm font-medium truncate">
-                  {branch && <span className="text-muted-foreground/70 mr-1.5">{branch}</span>}
-                  {relativeDir && <span className="text-muted-foreground">{relativeDir}</span>}
-                  <span className="text-canopy-text">{fileName}</span>
-                </AppDialog.Title>
-              </TooltipTrigger>
+              <AppDialog.Title className="text-sm font-medium min-w-0">
+                <TooltipTrigger asChild>
+                  <span className="truncate cursor-default">
+                    {branch && <span className="text-muted-foreground/70 mr-1.5">{branch}</span>}
+                    {relativeDir && <span className="text-muted-foreground">{relativeDir}</span>}
+                    <span className="text-canopy-text">{fileName}</span>
+                  </span>
+                </TooltipTrigger>
+              </AppDialog.Title>
               <TooltipContent side="bottom" className="max-w-lg break-all">
                 {filePath}
               </TooltipContent>

--- a/src/components/FileViewer/FileViewerModalHost.tsx
+++ b/src/components/FileViewer/FileViewerModalHost.tsx
@@ -1,25 +1,13 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { FileViewerModal } from "./FileViewerModal";
 import { useProjectStore } from "@/store";
-import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import { useBranchForPath } from "@/hooks/useBranchForPath";
 
 interface FileViewState {
   path: string;
   rootPath?: string;
   line?: number;
   col?: number;
-}
-
-function useBranchForPath(rootPath: string): string | undefined {
-  const worktrees = useWorktreeDataStore((s) => s.worktrees);
-  return useMemo(() => {
-    const normalized = rootPath.endsWith("/") ? rootPath.slice(0, -1) : rootPath;
-    for (const wt of worktrees.values()) {
-      const wtPath = wt.path.endsWith("/") ? wt.path.slice(0, -1) : wt.path;
-      if (wtPath === normalized) return wt.branch;
-    }
-    return undefined;
-  }, [worktrees, rootPath]);
 }
 
 export function FileViewerModalHost() {

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useCallback, useState, useRef, useMemo } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import type { GitStatus } from "@shared/types";
 import { actionService } from "@/services/ActionService";
 import { FileViewerModal } from "@/components/FileViewer/FileViewerModal";
-import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import { useBranchForPath } from "@/hooks/useBranchForPath";
 
 export interface FileDiffModalProps {
   isOpen: boolean;
@@ -21,15 +21,7 @@ export function FileDiffModal({
 }: FileDiffModalProps) {
   const [diff, setDiff] = useState<string | undefined>(undefined);
   const requestRef = useRef(0);
-  const worktrees = useWorktreeDataStore((s) => s.worktrees);
-  const branch = useMemo(() => {
-    const normalized = worktreePath.endsWith("/") ? worktreePath.slice(0, -1) : worktreePath;
-    for (const wt of worktrees.values()) {
-      const wtPath = wt.path.endsWith("/") ? wt.path.slice(0, -1) : wt.path;
-      if (wtPath === normalized) return wt.branch;
-    }
-    return undefined;
-  }, [worktrees, worktreePath]);
+  const branch = useBranchForPath(worktreePath);
 
   const absoluteFilePath = worktreePath.endsWith("/")
     ? worktreePath + filePath

--- a/src/hooks/useBranchForPath.ts
+++ b/src/hooks/useBranchForPath.ts
@@ -1,0 +1,15 @@
+import { useMemo } from "react";
+import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+
+export function useBranchForPath(rootPath: string): string | undefined {
+  const worktrees = useWorktreeDataStore((s) => s.worktrees);
+  return useMemo(() => {
+    if (!rootPath) return undefined;
+    const normalized = rootPath.endsWith("/") ? rootPath.slice(0, -1) : rootPath;
+    for (const wt of worktrees.values()) {
+      const wtPath = wt.path.endsWith("/") ? wt.path.slice(0, -1) : wt.path;
+      if (wtPath === normalized) return wt.branch;
+    }
+    return undefined;
+  }, [worktrees, rootPath]);
+}


### PR DESCRIPTION
## Summary

Replaces the `refractor`-based `CodeViewer` with `@uiw/react-codemirror` in read-only mode, and reworks the modal title to show branch name and project-relative path instead of the full absolute path.

Resolves #2562

## Changes Made

- **CodeViewer rewrite**: uses `@uiw/react-codemirror` with `canopyTheme`, `@codemirror/language-data` for automatic language detection by filename, persistent line highlighting via `StateField`+`Decoration.line` (survives redraws), and DOM `scrollIntoView` for correct scrolling when the outer wrapper owns the scroll container
- **FileViewerModal title**: adds `branch?: string` prop; computes relative path by stripping `rootPath` prefix (with empty-root guard); shows branch badge + relative directory + filename; full absolute path in a tooltip
- **Tooltip fix**: moves `TooltipTrigger asChild` inside `AppDialog.Title` to wrap a plain `<span>`, since `AppDialog.Title` does not forward refs
- **useBranchForPath hook**: extracted to `src/hooks/useBranchForPath.ts`, resolving branch from worktree store by matching `rootPath` — used in both `FileViewerModalHost` and `FileDiffModal`
- **No new dependencies**: all packages (`@uiw/react-codemirror`, `@codemirror/language-data`, `@uiw/codemirror-themes`) were already installed