### PR TITLE
fix(github): replace 90-second timeout with immediate query reset on close

### DIFF
--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -58,15 +58,10 @@ export function IssueSelector({
     return () => abortController.abort();
   }, [open, debouncedQuery, projectPath]);
 
-  useEffect(() => {
-    if (open) return;
-
-    const timer = setTimeout(() => {
-      setQuery("");
-    }, 90_000);
-
-    return () => clearTimeout(timer);
-  }, [open]);
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (!nextOpen) setQuery("");
+  };
 
   const handleClear = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -74,7 +69,7 @@ export function IssueSelector({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -155,7 +150,7 @@ export function IssueSelector({
                 aria-selected={selectedIssue?.number === issue.number}
                 onClick={() => {
                   onSelect(issue);
-                  setOpen(false);
+                  handleOpenChange(false);
                 }}
                 className={cn(
                   "flex items-center gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",


### PR DESCRIPTION
## Summary

- Removes the `useEffect`-based `setTimeout(..., 90_000)` in `IssueSelector.tsx` that was clearing the search query after 90 seconds of the dropdown being closed
- Replaces it with an immediate `setQuery("")` call directly in the `onOpenChange` handler, so the query resets the moment the dropdown closes
- Aligns with the standard pattern for single-select filterable popovers used by React Aria, Headless UI, and shadcn/ui

Resolves #3218

## Changes

- `src/components/GitHub/IssueSelector.tsx`: removed the 90-second timeout effect; `onOpenChange` now calls `setQuery("")` immediately when `open` transitions to `false`

## Testing

- `npm run check` passes (typecheck, lint, format)
- Closing the dropdown without selecting resets the query immediately
- The next open always shows the full unfiltered issue list
- Selecting an issue closes the dropdown and clears the query