### PR TITLE
fix(github): align second-line metadata with title text in list items

### DIFF
--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -136,218 +136,222 @@ export function GitHubListItem({
         isActive && "bg-muted/50"
       )}
     >
-      {/* Top row: state icon, title, CI dot, #number copy */}
-      <div className="flex items-center gap-2 px-3 pt-2.5">
-        <span className={cn("shrink-0", stateColor)}>
+      <div className="flex items-start gap-2 px-3 py-2.5">
+        <span className={cn("shrink-0 mt-0.5", stateColor)}>
           <StateIcon className="h-4 w-4" />
         </span>
 
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            handleOpenExternal();
-          }}
-          className="flex-1 min-w-0 text-sm font-medium text-foreground truncate text-left hover:underline cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-        >
-          {item.title}
-        </button>
-
-        {isItemPR && item.state === "OPEN" && item.ciStatus && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className={cn(
-                    "shrink-0 w-2 h-2 rounded-full",
-                    getCIStatusInfo(item.ciStatus).color
-                  )}
-                  aria-label={getCIStatusInfo(item.ciStatus).tooltip}
-                />
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {getCIStatusInfo(item.ciStatus).tooltip}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void handleCopyNumber();
-                }}
-                className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
-                aria-label={`Copy number ${item.number}`}
-              >
-                {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
-                <span>{item.number}</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{copied ? "Copied!" : "Copy number"}</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-
-      {/* Bottom row: metadata + worktree indicator + ellipsis menu */}
-      <div className="flex items-center gap-1.5 px-3 pb-2.5 mt-0.5 text-xs text-muted-foreground">
-        <span>{item.author.login}</span>
-        <span>&middot;</span>
-        <span>{formatTimeAgo(item.updatedAt)}</span>
-
-        {isItemPR && (item as GitHubPR).headRefName && (
-          <>
-            <span>&middot;</span>
-            <span className="truncate max-w-[120px]">{(item as GitHubPR).headRefName}</span>
-          </>
-        )}
-
-        {!isItemPR && issueLabels.length > 0 && (
-          <>
-            <span>&middot;</span>
-            {issueLabels.slice(0, 2).map((label) => (
-              <span key={label.name} className="inline-flex items-center gap-1">
-                <span
-                  className="w-2 h-2 rounded-full shrink-0"
-                  style={{ backgroundColor: `#${label.color}` }}
-                />
-                <span className="truncate max-w-[80px]">{label.name}</span>
-              </span>
-            ))}
-          </>
-        )}
-
-        {!isItemPR && "linkedPR" in item && item.linkedPR && (
-          <>
-            <span>&middot;</span>
+        <div className="flex-1 min-w-0">
+          {/* Title row: title, CI dot, #number copy */}
+          <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={(e) => {
                 e.stopPropagation();
-                void actionService.dispatch(
-                  "system.openExternal",
-                  { url: item.linkedPR!.url },
-                  { source: "user" }
-                );
+                handleOpenExternal();
               }}
-              className="text-muted-foreground hover:text-foreground hover:underline cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-0.5"
+              className="flex-1 min-w-0 text-sm font-medium text-foreground truncate text-left hover:underline cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
             >
-              PR #{item.linkedPR.number}
+              {item.title}
             </button>
-          </>
-        )}
 
-        <span className="flex-1" />
+            {isItemPR && item.state === "OPEN" && item.ciStatus && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className={cn(
+                        "shrink-0 w-2 h-2 rounded-full",
+                        getCIStatusInfo(item.ciStatus).color
+                      )}
+                      aria-label={getCIStatusInfo(item.ciStatus).tooltip}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {getCIStatusInfo(item.ciStatus).tooltip}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
 
-        {!isItemPR && item.assignees.length > 0 && (
-          <Avatar
-            src={item.assignees[0].avatarUrl}
-            alt={item.assignees[0].login}
-            title={`Assigned to ${item.assignees[0].login}`}
-            className="w-4 h-4 shrink-0"
-          />
-        )}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      void handleCopyNumber();
+                    }}
+                    className="shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-1"
+                    aria-label={`Copy number ${item.number}`}
+                  >
+                    {copied ? <Check className="w-3 h-3 text-status-success" /> : <span>#</span>}
+                    <span>{item.number}</span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{copied ? "Copied!" : "Copy number"}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
 
-        {hasWorktree ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className={cn(
-                    "shrink-0",
-                    isActiveWorktree ? "text-canopy-accent" : "text-muted-foreground"
-                  )}
-                >
-                  <GitBranch className="w-3.5 h-3.5" />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {isActiveWorktree ? "Active worktree" : "Has worktree"}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : item.state === "OPEN" && !isForkPR && onCreateWorktree ? (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
+          {/* Metadata row: author, time, branch/labels, worktree, menu */}
+          <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground">
+            <span>{item.author.login}</span>
+            <span>&middot;</span>
+            <span>{formatTimeAgo(item.updatedAt)}</span>
+
+            {isItemPR && (item as GitHubPR).headRefName && (
+              <>
+                <span>&middot;</span>
+                <span className="truncate max-w-[120px]">{(item as GitHubPR).headRefName}</span>
+              </>
+            )}
+
+            {!isItemPR && issueLabels.length > 0 && (
+              <>
+                <span>&middot;</span>
+                {issueLabels.slice(0, 2).map((label) => (
+                  <span key={label.name} className="inline-flex items-center gap-1">
+                    <span
+                      className="w-2 h-2 rounded-full shrink-0"
+                      style={{ backgroundColor: `#${label.color}` }}
+                    />
+                    <span className="truncate max-w-[80px]">{label.name}</span>
+                  </span>
+                ))}
+              </>
+            )}
+
+            {!isItemPR && "linkedPR" in item && item.linkedPR && (
+              <>
+                <span>&middot;</span>
                 <button
                   type="button"
                   onClick={(e) => {
                     e.stopPropagation();
-                    onCreateWorktree(item);
+                    void actionService.dispatch(
+                      "system.openExternal",
+                      { url: item.linkedPR!.url },
+                      { source: "user" }
+                    );
                   }}
-                  className="shrink-0 text-muted-foreground/40 hover:text-muted-foreground transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
-                  aria-label="Create worktree"
+                  className="text-muted-foreground hover:text-foreground hover:underline cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded px-0.5"
                 >
-                  <GitBranch className="w-3.5 h-3.5" />
+                  PR #{item.linkedPR.number}
                 </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Create worktree</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : null}
+              </>
+            )}
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              onClick={(e) => e.stopPropagation()}
-              className={cn(
-                "shrink-0 p-0.5 rounded hover:bg-muted transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-                isActive
-                  ? "opacity-100"
-                  : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-              )}
-              aria-label="More actions"
-            >
-              <MoreHorizontal className="h-3.5 w-3.5" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent side="bottom" align="end">
-            <DropdownMenuItem onSelect={() => handleOpenExternal()}>
-              <ExternalLink className="h-3.5 w-3.5 mr-2" />
-              Open in GitHub
-            </DropdownMenuItem>
+            <span className="flex-1" />
 
-            {hasWorktree && !isActiveWorktree && onSwitchToWorktree && matchedWorktree && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onSelect={() => onSwitchToWorktree(matchedWorktree.id)}>
-                  <GitBranch className="h-3.5 w-3.5 mr-2" />
-                  Switch to Worktree
+            {!isItemPR && item.assignees.length > 0 && (
+              <Avatar
+                src={item.assignees[0].avatarUrl}
+                alt={item.assignees[0].login}
+                title={`Assigned to ${item.assignees[0].login}`}
+                className="w-4 h-4 shrink-0"
+              />
+            )}
+
+            {hasWorktree ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className={cn(
+                        "shrink-0",
+                        isActiveWorktree ? "text-canopy-accent" : "text-muted-foreground"
+                      )}
+                    >
+                      <GitBranch className="w-3.5 h-3.5" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {isActiveWorktree ? "Active worktree" : "Has worktree"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : item.state === "OPEN" && !isForkPR && onCreateWorktree ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCreateWorktree(item);
+                      }}
+                      className="shrink-0 text-muted-foreground/40 hover:text-muted-foreground transition-colors opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+                      aria-label="Create worktree"
+                    >
+                      <GitBranch className="w-3.5 h-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Create worktree</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : null}
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => e.stopPropagation()}
+                  className={cn(
+                    "shrink-0 p-0.5 rounded hover:bg-muted transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    isActive
+                      ? "opacity-100"
+                      : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                  )}
+                  aria-label="More actions"
+                >
+                  <MoreHorizontal className="h-3.5 w-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="bottom" align="end">
+                <DropdownMenuItem onSelect={() => handleOpenExternal()}>
+                  <ExternalLink className="h-3.5 w-3.5 mr-2" />
+                  Open in GitHub
                 </DropdownMenuItem>
-              </>
-            )}
 
