### PR TITLE
fix(worktree): reorder secondary row so PR badge appears above branch label

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -464,14 +464,6 @@ export function WorktreeHeader({
         (worktree.issueNumber && !hasIssueTitle) ||
         (worktree.prNumber && worktree.prState !== "closed")) && (
         <div className="flex flex-col gap-0.5 mt-1.5">
-          {hasIssueTitle && (
-            <BranchLabel
-              label={branchLabel}
-              isActive={isActive}
-              isMuted={isMuted}
-              isMainWorktree={false}
-            />
-          )}
           {worktree.issueNumber && !hasIssueTitle && (
             <IssueBadge
               issueNumber={worktree.issueNumber}
@@ -486,6 +478,14 @@ export function WorktreeHeader({
               isSubordinate={!!worktree.issueNumber}
               worktreePath={worktree.path}
               onOpen={badges.onOpenPR}
+            />
+          )}
+          {hasIssueTitle && (
+            <BranchLabel
+              label={branchLabel}
+              isActive={isActive}
+              isMuted={isMuted}
+              isMainWorktree={false}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary

- Reorders the secondary row in `WorktreeHeader` so the PR badge renders directly beneath the issue title, with the branch label below it
- When the worktree title is the branch (no linked issue), ordering is unchanged

Resolves #3092

## Changes

The `BranchLabel` block in the secondary row of `WorktreeHeader.tsx` was moved after the `PullRequestBadge` block. This only affects the case where `hasIssueTitle` is true, so when the branch name is the headline (no issue), the PR badge still appears beneath the branch as before.

The visual hierarchy now reads: issue title, PR badge (with subordinate arrow), branch label. This matches the logical relationship where a PR is derived from the issue, not from the branch.

## Testing

Verified the conditional rendering logic covers both cases described in the acceptance criteria. The `hasIssueTitle` guard on the `BranchLabel` block means the reorder only applies when an issue is the headline title.