### PR TITLE
feat(terminal): add CSS containment to panel and terminal containers

### DIFF
--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -242,6 +242,7 @@ const ContentPanelInner = forwardRef<HTMLDivElement, ContentPanelProps>(function
         ref={ref}
         data-panel-id={id}
         data-panel-location={location}
+        style={{ contain: "content" }}
         className={cn(
           "flex flex-col h-full overflow-hidden group",
           location === "grid" && !isMaximized && "bg-surface",

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -497,7 +497,7 @@ function XtermAdapterComponent({
         !isAltBuffer && "pl-3 pt-3 pb-3 pr-3 rounded-b-[var(--radius-lg)]",
         className
       )}
-      style={{ backgroundColor: wrapperBackground }}
+      style={{ backgroundColor: wrapperBackground, contain: "strict" }}
     >
       <div
         ref={containerRef}

--- a/src/index.css
+++ b/src/index.css
@@ -1856,7 +1856,3 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     pointer-events: none !important;
   }
 }
-
-@utility contain-layout {
-  contain: layout;
-}


### PR DESCRIPTION
## Summary

- Add CSS `contain: strict` to the xterm wrapper div in `XtermAdapter` to isolate layout/paint per terminal
- Add CSS `contain: content` to the `ContentPanel` wrapper so panel content changes don't trigger sibling recalculation
- Remove the unused `contain-layout` utility class from `index.css`

Resolves #3786

## Changes

- `src/components/Terminal/XtermAdapter.tsx` -- Added `contain: "strict"` to the terminal wrapper's inline style. Terminal containers already have explicit dimensions via `w-full h-full`, so `contain: strict` (which implies `contain: size layout style paint`) is safe and gives the browser maximum optimization freedom.
- `src/components/Panel/ContentPanel.tsx` -- Added `contain: "content"` to the ContentPanel div. This is the lighter variant (`layout style paint` without `size`) since panel containers may rely on intrinsic sizing in some configurations.
- `src/index.css` -- Removed the `@utility contain-layout` class that was defined but never used anywhere.

## Testing

- TypeScript typecheck passes (`tsc --noEmit`)
- ESLint passes (0 errors, only pre-existing warnings)
- Prettier formatting clean (no changes needed)