### PR TITLE
feat(settings): separate dark and light themes in theme picker

### DIFF
--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -68,6 +68,8 @@ export function AppThemePicker() {
   const [importMessage, setImportMessage] = useState<string | null>(null);
 
   const allSchemes = [...BUILT_IN_APP_SCHEMES, ...customSchemes];
+  const darkSchemes = allSchemes.filter((s) => s.type !== "light");
+  const lightSchemes = allSchemes.filter((s) => s.type === "light");
   const warningsByScheme = useMemo(
     () => new Map(allSchemes.map((scheme) => [scheme.id, getAppThemeWarnings(scheme)])),
     [allSchemes]
@@ -146,36 +148,77 @@ export function AppThemePicker() {
           </div>
         </div>
       ) : null}
-      <div className="grid grid-cols-2 gap-2">
-        {allSchemes.map((scheme) => {
-          const warnings = warningsByScheme.get(scheme.id) ?? [];
-          return (
-            <button
-              key={scheme.id}
-              onClick={() => handleSelect(scheme.id)}
-              className={cn(
-                "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
-                selectedSchemeId === scheme.id
-                  ? "border-canopy-accent bg-canopy-accent/10"
-                  : "border-canopy-border bg-canopy-bg hover:border-canopy-text/30"
-              )}
-            >
-              <ThemePreview scheme={scheme} />
-              <div className="flex items-center gap-1.5 min-w-0">
-                <span className="text-xs text-canopy-text truncate">{scheme.name}</span>
-                {scheme.type === "light" && (
-                  <span className="text-[10px] text-canopy-text/50 shrink-0">light</span>
-                )}
-                {warnings.length > 0 ? (
-                  <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-[10px] text-status-warning shrink-0">
-                    <AlertTriangle className="h-3 w-3" />
-                    {warnings.length}
-                  </span>
-                ) : null}
-              </div>
-            </button>
-          );
-        })}
+      <div className="space-y-4">
+        {darkSchemes.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-canopy-text/40 select-none">
+              Dark
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {darkSchemes.map((scheme) => {
+                const warnings = warningsByScheme.get(scheme.id) ?? [];
+                return (
+                  <button
+                    key={scheme.id}
+                    onClick={() => handleSelect(scheme.id)}
+                    className={cn(
+                      "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
+                      selectedSchemeId === scheme.id
+                        ? "border-canopy-accent bg-canopy-accent/10"
+                        : "border-canopy-border bg-canopy-bg hover:border-canopy-text/30"
+                    )}
+                  >
+                    <ThemePreview scheme={scheme} />
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="text-xs text-canopy-text truncate">{scheme.name}</span>
+                      {warnings.length > 0 ? (
+                        <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-[10px] text-status-warning shrink-0">
+                          <AlertTriangle className="h-3 w-3" />
+                          {warnings.length}
+                        </span>
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+        {lightSchemes.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-[10px] font-medium uppercase tracking-wider text-canopy-text/40 select-none">
+              Light
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {lightSchemes.map((scheme) => {
+                const warnings = warningsByScheme.get(scheme.id) ?? [];
+                return (
+                  <button
+                    key={scheme.id}
+                    onClick={() => handleSelect(scheme.id)}
+                    className={cn(
+                      "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
+                      selectedSchemeId === scheme.id
+                        ? "border-canopy-accent bg-canopy-accent/10"
+                        : "border-canopy-border bg-canopy-bg hover:border-canopy-text/30"
+                    )}
+                  >
+                    <ThemePreview scheme={scheme} />
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="text-xs text-canopy-text truncate">{scheme.name}</span>
+                      {warnings.length > 0 ? (
+                        <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-status-warning/10 px-1.5 py-0.5 text-[10px] text-status-warning shrink-0">
+                          <AlertTriangle className="h-3 w-3" />
+                          {warnings.length}
+                        </span>
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </div>
       <button
         onClick={handleImport}


### PR DESCRIPTION
## Summary

- Splits the flat theme grid in Settings into two labelled sections: **Dark** and **Light**, using the `type` field already present on every `AppColorScheme`
- Empty sections are suppressed, so if only dark or only light themes exist only that section renders
- All existing functionality (tile layout, preview thumbnails, selection state, custom theme import) is unchanged

Resolves #3317

## Changes

- `src/components/Settings/AppThemePicker.tsx`: group schemes by `type` before rendering, add section headers with a short divider, preserve fallback to `"dark"` for any scheme missing a valid type

## Testing

- `npm run check` passes clean (typecheck, lint, format)
- Both Dark and Light sections render correctly in the Appearance tab
- Selected tile highlights correctly regardless of which section it belongs to
- Custom imported themes appear in the section matching their declared `type`