### PR TITLE
feat(worktree): improve branch type icons for better semantic clarity

### DIFF
--- a/src/components/Worktree/BranchLabel.tsx
+++ b/src/components/Worktree/BranchLabel.tsx
@@ -4,35 +4,35 @@ import { middleTruncate } from "../../utils/textParsing";
 import { BRANCH_PREFIX_MAP, DEFAULT_BRANCH_TYPE } from "@shared/config/branchPrefixes";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import {
+  BookOpen,
   Bug,
-  FileText,
+  Construction,
   FlaskConical,
   GitBranch,
-  Hammer,
   Infinity as InfinityIcon,
+  Layers,
+  Lightbulb,
   Package,
   Palette,
   Rocket,
-  RotateCw,
-  Sparkles,
   Wrench,
   Zap,
   type LucideIcon,
 } from "lucide-react";
 
 const BRANCH_TYPE_ICONS: Record<string, LucideIcon> = {
-  feature: Sparkles,
+  feature: Lightbulb,
   bugfix: Bug,
   chore: Wrench,
-  docs: FileText,
-  refactor: RotateCw,
+  docs: BookOpen,
+  refactor: Layers,
   test: FlaskConical,
   release: Rocket,
   ci: InfinityIcon,
   deps: Package,
   perf: Zap,
   style: Palette,
-  wip: Hammer,
+  wip: Construction,
   other: GitBranch,
 };
 


### PR DESCRIPTION
## Summary

- Replaced four branch type icons in the `BRANCH_TYPE_ICONS` map that had poor semantic clarity or degraded at 14px render size
- `feature`: Sparkles → Lightbulb (matches GitHub/GitLab feature request convention)
- `docs`: FileText → BookOpen (distinct silhouette that stays legible at 14px with 2.5px stroke)
- `refactor`: RotateCw → Layers (communicates structural rearrangement instead of "reload")
- `wip`: Hammer → Construction (visually distinct from the Wrench used for chore branches)

Resolves #3069

## Changes

All changes are in `src/components/Worktree/BranchLabel.tsx`:
- Updated icon imports from `lucide-react` (added BookOpen, Construction, Layers, Lightbulb; removed FileText, Hammer, RotateCw, Sparkles)
- Updated the `BRANCH_TYPE_ICONS` record with the new mappings
- No logic changes, purely visual

## Testing

- Typecheck passes (`tsc --noEmit`)
- Lint and format pass (`npm run fix` with 0 errors)
- All four replacement icons have distinct geometric silhouettes at 14px and avoid semantic overlap with other icons in the set