### PR TITLE
fix(store): clear commandHistory, historyIndex, and tempDraft in clearAllDraftInputs

### DIFF
--- a/src/store/__tests__/terminalInputStore.test.ts
+++ b/src/store/__tests__/terminalInputStore.test.ts
@@ -199,6 +199,21 @@ describe("terminalInputStore", () => {
       expect(useTerminalInputStore.getState().pendingDrafts.size).toBe(0);
       expect(useTerminalInputStore.getState().pendingDraftRevision).toBe(0);
     });
+
+    it("should clear commandHistory, historyIndex, and tempDraft", () => {
+      useTerminalInputStore.getState().addToHistory("term-1", "echo hello");
+      useTerminalInputStore.getState().navigateHistory("term-1", "up", "current-input");
+
+      expect(useTerminalInputStore.getState().commandHistory.size).toBe(1);
+      expect(useTerminalInputStore.getState().historyIndex.has("term-1")).toBe(true);
+      expect(useTerminalInputStore.getState().tempDraft.has("term-1")).toBe(true);
+
+      useTerminalInputStore.getState().clearAllDraftInputs();
+
+      expect(useTerminalInputStore.getState().commandHistory.size).toBe(0);
+      expect(useTerminalInputStore.getState().historyIndex.size).toBe(0);
+      expect(useTerminalInputStore.getState().tempDraft.size).toBe(0);
+    });
   });
 
   describe("stashed editor states", () => {

--- a/src/store/terminalInputStore.ts
+++ b/src/store/terminalInputStore.ts
@@ -148,6 +148,9 @@ export const useTerminalInputStore = create<TerminalInputState>()((set, get) => 
       pendingDrafts: new Map(),
       pendingDraftRevision: 0,
       stashedEditorStates: new Map(),
+      commandHistory: new Map(),
+      historyIndex: new Map(),
+      tempDraft: new Map(),
     }),
 
   stashEditorState: (terminalId, editorState, projectId) =>


### PR DESCRIPTION
## Summary

- `clearAllDraftInputs` was resetting `draftInputs`, `pendingDrafts`, and `stashedEditorStates` but leaving `commandHistory`, `historyIndex`, and `tempDraft` intact, causing stale entries to accumulate across the session lifetime.
- Added the three missing Map resets to the existing `set()` call in `clearAllDraftInputs`.
- Added a unit test covering the new behaviour: adds a history entry, navigates (which sets `historyIndex` and `tempDraft`), calls `clearAllDraftInputs`, then asserts all three Maps are empty.

Resolves #3276

## Changes

- `src/store/terminalInputStore.ts` — added `commandHistory`, `historyIndex`, and `tempDraft` resets to `clearAllDraftInputs`
- `src/store/__tests__/terminalInputStore.test.ts` — new test case verifying the fix

## Testing

Unit tests pass (`npm run check` clean). The new test exercises the exact maps that were previously left dirty after a clear.