### PR TITLE
fix(pty): preserve user locale instead of hardcoding en_US.UTF-8

### DIFF
--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -2,7 +2,7 @@ import * as pty from "node-pty";
 import type { IDisposable } from "node-pty";
 import os from "os";
 import { getDefaultShell, getDefaultShellArgs } from "./pty/terminalShell.js";
-import { filterEnvironment } from "./pty/EnvironmentFilter.js";
+import { filterEnvironment, ensureUtf8Locale } from "./pty/EnvironmentFilter.js";
 
 export interface PtyPoolConfig {
   poolSize?: number;
@@ -235,13 +235,11 @@ export class PtyPool {
     // TUI reliability: ensure rich terminal capabilities for Claude/Gemini CLIs
     filtered.TERM = "xterm-256color";
     filtered.COLORTERM = "truecolor";
-    filtered.LANG = "en_US.UTF-8";
-    filtered.LC_ALL = "en_US.UTF-8";
 
     // Avoid tools treating the environment as CI/non-interactive
     delete filtered.CI;
 
-    return filtered;
+    return ensureUtf8Locale(filtered);
   }
 
   private resolvePoolSize(poolSize: number | undefined): number {

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -37,6 +37,8 @@ describe("PtyPool", () => {
   const originalShell = process.env.SHELL;
   const originalHome = process.env.HOME;
   const originalCi = process.env.CI;
+  const originalLang = process.env.LANG;
+  const originalLcAll = process.env.LC_ALL;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,12 +46,18 @@ describe("PtyPool", () => {
     process.env.SHELL = "/bin/bash";
     process.env.HOME = "/home/tester";
     process.env.CI = "true";
+    delete process.env.LANG;
+    delete process.env.LC_ALL;
   });
 
   afterEach(() => {
     process.env.SHELL = originalShell;
     process.env.HOME = originalHome;
     process.env.CI = originalCi;
+    if (originalLang !== undefined) process.env.LANG = originalLang;
+    else delete process.env.LANG;
+    if (originalLcAll !== undefined) process.env.LC_ALL = originalLcAll;
+    else delete process.env.LC_ALL;
   });
 
   it("falls back to default pool size when configured pool size is invalid", () => {
@@ -114,7 +122,31 @@ describe("PtyPool", () => {
     expect(spawnOptions.env?.TERM).toBe("xterm-256color");
     expect(spawnOptions.env?.COLORTERM).toBe("truecolor");
     expect(spawnOptions.env?.LANG).toBe("en_US.UTF-8");
-    expect(spawnOptions.env?.LC_ALL).toBe("en_US.UTF-8");
+    expect(spawnOptions.env?.LC_ALL).toBeUndefined();
+    pool.dispose();
+  });
+
+  it("preserves user's UTF-8 LANG instead of overriding to en_US", async () => {
+    process.env.LANG = "ja_JP.UTF-8";
+    spawnMock.mockReturnValue(createFakeProcess(501));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    await pool.warmPool();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.LANG).toBe("ja_JP.UTF-8");
+    pool.dispose();
+  });
+
+  it("falls back to en_US.UTF-8 when LANG is non-UTF-8", async () => {
+    process.env.LANG = "C";
+    spawnMock.mockReturnValue(createFakeProcess(502));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    await pool.warmPool();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.LANG).toBe("en_US.UTF-8");
     pool.dispose();
   });
 });

--- a/electron/services/pty/EnvironmentFilter.ts
+++ b/electron/services/pty/EnvironmentFilter.ts
@@ -107,6 +107,21 @@ export function filterEnvironment(env: Record<string, string | undefined>): Reco
  * Inject CANOPY_* metadata into a filtered environment.
  * Returns a new object — does not mutate the input.
  */
+const UTF8_PATTERN = /utf-?8/i;
+
+/**
+ * Ensure the environment has a UTF-8 locale set in LANG.
+ * If LANG is already UTF-8, the env is returned unchanged.
+ * Otherwise, LANG is set to en_US.UTF-8 as a safe fallback.
+ * Never touches LC_ALL — it's too aggressive an override.
+ */
+export function ensureUtf8Locale(env: Record<string, string>): Record<string, string> {
+  if (env.LANG && UTF8_PATTERN.test(env.LANG)) {
+    return { ...env };
+  }
+  return { ...env, LANG: "en_US.UTF-8" };
+}
+
 export function injectCanopyMetadata(
   env: Record<string, string>,
   metadata: CanopyTerminalMetadata

--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { isSensitiveVar, filterEnvironment, injectCanopyMetadata } from "../EnvironmentFilter.js";
+import {
+  isSensitiveVar,
+  filterEnvironment,
+  injectCanopyMetadata,
+  ensureUtf8Locale,
+} from "../EnvironmentFilter.js";
 
 describe("isSensitiveVar", () => {
   describe("exact blocklist", () => {
@@ -152,6 +157,65 @@ describe("injectCanopyMetadata", () => {
     const env = { PATH: "/usr/bin" };
     injectCanopyMetadata(env, { paneId: "x", cwd: "/c" });
     expect("CANOPY_PANE_ID" in env).toBe(false);
+  });
+});
+
+describe("ensureUtf8Locale", () => {
+  it("preserves LANG when already UTF-8 (standard format)", () => {
+    expect(ensureUtf8Locale({ LANG: "fr_FR.UTF-8" }).LANG).toBe("fr_FR.UTF-8");
+  });
+
+  it("preserves LANG with lowercase utf8 variant", () => {
+    expect(ensureUtf8Locale({ LANG: "ja_JP.utf8" }).LANG).toBe("ja_JP.utf8");
+  });
+
+  it("preserves LANG with no-hyphen UTF8 variant", () => {
+    expect(ensureUtf8Locale({ LANG: "de_DE.UTF8" }).LANG).toBe("de_DE.UTF8");
+  });
+
+  it("falls back to en_US.UTF-8 when LANG is missing", () => {
+    expect(ensureUtf8Locale({}).LANG).toBe("en_US.UTF-8");
+  });
+
+  it("falls back to en_US.UTF-8 when LANG is empty", () => {
+    expect(ensureUtf8Locale({ LANG: "" }).LANG).toBe("en_US.UTF-8");
+  });
+
+  it("falls back to en_US.UTF-8 when LANG is C", () => {
+    expect(ensureUtf8Locale({ LANG: "C" }).LANG).toBe("en_US.UTF-8");
+  });
+
+  it("falls back to en_US.UTF-8 when LANG is POSIX", () => {
+    expect(ensureUtf8Locale({ LANG: "POSIX" }).LANG).toBe("en_US.UTF-8");
+  });
+
+  it("falls back when LANG has non-UTF-8 encoding", () => {
+    expect(ensureUtf8Locale({ LANG: "en_US.ISO-8859-1" }).LANG).toBe("en_US.UTF-8");
+  });
+
+  it("preserves C.UTF-8 (common Linux locale)", () => {
+    expect(ensureUtf8Locale({ LANG: "C.UTF-8" }).LANG).toBe("C.UTF-8");
+  });
+
+  it("does not add or remove LC_ALL", () => {
+    const withLcAll = ensureUtf8Locale({ LANG: "C", LC_ALL: "ja_JP.UTF-8" });
+    expect(withLcAll.LC_ALL).toBe("ja_JP.UTF-8");
+
+    const withoutLcAll = ensureUtf8Locale({ LANG: "en_US.UTF-8" });
+    expect("LC_ALL" in withoutLcAll).toBe(false);
+  });
+
+  it("does not mutate the input object", () => {
+    const env = { LANG: "C", PATH: "/usr/bin" };
+    ensureUtf8Locale(env);
+    expect(env.LANG).toBe("C");
+  });
+
+  it("preserves other env vars", () => {
+    const result = ensureUtf8Locale({ PATH: "/usr/bin", HOME: "/home/test" });
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.HOME).toBe("/home/test");
+    expect(result.LANG).toBe("en_US.UTF-8");
   });
 });
 

--- a/electron/services/pty/index.ts
+++ b/electron/services/pty/index.ts
@@ -4,6 +4,7 @@ export { AgentStateService } from "./AgentStateService.js";
 export { TerminalRegistry } from "./TerminalRegistry.js";
 export { TerminalProcess } from "./TerminalProcess.js";
 export {
+  ensureUtf8Locale,
   filterEnvironment,
   injectCanopyMetadata,
   isSensitiveVar,

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -1,6 +1,6 @@
 import * as pty from "node-pty";
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
-import { filterEnvironment, injectCanopyMetadata } from "./EnvironmentFilter.js";
+import { filterEnvironment, injectCanopyMetadata, ensureUtf8Locale } from "./EnvironmentFilter.js";
 import {
   buildNonInteractiveEnv,
   AGENT_ENV_EXCLUSIONS,
@@ -80,9 +80,11 @@ export function buildTerminalEnv(
     Object.entries(agentEnv).filter(([key]) => !exclusions.has(key) && !key.startsWith("CANOPY_"))
   ) as Record<string, string>;
 
-  return isAgentTerminal
-    ? { ...buildNonInteractiveEnv(mergedEnv, shell, agentId), ...filteredAgentEnv }
-    : mergedEnv;
+  return ensureUtf8Locale(
+    isAgentTerminal
+      ? { ...buildNonInteractiveEnv(mergedEnv, shell, agentId), ...filteredAgentEnv }
+      : mergedEnv
+  );
 }
 
 export function acquirePtyProcess(


### PR DESCRIPTION
## Summary

- PtyPool was unconditionally setting `LANG=en_US.UTF-8` and `LC_ALL=en_US.UTF-8` on every spawned terminal, overriding the user's system locale
- Now preserves the user's locale when it already includes UTF-8 encoding, and only falls back to `en_US.UTF-8` when no UTF-8 locale is set
- Removed the `LC_ALL` override entirely since it's a sledgehammer that suppresses all individual `LC_*` variables

Resolves #4178

## Changes

- **`electron/services/pty/EnvironmentFilter.ts`** — extracted `ensureUtf8Locale()` helper that checks the existing `LANG` value before overriding, and never sets `LC_ALL`
- **`electron/services/pty/terminalSpawn.ts`** — uses the new `ensureUtf8Locale()` for on-demand terminal spawns
- **`electron/services/PtyPool.ts`** — uses `ensureUtf8Locale()` in `getFilteredEnv()` instead of hardcoded locale values
- **`electron/services/pty/__tests__/EnvironmentFilter.test.ts`** — tests for all locale scenarios (existing UTF-8, missing locale, non-UTF-8 locale, case-insensitive matching)
- **`electron/services/__tests__/PtyPool.test.ts`** — updated pool tests to verify locale preservation behavior

## Testing

- All unit tests pass (`npx vitest run electron/services/pty/__tests__/EnvironmentFilter.test.ts` and `npx vitest run electron/services/__tests__/PtyPool.test.ts`)
- Typecheck, ESLint, and Prettier all pass clean