### PR TITLE
fix(hydration): reduce reconnect fallback timeout from 10s to 2s

### DIFF
--- a/src/utils/stateHydration.ts
+++ b/src/utils/stateHydration.ts
@@ -28,7 +28,7 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { isCanopyEnvEnabled } from "@/utils/env";
 
-const RECONNECT_TIMEOUT_MS = 10000;
+const RECONNECT_TIMEOUT_MS = 2000;
 const RESTORE_CONCURRENCY = 8;
 const RESTORE_SPAWN_BATCH_SIZE = 3;
 const RESTORE_SPAWN_BATCH_DELAY_MS = 100;


### PR DESCRIPTION
## Summary

- `RECONNECT_TIMEOUT_MS` in `src/utils/stateHydration.ts` was set to 10000ms, causing project switches to stall for up to 10 seconds per panel that had already exited
- The reconnect fallback runs sequentially, so with 4-8 panels the delays stack and can easily add tens of seconds to a project switch
- 2 seconds is more than enough for a live terminal to respond over IPC; anything that doesn't respond in that window should be treated as gone and respawned

Resolves #3161

## Changes

- `RECONNECT_TIMEOUT_MS`: 10000 → 2000 in `src/utils/stateHydration.ts`

## Testing

- Formatter and linter passed with no changes required
- The existing reconnect logic is unchanged; only the timeout duration is reduced