### PR TITLE
fix(pty-host): remove manual global.gc() calls from PtyHost

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -876,11 +876,6 @@ port.on("message", async (rawMsg: any) => {
       case "kill-by-project": {
         const killed = ptyManager.killByProject(msg.projectId);
         sendEvent({ type: "kill-by-project-result", requestId: msg.requestId, killed });
-        if (killed > 0) {
-          setTimeout(() => {
-            if (global.gc) global.gc();
-          }, 100);
-        }
         break;
       }
 
@@ -902,11 +897,6 @@ port.on("message", async (rawMsg: any) => {
           requestId: msg.requestId,
           results,
         });
-        if (results.length > 0) {
-          setTimeout(() => {
-            if (global.gc) global.gc();
-          }, 100);
-        }
         break;
       }
 

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -132,10 +132,6 @@ export class ResourceGovernor {
     this.deps.incrementPauseCount(pausedCount);
     console.log(`[ResourceGovernor] Paused ${pausedCount}/${terminals.length} terminals`);
 
-    if (global.gc) {
-      global.gc();
-    }
-
     this.deps.sendEvent({
       type: "host-throttled",
       isThrottled: true,

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -148,21 +148,8 @@ describe("ResourceGovernor", () => {
     governor.dispose();
   });
 
-  describe("engageThrottle GC", () => {
-    const originalGc = global.gc;
-
-    afterEach(() => {
-      if (originalGc) {
-        global.gc = originalGc;
-      } else {
-        delete (global as Record<string, unknown>).gc;
-      }
-    });
-
-    it("calls global.gc when memory exceeds throttle threshold", () => {
-      const gcMock = vi.fn();
-      global.gc = gcMock;
-
+  describe("engageThrottle", () => {
+    it("pauses terminals and emits host-throttled event under high memory", () => {
       const mockTerminal = { ptyProcess: { pause: vi.fn(), resume: vi.fn() } };
       const deps = createMockDeps({
         getTerminals: vi.fn().mockReturnValue([mockTerminal]),
@@ -180,30 +167,14 @@ describe("ResourceGovernor", () => {
 
       vi.advanceTimersByTime(2000);
 
-      expect(gcMock).toHaveBeenCalledOnce();
-
-      governor.dispose();
-    });
-
-    it("does not throw when global.gc is undefined", () => {
-      delete (global as Record<string, unknown>).gc;
-
-      const mockTerminal = { ptyProcess: { pause: vi.fn(), resume: vi.fn() } };
-      const deps = createMockDeps({
-        getTerminals: vi.fn().mockReturnValue([mockTerminal]),
-      });
-
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
-
-      const governor = new ResourceGovernor(deps);
-      governor.start();
-
-      expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+      expect(mockTerminal.ptyProcess.pause).toHaveBeenCalled();
+      expect(deps.incrementPauseCount).toHaveBeenCalledWith(1);
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-throttled",
+          isThrottled: true,
+        })
+      );
 
       governor.dispose();
     });

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -309,7 +309,7 @@ export class PtyClient extends EventEmitter {
         serviceName: "canopy-pty-host",
         stdio: "pipe",
         cwd: os.homedir(),
-        execArgv: [`--max-old-space-size=${this.config.memoryLimitMb}`, "--expose-gc"],
+        execArgv: [`--max-old-space-size=${this.config.memoryLimitMb}`],
         env: {
           ...(process.env as Record<string, string>),
           CANOPY_USER_DATA: app.getPath("userData"),

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -176,13 +176,13 @@ describe("PtyClient Handshake Protocol", () => {
       );
     });
 
-    it("should start pty-host with --expose-gc in execArgv", () => {
+    it("should not include --expose-gc in execArgv", () => {
       createClient();
       expect(forkMock).toHaveBeenCalledWith(
         expect.any(String),
         [],
         expect.objectContaining({
-          execArgv: expect.arrayContaining(["--expose-gc"]),
+          execArgv: expect.not.arrayContaining(["--expose-gc"]),
         })
       );
     });


### PR DESCRIPTION
## Summary

- Removed all three `global.gc()` calls from the PtyHost: two in `pty-host.ts` (after `kill-by-project` and `graceful-kill-by-project`) and one in `ResourceGovernor.engageThrottle()`
- Removed the `--expose-gc` flag from UtilityProcess spawn options since it's no longer needed
- Updated tests to remove `global.gc` mocking and assertions

Resolves #4201

## Changes

- `electron/pty-host.ts` — Removed `global.gc()` calls and their `setTimeout` wrappers from both project kill handlers, removed `--expose-gc` from `execArgv`
- `electron/pty-host/ResourceGovernor.ts` — Removed `global.gc()` call from `engageThrottle()`, kept the terminal pause/resume mechanism intact
- `electron/pty-host/__tests__/ResourceGovernor.test.ts` — Removed `global.gc` mock setup and related assertions
- `electron/services/PtyClient.ts` — Removed `--expose-gc` from the handshake capability declaration
- `electron/services/__tests__/PtyClient.handshake.test.ts` — Updated expected capabilities to exclude `--expose-gc`

## Testing

- TypeScript typecheck passes with no errors
- ESLint passes (only pre-existing warnings, no new issues)
- Formatting verified clean via Prettier