### PR TITLE
feat(github): add 'Select unassigned' button to issue search bulk actions

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -638,20 +638,38 @@ export function GitHubResourceList({
           !loading &&
           (() => {
             const allSelected = data.every((item) => selection.selectedIds.has(item.number));
+            const unassigned = data.filter((item) => (item as GitHubIssue).assignees.length === 0);
             return (
-              <button
-                type="button"
-                onClick={() => {
-                  if (allSelected) {
-                    selection.clear();
-                  } else {
-                    selection.selectAll(data.map((item) => item.number));
-                  }
-                }}
-                className="text-xs text-canopy-text/50 hover:text-canopy-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-canopy-accent transition-colors px-1 py-0.5 rounded self-start"
+              <div
+                className="flex items-center gap-1.5"
+                role="group"
+                aria-label="Selection actions"
               >
-                {allSelected ? "Deselect all" : `Select all (${data.length})`}
-              </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (allSelected) {
+                      selection.clear();
+                    } else {
+                      selection.selectAll(data.map((item) => item.number));
+                    }
+                  }}
+                  className="text-xs text-canopy-text/50 hover:text-canopy-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-canopy-accent transition-colors px-1 py-0.5 rounded"
+                >
+                  {allSelected ? "Deselect all" : `Select all (${data.length})`}
+                </button>
+                {unassigned.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      selection.selectAll(unassigned.map((item) => item.number));
+                    }}
+                    className="text-xs text-canopy-text/50 hover:text-canopy-text focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-canopy-accent transition-colors px-1 py-0.5 rounded"
+                  >
+                    {`Select unassigned (${unassigned.length})`}
+                  </button>
+                )}
+              </div>
             );
           })()}
 


### PR DESCRIPTION
## Summary

- Adds a "Select unassigned (N)" button next to the existing "Select all" button in issue search results
- Filters issues by empty `assignees` array and selects only those when clicked
- Button is hidden when there are no unassigned issues in the current results

Resolves #3720

## Changes

- Wrapped the existing "Select all" button and new "Select unassigned" button in a flex container with `role="group"`
- Computed `unassigned` list by filtering `data` for items with empty `assignees` arrays
- New button only renders when `unassigned.length > 0`, matching the pattern of minimal UI when not applicable
- Clicking "Select unassigned" replaces the current selection with only the unassigned issue numbers

## Testing

- Typecheck passes cleanly
- ESLint passes (406 pre-existing warnings, 0 errors)
- Prettier formatting verified clean