### PR TITLE
feat(pty-host): expose GC in PTY host utility process

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -889,6 +889,11 @@ port.on("message", async (rawMsg: any) => {
       case "kill-by-project": {
         const killed = ptyManager.killByProject(msg.projectId);
         sendEvent({ type: "kill-by-project-result", requestId: msg.requestId, killed });
+        if (killed > 0) {
+          setTimeout(() => {
+            if (global.gc) global.gc();
+          }, 100);
+        }
         break;
       }
 
@@ -910,6 +915,11 @@ port.on("message", async (rawMsg: any) => {
           requestId: msg.requestId,
           results,
         });
+        if (results.length > 0) {
+          setTimeout(() => {
+            if (global.gc) global.gc();
+          }, 100);
+        }
         break;
       }
 

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -148,6 +148,67 @@ describe("ResourceGovernor", () => {
     governor.dispose();
   });
 
+  describe("engageThrottle GC", () => {
+    const originalGc = global.gc;
+
+    afterEach(() => {
+      if (originalGc) {
+        global.gc = originalGc;
+      } else {
+        delete (global as Record<string, unknown>).gc;
+      }
+    });
+
+    it("calls global.gc when memory exceeds throttle threshold", () => {
+      const gcMock = vi.fn();
+      global.gc = gcMock;
+
+      const mockTerminal = { ptyProcess: { pause: vi.fn(), resume: vi.fn() } };
+      const deps = createMockDeps({
+        getTerminals: vi.fn().mockReturnValue([mockTerminal]),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 900 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      vi.advanceTimersByTime(2000);
+
+      expect(gcMock).toHaveBeenCalledOnce();
+
+      governor.dispose();
+    });
+
+    it("does not throw when global.gc is undefined", () => {
+      delete (global as Record<string, unknown>).gc;
+
+      const mockTerminal = { ptyProcess: { pause: vi.fn(), resume: vi.fn() } };
+      const deps = createMockDeps({
+        getTerminals: vi.fn().mockReturnValue([mockTerminal]),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 900 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+
+      governor.dispose();
+    });
+  });
+
   describe("trackKilledPid", () => {
     it("tracks killed PIDs and passes them to FdMonitor after grace period", () => {
       const deps = createMockDeps();

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -307,7 +307,7 @@ export class PtyClient extends EventEmitter {
         serviceName: "canopy-pty-host",
         stdio: "pipe",
         cwd: os.homedir(),
-        execArgv: [`--max-old-space-size=${this.config.memoryLimitMb}`],
+        execArgv: [`--max-old-space-size=${this.config.memoryLimitMb}`, "--expose-gc"],
         env: {
           ...(process.env as Record<string, string>),
           CANOPY_USER_DATA: app.getPath("userData"),

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -176,6 +176,17 @@ describe("PtyClient Handshake Protocol", () => {
       );
     });
 
+    it("should start pty-host with --expose-gc in execArgv", () => {
+      createClient();
+      expect(forkMock).toHaveBeenCalledWith(
+        expect.any(String),
+        [],
+        expect.objectContaining({
+          execArgv: expect.arrayContaining(["--expose-gc"]),
+        })
+      );
+    });
+
     it("should forward stdout/stderr lines into the main log buffer", () => {
       createClient();
 


### PR DESCRIPTION
## Summary

- Adds `--expose-gc` to the PTY host utility process so `global.gc()` is actually available
- Triggers explicit GC after batch terminal kills (project hibernation, bulk kill) to promptly reclaim native PTY bindings and parser memory
- Makes the existing `ResourceGovernor.engageThrottle()` GC call functional instead of a no-op

Resolves #3784

## Changes

- **`electron/services/PtyClient.ts`** — Added `--expose-gc` to the PTY host's `execArgv` alongside the existing `--max-old-space-size` flag
- **`electron/pty-host.ts`** — Added deferred `global.gc()` calls (100ms setTimeout) after `kill-by-project` and `bulk-kill` message handlers, only when terminals were actually killed
- **`electron/pty-host/__tests__/ResourceGovernor.test.ts`** — Added tests verifying `global.gc()` is called during throttle engagement and that missing `global.gc` doesn't throw
- **`electron/services/__tests__/PtyClient.handshake.test.ts`** — Added test asserting `--expose-gc` is present in the utility process's `execArgv`

## Testing

- TypeScript typecheck passes (`tsc --noEmit` for both renderer and electron configs)
- ESLint passes (0 errors)
- Prettier formatting clean
- Unit tests cover both the flag presence and the GC behavior