### PR TITLE
test(e2e): add terminal trash, restore, and TTL expiry tests

### DIFF
--- a/e2e/core/core-terminal-lifecycle-advanced.spec.ts
+++ b/e2e/core/core-terminal-lifecycle-advanced.spec.ts
@@ -67,6 +67,9 @@ test.describe.serial("Core: Terminal Trash & Restore", () => {
 
       const restored = getFirstGridPanel(window);
       await waitForTerminalText(restored, marker, T_LONG);
+
+      // Trash container should disappear after restore (entry consumed)
+      await expect(trashBtn).not.toBeVisible({ timeout: T_MEDIUM });
     });
 
     test("cleanup: close restored terminal", async () => {
@@ -174,7 +177,7 @@ test.describe.serial("Core: Terminal Trash & Restore", () => {
 
   test.describe.serial("TTL Expiry Permanently Removes Terminal", () => {
     test("trashed terminal is permanently removed after TTL", async () => {
-      test.setTimeout(60_000);
+      test.setTimeout(120_000);
       const { window } = ctx;
       const marker = uniqueMarker();
 


### PR DESCRIPTION
## Summary

- Adds E2E tests covering the terminal trash/restore lifecycle: close-to-trash, restore with content preservation, TTL expiry permanent removal, and reopen-last-closed ordering
- New spec file `e2e/core/core-terminal-lifecycle-advanced.spec.ts` with 4 test cases

Resolves #3851

## Changes

- **Trash and restore**: Verifies closing a terminal moves it to trash (not immediate kill), and restoring brings it back with scrollback content intact
- **TTL expiry**: Waits past the 20s TTL boundary and confirms the terminal is permanently gone and cannot be restored
- **Reopen last closed**: Closes two terminals sequentially, verifies "reopen last" restores the most recently closed one
- **Review fixes**: Addressed code review findings (typing, assertions, timing)

## Testing

- Tests designed to run with extended timeout for the TTL expiry case (>20s wait by design)
- Formatting and linting pass cleanly (`npm run fix`)