### PR TITLE
feat(bulk-worktree): add per-item status tracking, error display, and retry

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -106,7 +106,7 @@ const MAX_AUTO_RETRIES = 2;
 const RETRY_DELAYS = [1000, 2000];
 
 const TRANSIENT_ERROR_RE =
-  /\.lock['"]?:.*(?:File exists|exists)|Another git process|Resource temporarily unavailable/i;
+  /\.lock['"]?:.*(?:File exists|exists)|Another git process|Resource temporarily unavailable|cannot lock ref|could not lock config file/i;
 
 function isTransientError(message: string, code?: string): boolean {
   if (code === "VALIDATION_ERROR" || code === "NOT_FOUND") return false;

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -321,6 +321,9 @@ describe("BulkCreateWorktreeDialog", () => {
 
     // Should have dispatched again for only item 2
     expect(mockDispatch).toHaveBeenCalledTimes(4); // 3 initial + 1 retry
+    // Verify the retry call was for issue #2
+    const retryCall = mockDispatch.mock.calls[3]!;
+    expect(retryCall[1]).toMatchObject({ issueNumber: 2 });
 
     // Resolve the retry successfully
     await act(async () => {
@@ -426,5 +429,49 @@ describe("BulkCreateWorktreeDialog", () => {
 
     expect(screen.getByText("Network connection lost")).toBeTruthy();
     expect(screen.getByText(/1 failed/)).toBeTruthy();
+  });
+
+  it("stops processing items when dialog is closed during execution", async () => {
+    const resolvers: Array<(value: unknown) => void> = [];
+    mockDispatch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+
+    const onClose = vi.fn();
+    render(<BulkCreateWorktreeDialog {...defaultProps} onClose={onClose} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    // Resolve first item
+    await act(async () => {
+      resolvers[0]?.({ ok: true, result: { worktreeId: "wt-1" } });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Close the dialog (cancel) while items 2 and 3 are still pending
+    await act(async () => {
+      // Find cancel button in executing state
+      const buttons = screen.getAllByRole("button");
+      const cancelBtn = buttons.find((b) => b.textContent === "Cancel");
+      cancelBtn?.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(onClose).toHaveBeenCalled();
+
+    // Resolve remaining items — should be no-ops due to runIdRef invalidation
+    await act(async () => {
+      resolvers[1]?.({ ok: true, result: { worktreeId: "wt-2" } });
+      resolvers[2]?.({ ok: true, result: { worktreeId: "wt-3" } });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Dialog should not show done state (it was closed/reset)
+    expect(screen.queryByTestId("bulk-create-done-button")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds per-item status tracking (pending/creating/success/error) to the bulk worktree creation dialog so users can see exactly which items succeeded or failed
- Displays error messages for failed items directly in the dialog instead of silently discounting them
- Implements automatic retry with exponential backoff for transient errors (git lock contention, network timeouts) and a manual "Retry Failed" button for remaining failures

Resolves #3744

## Changes

- **`BulkCreateWorktreeDialog.tsx`**: Refactored progress state from aggregate counters to per-item `ItemStatus` tracking. Added `retryWithBackoff` helper for transient error handling. Progress view now shows individual item status with expandable error details. "Retry Failed" button re-queues only failed items.
- **`BulkCreateWorktreeDialog.test.tsx`**: New test suite covering per-item status transitions, error display, retry flows, transient error auto-retry, and edge cases (all fail, retry during retry, dialog dismissal during retry).

## Testing

- All new unit tests pass
- Typecheck, lint, and format pass cleanly (warnings only, pre-existing)
- Existing dialog API (`BulkCreateWorktreeDialogProps`) unchanged