### PR TITLE
test(e2e): add runtime error handling E2E tests

### DIFF
--- a/e2e/core/core-error-recovery.spec.ts
+++ b/e2e/core/core-error-recovery.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from "@playwright/test";
 import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo, createMultiProjectFixture } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
-import { waitForTerminalText, runTerminalCommand } from "../helpers/terminal";
-import { getFirstGridPanel, getGridPanelCount } from "../helpers/panels";
+import { runTerminalCommand } from "../helpers/terminal";
+import { getGridPanelCount } from "../helpers/panels";
 import {
   addAndSwitchToProject,
   selectExistingProject,


### PR DESCRIPTION
## Summary

- Adds `core-error-recovery.spec.ts` with E2E tests for runtime error handling scenarios
- Tests terminal process exit indicators (non-zero and zero exit codes) and missing worktree directory detection
- Uses auto-retrying assertions with appropriate timeouts for polling-based detection

Resolves #3878

## Changes

- New test: terminal shows exit indicator after `exit 1` (non-zero exit)
- New test: terminal shows clean exit state after `exit 0`
- New test: worktree card updates when its directory is deleted externally (detected via polling cycle)
- Platform-aware guards for directory deletion edge cases

## Testing

- Typecheck, ESLint, and Prettier all pass cleanly
- Tests follow existing E2E patterns from `core-crash-recovery.spec.ts`