-            {!hasWorktree && onCreateWorktree && item.state === "OPEN" && (
-              <>
-                <DropdownMenuSeparator />
-                {isForkPR ? (
-                  <DropdownMenuItem disabled>
-                    <div className="flex flex-col gap-0.5">
-                      <span className="flex items-center gap-2">
-                        <GitBranch className="h-3.5 w-3.5" />
-                        Create Worktree
-                      </span>
-                      <span className="text-[10px] text-muted-foreground leading-tight">
-                        Not available for fork PRs
-                      </span>
-                    </div>
-                  </DropdownMenuItem>
-                ) : (
-                  <DropdownMenuItem onSelect={() => onCreateWorktree(item)}>
-                    <GitBranch className="h-3.5 w-3.5 mr-2" />
-                    Create Worktree
-                  </DropdownMenuItem>
+                {hasWorktree && !isActiveWorktree && onSwitchToWorktree && matchedWorktree && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onSelect={() => onSwitchToWorktree(matchedWorktree.id)}>
+                      <GitBranch className="h-3.5 w-3.5 mr-2" />
+                      Switch to Worktree
+                    </DropdownMenuItem>
+                  </>
                 )}
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+
+                {!hasWorktree && onCreateWorktree && item.state === "OPEN" && (
+                  <>
+                    <DropdownMenuSeparator />
+                    {isForkPR ? (
+                      <DropdownMenuItem disabled>
+                        <div className="flex flex-col gap-0.5">
+                          <span className="flex items-center gap-2">
+                            <GitBranch className="h-3.5 w-3.5" />
+                            Create Worktree
+                          </span>
+                          <span className="text-[10px] text-muted-foreground leading-tight">
+                            Not available for fork PRs
+                          </span>
+                        </div>
+                      </DropdownMenuItem>
+                    ) : (
+                      <DropdownMenuItem onSelect={() => onCreateWorktree(item)}>
+                        <GitBranch className="h-3.5 w-3.5 mr-2" />
+                        Create Worktree
+                      </DropdownMenuItem>
+                    )}
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- In `GitHubListItem`, the top row and bottom metadata row were sibling divs both using `px-3`, so the metadata text started flush with the state icon rather than indented under the title text
- Restructured the layout to match `CommitListItem`: icon and content area are wrapped in a single flex row, with the metadata line as a child of the content div so it naturally aligns with the title text above it
- No changes to `CommitListItem` or any other list item component

Resolves #3193

## Changes

- `src/components/GitHub/GitHubListItem.tsx`: replaced the two-sibling-row layout with a single flex row (icon + content block), where both the title line and metadata line live inside the content div

## Testing

- Passed `npm run check` with zero errors (warnings only, pre-existing)
- Verified restructure matches the `CommitListItem` pattern described in the issue