### PR TITLE
fix(worktree): compact issue/PR badges to single row on worktree card

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -24,7 +24,6 @@ import {
   AlertCircle,
   Check,
   CircleDot,
-  CornerDownRight,
   GitPullRequest,
   MoreHorizontal,
   House,
@@ -83,7 +82,7 @@ const IssueBadge = memo(function IssueBadge({
               e.stopPropagation();
               onOpen?.();
             }}
-            className="flex items-center gap-1.5 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0"
+            className="flex items-center gap-1.5 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent shrink-0"
             aria-label={
               issueTitle
                 ? `Open issue #${issueNumber}: ${issueTitle}`
@@ -91,9 +90,7 @@ const IssueBadge = memo(function IssueBadge({
             }
           >
             <CircleDot className="w-3 h-3 text-github-open shrink-0" aria-hidden="true" />
-            <span className="truncate text-canopy-text/90 flex-1 min-w-0">
-              {issueTitle || <span className="text-github-open font-mono">#{issueNumber}</span>}
-            </span>
+            <span className="text-github-open font-mono">#{issueNumber}</span>
           </button>
         </TooltipTrigger>
         <TooltipContent side="right" align="start" className="p-3">
@@ -116,17 +113,10 @@ interface PRBadgeProps {
   prNumber: number;
   prState?: "open" | "merged" | "closed";
   worktreePath: string;
-  isSubordinate: boolean;
   onOpen?: () => void;
 }
 
-const PRBadge = memo(function PRBadge({
-  prNumber,
-  prState,
-  worktreePath,
-  isSubordinate,
-  onOpen,
-}: PRBadgeProps) {
+const PRBadge = memo(function PRBadge({ prNumber, prState, worktreePath, onOpen }: PRBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { data, loading, error, fetchTooltip, reset } = usePRTooltip(worktreePath, prNumber);
 
@@ -161,15 +151,9 @@ const PRBadge = memo(function PRBadge({
               e.stopPropagation();
               onOpen?.();
             }}
-            className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+            className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent shrink-0"
             aria-label={`Open ${prStateLabel} pull request #${prNumber} on GitHub`}
           >
-            {isSubordinate && (
-              <CornerDownRight
-                className="w-3 h-3 text-canopy-text/30 shrink-0"
-                aria-hidden="true"
-              />
-            )}
             <GitPullRequest className={cn("w-3 h-3 shrink-0", prStateColor)} aria-hidden="true" />
             <span className={cn("font-mono", prStateColor)}>#{prNumber}</span>
           </button>
@@ -427,7 +411,7 @@ export function WorktreeHeader({
       </div>
 
       {(worktree.issueNumber || (worktree.prNumber && worktree.prState !== "closed")) && (
-        <div className="flex flex-col gap-0.5 mt-2">
+        <div className="flex items-center gap-1.5 mt-2">
           {worktree.issueNumber && (
             <IssueBadge
               issueNumber={worktree.issueNumber}
@@ -441,7 +425,6 @@ export function WorktreeHeader({
               prNumber={worktree.prNumber}
               prState={worktree.prState}
               worktreePath={worktree.path}
-              isSubordinate={!!worktree.issueNumber}
               onOpen={badges.onOpenPR}
             />
           )}


### PR DESCRIPTION
## Summary

- Collapses the issue and PR badges from two stacked rows into a single horizontal row, reducing worktree card height when both are present
- Replaces the full inline issue title with a compact `#number` identifier (the full title is still available via tooltip on hover)
- Removes the `CornerDownRight` subordination arrow from PR badges since the parent-child relationship is implied by position

Resolves #2935

## Changes

All changes are in `src/components/Worktree/WorktreeCard/WorktreeHeader.tsx`:

- Changed the badge container from `flex-col gap-0.5` to `flex items-center gap-1.5` for horizontal layout
- Simplified `IssueBadge` to show only `#number` in mono font instead of the full issue title
- Removed the `isSubordinate` prop and `CornerDownRight` icon from `PRBadge`
- Added `shrink-0` to both badges so they hold their size in the flex row
- Removed the unused `CornerDownRight` import from lucide-react

## Testing

- TypeScript compilation passes with no errors
- ESLint and Prettier report no issues
- Cards with only an issue, only a PR, or both display correctly in the single-row layout
- Tooltip hover behavior preserved for both badges