### PR TITLE
fix(main): handle SIGTERM/SIGINT in dev mode to prevent crash recovery dialog

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -400,9 +400,12 @@ if (!gotTheLock) {
   // on every hot reload. Register explicit handlers to clean up and exit cleanly.
   if (!app.isPackaged) {
     const devSignalHandler = () => {
+      // Clean up synchronously before the async quit path — the before-quit handler
+      // guards on mainWindow existence and may skip cleanupOnExit() during startup.
       getCrashRecoveryService().cleanupOnExit();
-      if (!isSmokeTest) app.releaseSingleInstanceLock();
-      process.exit(0);
+      // Safety net: force exit if graceful shutdown hangs (nodemon will SIGKILL anyway).
+      setTimeout(() => process.exit(0), 3000).unref();
+      app.quit();
     };
     process.on("SIGTERM", devSignalHandler);
     process.on("SIGINT", devSignalHandler);


### PR DESCRIPTION
## Summary

In dev mode, nodemon/concurrently restarts Electron by sending SIGTERM. Electron's `before-quit` event does **not** fire on SIGTERM, so `cleanupOnExit()` never ran — leaving `running.lock` orphaned and causing the crash recovery dialog to appear on every hot reload or restart.

Resolves #2705

## Changes Made

- Register `process.on('SIGTERM')` and `process.on('SIGINT')` handlers in `electron/main.ts`, guarded by `!app.isPackaged` so they only run in development
- Handler calls `getCrashRecoveryService().cleanupOnExit()` synchronously first (guarantees lock file deletion even if `before-quit` skips cleanup due to no mainWindow yet)
- Routes through `app.quit()` for graceful async teardown (PtyClient, WorkspaceClient, MCP) rather than `process.exit(0)`
- Adds a 3-second unref'd safety timeout (`setTimeout(() => process.exit(0), 3000).unref()`) as a fallback if the graceful path hangs