### PR TITLE
fix(pty): remove dead agent state code for non-agent terminals

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -24,7 +24,7 @@ import {
 } from "./types.js";
 import { getTerminalSerializerService } from "./TerminalSerializerService.js";
 import { events } from "../events.js";
-import { AgentSpawnedSchema, AgentStateChangedSchema } from "../../schemas/agent.js";
+import { AgentSpawnedSchema } from "../../schemas/agent.js";
 import type { PtyPool } from "../PtyPool.js";
 import { installHeadlessResponder } from "./headlessResponder.js";
 import { styleUrls } from "./UrlStyler.js";
@@ -1338,30 +1338,6 @@ export class TerminalProcess {
         worktreeId: this.options.worktreeId,
         lastCommand,
       });
-
-      const newState = result.isBusy ? "running" : "idle";
-
-      if (terminal.agentState !== newState) {
-        const previousState = terminal.agentState || "idle";
-        terminal.agentState = newState;
-        terminal.lastStateChange = Date.now();
-
-        const stateChangePayload = {
-          agentId: this.terminalInfo.agentId,
-          terminalId: this.id,
-          state: newState,
-          previousState,
-          timestamp: terminal.lastStateChange,
-          trigger: "activity" as const,
-          confidence: 1.0,
-          worktreeId: this.options.worktreeId,
-        };
-
-        const validated = AgentStateChangedSchema.safeParse(stateChangePayload);
-        if (validated.success) {
-          events.emit("agent:state-changed", validated.data);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Non-agent terminals had dead code in `handleAgentDetection()` that mutated local `agentState` and attempted to emit `"agent:state-changed"` events, but the payload always failed schema validation because `agentId` was `undefined`
- Removed the dead state mutation and failed event emission code path (Option B from the issue), keeping the working `"terminal:activity"` event that already fires for non-agent terminals
- Verified that nothing depends on `terminal.agentState` being set for non-agent terminals (HibernationService checks are unaffected since non-agent terminals never had valid state propagation)

Resolves #3699

## Changes

- `electron/services/pty/TerminalProcess.ts`: Removed ~25 lines of dead code after the `if (!terminal.agentId)` guard that performed local state mutation and silently-failing event emission

## Testing

- `npm run check` passes (typecheck, lint, format)
- No runtime behavior change since the removed code path never successfully emitted events