### PR TITLE
fix(dock): prevent popover dismissal when interacting with panel header buttons

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -38,6 +38,7 @@ import {
 import { SortableTabButton } from "@/components/Panel/SortableTabButton";
 import type { TabGroup } from "@/types";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import { handleDockInteractOutside } from "./dockPopoverGuard";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface DockedTabGroupProps {
@@ -462,6 +463,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         align="start"
         sideOffset={10}
         collisionPadding={collisionPadding}
+        onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
         onEscapeKeyDown={(e) => e.preventDefault()}
         onOpenAutoFocus={(event) => {
           event.preventDefault();

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -19,6 +19,7 @@ import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useDockPanelPortal } from "./DockPanelOffscreenContainer";
 import { useDockBlockedState } from "./useDockBlockedState";
+import { handleDockInteractOutside } from "./dockPopoverGuard";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface DockedTerminalItemProps {
@@ -293,6 +294,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         align="start"
         sideOffset={10}
         collisionPadding={collisionPadding}
+        onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
         onEscapeKeyDown={(e) => e.preventDefault()}
         onOpenAutoFocus={(event) => {
           event.preventDefault();

--- a/src/components/Layout/__tests__/dockPopoverGuard.test.ts
+++ b/src/components/Layout/__tests__/dockPopoverGuard.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { handleDockInteractOutside } from "../dockPopoverGuard";
+
+function makeEvent(target: EventTarget | null): Event & { preventDefault: () => void } {
+  const preventDefault = vi.fn();
+  return { target, preventDefault } as unknown as Event & { preventDefault: () => void };
+}
+
+describe("handleDockInteractOutside", () => {
+  it("prevents dismissal when target is inside the portal container", () => {
+    const container = document.createElement("div");
+    const button = document.createElement("button");
+    container.appendChild(button);
+    document.body.appendChild(container);
+
+    const event = makeEvent(button);
+    handleDockInteractOutside(event, container);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    container.remove();
+  });
+
+  it("prevents dismissal when target is inside a Radix popper wrapper", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-radix-popper-content-wrapper", "");
+    const menuItem = document.createElement("div");
+    wrapper.appendChild(menuItem);
+    document.body.appendChild(wrapper);
+
+    const event = makeEvent(menuItem);
+    handleDockInteractOutside(event, null);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    wrapper.remove();
+  });
+
+  it("allows dismissal when target is outside both guards", () => {
+    const container = document.createElement("div");
+    const outsideElement = document.createElement("div");
+    document.body.appendChild(container);
+    document.body.appendChild(outsideElement);
+
+    const event = makeEvent(outsideElement);
+    handleDockInteractOutside(event, container);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    container.remove();
+    outsideElement.remove();
+  });
+
+  it("does nothing for non-Element targets", () => {
+    const event = makeEvent(document.createTextNode("text"));
+    handleDockInteractOutside(event, null);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("handles null portal container gracefully", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-radix-popper-content-wrapper", "");
+    const child = document.createElement("span");
+    wrapper.appendChild(child);
+    document.body.appendChild(wrapper);
+
+    const event = makeEvent(child);
+    handleDockInteractOutside(event, null);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    wrapper.remove();
+  });
+});
+
+describe("Dock popover guard integration", () => {
+  it("DockedTerminalItem uses onInteractOutside with handleDockInteractOutside", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+
+    const filePath = path.resolve(__dirname, "../DockedTerminalItem.tsx");
+    const content = await fs.readFile(filePath, "utf-8");
+
+    expect(content).toContain("handleDockInteractOutside");
+    expect(content).toContain("onInteractOutside");
+  });
+
+  it("DockedTabGroup uses onInteractOutside with handleDockInteractOutside", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+
+    const filePath = path.resolve(__dirname, "../DockedTabGroup.tsx");
+    const content = await fs.readFile(filePath, "utf-8");
+
+    expect(content).toContain("handleDockInteractOutside");
+    expect(content).toContain("onInteractOutside");
+  });
+});

--- a/src/components/Layout/dockPopoverGuard.ts
+++ b/src/components/Layout/dockPopoverGuard.ts
@@ -1,0 +1,25 @@
+/**
+ * Prevents Radix Popover from dismissing when the user interacts with elements
+ * inside a dock panel rendered via createPortal (which breaks the React context
+ * chain that Radix's DismissableLayer relies on for nested floating elements).
+ */
+export function handleDockInteractOutside(
+  event: Event & { preventDefault: () => void },
+  portalContainer: HTMLElement | null
+) {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  // Guard 1: Click originated inside the dock panel's portal container
+  if (portalContainer?.contains(target)) {
+    event.preventDefault();
+    return;
+  }
+
+  // Guard 2: Click is on a Radix floating element (DropdownMenu, Tooltip, Select, etc.)
+  // portaled to document.body — these carry data-radix-popper-content-wrapper
+  if (target.closest("[data-radix-popper-content-wrapper]")) {
+    event.preventDefault();
+    return;
+  }
+}


### PR DESCRIPTION
## Summary

- Dock panel popovers were closing prematurely when clicking panel header buttons (overflow menu, restore, close) because the panel DOM is rendered via `createPortal` from outside the Radix `Popover` React context tree. Radix's `DismissableLayer` treated these interactions as outside clicks.
- Added an `onInteractOutside` guard that checks whether the click target is inside the dock panel's portal container or a Radix floating element (dropdown, tooltip, etc.) before allowing dismissal.

Resolves #3109

## Changes

- **`dockPopoverGuard.ts`** (new): Shared handler that prevents `event.preventDefault()` from firing when the interaction target is inside the portal container or a `[data-radix-popper-content-wrapper]` element.
- **`DockedTerminalItem.tsx`**: Wired up `onInteractOutside` on `PopoverContent` using the guard.
- **`DockedTabGroup.tsx`**: Same change for tab group dock popovers.
- **`dockPopoverGuard.test.ts`** (new): Unit tests covering portal container clicks, Radix floating element clicks, outside clicks, and edge cases (null container, non-Element targets). Integration tests verify both consumer components import and use the guard.

## Testing

All new tests pass. Existing lint and typecheck pass with no regressions (only pre-existing warnings).