### PR TITLE
fix(crash-recovery): discard orphaned dev-mode markers on startup

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -457,10 +457,10 @@ if (!gotTheLock) {
   // must not consume/delete the current session's marker before it quits.
   initializeCrashRecoveryService();
 
-  // In dev mode, nodemon/concurrently restart the Electron process by sending SIGTERM.
-  // Electron's `before-quit` event does NOT fire on SIGTERM, so cleanupOnExit() would
-  // never run and running.lock would be orphaned — triggering the crash recovery dialog
-  // on every hot reload. Register explicit handlers to clean up and exit cleanly.
+  // Best-effort cleanup for dev-mode signal delivery (macOS/Linux SIGTERM/SIGINT,
+  // Windows Ctrl+C). On Windows, nodemon uses `taskkill /F` (TerminateProcess) which
+  // bypasses all Node.js shutdown hooks — that case is handled by CrashRecoveryService
+  // discarding orphaned dev-mode markers on next startup.
   if (!app.isPackaged) {
     const devSignalHandler = () => {
       // Clean up synchronously before the async quit path — the before-quit handler

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -198,6 +198,12 @@ export class CrashRecoveryService {
         return null;
       }
 
+      if (!app.isPackaged && marker.isPackaged === false && !marker.crashLogPath) {
+        console.log("[CrashRecovery] Orphaned dev-mode marker — discarding (not a crash)");
+        this.deleteMarker();
+        return null;
+      }
+
       this.deleteMarker();
 
       const logPath = marker.crashLogPath ?? null;
@@ -253,6 +259,7 @@ export class CrashRecoveryService {
         sessionStartMs: this.sessionStartMs,
         appVersion: app.getVersion(),
         platform: process.platform,
+        isPackaged: app.isPackaged,
         crashLogPath: crashEntry
           ? path.join(this.crashesDir, `crash-${crashEntry.id}.json`)
           : undefined,
@@ -397,6 +404,7 @@ interface MarkerFile {
   appVersion: string;
   platform: string;
   crashLogPath?: string;
+  isPackaged?: boolean;
 }
 
 interface SessionSnapshot {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -11,6 +11,7 @@ const storeMock = vi.hoisted(() => ({
 const appMock = vi.hoisted(() => ({
   getPath: vi.fn(() => "/fake/userData"),
   getVersion: vi.fn(() => "1.0.0"),
+  isPackaged: false as boolean,
 }));
 
 vi.mock("../../store.js", () => ({
@@ -36,6 +37,7 @@ describe("CrashRecoveryService", () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-recovery-test-"));
     userData = tmpDir;
     appMock.getPath.mockReturnValue(userData);
+    appMock.isPackaged = false;
     storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
     storeMock.set.mockImplementation(() => {});
     vi.spyOn(console, "log").mockImplementation(() => {});
@@ -58,6 +60,7 @@ describe("CrashRecoveryService", () => {
       const marker = JSON.parse(fs.readFileSync(markerPath, "utf8"));
       expect(typeof marker.sessionStartMs).toBe("number");
       expect(marker.appVersion).toBe("1.0.0");
+      expect(marker.isPackaged).toBe(false);
     });
 
     it("returns null pending crash when no marker exists", () => {
@@ -122,6 +125,119 @@ describe("CrashRecoveryService", () => {
       svc.initialize();
 
       expect(svc.getPendingCrash()).toBeNull();
+    });
+
+    it("silently discards orphaned dev-mode marker in dev session", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "win32",
+          isPackaged: false,
+        })
+      );
+
+      appMock.isPackaged = false;
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()).toBeNull();
+    });
+
+    it("surfaces dev-mode marker with crashLogPath as a genuine crash", () => {
+      const crashDir = path.join(userData, "crashes");
+      fs.mkdirSync(crashDir, { recursive: true });
+      const crashLogPath = path.join(crashDir, "crash-dev-123.json");
+      fs.writeFileSync(
+        crashLogPath,
+        JSON.stringify({
+          id: "dev-123",
+          timestamp: Date.now(),
+          appVersion: "1.0.0",
+          platform: "win32",
+          osVersion: "10.0",
+          arch: "x64",
+          errorMessage: "real dev crash",
+        })
+      );
+
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "win32",
+          isPackaged: false,
+          crashLogPath,
+        })
+      );
+
+      appMock.isPackaged = false;
+      const svc = makeService();
+      svc.initialize();
+
+      const pending = svc.getPendingCrash();
+      expect(pending).not.toBeNull();
+      expect(pending!.entry.errorMessage).toBe("real dev crash");
+    });
+
+    it("surfaces dev-mode marker when current session is packaged", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "win32",
+          isPackaged: false,
+        })
+      );
+
+      appMock.isPackaged = true;
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()).not.toBeNull();
+    });
+
+    it("surfaces legacy marker without isPackaged field in dev session", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      appMock.isPackaged = false;
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()).not.toBeNull();
+    });
+
+    it("surfaces packaged marker in dev session", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+          isPackaged: true,
+        })
+      );
+
+      appMock.isPackaged = false;
+      const svc = makeService();
+      svc.initialize();
+
+      expect(svc.getPendingCrash()).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- On Windows, nodemon restarts Electron via `taskkill /F` (TerminateProcess), which bypasses all Node.js signal handlers and `before-quit`. This orphaned `running.lock` on every hot-reload, triggering the crash recovery dialog each time.
- Added `isPackaged: false` to the marker file written at session start, then on the next startup, if both the current session and the stale marker are dev-mode and the marker has no crash log attached, it's silently discarded rather than surfaced as a crash.
- Existing SIGTERM/SIGINT handlers are kept for macOS/Linux where signal delivery works. The new marker field acts as a universal fallback that works even when the process is killed without any hooks firing.

Resolves #3183

## Changes

- `electron/services/CrashRecoveryService.ts` — writes `isPackaged` into the marker file; discards orphaned dev-mode markers on next startup when no crash log is present
- `electron/main.ts` — updated comment to reflect the two-path strategy (signals on unix, marker discard on Windows)
- `electron/services/__tests__/CrashRecoveryService.test.ts` — five new test cases covering the discard path, genuine dev crash (has log), packaged-to-dev transition, legacy markers without the field, and dev-to-packaged transition

## Testing

Unit test suite passes. The five new cases cover every branch of the discard logic, including edge cases like legacy markers (no `isPackaged` field) and cross-session packaging mismatches.