### PR TITLE
fix(terminal): reduce WebGL context pool to leave headroom for Chromium limit

### DIFF
--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -10,7 +10,11 @@ interface WebGLEntry {
 }
 
 export class TerminalWebGLManager {
-  static readonly MAX_CONTEXTS = 16;
+  // Chromium caps active WebGL contexts at 16 per renderer process.
+  // Reserve 4 slots for potential non-terminal WebGL consumers in the
+  // main renderer (browser/dev-preview panels are process-isolated via
+  // <webview> partitions and have their own budgets).
+  static readonly MAX_CONTEXTS = 12;
 
   private pool = new Map<string, WebGLEntry>();
   private lruOrder: string[] = [];


### PR DESCRIPTION
## Summary

- Reduces `TerminalWebGLManager.MAX_CONTEXTS` from 16 to 12, leaving 4 slots free for any non-terminal WebGL consumers sharing the renderer process
- Chromium enforces a hard limit of 16 active WebGL contexts per renderer process; claiming the full budget means the first external consumer triggers a forced `webglcontextlost` eviction on a terminal
- Adds an inline comment documenting the reasoning and noting that browser/dev-preview panels run in `<webview>` partitions with their own budgets (so the reservation is conservative headroom for future renderer-resident consumers)

Resolves #3277

## Changes

- `src/services/terminal/TerminalWebGLManager.ts`: `MAX_CONTEXTS` 16 → 12, with explanatory comment

## Testing

All existing WebGL lifecycle unit tests pass. The change is a single constant reduction with no behavioral impact on the eviction/fallback path.