### PR TITLE
fix(agent): add completed to waiting valid transitions

### DIFF
--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -15,7 +15,7 @@ const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
   idle: ["working", "running"],
   working: ["waiting", "completed"],
   running: ["idle"], // Shell process state - managed by TerminalProcess, not this state machine
-  waiting: ["working"],
+  waiting: ["working", "completed"],
   directing: [], // Renderer-only state, never produced by main process
   completed: ["working", "waiting"],
 };

--- a/electron/services/__tests__/AgentStateMachine.test.ts
+++ b/electron/services/__tests__/AgentStateMachine.test.ts
@@ -25,6 +25,10 @@ describe("AgentStateMachine", () => {
       expect(isValidTransition("waiting", "working")).toBe(true);
     });
 
+    it("should allow waiting → completed (exit while waiting)", () => {
+      expect(isValidTransition("waiting", "completed")).toBe(true);
+    });
+
     it("should allow completed → waiting (prompt after completion)", () => {
       expect(isValidTransition("completed", "waiting")).toBe(true);
     });
@@ -40,7 +44,6 @@ describe("AgentStateMachine", () => {
     it("should not allow invalid transitions", () => {
       expect(isValidTransition("idle", "waiting")).toBe(false);
       expect(isValidTransition("idle", "completed")).toBe(false);
-      expect(isValidTransition("waiting", "completed")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

- `VALID_TRANSITIONS` for the `waiting` state was missing `completed`, even though `nextAgentState` correctly transitions `waiting → completed` on process exit events
- Added `"completed"` to the `waiting` entry in the map so `isValidTransition` agrees with actual runtime behavior
- Updated the corresponding test to expect `isValidTransition("waiting", "completed")` to return `true`

Resolves #4358

## Changes

- `electron/services/AgentStateMachine.ts` — added `"completed"` to `VALID_TRANSITIONS["waiting"]`
- `electron/services/__tests__/AgentStateMachine.test.ts` — updated assertion to match corrected map

## Testing

Existing test suite updated and passing. The test already covered `nextAgentState("waiting", exit)` returning `"completed"` — this fix brings `isValidTransition` in line with that behavior.