### PR TITLE
fix(browser): prevent dark-mode color-scheme inheritance into webview

### DIFF
--- a/src/config/__tests__/colorSystem.contract.test.ts
+++ b/src/config/__tests__/colorSystem.contract.test.ts
@@ -169,4 +169,8 @@ describe("color system contract", () => {
     const themeBlock = indexCss.match(/@theme\s+inline\s*\{[\s\S]*?\}/)?.[0] ?? "";
     expect(themeBlock).toMatch(/--color-accent-foreground:\s*var\(--accent-foreground\)/);
   });
+
+  it("sets color-scheme: normal on webview elements to prevent dark-mode inheritance", () => {
+    expect(indexCss).toMatch(/webview\s*\{[^}]*color-scheme:\s*normal/s);
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1915,6 +1915,10 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
     border-radius: var(--radius-md);
   }
 
+  webview {
+    color-scheme: normal;
+  }
+
   [data-dragging="true"] webview,
   [data-dragging="true"] iframe {
     pointer-events: none !important;


### PR DESCRIPTION
## Summary

- The browser panel's `<webview>` was inheriting `color-scheme: dark` from the document root, which caused Chromium's built-in JSON viewer to render dark backgrounds with hardcoded light-mode syntax colors — making JSON responses unreadable on dark themes.
- Added `color-scheme: normal` to the `webview` selector in `src/index.css` to break the CSS inheritance chain, so the webview uses the OS/system default rather than the forced dark mode from the Canopy theme.
- Added a contract test to verify the `webview` color-scheme reset rule is present.

Resolves #4351

## Changes

- `src/index.css` — added `webview { color-scheme: normal; }` reset rule
- `src/config/__tests__/colorSystem.contract.test.ts` — contract test asserting the reset rule exists in the CSS

## Testing

- Contract test passes, confirming the rule is present in the stylesheet
- Verified the fix resolves dark-on-dark rendering for the Chromium JSON viewer