### PR TITLE
feat(setup): embed terminal in system health check step

### DIFF
--- a/src/components/Setup/SystemHealthCheckStep.tsx
+++ b/src/components/Setup/SystemHealthCheckStep.tsx
@@ -14,6 +14,7 @@ import type { PrerequisiteCheckResult, SystemHealthCheckResult } from "@shared/t
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
 import { detectOS } from "@/lib/agentInstall";
 import { InstallBlock } from "./InstallBlock";
+import { EmbeddedTerminal } from "./EmbeddedTerminal";
 
 interface SystemHealthCheckStepProps {
   onSkip: () => void;
@@ -73,6 +74,14 @@ export function SystemHealthCheckStep({ onSkip, agentIds }: SystemHealthCheckSte
                 loading={isChecking}
               />
             ))}
+      </div>
+
+      <div className="border-t border-canopy-border pt-4">
+        <div className="flex items-center gap-2 mb-3">
+          <div className="text-xs font-medium text-canopy-text/60">Terminal</div>
+          <div className="text-[11px] text-canopy-text/30">Run installation commands here</div>
+        </div>
+        <EmbeddedTerminal />
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary

- Adds an embedded terminal to the system prerequisites step of the setup wizard, matching the existing agent setup step UX
- Users can now install missing tools (Node.js, git, etc.) directly within Canopy instead of switching to an external terminal
- Reuses the existing `EmbeddedTerminal` component with the same visual treatment (border, label, height)

Resolves #4243

## Changes

- `src/components/Setup/SystemHealthCheckStep.tsx`: Added `EmbeddedTerminal` import and rendered it below the prerequisite status list with a "Terminal" label and "Run installation commands here" hint, wrapped in the same layout pattern used by the agent setup step

## Testing

- Typecheck, lint, and formatting all pass cleanly
- The change is purely additive UI using an existing, well-tested component