### PR TITLE
fix(github): replace unbounded tooltip caches with bounded TTL caches

### DIFF
--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
+import { TtlCache } from "@/utils/ttlCache";
 
 type TooltipState<T> = {
   data: T | null;
@@ -7,8 +8,11 @@ type TooltipState<T> = {
   error: boolean;
 };
 
-const issueCache = new Map<string, IssueTooltipData>();
-const prCache = new Map<string, PRTooltipData>();
+const TOOLTIP_CACHE_MAX = 100;
+const TOOLTIP_CACHE_TTL = 300_000; // 5 minutes, matching backend TTL
+
+const issueCache = new TtlCache<string, IssueTooltipData>(TOOLTIP_CACHE_MAX, TOOLTIP_CACHE_TTL);
+const prCache = new TtlCache<string, PRTooltipData>(TOOLTIP_CACHE_MAX, TOOLTIP_CACHE_TTL);
 
 export function useIssueTooltip(cwd: string | undefined, issueNumber: number | undefined) {
   const [state, setState] = useState<TooltipState<IssueTooltipData>>({

--- a/src/utils/__tests__/ttlCache.test.ts
+++ b/src/utils/__tests__/ttlCache.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TtlCache } from "../ttlCache";
+
+describe("TtlCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores and retrieves values", () => {
+    const cache = new TtlCache<string, number>(10, 60_000);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.get("b")).toBe(2);
+    expect(cache.size).toBe(2);
+  });
+
+  it("returns undefined for missing keys", () => {
+    const cache = new TtlCache<string, number>(10, 60_000);
+    expect(cache.get("missing")).toBeUndefined();
+  });
+
+  it("expires entries after TTL", () => {
+    const cache = new TtlCache<string, number>(10, 5_000);
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+
+    vi.advanceTimersByTime(5_001);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  it("evicts oldest entry when at capacity (FIFO)", () => {
+    const cache = new TtlCache<string, number>(3, 60_000);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+    expect(cache.size).toBe(3);
+
+    cache.set("d", 4);
+    expect(cache.size).toBe(3);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe(2);
+    expect(cache.get("d")).toBe(4);
+  });
+
+  it("updates existing key without changing eviction order", () => {
+    const cache = new TtlCache<string, number>(3, 60_000);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.set("c", 3);
+
+    // Update "a" — should NOT move it to the end
+    cache.set("a", 10);
+    expect(cache.get("a")).toBe(10);
+    expect(cache.size).toBe(3);
+
+    // Adding a new key should evict "a" (still oldest in insertion order)
+    cache.set("d", 4);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.get("b")).toBe(2);
+  });
+
+  it("clears all entries", () => {
+    const cache = new TtlCache<string, number>(10, 60_000);
+    cache.set("a", 1);
+    cache.set("b", 2);
+    cache.clear();
+    expect(cache.size).toBe(0);
+    expect(cache.get("a")).toBeUndefined();
+  });
+
+  it("does not count expired entries toward capacity", () => {
+    const cache = new TtlCache<string, number>(2, 5_000);
+    cache.set("a", 1);
+    cache.set("b", 2);
+
+    vi.advanceTimersByTime(5_001);
+
+    // Both entries are expired but still in the map
+    // Adding new entries should evict expired ones via FIFO, not block
+    cache.set("c", 3);
+    cache.set("d", 4);
+    expect(cache.get("c")).toBe(3);
+    expect(cache.get("d")).toBe(4);
+    expect(cache.size).toBe(2);
+  });
+});

--- a/src/utils/ttlCache.ts
+++ b/src/utils/ttlCache.ts
@@ -1,0 +1,34 @@
+export class TtlCache<K, V> {
+  private store = new Map<K, { value: V; expiresAt: number }>();
+
+  constructor(
+    private maxSize: number,
+    private ttlMs: number
+  ) {}
+
+  get(key: K): V | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  set(key: K, value: V): void {
+    if (!this.store.has(key) && this.store.size >= this.maxSize) {
+      const oldest = this.store.keys().next().value;
+      if (oldest !== undefined) this.store.delete(oldest);
+    }
+    this.store.set(key, { value, expiresAt: Date.now() + this.ttlMs });
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}


### PR DESCRIPTION
## Summary

- Replaced the plain `Map` objects used for GitHub tooltip caching with a new `TtlCache` class that enforces both a max size (100 entries) and a 5-minute TTL matching the backend
- Prevents memory from growing monotonically in long sessions where users hover many issues/PRs

Resolves #3777

## Changes

- **`src/utils/ttlCache.ts`** -- New lightweight `TtlCache<K, V>` class with FIFO eviction and TTL expiry. Keeps API compatible with `Map` (get/set/clear/size).
- **`src/hooks/useGitHubTooltip.ts`** -- Swapped `issueCache` and `prCache` from `new Map()` to `new TtlCache(100, 300_000)`. No behavioral changes to the hook itself.
- **`src/utils/__tests__/ttlCache.test.ts`** -- Comprehensive test suite covering get/set, TTL expiry, FIFO eviction at capacity, key updates, clear, and interaction between expired entries and capacity limits.

## Testing

- All existing tests pass (`npm run check` clean)
- New `TtlCache` unit tests pass with full coverage of eviction and expiry behavior
- TypeScript typecheck passes with no errors