### PR TITLE
fix(worktree): prevent finished state when agents are still active

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -518,16 +518,20 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         }
       }
 
+      const hasWorkingAgent = worktreeTerminals.some((t) => t.agentState === "working");
+      const hasRunningAgent = worktreeTerminals.some((t) => t.agentState === "running");
+
       const chipState = computeChipState({
         waitingTerminalCount,
         lifecycleStage,
         isComplete,
+        hasActiveAgent: hasWorkingAgent || hasRunningAgent,
       });
 
       map.set(worktree.id, {
         terminalCount: worktreeTerminals.length,
-        hasWorkingAgent: worktreeTerminals.some((t) => t.agentState === "working"),
-        hasRunningAgent: worktreeTerminals.some((t) => t.agentState === "running"),
+        hasWorkingAgent,
+        hasRunningAgent,
         hasWaitingAgent: worktreeTerminals.some((t) => t.agentState === "waiting"),
         hasCompletedAgent: worktreeTerminals.some((t) => t.agentState === "completed"),
         hasMergeConflict:

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -457,8 +457,15 @@ export const WorktreeCard = React.memo(function WorktreeCard({
         waitingTerminalCount: terminalCounts.byState.waiting,
         lifecycleStage,
         isComplete,
+        hasActiveAgent: terminalCounts.byState.working > 0 || terminalCounts.byState.running > 0,
       }),
-    [terminalCounts.byState.waiting, lifecycleStage, isComplete]
+    [
+      terminalCounts.byState.waiting,
+      terminalCounts.byState.working,
+      terminalCounts.byState.running,
+      lifecycleStage,
+      isComplete,
+    ]
   );
 
   const { setNodeRef, isOver } = useDroppable({

--- a/src/components/Worktree/__tests__/computeChipState.test.ts
+++ b/src/components/Worktree/__tests__/computeChipState.test.ts
@@ -5,6 +5,7 @@ const base: ComputeChipStateInput = {
   waitingTerminalCount: 0,
   lifecycleStage: null,
   isComplete: false,
+  hasActiveAgent: false,
 };
 
 describe("computeChipState", () => {
@@ -77,6 +78,40 @@ describe("computeChipState", () => {
           waitingTerminalCount: 1,
         })
       ).toBe("complete");
+    });
+  });
+
+  describe("active agent suppresses complete", () => {
+    it("returns null when isComplete but hasActiveAgent", () => {
+      expect(computeChipState({ ...base, isComplete: true, hasActiveAgent: true })).toBeNull();
+    });
+
+    it("cleanup beats hasActiveAgent", () => {
+      expect(
+        computeChipState({
+          ...base,
+          lifecycleStage: "merged",
+          isComplete: true,
+          hasActiveAgent: true,
+        })
+      ).toBe("cleanup");
+    });
+
+    it("returns waiting when isComplete, hasActiveAgent, and waitingTerminalCount > 0", () => {
+      expect(
+        computeChipState({
+          ...base,
+          isComplete: true,
+          hasActiveAgent: true,
+          waitingTerminalCount: 1,
+        })
+      ).toBe("waiting");
+    });
+
+    it("returns complete when isComplete and hasActiveAgent is false", () => {
+      expect(computeChipState({ ...base, isComplete: true, hasActiveAgent: false })).toBe(
+        "complete"
+      );
     });
   });
 

--- a/src/components/Worktree/utils/computeChipState.ts
+++ b/src/components/Worktree/utils/computeChipState.ts
@@ -6,12 +6,13 @@ export interface ComputeChipStateInput {
   waitingTerminalCount: number;
   lifecycleStage: WorktreeLifecycleStage | null;
   isComplete: boolean;
+  hasActiveAgent: boolean;
 }
 
 export function computeChipState(input: ComputeChipStateInput): ChipState {
   if (input.lifecycleStage === "merged" || input.lifecycleStage === "ready-for-cleanup")
     return "cleanup";
-  if (input.isComplete) return "complete";
+  if (input.isComplete && !input.hasActiveAgent) return "complete";
   if (input.waitingTerminalCount > 0) return "waiting";
   return null;
 }


### PR DESCRIPTION
## Summary

- Worktrees with active (working/running) agents no longer show as "Finished" in the quick state filter
- The "Working" filter now correctly includes worktrees with active agents even if they meet all metadata criteria for completion
- Agent activity is factored into `computeChipState` so `chipState` reflects real agent status

Resolves #4268

## Changes

- `src/components/Worktree/utils/computeChipState.ts` — Added `hasActiveAgent` parameter; when true, returns `null` instead of `"complete"` so the worktree stays out of the Finished bucket
- `src/App.tsx` — Passes `hasWorkingAgent || hasRunningAgent` into `computeChipState`
- `src/components/Worktree/WorktreeCard.tsx` — Same: passes agent activity flag into `computeChipState`
- `src/components/Worktree/__tests__/computeChipState.test.ts` — Added tests covering the new behavior (active agent overrides complete, no agent preserves complete, non-complete unaffected)

## Testing

- All existing `computeChipState` tests pass
- New tests verify active-agent override behavior
- Typecheck, ESLint, and Prettier all pass clean