### PR TITLE
feat(github): show author and comment count in issue selector rows

### DIFF
--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -163,7 +163,7 @@ export function IssueSelector({
                 <span className="truncate flex-1 min-w-0">
                   #{issue.number} {issue.title}
                 </span>
-                <span className="text-xs text-muted-foreground shrink-0 truncate max-w-[120px]">
+                <span className="text-xs text-muted-foreground shrink-0">
                   {issue.author.login.length > 20
                     ? `${issue.author.login.slice(0, 20)}…`
                     : issue.author.login}


### PR DESCRIPTION
## Summary

Adds the opener's username and comment count to each row in the IssueSelector dropdown used when creating a new worktree, giving developers useful at-a-glance context when choosing an issue to work on.

Resolves #2690

## Changes Made

- Display author login beside each issue row, truncated at 20 characters with an ellipsis for long usernames
- Display comment count with a `MessageCircle` icon (no label text), following the icon-only pattern used elsewhere in the GitHub components
- Add `min-w-0` to the title span to ensure correct flexbox truncation behaviour
- Popover width (`w-[400px]`) is unchanged; all additions are `shrink-0` with JS truncation as the single source of truth for the author cap