### PR TITLE
feat(toolbar): visually separate AI agent buttons from tool buttons

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -57,6 +57,14 @@ import { VoiceRecordingToolbarButton } from "./VoiceRecordingToolbarButton";
 import { useUIStore } from "@/store/uiStore";
 import { useShallow } from "zustand/react/shallow";
 
+const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
+  "agent-setup",
+  "claude",
+  "gemini",
+  "codex",
+  "opencode",
+]);
+
 interface ToolbarProps {
   onLaunchAgent: (
     type: "claude" | "gemini" | "codex" | "opencode" | "terminal" | "browser"
@@ -937,6 +945,27 @@ export function Toolbar({
       .map((id) => buttonRegistry[id].render());
   };
 
+  const renderLeftButtons = (buttonIds: ToolbarButtonId[]) => {
+    const visible = buttonIds.filter((id) => buttonRegistry[id]?.isAvailable);
+    const elements: React.ReactNode[] = [];
+    for (let i = 0; i < visible.length; i++) {
+      elements.push(buttonRegistry[visible[i]].render());
+      if (
+        i < visible.length - 1 &&
+        AGENT_TOOLBAR_IDS.has(visible[i]) !== AGENT_TOOLBAR_IDS.has(visible[i + 1])
+      ) {
+        elements.push(
+          <div
+            key={`group-divider-${i}`}
+            className="w-px h-5 bg-white/[0.08] mx-1"
+            aria-hidden="true"
+          />
+        );
+      }
+    }
+    return elements;
+  };
+
   const isDropdownOpen = projectSwitcher.isOpen && projectSwitcher.mode === "dropdown";
   const handleDropdownClose = useCallback(() => {
     if (projectSwitcher.mode !== "dropdown") return;
@@ -974,7 +1003,7 @@ export function Toolbar({
           <div className="w-px h-5 bg-white/[0.08] mx-1" />
 
           <div className="flex items-center gap-0.5">
-            {renderButtons(toolbarLayout.leftButtons)}
+            {renderLeftButtons(toolbarLayout.leftButtons)}
           </div>
         </div>
 

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -82,6 +82,24 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
   });
 
+  describe("Agent/tool button group divider — issue #2879", () => {
+    it("defines AGENT_TOOLBAR_IDS constant for group boundary detection", () => {
+      expect(source).toContain("AGENT_TOOLBAR_IDS");
+    });
+
+    it("has renderLeftButtons helper that inserts group dividers", () => {
+      expect(source).toContain("renderLeftButtons");
+    });
+
+    it("uses renderLeftButtons for the left button group", () => {
+      expect(source).toContain("renderLeftButtons(toolbarLayout.leftButtons)");
+    });
+
+    it("divider element has aria-hidden for accessibility", () => {
+      expect(source).toMatch(/group-divider[\s\S]{0,200}aria-hidden="true"/);
+    });
+  });
+
   describe("Project switcher trigger", () => {
     it("button has overflow-hidden for truncation", () => {
       // overflow-hidden appears in className before data-testid on the same button


### PR DESCRIPTION
## Summary

- Adds a subtle vertical divider between AI agent buttons (Claude, Gemini, Codex, OpenCode) and utility tool buttons (Terminal, Browser, Dev Preview) in the left toolbar section
- The grouping is semantic, not positional. It detects the boundary between agent and non-agent button IDs regardless of user-customized ordering
- Uses the same `w-px h-5 bg-white/[0.08]` divider style already established elsewhere in the toolbar for visual consistency

Resolves #2879

## Changes

- **`src/components/Layout/Toolbar.tsx`**: Added `AGENT_TOOLBAR_IDS` set and `renderLeftButtons()` helper that walks the visible button list and inserts a divider at each agent/tool boundary. Replaced the `renderButtons()` call for the left group with `renderLeftButtons()`.
- **`src/components/Layout/__tests__/Toolbar.layout.test.ts`**: Added structural tests verifying the `AGENT_TOOLBAR_IDS` constant exists, `renderLeftButtons` is used for the left group, and divider elements include `aria-hidden` for accessibility.

## Testing

- TypeScript compiles cleanly with `tsc --noEmit`
- ESLint passes (only pre-existing warnings, no new issues)
- Prettier confirms files are already formatted
- Existing toolbar layout tests pass alongside new test cases