### PR TITLE
test(e2e): add focus management and restoration tests

### DIFF
--- a/e2e/core/core-focus-management.spec.ts
+++ b/e2e/core/core-focus-management.spec.ts
@@ -147,10 +147,12 @@ test.describe.serial("Core: Focus Management", () => {
     // Open Action Palette on top (top of stack)
     await window.keyboard.press(`${mod}+Shift+P`);
     await expect(window.locator(SEL.actionPalette.dialog)).toBeVisible({ timeout: T_MEDIUM });
+    // Settle to let any delayed menu IPC arrive before dismissing
+    await window.waitForTimeout(T_SETTLE);
 
     // First Escape: palette closes, settings stays
     await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_SHORT });
+    await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
     await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_SHORT });
 
     // Second Escape: settings closes


### PR DESCRIPTION
## Summary

- Adds E2E tests for focus management across panels, palettes, and modals
- Covers focus restoration after dismissing action palette and quick switcher, F6 panel cycling, and Escape stack LIFO ordering
- Verifies focus targets the correct internal elements (`.xterm-helper-textarea` for terminals)

Resolves #3844

## Changes

- New `e2e/core/core-focus-management.spec.ts` with 5 test cases:
  - Focus returns to terminal after dismissing action palette (Cmd+Shift+P)
  - Focus returns to terminal after dismissing quick switcher (Cmd+P)
  - F6 cycles focus between multiple grid panels
  - Escape pops layered overlays in LIFO order
  - Focus returns to correct panel after closing Settings modal
- Minor version bump in package.json/package-lock.json

## Testing

- Tests follow established E2E patterns using `launchApp`/`closeApp` helpers and `electronApp.evaluate()` for window focus in CI