### PR TITLE
test(e2e): add PTY crash mid-output resilience test

### DIFF
--- a/e2e/core/core-pty-resilience.spec.ts
+++ b/e2e/core/core-pty-resilience.spec.ts
@@ -179,7 +179,9 @@ test.describe.serial("Core: PTY Resilience", () => {
       }
     }, capturedPid);
 
-    // Wait for panel to be trashed or show exit banner
+    // node-pty reports exitCode=null for signal deaths, normalized to 0 by TerminalProcess.
+    // Exit code 0 → panel auto-trashed. Non-zero → panel preserved with exit banner.
+    // Wait for either outcome: panel trashed (grid empty) or exit banner visible.
     await expect
       .poll(
         async () => {
@@ -204,10 +206,12 @@ test.describe.serial("Core: PTY Resilience", () => {
     const countBefore = await getGridPanelCount(window);
     await window.locator(SEL.toolbar.openTerminal).click();
 
+    // Wait for the new terminal to appear
     await expect
       .poll(() => getGridPanelCount(window), { timeout: T_LONG })
       .toBeGreaterThan(countBefore);
 
+    // Get the newest panel (last in grid — the crashed panel may still be first)
     const newPanel = window.locator(SEL.panel.gridPanel).last();
     await expect(newPanel).toBeVisible({ timeout: T_MEDIUM });
 


### PR DESCRIPTION
## Summary

- Adds E2E test coverage for PTY crash during active high-throughput output, validating that the terminal UI handles shell death gracefully
- Tests the full PTY lifecycle: spawn terminal, start flood output, SIGKILL the shell PID, verify UI stays responsive, spawn a new terminal and run a command

Resolves #3843

## Changes

- New test file `e2e/core/core-pty-resilience.spec.ts` with a serial test suite containing 3 tests:
  1. Spawns a terminal, captures the shell PID via echo, starts a slow flood loop
  2. Kills the PTY with SIGKILL from the main process, verifies the panel either auto-trashes (exit code 0) or shows an exit banner, confirms toolbar remains interactive
  3. Opens a new terminal post-crash, runs a command, verifies output appears

- Platform-robust design: uses `echo CANOPY_PID_$$` for PID capture (works on macOS/Linux), slow flood with sleep to avoid buffer overwhelm, polls for either "trashed" or "preserved" panel state since exit code normalization varies

## Testing

- Test structure validated against existing E2E patterns in the repo
- Formatting and linting pass clean (Prettier + ESLint, no changes needed)