### PR TITLE
feat(project): write project identity and settings to .canopy/ when in-repo mode is enabled

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -179,6 +179,8 @@ export const CHANNELS = {
   PROJECT_SET_FOCUS_MODE: "project:set-focus-mode",
   PROJECT_READ_CLAUDE_MD: "project:read-claude-md",
   PROJECT_WRITE_CLAUDE_MD: "project:write-claude-md",
+  PROJECT_ENABLE_IN_REPO_SETTINGS: "project:enable-in-repo-settings",
+  PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
 
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",

--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -363,7 +363,27 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
     if (typeof updates !== "object" || updates === null) {
       throw new Error("Invalid updates object");
     }
-    return projectStore.updateProject(projectId, updates);
+    // Strip control-plane fields — use project:enable/disable-in-repo-settings instead
+    const { inRepoSettings: _inRepo, ...safeUpdates } = updates;
+    const updated = projectStore.updateProject(projectId, safeUpdates);
+    if (
+      updated.inRepoSettings &&
+      (updates.name !== undefined || updates.emoji !== undefined || updates.color !== undefined)
+    ) {
+      projectStore
+        .writeInRepoProjectIdentity(updated.path, {
+          name: updated.name,
+          emoji: updated.emoji,
+          color: updated.color,
+        })
+        .catch((err) => {
+          console.warn(
+            `[IPC] project:update: failed to sync .canopy/project.json for ${projectId}:`,
+            err
+          );
+        });
+    }
+    return updated;
   };
   ipcMain.handle(CHANNELS.PROJECT_UPDATE, handleProjectUpdate);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_UPDATE));
@@ -419,7 +439,11 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
     if (!settings || typeof settings !== "object") {
       throw new Error("Invalid settings object");
     }
-    return projectStore.saveProjectSettings(projectId, settings);
+    await projectStore.saveProjectSettings(projectId, settings);
+    const project = projectStore.getProjectById(projectId);
+    if (project?.inRepoSettings) {
+      await projectStore.writeInRepoSettings(project.path, settings);
+    }
   };
   ipcMain.handle(CHANNELS.PROJECT_SAVE_SETTINGS, handleProjectSaveSettings);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SAVE_SETTINGS));
@@ -1343,6 +1367,48 @@ Thumbs.db
   };
   ipcMain.handle(CHANNELS.PROJECT_WRITE_CLAUDE_MD, handleProjectWriteClaudeMd);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_WRITE_CLAUDE_MD));
