### PR TITLE
feat(worktree): add content-visibility auto to worktree cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -953,11 +953,23 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         {hasNonMainWorktrees && <WorktreeSidebarSearchBar inputRef={searchInputRef} />}
 
         {/* Main worktree — visible unless excluded by text search */}
-        {mainMatchesQuery && <div className="shrink-0">{renderWorktreeCard(mainWorktree)}</div>}
+        {mainMatchesQuery && (
+          <div
+            className="shrink-0"
+            style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
+          >
+            {renderWorktreeCard(mainWorktree)}
+          </div>
+        )}
 
         {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
         {integrationMatchesQuery && (
-          <div className="shrink-0">{renderWorktreeCard(integrationWorktree)}</div>
+          <div
+            className="shrink-0"
+            style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
+          >
+            {renderWorktreeCard(integrationWorktree)}
+          </div>
         )}
 
         {/* Strong divider between pinned worktrees and scrollable list */}

--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -89,6 +89,10 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
+    ...(!isDragging && {
+      contentVisibility: "auto",
+      containIntrinsicSize: "auto 180px",
+    }),
   };
 
   const { role: _role, "aria-roledescription": _ariaRoleDesc, ...filteredAttributes } = attributes;

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -524,6 +524,10 @@ export function WorktreeOverviewModal({
                       {section.worktrees.map((worktree: WorktreeState) => (
                         <div
                           key={worktree.id}
+                          style={{
+                            contentVisibility: "auto",
+                            containIntrinsicSize: "auto 240px",
+                          }}
                           className={cn(
                             "rounded-lg overflow-hidden",
                             "border border-divider",
@@ -567,6 +571,10 @@ export function WorktreeOverviewModal({
                 {filteredWorktrees.map((worktree) => (
                   <div
                     key={worktree.id}
+                    style={{
+                      contentVisibility: "auto",
+                      containIntrinsicSize: "auto 240px",
+                    }}
                     className={cn(
                       "rounded-lg overflow-hidden",
                       "border border-divider",


### PR DESCRIPTION
## Summary

- Adds `content-visibility: auto` with `contain-intrinsic-size: auto 180px` to all worktree cards in the sidebar and `auto 240px` in the overview modal
- Lets Chromium skip layout, paint, and style calculations for cards scrolled out of the viewport — zero JS overhead
- Disabled during drag operations in `SortableWorktreeCard` to avoid interfering with dnd-kit's transform/transition

Resolves #4319

## Changes

- `src/App.tsx` — pinned main and integration worktree card wrappers get `content-visibility: auto`
- `src/components/DragDrop/SortableWorktreeCard.tsx` — sortable cards get `content-visibility: auto` except when actively dragging
- `src/components/Worktree/WorktreeOverviewModal.tsx` — both sectioned and flat card lists in the overview modal get `content-visibility: auto`

## Testing

- Formatter and linter pass cleanly (0 errors, warnings are pre-existing)
- Typecheck passes
- Verified `containIntrinsicSize: "auto 180px"` caches last-known height to prevent scrollbar jitter