### PR TITLE
test(e2e): add security property verification coverage

### DIFF
--- a/e2e/core/core-security.spec.ts
+++ b/e2e/core/core-security.spec.ts
@@ -23,10 +23,15 @@ test.describe.serial("Core: Security", () => {
   });
 
   test("main window uses secure webPreferences", async () => {
-    const prefs = await ctx.app.evaluate(({ BrowserWindow }) => {
-      const win = BrowserWindow.getAllWindows()[0];
-      return win?.webContents.getLastWebPreferences() ?? null;
-    });
+    const prefs = await ctx.app.evaluate(
+      ({ BrowserWindow }, { pageTitle }) => {
+        const win = BrowserWindow.getAllWindows().find(
+          (w) => w.webContents.getTitle() === pageTitle
+        );
+        return win?.webContents.getLastWebPreferences() ?? null;
+      },
+      { pageTitle: await ctx.window.title() }
+    );
     expect(prefs).not.toBeNull();
     expect(prefs!.contextIsolation).toBe(true);
     expect(prefs!.nodeIntegration).toBe(false);
@@ -37,6 +42,6 @@ test.describe.serial("Core: Security", () => {
     const content = await ctx.window
       .locator('meta[http-equiv="Content-Security-Policy"]')
       .getAttribute("content");
-    expect(content).toBeTruthy();
+    expect(content).toMatch(/\b(default-src|script-src)\b/);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a new `e2e/core/core-security.spec.ts` spec that verifies Electron's critical security properties at runtime
- Catches misconfigurations (leaked `require`/`process`, disabled `contextIsolation`, missing CSP) before they ship
- Runs in the core project with no fixtures, API keys, or network access required

Resolves #2905

## Changes

The spec covers four security assertions against a freshly launched app:

1. **`require` is undefined in the renderer** (Node.js not leaked)
2. **`process` is undefined in the renderer** (process not leaked)
3. **`webPreferences` confirm `contextIsolation: true`, `nodeIntegration: false`, `webSecurity: true`** via `getLastWebPreferences()` on the main window's `webContents`
4. **A Content-Security-Policy meta tag exists** with a valid `default-src` or `script-src` directive

The main window is matched by page title to avoid ambiguity when multiple windows exist. All tests share a single app launch via `test.describe.serial` with `beforeAll`/`afterAll`.

## Testing

Linting and formatting pass cleanly. The spec is platform-agnostic and should run on macOS, Linux, and Windows CI.