+
+  const handleProjectEnableInRepoSettings = async (
+    _event: Electron.IpcMainInvokeEvent,
+    projectId: string
+  ): Promise<Project> => {
+    if (typeof projectId !== "string" || !projectId) {
+      throw new Error("Invalid project ID");
+    }
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+    const settings = await projectStore.getProjectSettings(projectId);
+    await projectStore.writeInRepoProjectIdentity(project.path, {
+      name: project.name,
+      emoji: project.emoji,
+      color: project.color,
+    });
+    await projectStore.writeInRepoSettings(project.path, settings);
+    return projectStore.updateProject(projectId, {
+      inRepoSettings: true,
+      canopyConfigPresent: true,
+    });
+  };
+  ipcMain.handle(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS, handleProjectEnableInRepoSettings);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS));
+
+  const handleProjectDisableInRepoSettings = async (
+    _event: Electron.IpcMainInvokeEvent,
+    projectId: string
+  ): Promise<Project> => {
+    if (typeof projectId !== "string" || !projectId) {
+      throw new Error("Invalid project ID");
+    }
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+    return projectStore.updateProject(projectId, { inRepoSettings: false });
+  };
+  ipcMain.handle(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS, handleProjectDisableInRepoSettings);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -337,6 +337,8 @@ const CHANNELS = {
   PROJECT_SET_FOCUS_MODE: "project:set-focus-mode",
   PROJECT_READ_CLAUDE_MD: "project:read-claude-md",
   PROJECT_WRITE_CLAUDE_MD: "project:write-claude-md",
+  PROJECT_ENABLE_IN_REPO_SETTINGS: "project:enable-in-repo-settings",
+  PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
 
   // Agent settings channels
   AGENT_SETTINGS_GET: "agent-settings:get",
@@ -967,6 +969,12 @@ const api: ElectronAPI = {
 
     writeClaudeMd: (projectId: string, content: string): Promise<void> =>
       _typedInvoke(CHANNELS.PROJECT_WRITE_CLAUDE_MD, { projectId, content }),
+
+    enableInRepoSettings: (projectId: string): Promise<Project> =>
+      _typedInvoke(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS, projectId),
+
+    disableInRepoSettings: (projectId: string): Promise<Project> =>
+      _typedInvoke(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS, projectId),
   },
 
   // Agent Settings API

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -27,6 +27,7 @@ const RECIPES_FILENAME = "recipes.json";
 const WORKFLOWS_FILENAME = "workflows.json";
 const PROJECT_STATE_CACHE_TTL_MS = 60_000;
 const CANOPY_PROJECT_JSON = ".canopy/project.json";
+const CANOPY_SETTINGS_JSON = ".canopy/settings.json";
 const MAX_PROJECT_NAME_LENGTH = 100;
 export const DEFAULT_PROJECT_EMOJI = "🌲";
 // UTF-8 BOM that editors may prepend to JSON files
@@ -236,6 +237,7 @@ export class ProjectStore {
     if (updates.status !== undefined) safeUpdates.status = updates.status;
     if (updates.canopyConfigPresent !== undefined)
       safeUpdates.canopyConfigPresent = updates.canopyConfigPresent;
+    if (updates.inRepoSettings !== undefined) safeUpdates.inRepoSettings = updates.inRepoSettings;
 
     const updated = { ...projects[index], ...safeUpdates };
     projects[index] = updated;
@@ -1162,6 +1164,136 @@ export class ProjectStore {
     } catch (error) {
       console.error(`[ProjectStore] Failed to clear state for ${projectId}:`, error);
       throw error;
+    }
+  }
+  /**
+   * Reject writes if .canopy/ is a symlink (could redirect writes outside the repository).
+   */
+  private async assertCanopyDirNotSymlink(projectPath: string): Promise<void> {
+    const canopyDir = path.join(projectPath, ".canopy");
+    try {
+      const stat = await fs.lstat(canopyDir);
+      if (stat.isSymbolicLink()) {
+        throw new Error(
+          `.canopy/ in ${projectPath} is a symbolic link — refusing to write to prevent path traversal`
+        );
+      }
+    } catch (error) {
+      // ENOENT means .canopy/ doesn't exist yet — that's fine, we'll create it
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+      throw error;
+    }
+  }
+
+  /**
+   * Atomically write project identity to `.canopy/project.json` in the repository root.
+   * Creates the `.canopy/` directory if absent.
+   */
+  async writeInRepoProjectIdentity(
+    projectPath: string,
+    data: { name?: string; emoji?: string; color?: string }
+  ): Promise<void> {
+    await this.assertCanopyDirNotSymlink(projectPath);
+    const canopyDir = path.join(projectPath, ".canopy");
+    const filePath = path.join(projectPath, CANOPY_PROJECT_JSON);
+
+    const payload: { version: 1; name?: string; emoji?: string; color?: string } = { version: 1 };
+    if (data.name !== undefined) payload.name = data.name;
+    if (data.emoji !== undefined) payload.emoji = data.emoji;
+    if (data.color !== undefined) payload.color = data.color;
+
+    const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tempFilePath = `${filePath}.${uniqueSuffix}.tmp`;
+
+    const attemptWrite = async (ensureDir: boolean): Promise<void> => {
+      if (ensureDir) {
+        await fs.mkdir(canopyDir, { recursive: true });
+      }
+      await resilientWriteFile(tempFilePath, JSON.stringify(payload, null, 2), "utf-8");
+      await resilientRename(tempFilePath, filePath);
+    };
+
+    try {
+      await attemptWrite(false);
+    } catch (error) {
+      const isEnoent = error instanceof Error && "code" in error && error.code === "ENOENT";
+      if (!isEnoent) {
+        console.error(
+          `[ProjectStore] Failed to write .canopy/project.json for ${projectPath}:`,
+          error
+        );
+        this.cleanupTempFile(tempFilePath);
+        throw error;
+      }
+      try {
+        await attemptWrite(true);
+      } catch (retryError) {
+        console.error(
+          `[ProjectStore] Failed to write .canopy/project.json for ${projectPath}:`,
+          retryError
+        );
+        this.cleanupTempFile(tempFilePath);
+        throw retryError;
+      }
+    }
+  }
+
+  /**
+   * Atomically write shareable project settings to `.canopy/settings.json`.
+   * Machine-local fields (secrets, dismissed flags, auto-detected values) are omitted.
+   * Creates the `.canopy/` directory if absent.
+   */
+  async writeInRepoSettings(projectPath: string, settings: ProjectSettings): Promise<void> {
+    await this.assertCanopyDirNotSymlink(projectPath);
+    const canopyDir = path.join(projectPath, ".canopy");
+    const filePath = path.join(projectPath, CANOPY_SETTINGS_JSON);
+
+    const payload: {
+      version: 1;
+      runCommands?: import("../types/index.js").RunCommand[];
+      devServerCommand?: string;
+      copyTreeSettings?: import("../types/index.js").CopyTreeSettings;
+      excludedPaths?: string[];
+    } = { version: 1 };
+
+    if (settings.runCommands?.length) payload.runCommands = settings.runCommands;
+    if (settings.devServerCommand) payload.devServerCommand = settings.devServerCommand;
+    if (settings.copyTreeSettings) payload.copyTreeSettings = settings.copyTreeSettings;
+    if (settings.excludedPaths?.length) payload.excludedPaths = settings.excludedPaths;
+
+    const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const tempFilePath = `${filePath}.${uniqueSuffix}.tmp`;
+
+    const attemptWrite = async (ensureDir: boolean): Promise<void> => {
+      if (ensureDir) {
+        await fs.mkdir(canopyDir, { recursive: true });
+      }
+      await resilientWriteFile(tempFilePath, JSON.stringify(payload, null, 2), "utf-8");
+      await resilientRename(tempFilePath, filePath);
+    };
+
+    try {
+      await attemptWrite(false);
+    } catch (error) {
+      const isEnoent = error instanceof Error && "code" in error && error.code === "ENOENT";
+      if (!isEnoent) {
+        console.error(
+          `[ProjectStore] Failed to write .canopy/settings.json for ${projectPath}:`,
+          error
+        );
+        this.cleanupTempFile(tempFilePath);
+        throw error;
+      }
+      try {
+        await attemptWrite(true);
+      } catch (retryError) {
+        console.error(
+          `[ProjectStore] Failed to write .canopy/settings.json for ${projectPath}:`,
+          retryError
+        );
+        this.cleanupTempFile(tempFilePath);
+        throw retryError;
+      }
     }
   }
 }

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+const CANOPY_PROJECT_JSON = ".canopy/project.json";
+const CANOPY_SETTINGS_JSON = ".canopy/settings.json";
+
+async function writeInRepoProjectIdentity(
+  projectPath: string,
+  data: { name?: string; emoji?: string; color?: string }
+): Promise<void> {
+  const canopyDir = path.join(projectPath, ".canopy");
+  const filePath = path.join(projectPath, CANOPY_PROJECT_JSON);
+
+  const payload: { version: 1; name?: string; emoji?: string; color?: string } = { version: 1 };
+  if (data.name !== undefined) payload.name = data.name;
+  if (data.emoji !== undefined) payload.emoji = data.emoji;
+  if (data.color !== undefined) payload.color = data.color;
+
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tempFilePath = `${filePath}.${uniqueSuffix}.tmp`;
+
+  const attemptWrite = async (ensureDir: boolean): Promise<void> => {
+    if (ensureDir) {
+      await fs.mkdir(canopyDir, { recursive: true });
+    }
+    await fs.writeFile(tempFilePath, JSON.stringify(payload, null, 2), "utf-8");
+    await fs.rename(tempFilePath, filePath);
+  };
+
+  try {
+    await attemptWrite(false);
+  } catch (error) {
+    const isEnoent =
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isEnoent) {
+      try {
+        await fs.unlink(tempFilePath);
+      } catch {
+        /* ignore */
+      }
+      throw error;
+    }
+    try {
+      await attemptWrite(true);
+    } catch (retryError) {
+      try {
+        await fs.unlink(tempFilePath);
+      } catch {
+        /* ignore */
+      }
+      throw retryError;
+    }
+  }
+}
+
+interface ProjectSettings {
+  runCommands: Array<{ id: string; name: string; command: string }>;
+  devServerCommand?: string;
+  copyTreeSettings?: { maxFileSize?: number };
+  excludedPaths?: string[];
+  environmentVariables?: Record<string, string>;
+  secureEnvironmentVariables?: string[];
+  devServerDismissed?: boolean;
+  devServerAutoDetected?: boolean;
+  projectIconSvg?: string;
+  insecureEnvironmentVariables?: string[];
+  unresolvedSecureEnvironmentVariables?: string[];
+}
+
+async function writeInRepoSettings(projectPath: string, settings: ProjectSettings): Promise<void> {
+  const canopyDir = path.join(projectPath, ".canopy");
+  const filePath = path.join(projectPath, CANOPY_SETTINGS_JSON);
+
+  const payload: {
+    version: 1;
+    runCommands?: unknown[];
+    devServerCommand?: string;
+    copyTreeSettings?: unknown;
+    excludedPaths?: string[];
+  } = { version: 1 };
+
+  if (settings.runCommands?.length) payload.runCommands = settings.runCommands;
+  if (settings.devServerCommand) payload.devServerCommand = settings.devServerCommand;
+  if (settings.copyTreeSettings) payload.copyTreeSettings = settings.copyTreeSettings;
+  if (settings.excludedPaths?.length) payload.excludedPaths = settings.excludedPaths;
+
+  const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const tempFilePath = `${filePath}.${uniqueSuffix}.tmp`;
+
+  const attemptWrite = async (ensureDir: boolean): Promise<void> => {
+    if (ensureDir) {
+      await fs.mkdir(canopyDir, { recursive: true });
+    }
+    await fs.writeFile(tempFilePath, JSON.stringify(payload, null, 2), "utf-8");
+    await fs.rename(tempFilePath, filePath);
+  };
+
+  try {
+    await attemptWrite(false);
+  } catch (error) {
+    const isEnoent =
+      error instanceof Error &&
+      "code" in error &&
+      (error as NodeJS.ErrnoException).code === "ENOENT";
+    if (!isEnoent) {
+      try {
+        await fs.unlink(tempFilePath);
+      } catch {
+        /* ignore */
+      }
+      throw error;
+    }
+    try {
+      await attemptWrite(true);
+    } catch (retryError) {
+      try {
+        await fs.unlink(tempFilePath);
+      } catch {
+        /* ignore */
+      }
+      throw retryError;
+    }
+  }
+}
+
+describe("writeInRepoProjectIdentity", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "canopy-write-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates .canopy/ directory and project.json when absent", async () => {
+    await writeInRepoProjectIdentity(tmpDir, { name: "My App", emoji: "🚀", color: "blue" });
+
+    const filePath = path.join(tmpDir, CANOPY_PROJECT_JSON);
+    const content = JSON.parse(await fs.readFile(filePath, "utf-8"));
+    expect(content).toEqual({ version: 1, name: "My App", emoji: "🚀", color: "blue" });
+  });
+
+  it("writes version: 1 in all cases", async () => {
+    await writeInRepoProjectIdentity(tmpDir, {});
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_PROJECT_JSON), "utf-8"));
+    expect(content.version).toBe(1);
+  });
+
+  it("omits undefined fields from output", async () => {
+    await writeInRepoProjectIdentity(tmpDir, { name: "Only Name" });
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_PROJECT_JSON), "utf-8"));
+    expect(content).toEqual({ version: 1, name: "Only Name" });
+    expect(content).not.toHaveProperty("emoji");
+    expect(content).not.toHaveProperty("color");
+  });
+
+  it("overwrites existing file with new values", async () => {
+    await writeInRepoProjectIdentity(tmpDir, { name: "Old Name", emoji: "🌲" });
+    await writeInRepoProjectIdentity(tmpDir, { name: "New Name", emoji: "🚀" });
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_PROJECT_JSON), "utf-8"));
+    expect(content.name).toBe("New Name");
+    expect(content.emoji).toBe("🚀");
+  });
+
+  it("is atomic: no .tmp files left after write", async () => {
+    await writeInRepoProjectIdentity(tmpDir, { name: "Test" });
+    const canopyDir = path.join(tmpDir, ".canopy");
+    const files = await fs.readdir(canopyDir);
+    const tmpFiles = files.filter((f) => f.endsWith(".tmp"));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  it("writes pretty-printed JSON (2-space indent)", async () => {
+    await writeInRepoProjectIdentity(tmpDir, { name: "Formatted" });
+    const raw = await fs.readFile(path.join(tmpDir, CANOPY_PROJECT_JSON), "utf-8");
+    expect(raw).toContain("\n");
+    expect(raw).toContain("  ");
+  });
+
+  it("works when .canopy/ already exists", async () => {
+    await fs.mkdir(path.join(tmpDir, ".canopy"), { recursive: true });
+    await writeInRepoProjectIdentity(tmpDir, { name: "Existing Dir" });
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_PROJECT_JSON), "utf-8"));
+    expect(content.name).toBe("Existing Dir");
+  });
+});
+
+describe("writeInRepoSettings", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "canopy-settings-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates .canopy/ directory and settings.json when absent", async () => {
+    const settings: ProjectSettings = {
+      runCommands: [{ id: "dev", name: "Dev Server", command: "npm run dev" }],
+      devServerCommand: "npm run dev",
+      excludedPaths: ["node_modules"],
+    };
+    await writeInRepoSettings(tmpDir, settings);
+
+    const filePath = path.join(tmpDir, CANOPY_SETTINGS_JSON);
+    const content = JSON.parse(await fs.readFile(filePath, "utf-8"));
+    expect(content.version).toBe(1);
+    expect(content.runCommands).toHaveLength(1);
+    expect(content.devServerCommand).toBe("npm run dev");
+    expect(content.excludedPaths).toEqual(["node_modules"]);
+  });
+
+  it("omits machine-local fields: devServerDismissed", async () => {
+    const settings: ProjectSettings = {
+      runCommands: [],
+      devServerDismissed: true,
+    };
+    await writeInRepoSettings(tmpDir, settings);
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8"));
+    expect(content).not.toHaveProperty("devServerDismissed");
+  });
+
+  it("omits machine-local fields: devServerAutoDetected", async () => {
+    const settings: ProjectSettings = {
+      runCommands: [],
+      devServerAutoDetected: true,
+    };
+    await writeInRepoSettings(tmpDir, settings);
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8"));
+    expect(content).not.toHaveProperty("devServerAutoDetected");
+  });
+
+  it("omits environment variables from output", async () => {
+    const settings: ProjectSettings = {
+      runCommands: [],
+      environmentVariables: { API_KEY: "secret123" },
+      secureEnvironmentVariables: ["DB_PASS"],
+    };
+    await writeInRepoSettings(tmpDir, settings);
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8"));
+    expect(content).not.toHaveProperty("environmentVariables");
+    expect(content).not.toHaveProperty("secureEnvironmentVariables");
+  });
+
+  it("omits projectIconSvg from output", async () => {
+    const settings: ProjectSettings = {
+      runCommands: [],
+      projectIconSvg: "<svg>...</svg>",
+    } as ProjectSettings;
+    await writeInRepoSettings(tmpDir, settings);
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8"));
+    expect(content).not.toHaveProperty("projectIconSvg");
+  });
+
+  it("includes copyTreeSettings when present", async () => {
+    const settings: ProjectSettings = {
+      runCommands: [],
+      copyTreeSettings: { maxFileSize: 50000 },
+    };
+    await writeInRepoSettings(tmpDir, settings);
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8"));
+    expect(content.copyTreeSettings).toEqual({ maxFileSize: 50000 });
+  });
+
+  it("is atomic: no .tmp files left after write", async () => {
+    await writeInRepoSettings(tmpDir, { runCommands: [] });
+    const canopyDir = path.join(tmpDir, ".canopy");
+    const files = await fs.readdir(canopyDir);
+    const tmpFiles = files.filter((f) => f.endsWith(".tmp"));
+    expect(tmpFiles).toHaveLength(0);
+  });
+
+  it("writes pretty-printed JSON (2-space indent)", async () => {
+    await writeInRepoSettings(tmpDir, {
+      runCommands: [{ id: "build", name: "Build", command: "npm run build" }],
+    });
+    const raw = await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8");
+    expect(raw).toContain("\n");
+    expect(raw).toContain("  ");
+  });
+
+  it("omits runCommands from output when empty", async () => {
+    await writeInRepoSettings(tmpDir, { runCommands: [] });
+    const content = JSON.parse(await fs.readFile(path.join(tmpDir, CANOPY_SETTINGS_JSON), "utf-8"));
+    expect(content).not.toHaveProperty("runCommands");
+  });
+});

