### PR TITLE
fix(onboarding): remove asymmetric button nudging from telemetry consent

### DIFF
--- a/e2e/helpers/project.ts
+++ b/e2e/helpers/project.ts
@@ -17,7 +17,7 @@ export async function openProject(
 export async function dismissTelemetryConsent(window: Page): Promise<void> {
   const dialog = window.getByRole("dialog", { name: "Crash reporting consent" });
   if (await dialog.isVisible().catch(() => false)) {
-    await dialog.getByRole("button", { name: "No thanks" }).click();
+    await dialog.getByRole("button", { name: "Disable" }).click();
     await expect(dialog).not.toBeVisible({ timeout: 3_000 });
   }
 }

--- a/src/components/Onboarding/TelemetryConsentStep.tsx
+++ b/src/components/Onboarding/TelemetryConsentStep.tsx
@@ -33,16 +33,21 @@ export const TelemetryConsentStep = forwardRef<HTMLHeadingElement, TelemetryCons
               or personal data are ever collected.
             </p>
             <div className="flex gap-2">
-              <Button size="sm" onClick={() => void onDismiss(true)} className="flex-1">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => void onDismiss(true)}
+                className="flex-1"
+              >
                 Enable
               </Button>
               <Button
                 size="sm"
                 variant="outline"
                 onClick={() => void onDismiss(false)}
-                className="flex-1 text-canopy-text border-canopy-border hover:bg-canopy-border hover:text-canopy-text"
+                className="flex-1"
               >
-                No thanks
+                Disable
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Both Enable and Disable buttons now use the same `outline` variant, removing the visual hierarchy that nudged users toward enabling telemetry
- Renamed "No thanks" to "Disable" for neutral, non-confirmshaming language
- Removed custom muted styling overrides from the Disable button so both buttons render identically

Resolves #3664

## Changes

- `src/components/Onboarding/TelemetryConsentStep.tsx` -- Changed Enable button from default variant to `outline`, renamed "No thanks" to "Disable", removed custom className overrides on the Disable button
- `e2e/helpers/project.ts` -- Updated `dismissTelemetryConsent` helper to click "Disable" instead of "No thanks"

## Testing

- TypeScript typecheck passes
- ESLint and Prettier report no issues
- E2E helper updated to match the new button label