### PR TITLE
fix(renderer): block browser-default file navigation on non-terminal drop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { useWorktreePalette } from "./hooks/useWorktreePalette";
 import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
 import { useMcpBridge } from "./hooks/useMcpBridge";
+import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { createTooltipWithShortcut } from "./lib/platform";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import { CrashRecoveryDialog } from "./components/Recovery/CrashRecoveryDialog";
@@ -854,27 +855,7 @@ function App() {
     voiceRecordingService.initialize();
   }, []);
 
-  // Prevent browser-default file navigation when files are dropped on non-terminal areas
-  useEffect(() => {
-    const handleDragOver = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("Files")) return;
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "none";
-    };
-
-    const handleDrop = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("Files")) return;
-      e.preventDefault();
-    };
-
-    document.addEventListener("dragover", handleDragOver);
-    document.addEventListener("drop", handleDrop);
-
-    return () => {
-      document.removeEventListener("dragover", handleDragOver);
-      document.removeEventListener("drop", handleDrop);
-    };
-  }, []);
+  useFileDropGuard();
 
   if (!isElectronAvailable()) {
     return (

--- a/src/__tests__/App.fileDropGuard.test.tsx
+++ b/src/__tests__/App.fileDropGuard.test.tsx
@@ -3,34 +3,7 @@
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderHook, cleanup } from "@testing-library/react";
-import { useEffect } from "react";
-
-/**
- * Extracted copy of the drag-guard hook from App.tsx for isolated testing.
- * This avoids mounting the full App component with all its dependencies.
- */
-function useFileDropGuard() {
-  useEffect(() => {
-    const handleDragOver = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("Files")) return;
-      e.preventDefault();
-      e.dataTransfer.dropEffect = "none";
-    };
-
-    const handleDrop = (e: DragEvent) => {
-      if (!e.dataTransfer?.types.includes("Files")) return;
-      e.preventDefault();
-    };
-
-    document.addEventListener("dragover", handleDragOver);
-    document.addEventListener("drop", handleDrop);
-
-    return () => {
-      document.removeEventListener("dragover", handleDragOver);
-      document.removeEventListener("drop", handleDrop);
-    };
-  }, []);
-}
+import { useFileDropGuard } from "@/hooks/useFileDropGuard";
 
 function createDragEvent(
   type: string,
@@ -45,7 +18,7 @@ function createDragEvent(
   return { event, dataTransfer };
 }
 
-describe("file drop guard", () => {
+describe("useFileDropGuard", () => {
   afterEach(() => {
     cleanup();
   });
@@ -88,6 +61,34 @@ describe("file drop guard", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  it("skips events already handled by a child (defaultPrevented)", () => {
+    renderHook(() => useFileDropGuard());
+
+    const { event, dataTransfer } = createDragEvent("dragover", ["Files"]);
+    // Simulate a child component calling preventDefault before bubble reaches document
+    event.preventDefault();
+
+    document.dispatchEvent(event);
+
+    // dropEffect should remain unchanged — our handler skipped
+    expect(dataTransfer.dropEffect).toBe("copy");
+  });
+
+  it("catches file drops bubbling from a child element", () => {
+    renderHook(() => useFileDropGuard());
+
+    const child = document.createElement("div");
+    document.body.appendChild(child);
+
+    const { event, dataTransfer } = createDragEvent("dragover", ["Files"]);
+    child.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(dataTransfer.dropEffect).toBe("none");
+
+    document.body.removeChild(child);
+  });
+
   it("removes listeners on unmount", () => {
     const addSpy = vi.spyOn(document, "addEventListener");
     const removeSpy = vi.spyOn(document, "removeEventListener");
@@ -103,9 +104,13 @@ describe("file drop guard", () => {
     expect(removeSpy).toHaveBeenCalledWith("drop", expect.any(Function));
 
     // Verify events are no longer handled after unmount
-    const { event } = createDragEvent("dragover", ["Files"]);
-    document.dispatchEvent(event);
-    expect(event.defaultPrevented).toBe(false);
+    const { event: dragEvent } = createDragEvent("dragover", ["Files"]);
+    document.dispatchEvent(dragEvent);
+    expect(dragEvent.defaultPrevented).toBe(false);
+
+    const { event: dropEvent } = createDragEvent("drop", ["Files"]);
+    document.dispatchEvent(dropEvent);
+    expect(dropEvent.defaultPrevented).toBe(false);
 
     addSpy.mockRestore();
     removeSpy.mockRestore();

--- a/src/hooks/useFileDropGuard.ts
+++ b/src/hooks/useFileDropGuard.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+
+/**
+ * Prevents browser-default file navigation when files are dropped on
+ * non-terminal areas. Uses bubble phase so components that call
+ * stopPropagation (terminal, HybridInputBar) handle their own drops.
+ * Skips events already handled by a child (defaultPrevented check).
+ */
+export function useFileDropGuard() {
+  useEffect(() => {
+    const handleDragOver = (e: DragEvent) => {
+      if (e.defaultPrevented) return;
+      if (!e.dataTransfer?.types.includes("Files")) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "none";
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      if (e.defaultPrevented) return;
+      if (!e.dataTransfer?.types.includes("Files")) return;
+      e.preventDefault();
+    };
+
+    document.addEventListener("dragover", handleDragOver);
+    document.addEventListener("drop", handleDrop);
+
+    return () => {
+      document.removeEventListener("dragover", handleDragOver);
+      document.removeEventListener("drop", handleDrop);
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- Adds a `useFileDropGuard` hook that attaches `dragover` and `drop` listeners to the document, calling `preventDefault()` to suppress browser-default file navigation when files land outside a designated drop target.
- Applies the hook in `App.tsx` so the guard is active for the entire renderer lifetime.
- Guards against double-prevention with a `defaultPrevented` check, so custom DnD handling in terminal panels and the `DndProvider` layer is unaffected.

Resolves #3435

## Changes

- `src/hooks/useFileDropGuard.ts` — new hook; registers and cleans up the document-level guard
- `src/App.tsx` — calls `useFileDropGuard()` at the root
- `src/__tests__/App.fileDropGuard.test.tsx` — 118-line test covering guard activation, cleanup on unmount, `defaultPrevented` passthrough, and terminal-panel passthrough

## Testing

Unit tests pass (`npm run check`). Formatter and linter clean (warnings only, no errors). Manual verification: dropping a file on the toolbar or empty panel grid area no longer triggers navigation.