### PR TITLE
fix(notes): make New button smaller and more subtle in notes dialog

### DIFF
--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -226,12 +226,11 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
                     <TooltipTrigger asChild>
                       <Button
                         onClick={() => actions.handleCreateNote()}
-                        size="sm"
+                        variant="ghost"
+                        size="icon-sm"
                         aria-label="Create new note"
-                        className="h-7 px-2.5 text-xs"
                       >
-                        <Plus size={14} className="mr-1" />
-                        New
+                        <Plus />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom">


### PR DESCRIPTION
## Summary

- Replaced the text "New" button in the Notes dialog toolbar with a subtle ghost icon-only button
- Uses `variant="ghost"` and `size="icon-sm"` so the button blends into the toolbar instead of drawing attention away from note content
- Removes the explicit sizing classes and text label in favor of a clean `+` icon

Resolves #4128

## Changes

- `src/components/Notes/NotesPalette.tsx`: Changed the "New" button from `size="sm"` with text label to `variant="ghost" size="icon-sm"` with icon only

## Testing

- Typecheck, ESLint, and Prettier all pass cleanly