### PR TITLE
fix(menu): show 'About Canopy' instead of 'About canopy-app' on macOS

### DIFF
--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -25,7 +25,7 @@ fixPath();
 // each test run gets its own isolated data directory.
 const hasExplicitUserDataDir = process.argv.some((a) => a.startsWith("--user-data-dir"));
 if (!app.isPackaged && !hasExplicitUserDataDir) {
-  app.setPath("userData", path.join(app.getPath("appData"), `${app.name}-dev`));
+  app.setPath("userData", path.join(app.getPath("appData"), "canopy-app-dev"));
 }
 
 // GPU crash fallback: disable hardware acceleration before app.whenReady()

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "canopy-app",
+  "productName": "Canopy",
   "version": "0.5.3",
   "description": "Canopy IDE - An Electron-based development environment",
   "author": {


### PR DESCRIPTION
## Summary

- The About menu item in the macOS app menu was showing "About canopy-app" (the internal package name) instead of "About Canopy"
- Fixed by adding `productName: "Canopy"` to the top level of `package.json` — Electron reads this field to set `app.name`, which drives the menu label
- Hardcoded the dev userData path in `environment.ts` to preserve the existing dev data directory after the name change

Resolves #4434

## Changes

- `package.json` — added top-level `productName: "Canopy"`
- `electron/setup/environment.ts` — hardcode dev userData path to `canopy-app` to avoid breaking existing dev environments

## Testing

Unit tests pass. Fix verified by confirming Electron's `app.name` is now derived from `productName` rather than the `name` field, which controls the macOS menu label.