### PR TITLE
test(e2e): add project lifecycle and multi-project management tests

### DIFF
--- a/e2e/core/core-project-lifecycle.spec.ts
+++ b/e2e/core/core-project-lifecycle.spec.ts
@@ -16,17 +16,15 @@ const PROJECT_B = "Lifecycle Project B";
 const RECIPE_NAME = "Lifecycle Recipe";
 
 let ctx: AppContext;
+let repoBPath: string;
 
 test.describe.serial("Core: Project Lifecycle", () => {
   test.beforeAll(async () => {
     const repoA = createFixtureRepo({ name: "lifecycle-a" });
-    const repoB = createFixtureRepo({ name: "lifecycle-b" });
+    repoBPath = createFixtureRepo({ name: "lifecycle-b" });
 
     ctx = await launchApp();
     await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
-
-    // Store repoB path for adding later
-    (ctx as AppContext & { repoB: string }).repoB = repoB;
   });
 
   test.afterAll(async () => {
@@ -35,9 +33,8 @@ test.describe.serial("Core: Project Lifecycle", () => {
 
   test("add second project via project switcher", async () => {
     const { app, window } = ctx;
-    const repoB = (ctx as AppContext & { repoB: string }).repoB;
 
-    await addAndSwitchToProject(app, window, repoB, PROJECT_B);
+    await addAndSwitchToProject(app, window, repoBPath, PROJECT_B);
 
     // Verify both projects are listed in the switcher
     await window.locator(SEL.toolbar.projectSwitcherTrigger).click();


### PR DESCRIPTION
## Summary

- Adds E2E tests covering the full project lifecycle: adding a second project, switching between projects, verifying panel isolation, and removing a project
- Uses a second fixture repo created at test setup time with `mockOpenDialog()` to simulate the "Add Project" flow

Resolves #3893

## Changes

- New test file `e2e/core/core-project-lifecycle.spec.ts` with 5 tests:
  - Add a second project via the project switcher
  - Switch between projects and verify each has its own panel state
  - Project settings dialog shows the correct project name
  - Remove a project and confirm it disappears from the switcher
  - Full lifecycle flow combining add, switch, and remove

## Testing

- Formatted and linted with Prettier and ESLint (no issues)
- Rebased on latest develop