### PR TITLE
test(e2e): add cross-project terminal state preservation tests

### DIFF
--- a/e2e/core/core-cross-project-workflows.spec.ts
+++ b/e2e/core/core-cross-project-workflows.spec.ts
@@ -162,8 +162,8 @@ test.describe.serial("Core: Cross-Project Terminal Workflows", () => {
       "type new command and verify output",
       async () => {
         const panel = getPanelById(page, panelIdsA[0]);
-        await focusAndRunCommand(page, panel, "echo POST_SWITCH_INPUT");
-        await waitForTerminalText(panel, "POST_SWITCH_INPUT");
+        await focusAndRunCommand(page, panel, "echo INPUT_OK_$((40+2))");
+        await waitForTerminalText(panel, "INPUT_OK_42");
       },
       { box: true }
     );
@@ -286,7 +286,7 @@ test.describe.serial("Core: Cross-Project Terminal Workflows", () => {
     );
 
     await test.step(
-      "verify final state is A with 3 panels",
+      "verify final state is A with 3 panels and original content",
       async () => {
         const current = await page.evaluate(async () => {
           return await (window as any).electron.project.getCurrent();
@@ -294,6 +294,10 @@ test.describe.serial("Core: Cross-Project Terminal Workflows", () => {
         expect(current.name).toBe(PROJECT_A);
 
         await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(3);
+
+        // Verify original terminal markers survived rapid switching
+        const panel1 = getPanelById(page, panelIdsA[0]);
+        await waitForTerminalText(panel1, "MARKER_ALPHA_ONE");
       },
       { box: true }
     );


### PR DESCRIPTION
## Summary

- Adds E2E tests verifying terminal processes, scrollback content, and input capability survive project switches
- Covers multi-terminal count preservation, MRU ordering, and rapid switching resilience
- Strengthened assertions per code review (explicit content checks, tighter timeouts)

Resolves #3845

## Changes

- New spec file `e2e/core/core-cross-project-workflows.spec.ts` with 5 test cases:
  - Terminal content (unique markers) survives project round-trips
  - Terminal accepts new input after switching back (PTY reconnection)
  - Correct terminal count across 2+ projects after multiple switches
  - MRU order verified after 3-project switching sequence
  - No state corruption after rapid switching (4+ switches in <2s)
- All tests use `test.step()` for readable failure reporting
- Uses buffer API (`__canopyReadTerminalBuffer`) for scrollback verification

## Testing

- Typecheck, ESLint, and Prettier all pass cleanly
- Test structure follows existing E2E patterns from `core-advanced.spec.ts`