### PR TITLE
fix(terminal): use custom DockToBottomIcon for dock action in context menu

### DIFF
--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -15,7 +15,6 @@ import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import {
   ArrowDownFromLine,
-  ArrowDownToLine,
   Bell,
   BellOff,
   Bot,
@@ -42,6 +41,7 @@ import {
   Trash2,
   Unlock,
 } from "lucide-react";
+import { DockToBottomIcon } from "@/components/icons";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -408,7 +408,7 @@ export function TerminalContextMenu({
         onSelect={() => handleAction(currentLocation === "grid" ? "move-to-dock" : "move-to-grid")}
       >
         {currentLocation === "grid" ? (
-          <ArrowDownToLine className={ICON_CLASS} aria-hidden="true" />
+          <DockToBottomIcon className={ICON_CLASS} />
         ) : (
           <LayoutGrid className={ICON_CLASS} aria-hidden="true" />
         )}


### PR DESCRIPTION
## Summary

- Replaced the Lucide `ArrowDownToLine` icon with the custom `DockToBottomIcon` in the terminal right-click context menu's "Move to Dock" entry
- This brings the context menu in line with PanelHeader and WorktreeMenuItems, which already use `DockToBottomIcon`

Resolves #3763

## Changes

- `src/components/Terminal/TerminalContextMenu.tsx`: Swapped `ArrowDownToLine` import for `DockToBottomIcon` and updated the JSX reference

## Testing

- Typecheck, lint, and format all pass (`npm run check`)
- Visual consistency verified across all dock action locations