### PR TITLE
feat(e2e): add shared focus assertion helpers

### DIFF
--- a/e2e/core/core-action-palette-commands.spec.ts
+++ b/e2e/core/core-action-palette-commands.spec.ts
@@ -3,6 +3,7 @@ import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 import { getGridPanelCount } from "../helpers/panels";
+import { expectPaletteFocused } from "../helpers/focus";
 import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
@@ -45,8 +46,9 @@ test.describe.serial("Core: Action Palette, Command Picker & Quick Switcher", ()
     test("search input is focused and filters results", async () => {
       const { window } = ctx;
 
+      await expectPaletteFocused(window, "action", T_SHORT);
+
       const searchInput = window.locator(SEL.actionPalette.searchInput);
-      await expect(searchInput).toBeFocused({ timeout: T_SHORT });
 
       // Capture unfiltered count
       const options = window.locator(SEL.actionPalette.options);

--- a/e2e/core/core-terminal-search.spec.ts
+++ b/e2e/core/core-terminal-search.spec.ts
@@ -3,6 +3,7 @@ import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openProject, dismissTelemetryConsent } from "../helpers/project";
 import { waitForTerminalText, runTerminalCommand } from "../helpers/terminal";
+import { expectTerminalFocused } from "../helpers/focus";
 import { getFirstGridPanel } from "../helpers/panels";
 import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
@@ -75,6 +76,7 @@ test.describe.serial("Core: Terminal Search & Scrollback", () => {
 
       await panel.locator(SEL.terminal.xtermRows).click();
       await window.waitForTimeout(T_SETTLE);
+      await expectTerminalFocused(panel);
       await window.evaluate(() => window.dispatchEvent(new CustomEvent("canopy:find-in-panel")));
 
       await expect(panel.locator(SEL.terminal.searchInput)).toBeVisible({ timeout: T_MEDIUM });

--- a/e2e/helpers/focus.ts
+++ b/e2e/helpers/focus.ts
@@ -1,0 +1,47 @@
+import { expect, type ElectronApplication, type Locator, type Page } from "@playwright/test";
+import { SEL } from "./selectors";
+import { T_MEDIUM } from "./timeouts";
+
+export async function expectTerminalFocused(
+  panelLocator: Locator,
+  timeout = T_MEDIUM
+): Promise<void> {
+  const textarea = panelLocator.locator(SEL.terminal.xtermHelperTextarea);
+  await expect(textarea).toBeFocused({ timeout });
+}
+
+export async function expectInputBarFocused(
+  panelLocator: Locator,
+  timeout = T_MEDIUM
+): Promise<void> {
+  const cmContent = panelLocator.locator(SEL.terminal.cmEditor);
+  await expect(cmContent).toBeFocused({ timeout });
+}
+
+const paletteSearchSelectors = {
+  action: SEL.actionPalette.searchInput,
+  quickSwitcher: SEL.quickSwitcher.searchInput,
+  command: SEL.commandPicker.searchInput,
+} as const;
+
+export type PaletteType = keyof typeof paletteSearchSelectors;
+
+export async function expectPaletteFocused(
+  page: Page,
+  paletteType: PaletteType,
+  timeout = T_MEDIUM
+): Promise<void> {
+  const selector = paletteSearchSelectors[paletteType];
+  await expect(page.locator(selector)).toBeFocused({ timeout });
+}
+
+export async function ensureWindowFocused(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ BrowserWindow }) => {
+    const win = BrowserWindow.getAllWindows()[0];
+    if (!win) throw new Error("No BrowserWindow found");
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+    win.webContents.focus();
+  });
+}

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -52,6 +52,7 @@ export const SEL = {
   terminal: {
     xtermRows: ".xterm-screen",
     xtermViewport: ".xterm-viewport",
+    xtermHelperTextarea: ".xterm-helper-textarea",
     cmEditor: ".cm-content",
     titleButton: '[aria-label*="title"]',
     searchInput: "[data-terminal-search-input]",


### PR DESCRIPTION
## Summary

- Adds `e2e/helpers/focus.ts` with reusable focus assertion utilities for E2E tests
- Provides helpers for terminal (`.xterm-helper-textarea`), CodeMirror (`.cm-content`), palette search inputs, and window focus (for CI/Xvfb)
- Integrates the helpers into existing E2E specs to validate they work correctly

Resolves #3898

## Changes

- **`e2e/helpers/focus.ts`** — New file with `expectTerminalFocused()`, `expectInputBarFocused()`, `expectPaletteFocused()`, and `ensureWindowFocused()` helpers
- **`e2e/helpers/selectors.ts`** — Added `xtermHelperTextarea` selector (`.xterm-helper-textarea`)
- **`e2e/core/core-action-palette-commands.spec.ts`** — Switched to `expectPaletteFocused()` helper instead of inline focus assertion
- **`e2e/core/core-terminal-search.spec.ts`** — Added `expectTerminalFocused()` assertion before triggering search

## Testing

- TypeScript typecheck passes cleanly
- ESLint and Prettier pass with no issues
- Helpers are imported and used in two existing E2E test files