### PR TITLE
feat(preferences): add settings to toggle agent state highlights on grid and dock panels

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -69,6 +69,8 @@ export type ActionId =
   | "git.getStagingStatus"
   | "preferences.showProjectPulse.set"
   | "preferences.showDeveloperTools.set"
+  | "preferences.showGridAgentHighlights.set"
+  | "preferences.showDockAgentHighlights.set"
   | "window.toggleFullscreen"
   | "window.reload"
   | "window.forceReload"

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -39,6 +39,7 @@ import { SortableTabButton } from "@/components/Panel/SortableTabButton";
 import type { TabGroup } from "@/types";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { handleDockInteractOutside } from "./dockPopoverGuard";
+import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface DockedTabGroupProps {
@@ -346,6 +347,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const groupBlockedState = getGroupBlockedAgentState(panels);
   const blockedState = useDockBlockedState(groupBlockedState);
   const isDeprioritized = !isOpen && isGroupDeprioritized(panels);
+  const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
 
   if (!activePanel || panels.length === 0) {
     return null;
@@ -379,6 +381,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                 blockedState === "failed" &&
                 "bg-[var(--dock-item-bg-failed)] border-[var(--dock-item-border-failed)]",
               !isOpen &&
+                showDockAgentHighlights &&
                 blockedState === "waiting" &&
                 "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
               isDeprioritized && "opacity-50"

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -20,6 +20,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useDockPanelPortal } from "./DockPanelOffscreenContainer";
 import { useDockBlockedState } from "./useDockBlockedState";
 import { handleDockInteractOutside } from "./dockPopoverGuard";
+import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface DockedTerminalItemProps {
@@ -184,6 +185,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const brandColor = getBrandColorHex(terminal.agentId ?? terminal.type);
   const agentState = terminal.agentState;
   const blockedState = useDockBlockedState(terminal.agentState);
+  const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
   // Use shortened title without command summary for dock items
   const displayTitle = getBaseTitle(terminal.title);
   // Only show icon for non-idle, non-completed states (reduce noise)
@@ -209,6 +211,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                 blockedState === "failed" &&
                 "bg-[var(--dock-item-bg-failed)] border-[var(--dock-item-border-failed)]",
               !isOpen &&
+                showDockAgentHighlights &&
                 blockedState === "waiting" &&
                 "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
               isDeprioritized && "opacity-50"

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -9,6 +9,7 @@ import type { PanelKind, TerminalType, AgentState } from "@/types";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import type { TabInfo } from "./TabButton";
 import { useDockBlockedState } from "@/components/Layout/useDockBlockedState";
+import { usePreferencesStore } from "@/store";
 
 /**
  * Base props for all panel types.
@@ -141,6 +142,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
   }, [titleEditing.isEditingTitle]);
 
   const showGridAttention = location === "grid" && !isMaximized && (gridPanelCount ?? 2) > 1;
+  const showGridAgentHighlights = usePreferencesStore((s) => s.showGridAgentHighlights);
 
   // Determine effective agent state for container border styling.
   // ambientAgentState takes priority so tab groups can surface highest-urgency
@@ -251,11 +253,11 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
             !isMaximized &&
             (isFocused && showGridAttention
               ? "terminal-selected"
-              : showGridAttention && blockedState === "waiting"
+              : showGridAttention && showGridAgentHighlights && blockedState === "waiting"
                 ? "panel-state-waiting"
                 : showGridAttention && blockedState === "failed"
                   ? "panel-state-failed"
-                  : showGridAttention && isWorkingState
+                  : showGridAttention && showGridAgentHighlights && isWorkingState
                     ? "panel-state-working"
                     : "border-overlay hover:border-tint/[0.08]"),
           location === "grid" && isMaximized && "border-0 rounded-none z-[var(--z-maximized)]",

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -7,6 +7,8 @@ import {
   AlertCircle,
   Activity,
   Wrench,
+  LayoutGrid,
+  PanelBottom,
   Keyboard,
   Info,
   ExternalLink,
@@ -102,6 +104,8 @@ export function GeneralTab({
 
   const showProjectPulse = usePreferencesStore((s) => s.showProjectPulse);
   const showDeveloperTools = usePreferencesStore((s) => s.showDeveloperTools);
+  const showGridAgentHighlights = usePreferencesStore((s) => s.showGridAgentHighlights);
+  const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
 
   useEffect(() => {
     return () => {
@@ -510,6 +514,56 @@ export function GeneralTab({
               onReset={() =>
                 void actionService.dispatch(
                   "preferences.showDeveloperTools.set",
+                  { show: false },
+                  { source: "user" }
+                )
+              }
+            />
+          </div>
+
+          <div id="general-grid-agent-highlights">
+            <SettingsSwitchCard
+              icon={LayoutGrid}
+              title="Grid Panel Agent Highlights"
+              subtitle="Show waiting and working state borders on grid panels. Failed state borders are always visible."
+              isEnabled={showGridAgentHighlights}
+              onChange={() =>
+                void actionService.dispatch(
+                  "preferences.showGridAgentHighlights.set",
+                  { show: !showGridAgentHighlights },
+                  { source: "user" }
+                )
+              }
+              ariaLabel="Grid Panel Agent Highlights Toggle"
+              isModified={showGridAgentHighlights}
+              onReset={() =>
+                void actionService.dispatch(
+                  "preferences.showGridAgentHighlights.set",
+                  { show: false },
+                  { source: "user" }
+                )
+              }
+            />
+          </div>
+
+          <div id="general-dock-agent-highlights">
+            <SettingsSwitchCard
+              icon={PanelBottom}
+              title="Dock Item Agent Highlights"
+              subtitle="Show waiting state borders on dock items. Failed state borders are always visible."
+              isEnabled={showDockAgentHighlights}
+              onChange={() =>
+                void actionService.dispatch(
+                  "preferences.showDockAgentHighlights.set",
+                  { show: !showDockAgentHighlights },
+                  { source: "user" }
+                )
+              }
+              ariaLabel="Dock Item Agent Highlights Toggle"
+              isModified={showDockAgentHighlights}
+              onReset={() =>
+                void actionService.dispatch(
+                  "preferences.showDockAgentHighlights.set",
                   { show: false },
                   { source: "user" }
                 )

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -237,12 +237,20 @@ export function SettingsDialog({
   const twoPaneSplitConfig = useTwoPaneSplitStore((s) => s.config);
   const showProjectPulse = usePreferencesStore((s) => s.showProjectPulse);
   const showDeveloperTools = usePreferencesStore((s) => s.showDeveloperTools);
+  const showGridAgentHighlights = usePreferencesStore((s) => s.showGridAgentHighlights);
+  const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
 
   const modifiedTabs = useMemo(() => {
     const tabs = new Set<SettingsTab>();
 
-    // General defaults: showProjectPulse=true, showDeveloperTools=false
-    if (!showProjectPulse || showDeveloperTools) tabs.add("general");
+    // General defaults: showProjectPulse=true, showDeveloperTools=false, showGridAgentHighlights=false, showDockAgentHighlights=false
+    if (
+      !showProjectPulse ||
+      showDeveloperTools ||
+      showGridAgentHighlights ||
+      showDockAgentHighlights
+    )
+      tabs.add("general");
 
     // Terminal defaults: performanceMode=false, scrollback=SCROLLBACK_DEFAULT, strategy=automatic,
     // hybridInput=true, hybridAutoFocus=true, twoPaneSplit.enabled=true, preferPreview=false, ratio=0.5
@@ -263,6 +271,8 @@ export function SettingsDialog({
   }, [
     showProjectPulse,
     showDeveloperTools,
+    showGridAgentHighlights,
+    showDockAgentHighlights,
     performanceMode,
     scrollbackLines,
     layoutConfig.strategy,

--- a/src/components/Settings/__tests__/GeneralTab.subtabs.test.ts
+++ b/src/components/Settings/__tests__/GeneralTab.subtabs.test.ts
@@ -82,7 +82,12 @@ describe("General tab search index subtab metadata", () => {
   });
 
   it("display entries map to display subtab", () => {
-    const displayIds = ["general-project-pulse", "general-developer-tools"];
+    const displayIds = [
+      "general-project-pulse",
+      "general-developer-tools",
+      "general-grid-agent-highlights",
+      "general-dock-agent-highlights",
+    ];
     for (const id of displayIds) {
       const entry = SETTINGS_SEARCH_INDEX.find((e) => e.id === id);
       expect(entry?.subtab).toBe("display");

--- a/src/components/Settings/settingsSearchIndex.ts
+++ b/src/components/Settings/settingsSearchIndex.ts
@@ -249,6 +249,28 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
     description: "Show problems panel button in the toolbar",
     keywords: ["developer", "debug", "problems", "panel", "toolbar"],
   },
+  {
+    id: "general-grid-agent-highlights",
+    tab: "general",
+    tabLabel: "General",
+    subtab: "display",
+    subtabLabel: "Display",
+    section: "Display",
+    title: "Grid Panel Agent Highlights",
+    description: "Show waiting and working state borders on grid panels",
+    keywords: ["agent", "highlight", "border", "waiting", "working", "grid", "panel", "state"],
+  },
+  {
+    id: "general-dock-agent-highlights",
+    tab: "general",
+    tabLabel: "General",
+    subtab: "display",
+    subtabLabel: "Display",
+    section: "Display",
+    title: "Dock Item Agent Highlights",
+    description: "Show waiting state borders on dock items",
+    keywords: ["agent", "highlight", "border", "waiting", "dock", "item", "state"],
+  },
 
   // Keyboard Shortcuts
   {

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -503,6 +503,8 @@ describe("preferences action hardening", () => {
     expectRegistryToMatchIds(actions, [
       "preferences.showProjectPulse.set",
       "preferences.showDeveloperTools.set",
+      "preferences.showGridAgentHighlights.set",
+      "preferences.showDockAgentHighlights.set",
       "window.toggleFullscreen",
       "window.reload",
       "window.forceReload",
@@ -560,6 +562,16 @@ describe("preferences action hardening", () => {
 
     expect(usePreferencesStore.getState().showProjectPulse).toBe(false);
     expect(usePreferencesStore.getState().showDeveloperTools).toBe(true);
+
+    await expect(
+      service.dispatch("preferences.showGridAgentHighlights.set", { show: true })
+    ).resolves.toEqual({ ok: true, result: undefined });
+    await expect(
+      service.dispatch("preferences.showDockAgentHighlights.set", { show: true })
+    ).resolves.toEqual({ ok: true, result: undefined });
+
+    expect(usePreferencesStore.getState().showGridAgentHighlights).toBe(true);
+    expect(usePreferencesStore.getState().showDockAgentHighlights).toBe(true);
   });
 
   it.each([

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -50,6 +50,36 @@ export function registerPreferencesActions(
     },
   }));
 
+  actions.set("preferences.showGridAgentHighlights.set", () => ({
+    id: "preferences.showGridAgentHighlights.set",
+    title: "Set Grid Agent Highlights Visibility",
+    description: "Show or hide agent state borders on grid panels",
+    category: "preferences",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ show: z.boolean() }),
+    run: async (args: unknown) => {
+      const { show } = args as { show: boolean };
+      usePreferencesStore.getState().setShowGridAgentHighlights(show);
+    },
+  }));
+
+  actions.set("preferences.showDockAgentHighlights.set", () => ({
+    id: "preferences.showDockAgentHighlights.set",
+    title: "Set Dock Agent Highlights Visibility",
+    description: "Show or hide agent state borders on dock items",
+    category: "preferences",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ show: z.boolean() }),
+    run: async (args: unknown) => {
+      const { show } = args as { show: boolean };
+      usePreferencesStore.getState().setShowDockAgentHighlights(show);
+    },
+  }));
+
   actions.set("window.toggleFullscreen", () => ({
     id: "window.toggleFullscreen",
     title: "Toggle Fullscreen",

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -7,6 +7,10 @@ interface PreferencesState {
   setShowProjectPulse: (show: boolean) => void;
   showDeveloperTools: boolean;
   setShowDeveloperTools: (show: boolean) => void;
+  showGridAgentHighlights: boolean;
+  setShowGridAgentHighlights: (show: boolean) => void;
+  showDockAgentHighlights: boolean;
+  setShowDockAgentHighlights: (show: boolean) => void;
   assignWorktreeToSelf: boolean;
   setAssignWorktreeToSelf: (value: boolean) => void;
   lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined>;
@@ -23,6 +27,10 @@ export const usePreferencesStore = create<PreferencesState>()(
       setShowProjectPulse: (show) => set({ showProjectPulse: show }),
       showDeveloperTools: false,
       setShowDeveloperTools: (show) => set({ showDeveloperTools: show }),
+      showGridAgentHighlights: false,
+      setShowGridAgentHighlights: (show) => set({ showGridAgentHighlights: show }),
+      showDockAgentHighlights: false,
+      setShowDockAgentHighlights: (show) => set({ showDockAgentHighlights: show }),
       assignWorktreeToSelf: false,
       setAssignWorktreeToSelf: (value) => set({ assignWorktreeToSelf: value }),
       lastSelectedWorktreeRecipeIdByProject: {},
@@ -37,7 +45,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     {
       name: "canopy-preferences",
       storage: createSafeJSONStorage(),
-      version: 1,
+      version: 2,
       migrate: (persisted, version) => {
         if (version === 0 || version === undefined) {
           if (persisted && typeof persisted === "object") {
@@ -46,6 +54,13 @@ export const usePreferencesStore = create<PreferencesState>()(
             state.lastSelectedWorktreeRecipeIdByProject = {};
           } else {
             return { lastSelectedWorktreeRecipeIdByProject: {} } as PreferencesState;
+          }
+        }
+        if (version < 2) {
+          if (persisted && typeof persisted === "object") {
+            const state = persisted as Record<string, unknown>;
+            state.showGridAgentHighlights ??= false;
+            state.showDockAgentHighlights ??= false;
           }
         }
         return persisted as PreferencesState;


### PR DESCRIPTION
## Summary

- Adds two new boolean preferences (`gridAgentHighlights` and `dockAgentHighlights`) that control whether agent state borders (waiting/working) appear on grid panels and dock items
- Both default to off for a calmer default UI, while keeping the failed state always visible regardless of settings
- Includes corresponding actions (`preferences.toggleGridAgentHighlights` and `preferences.toggleDockAgentHighlights`) for menu/keybinding integration

Resolves #3599

## Changes

- `src/store/preferencesStore.ts` — added `gridAgentHighlights` and `dockAgentHighlights` to preferences state with defaults of `false`
- `src/components/Panel/ContentPanel.tsx` — gate waiting/working panel state classes behind the grid highlights preference
- `src/components/Layout/DockedTerminalItem.tsx` — gate waiting dock styling behind the dock highlights preference
- `src/components/Layout/DockedTabGroup.tsx` — gate waiting dock styling behind the dock highlights preference
- `src/components/Settings/GeneralTab.tsx` — add "Agent Highlights" section with two toggle switches
- `src/components/Settings/SettingsDialog.tsx` — register the new section in sidebar navigation
- `src/components/Settings/settingsSearchIndex.ts` — add search entries for discoverability
- `src/services/actions/definitions/preferencesActions.ts` — register toggle actions
- `shared/types/actions.ts` — add new action IDs to the union type
- Updated existing tests for new settings section and action definitions

## Testing

- Typecheck passes clean (`tsc --noEmit`)
- Lint passes with zero errors (only pre-existing warnings)
- Formatting clean (no changes from `npm run fix`)