### PR TITLE
refactor(worktree): consolidate TooltipProviders into scoped providers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import { useMcpBridge } from "./hooks/useMcpBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { removeStartupSkeleton } from "./utils/removeStartupSkeleton";
 import { createTooltipWithShortcut } from "./lib/platform";
+import { TooltipProvider } from "./components/ui/tooltip";
 import { useCrashRecoveryGate } from "./hooks/app/useCrashRecoveryGate";
 import { CrashRecoveryDialog } from "./components/Recovery/CrashRecoveryDialog";
 import {
@@ -799,152 +800,156 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   );
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Header Section */}
-      <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
-        <div className="flex items-baseline gap-1.5">
-          <h2 className="text-canopy-text font-semibold text-sm tracking-wide">Worktrees</h2>
-          <span className="text-canopy-text/50 text-xs">
-            {hasFilters && visibleCount !== deferredWorktrees.length
-              ? `(${visibleCount} of ${deferredWorktrees.length})`
-              : `(${deferredWorktrees.length})`}
-          </span>
-        </div>
-        <div className="flex items-center gap-1">
-          <div className="invisible group-hover/header:visible group-focus-within/header:visible flex items-center gap-1">
+    <TooltipProvider delayDuration={400} skipDelayDuration={300}>
+      <div className="flex flex-col h-full">
+        {/* Header Section */}
+        <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
+          <div className="flex items-baseline gap-1.5">
+            <h2 className="text-canopy-text font-semibold text-sm tracking-wide">Worktrees</h2>
+            <span className="text-canopy-text/50 text-xs">
+              {hasFilters && visibleCount !== deferredWorktrees.length
+                ? `(${visibleCount} of ${deferredWorktrees.length})`
+                : `(${deferredWorktrees.length})`}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="invisible group-hover/header:visible group-focus-within/header:visible flex items-center gap-1">
+              <button
+                onClick={onOpenOverview}
+                className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-tint/[0.06] rounded transition-colors"
+                title={createTooltipWithShortcut("Open worktrees overview", "Cmd+Shift+O")}
+                aria-label="Open worktrees overview"
+              >
+                <LayoutGrid className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={handleRefreshAll}
+                disabled={isRefreshing}
+                className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                title="Refresh sidebar"
+                aria-label="Refresh sidebar"
+              >
+                <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
+              </button>
+            </div>
             <button
-              onClick={onOpenOverview}
+              onClick={() =>
+                actionService.dispatch("worktree.createDialog.open", undefined, {
+                  source: "user",
+                })
+              }
               className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-tint/[0.06] rounded transition-colors"
-              title={createTooltipWithShortcut("Open worktrees overview", "Cmd+Shift+O")}
-              aria-label="Open worktrees overview"
+              title="Create new worktree"
+              aria-label="Create new worktree"
             >
-              <LayoutGrid className="w-3.5 h-3.5" />
-            </button>
-            <button
-              onClick={handleRefreshAll}
-              disabled={isRefreshing}
-              className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              title="Refresh sidebar"
-              aria-label="Refresh sidebar"
-            >
-              <RefreshCw className={`w-3.5 h-3.5 ${isRefreshing ? "animate-spin" : ""}`} />
+              <Plus className="w-3.5 h-3.5" />
             </button>
           </div>
-          <button
-            onClick={() =>
-              actionService.dispatch("worktree.createDialog.open", undefined, {
-                source: "user",
-              })
-            }
-            className="p-1 text-canopy-text/40 hover:text-canopy-text hover:bg-tint/[0.06] rounded transition-colors"
-            title="Create new worktree"
-            aria-label="Create new worktree"
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </button>
         </div>
-      </div>
 
