### PR TITLE
perf(events): replace O(n) shift eviction with slice in EventBuffer

### DIFF
--- a/electron/services/EventBuffer.ts
+++ b/electron/services/EventBuffer.ts
@@ -153,8 +153,8 @@ export class EventBuffer {
       }
     }
 
-    while (this.buffer.length > this.maxSize) {
-      this.buffer.shift();
+    if (this.buffer.length > this.maxSize) {
+      this.buffer = this.buffer.slice(-this.maxSize);
     }
   }
 


### PR DESCRIPTION
## Summary

- Replaces the `while (shift())` eviction loop in `EventBuffer.push` with a single `this.buffer = this.buffer.slice(-this.maxSize)` assignment
- Aligns `EventBuffer` with the existing pattern in `LogBuffer`, which already uses the efficient slice approach
- Eliminates repeated O(n) re-indexing on every write once the buffer reaches capacity (default 1000 events)

Resolves #3536

## Changes

- `electron/services/EventBuffer.ts`: removed `while` loop with `Array.shift()`, replaced with `slice(-this.maxSize)` after push

## Testing

- All existing `EventBuffer` unit tests pass without modification
- Buffer length correctly enforced at `maxSize` after overflow — same observable behaviour, cheaper implementation