### PR TITLE
fix(errors): classify renderer errors by structured properties before message matching

### DIFF
--- a/src/utils/__tests__/errorContext.test.ts
+++ b/src/utils/__tests__/errorContext.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { classifyError, isTransientError, getErrorMessage } from "../errorContext";
+
+/** Helper: create an error-like object with structured properties */
+function makeError(
+  message: string,
+  props?: { name?: string; code?: string; syscall?: string }
+): Error & Record<string, unknown> {
+  const err = new Error(message) as Error & Record<string, unknown>;
+  if (props?.name) err.name = props.name;
+  if (props?.code) err.code = props.code;
+  if (props?.syscall) err.syscall = props.syscall;
+  return err;
+}
+
+describe("classifyError", () => {
+  describe("tier 1: error.name (Canopy error classes)", () => {
+    it("classifies GitError by name regardless of message", () => {
+      expect(classifyError(makeError("fetch something", { name: "GitError" }))).toBe("git");
+    });
+
+    it("classifies WorktreeRemovedError as git", () => {
+      expect(classifyError(makeError("directory removed", { name: "WorktreeRemovedError" }))).toBe(
+        "git"
+      );
+    });
+
+    it("classifies FileSystemError by name even with misleading message", () => {
+      expect(classifyError(makeError("network timeout", { name: "FileSystemError" }))).toBe(
+        "filesystem"
+      );
+    });
+
+    it("classifies ProcessError by name", () => {
+      expect(classifyError(makeError("something", { name: "ProcessError" }))).toBe("process");
+    });
+
+    it("classifies WatcherError as process", () => {
+      expect(classifyError(makeError("something", { name: "WatcherError" }))).toBe("process");
+    });
+
+    it("classifies ConfigError as validation", () => {
+      expect(classifyError(makeError("something", { name: "ConfigError" }))).toBe("validation");
+    });
+
+    it("does not match plain Error name", () => {
+      // name="Error" should fall through to message matching
+      expect(classifyError(new Error("git branch list"))).toBe("git");
+    });
+
+    it("does not match unknown custom error names", () => {
+      expect(classifyError(makeError("something", { name: "MyCustomError" }))).toBe("unknown");
+    });
+  });
+
+  describe("tier 2: error.code (POSIX codes)", () => {
+    it("classifies ENOENT as filesystem even with misleading message", () => {
+      expect(classifyError(makeError("fetch failed", { code: "ENOENT" }))).toBe("filesystem");
+    });
+
+    it("classifies ECONNREFUSED as network even with git message", () => {
+      expect(classifyError(makeError("git operation", { code: "ECONNREFUSED" }))).toBe("network");
+    });
+
+    it("classifies EACCES as filesystem", () => {
+      expect(classifyError(makeError("spawn terminal", { code: "EACCES" }))).toBe("filesystem");
+    });
+
+    it("classifies ETIMEDOUT as network", () => {
+      expect(classifyError(makeError("something", { code: "ETIMEDOUT" }))).toBe("network");
+    });
+
+    it("classifies EBUSY as filesystem", () => {
+      expect(classifyError(makeError("file is busy", { code: "EBUSY" }))).toBe("filesystem");
+    });
+
+    it("classifies EADDRINUSE as network", () => {
+      expect(classifyError(makeError("something", { code: "EADDRINUSE" }))).toBe("network");
+    });
+  });
+
+  describe("tier 3: error.syscall", () => {
+    it("classifies spawn syscall as process", () => {
+      expect(classifyError(makeError("failed", { syscall: "spawn sh" }))).toBe("process");
+    });
+
+    it("classifies spawn without prefix as non-process", () => {
+      expect(classifyError(makeError("something unknown", { syscall: "open" }))).toBe("unknown");
+    });
+  });
+
+  describe("tier priority: name > code > syscall > message", () => {
+    it("name wins over code", () => {
+      expect(classifyError(makeError("something", { name: "GitError", code: "ENOENT" }))).toBe(
+        "git"
+      );
+    });
+
+    it("code wins over syscall", () => {
+      expect(classifyError(makeError("something", { code: "ENOENT", syscall: "spawn sh" }))).toBe(
+        "filesystem"
+      );
+    });
+
+    it("syscall wins over message", () => {
+      expect(classifyError(makeError("network error", { syscall: "spawn node" }))).toBe("process");
+    });
+  });
+
+  describe("tier 4: message fallback", () => {
+    it("classifies network messages", () => {
+      expect(classifyError(new Error("network request failed"))).toBe("network");
+    });
+
+    it("classifies git messages", () => {
+      expect(classifyError(new Error("git branch list failed"))).toBe("git");
+    });
+
+    it("classifies filesystem messages", () => {
+      expect(classifyError(new Error("file not found"))).toBe("filesystem");
+    });
+
+    it("classifies process messages", () => {
+      expect(classifyError(new Error("terminal crashed"))).toBe("process");
+    });
+
+    it("classifies validation messages", () => {
+      expect(classifyError(new Error("invalid input"))).toBe("validation");
+    });
+
+    it("returns unknown for unrecognized messages", () => {
+      expect(classifyError(new Error("something happened"))).toBe("unknown");
+    });
+  });
+
+  describe("bug cases from issue #4301", () => {
+    it("fetch git branch list → git (not network from 'fetch')", () => {
+      expect(classifyError(makeError("fetch git branch list", { name: "GitError" }))).toBe("git");
+    });
+
+    it("ENOENT with git/directory message → filesystem (code wins)", () => {
+      expect(
+        classifyError(makeError("invalid directory path for git worktree", { code: "ENOENT" }))
+      ).toBe("filesystem");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles null", () => {
+      expect(classifyError(null)).toBe("unknown");
+    });
+
+    it("handles undefined", () => {
+      expect(classifyError(undefined)).toBe("unknown");
+    });
+
+    it("handles string errors", () => {
+      expect(classifyError("git error")).toBe("git");
+    });
+
+    it("handles empty object", () => {
+      expect(classifyError({})).toBe("unknown");
+    });
+
+    it("handles numeric code (not a string)", () => {
+      const err = new Error("something") as Error & { code: number };
+      err.code = 42;
+      expect(classifyError(err)).toBe("unknown");
+    });
+  });
+});
+
+describe("isTransientError", () => {
+  describe("code-based detection", () => {
+    it.each(["EBUSY", "EAGAIN", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"])(
+      "returns true for transient code %s",
+      (code) => {
+        expect(isTransientError(makeError("something", { code }))).toBe(true);
+      }
+    );
+
+    it("returns false for ECONNREFUSED (not in transient set)", () => {
+      expect(isTransientError(makeError("something", { code: "ECONNREFUSED" }))).toBe(false);
+    });
+
+    it("returns false for ENOENT", () => {
+      expect(isTransientError(makeError("something", { code: "ENOENT" }))).toBe(false);
+    });
+  });
+
+  describe("message fallback", () => {
+    it("detects timeout in message", () => {
+      expect(isTransientError(new Error("connection timeout"))).toBe(true);
+    });
+
+    it("detects 429 in message", () => {
+      expect(isTransientError(new Error("retry after 429"))).toBe(true);
+    });
+
+    it("detects 503 in message", () => {
+      expect(isTransientError(new Error("service 503"))).toBe(true);
+    });
+
+    it("returns false for non-transient message", () => {
+      expect(isTransientError(new Error("file not found"))).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns false for null", () => {
+      expect(isTransientError(null)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isTransientError(undefined)).toBe(false);
+    });
+
+    it("returns false for string errors without transient keywords", () => {
+      expect(isTransientError("permanent failure")).toBe(false);
+    });
+  });
+});
+
+describe("getErrorMessage", () => {
+  it("extracts message from Error", () => {
+    expect(getErrorMessage(new Error("test"))).toBe("test");
+  });
+
+  it("returns string directly", () => {
+    expect(getErrorMessage("test")).toBe("test");
+  });
+
+  it("extracts message from object", () => {
+    expect(getErrorMessage({ message: "test" })).toBe("test");
+  });
+
+  it("stringifies other types", () => {
+    expect(getErrorMessage(42)).toBe("42");
+  });
+});

--- a/src/utils/errorContext.ts
+++ b/src/utils/errorContext.ts
@@ -18,7 +18,68 @@ export function getErrorMessage(error: unknown): string {
   return String(error);
 }
 
+const NAME_TO_CATEGORY: Record<string, ErrorCategory> = {
+  GitError: "git",
+  WorktreeRemovedError: "git",
+  FileSystemError: "filesystem",
+  ProcessError: "process",
+  WatcherError: "process",
+  ConfigError: "validation",
+};
+
+const FILESYSTEM_CODES = new Set([
+  "ENOENT",
+  "EACCES",
+  "EPERM",
+  "EBUSY",
+  "EEXIST",
+  "EISDIR",
+  "ENOTDIR",
+  "ENOTEMPTY",
+  "EROFS",
+  "EMFILE",
+  "ENFILE",
+]);
+
+const NETWORK_CODES = new Set([
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "ECONNABORTED",
+  "ENETUNREACH",
+  "EHOSTUNREACH",
+  "EADDRINUSE",
+]);
+
+function getStructuredProps(error: unknown) {
+  const err = typeof error === "object" && error !== null ? (error as Record<string, unknown>) : {};
+  return {
+    name: typeof err.name === "string" ? err.name : "",
+    code: typeof err.code === "string" ? err.code : "",
+    syscall: typeof err.syscall === "string" ? err.syscall : "",
+  };
+}
+
 export function classifyError(error: unknown): ErrorCategory {
+  const { name, code, syscall } = getStructuredProps(error);
+
+  // Tier 1: known Canopy error class names (preserved through IPC deserialization)
+  if (name && name !== "Error") {
+    const category = NAME_TO_CATEGORY[name];
+    if (category) return category;
+  }
+
+  // Tier 2: POSIX error codes
+  if (code) {
+    if (NETWORK_CODES.has(code)) return "network";
+    if (FILESYSTEM_CODES.has(code)) return "filesystem";
+  }
+
+  // Tier 3: syscall-based detection
+  if (syscall.startsWith("spawn")) return "process";
+
+  // Tier 4: message substring fallback (for third-party errors without structured properties)
   const message = getErrorMessage(error).toLowerCase();
 
   if (
@@ -77,7 +138,13 @@ export function logErrorWithContext(error: unknown, context: ErrorContext): void
   });
 }
 
