### PR TITLE
fix(github): simplify commit list hash UX and remove type color coding

### DIFF
--- a/src/components/GitHub/CommitListItem.tsx
+++ b/src/components/GitHub/CommitListItem.tsx
@@ -1,11 +1,11 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import type { MouseEvent } from "react";
-import { GitCommitHorizontal, Copy, Check } from "lucide-react";
+import { GitCommitHorizontal, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import type { GitCommit } from "@shared/types/github";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
-import { parseConventionalCommit, getCommitTypeColor } from "./commitListUtils";
+import { parseConventionalCommit } from "./commitListUtils";
 
 interface CommitListItemProps {
   commit: GitCommit;
@@ -52,9 +52,7 @@ export function CommitListItem({ commit, optionId, isActive }: CommitListItemPro
       return <span className="text-sm font-medium text-foreground truncate">{commit.message}</span>;
     }
 
-    const typeColor = parsed.breaking
-      ? "text-status-danger font-bold"
-      : getCommitTypeColor(parsed.type);
+    const typeColor = parsed.breaking ? "text-status-danger font-bold" : "text-muted-foreground";
 
     return (
       <span className="text-sm font-medium truncate">
@@ -100,25 +98,14 @@ export function CommitListItem({ commit, optionId, isActive }: CommitListItemPro
                     type="button"
                     onClick={handleCopyHash}
                     className={cn(
-                      "font-mono hover:text-foreground transition-colors flex items-center gap-1",
+                      "font-mono hover:text-foreground transition-colors flex items-center",
                       copied && "text-status-success"
                     )}
                   >
-                    <span>{commit.shortHash}</span>
-                    <span className="relative h-3 w-3 shrink-0">
-                      <Copy
-                        className={cn(
-                          "absolute inset-0 h-3 w-3 transition-opacity",
-                          copied ? "opacity-0" : "opacity-0 group-hover:opacity-100"
-                        )}
-                      />
-                      <Check
-                        className={cn(
-                          "absolute inset-0 h-3 w-3 transition-opacity",
-                          copied ? "opacity-100" : "opacity-0"
-                        )}
-                      />
+                    <span className="inline-flex items-center justify-center w-3 shrink-0">
+                      {copied ? <Check className="h-3 w-3" /> : <span>#</span>}
                     </span>
+                    <span>{commit.shortHash}</span>
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">

--- a/src/components/GitHub/__tests__/commitListUtils.test.ts
+++ b/src/components/GitHub/__tests__/commitListUtils.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   parseConventionalCommit,
-  getCommitTypeColor,
   getCommitDateGroupLabel,
   buildGroupedRows,
 } from "../commitListUtils";
@@ -87,31 +86,6 @@ describe("parseConventionalCommit", () => {
       breaking: false,
       description: "button alignment",
     });
-  });
-});
-
-describe("getCommitTypeColor", () => {
-  it("returns green for feat", () => {
-    expect(getCommitTypeColor("feat")).toBe("text-category-green");
-  });
-
-  it("returns rose for fix", () => {
-    expect(getCommitTypeColor("fix")).toBe("text-category-rose");
-  });
-
-  it("is case-insensitive", () => {
-    expect(getCommitTypeColor("FEAT")).toBe("text-category-green");
-    expect(getCommitTypeColor("Fix")).toBe("text-category-rose");
-  });
-
-  it("returns muted for unknown types", () => {
-    expect(getCommitTypeColor("unknown")).toBe("text-muted-foreground");
-  });
-
-  it("returns muted for chore/build/ci", () => {
-    expect(getCommitTypeColor("chore")).toBe("text-muted-foreground");
-    expect(getCommitTypeColor("build")).toBe("text-muted-foreground");
-    expect(getCommitTypeColor("ci")).toBe("text-muted-foreground");
   });
 });
 

--- a/src/components/GitHub/commitListUtils.ts
+++ b/src/components/GitHub/commitListUtils.ts
@@ -18,24 +18,6 @@ export function parseConventionalCommit(message: string): ParsedCommit | null {
   return { type, scope: trimmedScope, breaking: !!breakingMark, description };
 }
 
-const COMMIT_TYPE_COLORS: Record<string, string> = {
-  feat: "text-category-green",
-  fix: "text-category-rose",
-  docs: "text-category-teal",
-  style: "text-category-purple",
-  refactor: "text-category-purple",
-  perf: "text-category-amber",
-  test: "text-category-cyan",
-  chore: "text-muted-foreground",
-  build: "text-muted-foreground",
-  ci: "text-muted-foreground",
-  revert: "text-category-orange",
-};
-
-export function getCommitTypeColor(type: string): string {
-  return COMMIT_TYPE_COLORS[type.toLowerCase()] ?? "text-muted-foreground";
-}
-
 function dayMidnightMs(date: Date): number {
   return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 }


### PR DESCRIPTION
## Summary

- Removed per-type color coding from conventional commit prefixes in the commit list. All type labels now render in a uniform muted color, cutting down on visual noise. Breaking-change indicators still use danger color.
- Replaced the hover-triggered copy icon on commit hashes with a persistent `#` prefix. Clicking the hash copies it to clipboard, and the `#` briefly becomes a checkmark for feedback.

Resolves #3120

## Changes

- **`CommitListItem.tsx`** — Removed `Copy` icon import and the hover-show/hide icon logic. Hash now shows `#` prefix that swaps to a `Check` icon for 2s after copy. Commit type color simplified to a single `text-muted-foreground` class (with `text-status-danger` retained for breaking changes).
- **`commitListUtils.ts`** — Removed `COMMIT_TYPE_COLORS` map and `getCommitTypeColor` function entirely.
- **`commitListUtils.test.ts`** — Removed the `getCommitTypeColor` test suite and its import.

## Testing

Typecheck, ESLint, and Prettier all pass (`npm run check`). Existing tests for `parseConventionalCommit`, `getCommitDateGroupLabel`, and `buildGroupedRows` continue to pass.