### PR TITLE
test(e2e): add IPC error propagation E2E tests

### DIFF
--- a/e2e/core/core-ipc-error-propagation.spec.ts
+++ b/e2e/core/core-ipc-error-propagation.spec.ts
@@ -247,8 +247,8 @@ test.describe.serial("Core: IPC Error Propagation", () => {
     const rows = panel.locator("tbody tr").filter({ hasText: "E2E dedup test error" });
     await expect(rows).toHaveCount(1);
 
-    // Wait past the dedup window, then send the same error again
-    await ctx.window.waitForTimeout(550);
+    // Wait past the dedup window (1000ms margin for CI — timestamp refreshes on each dup)
+    await ctx.window.waitForTimeout(1000);
     await emitError(ctx.app, {
       type: "git",
       message: "E2E dedup test error",


### PR DESCRIPTION
## Summary

- Adds a comprehensive E2E test suite (`core-ipc-error-propagation.spec.ts`) that verifies IPC errors propagate correctly through the error pipeline to the UI
- Covers all acceptance criteria: git errors in problems panel, network error toasts, terminal spawn error banners (ENOENT/ENOTDIR), diagnostics dock auto-open, transient vs permanent error differentiation, and error deduplication

Resolves #3862

## Changes

- **`e2e/core/core-ipc-error-propagation.spec.ts`** (324 lines): 7 test cases using the fault injection infrastructure from #3854
  - Git operation failure → problems panel row with recovery hint
  - Network failure → error toast notification
  - Terminal ENOENT spawn → SpawnErrorBanner with retry/trash buttons
  - Terminal ENOTDIR spawn → SpawnErrorBanner with "Update Directory" action
  - DiagnosticsDock auto-opens on first error
  - Transient errors display differently from permanent errors
  - 5 identical errors within 500ms deduplicate to 1 displayed

## Testing

- Formatted with Prettier, linted with ESLint, both clean
- Rebased on latest develop