### PR TITLE
feat(github): auto-clear issue search after 90s of inactivity

### DIFF
--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -58,6 +58,16 @@ export function IssueSelector({
     return () => abortController.abort();
   }, [open, debouncedQuery, projectPath]);
 
+  useEffect(() => {
+    if (open) return;
+
+    const timer = setTimeout(() => {
+      setQuery("");
+    }, 90_000);
+
+    return () => clearTimeout(timer);
+  }, [open]);
+
   const handleClear = (e: React.MouseEvent) => {
     e.stopPropagation();
     onSelect(null);


### PR DESCRIPTION
## Summary

- Adds a 90-second idle timer to `IssueSelector` that clears the search query when the dropdown has been continuously closed for that duration
- Timer cancels on re-open, so quick round-trips preserve the active query exactly as before
- Resets on every close event, not just the first

Resolves #3171

## Changes

A single `useEffect` in `src/components/GitHub/IssueSelector.tsx` watches the `open` state. When the popover closes, it schedules a `setTimeout` for 90 seconds to call `setQuery("")`. If the popover reopens before the timer fires, the cleanup function cancels it. No new state, no visible UI indicator.

## Testing

- `npm run check` passes (typecheck, lint ratchet, prettier)
- Manually verified: search query persists on quick close/reopen; query clears after 90s of the dropdown being closed