### PR TITLE
refactor(store): remove duplicate dynamic imports of TerminalInstanceService

### DIFF
--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -26,6 +26,7 @@ import {
 } from "@/services/projectSwitchRendererCache";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
 interface ProjectState {
   projects: Project[];
@@ -111,20 +112,18 @@ function evictRendererTerminalInstances(terminalIds: string[]): void {
     return;
   }
 
-  void import("@/services/TerminalInstanceService")
-    .then(({ terminalInstanceService }) => {
-      for (const terminalId of terminalIds) {
-        terminalInstanceService.destroy(terminalId);
-      }
-    })
-    .catch((error) => {
-      logErrorWithContext(error, {
-        operation: "evict_project_switch_terminal_instances",
-        component: "projectStore",
-        errorType: "process",
-        details: { terminalCount: terminalIds.length },
-      });
+  try {
+    for (const terminalId of terminalIds) {
+      terminalInstanceService.destroy(terminalId);
+    }
+  } catch (error) {
+    logErrorWithContext(error, {
+      operation: "evict_project_switch_terminal_instances",
+      component: "projectStore",
+      errorType: "process",
+      details: { terminalCount: terminalIds.length },
     });
+  }
 }
 
 const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
@@ -272,7 +271,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
           .map(terminalToSnapshot);
 
         const terminalSizes: Record<string, { cols: number; rows: number }> = {};
-        const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
         for (const terminal of currentTerminals) {
           const instance = terminalInstanceService.get(terminal.id);
           if (instance) {
@@ -604,7 +602,6 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
           .map(terminalToSnapshot);
 
         const terminalSizes: Record<string, { cols: number; rows: number }> = {};
-        const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
         for (const terminal of currentTerminals) {
           const instance = terminalInstanceService.get(terminal.id);
           if (instance) {

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -427,7 +427,6 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
     reset: async () => {
       const state = get();
 
-      const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
       for (const terminal of state.terminals) {
         try {
           terminalInstanceService.destroy(terminal.id);
@@ -468,8 +467,6 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
       const state = get();
 
       flushTerminalPersistence();
-
-      const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
 
       const allTerminalIds = state.terminals.map((t) => t.id);
       terminalInstanceService.suppressResizesDuringProjectSwitch(


### PR DESCRIPTION
## Summary

- `projectStore.ts` and `terminalStore.ts` both contained multiple `await import('@/services/TerminalInstanceService')` calls in hot paths, adding unnecessary async boundaries on every project switch even though V8 returns the cached module immediately
- Replaced all dynamic imports with a static top-level import, and converted the fire-and-forget promise chain in `evictRendererTerminalInstances` to a synchronous try/catch

Resolves #3162

## Changes

- `src/store/projectStore.ts`: static import at top of file; removed two redundant `await import()` calls in `switchProject` and `reopenProject`; converted `evictRendererTerminalInstances` from async fire-and-forget to synchronous try/catch
- `src/store/terminalStore.ts`: removed two duplicate `await import()` calls inside `resetWithoutKilling` (the static import was already present via the store's existing import chain)

## Testing

No functional change. `npm run check` passes clean. Project switching and terminal detach behaviour are unchanged.