### PR TITLE
feat(pulse): filter merged count by selected time range

### DIFF
--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -31,7 +31,7 @@ export const PROJECT_HEALTH_QUERY = `
       vulnerabilityAlerts(first: 1) {
         totalCount
       }
-      recentMergedPRs: pullRequests(first: 10, states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      recentMergedPRs: pullRequests(first: 100, states: MERGED, orderBy: {field: UPDATED_AT, direction: DESC}) {
         nodes {
           mergedAt
         }

--- a/electron/services/github/__tests__/GitHubQueries.test.ts
+++ b/electron/services/github/__tests__/GitHubQueries.test.ts
@@ -31,6 +31,10 @@ describe("PROJECT_HEALTH_QUERY", () => {
     expect(PROJECT_HEALTH_QUERY).toContain("mergedAt");
   });
 
+  it("fetches up to 100 merged PRs to cover longer time ranges", () => {
+    expect(PROJECT_HEALTH_QUERY).toContain("first: 100");
+  });
+
   it("does NOT use MERGED_AT as orderBy (not a valid PullRequestOrderField)", () => {
     expect(PROJECT_HEALTH_QUERY).not.toContain("MERGED_AT");
     expect(PROJECT_HEALTH_QUERY).toContain("UPDATED_AT");

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -129,11 +129,22 @@ function HealthChip({ icon, label, onClick, className }: HealthChipProps) {
   );
 }
 
-function HealthSignals({ health }: { health: ProjectHealthData }) {
+function HealthSignals({
+  health,
+  rangeDays,
+}: {
+  health: ProjectHealthData;
+  rangeDays: PulseRangeDays;
+}) {
   const openUrl = (path: string) => {
     const url = path.startsWith("http") ? path : `${health.repoUrl}${path}`;
     systemClient.openExternal(url);
   };
+
+  const cutoff = Date.now() - rangeDays * 24 * 60 * 60 * 1000;
+  const mergedInRange = health.mergeVelocity.recentMergedDates.filter(
+    (d) => new Date(d).getTime() >= cutoff
+  ).length;
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
@@ -166,10 +177,10 @@ function HealthSignals({ health }: { health: ProjectHealthData }) {
           onClick={() => openUrl("/security/dependabot")}
         />
       )}
-      {health.mergeVelocity.recentMergedCount > 0 && (
+      {mergedInRange > 0 && (
         <HealthChip
           icon={<GitMerge className="w-3.5 h-3.5 text-purple-400" />}
-          label={`${health.mergeVelocity.recentMergedCount} merged`}
+          label={`${mergedInRange} merged (${rangeDays}d)`}
           onClick={() => openUrl("/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc")}
         />
       )}
@@ -426,7 +437,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         {health && !health.error && health.repoUrl ? (
           <div className="border-t border-canopy-border pt-3">
-            <HealthSignals health={health} />
+            <HealthSignals health={health} rangeDays={rangeDays} />
           </div>
         ) : healthLoading ? (
           <HealthSectionSkeleton />


### PR DESCRIPTION
## Summary

- The merged PR count chip in the pulse card now reflects the user's selected time range (60/120/180 days) instead of always showing the last 10 merged PRs regardless of when they happened
- The GraphQL query fetches up to 100 merged PRs (was 10) so the count is accurate for active repos across all time ranges
- The chip label now includes the time context (e.g. "10 merged (60d)") so users understand what period the number covers

Resolves #3684

## Changes

- **`electron/services/github/GitHubQueries.ts`** — Bumped `recentMergedPRs` query from `first: 10` to `first: 100` to cover longer time ranges
- **`src/components/Pulse/ProjectPulseCard.tsx`** — `HealthSignals` now accepts `rangeDays` prop, filters `recentMergedDates` by a date cutoff derived from the selected range, and displays the count with the range suffix
- **`electron/services/github/__tests__/GitHubQueries.test.ts`** — Added test verifying the query fetches 100 PRs

## Testing

- TypeScript typecheck passes cleanly
- ESLint passes (0 errors, 406 warnings matching the ratchet baseline)
- Prettier formatting verified with no changes needed
- Existing unit tests pass including new query coverage test