### PR TITLE
feat(ui): consolidate loading spinners into unified Spinner component

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -4,6 +4,7 @@ import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
 import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { AlertTriangle, ExternalLink } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { useTerminalStore } from "@/store";
 import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
@@ -746,7 +747,7 @@ export function BrowserPane({
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
               {isLoading && (
                 <div className="absolute inset-0 flex items-center justify-center bg-canopy-bg z-10">
-                  <div className="w-8 h-8 border-2 border-status-info border-t-transparent rounded-full animate-spin" />
+                  <Spinner size="2xl" className="text-status-info" />
                 </div>
               )}
               {findInPage.isOpen && <FindBar find={findInPage} />}

--- a/src/components/Commands/CommandBuilder.tsx
+++ b/src/components/Commands/CommandBuilder.tsx
@@ -9,7 +9,8 @@ import type {
   BuilderStep,
   BuilderField,
 } from "@shared/types/commands";
-import { ChevronLeft, ChevronRight, Loader2, AlertCircle, CheckCircle } from "lucide-react";
+import { ChevronLeft, ChevronRight, AlertCircle, CheckCircle } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 
 interface CommandBuilderProps {
   command: CommandManifestEntry;
@@ -534,7 +535,7 @@ export function CommandBuilder({
                 <Button onClick={handleExecute} disabled={isExecuting}>
                   {isExecuting ? (
                     <>
-                      <Loader2 className="h-4 w-4 animate-spin" />
+                      <Spinner size="md" />
                       Executing...
                     </>
                   ) : (

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, useDeferredValue } from "react";
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import type { CommandManifestEntry, CommandCategory } from "@shared/types/commands";
 
 interface CommandPickerProps {
@@ -165,7 +165,7 @@ export function CommandPicker({
         itemIdPrefix="command"
         renderBody={() => (
           <div className="flex flex-col items-center justify-center py-8 space-y-2">
-            <Loader2 className="h-6 w-6 animate-spin text-canopy-text/40" />
+            <Spinner size="xl" className="text-canopy-text/40" />
             <p className="text-sm text-canopy-text/50">Loading commands...</p>
           </div>
         )}

--- a/src/components/Commands/CommandPickerHost.tsx
+++ b/src/components/Commands/CommandPickerHost.tsx
@@ -5,7 +5,8 @@ import { CommandPicker } from "./CommandPicker";
 import { CommandBuilder } from "./CommandBuilder";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
-import { Loader2, AlertCircle } from "lucide-react";
+import { AlertCircle } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import type { CommandManifestEntry, CommandContext, CommandResult } from "@shared/types/commands";
 
 interface CommandPickerHostProps {
@@ -108,7 +109,7 @@ export function CommandPickerHost({ context, onCommandExecuted }: CommandPickerH
           </AppDialog.Header>
           <AppDialog.Body>
             <div className="flex flex-col items-center justify-center py-8 space-y-4">
-              <Loader2 className="h-8 w-8 animate-spin text-canopy-accent" />
+              <Spinner size="2xl" className="text-canopy-accent" />
               <p className="text-sm text-canopy-text/70">Loading command configuration...</p>
             </div>
           </AppDialog.Body>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { AlertTriangle, RotateCw, ExternalLink, Settings, WandSparkles } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { useTerminalStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
@@ -601,7 +602,7 @@ export function DevPreviewPane({
         <div className="relative flex-1 min-h-0 bg-surface-canvas">
           {isRestarting || status === "starting" || status === "installing" ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-canopy-bg">
-              <div className="w-12 h-12 border-2 border-status-info border-t-transparent rounded-full animate-spin mb-4" />
+              <Spinner size="2xl" className="text-status-info mb-4" />
               <p className="text-sm text-canopy-text/60">
                 {isRestarting ? "Restarting" : status === "installing" ? "Installing" : "Starting"}
                 ...

--- a/src/components/DevPreview/DevPreviewToolbar.tsx
+++ b/src/components/DevPreview/DevPreviewToolbar.tsx
@@ -17,12 +17,12 @@ const STATUS_CONFIG: Record<
 > = {
   installing: {
     icon: Loader2,
-    iconClass: "text-status-warning animate-spin",
+    iconClass: "text-status-warning animate-spin motion-reduce:animate-none",
     ariaLabel: "Installing dependencies",
   },
   starting: {
     icon: Loader2,
-    iconClass: "text-status-info animate-spin",
+    iconClass: "text-status-info animate-spin motion-reduce:animate-none",
     ariaLabel: "Starting dev server",
   },
   running: {

--- a/src/components/DragDrop/TerminalDragPreview.tsx
+++ b/src/components/DragDrop/TerminalDragPreview.tsx
@@ -97,7 +97,7 @@ export function TerminalDragPreview({ terminal, groupTabCount }: TerminalDragPre
         {/* Working indicator */}
         {isWorking && (
           <Loader2
-            className="w-3 h-3 animate-spin"
+            className="w-3 h-3 animate-spin motion-reduce:animate-none"
             style={{ color: brandColor }}
             aria-hidden="true"
           />

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -7,6 +7,7 @@ import type { CodeViewerHandle } from "./CodeViewer";
 import { filesClient } from "@/clients/filesClient";
 import { actionService } from "@/services/ActionService";
 import { ExternalLink, Copy, Check, Image as ImageIcon } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
@@ -408,22 +409,7 @@ export function FileViewerModal({
             {loadState === "loading" && (
               <div className="flex items-center justify-center h-64">
                 <div className="flex items-center gap-3 text-muted-foreground">
-                  <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24">
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                      fill="none"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
+                  <Spinner size="lg" />
                   <span>Loading file...</span>
                 </div>
               </div>
@@ -483,22 +469,7 @@ export function FileViewerModal({
         {!isImageMode && mode === "diff" && !diff && (
           <div className="flex items-center justify-center h-64">
             <div className="flex items-center gap-3 text-muted-foreground">
-              <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24">
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                  fill="none"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <Spinner size="lg" />
               <span>Loading diff...</span>
             </div>
           </div>

--- a/src/components/FileViewer/FileViewerModalHost.tsx
+++ b/src/components/FileViewer/FileViewerModalHost.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { useProjectStore } from "@/store";
 import { useBranchForPath } from "@/hooks/useBranchForPath";
 
@@ -46,7 +46,7 @@ export function FileViewerModalHost() {
     <Suspense
       fallback={
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-scrim-medium">
-          <Loader2 className="h-6 w-6 animate-spin text-text-inverse" />
+          <Spinner size="xl" className="text-text-inverse" />
         </div>
       }
     >

--- a/src/components/FileViewer/PlanFileViewer.tsx
+++ b/src/components/FileViewer/PlanFileViewer.tsx
@@ -2,6 +2,7 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { CodeViewer } from "./CodeViewer";
 import { usePlanFileContent } from "@/hooks/usePlanFileContent";
 import { FileText } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 
 interface PlanFileViewerProps {
   isOpen: boolean;
@@ -42,22 +43,7 @@ export function PlanFileViewer({ isOpen, filePath, rootPath, onClose }: PlanFile
         {filePath && !isGone && status === "loading" && (
           <div className="flex items-center justify-center h-48">
             <div className="flex items-center gap-3 text-muted-foreground">
-              <svg className="w-5 h-5 animate-spin" viewBox="0 0 24 24">
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                  fill="none"
-                />
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                />
-              </svg>
+              <Spinner size="lg" />
               <span>Loading plan...</span>
             </div>
           </div>

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1,14 +1,7 @@
 import { useCallback, useReducer, useRef, useMemo, useEffect } from "react";
 import PQueue from "p-queue";
-import {
-  Loader2,
-  Check,
-  AlertTriangle,
-  UserPlus,
-  Play,
-  ChevronsUpDown,
-  RotateCcw,
-} from "lucide-react";
+import { Check, AlertTriangle, UserPlus, Play, ChevronsUpDown, RotateCcw } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
@@ -833,7 +826,7 @@ export function BulkCreateWorktreeDialog({
         <AppDialog.Title
           icon={
             isExecuting ? (
-              <Loader2 className="w-5 h-5 text-canopy-accent animate-spin" />
+              <Spinner size="lg" className="text-canopy-accent" />
             ) : isDone ? (
               failedCount > 0 ? (
                 <AlertTriangle className="w-5 h-5 text-status-warning" />
@@ -1069,7 +1062,7 @@ export function BulkCreateWorktreeDialog({
                     >
                       <div className="mt-0.5 shrink-0">
                         {isInProgress ? (
-                          <Loader2 className="w-4 h-4 animate-spin text-canopy-accent" />
+                          <Spinner size="md" className="text-canopy-accent" />
                         ) : itemStatus?.stage === "succeeded" ? (
                           <Check className="w-4 h-4 text-status-success" />
                         ) : itemStatus?.stage === "failed" ? (

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -23,7 +23,6 @@ import {
   PanelLeftOpen,
   PanelLeftClose,
   Check,
-  Loader2,
   ChevronsUpDown,
   Globe,
   Leaf,
@@ -34,6 +33,7 @@ import {
   Ellipsis,
   GitBranch,
 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { CopyTreeIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { isMac, isLinux, createTooltipWithShortcut } from "@/lib/platform";
@@ -1009,13 +1009,7 @@ export function Toolbar({
                     isCopyingTree ? "Copying…" : treeCopied ? "Context Copied" : "Copy Context"
                   }
                 >
-                  {isCopyingTree ? (
-                    <Loader2 className="animate-spin motion-reduce:animate-none" />
-                  ) : treeCopied ? (
-                    <Check />
-                  ) : (
-                    <CopyTreeIcon />
-                  )}
+                  {isCopyingTree ? <Spinner /> : treeCopied ? <Check /> : <CopyTreeIcon />}
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="bottom" className="font-medium">

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -1,4 +1,5 @@
-import { Loader2, Mic } from "lucide-react";
+import { Mic } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -72,7 +73,7 @@ export function VoiceRecordingToolbarButton({
             aria-label={tooltipTitle}
           >
             {status === "finishing" ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Spinner size="md" />
             ) : (
               <div className="relative">
                 <Mic className="h-4 w-4" />

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Check, AlertCircle, Loader2 } from "lucide-react";
+import { Check, AlertCircle } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { projectClient } from "@/clients";
 import type { GitInitProgressEvent } from "@shared/types/ipc/gitInit";
@@ -122,7 +123,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
 
   const getStepIcon = (event: GitInitProgressEvent) => {
     if (event.status === "start") {
-      return <Loader2 className="h-4 w-4 animate-spin text-status-info" />;
+      return <Spinner size="md" className="text-status-info" />;
     } else if (event.status === "success") {
       return <Check className="h-4 w-4 text-status-success" />;
     } else if (event.status === "error") {
@@ -148,7 +149,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
         <div className="rounded-lg bg-muted/50 p-4 min-h-[200px] max-h-[400px] overflow-y-auto font-mono text-sm">
           {progressEvents.length === 0 && isInitializing && (
             <div className="flex items-center gap-2 text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Spinner size="md" />
               <span>Starting initialization...</span>
             </div>
           )}

--- a/src/components/Project/ProjectSwitchOverlay.tsx
+++ b/src/components/Project/ProjectSwitchOverlay.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { createPortal } from "react-dom";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { Button } from "@/components/ui/button";
@@ -70,10 +70,7 @@ export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitch
           isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.96]"
         )}
       >
-        <Loader2
-          className="h-8 w-8 text-canopy-accent animate-spin motion-reduce:animate-none"
-          aria-hidden="true"
-        />
+        <Spinner size="2xl" className="text-canopy-accent" />
         <div>
           {cachedProjectName ? (
             <>

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -4,7 +4,6 @@ import type { PulseRangeDays, ProjectPulse, ProjectHealthData } from "@shared/ty
 import { usePulseStore, useProjectStore } from "@/store";
 import { cn } from "@/lib/utils";
 import {
-  Loader2,
   AlertCircle,
   RefreshCw,
   Activity,
@@ -21,6 +20,7 @@ import {
   Github,
   WifiOff,
 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { PulseHeatmap } from "./PulseHeatmap";
 import { PulseSummary } from "./PulseSummary";
 import { useProjectHealth } from "@/hooks/useProjectHealth";
@@ -407,7 +407,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
               role="status"
               aria-live="polite"
             >
-              <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+              <Spinner size="xs" />
               <span className="text-xs">
                 Retrying ({retryCount}/{MAX_RETRIES})...
               </span>
@@ -433,7 +433,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-status-success" />
           <span className="text-sm font-medium text-canopy-text/90">{title}</span>
-          {isLoading && <Loader2 className="w-3 h-3 animate-spin text-canopy-text/55" />}
+          {isLoading && <Spinner size="xs" className="text-canopy-text/55" />}
         </div>
 
         <div className="flex items-center gap-2">

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Copy, RefreshCw, Loader2 } from "lucide-react";
+import { Copy, RefreshCw } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { agentHelpClient } from "@/clients";
 import { cliAvailabilityClient } from "@/clients";
 import type { AgentHelpResult } from "@shared/types/ipc/agent";
@@ -192,7 +193,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
 
       {isLoading && (
         <div className="flex items-center justify-center py-8">
-          <Loader2 size={20} className="animate-spin text-canopy-text/40" />
+          <Spinner size="lg" className="text-canopy-text/40" />
         </div>
       )}
 

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Key, Lock, ShieldAlert, Eye, EyeOff, Trash2, Plus, Save, FolderOpen } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { SettingsSection } from "./SettingsSection";
 import { useProjectStore } from "@/store/projectStore";
@@ -198,7 +199,7 @@ export function EnvironmentSettingsTab() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-16">
-        <div className="w-5 h-5 border-2 border-canopy-accent/30 border-t-canopy-accent rounded-full animate-spin" />
+        <Spinner size="lg" />
       </div>
     );
   }

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { Key, Check, AlertCircle, Loader2, FlaskConical, ExternalLink, Github } from "lucide-react";
+import { Key, Check, AlertCircle, FlaskConical, ExternalLink, Github } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { useGitHubConfigStore } from "@/store";
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
@@ -222,7 +223,7 @@ export function GitHubSettingsTab() {
               className="min-w-[70px] text-canopy-text border-canopy-border hover:bg-canopy-border"
             >
               {isTesting ? (
-                <Loader2 className="animate-spin" aria-hidden="true" />
+                <Spinner />
               ) : (
                 <>
                   <FlaskConical aria-hidden="true" />
@@ -238,7 +239,7 @@ export function GitHubSettingsTab() {
               aria-busy={isValidating}
               className="min-w-[70px]"
             >
-              {isValidating ? <Loader2 className="animate-spin" aria-hidden="true" /> : "Save"}
+              {isValidating ? <Spinner /> : "Save"}
             </Button>
             {githubConfig?.hasToken && (
               <Button

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -11,13 +11,13 @@ import {
   Shield,
   Check,
   AlertCircle,
-  Loader2,
   ExternalLink,
   Sparkles,
   ChevronDown,
   ChevronUp,
   AlignLeft,
 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { SettingsSection } from "./SettingsSection";
@@ -494,7 +494,7 @@ function ApiKeyRow({
           variant="outline"
           className="text-canopy-text border-canopy-border hover:bg-canopy-border"
         >
-          {validation === "testing" ? <Loader2 className="animate-spin w-3.5 h-3.5" /> : "Save"}
+          {validation === "testing" ? <Spinner size="sm" /> : "Save"}
         </Button>
         {value && (
           <Button
@@ -611,7 +611,7 @@ function MicPermissionRow({
                   className="text-canopy-text border-canopy-border hover:bg-canopy-border"
                 >
                   {isRequesting ? (
-                    <Loader2 className="animate-spin w-3.5 h-3.5" />
+                    <Spinner size="sm" />
                   ) : (
                     <>
                       <Mic className="w-3.5 h-3.5" />

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { AlertCircle, Check, RotateCcw } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
@@ -140,7 +141,7 @@ export function WorktreeSettingsTab() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="w-5 h-5 border-2 border-canopy-accent border-t-transparent rounded-full animate-spin" />
+        <Spinner size="lg" />
         <span className="ml-2 text-sm text-canopy-text/60">Loading settings...</span>
       </div>
     );

--- a/src/components/Setup/AgentSelectionStep.tsx
+++ b/src/components/Setup/AgentSelectionStep.tsx
@@ -4,7 +4,8 @@ import { Button } from "@/components/ui/button";
 import { useAgentSettingsStore } from "@/store";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { AGENT_REGISTRY, AGENT_IDS } from "@/config/agents";
-import { TreeDeciduous, Loader2 } from "lucide-react";
+import { TreeDeciduous } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 
 const AGENT_DESCRIPTIONS: Record<string, string> = {
   claude: "Deep refactoring, architecture, and complex reasoning",
@@ -90,7 +91,7 @@ export function AgentSelectionStep({ isOpen, onContinue, onSkip }: AgentSelectio
 
           {isLoading ? (
             <div className="flex items-center justify-center py-8">
-              <Loader2 className="w-5 h-5 animate-spin text-canopy-text/40" />
+              <Spinner size="lg" className="text-canopy-text/40" />
             </div>
           ) : (
             <div className="space-y-2">

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { AlertTriangle, Loader2, RefreshCw, Settings } from "lucide-react";
+import { AlertTriangle, RefreshCw, Settings } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import type {
   TerminalType,
   TerminalRestartError,
@@ -771,7 +772,7 @@ function TerminalPaneComponent({
             >
               {isBackendRecovering ? (
                 <div className="flex flex-col items-center gap-3">
-                  <Loader2 className="w-8 h-8 animate-spin motion-reduce:animate-none text-status-warning" />
+                  <Spinner size="2xl" className="text-status-warning" />
                   <span className="text-text-inverse font-medium">Reconnecting...</span>
                 </div>
               ) : (
@@ -831,7 +832,7 @@ function TerminalPaneComponent({
                       className="px-4 py-2 bg-canopy-accent/20 hover:bg-canopy-accent/30 text-canopy-accent rounded-lg border border-canopy-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
                     >
                       {isRestartingService ? (
-                        <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none" />
+                        <Spinner size="md" />
                       ) : (
                         <RefreshCw className="w-4 h-4" />
                       )}

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { AlertTriangle, Loader2, RotateCcw, X } from "lucide-react";
+import { AlertTriangle, RotateCcw, X } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import type { RestartBannerVariant } from "./restartStatus";
 
@@ -21,7 +22,7 @@ function TerminalRestartStatusBannerComponent({
     case "auto-restarting":
       return (
         <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-canopy-text/60 bg-canopy-accent/5 border-b border-canopy-border shrink-0">
-          <Loader2 className="h-3 w-3 animate-spin text-canopy-accent" />
+          <Spinner size="xs" className="text-canopy-accent" />
           <span>Auto-restarting…</span>
         </div>
       );

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react";
-import { Mic, Loader2 } from "lucide-react";
+import { Mic } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
@@ -272,7 +273,7 @@ export function VoiceInputButton({
         aria-pressed={isConfigured ? isListening : undefined}
       >
         {isFinishing && !showOrbit ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <Spinner size="sm" />
         ) : showOrbit ? (
           <span
             ref={iconRef}

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
-import { GitCompare, FileIcon, Loader2, AlertCircle } from "lucide-react";
+import { GitCompare, FileIcon, AlertCircle } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { useWorktreeDataStore } from "@/store/worktreeDataStore";
 import { AppDialog } from "@/components/ui/AppDialog";
@@ -198,7 +199,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
           <div className="flex-1 overflow-y-auto">
             {loading && (
               <div className="flex items-center justify-center gap-2 p-6 text-text-muted text-sm">
-                <Loader2 className="w-4 h-4 animate-spin" />
+                <Spinner size="md" />
                 Comparing…
               </div>
             )}
@@ -250,7 +251,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
           )}
           {selectedFile && fileDiffLoading && (
             <div className="flex items-center justify-center gap-2 h-full text-text-muted text-sm">
-              <Loader2 className="w-4 h-4 animate-spin" />
+              <Spinner size="md" />
               Loading diff…
             </div>
           )}

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -1,7 +1,8 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
-import { CircleDot, Search, Loader2, Link, Unlink, CircleCheck } from "lucide-react";
+import { CircleDot, Search, Link, Unlink, CircleCheck } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
@@ -166,7 +167,7 @@ export function IssuePickerDialog({
       <div className="flex-1 overflow-y-auto min-h-0 px-6 pb-4">
         {isLoading && issues.length === 0 ? (
           <div className="flex items-center justify-center py-8 text-canopy-text/50">
-            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            <Spinner size="lg" className="mr-2" />
             <span className="text-sm">Loading issues...</span>
           </div>
         ) : error ? (

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -5,7 +5,6 @@ import {
   FolderOpen,
   Check,
   AlertCircle,
-  Loader2,
   ChevronsUpDown,
   Search,
   UserPlus,
@@ -13,6 +12,7 @@ import {
   Info,
   ChevronDown,
 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import type { BranchInfo, CreateWorktreeOptions } from "@/types/electron";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
@@ -556,7 +556,7 @@ export function NewWorktreeDialog({
       <AppDialog.Body>
         {loading ? (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="w-6 h-6 animate-spin text-canopy-accent" />
+            <Spinner size="xl" className="text-canopy-accent" />
             <span className="ml-2 text-sm text-canopy-text/60">Loading branches...</span>
           </div>
         ) : (
@@ -835,9 +835,9 @@ export function NewWorktreeDialog({
                         aria-expanded={prefixPickerOpen}
                       />
                       {isCheckingBranch && (
-                        <Loader2
-                          className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-canopy-text/40 pointer-events-none"
-                          aria-hidden="true"
+                        <Spinner
+                          size="md"
+                          className="absolute right-3 top-1/2 -translate-y-1/2 text-canopy-text/40 pointer-events-none"
                         />
                       )}
                     </div>
@@ -948,9 +948,9 @@ export function NewWorktreeDialog({
                       disabled={isPending}
                     />
                     {isGeneratingPath && (
-                      <Loader2
-                        className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 animate-spin text-canopy-text/40 pointer-events-none"
-                        aria-hidden="true"
+                      <Spinner
+                        size="md"
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-canopy-text/40 pointer-events-none"
                       />
                     )}
                   </div>
@@ -1249,7 +1249,7 @@ export function NewWorktreeDialog({
             >
               {isPending ? (
                 <>
-                  <Loader2 className="animate-spin" />
+                  <Spinner />
                   Creating...
                 </>
               ) : creationError ? (

--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
-import { GitCommit, ArrowUpFromLine, Loader2 } from "lucide-react";
+import { GitCommit, ArrowUpFromLine } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 
 const MAX_SUBJECT_LENGTH = 72;
@@ -122,7 +123,7 @@ export function CommitPanel({
               className="flex-1"
             >
               {isPushing ? (
-                <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+                <Spinner size="sm" className="mr-1.5" />
               ) : (
                 <ArrowUpFromLine className="w-3.5 h-3.5 mr-1.5" />
               )}
@@ -136,7 +137,7 @@ export function CommitPanel({
               className="flex-1"
             >
               {isCommitting ? (
-                <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+                <Spinner size="sm" className="mr-1.5" />
               ) : (
                 <GitCommit className="w-3.5 h-3.5 mr-1.5" />
               )}
@@ -152,7 +153,7 @@ export function CommitPanel({
             className="flex-1"
           >
             {isCommitting ? (
-              <Loader2 className="w-3.5 h-3.5 mr-1.5 animate-spin" />
+              <Spinner size="sm" className="mr-1.5" />
             ) : (
               <GitCommit className="w-3.5 h-3.5 mr-1.5" />
             )}

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -9,12 +9,12 @@ import {
   RefreshCw,
   CheckSquare,
   Square,
-  Loader2,
   AlertTriangle,
   GitBranch,
   GitPullRequest,
   FileIcon,
 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { FileStageRow } from "./FileStageRow";
 import { CommitPanel } from "./CommitPanel";
 import { FileDiffModal } from "../FileDiffModal";
@@ -566,7 +566,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
               /* Base-branch diff panel */
               baseBranchLoading ? (
                 <div className="flex items-center justify-center py-12">
-                  <Loader2 className="w-5 h-5 text-canopy-text/40 animate-spin" />
+                  <Spinner size="lg" className="text-canopy-text/40" />
                 </div>
               ) : baseBranchError ? (
                 <div className="p-4 text-xs text-status-error">
@@ -632,7 +632,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
               <>
                 {loading && !status ? (
                   <div className="flex items-center justify-center py-12">
-                    <Loader2 className="w-5 h-5 text-canopy-text/40 animate-spin" />
+                    <Spinner size="lg" className="text-canopy-text/40" />
                   </div>
                 ) : loadError ? (
                   <div className="p-4 text-xs text-status-error">

--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
-import { Loader2, User, Users, Calendar } from "lucide-react";
+import { User, Users, Calendar } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 
 function formatDate(dateString: string): string {
@@ -19,7 +20,7 @@ interface TooltipLoadingProps {
 export const TooltipLoading = memo(function TooltipLoading({ type }: TooltipLoadingProps) {
   return (
     <div className="flex items-center gap-2 text-canopy-text/70 py-1">
-      <Loader2 className="w-3 h-3 animate-spin" />
+      <Spinner size="xs" />
       <span className="text-xs">Loading {type} details...</span>
     </div>
   );

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -6,7 +6,8 @@ import { cn } from "@/lib/utils";
 import { ActivityLight } from "../ActivityLight";
 import { LiveTimeAgo } from "../LiveTimeAgo";
 import { WorktreeDetails } from "../WorktreeDetails";
-import { ChevronRight, GitCommitHorizontal, Loader2 } from "lucide-react";
+import { ChevronRight, GitCommitHorizontal } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import type { ComputedSubtitle } from "./hooks/useWorktreeStatus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -108,7 +109,7 @@ export function WorktreeDetailsSection({
             <span className="text-xs truncate min-w-0 flex-1">
               {isLifecycleRunning && lifecycleLabel ? (
                 <span className="flex items-center gap-1.5 text-text-secondary">
-                  <Loader2 className="w-3 h-3 animate-spin shrink-0" aria-hidden="true" />
+                  <Spinner size="xs" className="shrink-0" />
                   <span className="truncate">{lifecycleLabel}</span>
                 </span>
               ) : lifecycleLabel &&

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -12,7 +12,8 @@ import {
   UI_EXIT_EASING,
   getUiTransitionDuration,
 } from "@/lib/animationUtils";
-import { X, Loader2 } from "lucide-react";
+import { X } from "lucide-react";
+import { Spinner } from "./Spinner";
 import { Button } from "./button";
 
 type DialogSize = "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "6xl";
@@ -380,7 +381,7 @@ AppDialog.Footer = function AppDialogFooter({
           disabled={secondaryAction.disabled || secondaryAction.loading}
           className="text-canopy-text/70 hover:text-canopy-text"
         >
-          {secondaryAction.loading && <Loader2 className="animate-spin" />}
+          {secondaryAction.loading && <Spinner />}
           {secondaryAction.label}
         </Button>
       )}
@@ -390,7 +391,7 @@ AppDialog.Footer = function AppDialogFooter({
           onClick={primaryAction.onClick}
           disabled={primaryAction.disabled || primaryAction.loading}
         >
-          {primaryAction.loading && <Loader2 className="animate-spin" />}
+          {primaryAction.loading && <Spinner />}
           {primaryAction.label}
         </Button>
       )}

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,0 +1,28 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const SIZE_CLASSES = {
+  xs: "w-3 h-3",
+  sm: "w-3.5 h-3.5",
+  md: "w-4 h-4",
+  lg: "w-5 h-5",
+  xl: "w-6 h-6",
+  "2xl": "w-8 h-8",
+} as const;
+
+type SpinnerSize = keyof typeof SIZE_CLASSES;
+
+interface SpinnerProps {
+  size?: SpinnerSize;
+  className?: string;
+}
+
+export function Spinner({ size = "md", className }: SpinnerProps) {
+  return (
+    <Loader2
+      className={cn("animate-spin motion-reduce:animate-none", SIZE_CLASSES[size], className)}
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/components/ui/__tests__/Spinner.test.tsx
+++ b/src/components/ui/__tests__/Spinner.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Spinner } from "../Spinner";
+
+describe("Spinner", () => {
+  it("renders an SVG with animate-spin and motion-reduce classes", () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg!.className.baseVal).toContain("animate-spin");
+    expect(svg!.className.baseVal).toContain("motion-reduce:animate-none");
+  });
+
+  it("has aria-hidden by default", () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector("svg");
+    expect(svg!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("applies default md size classes", () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector("svg");
+    expect(svg!.className.baseVal).toContain("w-4");
+    expect(svg!.className.baseVal).toContain("h-4");
+  });
+
+  it("applies correct classes for each size", () => {
+    const sizes = {
+      xs: ["w-3", "h-3"],
+      sm: ["w-3.5", "h-3.5"],
+      md: ["w-4", "h-4"],
+      lg: ["w-5", "h-5"],
+      xl: ["w-6", "h-6"],
+      "2xl": ["w-8", "h-8"],
+    } as const;
+
+    for (const [size, [w, h]] of Object.entries(sizes)) {
+      const { container } = render(<Spinner size={size as keyof typeof sizes} />);
+      const svg = container.querySelector("svg");
+      expect(svg!.className.baseVal).toContain(w);
+      expect(svg!.className.baseVal).toContain(h);
+    }
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(<Spinner className="text-status-info mb-4" />);
+    const svg = container.querySelector("svg");
+    expect(svg!.className.baseVal).toContain("text-status-info");
+    expect(svg!.className.baseVal).toContain("mb-4");
+  });
+});

--- a/src/registry/builtInPanelRegistrations.tsx
+++ b/src/registry/builtInPanelRegistrations.tsx
@@ -3,7 +3,7 @@
  * Called once at app startup to register terminal, agent, browser, and notes panels.
  */
 import { Suspense, lazy } from "react";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@/components/ui/Spinner";
 import { registerPanelComponent } from "./panelComponentRegistry";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -21,7 +21,7 @@ const LazyDevPreviewPane = lazy(() =>
 function PanelLoadingFallback() {
   return (
     <div className="flex h-full w-full items-center justify-center">
-      <Loader2 className="h-5 w-5 animate-spin text-canopy-text/30" />
+      <Spinner size="lg" className="text-canopy-text/30" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Creates a unified `Spinner` component at `src/components/ui/Spinner.tsx` with size variants (xs/sm/md/lg/xl/2xl), `motion-reduce:animate-none` baked in, and `aria-hidden="true"` by default
- Replaces 4 CSS border spinners and 3 inline SVG spinners with the new component
- Migrates ~30 bare `Loader2` usages to `Spinner` across all components
- Adds `motion-reduce:animate-none` to remaining edge cases (DevPreviewToolbar STATUS_CONFIG, TerminalDragPreview)

Resolves #4316

## Changes

- **New:** `src/components/ui/Spinner.tsx` — unified spinner with `xs`/`sm`/`md`/`lg`/`xl`/`2xl` sizes
- **New:** `src/components/ui/__tests__/Spinner.test.tsx` — 5 unit tests (sizes, aria-hidden, className merge)
- **Updated:** 34 component files to use `<Spinner>` instead of inline implementations

## Test plan

- [x] Unit tests pass (7744 tests, 519 files)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Lint clean (405 warnings, matching baseline)
- [x] Format clean (Prettier)
- [ ] Visual check: loading states in Settings, Browser, DevPreview, FileViewer, Commands