### PR TITLE
fix(github): display issue labels in GitHub issues dropdown

### DIFF
--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -47,7 +47,7 @@ function getLabelStyles(color: string): React.CSSProperties {
   return {
     backgroundColor: `color-mix(in oklab, ${hex} 15%, transparent)`,
     border: `1px solid color-mix(in oklab, ${hex} 40%, transparent)`,
-    color: `color-mix(in oklab, ${hex} 85%, white)`,
+    color: `color-mix(in oklab, ${hex} 65%, white)`,
   };
 }
 
@@ -290,7 +290,11 @@ export function GitHubListItem({ item, type, onCreateWorktree }: GitHubListItemP
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="text-[10px] text-muted-foreground cursor-default shrink-0">
+                      <span
+                        className="text-[10px] text-muted-foreground cursor-default shrink-0"
+                        tabIndex={0}
+                        role="note"
+                      >
                         +{overflowLabels.length}
                       </span>
                     </TooltipTrigger>


### PR DESCRIPTION
## Summary

- Renders issue labels as colored pills in the GitHub issues dropdown, using data that was already fetched but never displayed
- Adapts GitHub's light-theme label colors for the dark UI using `color-mix(in oklab, ...)`, which correctly handles gray/achromatic colors without the hue-shift artifacts that `oklch()` produces
- Shows up to 3 labels inline with a `+N` tooltip for overflow, keeping the row compact

Resolves #2864

## Changes

- `src/components/GitHub/GitHubListItem.tsx`: Added `getLabelStyles()` helper that produces muted background, semi-transparent border, and bright text from the raw hex color. Label pills render below the existing metadata row with truncation at 120px. Overflow labels collapse to a `+N` indicator with a tooltip listing remaining names.

## Testing

- Typecheck passes (`tsc --noEmit`)
- Lint and format pass with zero errors
- PR and commit items remain visually unchanged since labels only render for issue items