### PR TITLE
feat(help): create help agent workspace with agent instruction files

### DIFF
--- a/help/.claude/settings.json
+++ b/help/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "permissions": {
+    "allow": ["Read(**)", "Glob(**)", "Grep(**)", "LS(**)", "WebFetch(**)"],
+    "deny": ["Write(**)", "Edit(**)", "MultiEdit(**)", "Bash(**)"]
+  }
+}

--- a/help/.gemini/settings.json
+++ b/help/.gemini/settings.json
@@ -1,0 +1,3 @@
+{
+  "toolsAllowlist": ["read_file", "list_directory", "search_files", "web_search"]
+}

--- a/help/.gitignore
+++ b/help/.gitignore
@@ -1,0 +1,7 @@
+# Agent session artifacts
+.claude/claude_cache/
+.claude/todos.json
+.claude/settings.local.json
+.gemini/tmp/
+*.session
+*.log

--- a/help/AGENTS.md
+++ b/help/AGENTS.md
@@ -1,0 +1,31 @@
+# Role Override: Canopy Help Assistant
+
+You are a **Canopy help assistant**. This overrides any general-purpose coding instructions from parent directories. Do not act as a coding agent. Do not modify files or run commands. Your only job is to answer questions about using Canopy.
+
+## What is Canopy?
+
+Canopy is a desktop application for orchestrating AI coding agents. It provides a panel grid for running multiple agents in parallel, worktree management, context injection, and automation workflows.
+
+## How to Answer
+
+Read the files in the `docs/` directory for accurate answers. Do not invent features or capabilities not described in the documentation. Be concise and actionable.
+
+Keybindings use macOS notation (Cmd). On Windows/Linux, substitute Ctrl for Cmd.
+
+## Documentation Files
+
+- `docs/getting-started.md` — Onboarding, installation, first project
+- `docs/panels-and-grid.md` — Panel types, grid layout, dock
+- `docs/agents.md` — Agent support, launching, state detection
+- `docs/worktrees.md` — Git worktree orchestration
+- `docs/keybindings.md` — Keyboard shortcuts reference
+- `docs/actions.md` — Action system and command palette
+- `docs/context-injection.md` — CopyTree and context workflows
+- `docs/recipes.md` — Terminal recipes
+- `docs/themes.md` — Theme system and customization
+- `docs/browser-and-devpreview.md` — Embedded browser and dev preview
+- `docs/workflows.md` — Workflow engine and automation
+
+## When You Cannot Answer
+
+Suggest the user check the Canopy GitHub repository (https://github.com/canopyide/canopy) or file an issue.

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -1,0 +1,52 @@
+# Canopy Help Assistant
+
+You are a **Canopy help assistant**. Your role is to answer questions about using Canopy — a desktop application for orchestrating AI coding agents. You are NOT a general-purpose coding agent. Do not attempt to modify code, run shell commands, or perform tasks outside of helping users understand Canopy.
+
+## How to Answer
+
+1. **Read the `docs/` directory** in this workspace for accurate answers. These files cover all major Canopy features.
+2. **Stay grounded in the documentation.** Do not invent features, keybindings, or capabilities that are not described in the docs.
+3. **Be concise.** Users want quick, actionable answers — not essays.
+4. **Use specific keybindings and action names** when relevant. Always note that keybindings shown use macOS notation (Cmd) — on Windows/Linux, substitute Ctrl for Cmd.
+
+## Topics You Can Help With
+
+- Getting started and first-run setup
+- Panel grid and dock layout
+- Launching and configuring AI agents (Claude, Gemini, Codex, OpenCode, Cursor)
+- Worktree orchestration and monitoring
+- Keybindings and keyboard shortcuts
+- The action system and command palette
+- Context injection with CopyTree
+- Terminal recipes for repeatable setups
+- Themes and visual customization
+- Embedded browser and dev server preview
+- Workflow engine and automation
+
+## When You Cannot Answer
+
+If a question is outside the scope of the bundled documentation:
+
+- Suggest the user check the Canopy website or GitHub repository (https://github.com/canopyide/canopy)
+- Suggest filing a GitHub issue for feature requests or bug reports
+- Do not guess or fabricate answers
+
+## Documentation Index
+
+Refer to these files in `docs/` for answers:
+
+- `getting-started.md` — Onboarding, installation, first project
+- `panels-and-grid.md` — Panel types, grid layout, dock
+- `agents.md` — Agent support, launching, state detection
+- `worktrees.md` — Git worktree orchestration
+- `keybindings.md` — Keyboard shortcuts reference
+- `actions.md` — Action system and command palette
+- `context-injection.md` — CopyTree and context workflows
+- `recipes.md` — Terminal recipes
+- `themes.md` — Theme system and customization
+- `browser-and-devpreview.md` — Embedded browser and dev preview
+- `workflows.md` — Workflow engine and automation
+
+## Future Enhancement
+
+A docs API from the Canopy website will provide richer search capabilities in the future. For now, the bundled docs are the authoritative source.

--- a/help/GEMINI.md
+++ b/help/GEMINI.md
@@ -1,0 +1,48 @@
+# Canopy Help Assistant
+
+You are a **Canopy help assistant**. Your role is to answer questions about using Canopy — a desktop application for orchestrating AI coding agents. You are NOT a general-purpose coding agent. Do not attempt to modify code, run shell commands, or perform tasks outside of helping users understand Canopy.
+
+## How to Answer
+
+1. **Read the `docs/` directory** in this workspace for accurate answers. These files cover all major Canopy features.
+2. **Stay grounded in the documentation.** Do not invent features, keybindings, or capabilities that are not described in the docs.
+3. **Be concise.** Users want quick, actionable answers.
+4. **Use specific keybindings and action names** when relevant. Keybindings use macOS notation (Cmd) — on Windows/Linux, substitute Ctrl for Cmd.
+
+## Topics You Can Help With
+
+- Getting started and first-run setup
+- Panel grid and dock layout
+- Launching and configuring AI agents (Claude, Gemini, Codex, OpenCode, Cursor)
+- Worktree orchestration and monitoring
+- Keybindings and keyboard shortcuts
+- The action system and command palette
+- Context injection with CopyTree
+- Terminal recipes for repeatable setups
+- Themes and visual customization
+- Embedded browser and dev server preview
+- Workflow engine and automation
+
+## When You Cannot Answer
+
+If a question is outside the scope of the bundled documentation:
+
+- Suggest the user check the Canopy website or GitHub repository (https://github.com/canopyide/canopy)
+- Suggest filing a GitHub issue for feature requests or bug reports
+- Do not guess or fabricate answers
+
+## Documentation Files
+
+The `docs/` directory contains these reference files:
+
+- `getting-started.md` — Onboarding, installation, first project
+- `panels-and-grid.md` — Panel types, grid layout, dock
+- `agents.md` — Agent support, launching, state detection
+- `worktrees.md` — Git worktree orchestration
+- `keybindings.md` — Keyboard shortcuts reference
+- `actions.md` — Action system and command palette
+- `context-injection.md` — CopyTree and context workflows
+- `recipes.md` — Terminal recipes
+- `themes.md` — Theme system and customization
+- `browser-and-devpreview.md` — Embedded browser and dev preview
+- `workflows.md` — Workflow engine and automation

--- a/help/README.md
+++ b/help/README.md
@@ -1,0 +1,56 @@
+# Canopy Help System
+
+This directory is a self-contained workspace for running an AI coding agent as an interactive Canopy help assistant. Start any supported CLI agent here and it will automatically pick up the instruction files and documentation.
+
+## Quick Start
+
+```bash
+cd help
+
+# Use any of these:
+claude          # Claude Code
+gemini          # Gemini CLI
+codex           # Codex CLI
+```
+
+The agent will identify itself as a Canopy help assistant and answer questions about features, keybindings, workflows, and configuration using the bundled documentation.
+
+## Supported Agents
+
+| Agent       | Command  | Instruction File | Config                  |
+| ----------- | -------- | ---------------- | ----------------------- |
+| Claude Code | `claude` | `CLAUDE.md`      | `.claude/settings.json` |
+| Gemini CLI  | `gemini` | `GEMINI.md`      | `.gemini/settings.json` |
+| Codex CLI   | `codex`  | `AGENTS.md`      | —                       |
+
+## Documentation
+
+The `docs/` directory contains user-facing documentation covering all major Canopy features:
+
+| File                        | Topic                                     |
+| --------------------------- | ----------------------------------------- |
+| `getting-started.md`        | Onboarding, installation, first project   |
+| `panels-and-grid.md`        | Panel types, grid layout, dock            |
+| `agents.md`                 | Agent support, launching, state detection |
+| `worktrees.md`              | Git worktree orchestration                |
+| `keybindings.md`            | Keyboard shortcuts reference              |
+| `actions.md`                | Action system and command palette         |
+| `context-injection.md`      | CopyTree and context workflows            |
+| `recipes.md`                | Terminal recipes                          |
+| `themes.md`                 | Theme system and customization            |
+| `browser-and-devpreview.md` | Embedded browser and dev preview          |
+| `workflows.md`              | Workflow engine and automation            |
+
+## How It Works
+
+Each agent CLI looks for instruction files in its working directory:
+
+- **Claude Code** reads `CLAUDE.md` and `.claude/settings.json`
+- **Gemini CLI** reads `GEMINI.md` and `.gemini/settings.json`
+- **Codex CLI** reads `AGENTS.md`
+
+The instruction files tell the agent to act as a help assistant rather than a general-purpose coding agent. Permission configs restrict agents to read-only access — they can read the documentation but cannot modify files or run commands.
+
+## Future
+
+A docs API from the Canopy website will provide richer search capabilities (see canopyide/canopy-website#3). When available, MCP server configuration can be added to the agent settings files for live documentation search.

--- a/help/docs/actions.md
+++ b/help/docs/actions.md
@@ -1,0 +1,54 @@
+# Actions
+
+## Overview
+
+Every operation in Canopy is an **action** — a typed, named command that can be triggered from multiple sources: keyboard shortcuts, menus, the command palette, context menus, or programmatically by the Canopy Assistant.
+
+## The Command Palette
+
+Press **Cmd+Shift+P** to open the command palette. This gives you searchable access to every action in Canopy. Type to filter, then press Enter to execute.
+
+The command palette is the fastest way to discover features you might not know about.
+
+## Action Categories
+
+Actions are organized into categories:
+
+| Category        | Examples                                                   |
+| --------------- | ---------------------------------------------------------- |
+| **Terminal**    | Close, restart, maximize, inject context, stash input      |
+| **Agent**       | Launch agents, focus waiting/working agents, bulk commands |
+| **Panel**       | Create panels, toggle dock, move in grid                   |
+| **Worktree**    | Switch worktrees, open palette, copy tree                  |
+| **Git**         | Stage all, commit, push                                    |
+| **Navigation**  | Quick switcher, toggle sidebar, focus regions              |
+| **App**         | Settings, zoom, quit                                       |
+| **Preferences** | Theme selection, keymap configuration                      |
+| **Browser**     | Portal tab management                                      |
+| **Notes**       | Open notes palette                                         |
+| **Voice**       | Toggle voice input                                         |
+
+## Action Sources
+
+Each action tracks where it was triggered from:
+
+- **User** — Direct invocation from the command palette
+- **Keybinding** — Triggered via keyboard shortcut
+- **Menu** — Triggered from the application menu
+- **Context Menu** — Triggered from a right-click menu
+- **Agent** — Triggered by the Canopy Assistant
+
+## Safety Levels
+
+Actions have safety classifications:
+
+- **Safe** — Can be executed without confirmation (most actions)
+- **Confirm** — Requires confirmation before executing (destructive operations like ending all sessions)
+- **Restricted** — Limited to specific contexts or requires elevated permissions
+
+## Discovering Actions
+
+1. **Command Palette** (Cmd+Shift+P) — Browse and search all actions
+2. **Keyboard Shortcuts** (Cmd+K Cmd+S) — See all keybinding assignments
+3. **Context Menus** — Right-click panels or worktree cards for contextual actions
+4. **Application Menu** — Standard menu bar with categorized actions

--- a/help/docs/agents.md
+++ b/help/docs/agents.md
@@ -1,0 +1,74 @@
+# Agents
+
+## Overview
+
+Canopy orchestrates external AI coding agent CLIs. Agents run in real terminal panels — Canopy wraps them with state intelligence, context injection, and multi-agent coordination.
+
+## Supported Agents
+
+| Agent        | Command        | Shortcut  | Strengths                                |
+| ------------ | -------------- | --------- | ---------------------------------------- |
+| **Claude**   | `claude`       | Cmd+Alt+C | Refactoring, debugging, code review      |
+| **Gemini**   | `gemini`       | Cmd+Alt+G | Architecture, exploration, system design |
+| **Codex**    | `codex`        | Cmd+Alt+X | Frontend, testing, methodical execution  |
+| **OpenCode** | `opencode`     | Cmd+Alt+O | Provider-agnostic, open source           |
+| **Cursor**   | `cursor-agent` | Cmd+Alt+U | General-purpose agentic CLI              |
+
+## Launching Agents
+
+There are several ways to launch an agent:
+
+1. **Agent Palette** (Cmd+Shift+A) — Select from all available agents
+2. **Direct shortcut** — Use the agent-specific keyboard shortcut
+3. **Panel Palette** (Cmd+N) — Choose "Agent" panel type
+4. **Context menu** — Right-click a worktree card to launch an agent in that worktree
+
+Agents launch in the active worktree by default.
+
+## Agent State Detection
+
+Canopy monitors agent terminal output to detect the agent's current state:
+
+| State         | Meaning                                                       |
+| ------------- | ------------------------------------------------------------- |
+| **Idle**      | Agent is at its prompt, waiting for input                     |
+| **Working**   | Agent is actively processing (generating code, running tools) |
+| **Waiting**   | Agent is waiting for user input or confirmation               |
+| **Completed** | Agent has finished a task                                     |
+
+State detection drives several features:
+
+- The panel header shows the current state with a colored indicator
+- **Cmd+Alt+/** jumps to the next waiting agent (needs your attention)
+- **Cmd+Alt+.** jumps to the next working agent
+- Completion notifications alert you when an agent finishes
+
+## Agent Navigation
+
+- **Cmd+Alt+K** — Cycle to the next agent panel
+- **Cmd+Alt+J** — Cycle to the previous agent panel
+- **Cmd+Alt+/** — Jump to the next waiting agent
+- **Cmd+Alt+.** — Jump to the next working agent
+- **Cmd+Shift+/** — Jump to the next waiting dock agent
+
+## Model Selection
+
+Some agents support model selection at launch time:
+
+- **Claude**: Sonnet 4.6, Opus 4.6, Haiku 4.5
+- **Gemini**: Gemini 2.5 Pro, Gemini 2.5 Flash
+- **Codex**: GPT-5.4, o3
+
+The model can be selected in the agent palette before launching.
+
+## Session Management
+
+- Agents can be **restarted** (Cmd+K Cmd+R restarts all)
+- Agent sessions can be **resumed** if the agent CLI supports it (Claude, Gemini, Codex)
+- Panels can be **hibernated** when switching projects and restored later
+
+## Bulk Operations
+
+- **Cmd+Shift+B** — Open bulk command center to send commands to multiple agents
+- **Cmd+K Cmd+E** — End all sessions in the active worktree
+- **Cmd+K Cmd+T** — Restart all sessions in the active worktree

--- a/help/docs/browser-and-devpreview.md
+++ b/help/docs/browser-and-devpreview.md
@@ -1,0 +1,51 @@
+# Browser and Dev Preview
+
+## Embedded Browser
+
+Canopy includes an embedded browser panel for viewing web content alongside your agent terminals. This is useful for:
+
+- Previewing localhost development servers
+- Viewing documentation while working
+- Checking agent-generated web output
+- Debugging frontend applications with the console visible
+
+### Opening a Browser Panel
+
+Open the panel palette (Cmd+N) and select "Browser". Enter a URL to navigate to.
+
+### Portal
+
+The **Portal** is a tabbed dock for web-based interfaces. Toggle it with **Cmd+\\**.
+
+Portal tab shortcuts (when portal is focused):
+
+- **Cmd+T** — New tab
+- **Cmd+W** — Close tab
+- **Ctrl+Tab** / **Ctrl+Shift+Tab** — Next/previous tab
+
+The portal is ideal for keeping web-based AI agent UIs (like ChatGPT or Claude.ai) open alongside your terminal-based agents.
+
+## Dev Server Preview
+
+The Dev Preview panel auto-detects and manages development servers running in your worktrees.
+
+### How It Works
+
+1. Canopy monitors your worktrees for running dev servers (Vite, Next.js, Webpack, etc.)
+2. When a dev server is detected on a localhost port, it appears in the Dev Preview panel
+3. The preview shows a live, embedded view of your application
+4. Changes to your code trigger hot-reloads visible in the preview
+
+### Opening a Dev Preview
+
+Open the panel palette (Cmd+N) and select "Dev Preview". It will auto-detect available dev servers in the current worktree.
+
+### Dev Server Management
+
+Canopy tracks dev servers per worktree. When you switch worktrees, the Dev Preview updates to show servers associated with that worktree. Servers from inactive worktrees continue running in the background.
+
+## Tips
+
+- Use the browser panel for documentation and the dev preview for your app — they serve different purposes
+- The dev preview is read-only; it shows your app but you can't edit code from it (use your editor for that)
+- Multiple dev servers can run simultaneously across different worktrees

--- a/help/docs/context-injection.md
+++ b/help/docs/context-injection.md
@@ -1,0 +1,43 @@
+# Context Injection
+
+## Overview
+
+Context injection is how you feed your AI agents the right codebase information. Canopy's CopyTree service generates structured context summaries that you can paste into agent prompts, giving them a clear picture of the relevant code.
+
+## What is CopyTree?
+
+CopyTree generates a text representation of your project's file structure and contents, optimized for AI agent consumption. It includes:
+
+- Directory tree structure
+- File contents (respecting .gitignore and size limits)
+- Focused selections when you want to highlight specific files or directories
+
+## Using Context Injection
+
+### Quick Inject
+
+Press **Cmd+Shift+I** to inject context into the focused terminal. This pastes a CopyTree summary directly into the agent's input.
+
+### Copy Tree Context
+
+Press **Cmd+Shift+C** to copy a tree context summary for the active worktree to the clipboard. You can then paste it into any agent manually.
+
+### Send to Agent
+
+Press **Cmd+Shift+E** to send a selection from one terminal to another. This is useful for forwarding error messages or code snippets between agents.
+
+## Context Workflow
+
+A typical context injection workflow:
+
+1. **Identify the relevant code** — Know which files or directories the agent needs to see
+2. **Generate context** — Use Cmd+Shift+I or Cmd+Shift+C to create the summary
+3. **Inject into agent** — The context is pasted into the agent's terminal input
+4. **Ask your question** — The agent now has the codebase context to give an informed answer
+
+## Tips
+
+- Context injection works best when you focus it on the relevant subset of your codebase rather than the entire project
+- Agents that support context injection: Claude, Gemini, Codex, OpenCode, Cursor (all built-in agents)
+- The generated context respects .gitignore rules to avoid including build artifacts, dependencies, or sensitive files
+- For large codebases, consider using worktree-scoped context (Cmd+Shift+C) to limit the scope

--- a/help/docs/getting-started.md
+++ b/help/docs/getting-started.md
@@ -1,0 +1,63 @@
+# Getting Started
+
+## What is Canopy?
+
+Canopy is a desktop application for orchestrating AI coding agents. Think of it as mission control for your AI-assisted development workflow. Agents like Claude, Gemini, and Codex run in real terminals inside Canopy, and you manage them through a panel grid with state intelligence, context injection, and automation.
+
+Canopy is **not** a code editor (use VS Code for that) and **not** a chat UI (agents run in actual terminals). It's the orchestration layer where you direct work, monitor progress, and intervene when agents need help.
+
+## Installation
+
+Download Canopy from the [GitHub releases page](https://github.com/canopyide/canopy/releases) for your platform (macOS, Windows, or Linux).
+
+## First Launch
+
+When you first open Canopy:
+
+1. **Project Setup** — Canopy will prompt you to open a project directory. This should be a git repository where you want to run agents.
+2. **Agent Detection** — Canopy checks which agent CLIs are installed on your system (Claude, Gemini, Codex, OpenCode, Cursor). Install any you want to use before starting.
+3. **Panel Grid** — You'll see the main panel grid where your terminals and agents live.
+
+## Installing Agents
+
+Canopy orchestrates external CLI agents. You need to install them separately:
+
+| Agent        | Install Command                                | Auth                   |
+| ------------ | ---------------------------------------------- | ---------------------- |
+| Claude Code  | `npm install -g @anthropic-ai/claude-code`     | `claude auth login`    |
+| Gemini CLI   | `npm install -g @google/gemini-cli`            | `gemini auth login`    |
+| Codex CLI    | `npm install -g @openai/codex`                 | `codex auth login`     |
+| OpenCode     | `npm install -g opencode-ai`                   | `/connect` in OpenCode |
+| Cursor Agent | `curl https://cursor.com/install -fsS \| bash` | `cursor-agent login`   |
+
+After installing an agent, restart Canopy to update the PATH.
+
+## Launching Your First Agent
+
+1. Press **Cmd+Shift+A** to open the agent palette
+2. Select an agent (e.g., Claude)
+3. The agent launches in a new panel in the grid
+4. Type your prompt and press Enter
+
+You can also use direct shortcuts:
+
+- **Cmd+Alt+C** — Launch Claude
+- **Cmd+Alt+G** — Launch Gemini
+- **Cmd+Alt+X** — Launch Codex
+- **Cmd+Alt+O** — Launch OpenCode
+- **Cmd+Alt+U** — Launch Cursor
+
+## Key Concepts
+
+- **Panels** — The visual units in the grid. Each panel runs a terminal, agent, browser, notes editor, or dev preview.
+- **Worktrees** — Git worktrees let you partition work across branches. Canopy monitors each worktree independently.
+- **Context Injection** — Feed your agents the right codebase context using CopyTree.
+- **Actions** — Every operation in Canopy is an action that can be triggered via keybinding, menu, or command palette.
+- **Dock** — A collapsed area at the bottom for panels you want running but not occupying grid space.
+
+## Platform Notes
+
+Canopy runs on macOS, Windows, and Linux. Keybindings shown in this documentation use macOS notation:
+
+- **Cmd** on macOS = **Ctrl** on Windows/Linux
+- **Alt/Option** is the same across platforms

--- a/help/docs/keybindings.md
+++ b/help/docs/keybindings.md
@@ -1,0 +1,145 @@
+# Keybindings
+
+All keybindings use macOS notation. On Windows/Linux, substitute **Ctrl** for **Cmd**.
+
+## Navigation
+
+| Shortcut    | Action                |
+| ----------- | --------------------- |
+| Cmd+P       | Quick Switcher        |
+| Cmd+Shift+P | Command palette       |
+| Cmd+B       | Toggle sidebar        |
+| Cmd+F       | Find in focused panel |
+| F6          | Focus next region     |
+| Shift+F6    | Focus previous region |
+
+## Panels
+
+| Shortcut     | Action                           |
+| ------------ | -------------------------------- |
+| Cmd+N        | Panel palette (create any panel) |
+| Cmd+T        | Duplicate focused panel          |
+| Cmd+Alt+T    | New terminal                     |
+| Cmd+W        | Close focused panel              |
+| Cmd+K Cmd+W  | Close all panels                 |
+| Cmd+Shift+T  | Reopen last closed panel         |
+| Ctrl+Shift+F | Toggle maximize                  |
+| Shift+F10    | Panel context menu               |
+
+## Panel Focus
+
+| Shortcut            | Action                   |
+| ------------------- | ------------------------ |
+| Cmd+1 through Cmd+9 | Focus panel by index     |
+| Ctrl+Tab            | Focus next panel         |
+| Ctrl+Shift+Tab      | Focus previous panel     |
+| Cmd+Alt+Arrow       | Focus panel in direction |
+| Cmd+Shift+]         | Next tab                 |
+| Cmd+Shift+[         | Previous tab             |
+
+## Panel Movement
+
+| Shortcut            | Action               |
+| ------------------- | -------------------- |
+| Cmd+Shift+Alt+Arrow | Move panel in grid   |
+| Cmd+Shift+Alt+D     | Move to dock         |
+| Cmd+Shift+Alt+G     | Move to grid         |
+| Cmd+Alt+M           | Toggle dock/grid     |
+| Cmd+Alt+Shift+M     | Toggle all dock/grid |
+| Cmd+Alt+D           | Focus dock panel     |
+
+## Agents
+
+| Shortcut    | Action                          |
+| ----------- | ------------------------------- |
+| Cmd+Shift+A | Agent palette                   |
+| Cmd+Alt+C   | Launch Claude                   |
+| Cmd+Alt+G   | Launch Gemini                   |
+| Cmd+Alt+X   | Launch Codex                    |
+| Cmd+Alt+O   | Launch OpenCode                 |
+| Cmd+Alt+U   | Launch Cursor                   |
+| Cmd+Alt+N   | Terminal in current worktree    |
+| Cmd+Alt+K   | Next agent panel                |
+| Cmd+Alt+J   | Previous agent panel            |
+| Cmd+Alt+/   | Jump to next waiting agent      |
+| Cmd+Alt+.   | Jump to next working agent      |
+| Cmd+Shift+/ | Jump to next waiting dock agent |
+
+## Terminal
+
+| Shortcut    | Action                             |
+| ----------- | ---------------------------------- |
+| Cmd+K Cmd+K | End all terminals                  |
+| Cmd+K Cmd+R | Restart all terminals              |
+| Cmd+Shift+W | Toggle watch on terminal           |
+| Cmd+Alt+L   | Scroll to last activity            |
+| Cmd+Shift+I | Inject context                     |
+| Cmd+Shift+E | Send selection to another terminal |
+| Cmd+Shift+B | Bulk command center                |
+| Cmd+Shift+S | Stash current input                |
+| Cmd+Shift+X | Restore stashed input              |
+
+## Worktrees
+
+| Shortcut                    | Action                      |
+| --------------------------- | --------------------------- |
+| Cmd+Alt+1 through Cmd+Alt+9 | Switch to worktree by index |
+| Cmd+Alt+]                   | Next worktree               |
+| Cmd+Alt+[                   | Previous worktree           |
+| Cmd+K W                     | Worktree palette            |
+| Cmd+Shift+O                 | Toggle worktrees overview   |
+| Cmd+Shift+C                 | Copy tree context           |
+
+## Worktree Sessions
+
+| Shortcut    | Action                   |
+| ----------- | ------------------------ |
+| Cmd+K Cmd+M | Dock all sessions        |
+| Cmd+K Cmd+X | Maximize all sessions    |
+| Cmd+K Cmd+T | Restart all sessions     |
+| Cmd+K Cmd+E | End all sessions         |
+| Cmd+K Cmd+D | Close completed sessions |
+| Cmd+K Cmd+B | Trash all sessions       |
+| Cmd+K Cmd+N | Reset all renderers      |
+
+## Git
+
+| Shortcut    | Action                |
+| ----------- | --------------------- |
+| Cmd+K Cmd+A | Stage all changes     |
+| Cmd+K Cmd+C | Commit staged changes |
+| Cmd+K Cmd+P | Push to remote        |
+
+## Other
+
+| Shortcut              | Action                       |
+| --------------------- | ---------------------------- |
+| Cmd+Shift+D           | Toggle diagnostics dock      |
+| Cmd+\                 | Toggle portal panel          |
+| Cmd+Shift+N           | Notes palette                |
+| Cmd+Alt+P             | Project switcher             |
+| Cmd+K Cmd+S           | Keyboard shortcuts reference |
+| Cmd+/                 | Keyboard shortcuts (alt)     |
+| Cmd+,                 | Settings                     |
+| Cmd+Shift+V           | Toggle voice input           |
+| Cmd+= / Cmd+- / Cmd+0 | Zoom in / out / reset        |
+| Cmd+Alt+Z             | Undo layout                  |
+| Cmd+Alt+Shift+Z       | Redo layout                  |
+
+## Portal (when focused)
+
+| Shortcut       | Action       |
+| -------------- | ------------ |
+| Cmd+T          | New tab      |
+| Cmd+W          | Close tab    |
+| Ctrl+Tab       | Next tab     |
+| Ctrl+Shift+Tab | Previous tab |
+
+## Keymap Presets
+
+Canopy supports two keymap presets:
+
+- **Standard** — Default keybindings (arrow keys for navigation)
+- **Vim** — Vim-style navigation (hjkl) in the worktree list
+
+You can switch presets and customize individual bindings in Settings (Cmd+,).

--- a/help/docs/panels-and-grid.md
+++ b/help/docs/panels-and-grid.md
@@ -1,0 +1,67 @@
+# Panels and Grid
+
+## Overview
+
+The panel grid is Canopy's primary workspace. It displays multiple panels in a flexible grid layout, with an optional dock at the bottom for minimized panels.
+
+## Panel Types
+
+Canopy has five built-in panel types:
+
+| Type            | Description                                                  | Has Terminal |
+| --------------- | ------------------------------------------------------------ | ------------ |
+| **Terminal**    | Standard shell terminal                                      | Yes          |
+| **Agent**       | AI agent running in a terminal (Claude, Gemini, Codex, etc.) | Yes          |
+| **Browser**     | Embedded web browser for viewing URLs                        | No           |
+| **Notes**       | Markdown note editor for annotations alongside agent work    | No           |
+| **Dev Preview** | Dev server preview with auto-detected localhost URLs         | No           |
+
+## Creating Panels
+
+- **Cmd+N** — Open the panel palette to create any panel type
+- **Cmd+Shift+A** — Open the agent palette to launch a specific agent
+- **Cmd+Alt+T** — Open a plain terminal
+- **Cmd+T** — Duplicate the focused panel
+
+## Grid Layout
+
+Panels arrange in a responsive grid. Canopy automatically adjusts the grid as you add or remove panels.
+
+- **Cmd+Shift+Alt+Arrow** — Move a panel within the grid (left/right/up/down)
+- **Ctrl+Shift+F** — Toggle maximize on the focused panel (fills the entire grid)
+- **Cmd+Alt+Z** — Undo the last layout change
+- **Cmd+Alt+Shift+Z** — Redo a layout change
+
+## Panel Focus and Navigation
+
+- **Cmd+1** through **Cmd+9** — Focus panel by index
+- **Ctrl+Tab** / **Ctrl+Shift+Tab** — Cycle through panels
+- **Cmd+Alt+Arrow** — Focus the panel in that direction (up/down/left/right)
+- **Cmd+P** — Quick Switcher to find any panel by name
+
+## The Dock
+
+The dock is a collapsed strip at the bottom of the window. Panels in the dock continue running but don't take up grid space. This is useful for agents you want to monitor without dedicating screen real estate.
+
+- **Cmd+Alt+M** — Toggle the focused panel between grid and dock
+- **Cmd+Alt+D** — Focus the active dock panel
+- **Cmd+Shift+Alt+D** — Move focused panel to dock
+- **Cmd+Shift+Alt+G** — Move focused panel to grid
+- **Cmd+Alt+Shift+M** — Toggle all panels between grid and dock
+
+## Closing Panels
+
+- **Cmd+W** — Close the focused panel
+- **Cmd+K Cmd+W** — Close all panels
+- **Cmd+Shift+T** — Reopen the last closed panel
+
+## Panel Tabs
+
+When multiple panels share a grid cell, they display as tabs:
+
+- **Cmd+Shift+]** — Next tab
+- **Cmd+Shift+[** — Previous tab
+
+## Panel Context Menu
+
+Right-click a panel header or press **Shift+F10** to access panel-specific actions like restart, duplicate, move to dock, and close.

--- a/help/docs/recipes.md
+++ b/help/docs/recipes.md
@@ -1,0 +1,47 @@
+# Terminal Recipes
+
+## Overview
+
+Terminal recipes are saved panel configurations that let you launch repeatable multi-agent setups with a single action. Instead of manually opening panels and configuring agents each time, you define a recipe once and replay it whenever needed.
+
+## What Recipes Solve
+
+When working on a complex task, you might want:
+
+- A Claude agent for the main implementation
+- A Gemini agent for architecture review
+- A terminal running your test suite in watch mode
+- A dev preview showing your app
+
+Setting this up manually every time is tedious. A recipe captures this entire setup and restores it instantly.
+
+## Using Recipes
+
+Recipes are accessible from the command palette (Cmd+Shift+P) and the terminal recipe interface.
+
+### Creating a Recipe
+
+1. Set up your panels the way you want them — agents, terminals, browsers, in whatever layout works for your workflow
+2. Save the current layout as a recipe
+3. Give it a descriptive name (e.g., "Frontend dev setup", "PR review workflow")
+
+### Launching a Recipe
+
+1. Open the command palette (Cmd+Shift+P) or recipe picker
+2. Select your saved recipe
+3. Canopy recreates the full panel setup
+
+## Recipe Contents
+
+A recipe captures:
+
+- Which panels to create (agent type, terminal, browser, etc.)
+- Agent configurations (which agent CLI, which model)
+- Panel positions in the grid
+- The worktree context
+
+## Tips
+
+- Create recipes for your most common workflows to save setup time
+- Recipes work well with worktree switching — launch a recipe in a specific worktree
+- You can share recipe configurations with your team

--- a/help/docs/themes.md
+++ b/help/docs/themes.md
@@ -1,0 +1,65 @@
+# Themes
+
+## Overview
+
+Canopy has a rich theme system designed for long coding sessions. Themes affect the entire application — surfaces, text, accents, terminal colors, and syntax highlighting — providing a cohesive visual experience.
+
+## Built-In Themes
+
+Canopy ships with 14 built-in themes, named after natural places:
+
+### Dark Themes
+
+| Theme          | Character                    |
+| -------------- | ---------------------------- |
+| **Daintree**   | Deep forest greens           |
+| **Arashiyama** | Bamboo-inspired warm tones   |
+| **Fiordland**  | Cool, misty blues            |
+| **Galapagos**  | Ocean-inspired deep teals    |
+| **Highlands**  | Earthy, muted tones          |
+| **Namib**      | Desert-inspired warm palette |
+| **Redwoods**   | Rich, warm browns and reds   |
+
+### Light Themes
+
+| Theme              | Character               |
+| ------------------ | ----------------------- |
+| **Bondi**          | Bright coastal blues    |
+| **Table Mountain** | Clean, airy neutrals    |
+| **Atacama**        | Warm desert light       |
+| **Bali**           | Tropical green accents  |
+| **Hokkaido**       | Crisp, cool whites      |
+| **Serengeti**      | Warm savanna tones      |
+| **Svalbard**       | Arctic whites and blues |
+
+## Changing Themes
+
+Open Settings (Cmd+,) and navigate to the theme section. You can:
+
+- Browse all themes with previews
+- Switch between dark and light themes
+- Use the random theme cycler to discover themes you haven't tried
+
+## Theme Structure
+
+Each theme defines:
+
+- **Surfaces** — Background colors for canvas, sidebar, toolbar, panels, grid, inputs
+- **Text and borders** — Foreground colors at different emphasis levels
+- **Accent colors** — Primary brand color used for selections, links, focus rings
+- **Status colors** — Success, warning, error, info indicators
+- **Activity colors** — Agent state indicators (working, waiting, idle, completed)
+- **Terminal colors** — Full 16-color ANSI palette for terminal output
+- **Syntax colors** — Code highlighting in the file viewer
+
+## Custom Themes
+
+Canopy supports custom themes that follow the same palette structure as built-in themes. Custom themes can override any semantic token or component-specific CSS variable.
+
+## Accessibility
+
+Themes are designed with accessibility in mind:
+
+- Both dark and light variants are available for different lighting conditions and preferences
+- Color contrast ratios are maintained across themes
+- The theme system supports high-contrast overrides

--- a/help/docs/workflows.md
+++ b/help/docs/workflows.md
@@ -1,0 +1,61 @@
+# Workflows
+
+## Overview
+
+The workflow engine enables reactive automation in Canopy. Workflows are event-driven sequences that respond to conditions in your development environment — agent state changes, file modifications, build results — and execute actions automatically.
+
+## What Workflows Solve
+
+Without workflows, you manually monitor agents and react when things happen:
+
+- An agent finishes → you check its output
+- A test fails → you restart the agent with different context
+- A build succeeds → you push the changes
+
+Workflows automate these reactions so you can focus on higher-level orchestration.
+
+## Workflow Concepts
+
+### Triggers
+
+Workflows start with a trigger — an event that initiates the workflow:
+
+- Agent state changes (working → completed, idle → error)
+- File system events in a worktree
+- Timer-based intervals
+- Manual invocation
+
+### Actions
+
+Each workflow step executes an action from Canopy's action system. Any action available in the command palette can be used in a workflow.
+
+### Conditions
+
+Steps can have conditions that determine whether they execute, allowing branching logic based on agent state, file existence, or other criteria.
+
+## Built-In Workflows
+
+Canopy includes several pre-built workflow templates:
+
+- **Code Quality Check** — Runs quality checks on agent output
+- **Standard PR Review** — Structured review workflow for pull requests
+- **Worktree Snapshot** — Captures the state of a worktree at a point in time
+
+## Automation Levels
+
+Canopy features trend toward automation:
+
+| Level          | Description                 | Example                                  |
+| -------------- | --------------------------- | ---------------------------------------- |
+| **Manual**     | You do everything           | Opening terminals, typing commands       |
+| **Assisted**   | Canopy detects, you act     | State notifications, waiting indicators  |
+| **Reactive**   | Canopy detects and responds | Auto-inject context when agent asks      |
+| **Autonomous** | Canopy handles it           | Workflow chains run without intervention |
+
+Workflows operate at the Reactive and Autonomous levels — reducing the manual monitoring and intervention that slows down multi-agent development.
+
+## Tips
+
+- Start simple: automate your most repetitive reaction first
+- Workflows compose with recipes — use a recipe to set up panels, then workflows to automate the interactions
+- The workflow engine uses Canopy's action system, so any new action automatically becomes available in workflows

--- a/help/docs/worktrees.md
+++ b/help/docs/worktrees.md
@@ -1,0 +1,64 @@
+# Worktrees
+
+## Overview
+
+Canopy uses git worktrees to let you partition work across multiple branches simultaneously. Each worktree is an independent working copy of your repository with its own branch, and Canopy monitors all of them from a single window.
+
+## What Are Git Worktrees?
+
+A git worktree lets you check out multiple branches of a repository at the same time, each in its own directory. Instead of stashing changes and switching branches, you can have `feature-a`, `feature-b`, and `main` all checked out simultaneously.
+
+Canopy adds orchestration on top: monitoring file changes, tracking agent activity, and managing panels per worktree.
+
+## The Worktree Sidebar
+
+The sidebar (toggle with **Cmd+B**) shows all worktrees for the current project. Each worktree card displays:
+
+- Branch name
+- File change summary (modified, added, deleted)
+- Active agent sessions and their states
+- Sync status with remote
+
+## Switching Worktrees
+
+- **Cmd+Alt+1** through **Cmd+Alt+9** — Switch to worktree by index
+- **Cmd+Alt+]** / **Cmd+Alt+[** — Next/previous worktree
+- **Cmd+K W** — Open the worktree palette for search
+- **Cmd+Shift+O** — Toggle the worktrees overview
+
+When you switch worktrees, the panel grid updates to show panels associated with that worktree. Panels from other worktrees continue running in the background.
+
+## Worktree Operations
+
+From the worktree sidebar or overview:
+
+- **Launch agents** in a specific worktree via right-click context menu
+- **Open in editor** — Press **E** on a selected worktree card to open it in your code editor
+- **Copy tree context** — **Cmd+Shift+C** generates a CopyTree context summary for the active worktree
+
+## Worktree Sessions
+
+Each worktree tracks its own set of panel sessions. Bulk session operations apply to the active worktree:
+
+| Shortcut    | Action                   |
+| ----------- | ------------------------ |
+| Cmd+K Cmd+M | Dock all sessions        |
+| Cmd+K Cmd+X | Maximize all sessions    |
+| Cmd+K Cmd+T | Restart all sessions     |
+| Cmd+K Cmd+E | End all sessions         |
+| Cmd+K Cmd+D | Close completed sessions |
+| Cmd+K Cmd+B | Trash all sessions       |
+
+## Git Operations
+
+Canopy provides lightweight git operations per worktree (not a full git GUI — use your editor for complex git work):
+
+| Shortcut    | Action                |
+| ----------- | --------------------- |
+| Cmd+K Cmd+A | Stage all changes     |
+| Cmd+K Cmd+C | Commit staged changes |
+| Cmd+K Cmd+P | Push to remote        |
+
+## Project Switching
+
+Canopy supports multiple projects. Press **Cmd+Alt+P** to open the project switcher. Each project has its own set of worktrees and panel sessions.


### PR DESCRIPTION
## Summary

- Create `help/` directory as a self-contained workspace for running CLI agents (Claude Code, Gemini CLI, Codex CLI) as interactive Canopy help assistants
- Add 3 agent instruction files (CLAUDE.md, GEMINI.md, AGENTS.md) with help-assistant personas that override general coding agent behavior
- Add agent config files: `.claude/settings.json` with read-only permission allowlist (no `dangerouslySkipPermissions`), `.gemini/settings.json` with `toolsAllowlist`
- Add 11 user-facing docs covering all 8 Core Pillars: panels, agents, worktrees, keybindings, actions, context injection, recipes, themes, browser/devpreview, workflows

## Test plan

- [ ] Verify `npm run check` passes (typecheck + lint + format) — no source code changes, only new markdown/JSON files
- [ ] Run `cd help && claude` and confirm it picks up the help assistant persona and read-only permissions
- [ ] Verify no `dangerouslySkipPermissions` in `.claude/settings.json`
- [ ] Verify AGENTS.md starts with role override heading
- [ ] Spot-check keybindings in `help/docs/keybindings.md` against `src/services/defaultKeybindings.ts`

Closes #4341

🤖 Generated with [Claude Code](https://claude.com/claude-code)