### PR TITLE
fix(store): scope focus fallback to active worktree on panel close

### DIFF
--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -32,13 +32,20 @@ vi.mock("@/services/TerminalInstanceService", () => ({
 }));
 
 const { useTerminalStore } = await import("../terminalStore");
+const { useWorktreeSelectionStore } = await import("../worktreeStore");
 
-function makeTerminal(id: string, kind: "agent" | "terminal", agentId?: string) {
+function makeTerminal(
+  id: string,
+  kind: "agent" | "terminal",
+  agentId?: string,
+  worktreeId?: string
+) {
   return {
     id,
     type: "terminal" as const,
     kind: kind as "agent" | "terminal",
     agentId,
+    worktreeId,
     title: id,
     cwd: "/test",
     cols: 80,
@@ -216,5 +223,152 @@ describe("trashPanelGroup agent-aware focus", () => {
     useTerminalStore.getState().trashPanelGroup("agent-1");
 
     expect(useTerminalStore.getState().focusedId).toBe("shell-1");
+  });
+});
+
+describe("worktree-scoped focus fallback (#4327)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("trashTerminal: should prefer same-worktree terminal over cross-worktree", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("agent-1", "agent", "claude", "wt-1"),
+        makeTerminal("shell-other", "terminal", undefined, "wt-2"),
+        makeTerminal("shell-same", "terminal", undefined, "wt-1"),
+      ],
+      focusedId: "agent-1",
+    });
+
+    useTerminalStore.getState().trashTerminal("agent-1");
+
+    expect(useTerminalStore.getState().focusedId).toBe("shell-same");
+  });
+
+  it("trashTerminal: should fall back to null when no same-worktree grid terminals remain", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("agent-1", "agent", "claude", "wt-1"),
+        makeTerminal("shell-other", "terminal", undefined, "wt-2"),
+      ],
+      focusedId: "agent-1",
+    });
+
+    useTerminalStore.getState().trashTerminal("agent-1");
+
+    expect(useTerminalStore.getState().focusedId).toBeNull();
+  });
+
+  it("trashTerminal: should prefer same-worktree agent when trashing an agent", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("agent-1", "agent", "claude", "wt-1"),
+        makeTerminal("agent-other", "agent", "gemini", "wt-2"),
+        makeTerminal("agent-same", "agent", "codex", "wt-1"),
+        makeTerminal("shell-same", "terminal", undefined, "wt-1"),
+      ],
+      focusedId: "agent-1",
+    });
+
+    useTerminalStore.getState().trashTerminal("agent-1");
+
+    expect(useTerminalStore.getState().focusedId).toBe("agent-same");
+  });
+
+  it("trashTerminal: root worktree (null activeWorktreeId) matches undefined worktreeId", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("agent-1", "agent", "claude"),
+        makeTerminal("shell-root", "terminal"),
+        makeTerminal("shell-wt", "terminal", undefined, "wt-1"),
+      ],
+      focusedId: "agent-1",
+    });
+
+    useTerminalStore.getState().trashTerminal("agent-1");
+
+    expect(useTerminalStore.getState().focusedId).toBe("shell-root");
+  });
+
+  it("moveTerminalToDock: should prefer same-worktree terminal", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("panel-1", "terminal", undefined, "wt-1"),
+        makeTerminal("shell-other", "terminal", undefined, "wt-2"),
+        makeTerminal("shell-same", "terminal", undefined, "wt-1"),
+      ],
+      focusedId: "panel-1",
+    });
+
+    useTerminalStore.getState().moveTerminalToDock("panel-1");
+
+    expect(useTerminalStore.getState().focusedId).toBe("shell-same");
+  });
+
+  it("trashPanelGroup: should prefer same-worktree terminal", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("agent-1", "agent", "claude", "wt-1"),
+        makeTerminal("agent-2", "agent", "gemini", "wt-1"),
+        makeTerminal("shell-other", "terminal", undefined, "wt-2"),
+        makeTerminal("shell-same", "terminal", undefined, "wt-1"),
+      ],
+      tabGroups: new Map([
+        [
+          "group-1",
+          {
+            id: "group-1",
+            panelIds: ["agent-1", "agent-2"],
+            activeTabId: "agent-1",
+            location: "grid" as const,
+          },
+        ],
+      ]),
+      focusedId: "agent-1",
+    });
+
+    useTerminalStore.getState().trashPanelGroup("agent-1");
+
+    expect(useTerminalStore.getState().focusedId).toBe("shell-same");
+  });
+
+  it("moveTerminalToPosition to dock: should prefer same-worktree terminal", () => {
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("panel-1", "terminal", undefined, "wt-1"),
+        makeTerminal("shell-other", "terminal", undefined, "wt-2"),
+        makeTerminal("shell-same", "terminal", undefined, "wt-1"),
+      ],
+      focusedId: "panel-1",
+    });
+
+    useTerminalStore.getState().moveTerminalToPosition("panel-1", 0, "dock");
+
+    expect(useTerminalStore.getState().focusedId).toBe("shell-same");
   });
 });

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -162,7 +162,10 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
       const updates: Partial<PanelGridState> = {};
 
       if (state.focusedId === id) {
-        const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
+        const activeWt = getActiveWorktreeId() ?? undefined;
+        const gridTerminals = state.terminals.filter(
+          (t) => t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt
+        );
         updates.focusedId = gridTerminals[0]?.id ?? null;
       }
 
