### PR TITLE
feat(bulk-worktree): replace config UI with progress view during execution

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -606,7 +606,7 @@ export function BulkCreateWorktreeDialog({
               {/* Numeric progress */}
               <div className="flex items-center justify-center gap-1.5 text-sm text-canopy-text/70">
                 <span>
-                  {processedCount} of {progress.total} created
+                  {progress.completed} of {progress.total} created
                 </span>
                 {progress.failed > 0 && (
                   <span className="text-status-warning">&middot; {progress.failed} failed</span>


### PR DESCRIPTION
## Summary

- Replaces the cluttered configuration UI with a focused progress view when bulk worktree creation is running
- Shows current worktree being created, progress bar, numeric count, and failure indicators
- Adds Done/Cancel controls that swap based on execution phase

Resolves #3617

## Changes

- Extracted `BulkCreateProgressView` component that renders during `executing` and `done` phases
- Added `currentItem` tracking to the progress reducer to show which worktree is actively being created
- Configuration controls (assign toggle, recipe picker, worktree list) are hidden once creation starts
- Progress view displays issue number + title (or branch name) for the current item
- Failed count shown inline when failures occur

## Testing

- Typecheck, ESLint, and Prettier all pass cleanly
- Existing dialog behavior preserved for idle phase and edge cases (all items skipped)