### PR TITLE
feat(notifications): move toasts to top-right with improved glass styling and shorter duration

### DIFF
--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -128,7 +128,7 @@ export function Toaster() {
 
   return createPortal(
     <div
-      className="fixed top-6 z-[var(--z-toast)] flex flex-col gap-3 w-full max-w-[380px] pointer-events-none p-4"
+      className="fixed top-14 z-[var(--z-toast)] flex flex-col gap-3 w-full max-w-[380px] pointer-events-none p-4"
       style={{ right: "calc(var(--sidecar-right-offset, 0px))" }}
     >
       {[...toastNotifications].reverse().map((notification) => (


### PR DESCRIPTION
## Summary

Moves toast notifications from bottom-right to top-right of the window, reducing overlap with the hybrid input area. Improves the glass styling to feel lighter and less intrusive, reduces the auto-dismiss duration, and makes the dismiss button always visible.

Resolves #2671

## Changes Made

- Reposition toast container from `bottom-6` to `top-6` for top-right placement
- Reverse toast array rendering so newest toast appears at the top of the stack
- Lighten glass background from `bg-zinc-950/80 backdrop-blur-md` to `bg-zinc-900/60 backdrop-blur-xl`
- Reduce default auto-dismiss duration from 5000ms to 3000ms
- Make dismiss button always visible (remove `opacity-0 group-hover:opacity-100`)
- Remove redundant `focus-visible:opacity-100` class (no longer needed without base opacity)
- `sidecar-right-offset` CSS variable offset preserved on container