@@ -198,7 +201,10 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
       const updates: Partial<PanelGridState> = {};
 
       if (state.focusedId === id) {
-        const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
+        const activeWt = getActiveWorktreeId() ?? undefined;
+        const gridTerminals = state.terminals.filter(
+          (t) => t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt
+        );
         const trashedTerminal = state.terminals.find((t) => t.id === id);
         const wasAgent =
           trashedTerminal &&
@@ -234,8 +240,12 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
 
       // If any panel in the group was focused, find a new focus
       if (panelIdsInGroup.includes(state.focusedId ?? "")) {
+        const activeWt = getActiveWorktreeId() ?? undefined;
         const gridTerminals = state.terminals.filter(
-          (t) => !panelIdsInGroup.includes(t.id) && t.location === "grid"
+          (t) =>
+            !panelIdsInGroup.includes(t.id) &&
+            t.location === "grid" &&
+            (t.worktreeId ?? undefined) === activeWt
         );
         const focusedTerminal = state.terminals.find((t) => t.id === state.focusedId);
         const wasAgent =
@@ -335,7 +345,10 @@ export const useTerminalStore = create<PanelGridState>()((set, get, api) => {
       if (location === "grid") {
         set({ focusedId: id, activeDockTerminalId: null });
       } else if (state.focusedId === id) {
-        const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
+        const activeWt = getActiveWorktreeId() ?? undefined;
+        const gridTerminals = state.terminals.filter(
+          (t) => t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt
+        );
         set({ focusedId: gridTerminals[0]?.id ?? null });
       }
     },
@@ -674,7 +687,10 @@ export function setupTerminalStoreListeners() {
 
       const updates: Partial<PanelGridState> = {};
       if (state.focusedId === id) {
-        const gridTerminals = state.terminals.filter((t) => t.id !== id && t.location === "grid");
+        const activeWt = useWorktreeSelectionStore.getState().activeWorktreeId ?? undefined;
+        const gridTerminals = state.terminals.filter(
+          (t) => t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt
+        );
         updates.focusedId = gridTerminals[0]?.id ?? null;
       }
       if (state.maximizedId === id) {


### PR DESCRIPTION
## Summary

- Closing a docked agent panel was triggering an unintended worktree switch because the focus fallback picked a grid terminal from a different worktree, which then caused the focus-to-worktree orchestrator to switch worktrees.
- Fixed by scoping all focus fallback logic in `terminalStore` to only consider grid terminals belonging to the active worktree. Falls back to `null` if no same-worktree terminals remain.

Resolves #4327

## Changes

- `src/store/terminalStore.ts` — Added worktree filtering to focus fallback in `moveTerminalToDock`, `trashTerminal`, `trashPanelGroup`, `moveTerminalToPosition`, and the `terminal:exited` listener. Uses `getActiveWorktreeId()` to scope candidates. Handles root worktree (`null`/`undefined`) correctly.
- `src/store/__tests__/trashTerminalAgentFocus.test.ts` — Added 7 new test cases covering worktree-scoped focus fallback across all affected code paths, including root worktree null handling.

## Testing

All existing and new unit tests pass. Typecheck, lint, and formatting are clean.