### PR TITLE
refactor(github): hoist fs/promises and path to static imports

### DIFF
--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -1,4 +1,5 @@
 import { ipcMain, shell } from "electron";
+import fs from "fs/promises";
 import path from "path";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
@@ -63,13 +64,11 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       throw new Error("Working directory must be an absolute path");
     }
 
-    const fs = await import("fs/promises");
-    const pathModule = await import("path");
     const { getRepoStats } = await import("../../services/GitHubService.js");
     const { getCommitCount } = await import("../../utils/git.js");
 
     try {
-      const resolved = pathModule.resolve(cwd);
+      const resolved = path.resolve(cwd);
       const stat = await fs.stat(resolved);
       if (!stat.isDirectory()) {
         return {
@@ -120,12 +119,10 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       throw new Error("Working directory must be an absolute path");
     }
 
-    const fs = await import("fs/promises");
-    const pathModule = await import("path");
     const { getProjectHealth } = await import("../../services/GitHubService.js");
 
     try {
-      const resolved = pathModule.resolve(cwd);
+      const resolved = path.resolve(cwd);
       const stat = await fs.stat(resolved);
       if (!stat.isDirectory()) {
         return {


### PR DESCRIPTION
## Summary

- `handleGitHubGetRepoStats` and `handleGitHubGetProjectHealth` were dynamically importing `fs/promises` and `path` on every IPC call, even though `path` was already statically imported at the top of the file
- Hoisted both to static imports — no lazy-loading benefit exists for Node built-ins, and dynamic imports add a microtask tick on every call
- Removed the redundant dynamic `pathModule` alias; now uses the existing static `path` import throughout

Resolves #4360

## Changes

- `electron/ipc/handlers/github.ts`: added `import fs from "fs/promises"` static import; removed dynamic `import("fs/promises")` and `import("path")` calls in both handlers; replaced `pathModule.resolve` with `path.resolve`

## Testing

- Typecheck, lint, and format all pass (`npm run check`)
- No behaviour change — pure refactor