### PR TITLE
test(e2e): add worktree card interactions and multi-worktree coverage

### DIFF
--- a/e2e/core/core-worktree-cards.spec.ts
+++ b/e2e/core/core-worktree-cards.spec.ts
@@ -4,7 +4,7 @@ import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 import { getGridPanelCount } from "../helpers/panels";
 import { SEL } from "../helpers/selectors";
-import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
+import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 const MAIN = "main";
@@ -179,6 +179,8 @@ test.describe.serial("Core: Worktree Cards", () => {
     test("Escape dismisses the menu without side effects", async () => {
       const { window } = ctx;
 
+      // Wait for any panel creation from prior test to settle
+      await window.waitForTimeout(T_SETTLE);
       const panelsBefore = await getGridPanelCount(window);
 
       const featureCard = window.locator(SEL.worktree.card(FEATURE));


### PR DESCRIPTION
## Summary

- Adds a new E2E spec (`e2e/core/core-worktree-cards.spec.ts`) covering worktree card context menu interactions, multi-worktree switching behavior, and card status indicators
- Tests the actions menu open/dismiss flow, "Open Terminal" menu item triggering a terminal panel, multi-card visibility with selection state changes, and uncommitted changes indicator display
- Uses fixture repos with `withFeatureBranch` and `withUncommittedChanges` options to exercise realistic worktree scenarios

Resolves #2911

## Changes

- **`e2e/core/core-worktree-cards.spec.ts`** (new): Three test groups covering card context menu actions (open menu, select item, dismiss via Escape), multi-worktree behavior (3 cards visible, selection switching, panel isolation), and status indicators (uncommitted changes badge on dirty worktrees, clean state on unchanged ones)

## Testing

- Linting and formatting pass with zero errors (`npm run fix`)
- Tests follow established E2E patterns from `core-advanced.spec.ts` using `launchApp`, `createWorktree`, and existing selector helpers
- Structured to run in the `core` project without network access or API keys