### PR TITLE
fix(sidebar): remove root worktree background tint collision

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -562,7 +562,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       )}
 
       {/* Strong divider between pinned worktrees and scrollable list */}
-      {hasNonMainWorktrees && <div className="shrink-0 border-b-2 border-divider" />}
+      {hasNonMainWorktrees && <div className="shrink-0 border-b-2 border-divider/60" />}
 
       {/* Non-main worktree list */}
       <div className="relative flex-1 min-h-0">

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -396,8 +396,7 @@ export function WorktreeCard({
         isActive
           ? "bg-overlay-soft shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)]"
           : "hover:bg-overlay-subtle",
-        variant === "sidebar" && !isActive && !isMainWorktree && "bg-transparent",
-        variant === "sidebar" && !isActive && isMainWorktree && "bg-white/[0.03]",
+        variant === "sidebar" && !isActive && "bg-transparent",
         isActive &&
           !isSingleWorktree &&
           variant === "sidebar" &&


### PR DESCRIPTION
## Summary

- Removed the persistent `bg-white/[0.03]` background tint from the root worktree card so it no longer visually collides with the `bg-overlay-soft` selection state on sub-worktrees
- Consolidated the two separate inactive background rules (root vs non-root) into a single `bg-transparent` for all inactive sidebar worktrees
- Adjusted the divider between root and sub-worktree sections to `border-divider/60` for a cleaner structural separation that doesn't compete with card backgrounds

Resolves #2766

## Changes

- `src/components/Worktree/WorktreeCard.tsx`: Replaced the root/non-root background branching with a single `bg-transparent` for all inactive sidebar worktrees
- `src/App.tsx`: Updated the pinned-to-scrollable divider opacity from `border-divider` to `border-divider/60`

## Testing

- TypeScript typecheck passes with no errors
- ESLint and Prettier report no issues
- The root worktree's visual identity still comes from its House icon and bold/tracking-wide typography, with background fills reserved exclusively for interactive states (hover, selection)