### PR TITLE
test(e2e): add state persistence across app restart coverage

### DIFF
--- a/e2e/core/core-persistence.spec.ts
+++ b/e2e/core/core-persistence.spec.ts
@@ -3,7 +3,7 @@ import { launchApp, closeApp, waitForProcessExit, type AppContext } from "../hel
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 import { SEL } from "../helpers/selectors";
-import { T_SHORT, T_MEDIUM } from "../helpers/timeouts";
+import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import path from "path";
@@ -18,7 +18,9 @@ test.describe.serial("Persistence: Settings across restart", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) {
+      const pid = ctx.app.process().pid;
       await closeApp(ctx.app);
+      if (pid) await waitForProcessExit(pid).catch(() => {});
       ctx = null;
     }
     rmSync(userDataDir, { recursive: true, force: true });
@@ -43,11 +45,12 @@ test.describe.serial("Persistence: Settings across restart", () => {
     await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
 
     await w1.keyboard.press("Escape");
+    await w1.waitForTimeout(T_SETTLE);
 
     const pid = ctx.app.process().pid!;
     await closeApp(ctx.app);
-    ctx = null;
     await waitForProcessExit(pid);
+    ctx = null;
 
     // Session 2: Relaunch with same userDataDir, verify toggle persisted
     ctx = await launchApp({ userDataDir });
@@ -79,7 +82,9 @@ test.describe.serial("Persistence: Project memory across restart", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) {
+      const pid = ctx.app.process().pid;
       await closeApp(ctx.app);
+      if (pid) await waitForProcessExit(pid).catch(() => {});
       ctx = null;
     }
     rmSync(userDataDir, { recursive: true, force: true });
@@ -97,8 +102,8 @@ test.describe.serial("Persistence: Project memory across restart", () => {
 
     const pid = ctx.app.process().pid!;
     await closeApp(ctx.app);
-    ctx = null;
     await waitForProcessExit(pid);
+    ctx = null;
 
     // Session 2: Relaunch with same userDataDir, verify project is remembered
     ctx = await launchApp({ userDataDir });

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -149,7 +149,11 @@ export async function waitForProcessExit(pid: number, timeoutMs = 15_000): Promi
   while (Date.now() < deadline) {
     try {
       process.kill(pid, 0);
-    } catch {
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "EPERM") {
+        await wait(100);
+        continue;
+      }
       return;
     }
     await wait(100);


### PR DESCRIPTION
## Summary

- Adds E2E tests verifying that settings and project state survive a full app restart cycle (close + relaunch with the same `userDataDir`)
- Introduces a `waitForProcessExit` helper to ensure the Electron process fully exits before relaunching, preventing file handle conflicts on Windows

Resolves #2906

## Changes

**`e2e/core/core-persistence.spec.ts`** (new)
- Settings persistence test: toggles performance mode on, closes the app, relaunches, and confirms the toggle is still enabled
- Project memory test: onboards a project, closes the app, relaunches, and verifies the project appears in the project switcher
- Each test group uses its own isolated `userDataDir` via `mkdtempSync`, cleaned up in `afterAll`

**`e2e/helpers/launch.ts`**
- Added `waitForProcessExit(pid, timeoutMs)` that polls `process.kill(pid, 0)` until the process is gone, handling `EPERM` on Windows gracefully. Used between close and relaunch to guarantee disk writes are flushed.

## Testing

Both test groups use `test.describe.serial` to enforce the launch/close/relaunch ordering. The tests run in the `core` project without network access or API keys.