### PR TITLE
test(e2e): add project switch race condition tests

### DIFF
--- a/e2e/core/core-project-switch-race.spec.ts
+++ b/e2e/core/core-project-switch-race.spec.ts
@@ -6,7 +6,7 @@ import { openAndOnboardProject, completeOnboarding } from "../helpers/project";
 import { injectDelay, clearAllFaults } from "../helpers/ipcFaults";
 import { getGridPanelCount } from "../helpers/panels";
 import { SEL } from "../helpers/selectors";
-import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
+import { T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 const PROJECT_A_NAME = "Race Project A";


### PR DESCRIPTION
## Summary

- Adds E2E tests that verify terminal spawns land in the correct project when a project switch happens mid-spawn
- Introduces IPC fault injection infrastructure (delay/error injection on any IPC channel) for deterministic race condition testing
- Validates no orphaned PTY processes or stale panels remain after rapid project switching

Resolves #3909

## Changes

- `e2e/core/core-project-switch-race.spec.ts` — three test cases covering delayed spawn assignment, orphaned PTY detection, and panel grid cleanliness after switching
- `e2e/core/core-ipc-fault-smoke.spec.ts` — smoke tests for the fault injection system itself
- `e2e/helpers/ipcFaults.ts` — Playwright helper for injecting delays/errors on IPC channels
- `electron/ipc/faultRegistry.ts` — main-process fault registry (dev/test only)
- `electron/ipc/__tests__/faultRegistry.test.ts` — unit tests for the fault registry
- `electron/setup/security.ts` — registers fault injection IPC handlers behind E2E guard

## Testing

- TypeScript typecheck passes (`npx tsc --noEmit`)
- ESLint passes (0 errors)
- Prettier formatting clean