### PR TITLE
fix(github): use IssueOrder instead of PullRequestOrder in PR list query

### DIFF
--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -74,7 +74,7 @@ export const LIST_ISSUES_QUERY = `
 `;
 
 export const LIST_PRS_QUERY = `
-  query GetPRs($owner: String!, $repo: String!, $states: [PullRequestState!], $cursor: String, $limit: Int = 20, $orderBy: PullRequestOrder) {
+  query GetPRs($owner: String!, $repo: String!, $states: [PullRequestState!], $cursor: String, $limit: Int = 20, $orderBy: IssueOrder) {
     repository(owner: $owner, name: $repo) {
       pullRequests(first: $limit, after: $cursor, states: $states, orderBy: $orderBy) {
         totalCount

--- a/electron/services/github/__tests__/GitHubQueries.test.ts
+++ b/electron/services/github/__tests__/GitHubQueries.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildBatchPRQuery } from "../GitHubQueries.js";
+import { buildBatchPRQuery, LIST_PRS_QUERY } from "../GitHubQueries.js";
+
+describe("LIST_PRS_QUERY", () => {
+  it("uses IssueOrder (not PullRequestOrder) for the orderBy variable type", () => {
+    expect(LIST_PRS_QUERY).toContain("$orderBy: IssueOrder");
+    expect(LIST_PRS_QUERY).not.toContain("PullRequestOrder");
+  });
+});
 
 describe("buildBatchPRQuery", () => {
   it("escapes owner, repo, and branch values in generated GraphQL query", () => {


### PR DESCRIPTION
## Summary

- `LIST_PRS_QUERY` declared its sort variable as `$orderBy: PullRequestOrder`, which doesn't exist in GitHub's GraphQL schema. The `pullRequests` connection on `Repository` uses `IssueOrder`, the same type used by `issues`.
- Changed the variable type to `IssueOrder` to match the actual schema, fixing the type mismatch error.
- Added a test to `GitHubQueries.test.ts` that verifies the PR query variable declaration uses `IssueOrder`.

Resolves #3336

## Changes

- `electron/services/github/GitHubQueries.ts`: changed `$orderBy: PullRequestOrder` to `$orderBy: IssueOrder` in `LIST_PRS_QUERY`
- `electron/services/github/__tests__/GitHubQueries.test.ts`: added test asserting correct variable type in the PR list query

## Testing

Unit test added and passing. The fix matches the pattern already working correctly in `LIST_ISSUES_QUERY`.