### PR TITLE
fix(onboarding): remove hardcoded prompt sent to agent after wizard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -870,7 +870,6 @@ function App() {
     if (primaryAgent && availability[primaryAgent]) {
       launchAgent(primaryAgent, {
         worktreeId: activeWorktreeId ?? undefined,
-        prompt: "Hi! I'm ready to help with this project. What would you like to know?",
       }).catch(() => {});
     }
   }, [launchAgent, activeWorktreeId, availability, agentSettings]);


### PR DESCRIPTION
## Summary

Removes the nonsensical hardcoded prompt (`"Hi! I'm ready to help with this project. What would you like to know?"`) that was sent to the agent when the onboarding wizard completed. The string reads as assistant speech, not a user instruction, causing the agent to receive a confusing self-introduction rather than waiting for real input.

Resolves #2700

## Changes Made

- Remove `prompt` option from `launchAgent` call in `handleWizardFinish` (`src/App.tsx`)
- Agent now launches into a clean interactive session without any pre-filled input
- Consistent behavior across all supported agents (Claude, Gemini, Codex, OpenCode) — the `prompt` option is fully optional end-to-end