### PR TITLE
fix(grid): restore layout correctly when exiting maximize mode

### DIFF
--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -51,7 +51,7 @@ export function SortableTerminal({
       style={style}
       data-terminal-id={terminal.id}
       className={cn(
-        "h-full contain-layout",
+        "h-full min-w-0 contain-layout",
         isDragging && "opacity-40 ring-2 ring-canopy-accent/50 rounded"
       )}
       {...attributes}

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -554,6 +554,8 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
 
   // Track container dimensions for responsive layout and capacity calculation
   const gridContainerRef = useRef<HTMLDivElement>(null);
+  const preMaximizeLayoutRef = useRef(preMaximizeLayout);
+  preMaximizeLayoutRef.current = preMaximizeLayout;
   const [gridWidth, setGridWidth] = useState<number | null>(null);
 
   // Get placeholder state from DnD context
@@ -649,22 +651,28 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
   }, [setGridDimensions, gridTerminals.length, maximizedId, twoPaneSplitEnabled, showPlaceholder]);
 
   useEffect(() => {
-    if (preMaximizeLayout && preMaximizeLayout.worktreeId !== activeWorktreeId) {
+    if (
+      preMaximizeLayoutRef.current &&
+      preMaximizeLayoutRef.current.worktreeId !== activeWorktreeId
+    ) {
       clearPreMaximizeLayout();
     }
-  }, [activeWorktreeId, preMaximizeLayout, clearPreMaximizeLayout]);
+  }, [activeWorktreeId, clearPreMaximizeLayout]);
 
   useEffect(() => {
-    if (preMaximizeLayout && preMaximizeLayout.gridItemCount !== gridItemCount) {
+    if (
+      preMaximizeLayoutRef.current &&
+      preMaximizeLayoutRef.current.gridItemCount !== gridItemCount
+    ) {
       clearPreMaximizeLayout();
     }
-  }, [gridItemCount, preMaximizeLayout, clearPreMaximizeLayout]);
+  }, [gridItemCount, clearPreMaximizeLayout]);
 
   useEffect(() => {
-    if (preMaximizeLayout) {
+    if (preMaximizeLayoutRef.current) {
       clearPreMaximizeLayout();
     }
-  }, [layoutConfig, preMaximizeLayout, clearPreMaximizeLayout]);
+  }, [layoutConfig, clearPreMaximizeLayout]);
 
   const gridCols = useMemo(() => {
     if (
@@ -1060,7 +1068,7 @@ export function ContentGrid({ className, defaultCwd, agentAvailability }: Conten
             )}
             style={{
               display: "grid",
-              gridTemplateColumns: `repeat(${gridCols}, 1fr)`,
+              gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`,
               gridAutoRows: `minmax(${MIN_TERMINAL_HEIGHT_PX}px, 1fr)`,
               gap: "4px",
               backgroundColor: "var(--color-grid-bg)",


### PR DESCRIPTION
## Summary

- Fixed broken panel layout after exiting maximize mode where the previously maximized panel would shrink to a tiny size while others expanded disproportionately
- Root cause was a dependency cycle: effects that check `preMaximizeLayout` validity would fire during the restore transition, clearing the saved layout before it could be fully applied

Resolves #4049

## Changes

- **ContentGrid.tsx**: Replaced `preMaximizeLayout` state dependency in three cleanup effects with a ref (`preMaximizeLayoutRef`). This prevents the effects from re-firing when `preMaximizeLayout` changes during the restore process, breaking the dependency cycle that was clearing layout data prematurely.
- **ContentGrid.tsx**: Changed `gridTemplateColumns` from `repeat(N, 1fr)` to `repeat(N, minmax(0, 1fr))` so grid children can shrink below their content size and distribute space evenly.
- **SortableTerminal.tsx**: Added `min-w-0` to panel containers so flex/grid children don't force minimum width from content.

## Testing

- Typecheck, lint, and format all pass cleanly
- Verified the fix logic addresses the exact dependency cycle causing the layout break