### PR TITLE
fix(pty-host): release SharedArrayBuffer references in cleanup

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1308,6 +1308,13 @@ function cleanup(): void {
   }
 
   ptyManager.dispose();
+
+  // Release SharedArrayBuffer references so V8 can GC shared memory regions
+  visualBuffers = [];
+  visualSignalView = null;
+  analysisBuffer = null;
+  ipcDataMirrorTerminals.clear();
+
   events.removeAllListeners();
 
   console.log("[PtyHost] Disposed");


### PR DESCRIPTION
## Summary

- Nullifies `visualBuffers`, `visualSignalView`, and `analysisBuffer` in the PTY host `cleanup()` function so V8 can garbage-collect the underlying SharedArrayBuffer memory regions
- Also clears `ipcDataMirrorTerminals` map which holds per-terminal buffer routing state

Resolves #3839

## Changes

- `electron/pty-host.ts`: Added cleanup of four module-level references (`visualBuffers` set to `[]`, `visualSignalView` and `analysisBuffer` set to `null`, `ipcDataMirrorTerminals` cleared) in the existing `cleanup()` function, following the same pattern already used for `ptyPool`

## Testing

- All existing guard checks (`if (visualBuffers.length > 0)`, `if (analysisBuffer)`, `if (visualSignalView)`) already protect against post-cleanup access, so nullifying these references is safe
- No behavioral changes during normal operation since cleanup only runs on process exit or disposal