### PR TITLE
fix(worktree): correct overview button tooltip and align modal icon

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -518,7 +518,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             <button
               onClick={onOpenOverview}
               className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-white/[0.06] rounded transition-colors"
-              title={createTooltipWithShortcut("Toggle worktrees overview", "Cmd+Shift+O")}
+              title={createTooltipWithShortcut("Open worktrees overview", "Cmd+Shift+O")}
               aria-label="Open worktrees overview"
             >
               <LayoutGrid className="w-3.5 h-3.5" />

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useMemo } from "react";
-import { X, Maximize2, FilterX, House } from "lucide-react";
+import { X, LayoutGrid, FilterX, House } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useShallow } from "zustand/react/shallow";
 import { WorktreeCard } from "./WorktreeCard";
@@ -289,7 +289,7 @@ export function WorktreeOverviewModal({
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
           <div className="flex items-center gap-3">
-            <Maximize2 className="w-5 h-5 text-canopy-text/60" />
+            <LayoutGrid className="w-5 h-5 text-canopy-text/60" />
             <h2
               id="worktree-overview-title"
               className="text-canopy-text font-semibold text-base tracking-wide"


### PR DESCRIPTION
## Summary

- Changed the sidebar button tooltip from "Toggle worktrees overview" to "Open worktrees overview" to accurately describe the one-directional action
- Replaced the `Maximize2` icon in the overview modal header with `LayoutGrid` to match the sidebar button that opens it

Resolves #2852

## Changes

- `src/App.tsx`: Updated tooltip text from "Toggle" to "Open" (the `aria-label` already said "Open")
- `src/components/Worktree/WorktreeOverviewModal.tsx`: Swapped `Maximize2` import/usage for `LayoutGrid` so both surfaces use the same icon

## Testing

- Ran `npm run fix` (0 errors, only pre-existing warnings)
- Visual verification: both the sidebar button and modal header now use `LayoutGrid`, and the tooltip reads "Open worktrees overview"