### PR TITLE
chore(deps): bump node-pty to 1.2.0-beta.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "better-sqlite3": "^12.6.2",
         "copytree": "^0.14.2",
         "js-yaml": "^4.1.1",
-        "node-pty": "1.2.0-beta.11"
+        "node-pty": "1.2.0-beta.12"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
@@ -17030,9 +17030,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.2.0-beta.11",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.11.tgz",
-      "integrity": "sha512-THcUyu1WwdgoIyUvgXOZ70EOMXzheGa0q3tbEb5kUIfKgcpBJ+AJ9Q1kq0bKtYmQzr77usXiTORZTLmAUQlnoQ==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "better-sqlite3": "^12.6.2",
     "copytree": "^0.14.2",
     "js-yaml": "^4.1.1",
-    "node-pty": "1.2.0-beta.11"
+    "node-pty": "1.2.0-beta.12"
   },
   "overrides": {
     "node-gyp": "^10.3.1"


### PR DESCRIPTION
## Summary

- Bumps `node-pty` from `1.2.0-beta.11` to `1.2.0-beta.12`
- This release fixes a Windows-specific bug where `ConoutConnection` worker thread sockets aren't properly `unref()`'d after `kill()` is called, causing the process to hang on app quit
- No API or behavior changes on macOS/Linux

Resolves #3472

## Changes

- `package.json`: updated `node-pty` version specifier
- `package-lock.json`: updated lockfile to reflect new version

## Testing

Formatting and linting pass cleanly. The `postinstall` rebuild hook runs automatically on `npm install`, so native module compilation is handled without manual steps.