### PR TITLE
fix(errors): persist errors and record crashes in unhandledRejection handler

### DIFF
--- a/electron/setup/__tests__/globalErrorHandlers.test.ts
+++ b/electron/setup/__tests__/globalErrorHandlers.test.ts
@@ -288,13 +288,55 @@ describe("globalErrorHandlers", () => {
       expect(sentPayload.dismissed).toBe(false);
     });
 
-    it("does NOT call app.exit, app.relaunch, recordCrash, or persist errors", () => {
+    it("does NOT call app.exit or app.relaunch", () => {
       rejectionHandler(new Error("rejected"));
 
       expect(appMock.exit).not.toHaveBeenCalled();
       expect(appMock.relaunch).not.toHaveBeenCalled();
-      expect(crashRecoveryMock.recordCrash).not.toHaveBeenCalled();
-      expect(storeMock.set).not.toHaveBeenCalled();
+    });
+
+    it("calls CrashRecoveryService.recordCrash with the reason", () => {
+      const reason = new Error("rejected");
+      rejectionHandler(reason);
+
+      expect(crashRecoveryMock.recordCrash).toHaveBeenCalledWith(reason);
+    });
+
+    it("persists error to pendingErrors store with UNHANDLED_REJECTION payload", () => {
+      rejectionHandler(new Error("rejected"));
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "pendingErrors",
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "unknown",
+            message: expect.stringContaining("rejected"),
+            source: "main-process",
+            isTransient: false,
+            dismissed: false,
+            fromPreviousSession: true,
+            recoveryHint: expect.stringContaining("degraded state"),
+          }),
+        ])
+      );
+    });
+
+    it("persists error when store.get returns undefined", () => {
+      storeMock.get.mockReturnValue(undefined);
+      rejectionHandler(new Error("rejected"));
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "pendingErrors",
+        expect.arrayContaining([expect.objectContaining({ fromPreviousSession: true })])
+      );
+    });
+
+    it("does not throw when recordCrash throws", () => {
+      crashRecoveryMock.recordCrash.mockImplementation(() => {
+        throw new Error("record failed");
+      });
+
+      expect(() => rejectionHandler(new Error("rejected"))).not.toThrow();
     });
 
     it("handles non-Error rejection reasons", () => {

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -121,7 +121,19 @@ export function registerGlobalErrorHandlers(): void {
       // silent
     }
 
+    try {
+      getCrashRecoveryService().recordCrash(reason);
+    } catch {
+      // silent
+    }
+
     const appError = buildFatalAppError("UNHANDLED_REJECTION", reason);
+
+    try {
+      persistPendingError(appError);
+    } catch {
+      // silent
+    }
 
     try {
       notifyRenderer(appError);


### PR DESCRIPTION
## Summary

- The `unhandledRejection` handler was missing two steps that the `uncaughtException` handler performs: persisting the error to the electron store via `persistPendingError()` and recording the crash via `getCrashRecoveryService().recordCrash()`
- Without these, rejection errors were lost across app restarts and crash recovery patterns went untracked
- App still does NOT relaunch on unhandled rejections — that behavior is intentionally preserved

Resolves #4299

## Changes

- `electron/setup/globalErrorHandlers.ts` — added `persistPendingError(appError)` and `getCrashRecoveryService().recordCrash()` calls to the `unhandledRejection` handler, matching the exception handler's pattern
- `electron/setup/__tests__/globalErrorHandlers.test.ts` — extended test coverage to verify the two new calls are made on rejection, and that relaunch is NOT triggered

## Testing

Unit tests updated and passing. The new assertions confirm `persistPendingError` and `recordCrash` are called with the correct error shape, and that `app.relaunch`/`app.exit` are not called on rejection.