-      {/* Inline search bar — only when there are non-main worktrees */}
-      {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
+        {/* Inline search bar — only when there are non-main worktrees */}
+        {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
 
-      {/* Main worktree — visible unless excluded by text search */}
-      {mainMatchesQuery && <div className="shrink-0">{renderWorktreeCard(mainWorktree)}</div>}
+        {/* Main worktree — visible unless excluded by text search */}
+        {mainMatchesQuery && <div className="shrink-0">{renderWorktreeCard(mainWorktree)}</div>}
 
-      {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
-      {integrationMatchesQuery && (
-        <div className="shrink-0">{renderWorktreeCard(integrationWorktree)}</div>
-      )}
+        {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
+        {integrationMatchesQuery && (
+          <div className="shrink-0">{renderWorktreeCard(integrationWorktree)}</div>
+        )}
 
-      {/* Strong divider between pinned worktrees and scrollable list */}
-      {hasNonMainWorktrees && <div className="shrink-0 border-b-2 border-divider/60" />}
+        {/* Strong divider between pinned worktrees and scrollable list */}
+        {hasNonMainWorktrees && <div className="shrink-0 border-b-2 border-divider/60" />}
 
-      {/* Non-main worktree list */}
-      <div className="relative flex-1 min-h-0">
-        <div ref={scrollContainerRef} className="h-full overflow-y-auto scrollbar-none">
-          <div ref={scrollContentRef}>
-            {filteredWorktrees.length === 0 && hasActiveFilters() ? (
-              <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-                <FilterX className="w-10 h-10 text-canopy-text/40 mb-3" />
-                <p className="text-sm text-canopy-text/60 mb-3">No worktrees match your filters</p>
-                <button
-                  onClick={clearAllFilters}
-                  className="text-xs px-3 py-1.5 text-canopy-accent hover:bg-canopy-accent/10 rounded transition-colors"
-                >
-                  Clear filters
-                </button>
-              </div>
-            ) : groupedSections ? (
-              <div className="flex flex-col">
-                {groupedSections.map((section) => (
-                  <div key={section.type}>
-                    <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-canopy-text/50 uppercase tracking-wide bg-canopy-sidebar border-b border-divider">
-                      {section.displayName} ({section.worktrees.length})
-                    </div>
-                    {section.worktrees.map(renderWorktreeCard)}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
-                <div className="flex flex-col">
-                  {filteredWorktrees.map((worktree) => {
-                    const isPinned = pinnedWorktrees.includes(worktree.id);
-                    return (
-                      <SidebarWorktreeRow
-                        key={worktree.id}
-                        worktreeId={worktree.id}
-                        activeWorktreeId={activeWorktreeId}
-                        focusedWorktreeId={focusedWorktreeId}
-                        totalWorktreeCount={deferredWorktrees.length}
-                        selectWorktree={selectWorktree}
-                        worktreeActions={worktreeActions}
-                        availability={availability}
-                        agentSettings={agentSettings}
-                        homeDir={homeDir}
-                        dragStartOrder={dragStartOrder}
-                        isSortDisabled={isSortDisabled}
-                        isPinned={isPinned}
-                      />
-                    );
-                  })}
+        {/* Non-main worktree list */}
+        <div className="relative flex-1 min-h-0">
+          <div ref={scrollContainerRef} className="h-full overflow-y-auto scrollbar-none">
+            <div ref={scrollContentRef}>
+              {filteredWorktrees.length === 0 && hasActiveFilters() ? (
+                <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+                  <FilterX className="w-10 h-10 text-canopy-text/40 mb-3" />
+                  <p className="text-sm text-canopy-text/60 mb-3">
+                    No worktrees match your filters
+                  </p>
+                  <button
+                    onClick={clearAllFilters}
+                    className="text-xs px-3 py-1.5 text-canopy-accent hover:bg-canopy-accent/10 rounded transition-colors"
+                  >
+                    Clear filters
+                  </button>
                 </div>
-              </SortableContext>
-            )}
+              ) : groupedSections ? (
+                <div className="flex flex-col">
+                  {groupedSections.map((section) => (
+                    <div key={section.type}>
+                      <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-canopy-text/50 uppercase tracking-wide bg-canopy-sidebar border-b border-divider">
+                        {section.displayName} ({section.worktrees.length})
+                      </div>
+                      {section.worktrees.map(renderWorktreeCard)}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                  <div className="flex flex-col">
+                    {filteredWorktrees.map((worktree) => {
+                      const isPinned = pinnedWorktrees.includes(worktree.id);
+                      return (
+                        <SidebarWorktreeRow
+                          key={worktree.id}
+                          worktreeId={worktree.id}
+                          activeWorktreeId={activeWorktreeId}
+                          focusedWorktreeId={focusedWorktreeId}
+                          totalWorktreeCount={deferredWorktrees.length}
+                          selectWorktree={selectWorktree}
+                          worktreeActions={worktreeActions}
+                          availability={availability}
+                          agentSettings={agentSettings}
+                          homeDir={homeDir}
+                          dragStartOrder={dragStartOrder}
+                          isSortDisabled={isSortDisabled}
+                          isPinned={isPinned}
+                        />
+                      );
+                    })}
+                  </div>
+                </SortableContext>
+              )}
+            </div>
           </div>
+          <ScrollIndicator direction="above" count={hiddenAbove} onClick={scrollToTop} />
+          <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
         </div>
-        <ScrollIndicator direction="above" count={hiddenAbove} onClick={scrollToTop} />
-        <ScrollIndicator direction="below" count={hiddenBelow} onClick={scrollToBottom} />
-      </div>
 
-      <WorkflowSection />
+        <WorkflowSection />
 
-      <RecipeEditor
-        worktreeId={recipeEditorWorktreeId}
-        initialTerminals={recipeEditorInitialTerminals}
-        isOpen={isRecipeEditorOpen}
-        onClose={handleCloseRecipeEditor}
-      />
-
-      {rootPath && (
-        <NewWorktreeDialog
-          isOpen={createDialog.isOpen}
-          onClose={closeCreateDialog}
-          rootPath={rootPath}
-          onWorktreeCreated={refresh}
-          initialIssue={createDialog.initialIssue}
-          initialPR={createDialog.initialPR}
-          initialRecipeId={createDialog.initialRecipeId}
+        <RecipeEditor
+          worktreeId={recipeEditorWorktreeId}
+          initialTerminals={recipeEditorInitialTerminals}
+          isOpen={isRecipeEditorOpen}
+          onClose={handleCloseRecipeEditor}
         />
-      )}
 
-      <BulkCreateWorktreeDialog
-        isOpen={bulkCreateDialog.isOpen}
-        onClose={closeBulkCreateDialog}
-        selectedIssues={bulkCreateDialog.selectedIssues}
-        onComplete={closeBulkCreateDialog}
-      />
-    </div>
+        {rootPath && (
+          <NewWorktreeDialog
+            isOpen={createDialog.isOpen}
+            onClose={closeCreateDialog}
+            rootPath={rootPath}
+            onWorktreeCreated={refresh}
+            initialIssue={createDialog.initialIssue}
+            initialPR={createDialog.initialPR}
+            initialRecipeId={createDialog.initialRecipeId}
+          />
+        )}
+
+        <BulkCreateWorktreeDialog
+          isOpen={bulkCreateDialog.isOpen}
+          onClose={closeBulkCreateDialog}
+          selectedIssues={bulkCreateDialog.selectedIssues}
+          onComplete={closeBulkCreateDialog}
+        />
+      </div>
+    </TooltipProvider>
   );
 }
 

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -163,7 +163,7 @@ export function RecipesTab({
   };
 
   return (
-    <>
+    <TooltipProvider delayDuration={400} skipDelayDuration={300}>
       <div className="mb-6">
         <h3 className="text-sm font-semibold text-canopy-text/80 mb-2 flex items-center gap-2">
           <BookOpen className="h-4 w-4" />
@@ -195,16 +195,14 @@ export function RecipesTab({
                     <div className="flex items-start gap-3">
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <TooltipProvider>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="text-sm font-medium text-foreground truncate">
-                                  {recipe.name}
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent side="bottom">{recipe.name}</TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-sm font-medium text-foreground truncate">
+                                {recipe.name}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">{recipe.name}</TooltipContent>
+                          </Tooltip>
                           <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0">
                             {getRecipeScope(recipe)}
                           </span>
@@ -229,64 +227,54 @@ export function RecipesTab({
                         </div>
                       </div>
                       <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleEditRecipe(recipe)}
-                                className="h-7 px-2"
-                                aria-label={`Edit recipe ${recipe.name}`}
-                              >
-                                <Edit3 />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">Edit recipe</TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => handleExportRecipe(recipe.id)}
-                                className="h-7 px-2"
-                                aria-label={
-                                  exported
-                                    ? `Recipe ${recipe.name} exported to clipboard`
-                                    : `Export recipe ${recipe.name} to clipboard`
-                                }
-                              >
-                                {exported ? (
-                                  <Check className="text-status-success" />
-                                ) : (
-                                  <Download />
-                                )}
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">
-                              {exported ? "Exported" : "Export recipe to clipboard"}
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setRecipeToDelete(recipe.id)}
-                                className="h-7 px-2"
-                                aria-label={`Delete recipe ${recipe.name}`}
-                              >
-                                <Trash2 className="text-status-error" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">Delete recipe</TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleEditRecipe(recipe)}
+                              className="h-7 px-2"
+                              aria-label={`Edit recipe ${recipe.name}`}
+                            >
+                              <Edit3 />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Edit recipe</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleExportRecipe(recipe.id)}
+                              className="h-7 px-2"
+                              aria-label={
+                                exported
+                                  ? `Recipe ${recipe.name} exported to clipboard`
+                                  : `Export recipe ${recipe.name} to clipboard`
+                              }
+                            >
+                              {exported ? <Check className="text-status-success" /> : <Download />}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {exported ? "Exported" : "Export recipe to clipboard"}
+                          </TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => setRecipeToDelete(recipe.id)}
+                              className="h-7 px-2"
+                              aria-label={`Delete recipe ${recipe.name}`}
+                            >
+                              <Trash2 className="text-status-error" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">Delete recipe</TooltipContent>
+                        </Tooltip>
                       </div>
                     </div>
                   </div>
@@ -390,6 +378,6 @@ export function RecipesTab({
           </Button>
         </AppDialog.Footer>
       </AppDialog>
-    </>
+    </TooltipProvider>
   );
 }

--- a/src/components/Worktree/ActivityLight.tsx
+++ b/src/components/Worktree/ActivityLight.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import { getActivityColor } from "@/utils/colorInterpolation";
 import { formatTimestampExact } from "@/utils/textParsing";
 import { useGlobalSecondTicker } from "@/hooks/useGlobalSecondTicker";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface ActivityLightProps {
   lastActivityTimestamp?: number | null;
@@ -37,21 +37,19 @@ export function ActivityLight({ lastActivityTimestamp, className }: ActivityLigh
   const tooltipText = formatTimestampExact(lastActivityTimestamp);
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div
-            className={cn(
-              "w-2.5 h-2.5 rounded-full transition-colors duration-1000 ease-linear",
-              className
-            )}
-            style={{ backgroundColor: color }}
-            role="status"
-            aria-label={tooltipText}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{tooltipText}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className={cn(
+            "w-2.5 h-2.5 rounded-full transition-colors duration-1000 ease-linear",
+            className
+          )}
+          style={{ backgroundColor: color }}
+          role="status"
+          aria-label={tooltipText}
+        />
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{tooltipText}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -1,6 +1,6 @@
 import { cn } from "../../lib/utils";
 import type { AgentState } from "@/types";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface AgentStatusIndicatorProps {
   state: AgentState | null | undefined;
@@ -80,29 +80,27 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
   }
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className={cn(
-              "inline-flex items-center justify-center w-5 h-5 text-xs font-bold rounded-full",
-              config.color,
-              config.bgColor,
-              config.borderColor && "border",
-              config.borderColor,
-              config.glow,
-              config.pulse && "animate-agent-pulse",
-              className
-            )}
-            role="status"
-            aria-label={`Agent status: ${config.label}`}
-          >
-            {config.icon}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{config.tooltip}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            "inline-flex items-center justify-center w-5 h-5 text-xs font-bold rounded-full",
+            config.color,
+            config.bgColor,
+            config.borderColor && "border",
+            config.borderColor,
+            config.glow,
+            config.pulse && "animate-agent-pulse",
+            className
+          )}
+          role="status"
+          aria-label={`Agent status: ${config.label}`}
+        >
+          {config.icon}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{config.tooltip}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/Worktree/BranchLabel.tsx
+++ b/src/components/Worktree/BranchLabel.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { cn } from "../../lib/utils";
 import { middleTruncate } from "../../utils/textParsing";
 import { BRANCH_PREFIX_MAP, DEFAULT_BRANCH_TYPE } from "@shared/config/branchPrefixes";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   BookOpen,
   Bug,
@@ -81,41 +81,39 @@ export function BranchLabel({
   const Icon = typeId ? (BRANCH_TYPE_ICONS[typeId] ?? GitBranch) : null;
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className={cn("flex items-center gap-1.5 min-w-0 cursor-default", className)}>
-            {Icon && displayName && (
-              <span className="shrink-0 flex items-center" aria-label={displayName}>
-                <Icon
-                  className={cn(
-                    "w-3.5 h-3.5 transition-colors duration-200",
-                    isMuted ? "text-canopy-text/30" : "text-canopy-text/50"
-                  )}
-                  strokeWidth={2.5}
-                  aria-hidden="true"
-                />
-              </span>
-            )}
-            <span
-              className={cn(
-                "truncate font-mono transition-colors duration-200",
-                isMainWorktree ? "text-[13px] font-bold tracking-wide" : "text-[11px] font-medium",
-                isActive
-                  ? "text-canopy-text/95"
-                  : isMuted
-                    ? "text-canopy-text/40"
-                    : "text-canopy-text/60"
-              )}
-            >
-              {rest}
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("flex items-center gap-1.5 min-w-0 cursor-default", className)}>
+          {Icon && displayName && (
+            <span className="shrink-0 flex items-center" aria-label={displayName}>
+              <Icon
+                className={cn(
+                  "w-3.5 h-3.5 transition-colors duration-200",
+                  isMuted ? "text-canopy-text/30" : "text-canopy-text/50"
+                )}
+                strokeWidth={2.5}
+                aria-hidden="true"
+              />
             </span>
+          )}
+          <span
+            className={cn(
+              "truncate font-mono transition-colors duration-200",
+              isMainWorktree ? "text-[13px] font-bold tracking-wide" : "text-[11px] font-medium",
+              isActive
+                ? "text-canopy-text/95"
+                : isMuted
+                  ? "text-canopy-text/40"
+                  : "text-canopy-text/60"
+            )}
+          >
+            {rest}
           </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          {displayName ? `${displayName}: ${label}` : label}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">
+        {displayName ? `${displayName}: ${label}` : label}
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Worktree/LiveTimeAgo.tsx
+++ b/src/components/Worktree/LiveTimeAgo.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useGlobalSecondTicker } from "@/hooks/useGlobalSecondTicker";
 import { cn } from "@/lib/utils";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface LiveTimeAgoProps {
   timestamp?: number | null;
@@ -71,15 +71,13 @@ export function LiveTimeAgo({ timestamp, className }: LiveTimeAgoProps) {
   }
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className={cn("tabular-nums", className)} aria-label={timeData.fullLabel}>
-            {timeData.label}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{`${timeData.fullLabel} (${timeData.formattedDate})`}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("tabular-nums", className)} aria-label={timeData.fullLabel}>
+          {timeData.label}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{`${timeData.fullLabel} (${timeData.formattedDate})`}</TooltipContent>
+    </Tooltip>
   );
 }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -31,7 +31,7 @@ import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { useWorktreeMenu } from "./WorktreeCard/hooks/useWorktreeMenu";
 import { useWorktreeStatus } from "./WorktreeCard/hooks/useWorktreeStatus";
 import { computeChipState, type ChipState } from "./utils/computeChipState";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "../ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 
 export function worktreeCardPropsAreEqual(
   prev: WorktreeCardProps,
@@ -567,32 +567,20 @@ export const WorktreeCard = React.memo(function WorktreeCard({
         />
       )}
       {chipState !== null && (
-        <TooltipProvider>
-          <Tooltip delayDuration={400}>
-            <TooltipTrigger asChild>
-              <div
-                className={cn(
-                  "absolute w-3 h-3 z-10 cursor-default",
-                  chipState === "error" && "bg-github-closed",
-                  chipState === "waiting" && "bg-state-waiting",
-                  chipState === "cleanup" && "bg-github-merged",
-                  chipState === "complete" && "bg-github-open",
-                  variant === "sidebar" ? "top-0 left-[1px]" : "top-0 left-0 rounded-tl-lg"
-                )}
-                style={{ clipPath: "polygon(0 0, 100% 0, 0 100%)" }}
-                role="img"
-                aria-label={
-                  {
-                    error: "Error: attention needed",
-                    waiting: "Agent waiting for input",
-                    cleanup: "Ready for cleanup",
-                    complete: "Complete: in review",
-                  }[chipState]
-                }
-              />
-            </TooltipTrigger>
-            <TooltipContent side="right" align="start" className="text-xs">
-              {
+        <Tooltip delayDuration={400}>
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                "absolute w-3 h-3 z-10 cursor-default",
+                chipState === "error" && "bg-github-closed",
+                chipState === "waiting" && "bg-state-waiting",
+                chipState === "cleanup" && "bg-github-merged",
+                chipState === "complete" && "bg-github-open",
+                variant === "sidebar" ? "top-0 left-[1px]" : "top-0 left-0 rounded-tl-lg"
+              )}
+              style={{ clipPath: "polygon(0 0, 100% 0, 0 100%)" }}
+              role="img"
+              aria-label={
                 {
                   error: "Error: attention needed",
                   waiting: "Agent waiting for input",
@@ -600,9 +588,19 @@ export const WorktreeCard = React.memo(function WorktreeCard({
                   complete: "Complete: in review",
                 }[chipState]
               }
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+            />
+          </TooltipTrigger>
+          <TooltipContent side="right" align="start" className="text-xs">
+            {
+              {
+                error: "Error: attention needed",
+                waiting: "Agent waiting for input",
+                cleanup: "Ready for cleanup",
+                complete: "Complete: in review",
+              }[chipState]
+            }
+          </TooltipContent>
+        </Tooltip>
       )}
       <div className="flex">
         {dragHandleListeners && (

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -8,7 +8,7 @@ import { LiveTimeAgo } from "../LiveTimeAgo";
 import { WorktreeDetails } from "../WorktreeDetails";
 import { ChevronRight, GitCommitHorizontal, Loader2 } from "lucide-react";
 import type { ComputedSubtitle } from "./hooks/useWorktreeStatus";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface WorktreeDetailsSectionProps {
   worktree: WorktreeState;
@@ -155,46 +155,42 @@ export function WorktreeDetailsSection({
               )}
             </span>
 
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
-                    <ActivityLight
-                      lastActivityTimestamp={worktree.lastActivityTimestamp}
-                      className="w-1.5 h-1.5"
-                    />
-                    <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {worktree.lastActivityTimestamp
-                    ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
-                    : "No recent activity recorded"}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
+                  <ActivityLight
+                    lastActivityTimestamp={worktree.lastActivityTimestamp}
+                    className="w-1.5 h-1.5"
+                  />
+                  <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {worktree.lastActivityTimestamp
+                  ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
+                  : "No recent activity recorded"}
+              </TooltipContent>
+            </Tooltip>
           </button>
 
           {onOpenReviewHub && hasChanges && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    onClick={onOpenReviewHub}
-                    className={cn(
-                      "shrink-0 border-l border-border-subtle px-2 py-1 transition-colors",
-                      "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
-                      "rounded-r-[var(--radius-lg)]",
-                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent"
-                    )}
-                    aria-label="Open Review & Commit"
-                  >
-                    <GitCommitHorizontal className="w-3.5 h-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">Review & Commit</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onOpenReviewHub}
+                  className={cn(
+                    "shrink-0 border-l border-border-subtle px-2 py-1 transition-colors",
+                    "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
+                    "rounded-r-[var(--radius-lg)]",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent"
+                  )}
+                  aria-label="Open Review & Commit"
+                >
+                  <GitCommitHorizontal className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Review & Commit</TooltipContent>
+            </Tooltip>
           )}
         </div>
       )}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "../../ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "../../ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import {
   AlertCircle,
   ChevronRight,
@@ -77,55 +77,53 @@ const IssueBadge = memo(function IssueBadge({
   );
 
   return (
-    <TooltipProvider>
-      <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => {
-              onOpen?.();
-            }}
-            className={cn(
-              "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0",
-              isHeadline ? "text-[13px]" : "text-xs"
-            )}
-            aria-label={
-              issueTitle
-                ? `Open issue #${issueNumber}: ${issueTitle}`
-                : `Open issue #${issueNumber} on GitHub`
-            }
-          >
-            <CircleDot
-              className={cn("text-github-open shrink-0", isHeadline ? "w-3.5 h-3.5" : "w-3 h-3")}
-              aria-hidden="true"
-            />
-            <span
-              className={cn(
-                "truncate flex-1 min-w-0 hover:underline",
-                isHeadline
-                  ? isActive
-                    ? "text-text-primary font-medium"
-                    : "text-canopy-text/60 font-medium"
-                  : "text-canopy-text/90"
-              )}
-            >
-              {issueTitle || <span className="text-github-open font-mono">#{issueNumber}</span>}
-            </span>
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right" align="start" className="p-3">
-          {loading ? (
-            <TooltipLoading type="issue" />
-          ) : data ? (
-            <IssueTooltipContent data={data} />
-          ) : error ? (
-            <span className="text-xs text-canopy-text/70">Failed to load issue details</span>
-          ) : (
-            <span className="text-xs text-canopy-text/70">Issue #{issueNumber}</span>
+    <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => {
+            onOpen?.();
+          }}
+          className={cn(
+            "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0",
+            isHeadline ? "text-[13px]" : "text-xs"
           )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+          aria-label={
+            issueTitle
+              ? `Open issue #${issueNumber}: ${issueTitle}`
+              : `Open issue #${issueNumber} on GitHub`
+          }
+        >
+          <CircleDot
+            className={cn("text-github-open shrink-0", isHeadline ? "w-3.5 h-3.5" : "w-3 h-3")}
+            aria-hidden="true"
+          />
+          <span
+            className={cn(
+              "truncate flex-1 min-w-0 hover:underline",
+              isHeadline
+                ? isActive
+                  ? "text-text-primary font-medium"
+                  : "text-canopy-text/60 font-medium"
+                : "text-canopy-text/90"
+            )}
+          >
+            {issueTitle || <span className="text-github-open font-mono">#{issueNumber}</span>}
+          </span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right" align="start" className="p-3">
+        {loading ? (
+          <TooltipLoading type="issue" />
+        ) : data ? (
+          <IssueTooltipContent data={data} />
+        ) : error ? (
+          <span className="text-xs text-canopy-text/70">Failed to load issue details</span>
+        ) : (
+          <span className="text-xs text-canopy-text/70">Issue #{issueNumber}</span>
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 });
 
@@ -169,40 +167,35 @@ const PRBadge = memo(function PRBadge({
   const prStateLabel = prState === "merged" ? "merged" : prState === "closed" ? "closed" : "open";
 
   return (
-    <TooltipProvider>
-      <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            onClick={() => {
-              onOpen?.();
-            }}
-            className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0"
-            aria-label={`Open ${prStateLabel} pull request #${prNumber} on GitHub`}
-          >
-            {isSubordinate && (
-              <CornerDownRight
-                className="w-3 h-3 text-canopy-text/30 shrink-0"
-                aria-hidden="true"
-              />
-            )}
-            <GitPullRequest className={cn("w-3 h-3 shrink-0", prStateColor)} aria-hidden="true" />
-            <span className={cn("font-mono hover:underline", prStateColor)}>#{prNumber}</span>
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="right" align="start" className="p-3">
-          {loading ? (
-            <TooltipLoading type="pr" />
-          ) : data ? (
-            <PRTooltipContent data={data} />
-          ) : error ? (
-            <span className="text-xs text-canopy-text/70">Failed to load PR details</span>
-          ) : (
-            <span className="text-xs text-canopy-text/70">PR #{prNumber}</span>
+    <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={() => {
+            onOpen?.();
+          }}
+          className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent min-w-0"
+          aria-label={`Open ${prStateLabel} pull request #${prNumber} on GitHub`}
+        >
+          {isSubordinate && (
+            <CornerDownRight className="w-3 h-3 text-canopy-text/30 shrink-0" aria-hidden="true" />
           )}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+          <GitPullRequest className={cn("w-3 h-3 shrink-0", prStateColor)} aria-hidden="true" />
+          <span className={cn("font-mono hover:underline", prStateColor)}>#{prNumber}</span>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right" align="start" className="p-3">
+        {loading ? (
+          <TooltipLoading type="pr" />
+        ) : data ? (
+          <PRTooltipContent data={data} />
+        ) : error ? (
+          <span className="text-xs text-canopy-text/70">Failed to load PR details</span>
+        ) : (
+          <span className="text-xs text-canopy-text/70">PR #{prNumber}</span>
+        )}
+      </TooltipContent>
+    </Tooltip>
   );
 });
 
@@ -338,19 +331,17 @@ export function WorktreeHeader({
         </div>
 
         {worktreeErrorCount > 0 && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="flex items-center gap-0.5 text-status-error text-xs font-mono shrink-0">
-                  <AlertCircle className="w-3 h-3" />
-                  <span>{worktreeErrorCount}</span>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="text-xs">
-                {worktreeErrorCount} error{worktreeErrorCount !== 1 ? "s" : ""}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="flex items-center gap-0.5 text-status-error text-xs font-mono shrink-0">
+                <AlertCircle className="w-3 h-3" />
+                <span>{worktreeErrorCount}</span>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              {worktreeErrorCount} error{worktreeErrorCount !== 1 ? "s" : ""}
+            </TooltipContent>
+          </Tooltip>
         )}
 
         <div
@@ -382,23 +373,21 @@ export function WorktreeHeader({
             </button>
           )}
           <DropdownMenu>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      onClick={(e) => e.stopPropagation()}
-                      className="p-1.5 text-canopy-text/60 hover:text-text-primary hover:bg-overlay-soft rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-                      aria-label="More actions"
-                      data-testid="worktree-actions-menu"
-                    >
-                      <MoreHorizontal className="w-3.5 h-3.5" />
-                    </button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="top">More actions</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    onClick={(e) => e.stopPropagation()}
+                    className="p-1.5 text-canopy-text/60 hover:text-text-primary hover:bg-overlay-soft rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+                    aria-label="More actions"
+                    data-testid="worktree-actions-menu"
+                  >
+                    <MoreHorizontal className="w-3.5 h-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="top">More actions</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent
               align="end"
               side="bottom"

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -7,7 +7,7 @@ import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { cn } from "@/lib/utils";
 import type { WorktreeTerminalCounts } from "@/hooks/useWorktreeTerminals";
 import { STATE_COLORS, STATE_ICONS, STATE_LABELS, STATE_PRIORITY } from "../terminalStateConfig";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "../../ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { ChevronRight, GripVertical, LayoutGrid, PanelBottom, SquareTerminal } from "lucide-react";
 import {
   SortableWorktreeTerminal,
@@ -151,16 +151,14 @@ export function WorktreeTerminalSection({
                           {term.type === "terminal" &&
                             term.agentState === "running" &&
                             term.lastCommand && (
-                              <TooltipProvider>
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <span className="truncate text-[11px] font-mono text-text-muted">
-                                      {term.lastCommand}
-                                    </span>
-                                  </TooltipTrigger>
-                                  <TooltipContent side="bottom">{term.lastCommand}</TooltipContent>
-                                </Tooltip>
-                              </TooltipProvider>
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="truncate text-[11px] font-mono text-text-muted">
+                                    {term.lastCommand}
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">{term.lastCommand}</TooltipContent>
+                              </Tooltip>
                             )}
                         </div>
                       </button>
@@ -183,22 +181,20 @@ export function WorktreeTerminalSection({
                             );
                           })()}
 
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="text-text-muted transition-colors group-hover:text-text-secondary">
-                                {term.location === "dock" ? (
-                                  <PanelBottom className="w-3 h-3" />
-                                ) : (
-                                  <LayoutGrid className="w-3 h-3" />
-                                )}
-                              </div>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">
-                              {term.location === "dock" ? "Docked" : "On Grid"}
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="text-text-muted transition-colors group-hover:text-text-secondary">
+                              {term.location === "dock" ? (
+                                <PanelBottom className="w-3 h-3" />
+                              ) : (
+                                <LayoutGrid className="w-3 h-3" />
+                              )}
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            {term.location === "dock" ? "Docked" : "On Grid"}
+                          </TooltipContent>
+                        </Tooltip>
 
                         <button
                           type="button"
@@ -233,9 +229,7 @@ export function WorktreeTerminalSection({
           </div>
 
           {topTerminalState && (
-            <TooltipProvider>
-              <StateIcon state={topTerminalState.state} count={topTerminalState.count} />
-            </TooltipProvider>
+            <StateIcon state={topTerminalState.state} count={topTerminalState.count} />
           )}
         </button>
       )}

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { WorktreeHeader, type WorktreeHeaderProps } from "../WorktreeHeader";
 import type { WorktreeState } from "@shared/types";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
@@ -66,17 +67,19 @@ const baseMenu: WorktreeHeaderProps["menu"] = {
 
 function renderHeader(overrides: Partial<WorktreeHeaderProps> = {}) {
   return render(
-    <WorktreeHeader
-      worktree={baseWorktree}
-      isActive={false}
-      isMainWorktree={false}
-      isPinned={false}
-      branchLabel="feature/test"
-      worktreeErrorCount={0}
-      badges={{}}
-      menu={baseMenu}
-      {...overrides}
-    />
+    <TooltipProvider>
+      <WorktreeHeader
+        worktree={baseWorktree}
+        isActive={false}
+        isMainWorktree={false}
+        isPinned={false}
+        branchLabel="feature/test"
+        worktreeErrorCount={0}
+        badges={{}}
+        menu={baseMenu}
+        {...overrides}
+      />
+    </TooltipProvider>
   );
 }
 

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -9,7 +9,7 @@ import { cn } from "../../lib/utils";
 import { GitCommit, Copy, Check, ExternalLink } from "lucide-react";
 import { parseNoteWithLinks, formatPath, type TextSegment } from "../../utils/textParsing";
 import { actionService } from "@/services/ActionService";
-import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface WorktreeDetailsProps {
   worktree: WorktreeState;
@@ -204,50 +204,46 @@ export function WorktreeDetails({
       {/* System path footer */}
       <div className="border-t border-border-subtle pt-3">
         <div className="flex items-center gap-2">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onPathClick();
-                  }}
-                  className={cn(
-                    "flex min-w-0 flex-1 items-center gap-1.5 truncate rounded text-left font-mono text-xs text-text-muted hover:text-text-secondary",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
-                    isFocused && "text-text-secondary"
-                  )}
-                >
-                  <ExternalLink className="w-3 h-3 shrink-0 opacity-60" />
-                  <span className="truncate">{displayPath}</span>
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{`Open folder: ${worktree.path}`}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPathClick();
+                }}
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-1.5 truncate rounded text-left font-mono text-xs text-text-muted hover:text-text-secondary",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent",
+                  isFocused && "text-text-secondary"
+                )}
+              >
+                <ExternalLink className="w-3 h-3 shrink-0 opacity-60" />
+                <span className="truncate">{displayPath}</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{`Open folder: ${worktree.path}`}</TooltipContent>
+          </Tooltip>
 
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={handleCopyPath}
-                  className="shrink-0 rounded p-1 text-text-muted transition-colors hover:bg-overlay-soft hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
-                  aria-label={pathCopied ? "Path copied to clipboard" : "Copy path to clipboard"}
-                >
-                  {pathCopied ? (
-                    <Check className="w-3 h-3 text-status-success" />
-                  ) : (
-                    <Copy className="w-3 h-3" />
-                  )}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {pathCopied ? "Copied!" : "Copy full path"}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={handleCopyPath}
+                className="shrink-0 rounded p-1 text-text-muted transition-colors hover:bg-overlay-soft hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent"
+                aria-label={pathCopied ? "Path copied to clipboard" : "Copy path to clipboard"}
+              >
+                {pathCopied ? (
+                  <Check className="w-3 h-3 text-status-success" />
+                ) : (
+                  <Copy className="w-3 h-3" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {pathCopied ? "Copied!" : "Copy full path"}
+            </TooltipContent>
+          </Tooltip>
           <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
             {pathCopied ? "Path copied to clipboard" : ""}
           </div>

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -359,66 +359,66 @@ export function WorktreeOverviewModal({
       aria-modal="true"
       aria-labelledby="worktree-overview-title"
     >
-      <div
-        className={cn(
-          "relative flex flex-col",
-          "w-[calc(100vw-80px)] h-[calc(100vh-80px)]",
-          "max-w-[1800px] max-h-[1200px]",
-          "bg-canopy-bg rounded-xl",
-          "border border-divider",
-          "shadow-2xl shadow-black/40",
-          "motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
-        )}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
-          <div className="flex items-center gap-3">
-            <LayoutGrid className="w-5 h-5 text-canopy-text/60" />
-            <h2
-              id="worktree-overview-title"
-              className="text-canopy-text font-semibold text-base tracking-wide"
-            >
-              Worktrees Overview
-            </h2>
-            <span className="text-canopy-text/50 text-sm">
-              ({filteredWorktrees.length}
-              {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
-            </span>
-            {/* Aggregate activity statistics */}
-            {(aggregateStats.workingCount > 0 ||
-              aggregateStats.waitingCount > 0 ||
-              aggregateStats.failedCount > 0) && (
-              <div
-                className="flex items-center gap-2 ml-2 pl-3 border-l border-divider"
-                role="status"
-                aria-label="Agent activity statistics"
+      <TooltipProvider delayDuration={400} skipDelayDuration={300}>
+        <div
+          className={cn(
+            "relative flex flex-col",
+            "w-[calc(100vw-80px)] h-[calc(100vh-80px)]",
+            "max-w-[1800px] max-h-[1200px]",
+            "bg-canopy-bg rounded-xl",
+            "border border-divider",
+            "shadow-2xl shadow-black/40",
+            "motion-safe:animate-in motion-safe:zoom-in-95 motion-safe:duration-200"
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
+            <div className="flex items-center gap-3">
+              <LayoutGrid className="w-5 h-5 text-canopy-text/60" />
+              <h2
+                id="worktree-overview-title"
+                className="text-canopy-text font-semibold text-base tracking-wide"
               >
-                {aggregateStats.workingCount > 0 && (
-                  <span className="flex items-center gap-1 text-xs text-[var(--color-state-working)]">
-                    <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
-                    {aggregateStats.workingCount} working
-                  </span>
-                )}
-                {aggregateStats.waitingCount > 0 && (
-                  <span className="flex items-center gap-1 text-xs text-status-warning">
-                    <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
-                    {aggregateStats.waitingCount} waiting
-                  </span>
-                )}
-                {aggregateStats.failedCount > 0 && (
-                  <span className="flex items-center gap-1 text-xs text-status-error">
-                    <span className="w-1.5 h-1.5 rounded-full bg-status-error" />
-                    {aggregateStats.failedCount} failed
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            {/* Hide main worktree toggle - show if there are non-main worktrees OR if filter is active (to allow recovery) */}
-            {(hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree && (
-              <TooltipProvider>
+                Worktrees Overview
+              </h2>
+              <span className="text-canopy-text/50 text-sm">
+                ({filteredWorktrees.length}
+                {filteredWorktrees.length !== worktrees.length && ` of ${worktrees.length}`})
+              </span>
+              {/* Aggregate activity statistics */}
+              {(aggregateStats.workingCount > 0 ||
+                aggregateStats.waitingCount > 0 ||
+                aggregateStats.failedCount > 0) && (
+                <div
+                  className="flex items-center gap-2 ml-2 pl-3 border-l border-divider"
+                  role="status"
+                  aria-label="Agent activity statistics"
+                >
+                  {aggregateStats.workingCount > 0 && (
+                    <span className="flex items-center gap-1 text-xs text-[var(--color-state-working)]">
+                      <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-state-working)] motion-safe:animate-pulse" />
+                      {aggregateStats.workingCount} working
+                    </span>
+                  )}
+                  {aggregateStats.waitingCount > 0 && (
+                    <span className="flex items-center gap-1 text-xs text-status-warning">
+                      <span className="w-1.5 h-1.5 rounded-full bg-status-warning" />
+                      {aggregateStats.waitingCount} waiting
+                    </span>
+                  )}
+                  {aggregateStats.failedCount > 0 && (
+                    <span className="flex items-center gap-1 text-xs text-status-error">
+                      <span className="w-1.5 h-1.5 rounded-full bg-status-error" />
+                      {aggregateStats.failedCount} failed
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {/* Hide main worktree toggle - show if there are non-main worktrees OR if filter is active (to allow recovery) */}
+              {(hasNonMainWorktrees || hideMainWorktree) && !hasOnlyMainWorktree && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -455,13 +455,11 @@ export function WorktreeOverviewModal({
                     {hideMainWorktree ? "Show main worktree" : "Hide main worktree"}
                   </TooltipContent>
                 </Tooltip>
-              </TooltipProvider>
-            )}
-            {/* Filter Popover */}
-            <WorktreeFilterPopover />
-            {/* Clear Filters Button - only shown when filters are active */}
-            {hasActiveFilters() && (
-              <TooltipProvider>
+              )}
+              {/* Filter Popover */}
+              <WorktreeFilterPopover />
+              {/* Clear Filters Button - only shown when filters are active */}
+              {hasActiveFilters() && (
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <button
@@ -481,155 +479,155 @@ export function WorktreeOverviewModal({
                   </TooltipTrigger>
                   <TooltipContent side="bottom">Clear all filters</TooltipContent>
                 </Tooltip>
-              </TooltipProvider>
-            )}
-            {/* Close Button */}
-            <button
-              ref={closeButtonRef}
-              onClick={onClose}
-              className={cn(
-                "p-2 rounded-lg transition-colors",
-                "text-canopy-text/60 hover:text-canopy-text",
-                "hover:bg-tint/[0.06]",
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent"
               )}
-              aria-label="Close overview"
-            >
-              <X className="w-5 h-5" />
-            </button>
+              {/* Close Button */}
+              <button
+                ref={closeButtonRef}
+                onClick={onClose}
+                className={cn(
+                  "p-2 rounded-lg transition-colors",
+                  "text-canopy-text/60 hover:text-canopy-text",
+                  "hover:bg-tint/[0.06]",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent"
+                )}
+                aria-label="Close overview"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
           </div>
-        </div>
 
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {worktrees.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-canopy-text/50">
-              No worktrees available
-            </div>
-          ) : filteredWorktrees.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full gap-4 text-canopy-text/50">
-              <FilterX className="w-12 h-12 text-canopy-text/30" />
-              <div className="text-center">
-                <p className="text-sm font-medium text-canopy-text/70">
-                  No worktrees match filters
-                </p>
-                <p className="text-xs mt-1">
-                  {worktrees.length} worktree{worktrees.length !== 1 ? "s" : ""} hidden by active
-                  filters
-                </p>
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto p-6">
+            {worktrees.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-canopy-text/50">
+                No worktrees available
               </div>
-              <Button variant="subtle" size="sm" onClick={clearAllFilters} className="mt-2">
-                Clear all filters
-              </Button>
-            </div>
-          ) : groupedSections ? (
-            <div className="space-y-6">
-              {groupedSections.map((section: GroupedSection<WorktreeState>) => (
-                <div key={section.type}>
-                  <div className="flex items-center gap-2 mb-3">
-                    <h3 className="text-xs font-medium text-canopy-text/60 uppercase tracking-wider">
-                      {section.displayName}
-                    </h3>
-                    <span className="text-xs text-canopy-text/40">
-                      ({section.worktrees.length})
-                    </span>
+            ) : filteredWorktrees.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full gap-4 text-canopy-text/50">
+                <FilterX className="w-12 h-12 text-canopy-text/30" />
+                <div className="text-center">
+                  <p className="text-sm font-medium text-canopy-text/70">
+                    No worktrees match filters
+                  </p>
+                  <p className="text-xs mt-1">
+                    {worktrees.length} worktree{worktrees.length !== 1 ? "s" : ""} hidden by active
+                    filters
+                  </p>
+                </div>
+                <Button variant="subtle" size="sm" onClick={clearAllFilters} className="mt-2">
+                  Clear all filters
+                </Button>
+              </div>
+            ) : groupedSections ? (
+              <div className="space-y-6">
+                {groupedSections.map((section: GroupedSection<WorktreeState>) => (
+                  <div key={section.type}>
+                    <div className="flex items-center gap-2 mb-3">
+                      <h3 className="text-xs font-medium text-canopy-text/60 uppercase tracking-wider">
+                        {section.displayName}
+                      </h3>
+                      <span className="text-xs text-canopy-text/40">
+                        ({section.worktrees.length})
+                      </span>
+                    </div>
+                    <div
+                      className={cn(
+                        "grid gap-3",
+                        "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
+                        "justify-center",
+                        "auto-rows-min"
+                      )}
+                    >
+                      {section.worktrees.map((worktree: WorktreeState) => (
+                        <div
+                          key={worktree.id}
+                          className={cn(
+                            "rounded-lg overflow-hidden",
+                            "border border-divider",
+                            "bg-canopy-sidebar/50",
+                            "transition-all duration-200",
+                            "hover:border-canopy-accent/50 hover:shadow-lg hover:shadow-canopy-accent/5",
+                            worktree.id === activeWorktreeId &&
+                              "border-[var(--color-state-active)]/70 shadow-md"
+                          )}
+                        >
+                          <OverviewWorktreeCard
+                            worktreeId={worktree.id}
+                            activeWorktreeId={activeWorktreeId}
+                            focusedWorktreeId={focusedWorktreeId}
+                            totalWorktreeCount={worktrees.length}
+                            onSelectWorktree={onSelectWorktree}
+                            onCopyTree={onCopyTree}
+                            onOpenEditor={onOpenEditor}
+                            onSaveLayout={onSaveLayout}
+                            onLaunchAgent={onLaunchAgent}
+                            agentAvailability={agentAvailability}
+                            agentSettings={agentSettings}
+                            homeDir={homeDir}
+                            onClose={onClose}
+                          />
+                        </div>
+                      ))}
+                    </div>
                   </div>
+                ))}
+              </div>
+            ) : (
+              <div
+                className={cn(
+                  "grid gap-3",
+                  "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
+                  "justify-center",
+                  "items-start"
+                )}
+              >
+                {filteredWorktrees.map((worktree) => (
                   <div
+                    key={worktree.id}
                     className={cn(
-                      "grid gap-3",
-                      "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                      "justify-center",
-                      "auto-rows-min"
+                      "rounded-lg overflow-hidden",
+                      "border border-divider",
+                      "bg-canopy-sidebar/50",
+                      "transition-all duration-200",
+                      "hover:border-canopy-accent/50 hover:shadow-lg hover:shadow-canopy-accent/5",
+                      worktree.id === activeWorktreeId &&
+                        "border-[var(--color-state-active)]/70 shadow-md"
                     )}
                   >
-                    {section.worktrees.map((worktree: WorktreeState) => (
-                      <div
-                        key={worktree.id}
-                        className={cn(
-                          "rounded-lg overflow-hidden",
-                          "border border-divider",
-                          "bg-canopy-sidebar/50",
-                          "transition-all duration-200",
-                          "hover:border-canopy-accent/50 hover:shadow-lg hover:shadow-canopy-accent/5",
-                          worktree.id === activeWorktreeId &&
-                            "border-[var(--color-state-active)]/70 shadow-md"
-                        )}
-                      >
-                        <OverviewWorktreeCard
-                          worktreeId={worktree.id}
-                          activeWorktreeId={activeWorktreeId}
-                          focusedWorktreeId={focusedWorktreeId}
-                          totalWorktreeCount={worktrees.length}
-                          onSelectWorktree={onSelectWorktree}
-                          onCopyTree={onCopyTree}
-                          onOpenEditor={onOpenEditor}
-                          onSaveLayout={onSaveLayout}
-                          onLaunchAgent={onLaunchAgent}
-                          agentAvailability={agentAvailability}
-                          agentSettings={agentSettings}
-                          homeDir={homeDir}
-                          onClose={onClose}
-                        />
-                      </div>
-                    ))}
+                    <OverviewWorktreeCard
+                      variant="grid"
+                      worktreeId={worktree.id}
+                      activeWorktreeId={activeWorktreeId}
+                      focusedWorktreeId={focusedWorktreeId}
+                      totalWorktreeCount={worktrees.length}
+                      onSelectWorktree={onSelectWorktree}
+                      onCopyTree={onCopyTree}
+                      onOpenEditor={onOpenEditor}
+                      onSaveLayout={onSaveLayout}
+                      onLaunchAgent={onLaunchAgent}
+                      agentAvailability={agentAvailability}
+                      agentSettings={agentSettings}
+                      homeDir={homeDir}
+                      onClose={onClose}
+                    />
                   </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div
-              className={cn(
-                "grid gap-3",
-                "grid-cols-[repeat(auto-fit,minmax(min(320px,100%),480px))]",
-                "justify-center",
-                "items-start"
-              )}
-            >
-              {filteredWorktrees.map((worktree) => (
-                <div
-                  key={worktree.id}
-                  className={cn(
-                    "rounded-lg overflow-hidden",
-                    "border border-divider",
-                    "bg-canopy-sidebar/50",
-                    "transition-all duration-200",
-                    "hover:border-canopy-accent/50 hover:shadow-lg hover:shadow-canopy-accent/5",
-                    worktree.id === activeWorktreeId &&
-                      "border-[var(--color-state-active)]/70 shadow-md"
-                  )}
-                >
-                  <OverviewWorktreeCard
-                    variant="grid"
-                    worktreeId={worktree.id}
-                    activeWorktreeId={activeWorktreeId}
-                    focusedWorktreeId={focusedWorktreeId}
-                    totalWorktreeCount={worktrees.length}
-                    onSelectWorktree={onSelectWorktree}
-                    onCopyTree={onCopyTree}
-                    onOpenEditor={onOpenEditor}
-                    onSaveLayout={onSaveLayout}
-                    onLaunchAgent={onLaunchAgent}
-                    agentAvailability={agentAvailability}
-                    agentSettings={agentSettings}
-                    homeDir={homeDir}
-                    onClose={onClose}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+                ))}
+              </div>
+            )}
+          </div>
 
-        {/* Footer hint */}
-        <div className="px-6 py-3 border-t border-divider shrink-0">
-          <div className="flex items-center justify-center gap-4 text-xs text-canopy-text/40">
-            <span>
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd> to close
-            </span>
-            <span>Click a worktree to switch</span>
+          {/* Footer hint */}
+          <div className="px-6 py-3 border-t border-divider shrink-0">
+            <div className="flex items-center justify-center gap-4 text-xs text-canopy-text/40">
+              <span>
+                <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-[10px]">Esc</kbd> to close
+              </span>
+              <span>Click a worktree to switch</span>
+            </div>
           </div>
         </div>
-      </div>
+      </TooltipProvider>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces 17 individual `<TooltipProvider>` instances per worktree card with 3 scoped providers at strategic points in the component tree
- Adds providers to `App.tsx` (sidebar scope), `RecipesTab.tsx`, and `WorktreeOverviewModal.tsx` so all tooltip triggers share warm-state transitions
- Standardizes tooltip delay to 400ms cold / 300ms skip-delay across the worktree UI

Resolves #3811

## Changes

- **App.tsx**: Wrapped sidebar worktree list in a single `<TooltipProvider delayDuration={400} skipDelayDuration={300}>`
- **RecipesTab.tsx**: Added scoped provider for recipe tooltips that use `ActivityLight`
- **WorktreeOverviewModal.tsx**: Added scoped provider for the modal's worktree details
- **WorktreeCard.tsx**: Removed inner `TooltipProvider` wrapping chip state tooltip
- **WorktreeHeader.tsx**: Removed 4 inner `TooltipProvider` instances (IssueBadge, PRBadge, error count, menu button)
- **WorktreeDetailsSection.tsx**: Removed 2 inner providers (activity, review button)
- **WorktreeTerminalSection.tsx**: Removed 3 inner providers (command, location, state icon)
- **WorktreeDetails.tsx**: Removed 2 inner providers (path button, copy button)
- **BranchLabel.tsx**: Removed inner provider
- **ActivityLight.tsx**: Removed inner provider
- **LiveTimeAgo.tsx**: Removed inner provider
- **AgentStatusIndicator.tsx**: Removed inner provider
- Updated `WorktreeHeader.test.tsx` to wrap test renders in a `TooltipProvider`

## Testing

- TypeScript typecheck passes cleanly
- ESLint passes (0 errors, only pre-existing warnings)
- Prettier formatting verified clean
- Unit test for WorktreeHeader updated to include provider wrapper