### PR TITLE
test(e2e): add external worktree detection E2E test

### DIFF
--- a/e2e/core/core-worktree-external.spec.ts
+++ b/e2e/core/core-worktree-external.spec.ts
@@ -7,7 +7,7 @@ import { SEL } from "../helpers/selectors";
 import { T_LONG, T_MEDIUM } from "../helpers/timeouts";
 import { execSync } from "child_process";
 import path from "path";
-import { existsSync, rmSync } from "fs";
+import { existsSync } from "fs";
 
 const FEATURE_BRANCH = "feature/test-branch";
 const EXTERNAL_BRANCH = "feature/external-added";
@@ -113,6 +113,7 @@ test.describe.serial("Core: External Worktree Detection", () => {
     );
 
     // Trigger refresh so the app discovers the new worktree
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await window.evaluate(() => (window as any).electron.worktree.refresh());
 
     // New worktree card should appear


### PR DESCRIPTION
## Summary

- Adds a new E2E test (`core-worktree-external.spec.ts`) that verifies Canopy detects worktrees created and removed via the git CLI
- Tests that worktree cards appear/disappear in the sidebar when worktrees are added/removed externally through a terminal
- Validates the app remains stable after external worktree modifications (no crashes or error dialogs)

Resolves #3902

## Changes

- `e2e/core/core-worktree-external.spec.ts` — New test file covering external worktree addition detection, external worktree removal detection, and app stability after removal
- `e2e/core/core-rapid-terminal.spec.ts` — Minor fix (removed unused import)

## Testing

- Lint and format checks pass (`npm run fix` — 0 errors, warnings only from pre-existing code)
- Test exercises the `WorktreeMonitor` polling path by using `git worktree add` and `git worktree remove` commands in a Canopy terminal, then asserting sidebar UI updates within polling intervals