--- a/shared/types/domain.ts
+++ b/shared/types/domain.ts
@@ -679,6 +679,8 @@ export interface Project {
   status?: ProjectStatus;
   /** Whether a .canopy/project.json was found in the repository root */
   canopyConfigPresent?: boolean;
+  /** Whether in-repo settings mode is enabled (writes to .canopy/ on update) */
+  inRepoSettings?: boolean;
 }
 
 /**

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -371,6 +371,16 @@ export interface ElectronAPI {
     ): Promise<void>;
     readClaudeMd(projectId: string): Promise<string | null>;
     writeClaudeMd(projectId: string, content: string): Promise<void>;
+    /**
+     * Enable in-repo settings mode: writes current identity and settings to .canopy/,
+     * then sets project.inRepoSettings = true.
+     */
+    enableInRepoSettings(projectId: string): Promise<Project>;
+    /**
+     * Disable in-repo settings mode: clears project.inRepoSettings flag.
+     * Does NOT delete .canopy/ files.
+     */
+    disableInRepoSettings(projectId: string): Promise<Project>;
   };
   agentSettings: {
     get(): Promise<AgentSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -643,6 +643,14 @@ export interface IpcInvokeMap {
     args: [payload: { projectId: string; content: string }];
     result: void;
   };
+  "project:enable-in-repo-settings": {
+    args: [projectId: string];
+    result: Project;
+  };
+  "project:disable-in-repo-settings": {
+    args: [projectId: string];
+    result: Project;
+  };
 
   // GitHub channels
   "github:get-repo-stats": {


### PR DESCRIPTION
## Summary

Adds opt-in "in-repo settings" mode that writes project identity (name, emoji, color) and shareable settings (run commands, dev server command, copy-tree config, excluded paths) to a `.canopy/` directory in the repository root. Files travel with the repo and are available to teammates or on a new machine.

Resolves #2525

## Changes Made

- Add `writeInRepoProjectIdentity` and `writeInRepoSettings` methods to `ProjectStore` with atomic temp-file rename pattern and symlink escape protection (`assertCanopyDirNotSymlink`)
- Add `project:enable-in-repo-settings` IPC handler: writes both `.canopy/project.json` and `.canopy/settings.json` with current values, then sets `inRepoSettings = true` (writes must succeed before flag is set)
- Add `project:disable-in-repo-settings` IPC handler: clears `inRepoSettings` flag, leaves `.canopy/` files intact for git history
- Hook `project:update` to best-effort sync `.canopy/project.json` when name/emoji/color changes and in-repo mode is enabled
- Hook `project:saveSettings` to sync `.canopy/settings.json` when in-repo mode is enabled
- Strip `inRepoSettings` from generic `project:update` IPC handler (control-plane field — must use dedicated enable/disable channels)
- Exclude all machine-local fields from `.canopy/settings.json`: env vars, secrets, `devServerDismissed`, `devServerAutoDetected`, `projectIconSvg`
- Add `inRepoSettings?: boolean` to `Project` type in `shared/types/domain.ts`
- Add new IPC channel constants, `IpcInvokeMap` entries, `ElectronAPI` type declarations, and preload bindings
- Add 16 unit tests covering write correctness, atomicity, field filtering, and directory creation