### PR TITLE
refactor(security): remove bypassCSP from canopy-file protocol

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -65,7 +65,6 @@ protocol.registerSchemesAsPrivileged([
     scheme: "canopy-file",
     privileges: {
       secure: true,
-      bypassCSP: true,
       supportFetchAPI: true,
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ const DEV_CSP = [
   `style-src 'self' ${devServerOrigins.join(" ")} 'unsafe-inline'`,
   "font-src 'self' data:",
   `connect-src 'self' ${devServerOrigins.join(" ")} ${devServerWebSocketOrigins.join(" ")}`,
-  `img-src 'self' ${devServerOrigins.join(" ")} https://avatars.githubusercontent.com data:`,
+  `img-src 'self' ${devServerOrigins.join(" ")} https://avatars.githubusercontent.com canopy-file: data:`,
   "frame-src 'self' https://www.youtube.com http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
 ].join("; ");
 
@@ -30,7 +30,7 @@ const PROD_CSP = [
   "style-src 'self' 'unsafe-inline'",
   "font-src 'self' data:",
   "connect-src 'self'",
-  "img-src 'self' https://avatars.githubusercontent.com data: blob:",
+  "img-src 'self' https://avatars.githubusercontent.com canopy-file: data: blob:",
   "frame-src 'self' https://www.youtube.com http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*",
   "worker-src 'self' blob:",
   "object-src 'none'",


### PR DESCRIPTION
## Summary

- Removed the `bypassCSP: true` privilege from the `canopy-file` protocol registration, reducing the protocol's attack surface
- Added `canopy-file:` to the `img-src` CSP directive in both dev and production configurations so images served via the protocol continue to load correctly
- The protocol's other privileges (`secure`, `supportFetchAPI`) are retained

Resolves #3706

## Changes

- **electron/main.ts** -- Removed `bypassCSP: true` from `protocol.registerSchemesAsPrivileged` for the `canopy-file` scheme
- **vite.config.ts** -- Added `canopy-file:` to `img-src` in both `DEV_CSP` and `PROD_CSP` strings, which is the proper way to allow images from this protocol rather than bypassing CSP entirely

## Testing

- TypeScript typecheck passes cleanly
- ESLint and Prettier report no issues
- The CSP now explicitly whitelists `canopy-file:` for image sources, so `canopy-file://` image loads continue working without the broad CSP bypass