### PR TITLE
fix(ui): use static spinner arc for waiting state indicator

### DIFF
--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -1,11 +1,11 @@
 import { Play, Circle, CheckCircle2, XCircle } from "lucide-react";
 import type { AgentState } from "@/types";
-import { SpinnerCircle, HollowCircle, SolidCircle } from "@/components/icons/AgentStateCircles";
+import { SpinnerCircle, SolidCircle } from "@/components/icons/AgentStateCircles";
 
 export const STATE_ICONS: Record<AgentState, React.ComponentType<{ className?: string }>> = {
   working: SpinnerCircle,
   running: Play,
-  waiting: HollowCircle,
+  waiting: SpinnerCircle,
   directing: SolidCircle,
   idle: Circle,
   completed: CheckCircle2,


### PR DESCRIPTION
## Summary

- The `waiting` agent state now uses `SpinnerCircle` (the same half-arc shape as `working`) instead of `HollowCircle`, making the two states visually related
- The transition from `waiting` to `working` now looks like the icon waking up: same shape, animation starts
- `HollowCircle` is no longer imported in `terminalStateConfig.tsx` since nothing else in that file uses it

Resolves #3250

## Changes

- `src/components/Worktree/terminalStateConfig.tsx`: swap `waiting` icon from `HollowCircle` to `SpinnerCircle`, remove unused `HollowCircle` import

## Testing

- Checked all `STATE_ICONS` render sites: animation is applied conditionally (`agentState === "working"`) in `TerminalHeaderContent.tsx`, so `waiting` gets the static arc with no extra changes needed
- `HollowCircle` is still defined in `AgentStateCircles.tsx` and available for future use; no other states reference it