### PR TITLE
fix(panel): use DropdownMenuItem for agent settings in overflow menu

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -625,11 +625,7 @@ function PanelHeaderComponent({
               {headerActions && ((canRestart && !!onRestart) || showCancelWatch) && (
                 <DropdownMenuSeparator />
               )}
-              {headerActions && (
-                <div role="presentation" onKeyDown={(e) => e.stopPropagation()}>
-                  {headerActions}
-                </div>
-              )}
+              {headerActions}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -37,7 +37,7 @@ import { HybridInputBar, type HybridInputBarHandle } from "./HybridInputBar";
 import { getTerminalFocusTarget } from "./terminalFocus";
 import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 import { getCanopyCommand, isEscapedCommand, unescapeCommand } from "./canopySlashCommands";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 export type { TerminalType };
 
@@ -558,28 +558,18 @@ function TerminalPaneComponent({
     const agentConfig = getAgentConfig(effectiveAgentId);
     const agentName = agentConfig?.name ?? effectiveAgentId;
     return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                void actionService.dispatch(
-                  "app.settings.openTab",
-                  { tab: "agents", subtab: effectiveAgentId },
-                  { source: "user" }
-                );
-              }}
-              className="p-1 rounded-[var(--radius-sm)] text-canopy-text/50 hover:text-canopy-text hover:bg-canopy-text/10 transition-colors"
-              aria-label={`Configure ${agentName} settings`}
-            >
-              <Settings className="w-3 h-3" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{agentName} Settings</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      <DropdownMenuItem
+        onSelect={() =>
+          void actionService.dispatch(
+            "app.settings.openTab",
+            { tab: "agents", subtab: effectiveAgentId },
+            { source: "user" }
+          )
+        }
+      >
+        <Settings className="w-3 h-3 mr-2" />
+        {agentName} Settings
+      </DropdownMenuItem>
     );
   }, [effectiveAgentId]);
 


### PR DESCRIPTION
## Summary

- Replaced the standalone tooltip-wrapped button for agent settings with a proper `DropdownMenuItem` in the panel overflow menu
- Removed the unnecessary `<div role="presentation">` wrapper in `PanelHeader.tsx` that was preventing `headerActions` from integrating with the dropdown menu styling

Resolves #3101

## Changes

- **`src/components/Terminal/TerminalPane.tsx`** — Swapped the `TooltipProvider`/`Tooltip`/`button` structure for a `DropdownMenuItem` with `onSelect`. The agent settings entry now uses the same component, height, padding, hover/focus states, and keyboard navigation as "Restart Session" and "Move to Dock".
- **`src/components/Panel/PanelHeader.tsx`** — Removed the `<div role="presentation">` wrapper around `headerActions`, so injected menu items render directly inside `DropdownMenuContent` as proper menu items.

## Testing

- Typecheck, lint, and format all pass (`npm run fix` with 0 errors)
- Non-agent panels are unaffected since `headerActions` is only set for agent panels