### PR TITLE
test(e2e): add race condition tests for concurrent IPC operations

### DIFF
--- a/e2e/core/core-race-conditions.spec.ts
+++ b/e2e/core/core-race-conditions.spec.ts
@@ -115,7 +115,9 @@ test.describe.serial("Core: Race Conditions from Concurrent IPC", () => {
     await window.evaluate(async (id: string) => {
       try {
         await (window as any).electron.terminal.kill(id);
-      } catch {}
+      } catch {
+        // terminal may already be dead
+      }
     }, terminalId);
   });
 
@@ -164,7 +166,9 @@ test.describe.serial("Core: Race Conditions from Concurrent IPC", () => {
       await window.evaluate(async (id: string) => {
         try {
           await (window as any).electron.terminal.kill(id);
-        } catch {}
+        } catch {
+          // terminal may already be dead
+        }
       }, terminalId);
     }
   });
@@ -231,7 +235,9 @@ test.describe.serial("Core: Race Conditions from Concurrent IPC", () => {
     await window.evaluate(async (id: string) => {
       try {
         await (window as any).electron.terminal.kill(id);
-      } catch {}
+      } catch {
+        // terminal may already be dead
+      }
     }, terminalId);
   });
 


### PR DESCRIPTION
## Summary

- Adds E2E tests that deliberately trigger concurrent IPC operations to detect race conditions
- Covers concurrent terminal spawns, panel close during spawn, trash/restore races, spawn queue overflow, and main process stability
- Tests use `page.evaluate()` with `Promise.all()` to bypass UI debouncing and maximize concurrency

Resolves #3872

## Changes

- `e2e/core/core-race-conditions.spec.ts` — new test file with 6 test cases:
  - Concurrent terminal spawn with same ID produces exactly one running terminal
  - Closing a panel during spawn doesn't crash the main process
  - Concurrent trash + restore ends in consistent state
  - Spawn queue overflow (51+ concurrent spawns) returns errors rather than hanging
  - Rapid create/destroy cycles don't leave orphaned processes
  - Main process remains alive after all concurrent operations

## Testing

- Typecheck, ESLint, and Prettier all pass with no issues
- Tests designed to be timing-insensitive by asserting on final state rather than intermediate ordering