### PR TITLE
feat(build): strip debug console statements from production builds

### DIFF
--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -27,6 +27,7 @@ const common = {
   external,
   logLevel: "info",
   absWorkingDir: root,
+  pure: isProd ? ["console.log", "console.info", "console.warn", "console.debug"] : [],
   define: {
     "process.env.SENTRY_DSN": JSON.stringify(process.env.SENTRY_DSN || ""),
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,10 +92,14 @@ function getVendorChunk(id: string): string | undefined {
   return "vendor";
 }
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   envPrefix: ["VITE_", "CANOPY_"],
   plugins: [react(), tailwindcss(), cspTransformPlugin()],
   base: "./",
+  esbuild:
+    mode === "production"
+      ? { pure: ["console.log", "console.info", "console.warn", "console.debug"] }
+      : {},
   build: {
     outDir: "dist",
     emptyOutDir: true,
@@ -123,4 +127,4 @@ export default defineConfig({
       "Cross-Origin-Embedder-Policy": "credentialless",
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary

- Adds `pure` annotations for `console.log`, `console.info`, `console.warn`, and `console.debug` to both the Vite (renderer) and esbuild (main process) production build configs
- `console.error` is preserved in both pipelines so crash reporters and CLI users still see unhandled exceptions
- Dev builds are unaffected — all console output remains available during `npm run dev`

Resolves #3428

## Changes

- `vite.config.ts`: converted the default export to a factory function (`defineConfig(({ mode }) => ...)`) so `mode` is available, then conditionally applies `esbuild.pure` in production
- `scripts/build-main.mjs`: adds `pure` to the shared esbuild options when `isProd` is true

## Testing

- `npm run check` passes with no errors (304 pre-existing warnings, all unrelated)
- Build configs verified against esbuild docs: `pure` marks calls as side-effect-free and removes them only when the return value is unused, which is always the case for console calls