### PR TITLE
fix(toolbar): improve notification badge contrast for WCAG AA compliance

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -604,7 +604,7 @@ export function Toolbar({
                   >
                     <Bell />
                     {notificationUnreadCount > 0 && (
-                      <span className="absolute top-1 right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-canopy-accent text-[9px] font-bold text-white px-0.5 leading-none">
+                      <span className="absolute top-1 right-1 min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-emerald-800 text-[9px] font-bold text-white px-0.5 leading-none">
                         {notificationUnreadCount > 99 ? "99+" : notificationUnreadCount}
                       </span>
                     )}


### PR DESCRIPTION
## Summary

The notification count badge on the toolbar bell icon used `bg-canopy-accent` (Emerald-500, `#10b981`) with `text-white`, producing a contrast ratio of ~2.35:1 — well below the WCAG 2.1 AA minimum of 4.5:1. This makes the count unreadable for many users.

Resolves #2570

## Changes Made

- Replace `bg-canopy-accent` with `bg-emerald-800` (`#065f46`) on the notification count badge span in `Toolbar.tsx:607`
- Achieves ~7.2:1 contrast ratio against white text, meeting WCAG 2.1 AAA (>7:1)
- No other accent usages are modified (e.g., the Beta badge at line 916 uses `bg-canopy-accent/20` with `text-canopy-accent`, a different context that does not fail contrast)

## Notes

During review, a similar contrast issue was identified in `WorktreeFilterPopover.tsx:206` (same `bg-canopy-accent text-white text-[9px]` pattern). That component is out of scope for this PR and should be addressed separately.