### PR TITLE
feat(review-hub): redesign modal with improved visual hierarchy

### DIFF
--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -10,7 +10,6 @@ interface CommitPanelProps {
   isDetachedHead: boolean;
   hasConflicts: boolean;
   hasRemote: boolean;
-  currentBranch: string | null;
   onCommit: (message: string) => Promise<void>;
   onCommitAndPush: (message: string) => Promise<void>;
 }
@@ -59,14 +58,14 @@ export function CommitPanel({
     (e: React.KeyboardEvent) => {
       if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        if (e.shiftKey) {
+        if (e.shiftKey && hasRemote) {
           void handleCommitAndPush();
         } else {
           void handleCommit();
         }
       }
     },
-    [handleCommit, handleCommitAndPush]
+    [handleCommit, handleCommitAndPush, hasRemote]
   );
 
   return (

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -126,6 +126,7 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
       </TooltipProvider>
 
       <span
+        aria-hidden="true"
         className={cn(
           "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
           "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
@@ -142,7 +143,7 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
             {dir}/
           </span>
         )}
-        <span className="shrink-0 text-canopy-text group-hover:text-white font-medium font-mono text-[11px] transition-colors">
+        <span className="shrink truncate text-canopy-text group-hover:text-white font-medium font-mono text-[11px] transition-colors">
           {base}
         </span>
       </div>

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -213,7 +213,10 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                 Review & Commit
               </h2>
               {status?.currentBranch && (
-                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-white/[0.07] border border-white/[0.08] text-[11px] text-canopy-text/60 font-mono truncate max-w-[200px]">
+                <span
+                  title={status.currentBranch}
+                  className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-white/[0.07] border border-white/[0.08] text-[11px] text-canopy-text/60 font-mono truncate max-w-[200px]"
+                >
                   <GitBranch className="w-3 h-3 shrink-0" />
                   <span className="truncate">{status.currentBranch}</span>
                 </span>
@@ -388,7 +391,6 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
               isDetachedHead={status.isDetachedHead}
               hasConflicts={hasConflicts}
               hasRemote={status.hasRemote}
-              currentBranch={status.currentBranch}
               onCommit={handleCommit}
               onCommitAndPush={handleCommitAndPush}
             />


### PR DESCRIPTION
## Summary

Redesigns the ReviewHub modal (Review & Commit dialog) with improved visual hierarchy, spatial clarity, and information density consistent with native git clients like Git Tower and VS Code.

Resolves #2575

## Changes Made

- Replace bare single-letter status characters with colored pill badges (M=amber, A=green, D=red, R/C=muted) — consistent with VS Code and Tower conventions
- Add subtle green tint to staged file rows for at-a-glance visual differentiation from unstaged
- Increase file row padding for better scanability (6px vertical minimum)
- Move branch name from CommitPanel footer into the modal header as a compact pill with GitBranch icon
- Redesign section headers with uppercase labels, bolder weight, and count badge chip
- Increase modal max-width from 520px to 600px and max-height to `calc(100vh-80px)`; add 320px min-height
- Increase commit textarea from 3 to 4 rows minimum
- Remove keyboard shortcut hint bar from CommitPanel footer (shortcuts still functional via ⌘Enter / ⌘⇧Enter)
- Promote "Commit & Push" to primary action button when a remote exists
- Remove unused `currentBranch` prop from `CommitPanel` interface
- Gate ⌘⇧Enter push shortcut on `hasRemote` to prevent silent no-ops
- Fix long basename overflow: `shrink-0` → `shrink truncate` on filename span
- Add `aria-hidden` to status pill badge; add `title` tooltip to branch pill for overflow readability