### PR TITLE
fix(bulk-command): prevent infinite re-render loop in BulkCommandPalette

### DIFF
--- a/src/components/BulkCommandCenter/BulkCommandPalette.tsx
+++ b/src/components/BulkCommandCenter/BulkCommandPalette.tsx
@@ -4,6 +4,7 @@ import { usePaletteStore } from "@/store/paletteStore";
 import { useTerminalStore } from "@/store/terminalStore";
 import { useWorktreeDataStore } from "@/store/worktreeDataStore";
 import { useRecipeStore } from "@/store/recipeStore";
+import { useShallow } from "zustand/react/shallow";
 import { isAgentTerminal } from "@/utils/terminalType";
 import { getDominantAgentState } from "@/components/Worktree/AgentStatusIndicator";
 import { STATE_ICONS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
@@ -141,7 +142,9 @@ function BulkCommandPaletteInner() {
   const doubleEscapeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const queueRef = useRef<PQueue | null>(null);
 
-  const projectRecipes = useRecipeStore((s) => s.recipes.filter((r) => r.worktreeId === undefined));
+  const projectRecipes = useRecipeStore(
+    useShallow((s) => s.recipes.filter((r) => r.worktreeId === undefined))
+  );
 
   useEffect(() => {
     return () => {

--- a/src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx
+++ b/src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { BulkCommandPalette, openBulkCommandPalette } from "../BulkCommandPalette";
 import { usePaletteStore } from "@/store/paletteStore";
 
+vi.mock("zustand/react/shallow", () => ({ useShallow: (fn: unknown) => fn }));
+
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
 }));


### PR DESCRIPTION
## Summary

- Fixed "Maximum update depth exceeded" crash when opening the Bulk Command Center
- Root cause: `useRecipeStore` selector used `.filter()` which returns a new array reference on every store change, causing infinite re-renders
- Wrapped the selector with `useShallow` from Zustand to perform shallow equality comparison

Resolves #4132

## Changes

- `src/components/BulkCommandCenter/BulkCommandPalette.tsx` — Wrapped the `useRecipeStore` filter selector with `useShallow` to stabilize the array reference
- `src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx` — Added mock for `zustand/react/shallow` to keep tests working

## Testing

- Typecheck, ESLint, and Prettier all pass cleanly
- Existing unit tests pass with the new `useShallow` mock