### PR TITLE
feat(terminal): enrich agent state chip tooltip with session metadata

### DIFF
--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/comp
 import { STATE_ICONS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
 import type { ActivityState } from "./TerminalPane";
 import { useTerminalStore } from "@/store";
+import { useShallow } from "zustand/react/shallow";
 import { formatElapsedDuration } from "@/utils/formatElapsedDuration";
 import { formatTimeAgo } from "@/utils/timeAgo";
 
@@ -57,16 +58,18 @@ function TerminalHeaderContentComponent({
   flowStatus,
 }: TerminalHeaderContentProps) {
   const { isInputLocked, startedAt, lastStateChange, stateChangeTrigger, stateChangeConfidence } =
-    useTerminalStore((state) => {
-      const t = state.terminals.find((t) => t.id === id);
-      return {
-        isInputLocked: t?.isInputLocked ?? false,
-        startedAt: t?.startedAt,
-        lastStateChange: t?.lastStateChange,
-        stateChangeTrigger: t?.stateChangeTrigger,
-        stateChangeConfidence: t?.stateChangeConfidence,
-      };
-    });
+    useTerminalStore(
+      useShallow((state) => {
+        const t = state.terminals.find((t) => t.id === id);
+        return {
+          isInputLocked: t?.isInputLocked ?? false,
+          startedAt: t?.startedAt,
+          lastStateChange: t?.lastStateChange,
+          stateChangeTrigger: t?.stateChangeTrigger,
+          stateChangeConfidence: t?.stateChangeConfidence,
+        };
+      })
+    );
 
   // Show command pill only for plain terminals (not agent terminals)
   // Use kind to distinguish - agent panels have kind="agent"

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -42,6 +42,10 @@ vi.mock("@/components/Worktree/terminalStateConfig", () => ({
 
 let mockTerminal: Record<string, unknown> = {};
 
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
 vi.mock("@/store", () => ({
   useTerminalStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({ terminals: [mockTerminal] }),
@@ -231,5 +235,31 @@ describe("TerminalHeaderContent — agent state chip tooltip", () => {
     const tooltips = screen.getAllByTestId("tooltip-content");
     const agentTooltip = tooltips.find((el) => el.textContent?.includes("Agent directing"));
     expect(agentTooltip).toBeTruthy();
+  });
+
+  it("shows exit code 0 correctly", () => {
+    mockTerminal = { id: "t1" };
+
+    render(<TerminalHeaderContent id="t1" agentState="failed" isExited={true} exitCode={0} />);
+
+    const tooltips = screen.getAllByTestId("tooltip-content");
+    const agentTooltip = tooltips.find((el) => el.textContent?.includes("Agent failed"));
+    expect(agentTooltip).toBeTruthy();
+    expect(agentTooltip!.textContent).toContain("Exit code: 0");
+  });
+
+  it("shows 0% confidence when stateChangeConfidence is 0", () => {
+    mockTerminal = {
+      id: "t1",
+      stateChangeTrigger: "heuristic",
+      stateChangeConfidence: 0,
+    };
+
+    render(<TerminalHeaderContent id="t1" agentState="working" />);
+
+    const tooltips = screen.getAllByTestId("tooltip-content");
+    const agentTooltip = tooltips.find((el) => el.textContent?.includes("Agent working"));
+    expect(agentTooltip).toBeTruthy();
+    expect(agentTooltip!.textContent).toContain("(0%)");
   });
 });


### PR DESCRIPTION
## Summary

- Enriches the agent state chip tooltip to show structured session metadata: activity headline, state change trigger, confidence score, exit code, and relative time since last state change
- Integrates with the elapsed time feature from #3738, showing session duration inline with the headline
- Uses `useShallow` for the store selector to prevent unnecessary re-renders

Resolves #3740

## Changes

- **`src/components/Terminal/TerminalHeaderContent.tsx`** — Replaced the simple text tooltip with a multi-line structured tooltip. Added `TRIGGER_LABELS` map for human-readable trigger names. Extended the store selector to read `lastStateChange`, `stateChangeTrigger`, `stateChangeConfidence`, and `startedAt`. Confidence is shown only when below 100%. Missing fields are gracefully omitted.
- **`src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx`** — 13 tests covering: full metadata display, trigger labels (including AI classification), exit codes (including 0), missing field handling, confidence hiding at 1.0, elapsed time display and timer updates, idle/completed chip hiding, and headline fallback.

## Testing

All 13 unit tests pass. Typecheck, lint, and format checks are clean.