### PR TITLE
fix(input): remove RAF deferral from submit to prevent dropped input

### DIFF
--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -880,7 +880,11 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             isComposingRef.current = false;
             if (!submitAfterCompositionRef.current) return false;
             submitAfterCompositionRef.current = false;
-            sendFromEditor();
+            // Defer one tick so CM6 can commit the final composition text to
+            // view.state.doc before we read it.  Unlike the old RAF approach,
+            // setTimeout is NOT canceled by the blur handler, so a focus shift
+            // during composition cannot silently drop the submission.
+            setTimeout(sendFromEditor, 0);
             return false;
           },
           keydown: (event) => {


### PR DESCRIPTION
## Summary
- Removes the `requestAnimationFrame` deferral from `queueSend()` that caused a race condition where blur events could cancel pending submissions, silently dropping user input
- Replaces all `queueSend()` call sites with direct synchronous `sendFromEditor()` calls, eliminating the 16ms window where focus changes could intercept the send
- Defers `compositionend` send via `setTimeout(0)` instead of RAF to let CodeMirror 6 commit final composition text before reading

Closes #2737

## Test plan
- [ ] Open two agent sessions side by side
- [ ] In the left session, copy a report/output
- [ ] Paste into the right session's input field, add a comment, press Enter
- [ ] Verify the input is sent correctly (not silently dropped)
- [ ] Repeat rapidly switching focus between panels after pressing Enter
- [ ] Test IME composition input (e.g., CJK characters) submits correctly
- [ ] Verify `npm run check` passes with no errors

Generated with [Claude Code](https://claude.com/claude-code)