### PR TITLE
fix(dock): remove yellow background highlight from waiting-state dock items

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -376,9 +376,6 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
               isOpen &&
                 "bg-[var(--dock-item-bg-active)] text-canopy-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-canopy-accent/30",
               !isOpen &&
-                blockedState === "waiting" &&
-                "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-              !isOpen &&
                 blockedState === "failed" &&
                 "bg-[var(--dock-item-bg-failed)] border-[var(--dock-item-border-failed)]",
               isDeprioritized && "opacity-50"

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -206,9 +206,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
               isOpen &&
                 "bg-[var(--dock-item-bg-active)] text-canopy-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-canopy-accent/30",
               !isOpen &&
-                blockedState === "waiting" &&
-                "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-              !isOpen &&
                 blockedState === "failed" &&
                 "bg-[var(--dock-item-bg-failed)] border-[var(--dock-item-border-failed)]",
               isDeprioritized && "opacity-50"

--- a/src/index.css
+++ b/src/index.css
@@ -507,8 +507,6 @@ code.hljs {
   --dock-item-bg-active: color-mix(in oklab, var(--theme-accent-primary) 12%, transparent);
   --dock-item-border: var(--theme-border-subtle);
   --dock-item-border-active: rgba(var(--theme-accent-rgb), 0.32);
-  --dock-item-bg-waiting: color-mix(in oklab, var(--color-state-waiting) 8%, transparent);
-  --dock-item-border-waiting: color-mix(in oklab, var(--color-state-waiting) 35%, transparent);
   --dock-item-bg-failed: color-mix(in oklab, var(--color-status-error) 8%, transparent);
   --dock-item-border-failed: color-mix(in oklab, var(--color-status-error) 40%, transparent);
 


### PR DESCRIPTION
## Summary

- Removes the amber/yellow background and border tint applied to docked terminal items when an agent is in the `waiting` state
- The amber circle icon already communicates waiting state clearly — the background wash was redundant and visually distracting
- The `failed` state red highlight is unaffected

Resolves #3523

## Changes

- `src/components/Layout/DockedTerminalItem.tsx` — removed `waiting` state conditional that applied `--dock-item-bg-waiting` and `--dock-item-border-waiting`
- `src/components/Layout/DockedTabGroup.tsx` — same removal in the tab group dock item renderer
- `src/index.css` — removed the two unused CSS custom property definitions (`--dock-item-bg-waiting`, `--dock-item-border-waiting`)

## Testing

- Prettier ran clean (no formatting changes needed)
- Changes are pure deletions of 8 lines across 3 files — no logic added, no regressions possible in other agent states