+const TRANSIENT_CODES = new Set(["EBUSY", "EAGAIN", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"]);
+
 export function isTransientError(error: unknown): boolean {
+  const { code } = getStructuredProps(error);
+
+  if (code && TRANSIENT_CODES.has(code)) return true;
+
   const message = getErrorMessage(error).toLowerCase();
 
   return (


### PR DESCRIPTION
## Summary

- The renderer's `classifyError()` was using substring message matching to categorize errors, leading to misclassification when messages contained common words like "fetch", "file", or "process"
- Updated `classifyError()` to check `error.code` first (ENOENT, EACCES, ECONNREFUSED, etc.), then `error.name` (GitError, etc.), then fall back to message matching — mirroring the approach already used in the main process
- Applied the same fix to `isTransientError()`, which had the same problem with "timeout", "busy", and similar strings

Resolves #4301

## Changes

- `src/utils/errorContext.ts`: rewrote `classifyError()` and `isTransientError()` to prioritize structured error properties over message substring matching
- `src/utils/__tests__/errorContext.test.ts`: comprehensive tests covering code-based classification, name-based classification, mixed cases, and message fallback

## Testing

Unit tests cover all acceptance criteria from the issue: ENOENT → filesystem, ECONNREFUSED → network, GitError name → git, message fallback still works for unstructured errors. All tests pass with `npm test`.