### PR TITLE
feat(notes): move notes storage from project directory to user data

### DIFF
--- a/electron/ipc/handlers/notes.ts
+++ b/electron/ipc/handlers/notes.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { app, ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { NotesService, NoteConflictError, type NoteMetadata } from "../../services/NotesService.js";
@@ -57,8 +57,8 @@ function getNotesService(): NotesService {
     throw new Error("No active project");
   }
 
-  if (!notesService || notesService.getProjectPath() !== currentProject.path) {
-    notesService = new NotesService(currentProject.path);
+  if (!notesService || notesService.getProjectId() !== currentProject.id) {
+    notesService = new NotesService(app.getPath("userData"), currentProject.id);
   }
 
   return notesService;

--- a/electron/services/NotesService.ts
+++ b/electron/services/NotesService.ts
@@ -49,14 +49,16 @@ export class NoteConflictError extends Error {
 }
 
 export class NotesService {
-  private projectPath: string;
+  private userDataPath: string;
+  private projectId: string;
 
-  constructor(projectPath: string) {
-    this.projectPath = projectPath;
+  constructor(userDataPath: string, projectId: string) {
+    this.userDataPath = userDataPath;
+    this.projectId = projectId;
   }
 
   private getNotesDir(): string {
-    return path.join(this.projectPath, ".canopy", "notes");
+    return path.join(this.userDataPath, "notes", this.projectId);
   }
 
   private validatePath(notePath: string): string {
@@ -89,31 +91,6 @@ export class NotesService {
   async ensureNotesDir(): Promise<void> {
     const notesDir = this.getNotesDir();
     await fs.mkdir(notesDir, { recursive: true });
-    await this.ensureGitignore();
-  }
-
-  private async ensureGitignore(): Promise<void> {
-    const gitignorePath = path.join(this.projectPath, ".gitignore");
-    const canopyNotesEntry = ".canopy/notes/";
-
-    try {
-      let content = "";
-      try {
-        content = await fs.readFile(gitignorePath, "utf-8");
-      } catch {
-        // File doesn't exist, will create
-      }
-
-      if (!content.includes(canopyNotesEntry)) {
-        const newEntry =
-          content.endsWith("\n") || content === ""
-            ? `${canopyNotesEntry}\n`
-            : `\n${canopyNotesEntry}\n`;
-        await fs.appendFile(gitignorePath, newEntry, "utf-8");
-      }
-    } catch (error) {
-      console.error("[NotesService] Failed to update .gitignore:", error);
-    }
   }
 
   private extractPreview(content: string, maxLength: number = 100): string {
@@ -395,11 +372,7 @@ export class NotesService {
     await resilientUnlink(absolutePath);
   }
 
-  getProjectPath(): string {
-    return this.projectPath;
-  }
-
-  setProjectPath(projectPath: string): void {
-    this.projectPath = projectPath;
+  getProjectId(): string {
+    return this.projectId;
   }
 }

--- a/electron/services/__tests__/NotesService.test.ts
+++ b/electron/services/__tests__/NotesService.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { NotesService, NoteConflictError, type NoteMetadata } from "../NotesService.js";
 
+const projectId = "test-project-id";
+
 function makeMetadata(overrides: Partial<NoteMetadata> = {}): NoteMetadata {
   return {
     id: "note-1",
@@ -15,27 +17,37 @@ function makeMetadata(overrides: Partial<NoteMetadata> = {}): NoteMetadata {
 }
 
 describe("NotesService", () => {
-  let projectDir: string;
+  let userDataDir: string;
   let service: NotesService;
 
   beforeEach(async () => {
-    projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "canopy-notes-service-"));
-    service = new NotesService(projectDir);
+    userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "canopy-notes-service-"));
+    service = new NotesService(userDataDir, projectId);
   });
 
   afterEach(async () => {
-    await fs.rm(projectDir, { recursive: true, force: true });
+    await fs.rm(userDataDir, { recursive: true, force: true });
   });
 
-  it("adds .canopy/notes entry to .gitignore only once", async () => {
-    await service.create("First note", "project");
-    await service.create("Second note", "project");
+  it("stores notes under userData/notes/projectId, not in project directory", async () => {
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "canopy-project-"));
+    try {
+      await service.create("Test note", "project");
 
-    const gitignorePath = path.join(projectDir, ".gitignore");
-    const content = await fs.readFile(gitignorePath, "utf8");
-    const matches = content.match(/\.canopy\/notes\//g) ?? [];
+      const notesDir = path.join(userDataDir, "notes", projectId);
+      const files = await fs.readdir(notesDir);
+      expect(files.length).toBe(1);
+      expect(files[0]).toMatch(/\.md$/);
 
-    expect(matches).toHaveLength(1);
+      // Ensure no .canopy directory was created in any project-like dir
+      const canopyExists = await fs
+        .access(path.join(projectDir, ".canopy"))
+        .then(() => true)
+        .catch(() => false);
+      expect(canopyExists).toBe(false);
+    } finally {
+      await fs.rm(projectDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects mixed-separator traversal paths in write/read/delete", async () => {
@@ -98,7 +110,7 @@ describe("NotesService", () => {
 
   it("skips malformed note files during list/search without crashing", async () => {
     const created = await service.create("Search me", "project");
-    const notesDir = path.join(projectDir, ".canopy", "notes");
+    const notesDir = path.join(userDataDir, "notes", projectId);
     await fs.writeFile(path.join(notesDir, "bad.md"), "---\nfoo: [\n---\ncontent", "utf8");
 
     const listed = await service.list();
@@ -110,7 +122,7 @@ describe("NotesService", () => {
 
   it("skips files with invalid note metadata schema", async () => {
     const created = await service.create("Healthy note", "project");
-    const notesDir = path.join(projectDir, ".canopy", "notes");
+    const notesDir = path.join(userDataDir, "notes", projectId);
     await fs.writeFile(
       path.join(notesDir, "invalid-metadata.md"),
       "---\nid: invalid\nscope: project\ncreatedAt: nope\n---\nbody",
@@ -142,7 +154,7 @@ describe("NotesService", () => {
   });
 
   it("handles scalar string tags in YAML frontmatter", async () => {
-    const notesDir = path.join(projectDir, ".canopy", "notes");
+    const notesDir = path.join(userDataDir, "notes", projectId);
     await fs.mkdir(notesDir, { recursive: true });
     await fs.writeFile(
       path.join(notesDir, "scalar-tag.md"),
@@ -170,7 +182,7 @@ describe("NotesService", () => {
   });
 
   it("normalizes scalar tags when reading a note", async () => {
-    const notesDir = path.join(projectDir, ".canopy", "notes");
+    const notesDir = path.join(userDataDir, "notes", projectId);
     await fs.mkdir(notesDir, { recursive: true });
     await fs.writeFile(
       path.join(notesDir, "scalar-read.md"),
@@ -186,7 +198,7 @@ describe("NotesService", () => {
     const metadata = makeMetadata({ tags: [] });
     await service.write("no-tags.md", "body", metadata);
 
-    const raw = await fs.readFile(path.join(projectDir, ".canopy", "notes", "no-tags.md"), "utf8");
+    const raw = await fs.readFile(path.join(userDataDir, "notes", projectId, "no-tags.md"), "utf8");
     expect(raw).not.toContain("tags:");
   });
 });


### PR DESCRIPTION
## Summary

- Notes were stored in `.canopy/notes/` inside the project directory, where they were visible to git and at risk of accidental commits in user projects
- Storage now uses `{userData}/notes/{projectId}/` — the Electron user data directory, which is outside the project tree entirely
- The project ID is derived from the project root path (SHA-256 hash), so notes are isolated per project without polluting the working directory

Resolves #4399

## Changes

- `NotesService`: resolved storage path to `app.getPath('userData')/notes/{projectId}/` instead of `{projectRoot}/.canopy/notes/`
- `electron/ipc/handlers/notes.ts`: updated handler to pass `userData` path to NotesService
- Tests updated to reflect new storage path resolution

## Testing

- Unit tests updated and passing — `NotesService.test.ts` covers path resolution with mocked `userData`
- No migration needed (pre-release, existing notes in old location are abandoned per issue spec)