### PR TITLE
feat(main): enable Node.js compile cache for faster cold start

### DIFF
--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -1,0 +1,5 @@
+import { enableCompileCache } from "node:module";
+
+enableCompileCache();
+
+await import("./main.js");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Greg Priday",
     "email": "greg@siteorigin.com"
   },
-  "main": "dist-electron/electron/main.js",
+  "main": "dist-electron/electron/bootstrap.js",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -93,7 +93,12 @@ async function run() {
   // Config for ESM files (Main, Hosts)
   const esmConfig = {
     ...common,
-    entryPoints: ["electron/main.ts", "electron/pty-host.ts", "electron/workspace-host.ts"],
+    entryPoints: [
+      "electron/bootstrap.ts",
+      "electron/main.ts",
+      "electron/pty-host.ts",
+      "electron/workspace-host.ts",
+    ],
     outdir: "dist-electron/electron",
     format: "esm",
     splitting: true, // Share chunks between main/hosts

--- a/scripts/run-smoke.mjs
+++ b/scripts/run-smoke.mjs
@@ -12,7 +12,11 @@ const electronPath = require("electron");
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(SCRIPT_DIR, "..");
 
-const BUILD_ARTIFACTS = ["dist/index.html", "dist-electron/electron/main.js"];
+const BUILD_ARTIFACTS = [
+  "dist/index.html",
+  "dist-electron/electron/bootstrap.js",
+  "dist-electron/electron/main.js",
+];
 
 const REQUIRED_MARKERS = [
   "[SMOKE] CHECK: node-pty native module",


### PR DESCRIPTION
## Summary

- Adds `electron/bootstrap.ts` as a new entry point that calls `enableCompileCache()` before any other imports, satisfying the requirement that it runs before any module loading begins
- Updates `package.json` `main` field to point to `bootstrap.js` so Electron loads the bootstrap instead of `main.js` directly
- Adds `bootstrap.ts` to the esbuild config and smoke test artifact checks

Resolves #3429

## Changes

- `electron/bootstrap.ts` — new file, calls `enableCompileCache()` then dynamically imports `./main.js`
- `package.json` — `main` field updated from `dist-electron/electron/main.js` to `dist-electron/electron/bootstrap.js`
- `scripts/build-main.mjs` — `bootstrap.ts` added to esbuild ESM entry points
- `scripts/run-smoke.mjs` — `bootstrap.js` added to the build artifact verification list

## Testing

The `npm run check` suite (typecheck, lint, format) passes clean. The bootstrap approach keeps the compile cache activation completely isolated from application logic, so no behavioural changes are expected.