### PR TITLE
feat(github): add select all button to issues dropdown when searching

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -632,24 +632,28 @@ export function GitHubResourceList({
           </Popover>
         </div>
 
-        {type === "issue" && searchQuery.trim() !== "" && data.length > 0 && !loading && (
-          <button
-            type="button"
-            onClick={() => {
-              const allSelected = data.every((item) => selection.selectedIds.has(item.number));
-              if (allSelected) {
-                selection.clear();
-              } else {
-                selection.selectAll(data.map((item) => item.number));
-              }
-            }}
-            className="text-xs text-canopy-text/50 hover:text-canopy-text transition-colors px-1 py-0.5 rounded self-start"
-          >
-            {data.every((item) => selection.selectedIds.has(item.number))
-              ? "Deselect all"
-              : `Select all (${data.length})`}
-          </button>
-        )}
+        {type === "issue" &&
+          searchQuery.trim() !== "" &&
+          data.length > 0 &&
+          !loading &&
+          (() => {
+            const allSelected = data.every((item) => selection.selectedIds.has(item.number));
+            return (
+              <button
+                type="button"
+                onClick={() => {
+                  if (allSelected) {
+                    selection.clear();
+                  } else {
+                    selection.selectAll(data.map((item) => item.number));
+                  }
+                }}
+                className="text-xs text-canopy-text/50 hover:text-canopy-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-canopy-accent transition-colors px-1 py-0.5 rounded self-start"
+              >
+                {allSelected ? "Deselect all" : `Select all (${data.length})`}
+              </button>
+            );
+          })()}
 
         <div
           className="flex p-0.5 bg-overlay-soft border border-[var(--border-divider)] rounded-[var(--radius-md)]"


### PR DESCRIPTION
## Summary

- Adds a "Select all" button to the GitHub issues dropdown that appears only when the user has an active search query
- Toggles to "Deselect all" when all visible issues are already selected
- Consistent with existing Cmd/Ctrl+A keyboard shortcut behavior

Resolves #3618

## Changes

- `src/components/GitHub/GitHubResourceList.tsx`: Added a compact "Select all" / "Deselect all" button between the search input and the issues list. Only renders when the resource type is "issues" and the search query is non-empty. Uses the existing `selection.selectAll()` and `selection.clear()` methods. Extracted an `allSelected` computed variable for reuse. Added focus-visible styling to the button.

## Testing

- Typecheck, lint, and format all pass (`npm run check` clean)
- Button visibility logic verified: only shows for issues with active search query
- Toggle behavior: switches between select all / deselect all based on current selection state