### PR TITLE
fix(pty): replace wmic with PowerShell Get-CimInstance for process start time on Windows

### DIFF
--- a/electron/services/TrashedPidTracker.ts
+++ b/electron/services/TrashedPidTracker.ts
@@ -16,16 +16,26 @@ function getProcessStartTime(pid: number): string | null {
   try {
     if (process.platform === "win32") {
       const out = execFileSync(
-        "wmic",
-        ["process", "where", `ProcessId=${pid}`, "get", "CreationDate", "/value"],
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-NonInteractive",
+          "-NoLogo",
+          "-Command",
+          "$ErrorActionPreference = 'SilentlyContinue'; " +
+            "$p = Get-CimInstance Win32_Process -Filter 'ProcessId=" +
+            pid +
+            "'; if ($p -and $p.CreationDate) { $p.CreationDate.ToString('o') }",
+        ],
         {
           windowsHide: true,
-          stdio: ["pipe", "pipe", "pipe"],
+          encoding: "utf8",
           timeout: 3000,
         }
-      ).toString("utf8");
-      const match = out.match(/CreationDate=(\S+)/);
-      return match?.[1] ?? null;
+      )
+        .replace(/^\uFEFF/, "")
+        .trim();
+      return out || null;
     }
     const out = execFileSync("ps", ["-p", String(pid), "-o", "lstart="], {
       stdio: ["pipe", "pipe", "pipe"],

--- a/electron/services/__tests__/TrashedPidTracker.test.ts
+++ b/electron/services/__tests__/TrashedPidTracker.test.ts
@@ -9,14 +9,14 @@ vi.mock("electron", () => ({
 
 const MOCK_START_TIME =
   process.platform === "win32"
-    ? "CreationDate=20260101000000.000000+000\n"
+    ? "2026-01-01T00:00:00.0000000+00:00\n"
     : "Thu Jan  1 00:00:00 2026\n";
 
 const MOCK_START_TIME_PARSED =
-  process.platform === "win32" ? "20260101000000.000000+000" : "Thu Jan  1 00:00:00 2026";
+  process.platform === "win32" ? "2026-01-01T00:00:00.0000000+00:00" : "Thu Jan  1 00:00:00 2026";
 
 vi.mock("node:child_process", () => ({
-  execFileSync: vi.fn(() => Buffer.from(MOCK_START_TIME)),
+  execFileSync: vi.fn(() => MOCK_START_TIME),
   spawnSync: vi.fn(() => ({ status: 0 })),
 }));
 


### PR DESCRIPTION
## Summary

- `wmic` was removed from Windows 11, causing `TrashedPidTracker.getProcessStartTime()` to silently return `null` for every PID via a caught `ENOENT` error — so orphaned PTY processes were never cleaned up on Windows 11
- Replaced `wmic` with `powershell.exe -Command Get-CimInstance Win32_Process` to retrieve process creation time, matching the approach already used by `ProcessTreeCache.ts`
- Updated start-time parsing to handle PowerShell's `DateTime` output format (ISO-style string) instead of `wmic`'s `YYYYMMDDHHMMSS.mmmmmSzzz` format

Resolves #4417

## Changes

- `electron/services/TrashedPidTracker.ts` — swap `execFileSync('wmic', ...)` for `execFileSync('powershell.exe', ['Get-CimInstance', ...])` and update the timestamp parsing regex
- `electron/services/__tests__/TrashedPidTracker.test.ts` — update mock output strings to match PowerShell's response format

## Testing

Unit tests updated and passing. The fix follows the same pattern as `ProcessTreeCache.ts` which already uses `Get-CimInstance` successfully.