### PR TITLE
fix(pty): use taskkill /T to kill orphaned PTY process trees on Windows

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -29,6 +29,7 @@ import { utilityProcess, UtilityProcess, dialog, app, MessagePortMain } from "el
 import { EventEmitter } from "events";
 import path from "path";
 import os from "os";
+import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { RequestResponseBroker } from "./rpc/index.js";
@@ -723,6 +724,17 @@ export class PtyClient extends EventEmitter {
           killed = true;
         } catch {
           // ignore - fall back to direct kill
+        }
+      }
+
+      if (!killed && process.platform === "win32") {
+        const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
+          windowsHide: true,
+          stdio: "ignore",
+          timeout: 3000,
+        });
+        if (result.status === 0 || result.status === 128) {
+          killed = true;
         }
       }
 


### PR DESCRIPTION
## Summary

- On Windows, `process.kill(pid, 'SIGKILL')` only terminates the root PTY process and leaves child processes (shells, running commands) as orphans. `taskkill /T /F /PID` terminates the entire process tree.
- Exit code 128 from `taskkill` means the process was already gone, which is treated as a successful cleanup alongside exit code 0.
- The existing `process.kill` call is kept as a last-resort fallback for cases where `taskkill` fails (e.g., access-denied on protected processes).

Resolves #3182

## Changes

- `electron/services/PtyClient.ts`: import `spawnSync` from `child_process`; add Windows-specific `taskkill /T /F /PID` block in `cleanupOrphanedPtys()` before the fallback `process.kill`

## Testing

- `npm run check` passes clean (typecheck, lint, format)
- Logic verified: `taskkill` runs only on `win32`, timeout is 3 seconds, stdio is suppressed so it never blocks the cleanup loop