### PR TITLE
feat(e2e): add E2E online test for OpenCode agent

### DIFF
--- a/.github/workflows/e2e-online.yml
+++ b/.github/workflows/e2e-online.yml
@@ -117,6 +117,9 @@ jobs:
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Install OpenCode
+        run: npm install -g opencode-ai
+
       - name: Configure Claude Code (macOS/Linux)
         if: runner.os != 'Windows'
         run: |

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -138,6 +138,10 @@ export const SEL = {
     panel: '[aria-label^="Claude agent:"]',
     startButton: '[aria-label="Start Claude Agent"]',
   },
+  opencodeAgent: {
+    panel: '[aria-label^="OpenCode agent:"]',
+    startButton: '[aria-label="Start OpenCode Agent"]',
+  },
   fileViewer: {
     dialog: '[data-testid="file-viewer-dialog"]',
     closeButton: '[aria-label="Close dialog"]',

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from "@playwright/test";
+import { launchApp, closeApp, mockOpenDialog, type AppContext } from "../helpers/launch";
+import { createFixtureRepo } from "../helpers/fixtures";
+import { dismissTelemetryConsent } from "../helpers/project";
+import { getTerminalText } from "../helpers/terminal";
+import { SEL } from "../helpers/selectors";
+
+let ctx: AppContext;
+let fixtureDir: string;
+
+test.describe("OpenCode Online Flow", () => {
+  test.beforeAll(async () => {
+    fixtureDir = createFixtureRepo({ name: "opencode-online" });
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+  });
+
+  test("full OpenCode agent interaction", async () => {
+    await test.step("launch app", async () => {
+      ctx = await launchApp();
+    });
+
+    await test.step("open folder and complete onboarding", async () => {
+      const { app, window } = ctx;
+
+      await mockOpenDialog(app, fixtureDir);
+      await window.getByRole("button", { name: "Open Folder" }).click();
+
+      const heading = window.locator("h2", { hasText: "Set up your project" });
+      await expect(heading).toBeVisible({ timeout: 10_000 });
+
+      const nameInput = window.getByRole("textbox", { name: "Project Name" });
+      await nameInput.fill("OpenCode Online Test");
+
+      await window.getByRole("button", { name: "Finish" }).click();
+      await expect(heading).not.toBeVisible({ timeout: 5_000 });
+
+      await dismissTelemetryConsent(window);
+    });
+
+    await test.step("launch OpenCode agent", async () => {
+      const { window } = ctx;
+
+      await window.locator(SEL.opencodeAgent.startButton).click();
+
+      const agentPanel = window.locator(SEL.opencodeAgent.panel);
+      await expect(agentPanel).toBeVisible({ timeout: 5_000 });
+    });
+
+    await test.step("handle prompts and wait for ready state", async () => {
+      const { window } = ctx;
+      const agentPanel = window.locator(SEL.opencodeAgent.panel);
+      const cmEditor = agentPanel.locator(SEL.terminal.cmEditor);
+
+      const deadline = Date.now() + 90_000;
+      let reachedReady = false;
+
+      while (Date.now() < deadline && !reachedReady) {
+        await dismissTelemetryConsent(window);
+
+        const text = await getTerminalText(agentPanel);
+        const lower = text.toLowerCase();
+
+        if (lower.includes("ask anything") || /build\s+opencode/i.test(text)) {
+          reachedReady = true;
+        } else if (lower.includes("provider") || lower.includes("/connect")) {
+          await cmEditor.click();
+          await window.keyboard.press("Enter");
+          await window.waitForTimeout(2_000);
+        } else if (lower.includes("api key")) {
+          await cmEditor.click();
+          await window.keyboard.press("ArrowUp");
+          await window.keyboard.press("Enter");
+          await window.waitForTimeout(2_000);
+        } else {
+          await window.waitForTimeout(1_000);
+        }
+      }
+
+      expect(reachedReady).toBe(true);
+    });
+
+    await test.step("send hello world command", async () => {
+      const { window } = ctx;
+
+      const agentPanel = window.locator(SEL.opencodeAgent.panel);
+      const cmEditor = agentPanel.locator(SEL.terminal.cmEditor);
+      await cmEditor.click();
+      await cmEditor.pressSequentially("Please say hello world", { delay: 30 });
+      await window.keyboard.press("Enter");
+    });
+
+    await test.step("verify response contains hello", async () => {
+      const { window } = ctx;
+
+      const agentPanel = window.locator(SEL.opencodeAgent.panel);
+
+      await expect
+        .poll(
+          async () => {
+            const text = await getTerminalText(agentPanel);
+            return text.toLowerCase().split("hello").length - 1;
+          },
+          { timeout: 60_000, intervals: [1_000] }
+        )
+        .toBeGreaterThanOrEqual(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an end-to-end online test for the OpenCode agent, mirroring the existing Claude agent test structure
- Updates the CI workflow to install OpenCode CLI alongside Claude Code
- Extends the shared selectors with OpenCode-specific panel and button locators

Resolves #3035

## Changes

**`e2e/online/opencode-online.spec.ts`** (new): Full OpenCode agent interaction test covering app launch, folder onboarding, agent start, prompt handling (provider selection, API key), ready state detection (`"Ask anything"` / `"Build OpenCode"`), sending a message, and verifying the response.

**`e2e/helpers/selectors.ts`**: Added `opencodeAgent` selector group with `panel` and `startButton` entries matching the existing aria-label conventions.

**`.github/workflows/e2e-online.yml`**: Added an "Install OpenCode" step (`npm install -g opencode-ai`) so the CLI is available during online test runs. No new secrets required since OpenCode uses the existing `ANTHROPIC_API_KEY`.

## Testing

- TypeScript typecheck passes (`tsc --noEmit`)
- ESLint and Prettier pass with no new errors
- Test structure follows the established pattern in `claude-online.spec.ts`