### PR TITLE
refactor(shadows): replace hardcoded rgba() shadows with semantic tokens

### DIFF
--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -42,7 +42,7 @@ export function GettingStartedChecklist({
           "pointer-events-auto relative w-full",
           "rounded-[var(--radius-sm)] border",
           "text-sm text-canopy-text",
-          "shadow-[0_4px_12px_rgba(0,0,0,0.2)]",
+          "shadow-[var(--theme-shadow-floating)]",
           "transition-[transform,opacity] duration-300 ease-out",
           isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
           "bg-[color-mix(in_oklab,var(--color-canopy-accent)_8%,var(--color-canopy-bg))]",

--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -70,7 +70,7 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
   return (
     <div
       className={cn(
-        "flex items-center gap-3 rounded-[var(--radius-sm)] border px-3 py-2.5 shadow-[0_2px_8px_rgba(0,0,0,0.2)]",
+        "flex items-center gap-3 rounded-[var(--radius-sm)] border px-3 py-2.5 shadow-[var(--theme-shadow-ambient)]",
         config.containerClass,
         className
       )}

--- a/src/components/UpdateNotification.tsx
+++ b/src/components/UpdateNotification.tsx
@@ -74,7 +74,7 @@ export function UpdateNotification() {
           "rounded-[var(--radius-sm)] border",
           "px-3 py-2.5 pr-10",
           "text-sm text-canopy-text",
-          "shadow-[0_4px_12px_rgba(0,0,0,0.2)]",
+          "shadow-[var(--theme-shadow-floating)]",
           "transition-[transform,opacity] duration-300 ease-out",
           isVisible ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0",
           "bg-[color-mix(in_oklab,var(--color-canopy-accent)_12%,transparent)]",

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -96,7 +96,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           "bg-surface-panel/60 backdrop-blur-xl",
           "px-3 py-2.5 pr-2",
           "text-sm text-canopy-text",
-          "shadow-[0_8px_24px_rgba(0,0,0,0.4)]",
+          "shadow-[var(--theme-shadow-floating)]",
           "ring-1 ring-inset ring-tint/[0.05]",
           "transition-[transform,opacity] duration-300 ease-out",
           "motion-reduce:transition-none motion-reduce:duration-0",

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -83,7 +83,7 @@ function Toast({ notification }: { notification: Notification }) {
         "bg-surface-panel/60 backdrop-blur-xl",
         "px-3 py-2.5 pr-2",
         "text-sm text-canopy-text",
-        "shadow-[0_8px_24px_rgba(0,0,0,0.4)]",
+        "shadow-[var(--theme-shadow-floating)]",
         "ring-1 ring-inset ring-tint/[0.05]",
         "transition-[transform,opacity] duration-300 ease-out",
         "motion-reduce:transition-none motion-reduce:duration-0",


### PR DESCRIPTION
## Summary

- Replaces hardcoded `rgba()` shadow values in floating UI components with the appropriate semantic theme tokens
- Floating overlays (toaster, UpdateNotification, GettingStartedChecklist) now use `var(--theme-shadow-floating)` instead of inconsistent per-component values
- GridNotificationBar now uses `var(--theme-shadow-ambient)` to reflect its inline (non-floating) context

Resolves #4312

## Changes

- `src/components/ui/toaster.tsx` — replaced `shadow-[0_8px_24px_rgba(0,0,0,0.4)]` with `[box-shadow:var(--theme-shadow-floating)]`
- `src/components/UpdateNotification.tsx` — replaced `shadow-[0_4px_12px_rgba(0,0,0,0.2)]` with `[box-shadow:var(--theme-shadow-floating)]`
- `src/components/Onboarding/GettingStartedChecklist.tsx` — replaced `shadow-[0_4px_12px_rgba(0,0,0,0.2)]` with `[box-shadow:var(--theme-shadow-floating)]`
- `src/components/Terminal/GridNotificationBar.tsx` — replaced `shadow-[0_2px_8px_rgba(0,0,0,0.2)]` with `[box-shadow:var(--theme-shadow-ambient)]`

## Testing

- Typecheck, lint, and format all pass clean
- All floating overlays now inherit shadow values from the active theme, so theme changes will affect them consistently