### PR TITLE
fix(worktree): block refresh() during project switch to prevent cross-project contamination

### DIFF
--- a/src/store/__tests__/worktreeDataStore.projectSwitchRace.test.ts
+++ b/src/store/__tests__/worktreeDataStore.projectSwitchRace.test.ts
@@ -53,6 +53,7 @@ const {
   cleanupWorktreeDataStore,
   forceReinitializeWorktreeDataStore,
   prePopulateWorktreeSnapshot,
+  resetSnapshotCacheForTests,
 } = await import("../worktreeDataStore");
 
 function createMockWorktree(id: string, overrides: Partial<WorktreeState> = {}): WorktreeState {
@@ -78,6 +79,9 @@ describe("worktreeDataStore project switch race conditions", () => {
     refreshMock.mockReset();
     vi.clearAllMocks();
     cleanupWorktreeDataStore();
+    // Clear the snapshot cache so earlier test runs cannot supply pre-cached
+    // data to prePopulateWorktreeSnapshot() calls in later tests.
+    resetSnapshotCacheForTests();
     useWorktreeDataStore.setState({
       worktrees: new Map(),
       projectId: null,
@@ -282,12 +286,21 @@ describe("worktreeDataStore project switch race conditions", () => {
     });
 
     // Now refresh() must work normally (isSwitching = false after forceReinit).
+    // refreshMock returns undefined (already configured) and getAll returns updated list.
+    refreshMock.mockResolvedValue(undefined);
     getAllMock.mockResolvedValueOnce(projectBWorktreesAfterRefresh);
+
+    const refreshCallsBefore = refreshMock.mock.calls.length;
     await useWorktreeDataStore.getState().refresh();
+
+    // Verify that the IPC refresh was actually invoked (lock was cleared).
+    expect(refreshMock.mock.calls.length).toBe(refreshCallsBefore + 1);
 
     const state = useWorktreeDataStore.getState();
     expect(state.worktrees.has("project-b-main")).toBe(true);
     expect(state.worktrees.has("project-b-feature")).toBe(true);
     expect(state.worktrees.has("project-a-main")).toBe(false);
+    expect(state.worktrees.size).toBe(2);
+    expect(state.projectId).toBe("project-b");
   });
 });

--- a/src/store/__tests__/worktreeDataStore.refresh.test.ts
+++ b/src/store/__tests__/worktreeDataStore.refresh.test.ts
@@ -54,7 +54,8 @@ vi.mock("../notificationStore", () => ({
   },
 }));
 
-const { useWorktreeDataStore, cleanupWorktreeDataStore } = await import("../worktreeDataStore");
+const { useWorktreeDataStore, cleanupWorktreeDataStore, forceReinitializeWorktreeDataStore } =
+  await import("../worktreeDataStore");
 
 function createMockWorktree(id: string, overrides: Partial<WorktreeState> = {}): WorktreeState {
   return {
@@ -136,5 +137,40 @@ describe("worktreeDataStore.refresh", () => {
     expect(refreshedFeature?.prNumber).toBe(42);
     expect(refreshedFeature?.prTitle).toBe("WIP PR");
     expect(useWorktreeDataStore.getState().worktrees.get("feature-new")).toBeDefined();
+  });
+
+  it("rejects stale onUpdate events arriving after a project switch (listenerGeneration guard)", async () => {
+    const main = createMockWorktree("main", { isMainWorktree: true, branch: "main" });
+    const foreignWorktree = createMockWorktree("foreign-wt");
+
+    getAllMock.mockResolvedValueOnce([main]);
+    refreshMock.mockResolvedValue(undefined);
+
+    useWorktreeDataStore.getState().initialize();
+    await vi.waitFor(() => {
+      expect(useWorktreeDataStore.getState().isInitialized).toBe(true);
+      expect(onUpdateCallback).toBeTypeOf("function");
+    });
+
+    // Capture the old listener before the project switch.
+    const oldOnUpdateCallback = onUpdateCallback;
+
+    // Switch to a new project — generation changes, old listeners torn down, new ones set up.
+    getAllMock.mockResolvedValueOnce([
+      createMockWorktree("new-project-main", { isMainWorktree: true }),
+    ]);
+    forceReinitializeWorktreeDataStore("new-project");
+
+    await vi.waitFor(() => {
+      expect(useWorktreeDataStore.getState().isInitialized).toBe(true);
+    });
+
+    // Fire the OLD onUpdate callback (simulates a delayed IPC push from the outgoing project).
+    // The generation guard must reject it — it must NOT insert foreignWorktree into the store.
+    oldOnUpdateCallback?.(foreignWorktree);
+
+    const state = useWorktreeDataStore.getState();
+    expect(state.worktrees.has("foreign-wt")).toBe(false);
+    expect(state.worktrees.has("new-project-main")).toBe(true);
   });
 });

--- a/src/store/worktreeDataStore.ts
+++ b/src/store/worktreeDataStore.ts
@@ -532,6 +532,11 @@ export function forceReinitializeWorktreeDataStore(projectId?: string) {
  * This should be called after terminal hydration completes to ensure
  * terminals are loaded before checking for orphans.
  */
+export function resetSnapshotCacheForTests(): void {
+  projectSnapshotCache.clear();
+  isSwitching = false;
+}
+
 export function cleanupOrphanedTerminals() {
   const getWorktreeIds = (wtMap: Map<string, WorktreeState>) => {
     const ids = new Set<string>();


### PR DESCRIPTION
## Summary

Closes the recurring cross-project worktree contamination window introduced by the concurrent refresh operations added in PR #2642.

The root cause: `refresh()` could be called during the async gap between `prePopulateWorktreeSnapshot()` (renderer optimistically sets `projectId` to the incoming project) and `forceReinitializeWorktreeDataStore()` (called only after the main process confirms the switch is complete). During this window, `targetProjectId` points to the new project but the IPC layer is still serving the outgoing project's data. The `storeGeneration` counter didn't protect against this because no switch had finished — the generation was stable from `prePopulate`'s perspective — so the stale IPC response passed all guards and was written to the store under the new `projectId`, poisoning the snapshot cache and bypassing the `projectMismatch` filter in `useWorktrees`.

Resolves #2703

## Changes Made

- Add `isSwitching` module-level flag to `worktreeDataStore.ts`; set to `true` in `prePopulateWorktreeSnapshot()`, cleared to `false` in `forceReinitializeWorktreeDataStore()`
- Guard `refresh()` with early-return + diagnostic `console.warn` when `isSwitching` is true
- Add generation capture (`listenerGeneration`) inside the `onUpdate` IPC listener for defense-in-depth: stale push events arriving after a project switch are logged and rejected
- Export `resetSnapshotCacheForTests()` to clear the module-level snapshot cache between test runs
- Call `resetSnapshotCacheForTests()` in `beforeEach` to prevent stale cache state leaking across tests
- Two new targeted tests: `isSwitching` blocks `refresh()` in the switch window; flag is cleared correctly by `forceReinitializeWorktreeDataStore`
- Strengthen second new test: assert exact `worktrees.size`, `projectId`, and that IPC `refresh` was actually invoked after the lock clears
- Add `onUpdate` listenerGeneration guard regression test using captured callback