### PR TITLE
fix(review-hub): render modal over full window via createPortal

### DIFF
--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { StagingStatus, GitStatus } from "@shared/types";
 import { cn } from "@/lib/utils";
+import { useOverlayState } from "@/hooks";
 import { X, RefreshCw, CheckSquare, Square, Loader2, AlertTriangle } from "lucide-react";
 import { FileStageRow } from "./FileStageRow";
 import { CommitPanel } from "./CommitPanel";
@@ -26,6 +27,8 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
   } | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const refreshIdRef = useRef(0);
+
+  useOverlayState(isOpen);
 
   const refresh = useCallback(async () => {
     if (!worktreePath) return;


### PR DESCRIPTION
## Summary

The Review Hub modal was rendering clipped inside the sidebar instead of covering the full application window. The sidebar's `backdrop-blur-sm` applies `backdrop-filter` CSS, which creates a new containing block for `position: fixed` descendants — causing `ReviewHub`'s `fixed inset-0` backdrop to be relative to the sidebar rather than the viewport.

Resolves #2573

## Changes Made

- Wrap `ReviewHub`'s return in `createPortal(…, document.body)` so the modal escapes the sidebar's CSS containing block and renders viewport-relative, matching `AppDialog` and all other dialogs
- Add `useOverlayState(isOpen)` call so `ReviewHub` participates in the app-wide overlay stack (sidecar hide/show, floating UI dismissal) — consistent with every other modal component