### PR TITLE
feat(project): enable New Folder button in open directory dialogs

### DIFF
--- a/electron/ipc/handlers/project.ts
+++ b/electron/ipc/handlers/project.ts
@@ -456,7 +456,7 @@ export function registerProjectHandlers(deps: HandlerDependencies): () => void {
 
   const handleProjectOpenDialog = async () => {
     const result = await dialog.showOpenDialog(mainWindow, {
-      properties: ["openDirectory"],
+      properties: ["openDirectory", "createDirectory"],
       title: "Open Git Repository",
     });
 

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -77,7 +77,7 @@ export function createApplicationMenu(
           click: async () => {
             if (mainWindow.isDestroyed()) return;
             const result = await dialog.showOpenDialog(mainWindow, {
-              properties: ["openDirectory"],
+              properties: ["openDirectory", "createDirectory"],
               title: "Open Git Repository",
             });
 


### PR DESCRIPTION
## Summary

Adds the `createDirectory` property to Electron's `showOpenDialog` options so macOS displays a native **New Folder** button when selecting a project directory. This allows users to create and immediately open a fresh project folder without leaving the dialog.

Resolves #2664

## Changes Made

- Add `"createDirectory"` to dialog properties in `electron/ipc/handlers/project.ts` (Add Project IPC handler)
- Add `"createDirectory"` to dialog properties in `electron/menu.ts` (File > Open Directory menu item)
- Property is macOS-only per Electron docs; harmlessly ignored on Windows and Linux