### PR TITLE
test(e2e): add multi-terminal isolation test under flood

### DIFF
--- a/e2e/core/core-terminal-isolation.spec.ts
+++ b/e2e/core/core-terminal-isolation.spec.ts
@@ -22,7 +22,10 @@ let probePanelId: string;
  */
 async function ptyWrite(page: import("@playwright/test").Page, panelId: string, data: string) {
   await page.evaluate(
-    ([id, d]) => (window as unknown as Record<string, any>).electron.terminal.write(id, d),
+    ([id, d]) =>
+      (
+        window as unknown as { electron: { terminal: { write: (id: string, d: string) => void } } }
+      ).electron.terminal.write(id, d),
     [panelId, data]
   );
 }


### PR DESCRIPTION
## Summary

- Adds E2E test that validates terminal isolation when one terminal floods output
- Opens 3 terminals, floods one with `yes`, confirms another terminal can still execute commands and return output within a reasonable timeout
- Verifies the flooded terminal recovers after killing the flood command

Resolves #3911

## Changes

- `e2e/core/core-terminal-isolation.spec.ts` — new test file covering multi-terminal responsiveness under single-terminal flood. Tests that non-flooded terminals remain responsive, and that the flooded terminal recovers after Ctrl+C.

## Testing

- Typecheck, ESLint, and Prettier all pass with no issues
- Test follows established E2E patterns (launchApp helper, CI timeout multipliers, proper cleanup)