### PR TITLE
perf(build): tune Vite build target for Electron 40 Chromium 144

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -101,6 +101,8 @@ export default defineConfig(({ mode }) => ({
       ? { pure: ["console.log", "console.info", "console.warn", "console.debug"] }
       : {},
   build: {
+    target: "chrome144",
+    modulePreload: { polyfill: false },
     outDir: "dist",
     emptyOutDir: true,
     sourcemap: false,
@@ -110,6 +112,11 @@ export default defineConfig(({ mode }) => ({
           return getVendorChunk(id);
         },
       },
+    },
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      target: "chrome144",
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

- Vite was defaulting to the `modules` preset which targets `['es2019', 'edge88', 'firefox78', 'chrome87', 'safari14']`, well below Chromium 144 in Electron 40
- Added `build.target: 'chrome144'` to stop Vite from emitting compatibility shims for features Chromium 144 already supports natively
- Disabled the module preload polyfill (`modulePreload: { polyfill: false }`) since native module preload is supported
- Added `optimizeDeps.esbuildOptions.target: 'chrome144'` to keep dev and production builds consistent

Resolves #3471

## Changes

- `vite.config.ts`: three additions to the build config

## Testing

`npm run build` completes without errors. The change is targeted and non-breaking since the bundled output only ever runs in Electron 40's Chromium 144 engine.