### PR TITLE
fix(toolbar): darken notification badge bg for WCAG AA contrast

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -604,7 +604,7 @@ export function Toolbar({
                   >
                     <Bell />
                     {notificationUnreadCount > 0 && (
-                      <span className="absolute top-1 right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-canopy-accent text-[9px] font-bold text-white px-0.5 leading-none">
+                      <span className="absolute top-1 right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-emerald-800 text-[9px] font-bold text-white px-0.5 leading-none">
                         {notificationUnreadCount > 99 ? "99+" : notificationUnreadCount}
                       </span>
                     )}


### PR DESCRIPTION
## Summary

The notification count badge on the toolbar bell icon used `bg-canopy-accent` (Emerald-500, `#10b981`) with white text, producing a contrast ratio of ~2.35:1 — far below the WCAG 2.1 Level AA minimum of 4.5:1 for normal text.

Resolves #2570

## Changes Made

- Replace `bg-canopy-accent` with `bg-emerald-800` (`#065f46`) on the notification badge span in `Toolbar.tsx`
- Achieves ~7.2:1 contrast ratio against white text (WCAG 2.1 AAA compliant)
- Does not affect the global `--color-canopy-accent` variable or any other accent usages across the UI