### PR TITLE
fix(github): worktree branch icon distinct color and clickable navigation

### DIFF
--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -258,17 +258,34 @@ export function GitHubListItem({
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span
-                      className={cn(
-                        "shrink-0",
-                        isActiveWorktree ? "text-canopy-accent" : "text-muted-foreground"
-                      )}
-                    >
-                      <GitBranch className="w-3.5 h-3.5" />
-                    </span>
+                    {isActiveWorktree ? (
+                      <span className="shrink-0 text-canopy-accent">
+                        <GitBranch className="w-3.5 h-3.5" />
+                      </span>
+                    ) : onSwitchToWorktree && matchedWorktree ? (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSwitchToWorktree(matchedWorktree.id);
+                        }}
+                        className="shrink-0 text-github-open hover:text-github-open/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded p-0.5"
+                        aria-label="Switch to worktree"
+                      >
+                        <GitBranch className="w-3.5 h-3.5" />
+                      </button>
+                    ) : (
+                      <span className="shrink-0 text-github-open">
+                        <GitBranch className="w-3.5 h-3.5" />
+                      </span>
+                    )}
                   </TooltipTrigger>
                   <TooltipContent side="bottom">
-                    {isActiveWorktree ? "Active worktree" : "Has worktree"}
+                    {isActiveWorktree
+                      ? "Active worktree"
+                      : onSwitchToWorktree && matchedWorktree
+                        ? "Switch to worktree"
+                        : "Has worktree"}
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>


### PR DESCRIPTION
## Summary

- The worktree branch icon in the issues list was visually indistinguishable between "has worktree" and "create worktree" states, and clicking an existing worktree icon did nothing
- When a worktree exists (not active), the branch icon now renders in green (`text-github-open`) so it clearly stands out from the muted ghost create affordance
- The icon is now an interactive button that calls `onSwitchToWorktree` on click, matching the behavior of "Switch to Worktree" in the ellipsis menu; tooltips updated to reflect the action in each state

Resolves #3196

## Changes

- `src/components/GitHub/GitHubListItem.tsx`: replaced the passive `<span>` for existing worktrees with an interactive `<button>`; applied `text-github-open` for the non-active worktree state and retained `text-canopy-accent` for the active state; updated tooltip text to "Switch to worktree" / "Active worktree" accordingly

## Testing

- Typecheck, lint, and format all pass cleanly with no new warnings introduced
- Manually verified: non-active worktree branch icon appears green and navigates to the worktree on click; active worktree icon uses accent color with "Active worktree" tooltip; ghost create-worktree button (no worktree state) is unchanged