### PR TITLE
perf(renderer): enable V8 bytecode caching for faster startup

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -55,6 +55,7 @@ protocol.registerSchemesAsPrivileged([
       secure: true,
       supportFetchAPI: true,
       corsEnabled: true,
+      codeCache: true,
     },
   },
   {

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -86,6 +86,7 @@ export function setupBrowserWindow(dirname: string): CreateWindowResult {
       sandbox: true,
       webviewTag: true,
       navigateOnDragDrop: false,
+      v8CacheOptions: "code",
     },
     ...(process.platform === "darwin"
       ? {


### PR DESCRIPTION
## Summary

- Adds `v8CacheOptions: 'code'` to the BrowserWindow `webPreferences`, enabling V8 bytecode caching for the renderer process
- Adds `codeCache: true` to the custom protocol scheme registration so cached bytecode applies to app:// resources
- The main process already had compile caching via `enableCompileCache()` in bootstrap.ts, but the renderer was left out

Resolves #3612

## Changes

- `electron/window/createWindow.ts` — added `v8CacheOptions: "code"` to `webPreferences`
- `electron/main.ts` — added `codeCache: true` to the `app://` protocol scheme privileges

## Testing

- Typecheck, lint, and format all pass (`npm run fix` — 0 errors, only pre-existing warnings)