### PR TITLE
feat(panel-palette): skip model selection and launch agents directly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialog
 import { FileViewerModalHost } from "./components/FileViewer/FileViewerModalHost";
 import { NewTerminalPalette } from "./components/TerminalPalette";
 import { PanelPalette } from "./components/PanelPalette/PanelPalette";
-import { MORE_AGENTS_PANEL_ID, DEFAULT_MODEL_OPTION_ID } from "./hooks/usePanelPalette";
+import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
 import { GitInitDialog, ProjectOnboardingWizard, WelcomeScreen } from "./components/Project";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
@@ -1435,7 +1435,6 @@ function App() {
       <QuickCreatePalette palette={quickCreatePalette} />
       <PanelPalette
         isOpen={panelPalette.isOpen}
-        phase={panelPalette.phase}
         query={panelPalette.query}
         results={panelPalette.results}
         totalResults={panelPalette.totalResults}
@@ -1446,14 +1445,6 @@ function App() {
         onSelect={(kind) => {
           const result = panelPalette.handleSelect(kind);
           if (!result) return;
-          if (result.category === "model") {
-            const agentId = panelPalette.pendingAgentId;
-            if (agentId) {
-              const modelId = result.id === DEFAULT_MODEL_OPTION_ID ? undefined : result.id;
-              launchAgent(agentId, { modelId });
-            }
-            return;
-          }
           if (result.id.startsWith("agent:")) {
             const agentId = result.id.slice("agent:".length);
             if (agentId) {
@@ -1469,15 +1460,8 @@ function App() {
           }
         }}
         onConfirm={() => {
-          const currentPhase = panelPalette.phase;
-          const pendingAgent = panelPalette.pendingAgentId;
           const selected = panelPalette.confirmSelection();
           if (!selected) return;
-          if (currentPhase === "model" && selected.category === "model" && pendingAgent) {
-            const modelId = selected.id === DEFAULT_MODEL_OPTION_ID ? undefined : selected.id;
-            launchAgent(pendingAgent, { modelId });
-            return;
-          }
           if (selected.id === MORE_AGENTS_PANEL_ID) return;
           if (selected.id.startsWith("agent:")) {
             const agentId = selected.id.slice("agent:".length);
@@ -1494,7 +1478,6 @@ function App() {
           }
         }}
         onClose={panelPalette.close}
-        onBack={panelPalette.backToPanel}
       />
       <ProjectSwitcherPalette
         isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -2,14 +2,13 @@ import { useEffect, useRef, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { PaletteOverflowNotice } from "@/components/ui/PaletteOverflowNotice";
-import type { PanelKindOption, PanelPalettePhase } from "@/hooks/usePanelPalette";
+import type { PanelKindOption } from "@/hooks/usePanelPalette";
 import { PanelKindIcon } from "./PanelKindIcon";
 import { useTerminalStore } from "@/store/terminalStore";
 import { usePanelLimitStore } from "@/store/panelLimitStore";
 
 interface PanelPaletteProps {
   isOpen: boolean;
-  phase: PanelPalettePhase;
   query: string;
   results: PanelKindOption[];
   totalResults?: number;
@@ -20,7 +19,6 @@ interface PanelPaletteProps {
   onSelect: (kind: PanelKindOption) => void;
   onConfirm: () => void;
   onClose: () => void;
-  onBack: () => void;
 }
 
 const SECTION_LABELS: Record<"agent" | "tool", string> = {
@@ -30,7 +28,6 @@ const SECTION_LABELS: Record<"agent" | "tool", string> = {
 
 export function PanelPalette({
   isOpen,
-  phase,
   query,
   results,
   totalResults,
@@ -41,7 +38,6 @@ export function PanelPalette({
   onSelect,
   onConfirm,
   onClose,
-  onBack,
 }: PanelPaletteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const itemsRef = useRef(new Map<string, HTMLElement>());
@@ -76,11 +72,7 @@ export function PanelPalette({
           break;
         case "Escape":
           e.preventDefault();
-          if (phase === "model") {
-            onBack();
-          } else {
-            onClose();
-          }
+          onClose();
           break;
         case "Tab":
           e.preventDefault();
@@ -92,7 +84,7 @@ export function PanelPalette({
           break;
       }
     },
-    [onSelectPrevious, onSelectNext, onConfirm, onClose, onBack, phase]
+    [onSelectPrevious, onSelectNext, onConfirm, onClose]
   );
 
   const panelCount = useTerminalStore(
@@ -101,14 +93,6 @@ export function PanelPalette({
   const hardLimit = usePanelLimitStore((state) => state.hardLimit);
 
   const isSearching = query.trim().length > 0;
-  const isModelPhase = phase === "model";
-
-  const headerLabel = isModelPhase ? "Select Model" : `New Panel (${panelCount} / ${hardLimit})`;
-  const placeholder = isModelPhase ? "Select a model..." : "Select a panel type...";
-  const emptyMessage = isModelPhase
-    ? `No models match "${query}"`
-    : `No panel types match "${query}"`;
-  const escHint = isModelPhase ? "to go back" : "to close";
 
   const renderOption = (kind: PanelKindOption, index: number) => (
     <button
@@ -184,17 +168,17 @@ export function PanelPalette({
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Panel palette">
-      <AppPaletteDialog.Header label={headerLabel} keyHint="⌘⇧P">
+      <AppPaletteDialog.Header label={`New Panel (${panelCount} / ${hardLimit})`} keyHint="⌘⇧P">
         <AppPaletteDialog.Input
           inputRef={inputRef}
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder={placeholder}
+          placeholder="Select a panel type..."
           role="combobox"
           aria-expanded={isOpen}
           aria-haspopup="listbox"
-          aria-label={isModelPhase ? "Select model" : "Select panel type"}
+          aria-label="Select panel type"
           aria-controls="panel-list"
           aria-activedescendant={
             results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length
@@ -205,10 +189,10 @@ export function PanelPalette({
       </AppPaletteDialog.Header>
 
       <AppPaletteDialog.Body>
-        <div id="panel-list" role="listbox" aria-label={isModelPhase ? "Models" : "Panel types"}>
+        <div id="panel-list" role="listbox" aria-label="Panel types">
           {results.length === 0 ? (
-            <div className="px-3 py-8 text-center text-canopy-text/50 text-sm">{emptyMessage}</div>
-          ) : isModelPhase || isSearching ? (
+            <div className="px-3 py-8 text-center text-canopy-text/50 text-sm">{`No panel types match "${query}"`}</div>
+          ) : isSearching ? (
             results.map((kind, index) => renderOption(kind, index))
           ) : (
             renderSectionedList()
@@ -233,13 +217,13 @@ export function PanelPalette({
           <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
             Enter
           </kbd>
-          <span className="ml-1.5">{isModelPhase ? "to select" : "to create"}</span>
+          <span className="ml-1.5">to create</span>
         </span>
         <span>
           <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
             Esc
           </kbd>
-          <span className="ml-1.5">{escHint}</span>
+          <span className="ml-1.5">to close</span>
         </span>
       </AppPaletteDialog.Footer>
     </AppPaletteDialog>

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -2,6 +2,7 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MORE_AGENTS_PANEL_ID } from "../usePanelPalette";
+import { actionService } from "@/services/ActionService";
 
 const {
   getPanelKindIdsMock,
@@ -134,5 +135,57 @@ describe("usePanelPalette", () => {
     expect(tools).toHaveLength(0);
     const agents = result.current.results.filter((item) => item.category === "agent");
     expect(agents.length).toBeGreaterThan(0);
+  });
+
+  it("handleSelect returns option immediately for agents with models (no model phase)", () => {
+    getEffectiveAgentConfigMock.mockReturnValue({
+      name: "Claude",
+      iconId: "claude",
+      color: "#f80",
+      tooltip: "Claude agent",
+      models: [
+        { id: "sonnet", name: "Sonnet" },
+        { id: "opus", name: "Opus" },
+      ],
+    });
+
+    const { result } = renderHook(() => usePanelPalette());
+
+    const claudeOption = result.current.results.find((item) => item.id === "agent:claude");
+    expect(claudeOption).toBeDefined();
+
+    const selected = result.current.handleSelect(claudeOption!);
+    expect(selected).toBe(claudeOption);
+  });
+
+  it("confirmSelection returns option immediately for agents with models", () => {
+    getEffectiveAgentConfigMock.mockReturnValue({
+      name: "Claude",
+      iconId: "claude",
+      color: "#f80",
+      tooltip: "Claude agent",
+      models: [{ id: "sonnet", name: "Sonnet" }],
+    });
+
+    const { result } = renderHook(() => usePanelPalette());
+
+    const selected = result.current.confirmSelection();
+    expect(selected).toBeDefined();
+    expect(selected!.id).toBe("agent:claude");
+  });
+
+  it("handleSelect dispatches settings action and returns null for MORE_AGENTS", () => {
+    const { result } = renderHook(() => usePanelPalette());
+
+    const moreAgents = result.current.results.find((item) => item.id === MORE_AGENTS_PANEL_ID);
+    expect(moreAgents).toBeDefined();
+
+    const selected = result.current.handleSelect(moreAgents!);
+    expect(selected).toBeNull();
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "agents" },
+      { source: "user" }
+    );
   });
 });

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { getPanelKindIds, getPanelKindConfig } from "@shared/config/panelKindRegistry";
 import { hasPanelComponent } from "@/registry/panelComponentRegistry";
-import {
-  getEffectiveAgentIds,
-  getEffectiveAgentConfig,
-  type AgentModelConfig,
-} from "@shared/config/agentRegistry";
+import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
@@ -19,19 +15,12 @@ export interface PanelKindOption {
   iconId: string;
   color: string;
   description?: string;
-  category: "agent" | "tool" | "model";
+  category: "agent" | "tool";
 }
 
-export type PanelPalettePhase = "panel" | "model";
-
-export const DEFAULT_MODEL_OPTION_ID = "__default__";
-
 export type UsePanelPaletteReturn = UseSearchablePaletteReturn<PanelKindOption> & {
-  phase: PanelPalettePhase;
-  pendingAgentId: string | null;
   handleSelect: (option: PanelKindOption) => PanelKindOption | null;
   confirmSelection: () => PanelKindOption | null;
-  backToPanel: () => void;
 };
 
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
@@ -52,38 +41,10 @@ function filterPanelKinds(items: PanelKindOption[], query: string): PanelKindOpt
 
 export const MORE_AGENTS_PANEL_ID = "more-agents";
 
-function buildModelOptions(agentId: string): PanelKindOption[] {
-  const agentConfig = getEffectiveAgentConfig(agentId);
-  if (!agentConfig?.models?.length) return [];
-
-  const options: PanelKindOption[] = [
-    {
-      id: DEFAULT_MODEL_OPTION_ID,
-      name: "Use default model",
-      iconId: agentConfig.iconId,
-      color: agentConfig.color,
-      description: "Launch with the agent's default model",
-      category: "model",
-    },
-    ...agentConfig.models.map(
-      (m: AgentModelConfig): PanelKindOption => ({
-        id: m.id,
-        name: m.name,
-        iconId: agentConfig.iconId,
-        color: agentConfig.color,
-        category: "model",
-      })
-    ),
-  ];
-  return options;
-}
-
 export function usePanelPalette(): UsePanelPaletteReturn {
   const userRegistry = useUserAgentRegistryStore((state) => state.registry);
   const agentSettings = useAgentSettingsStore((state) => state.settings);
   const [keybindingVersion, setKeybindingVersion] = useState(0);
-  const [phase, setPhase] = useState<PanelPalettePhase>("panel");
-  const [pendingAgentId, setPendingAgentId] = useState<string | null>(null);
 
   useEffect(() => {
     return keybindingService.subscribe(() => setKeybindingVersion((v) => v + 1));
@@ -164,82 +125,24 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     ];
   }, [userRegistry, keybindingVersion, agentSettings]);
 
-  const modelOptions = useMemo<PanelKindOption[]>(() => {
-    if (!pendingAgentId) return [];
-    return buildModelOptions(pendingAgentId);
-  }, [pendingAgentId]);
-
-  const items = phase === "model" ? modelOptions : availableKinds;
-
-  const {
-    results,
-    selectedIndex,
-    close: baseClose,
-    ...paletteRest
-  } = useSearchablePalette<PanelKindOption>({
-    items,
+  const { results, selectedIndex, close, ...paletteRest } = useSearchablePalette<PanelKindOption>({
+    items: availableKinds,
     filterFn: filterPanelKinds,
     maxResults: 20,
     paletteId: "panel",
   });
 
-  const resetPhase = useCallback(() => {
-    setPhase("panel");
-    setPendingAgentId(null);
-  }, []);
-
-  const open = useCallback(() => {
-    resetPhase();
-    paletteRest.open();
-  }, [resetPhase, paletteRest]);
-
-  const close = useCallback(() => {
-    baseClose();
-    resetPhase();
-  }, [baseClose, resetPhase]);
-
-  const backToPanel = useCallback(() => {
-    resetPhase();
-    paletteRest.setQuery("");
-  }, [resetPhase, paletteRest]);
-
-  const enterModelPhase = useCallback(
-    (agentId: string) => {
-      setPendingAgentId(agentId);
-      setPhase("model");
-      paletteRest.setQuery("");
-    },
-    [paletteRest]
-  );
-
   const handleSelect = useCallback(
     (option: PanelKindOption): PanelKindOption | null => {
-      if (phase === "panel") {
-        if (option.id === MORE_AGENTS_PANEL_ID) {
-          close();
-          void actionService.dispatch(
-            "app.settings.openTab",
-            { tab: "agents" },
-            { source: "user" }
-          );
-          return null;
-        }
-        if (option.id.startsWith("agent:")) {
-          const agentId = option.id.slice("agent:".length);
-          const agentConfig = getEffectiveAgentConfig(agentId);
-          if (agentConfig?.models?.length) {
-            enterModelPhase(agentId);
-            return null;
-          }
-        }
+      if (option.id === MORE_AGENTS_PANEL_ID) {
         close();
-        return option;
+        void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
+        return null;
       }
-      // model phase — close and return the selected model option
       close();
       return option;
     },
-    [phase, close, enterModelPhase]
+    [close]
   );
 
   const confirmSelection = useCallback((): PanelKindOption | null => {
@@ -247,39 +150,21 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     const selected = results[selectedIndex];
     if (!selected) return null;
 
-    if (phase === "panel") {
-      if (selected.id === MORE_AGENTS_PANEL_ID) {
-        close();
-        void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
-        return selected;
-      }
-      if (selected.id.startsWith("agent:")) {
-        const agentId = selected.id.slice("agent:".length);
-        const agentConfig = getEffectiveAgentConfig(agentId);
-        if (agentConfig?.models?.length) {
-          enterModelPhase(agentId);
-          return null;
-        }
-      }
+    if (selected.id === MORE_AGENTS_PANEL_ID) {
       close();
+      void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
       return selected;
     }
-
-    // model phase
     close();
     return selected;
-  }, [results, selectedIndex, phase, close, enterModelPhase]);
+  }, [results, selectedIndex, close]);
 
   return {
     results,
     selectedIndex,
     close,
     ...paletteRest,
-    open,
-    phase,
-    pendingAgentId,
     handleSelect,
     confirmSelection,
-    backToPanel,
   };
 }


### PR DESCRIPTION
## Summary

- Removes the two-step agent launch flow from the Panel Palette (select agent -> select model) and replaces it with single-click launch using the default model
- Eliminates the `model` phase, `pendingAgentId` state, and `buildModelOptions` helper from `usePanelPalette`
- Cleans up the `PanelPalette` component and `App.tsx` by removing model-phase rendering and unused callbacks

Resolves #4256

## Changes

- **`src/hooks/usePanelPalette.ts`** — Removed `PanelPalettePhase` type (now always `panel` phase), removed `buildModelOptions`, removed `pendingAgentId` state, simplified `handleSelect` and `confirmSelection` to launch agents immediately with their default model
- **`src/components/PanelPalette/PanelPalette.tsx`** — Removed model-phase UI branch and related props (`onModelSelect`, `modelOptions`, phase checks)
- **`src/App.tsx`** — Removed model-phase callback wiring and simplified PanelPalette props
- **`src/hooks/__tests__/usePanelPalette.test.tsx`** — Added tests confirming agents launch immediately without model selection step

## Testing

- New unit tests verify single-click agent launch behavior
- TypeScript typecheck passes cleanly
- ESLint passes (0 errors, only pre-existing warnings)
- Prettier formatting verified