### PR TITLE
fix(main): move logger init after single-instance lock

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -82,33 +82,35 @@ if (process.platform === "darwin") {
   app.commandLine.appendSwitch("disable-features", "CalculateNativeWinOcclusion");
 }
 
-// Prune old log files based on retention setting
-{
-  const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
-  if (retentionDays > 0) {
-    pruneOldLogs(app.getPath("userData"), retentionDays);
-  }
-}
-
-initializeLogger(app.getPath("userData"));
-registerCommands();
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-void initializeTelemetry();
-
-crashReporter.start({ uploadToServer: false });
-registerGlobalErrorHandlers();
-
-const distPath = path.join(__dirname, "../../dist");
-
+// Acquire single-instance lock before any file I/O or service initialization.
+// A second instance must not touch log files, telemetry, or crash reporters.
 const gotTheLock = isSmokeTest || app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
   console.log("[MAIN] Another instance is already running. Quitting...");
   app.quit();
 } else {
+  // Prune old log files based on retention setting
+  {
+    const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
+    if (retentionDays > 0) {
+      pruneOldLogs(app.getPath("userData"), retentionDays);
+    }
+  }
+
+  initializeLogger(app.getPath("userData"));
+  registerCommands();
+
+  void initializeTelemetry();
+
+  crashReporter.start({ uploadToServer: false });
+  registerGlobalErrorHandlers();
+
+  const distPath = path.join(__dirname, "../../dist");
+
   initializeCrashRecoveryService();
   initializeTrashedPidCleanup();
   initializeGpuCrashMonitor();


### PR DESCRIPTION
## Summary

- Launching a second Canopy instance (e.g., double-clicking the AppImage) was clearing all log files of the already-running instance because `initializeLogger()` ran before `app.requestSingleInstanceLock()`
- Moved `initializeLogger()` call to after the lock is acquired, so the second instance exits cleanly without touching logs

Resolves #4237

## Changes

- `electron/main.ts`: Relocated `initializeLogger(app.getPath("userData"))` from before the single-instance lock check to inside the lock-acquired branch, ensuring only the primary instance clears session logs

## Testing

- Typecheck, ESLint, and Prettier all pass cleanly
- Logic verified: second instance now calls `app.quit()` before any logger initialization occurs