### PR TITLE
feat(github): default issues/PR dropdown sort to recently updated

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -556,11 +556,11 @@ export function GitHubResourceList({
                   "relative flex items-center justify-center w-7 h-7 rounded shrink-0",
                   "text-canopy-text/60 hover:text-canopy-text hover:bg-tint/[0.06]",
                   "transition-colors",
-                  sortOrder !== "created" && "text-canopy-accent"
+                  sortOrder !== "updated" && "text-canopy-accent"
                 )}
               >
                 <Filter className="w-3.5 h-3.5" />
-                {sortOrder !== "created" && (
+                {sortOrder !== "updated" && (
                   <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-canopy-accent" />
                 )}
               </button>

--- a/src/store/__tests__/githubFilterStore.test.ts
+++ b/src/store/__tests__/githubFilterStore.test.ts
@@ -98,41 +98,41 @@ describe("githubFilterStore", () => {
     expect(state.prSearchQuery).toBe("");
   });
 
-  it("defaults sort orders to created", () => {
+  it("defaults sort orders to updated", () => {
     const state = useGitHubFilterStore.getState();
-    expect(state.issueSortOrder).toBe("created");
-    expect(state.prSortOrder).toBe("created");
+    expect(state.issueSortOrder).toBe("updated");
+    expect(state.prSortOrder).toBe("updated");
   });
 
   it("setIssueSortOrder updates only issueSortOrder", () => {
-    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    useGitHubFilterStore.getState().setIssueSortOrder("created");
     const state = useGitHubFilterStore.getState();
-    expect(state.issueSortOrder).toBe("updated");
-    expect(state.prSortOrder).toBe("created");
+    expect(state.issueSortOrder).toBe("created");
+    expect(state.prSortOrder).toBe("updated");
   });
 
   it("setPrSortOrder updates only prSortOrder", () => {
-    useGitHubFilterStore.getState().setPrSortOrder("updated");
+    useGitHubFilterStore.getState().setPrSortOrder("created");
     const state = useGitHubFilterStore.getState();
-    expect(state.prSortOrder).toBe("updated");
-    expect(state.issueSortOrder).toBe("created");
+    expect(state.prSortOrder).toBe("created");
+    expect(state.issueSortOrder).toBe("updated");
   });
 
   it("issue and PR sort orders are fully independent", () => {
-    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    useGitHubFilterStore.getState().setIssueSortOrder("created");
     useGitHubFilterStore.getState().setPrSortOrder("created");
-    const state = useGitHubFilterStore.getState();
-    expect(state.issueSortOrder).toBe("updated");
-    expect(state.prSortOrder).toBe("created");
-  });
-
-  it("resetGitHubFilterStore resets sort orders to created", () => {
-    useGitHubFilterStore.getState().setIssueSortOrder("updated");
-    useGitHubFilterStore.getState().setPrSortOrder("updated");
-    resetGitHubFilterStore();
     const state = useGitHubFilterStore.getState();
     expect(state.issueSortOrder).toBe("created");
     expect(state.prSortOrder).toBe("created");
+  });
+
+  it("resetGitHubFilterStore resets sort orders to updated", () => {
+    useGitHubFilterStore.getState().setIssueSortOrder("created");
+    useGitHubFilterStore.getState().setPrSortOrder("created");
+    resetGitHubFilterStore();
+    const state = useGitHubFilterStore.getState();
+    expect(state.issueSortOrder).toBe("updated");
+    expect(state.prSortOrder).toBe("updated");
   });
 
   it("changing sort order does not disturb filters or search queries", () => {
@@ -140,8 +140,8 @@ describe("githubFilterStore", () => {
     useGitHubFilterStore.getState().setPrFilter("merged");
     useGitHubFilterStore.getState().setIssueSearchQuery("bug");
     useGitHubFilterStore.getState().setPrSearchQuery("feat");
-    useGitHubFilterStore.getState().setIssueSortOrder("updated");
-    useGitHubFilterStore.getState().setPrSortOrder("updated");
+    useGitHubFilterStore.getState().setIssueSortOrder("created");
+    useGitHubFilterStore.getState().setPrSortOrder("created");
     const state = useGitHubFilterStore.getState();
     expect(state.issueFilter).toBe("closed");
     expect(state.prFilter).toBe("merged");
@@ -154,15 +154,15 @@ describe("githubFilterStore", () => {
     useGitHubFilterStore.getState().setPrFilter("closed");
     useGitHubFilterStore.getState().setIssueSearchQuery("search1");
     useGitHubFilterStore.getState().setPrSearchQuery("search2");
-    useGitHubFilterStore.getState().setIssueSortOrder("updated");
-    useGitHubFilterStore.getState().setPrSortOrder("updated");
+    useGitHubFilterStore.getState().setIssueSortOrder("created");
+    useGitHubFilterStore.getState().setPrSortOrder("created");
     resetGitHubFilterStore();
     const state = useGitHubFilterStore.getState();
     expect(state.issueFilter).toBe("open");
     expect(state.prFilter).toBe("open");
     expect(state.issueSearchQuery).toBe("");
     expect(state.prSearchQuery).toBe("");
-    expect(state.issueSortOrder).toBe("created");
-    expect(state.prSortOrder).toBe("created");
+    expect(state.issueSortOrder).toBe("updated");
+    expect(state.prSortOrder).toBe("updated");
   });
 });

--- a/src/store/githubFilterStore.ts
+++ b/src/store/githubFilterStore.ts
@@ -24,8 +24,8 @@ export const useGitHubFilterStore = create<GitHubFilterState>()((set) => ({
   prFilter: "open",
   issueSearchQuery: "",
   prSearchQuery: "",
-  issueSortOrder: "created",
-  prSortOrder: "created",
+  issueSortOrder: "updated",
+  prSortOrder: "updated",
   setIssueFilter: (filter) => set({ issueFilter: filter }),
   setPrFilter: (filter) => set({ prFilter: filter }),
   setIssueSearchQuery: (query) => set({ issueSearchQuery: query }),
@@ -40,7 +40,7 @@ export function resetGitHubFilterStore() {
     prFilter: "open",
     issueSearchQuery: "",
     prSearchQuery: "",
-    issueSortOrder: "created",
-    prSortOrder: "created",
+    issueSortOrder: "updated",
+    prSortOrder: "updated",
   });
 }


### PR DESCRIPTION
## Summary

- Changes the default sort order for both issues and PR dropdowns from "created" (newest) to "updated" (recently updated), so active items appear first without manual switching
- Updates the sort indicator dot to treat "updated" as the neutral state instead of "created"
- Updates all related tests to reflect the new defaults

Resolves #3782

## Changes

- `src/store/githubFilterStore.ts` — default and reset values for `issueSortOrder` and `prSortOrder` changed from `"created"` to `"updated"`
- `src/components/GitHub/GitHubResourceList.tsx` — sort indicator dot logic now uses `sortOrder !== "updated"` instead of `sortOrder !== "created"`
- `src/store/__tests__/githubFilterStore.test.ts` — test assertions updated to expect `"updated"` as the default and reset value

## Testing

- TypeScript typecheck passes
- ESLint and Prettier pass with no changes needed
- Unit tests in `githubFilterStore.test.ts` updated and passing