### PR TITLE
fix(worktree): remove spurious self-assign success notification

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -463,13 +463,6 @@ export function NewWorktreeDialog({
         if (selectedIssue && assignWorktreeToSelf && currentUser) {
           try {
             await githubClient.assignIssue(rootPath, selectedIssue.number, currentUser);
-            notify({
-              type: "success",
-              title: "Issue Assigned",
-              message: `Issue #${selectedIssue.number} assigned to @${currentUser}`,
-              priority: "low",
-              countable: false,
-            });
           } catch (assignErr) {
             const message =
               assignErr instanceof Error ? assignErr.message : "Failed to assign issue";


### PR DESCRIPTION
## Summary

- Removes the success `notify()` call after a self-assign during worktree creation so it no longer appears in the re-entry summary when the user returns to the app
- The user explicitly checked "Assign to me" in the dialog, so confirming the outcome is noise, not signal
- The warning notification on assignment failure is untouched

Resolves #3444

## Changes

- `src/components/Worktree/NewWorktreeDialog.tsx`: deleted the `notify({ type: "success", ... })` block in the self-assign success path; the failure path (`type: "warning"`) is preserved

## Testing

- Formatter (Prettier) ran clean with no changes
- The single changed file is the call site identified in the issue's root cause analysis
- Re-entry summary behaviour for background events (agent completions, etc.) is unaffected since no other notification paths were modified