### PR TITLE
fix(worktree): add dialog accessibility to CrossWorktreeDiff modal

### DIFF
--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
-import { X, GitCompare, FileIcon, Loader2, AlertCircle } from "lucide-react";
+import { GitCompare, FileIcon, Loader2, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWorktreeDataStore } from "@/store/worktreeDataStore";
+import { AppDialog } from "@/components/ui/AppDialog";
 import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "@shared/types/ipc/git";
 import { DiffViewer } from "./DiffViewer";
 import { WorktreeSelector } from "./WorktreeSelector";
@@ -31,7 +32,6 @@ function statusLabel(status: string): { label: string; className: string } {
 }
 
 export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossWorktreeDiffProps) {
-  const modalRef = useRef<HTMLDivElement>(null);
   const worktreeMap = useWorktreeDataStore((state) => state.worktrees);
   const worktrees = useMemo(() => sortWorktreesForComparison(worktreeMap.values()), [worktreeMap]);
 
@@ -145,150 +145,126 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
     [leftWorktree, rightWorktree]
   );
 
-  // Keyboard: Escape to close
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
-
   return (
-    <div
-      className={cn(
-        "fixed inset-0 z-[var(--z-modal)] flex items-center justify-center",
-        "bg-scrim-medium backdrop-blur-sm"
-      )}
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
+    <AppDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      size="6xl"
+      maxHeight="h-[80vh]"
+      className="max-h-[800px] overflow-hidden"
     >
-      <div
-        ref={modalRef}
-        className="flex flex-col bg-surface-panel border border-border-default rounded-xl shadow-[var(--theme-shadow-dialog)] w-[90vw] max-w-6xl h-[80vh] max-h-[800px] overflow-hidden"
-      >
-        {/* Header */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-border-subtle shrink-0">
-          <GitCompare className="w-4 h-4 text-text-muted" />
-          <h2 className="text-sm font-semibold text-text-primary flex-1">Compare Worktrees</h2>
-          <button
-            onClick={onClose}
-            className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface-panel-elevated transition-colors"
-            aria-label="Close"
-          >
-            <X className="w-4 h-4" />
-          </button>
+      <AppDialog.Header className="px-4 py-3 border-b border-border-subtle bg-transparent">
+        <AppDialog.Title
+          icon={<GitCompare className="w-4 h-4 text-text-muted" />}
+          className="text-sm font-semibold text-text-primary"
+        >
+          Compare Worktrees
+        </AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      {/* Selectors */}
+      <div className="flex items-end gap-4 px-4 py-3 border-b border-border-subtle bg-surface-panel/50 shrink-0">
+        <div className="flex-1 min-w-0">
+          <WorktreeSelector
+            label="Left (base)"
+            worktrees={worktrees}
+            selectedId={leftId}
+            disabledId={rightId}
+            onChange={setLeftId}
+          />
         </div>
-
-        {/* Selectors */}
-        <div className="flex items-end gap-4 px-4 py-3 border-b border-border-subtle bg-surface-panel/50 shrink-0">
-          <div className="flex-1 min-w-0">
-            <WorktreeSelector
-              label="Left (base)"
-              worktrees={worktrees}
-              selectedId={leftId}
-              disabledId={rightId}
-              onChange={setLeftId}
-            />
-          </div>
-          <div className="text-text-muted text-xs pb-2">vs</div>
-          <div className="flex-1 min-w-0">
-            <WorktreeSelector
-              label="Right (compare)"
-              worktrees={worktrees}
-              selectedId={rightId}
-              disabledId={leftId}
-              onChange={setRightId}
-            />
-          </div>
-        </div>
-
-        {/* Body */}
-        <div className="flex flex-1 overflow-hidden">
-          {/* File list sidebar */}
-          <div className="w-64 shrink-0 border-r border-border-subtle flex flex-col overflow-hidden">
-            <div className="px-3 py-2 text-xs text-text-muted border-b border-border-subtle shrink-0">
-              {result
-                ? `${result.files.length} file${result.files.length === 1 ? "" : "s"} changed`
-                : "Files"}
-            </div>
-            <div className="flex-1 overflow-y-auto">
-              {loading && (
-                <div className="flex items-center justify-center gap-2 p-6 text-text-muted text-sm">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  Comparing…
-                </div>
-              )}
-              {error && (
-                <div className="flex items-start gap-2 p-4 text-status-error text-xs">
-                  <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
-                  <span>{error}</span>
-                </div>
-              )}
-              {!loading && !error && !result && (
-                <div className="p-4 text-text-muted text-xs">Select two worktrees to compare</div>
-              )}
-              {result?.files.length === 0 && (
-                <div className="p-4 text-text-muted text-xs">
-                  No differences between these branches
-                </div>
-              )}
-              {result?.files.map((file) => {
-                const { label, className: statusClass } = statusLabel(file.status);
-                const isSelected = selectedFile?.path === file.path;
-                return (
-                  <button
-                    key={`${file.status}:${file.path}`}
-                    onClick={() => void fetchFileDiff(file)}
-                    className={cn(
-                      "w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-surface-panel-elevated transition-colors",
-                      isSelected && "bg-surface-panel-elevated"
-                    )}
-                  >
-                    <span
-                      className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}
-                    >
-                      {label}
-                    </span>
-                    <FileIcon className="w-3 h-3 shrink-0 text-text-muted" />
-                    <span className="text-text-secondary truncate min-w-0" title={file.path}>
-                      {file.path.split("/").pop()}
-                    </span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Diff panel */}
-          <div className="flex-1 overflow-auto bg-surface-canvas">
-            {!selectedFile && (
-              <div className="flex items-center justify-center h-full text-text-muted text-sm">
-                {result ? "Select a file to view its diff" : ""}
-              </div>
-            )}
-            {selectedFile && fileDiffLoading && (
-              <div className="flex items-center justify-center gap-2 h-full text-text-muted text-sm">
-                <Loader2 className="w-4 h-4 animate-spin" />
-                Loading diff…
-              </div>
-            )}
-            {selectedFile && !fileDiffLoading && fileDiffError && (
-              <div className="flex items-center justify-center gap-2 h-full text-status-error text-sm">
-                <AlertCircle className="w-4 h-4" />
-                Failed to load diff
-              </div>
-            )}
-            {selectedFile && !fileDiffLoading && !fileDiffError && fileDiff !== null && (
-              <DiffViewer diff={fileDiff} filePath={selectedFile.path} viewType="split" />
-            )}
-          </div>
+        <div className="text-text-muted text-xs pb-2">vs</div>
+        <div className="flex-1 min-w-0">
+          <WorktreeSelector
+            label="Right (compare)"
+            worktrees={worktrees}
+            selectedId={rightId}
+            disabledId={leftId}
+            onChange={setRightId}
+          />
         </div>
       </div>
-    </div>
+
+      {/* Body */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* File list sidebar */}
+        <div className="w-64 shrink-0 border-r border-border-subtle flex flex-col overflow-hidden">
+          <div className="px-3 py-2 text-xs text-text-muted border-b border-border-subtle shrink-0">
+            {result
+              ? `${result.files.length} file${result.files.length === 1 ? "" : "s"} changed`
+              : "Files"}
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {loading && (
+              <div className="flex items-center justify-center gap-2 p-6 text-text-muted text-sm">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Comparing…
+              </div>
+            )}
+            {error && (
+              <div className="flex items-start gap-2 p-4 text-status-error text-xs">
+                <AlertCircle className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+                <span>{error}</span>
+              </div>
+            )}
+            {!loading && !error && !result && (
+              <div className="p-4 text-text-muted text-xs">Select two worktrees to compare</div>
+            )}
+            {result?.files.length === 0 && (
+              <div className="p-4 text-text-muted text-xs">
+                No differences between these branches
+              </div>
+            )}
+            {result?.files.map((file) => {
+              const { label, className: statusClass } = statusLabel(file.status);
+              const isSelected = selectedFile?.path === file.path;
+              return (
+                <button
+                  key={`${file.status}:${file.path}`}
+                  onClick={() => void fetchFileDiff(file)}
+                  className={cn(
+                    "w-full flex items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-surface-panel-elevated transition-colors",
+                    isSelected && "bg-surface-panel-elevated"
+                  )}
+                >
+                  <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
+                    {label}
+                  </span>
+                  <FileIcon className="w-3 h-3 shrink-0 text-text-muted" />
+                  <span className="text-text-secondary truncate min-w-0" title={file.path}>
+                    {file.path.split("/").pop()}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Diff panel */}
+        <div className="flex-1 overflow-auto bg-surface-canvas">
+          {!selectedFile && (
+            <div className="flex items-center justify-center h-full text-text-muted text-sm">
+              {result ? "Select a file to view its diff" : ""}
+            </div>
+          )}
+          {selectedFile && fileDiffLoading && (
+            <div className="flex items-center justify-center gap-2 h-full text-text-muted text-sm">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Loading diff…
+            </div>
+          )}
+          {selectedFile && !fileDiffLoading && fileDiffError && (
+            <div className="flex items-center justify-center gap-2 h-full text-status-error text-sm">
+              <AlertCircle className="w-4 h-4" />
+              Failed to load diff
+            </div>
+          )}
+          {selectedFile && !fileDiffLoading && !fileDiffError && fileDiff !== null && (
+            <DiffViewer diff={fileDiff} filePath={selectedFile.path} viewType="split" />
+          )}
+        </div>
+      </div>
+    </AppDialog>
   );
 }

--- a/src/components/Worktree/__tests__/CrossWorktreeDiff.a11y.test.tsx
+++ b/src/components/Worktree/__tests__/CrossWorktreeDiff.a11y.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { render, screen, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { CrossWorktreeDiff } from "../CrossWorktreeDiff";
+import { _resetForTests } from "@/lib/escapeStack";
+import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/store/worktreeDataStore", () => ({
+  useWorktreeDataStore: (sel: (s: { worktrees: Map<string, unknown> }) => unknown) =>
+    sel({ worktrees: new Map() }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useOverlayState: () => {},
+  };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.mock("../DiffViewer", () => ({
+  DiffViewer: () => <div data-testid="diff-viewer" />,
+}));
+
+vi.mock("../WorktreeSelector", () => ({
+  WorktreeSelector: ({ label }: { label: string }) => (
+    <select aria-label={label}>
+      <option>mock</option>
+    </select>
+  ),
+}));
+
+function Dispatcher() {
+  useGlobalEscapeDispatcher();
+  return null;
+}
+
+function renderModal(props: { isOpen?: boolean; onClose?: () => void } = {}) {
+  const { isOpen = true, onClose = vi.fn() } = props;
+  return {
+    onClose,
+    ...render(
+      <>
+        <Dispatcher />
+        <CrossWorktreeDiff isOpen={isOpen} onClose={onClose} initialWorktreeId={null} />
+      </>
+    ),
+  };
+}
+
+function pressEscape() {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+}
+
+describe("CrossWorktreeDiff dialog accessibility", () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it("renders with role='dialog' and aria-modal='true' when open", async () => {
+    renderModal();
+    await act(() => vi.runAllTimersAsync());
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("has aria-labelledby linking to the Compare Worktrees heading", async () => {
+    renderModal();
+    await act(() => vi.runAllTimersAsync());
+
+    const dialog = screen.getByRole("dialog");
+    const labelledById = dialog.getAttribute("aria-labelledby");
+    expect(labelledById).toBeTruthy();
+
+    const heading = screen.getByText("Compare Worktrees");
+    expect(heading.id).toBe(labelledById);
+  });
+
+  it("closes on Escape via useEscapeStack", async () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    await act(() => vi.runAllTimersAsync());
+
+    pressEscape();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not render the dialog when closed", () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("restores focus to the previously active element on close", async () => {
+    const outerButton = document.createElement("button");
+    outerButton.textContent = "Trigger";
+    document.body.appendChild(outerButton);
+    outerButton.focus();
+
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <>
+        <Dispatcher />
+        <CrossWorktreeDiff isOpen={true} onClose={onClose} initialWorktreeId={null} />
+      </>
+    );
+    await act(() => vi.runAllTimersAsync());
+
+    // Focus should have moved into the dialog
+    expect(document.activeElement).not.toBe(outerButton);
+
+    rerender(
+      <>
+        <Dispatcher />
+        <CrossWorktreeDiff isOpen={false} onClose={onClose} initialWorktreeId={null} />
+      </>
+    );
+
+    expect(document.activeElement).toBe(outerButton);
+    document.body.removeChild(outerButton);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the CrossWorktreeDiff modal container, matching the pattern used by ReviewHub and other modals in the codebase
- Adds a unique `id` to the "Compare Worktrees" heading so `aria-labelledby` has a valid target
- Adds focus trap and focus restoration on open/close so keyboard-only users can't navigate behind the backdrop

Resolves #4385

## Changes

- `src/components/Worktree/CrossWorktreeDiff.tsx` — dialog semantics, focus trap, focus restoration
- `src/components/Worktree/__tests__/CrossWorktreeDiff.a11y.test.tsx` — new accessibility test suite covering role, aria attributes, focus behaviour, and escape-to-close

## Testing

Unit tests pass. Accessibility attributes verified against the ReviewHub and WorktreeDeleteDialog patterns already established in the codebase.