### PR TITLE
fix(worktree): remove inline Copy Context button and Inject Context menu item

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -144,16 +144,12 @@ export function WorktreeCard({
   const {
     runningRecipeId,
     isRestartValidating,
-    treeCopied,
-    isCopyingTree,
-    copyFeedback,
     confirmDialog,
     showDeleteDialog,
     setShowDeleteDialog,
     closeConfirmDialog,
     handlePathClick,
     handleCopyTree,
-    handleCopyTreeClick,
     handleRunRecipe,
     handleCloseCompleted,
     handleCloseFailed,
@@ -197,10 +193,6 @@ export function WorktreeCard({
     void actionService.dispatch("worktree.openPR", { worktreeId: worktree.id }, { source: "user" });
   }, [worktree.id]);
 
-  const handleInjectContext = useCallback(() => {
-    void actionService.dispatch("worktree.inject", { worktreeId: worktree.id }, { source: "user" });
-  }, [worktree.id]);
-
   const handleResetRenderers = useCallback(() => {
     void actionService.dispatch(
       "worktree.sessions.resetRenderers",
@@ -220,8 +212,6 @@ export function WorktreeCard({
       { source: "user" }
     );
   }, [worktree.id]);
-
-  const hasFocusedTerminal = useTerminalStore((state) => state.focusedId !== null);
 
   const [showIssuePicker, setShowIssuePicker] = useState(false);
   const [showReviewHub, setShowReviewHub] = useState(false);
@@ -457,12 +447,6 @@ export function WorktreeCard({
           isPinned={isPinned}
           branchLabel={branchLabel}
           worktreeErrorCount={worktreeErrors.length}
-          copy={{
-            treeCopied,
-            isCopyingTree,
-            copyFeedback,
-            onCopyTreeClick: handleCopyTreeClick,
-          }}
           badges={{
             onOpenIssue: worktree.issueNumber ? handleOpenIssueExternal : undefined,
             onOpenPR: worktree.prNumber ? handleOpenPRExternal : undefined,
@@ -472,7 +456,6 @@ export function WorktreeCard({
             recipes,
             runningRecipeId,
             isRestartValidating,
-            hasFocusedTerminal,
             counts: {
               grid: gridCount,
               dock: dockCount,
@@ -483,7 +466,6 @@ export function WorktreeCard({
             },
             onCopyContextFull: handleCopyContextFull,
             onCopyContextModified: handleCopyContextModified,
-            onInjectContext: handleInjectContext,
             onOpenEditor,
             onRevealInFinder: handlePathClick,
             onOpenIssueSidecar: worktree.issueNumber ? handleOpenIssueSidecar : undefined,

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState, memo } from "react";
-import type React from "react";
 import type { TerminalRecipe, WorktreeState } from "@/types";
 import { cn } from "@/lib/utils";
 import { BranchLabel } from "../BranchLabel";
@@ -23,12 +22,9 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "../../ui/tooltip";
 import {
   AlertCircle,
-  Check,
   CircleDot,
-  Copy,
   CornerDownRight,
   GitPullRequest,
-  Loader2,
   MoreHorizontal,
   House,
   Pin,
@@ -199,13 +195,6 @@ export interface WorktreeHeaderProps {
   branchLabel: string;
   worktreeErrorCount: number;
 
-  copy: {
-    treeCopied: boolean;
-    isCopyingTree: boolean;
-    copyFeedback: string;
-    onCopyTreeClick: (e: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
-  };
-
   badges: {
     onOpenIssue?: () => void;
     onOpenPR?: () => void;
@@ -216,7 +205,6 @@ export interface WorktreeHeaderProps {
     recipes: TerminalRecipe[];
     runningRecipeId: string | null;
     isRestartValidating: boolean;
-    hasFocusedTerminal: boolean;
     counts: {
       grid: number;
       dock: number;
@@ -227,7 +215,6 @@ export interface WorktreeHeaderProps {
     };
     onCopyContextFull: () => void;
     onCopyContextModified: () => void;
-    onInjectContext: () => void;
     onOpenEditor: () => void;
     onRevealInFinder: () => void;
     onOpenIssueSidecar?: () => void;
@@ -260,7 +247,6 @@ export function WorktreeHeader({
   isPinned,
   branchLabel,
   worktreeErrorCount,
-  copy,
   badges,
   menu,
 }: WorktreeHeaderProps) {
@@ -314,57 +300,12 @@ export function WorktreeHeader({
 
         <div
           className={cn(
-            "flex items-center gap-1 shrink-0 transition-opacity duration-150",
-            isActive || copy.treeCopied || copy.isCopyingTree
+            "shrink-0 transition-opacity duration-150",
+            isActive
               ? "opacity-100"
               : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
           )}
         >
-          <TooltipProvider>
-            <Tooltip open={copy.treeCopied || undefined} delayDuration={copy.treeCopied ? 0 : 300}>
-              <TooltipTrigger asChild>
-                <button
-                  onClick={copy.onCopyTreeClick}
-                  disabled={copy.isCopyingTree}
-                  className={cn(
-                    "p-1 rounded transition-colors",
-                    copy.treeCopied
-                      ? "text-status-success bg-status-success/10"
-                      : "text-canopy-text/40 hover:text-canopy-text hover:bg-white/5",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
-                    copy.isCopyingTree && "cursor-wait opacity-70"
-                  )}
-                  aria-label={
-                    copy.isCopyingTree
-                      ? "Copying…"
-                      : copy.treeCopied
-                        ? "Context Copied"
-                        : "Copy Context"
-                  }
-                >
-                  {copy.isCopyingTree ? (
-                    <Loader2 className="w-3.5 h-3.5 animate-spin motion-reduce:animate-none text-canopy-text" />
-                  ) : copy.treeCopied ? (
-                    <Check className="w-3.5 h-3.5" />
-                  ) : (
-                    <Copy className="w-3.5 h-3.5" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="font-medium">
-                {copy.isCopyingTree ? (
-                  "Copying…"
-                ) : copy.treeCopied ? (
-                  <span role="status" aria-live="polite">
-                    {copy.copyFeedback}
-                  </span>
-                ) : (
-                  "Copy Context"
-                )}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-
           <DropdownMenu>
             <TooltipProvider>
               <Tooltip>
@@ -399,12 +340,10 @@ export function WorktreeHeader({
                 runningRecipeId={menu.runningRecipeId}
                 isRestartValidating={menu.isRestartValidating}
                 isPinned={isPinned}
-                hasFocusedTerminal={menu.hasFocusedTerminal}
                 counts={menu.counts}
                 onLaunchAgent={menu.onLaunchAgent ? handleLaunchAgent : undefined}
                 onCopyContextFull={menu.onCopyContextFull}
                 onCopyContextModified={menu.onCopyContextModified}
-                onInjectContext={menu.onInjectContext}
                 onOpenEditor={menu.onOpenEditor}
                 onRevealInFinder={menu.onRevealInFinder}
                 onOpenIssueSidecar={menu.onOpenIssueSidecar}

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import type React from "react";
+import { useCallback, useState } from "react";
 import type { WorktreeState } from "@/types";
 import { actionService } from "@/services/ActionService";
 import { useRecipeStore } from "@/store/recipeStore";
@@ -16,10 +15,6 @@ export interface UseWorktreeActionsResult {
   runningRecipeId: string | null;
   isRestartValidating: boolean;
 
-  treeCopied: boolean;
-  isCopyingTree: boolean;
-  copyFeedback: string;
-
   confirmDialog: ConfirmDialogState;
   showDeleteDialog: boolean;
 
@@ -28,7 +23,6 @@ export interface UseWorktreeActionsResult {
 
   handlePathClick: () => void;
   handleCopyTree: () => Promise<void>;
-  handleCopyTreeClick: (e: React.MouseEvent<HTMLButtonElement>) => Promise<void>;
 
   handleRunRecipe: (recipeId: string) => Promise<void>;
 
@@ -59,12 +53,6 @@ export function useWorktreeActions({
 
   const [runningRecipeId, setRunningRecipeId] = useState<string | null>(null);
 
-  const [treeCopied, setTreeCopied] = useState(false);
-  const [isCopyingTree, setIsCopyingTree] = useState(false);
-  const [copyFeedback, setCopyFeedback] = useState<string>("");
-  const treeCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const copyTreeRequestIdRef = useRef(0);
-
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState>({
     isOpen: false,
     title: "",
@@ -74,16 +62,6 @@ export function useWorktreeActions({
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isRestartValidating, setIsRestartValidating] = useState(false);
-
-  useEffect(() => {
-    return () => {
-      copyTreeRequestIdRef.current = -1;
-      if (treeCopyTimeoutRef.current) {
-        clearTimeout(treeCopyTimeoutRef.current);
-        treeCopyTimeoutRef.current = null;
-      }
-    };
-  }, []);
 
   const closeConfirmDialog = useCallback(() => {
     setConfirmDialog((prev) => ({ ...prev, isOpen: false }));
@@ -213,60 +191,18 @@ export function useWorktreeActions({
   }, [isRestartValidating, bulkRestartPreflightCheckByWorktree, worktree.id, closeConfirmDialog]);
 
   const handleCopyTree = useCallback(async () => {
-    if (isCopyingTree) return;
-
-    const requestId = ++copyTreeRequestIdRef.current;
-    setIsCopyingTree(true);
-
-    try {
-      const resultMessage = await onCopyTree();
-
-      if (copyTreeRequestIdRef.current !== requestId) return;
-
-      if (resultMessage) {
-        setTreeCopied(true);
-        setCopyFeedback(resultMessage);
-
-        if (treeCopyTimeoutRef.current) {
-          clearTimeout(treeCopyTimeoutRef.current);
-        }
-
-        treeCopyTimeoutRef.current = setTimeout(() => {
-          if (copyTreeRequestIdRef.current !== requestId) return;
-          setTreeCopied(false);
-          setCopyFeedback("");
-          treeCopyTimeoutRef.current = null;
-        }, 2000);
-      }
-    } finally {
-      if (copyTreeRequestIdRef.current === requestId) {
-        setIsCopyingTree(false);
-      }
-    }
-  }, [onCopyTree, isCopyingTree]);
-
-  const handleCopyTreeClick = useCallback(
-    async (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation();
-      e.currentTarget.blur();
-      await handleCopyTree();
-    },
-    [handleCopyTree]
-  );
+    await onCopyTree();
+  }, [onCopyTree]);
 
   return {
     runningRecipeId,
     isRestartValidating,
-    treeCopied,
-    isCopyingTree,
-    copyFeedback,
     confirmDialog,
     showDeleteDialog,
     setShowDeleteDialog,
     closeConfirmDialog,
     handlePathClick,
     handleCopyTree,
-    handleCopyTreeClick,
     handleRunRecipe,
     handleCloseCompleted,
     handleCloseFailed,

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeMenu.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo } from "react";
 import type React from "react";
 import { actionService } from "@/services/ActionService";
 import { useNativeContextMenu } from "@/hooks";
-import { useTerminalStore } from "@/store/terminalStore";
 import type { MenuItemOption, TerminalRecipe, WorktreeState } from "@/types";
 
 export function useWorktreeMenu({
@@ -50,7 +49,6 @@ export function useWorktreeMenu({
 } {
   const { showMenu } = useNativeContextMenu();
   const isMainWorktree = worktree.isMainWorktree;
-  const focusedTerminalId = useTerminalStore((state) => state.focusedId);
 
   const contextMenuTemplate = useMemo((): MenuItemOption[] => {
     const launchSubmenu: MenuItemOption[] = [
@@ -139,11 +137,6 @@ export function useWorktreeMenu({
           { id: "worktree:copy-context:modified", label: "Modified Files Only" },
         ],
       },
-      {
-        id: "worktree:inject-context",
-        label: "Inject Context into Focused Terminal",
-        enabled: focusedTerminalId !== null,
-      },
       { id: "worktree:open-editor", label: "Open in Editor" },
       { id: "worktree:reveal", label: "Reveal in Finder" },
     ];
@@ -213,7 +206,6 @@ export function useWorktreeMenu({
     counts.dock,
     counts.failed,
     counts.grid,
-    focusedTerminalId,
     isMainWorktree,
     isRestartValidating,
     launchAgents,
@@ -318,13 +310,6 @@ export function useWorktreeMenu({
           void actionService.dispatch(
             "worktree.copyTree",
             { worktreeId: worktree.id, modified: true },
-            { source: "context-menu" }
-          );
-          break;
-        case "worktree:inject-context":
-          void actionService.dispatch(
-            "worktree.inject",
-            { worktreeId: worktree.id },
             { source: "context-menu" }
           );
           break;

--- a/src/components/Worktree/WorktreeMenuItems.tsx
+++ b/src/components/Worktree/WorktreeMenuItems.tsx
@@ -1,7 +1,6 @@
 import type * as React from "react";
 import type { WorktreeState } from "../../types";
 import {
-  ArrowDownToLine,
   CircleDot,
   Code,
   Copy,
@@ -54,7 +53,6 @@ export interface WorktreeMenuItemsProps {
   runningRecipeId: string | null;
   isRestartValidating: boolean;
   isPinned?: boolean;
-  hasFocusedTerminal: boolean;
   counts: {
     grid: number;
     dock: number;
@@ -66,7 +64,6 @@ export interface WorktreeMenuItemsProps {
   onLaunchAgent?: (agentId: string) => void;
   onCopyContextFull: () => void;
   onCopyContextModified: () => void;
-  onInjectContext: () => void;
   onOpenEditor: () => void;
   onRevealInFinder: () => void;
   onOpenIssueSidecar?: () => void;
@@ -98,12 +95,10 @@ export function WorktreeMenuItems({
   runningRecipeId,
   isRestartValidating,
   isPinned,
-  hasFocusedTerminal,
   counts,
   onLaunchAgent,
   onCopyContextFull,
   onCopyContextModified,
-  onInjectContext,
   onOpenEditor,
   onRevealInFinder,
   onOpenIssueSidecar,
@@ -269,11 +264,6 @@ export function WorktreeMenuItems({
           <C.Item onSelect={onCopyContextModified}>Modified Files Only</C.Item>
         </C.SubContent>
       </C.Sub>
-
-      <C.Item onSelect={onInjectContext} disabled={!hasFocusedTerminal}>
-        <ArrowDownToLine className="w-3.5 h-3.5 mr-2" />
-        Inject Context into Focused Terminal
-      </C.Item>
 
       <C.Item onSelect={onOpenEditor}>
         <Code className="w-3.5 h-3.5 mr-2" />


### PR DESCRIPTION
## Summary

- Removes the redundant inline Copy Context button from the worktree card header (the same action is already available in the dropdown's Copy Context submenu)
- Removes the "Inject Context into Focused Terminal" dropdown item, which was misleading and visually problematic (wrapping to two lines)
- Cleans up all orphaned props, state, and handler plumbing across the component chain

Resolves #2763

## Changes

- **WorktreeHeader.tsx**: Removed the inline Copy Context button and its `copy` prop, along with unused icon imports (`Check`, `Copy`, `Loader2`) and the `React` type import
- **WorktreeCard.tsx**: Removed `handleInjectContext`, `hasFocusedTerminal`, and the `copy` prop object passed to `WorktreeHeader`
- **useWorktreeActions.ts**: Stripped out `treeCopied`, `isCopyingTree`, `copyFeedback` state, the timeout/ref cleanup effect, and `handleCopyTreeClick`. Simplified `handleCopyTree` to a direct passthrough
- **useWorktreeMenu.ts**: Removed the "Inject Context into Focused Terminal" context menu item and its dispatch handler, plus the `focusedTerminalId` store subscription
- **WorktreeMenuItems.tsx**: Removed `onInjectContext`, `hasFocusedTerminal` props and the corresponding menu item with its `ArrowDownToLine` icon import

## Testing

- TypeScript typecheck passes with zero errors
- ESLint + Prettier pass with zero errors (only pre-existing warnings)
- Copy Context submenu (Full Context / Modified Files Only) remains accessible in the dropdown