### PR TITLE
fix(ui): constrain dropdown and context menu height to available viewport space

### DIFF
--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -44,7 +44,7 @@ const ContextMenuSubContent = React.forwardRef<
       sideOffset={sideOffset}
       collisionPadding={collisionPadding}
       className={cn(
-        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
+        "z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
         className
       )}
       {...props}
@@ -62,7 +62,7 @@ const ContextMenuContent = React.forwardRef<
       ref={ref}
       collisionPadding={collisionPadding}
       className={cn(
-        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
+        "z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -44,7 +44,7 @@ const DropdownMenuSubContent = React.forwardRef<
       sideOffset={sideOffset}
       collisionPadding={collisionPadding}
       className={cn(
-        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
+        "z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
         className
       )}
       {...props}
@@ -62,7 +62,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-[var(--z-popover)] min-w-[10rem] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
+        "z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-canopy-text",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}


### PR DESCRIPTION
## Summary

- Context menus and dropdowns rendered outside the viewport on smaller screens (e.g., 1200x763 on Linux), making bottom items unreachable via click
- Added `max-h` constraint using CSS viewport units and `overflow-y-auto` to both `DropdownMenuContent` and `ContextMenuContent` so menus scroll when they exceed available space
- Fixes the E2E core test failure where "Delete Worktree..." was outside the viewport and unclickable

Resolves #4239

## Changes

- `src/components/ui/context-menu.tsx` — added `max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto` to `ContextMenuContent`
- `src/components/ui/dropdown-menu.tsx` — added `max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto` to `DropdownMenuContent`

## Testing

- Formatting and lint checks pass with no changes required
- The fix uses Radix UI's built-in CSS variables for available height, which are set automatically based on viewport position — no custom JS needed