### PR TITLE
fix(worktree): add visual separation between identity row and badge metadata

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -315,7 +315,7 @@ export function WorktreeHeader({
   );
 
   return (
-    <div className="space-y-1">
+    <div>
       <div className="flex items-center gap-2 min-h-[22px]">
         <div className="flex items-center gap-2 min-w-0 flex-1">
           {isMainWorktree && (
@@ -427,7 +427,7 @@ export function WorktreeHeader({
       </div>
 
       {(worktree.issueNumber || (worktree.prNumber && worktree.prState !== "closed")) && (
-        <div className="flex flex-col gap-0.5">
+        <div className="flex flex-col gap-0.5 mt-2">
           {worktree.issueNumber && (
             <IssueBadge
               issueNumber={worktree.issueNumber}


### PR DESCRIPTION
## Summary

- Increases spacing between the branch name row and the issue/PR badge metadata in worktree cards, making the two tiers visually distinct
- Removes the uniform `space-y-1` from the header container and applies a targeted `mt-2` to the metadata section, so the identity row reads as the primary element when scanning the sidebar

Resolves #2934

## Changes

The fix is entirely in `WorktreeHeader.tsx` with two small adjustments:

- Removed `space-y-1` from the outer container div, which was applying uniform 4px gaps between all rows
- Added `mt-2` (8px) to the metadata badge container, creating a clear visual break between the branch name and the issue/PR badges below it

Cards without badges are unaffected since the `mt-2` only applies when the metadata section renders.

## Testing

- Linting and formatting pass cleanly (`npm run fix`, 0 errors)
- Verified the change is spacing-only, no borders or background fills introduced