### PR TITLE
test(e2e): add HybridInputBar E2E test suite

### DIFF
--- a/e2e/core/core-hybrid-input-bar.spec.ts
+++ b/e2e/core/core-hybrid-input-bar.spec.ts
@@ -85,8 +85,6 @@ test.describe.serial("Core: HybridInputBar", () => {
   });
 
   test("slash autocomplete appears when typing /", async () => {
-    const { window } = ctx;
-
     await cmEditor.click();
     await cmEditor.pressSequentially("/", { delay: 30 });
 


### PR DESCRIPTION
## Summary

- Adds E2E test coverage for the HybridInputBar (CodeMirror-based agent input), covering text input, submit via Enter, newline via Shift+Enter, slash-command autocomplete, and input draft persistence across panel switches
- Tests interact with CodeMirror's contenteditable surface using pressSequentially for reliable character input

Resolves #3846

## Changes

- `e2e/core/core-hybrid-input-bar.spec.ts` — new test suite with 5 tests:
  - Type text into CodeMirror editor and verify content
  - Enter submits command (text appears in terminal output)
  - Shift+Enter inserts newline without submitting
  - Slash command autocomplete menu appears and allows selection
  - Input draft preserved when switching panels and returning

## Testing

- All tests pass locally in headless mode
- Formatting and linting clean