### PR TITLE
fix(update): suppress update error notifications for automatic checks

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -322,7 +322,6 @@ export const CHANNELS = {
   UPDATE_AVAILABLE: "update:available",
   UPDATE_DOWNLOAD_PROGRESS: "update:download-progress",
   UPDATE_DOWNLOADED: "update:downloaded",
-  UPDATE_ERROR: "update:error",
   UPDATE_QUIT_AND_INSTALL: "update:quit-and-install",
   UPDATE_CHECK_FOR_UPDATES: "update:check-for-updates",
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -529,7 +529,6 @@ const CHANNELS = {
   UPDATE_AVAILABLE: "update:available",
   UPDATE_DOWNLOAD_PROGRESS: "update:download-progress",
   UPDATE_DOWNLOADED: "update:downloaded",
-  UPDATE_ERROR: "update:error",
   UPDATE_QUIT_AND_INSTALL: "update:quit-and-install",
   UPDATE_CHECK_FOR_UPDATES: "update:check-for-updates",
 
@@ -1875,9 +1874,6 @@ const api: ElectronAPI = {
 
     onUpdateDownloaded: (callback: (info: { version: string }) => void) =>
       _typedOn(CHANNELS.UPDATE_DOWNLOADED, callback),
-
-    onUpdateError: (callback: (info: { message: string }) => void) =>
-      _typedOn(CHANNELS.UPDATE_ERROR, callback),
 
     quitAndInstall: () => _unwrappingInvoke(CHANNELS.UPDATE_QUIT_AND_INSTALL),
 

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -138,7 +138,6 @@ class AutoUpdaterService {
         console.error("[MAIN] Auto-updater error:", err);
         const wasManual = this.isManualCheck;
         this.isManualCheck = false;
-        this.sendToWindow(CHANNELS.UPDATE_ERROR, { message: err.message });
         if (wasManual) {
           const win = this.window && !this.window.isDestroyed() ? this.window : null;
           const opts = {

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -239,6 +239,11 @@ describe("AutoUpdaterService", () => {
           buttons: ["Retry", "Cancel"],
         })
       );
+      // No renderer IPC — the native dialog is sufficient for manual errors
+      expect(windowMock.webContents.send).not.toHaveBeenCalledWith(
+        "update:error",
+        expect.anything()
+      );
     });
 
     it("does not show error dialog for automatic check errors", async () => {
@@ -248,6 +253,10 @@ describe("AutoUpdaterService", () => {
       await Promise.resolve();
 
       expect(dialogMock.showMessageBox).not.toHaveBeenCalled();
+      expect(windowMock.webContents.send).not.toHaveBeenCalledWith(
+        "update:error",
+        expect.anything()
+      );
     });
 
     it("retries when user clicks Retry in error dialog", async () => {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -891,7 +891,6 @@ export interface ElectronAPI {
     onUpdateAvailable(callback: (info: { version: string }) => void): () => void;
     onDownloadProgress(callback: (info: { percent: number }) => void): () => void;
     onUpdateDownloaded(callback: (info: { version: string }) => void): () => void;
-    onUpdateError(callback: (info: { message: string }) => void): () => void;
     quitAndInstall(): Promise<void>;
     checkForUpdates(): Promise<void>;
   };

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1768,7 +1768,6 @@ export interface IpcEventMap {
   "update:available": { version: string };
   "update:download-progress": { percent: number };
   "update:downloaded": { version: string };
-  "update:error": { message: string };
 
   // Dev Preview events
   "dev-preview:state-changed": DevPreviewStateChangedPayload;

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
-import { Download, RefreshCw, X, AlertCircle } from "lucide-react";
+import { Download, RefreshCw, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUpdateStore } from "@/store/updateStore";
 
@@ -12,11 +12,7 @@ export function UpdateNotification() {
   const dismissTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const shouldShow =
-    !dismissed &&
-    (status === "available" ||
-      status === "downloading" ||
-      status === "downloaded" ||
-      status === "error");
+    !dismissed && (status === "available" || status === "downloading" || status === "downloaded");
 
   useEffect(() => {
     if (dismissTimerRef.current) {
@@ -72,16 +68,9 @@ export function UpdateNotification() {
           "backdrop-blur-sm"
         )}
       >
-        <div
-          className={cn(
-            "mt-0.5 shrink-0",
-            status === "error" ? "text-status-error" : "text-canopy-accent"
-          )}
-        >
+        <div className="mt-0.5 shrink-0 text-canopy-accent">
           {status === "downloaded" ? (
             <RefreshCw className="h-4 w-4" />
-          ) : status === "error" ? (
-            <AlertCircle className="h-4 w-4" />
           ) : (
             <Download className="h-4 w-4" />
           )}
@@ -137,17 +126,6 @@ export function UpdateNotification() {
               >
                 Restart to Update
               </Button>
-            </>
-          )}
-
-          {status === "error" && (
-            <>
-              <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-status-error">
-                Update Failed
-              </h4>
-              <div className="text-xs text-canopy-text/90 leading-snug">
-                Unable to check for updates. Please try again later.
-              </div>
             </>
           )}
         </div>

--- a/src/hooks/useUpdateListener.ts
+++ b/src/hooks/useUpdateListener.ts
@@ -5,8 +5,6 @@ export function useUpdateListener(): void {
   const setAvailable = useUpdateStore((state) => state.setAvailable);
   const setDownloading = useUpdateStore((state) => state.setDownloading);
   const setDownloaded = useUpdateStore((state) => state.setDownloaded);
-  const setError = useUpdateStore((state) => state.setError);
-
   useEffect(() => {
     if (!window.electron?.update) return;
 
@@ -22,15 +20,10 @@ export function useUpdateListener(): void {
       setDownloaded(info.version);
     });
 
-    const cleanupError = window.electron.update.onUpdateError((info) => {
-      setError(info.message);
-    });
-
     return () => {
       cleanupAvailable();
       cleanupProgress();
       cleanupDownloaded();
-      cleanupError();
     };
-  }, [setAvailable, setDownloading, setDownloaded, setError]);
+  }, [setAvailable, setDownloading, setDownloaded]);
 }

--- a/src/store/updateStore.ts
+++ b/src/store/updateStore.ts
@@ -1,17 +1,15 @@
 import { create } from "zustand";
 
-export type UpdateStatus = "idle" | "available" | "downloading" | "downloaded" | "error";
+export type UpdateStatus = "idle" | "available" | "downloading" | "downloaded";
 
 interface UpdateStore {
   status: UpdateStatus;
   version: string | null;
   progress: number;
-  error: string | null;
   dismissed: boolean;
   setAvailable: (version: string) => void;
   setDownloading: (percent: number) => void;
   setDownloaded: (version: string) => void;
-  setError: (message: string) => void;
   dismiss: () => void;
   reset: () => void;
 }
@@ -20,15 +18,12 @@ export const useUpdateStore = create<UpdateStore>((set) => ({
   status: "idle",
   version: null,
   progress: 0,
-  error: null,
   dismissed: false,
-  setAvailable: (version) =>
-    set({ status: "available", version, progress: 0, error: null, dismissed: false }),
+  setAvailable: (version) => set({ status: "available", version, progress: 0, dismissed: false }),
   setDownloading: (percent) =>
     set({ status: "downloading", progress: Math.min(Math.max(percent, 0), 100) }),
   setDownloaded: (version) =>
-    set({ status: "downloaded", version, progress: 100, error: null, dismissed: false }),
-  setError: (message) => set({ status: "error", error: message, progress: 0 }),
+    set({ status: "downloaded", version, progress: 100, dismissed: false }),
   dismiss: () => set({ dismissed: true }),
-  reset: () => set({ status: "idle", version: null, progress: 0, error: null, dismissed: false }),
+  reset: () => set({ status: "idle", version: null, progress: 0, dismissed: false }),
 }));


### PR DESCRIPTION
## Summary

- Removes `UPDATE_ERROR` IPC channel and the renderer-side error toast for update failures
- Automatic check failures (initial and periodic) now only log to the main process — no user-facing noise
- Manual check failures retain the existing native dialog with Retry/Cancel, which was already the right UX

Resolves #4370

## Changes

- `AutoUpdaterService.ts`: removed the `sendToWindow(UPDATE_ERROR, ...)` call that fired unconditionally before the `wasManual` branch
- `channels.ts`, `preload.cts`, `api.ts`, `maps.ts`: removed `UPDATE_ERROR` channel definition and bridge exposure
- `updateStore.ts`: removed `error` state field and `setError` action
- `useUpdateListener.ts`: removed `onError` handler
- `UpdateNotification.tsx`: removed error toast rendering
- `AutoUpdaterService.test.ts`: added test asserting error is not sent to renderer on automatic check failure

## Testing

Unit test added to `AutoUpdaterService.test.ts` verifying the renderer is not notified on automatic check failures. Existing tests pass. `npm run fix` runs clean (warnings only, no errors).