### PR TITLE
feat(terminal): wrap terminal writes with DEC Mode 2026 synchronized output

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -38,6 +38,25 @@ const SS3_NAV_RE = /^\x1bO[ABCDHFPQRS]$/;
 // eslint-disable-next-line no-control-regex
 const TILDE_NAV_RE = /^\x1b\[(2|3|5|6|15|17|18|19|20|21|23|24)(;\d+)?~$/;
 
+const DEC_2026_BEGIN = "\x1b[?2026h";
+const DEC_2026_END = "\x1b[?2026l";
+const DEC_2026_BEGIN_BYTES = new Uint8Array([0x1b, 0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36, 0x68]);
+const DEC_2026_END_BYTES = new Uint8Array([0x1b, 0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36, 0x6c]);
+
+export function wrapWithSyncOutput(data: string): string;
+export function wrapWithSyncOutput(data: Uint8Array): Uint8Array;
+export function wrapWithSyncOutput(data: string | Uint8Array): string | Uint8Array;
+export function wrapWithSyncOutput(data: string | Uint8Array): string | Uint8Array {
+  if (typeof data === "string") {
+    return DEC_2026_BEGIN + data + DEC_2026_END;
+  }
+  const wrapped = new Uint8Array(data.byteLength + 16);
+  wrapped.set(DEC_2026_BEGIN_BYTES, 0);
+  wrapped.set(data, 8);
+  wrapped.set(DEC_2026_END_BYTES, data.byteLength + 8);
+  return wrapped;
+}
+
 export function isNonKeyboardInput(data: string): boolean {
   // Mouse sequences
   if (data.startsWith("\x1b[M")) return true;
@@ -263,7 +282,8 @@ class TerminalInstanceService {
         ? performance.now()
         : Date.now()
       : 0;
-    terminal.write(data, () => {
+    const wrappedData = wrapWithSyncOutput(data);
+    terminal.write(wrappedData, () => {
       if (this.instances.get(id) !== managed) return;
 
       managed.pendingWrites = Math.max(0, (managed.pendingWrites ?? 1) - 1);

--- a/src/services/terminal/__tests__/syncOutputWrapping.test.ts
+++ b/src/services/terminal/__tests__/syncOutputWrapping.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { wrapWithSyncOutput } from "../TerminalInstanceService";
+
+const DEC_2026_BEGIN = "\x1b[?2026h";
+const DEC_2026_END = "\x1b[?2026l";
+const DEC_2026_BEGIN_BYTES = [0x1b, 0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36, 0x68];
+const DEC_2026_END_BYTES = [0x1b, 0x5b, 0x3f, 0x32, 0x30, 0x32, 0x36, 0x6c];
+
+describe("wrapWithSyncOutput", () => {
+  describe("string data", () => {
+    it("wraps string with DEC 2026 begin and end sequences", () => {
+      const result = wrapWithSyncOutput("hello world");
+      expect(result).toBe(DEC_2026_BEGIN + "hello world" + DEC_2026_END);
+    });
+
+    it("wraps empty string", () => {
+      const result = wrapWithSyncOutput("");
+      expect(result).toBe(DEC_2026_BEGIN + DEC_2026_END);
+    });
+
+    it("wraps string containing escape sequences", () => {
+      const data = "\x1b[31mred text\x1b[0m";
+      const result = wrapWithSyncOutput(data);
+      expect(result).toBe(DEC_2026_BEGIN + data + DEC_2026_END);
+    });
+
+    it("wraps string containing nested DEC 2026 sequences", () => {
+      const data = "\x1b[?2026hagent output\x1b[?2026l";
+      const result = wrapWithSyncOutput(data);
+      expect(result).toBe(DEC_2026_BEGIN + data + DEC_2026_END);
+    });
+  });
+
+  describe("Uint8Array data", () => {
+    it("wraps Uint8Array with DEC 2026 begin and end byte sequences", () => {
+      const input = new Uint8Array([0x41, 0x42, 0x43]); // "ABC"
+      const result = wrapWithSyncOutput(input);
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.byteLength).toBe(input.byteLength + 16);
+
+      const bytes = Array.from(result as Uint8Array);
+      expect(bytes.slice(0, 8)).toEqual(DEC_2026_BEGIN_BYTES);
+      expect(bytes.slice(8, 11)).toEqual([0x41, 0x42, 0x43]);
+      expect(bytes.slice(11, 19)).toEqual(DEC_2026_END_BYTES);
+    });
+
+    it("wraps empty Uint8Array", () => {
+      const input = new Uint8Array(0);
+      const result = wrapWithSyncOutput(input);
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.byteLength).toBe(16);
+
+      const bytes = Array.from(result as Uint8Array);
+      expect(bytes.slice(0, 8)).toEqual(DEC_2026_BEGIN_BYTES);
+      expect(bytes.slice(8, 16)).toEqual(DEC_2026_END_BYTES);
+    });
+
+    it("does not mutate the original Uint8Array", () => {
+      const input = new Uint8Array([0x41, 0x42, 0x43]);
+      const inputCopy = new Uint8Array(input);
+      wrapWithSyncOutput(input);
+      expect(Array.from(input)).toEqual(Array.from(inputCopy));
+    });
+
+    it("handles large Uint8Array payloads", () => {
+      const input = new Uint8Array(65536);
+      input.fill(0x58); // 'X'
+      const result = wrapWithSyncOutput(input) as Uint8Array;
+
+      expect(result.byteLength).toBe(65536 + 16);
+      expect(Array.from(result.slice(0, 8))).toEqual(DEC_2026_BEGIN_BYTES);
+      expect(result[8]).toBe(0x58);
+      expect(result[65536 + 7]).toBe(0x58);
+      expect(Array.from(result.slice(65536 + 8, 65536 + 16))).toEqual(DEC_2026_END_BYTES);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Wraps every `terminal.write()` call with DEC Mode 2026 escape sequences so xterm.js buffers all grid mutations and renders them in a single frame
- Eliminates visual tearing during high-throughput agent output by treating each ~8ms batch as an atomic rendering unit
- Handles both string and Uint8Array data paths with properly typed overloads

Resolves #3658

## Changes

- Added `wrapWithSyncOutput()` exported helper in `TerminalInstanceService.ts` with three overload signatures (string, Uint8Array, union)
- String path: simple concatenation with cached DEC 2026 begin/end constants
- Uint8Array path: allocates a new buffer with 16 extra bytes for the prefix/suffix sequences
- Wired into `writeToTerminal()` just before the `terminal.write()` call, after byte accounting
- Added comprehensive test suite covering string wrapping, Uint8Array wrapping, empty inputs, nested DEC 2026 sequences, large payloads, and immutability

## Testing

- All unit tests pass (vitest)
- TypeScript typecheck clean
- ESLint and Prettier pass with no changes needed