### PR TITLE
refactor(terminal): remove redundant WebLinksAddon

### DIFF
--- a/electron/services/pty/UrlStyler.ts
+++ b/electron/services/pty/UrlStyler.ts
@@ -3,7 +3,7 @@
  *
  * Links in xterm.js terminals need explicit hyperlink sequences to be both
  * visually styled and clickable. OSC 8 is the standard terminal hyperlink
- * escape sequence, supported natively by xterm.js without requiring WebLinksAddon.
+ * escape sequence, supported natively by xterm.js.
  *
  * OSC 8 Format: \x1b]8;;URI\x07DISPLAY_TEXT\x1b]8;;\x07
  */
@@ -35,7 +35,7 @@ const ESCAPE_REGEX = /\x1b[\[\]]/;
  * Wrap a URL with OSC 8 hyperlink sequence and ANSI styling.
  *
  * Creates a native terminal hyperlink that is:
- * - Clickable without WebLinksAddon
+ * - Clickable in xterm.js via the native linkHandler
  * - Styled with blue color and underline
  */
 function wrapUrl(url: string): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "@xterm/addon-image": "^0.9.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
-        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/headless": "^6.0.0",
         "@xterm/xterm": "^6.0.0",
         "anser": "^2.3.5",
@@ -6364,11 +6363,6 @@
     },
     "node_modules/@xterm/addon-serialize": {
       "version": "0.14.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-web-links": {
-      "version": "0.12.0",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@xterm/addon-image": "^0.9.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",
-    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/headless": "^6.0.0",
     "@xterm/xterm": "^6.0.0",
     "anser": "^2.3.5",

--- a/src/services/terminal/TerminalAddonManager.ts
+++ b/src/services/terminal/TerminalAddonManager.ts
@@ -1,7 +1,6 @@
 import { Terminal, IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
 import { FileLinksAddon } from "./FileLinksAddon";
@@ -9,17 +8,12 @@ import { FileLinksAddon } from "./FileLinksAddon";
 export interface TerminalAddons {
   fitAddon: FitAddon;
   serializeAddon: SerializeAddon;
-  webLinksAddon: WebLinksAddon;
   imageAddon: ImageAddon;
   searchAddon: SearchAddon;
   fileLinksDisposable: IDisposable;
 }
 
-export function setupTerminalAddons(
-  terminal: Terminal,
-  openLink: (url: string, event?: MouseEvent) => void,
-  getCwd: () => string
-): TerminalAddons {
+export function setupTerminalAddons(terminal: Terminal, getCwd: () => string): TerminalAddons {
   // Base addons loaded for all terminals. WebGL is managed separately
   // by TerminalWebGLManager (attached only to the focused terminal).
 
@@ -27,9 +21,6 @@ export function setupTerminalAddons(
   const serializeAddon = new SerializeAddon();
   terminal.loadAddon(fitAddon);
   terminal.loadAddon(serializeAddon);
-
-  const webLinksAddon = new WebLinksAddon((event, uri) => openLink(uri, event));
-  terminal.loadAddon(webLinksAddon);
 
   const imageAddon = new ImageAddon();
   terminal.loadAddon(imageAddon);
@@ -43,7 +34,6 @@ export function setupTerminalAddons(
   return {
     fitAddon,
     serializeAddon,
-    webLinksAddon,
     imageAddon,
     searchAddon,
     fileLinksDisposable,

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -418,9 +418,7 @@ class TerminalInstanceService {
 
     const terminal = new Terminal(terminalOptions);
     this.cwdProviders.set(id, getCwd ?? (() => ""));
-    const addons = setupTerminalAddons(terminal, openLink, () =>
-      (this.cwdProviders.get(id) ?? (() => ""))()
-    );
+    const addons = setupTerminalAddons(terminal, () => (this.cwdProviders.get(id) ?? (() => ""))());
 
     const hostElement = document.createElement("div");
     hostElement.style.width = "100%";

--- a/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
@@ -35,7 +35,6 @@ vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
     fitAddon: { fit: vi.fn() },
     serializeAddon: { serialize: vi.fn() },
-    webLinksAddon: {},
     imageAddon: {},
     searchAddon: {},
   })),

--- a/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
@@ -42,7 +42,6 @@ vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
     fitAddon: { fit: vi.fn() },
     serializeAddon: { serialize: vi.fn() },
-    webLinksAddon: {},
     imageAddon: {},
     searchAddon: {},
   })),

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -40,7 +40,6 @@ vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
     fitAddon: { fit: vi.fn() },
     serializeAddon: { serialize: vi.fn() },
-    webLinksAddon: {},
     imageAddon: {},
     searchAddon: {},
   })),

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -35,7 +35,6 @@ vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
     fitAddon: { fit: vi.fn() },
     serializeAddon: { serialize: vi.fn() },
-    webLinksAddon: {},
     imageAddon: {},
     searchAddon: {},
   })),

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -37,7 +37,6 @@ vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
     fitAddon: { fit: vi.fn() },
     serializeAddon: { serialize: vi.fn() },
-    webLinksAddon: {},
     imageAddon: {},
     searchAddon: {},
   })),

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -1,7 +1,6 @@
 import { Terminal, IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
-import { WebLinksAddon } from "@xterm/addon-web-links";
 import { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
 import { TerminalRefreshTier, TerminalType, TerminalKind, AgentState } from "@/types";
@@ -19,7 +18,6 @@ export interface ManagedTerminal {
   agentStateSubscribers: Set<AgentStateCallback>;
   fitAddon: FitAddon;
   serializeAddon: SerializeAddon;
-  webLinksAddon: WebLinksAddon;
   imageAddon: ImageAddon;
   searchAddon: SearchAddon;
   fileLinksDisposable: IDisposable;


### PR DESCRIPTION
## Summary

- Remove `@xterm/addon-web-links` since the backend `UrlStyler` already wraps URLs with OSC 8 hyperlink sequences, making the frontend addon purely redundant
- Eliminates per-line regex evaluation in the renderer across all terminal instances during every render cycle
- URLs remain clickable via native xterm.js OSC 8 support

Resolves #3659

## Changes

- Removed `WebLinksAddon` creation and loading from `TerminalAddonManager`
- Removed `webLinks` from `TerminalAddonRefs` type and all addon disposal logic
- Removed `openLink` handler from `TerminalInstanceService` (OSC 8 uses xterm.js native link handling)
- Removed `@xterm/addon-web-links` from `package.json` and `package-lock.json`
- Cleaned up WebLinksAddon references from 5 test files
- Updated `UrlStyler` comment to reflect the addon has been removed

## Testing

- TypeScript typecheck passes cleanly
- ESLint passes with zero errors (existing warnings only)
- Prettier formatting verified clean