### PR TITLE
fix(settings): make description and help text selectable across UI

### DIFF
--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -159,7 +159,9 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
       <div className="flex items-center justify-between">
         <div>
           <h5 className="text-sm font-medium text-canopy-text">Help Output</h5>
-          <p className="text-xs text-canopy-text/50">Available CLI flags for {agentName}</p>
+          <p className="text-xs text-canopy-text/50 select-text">
+            Available CLI flags for {agentName}
+          </p>
         </div>
 
         {isCliAvailable && (
@@ -200,7 +202,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
       {!isLoading && isCliAvailable === false && (
         <div className="px-4 py-6 rounded-[var(--radius-md)] border border-canopy-border bg-surface text-center space-y-2">
           <p className="text-sm text-canopy-text/60">CLI not found</p>
-          <p className="text-xs text-canopy-text/40">
+          <p className="text-xs text-canopy-text/40 select-text">
             {agentName} is not installed or not in your PATH
           </p>
           {usageUrl && (

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -208,7 +208,7 @@ export function AgentSettings({
         <div className="flex items-center justify-between">
           <div>
             <h4 className="text-sm font-medium mb-1">CLI Agents</h4>
-            <p className="text-xs text-canopy-text/50">
+            <p className="text-xs text-canopy-text/50 select-text">
               Configure global agent preferences and per-agent settings
             </p>
           </div>
@@ -239,7 +239,7 @@ export function AgentSettings({
           >
             <div className="pb-3 border-b border-canopy-border">
               <h4 className="text-sm font-medium text-canopy-text">Global Agent Settings</h4>
-              <p className="text-xs text-canopy-text/50 mt-0.5">
+              <p className="text-xs text-canopy-text/50 mt-0.5 select-text">
                 Settings that apply across all agents
               </p>
             </div>
@@ -260,7 +260,7 @@ export function AgentSettings({
                   </option>
                 ))}
               </select>
-              <p className="text-xs text-canopy-text/40">
+              <p className="text-xs text-canopy-text/40 select-text">
                 Agent used for automated workflows ("What's Next?", onboarding, project
                 explanations). Distinct from the Portal "Default New Tab Agent" which controls the
                 browser panel opened by the + button.
@@ -280,7 +280,7 @@ export function AgentSettings({
                   <h4 className="text-sm font-medium text-canopy-text">
                     {activeAgent.name} Settings
                   </h4>
-                  <p className="text-xs text-canopy-text/50">
+                  <p className="text-xs text-canopy-text/50 select-text">
                     Configure how {activeAgent.name.toLowerCase()} runs in terminals
                   </p>
                 </div>
@@ -425,7 +425,9 @@ export function AgentSettings({
                 onChange={(e) => updateAgent(activeAgent.id, { customFlags: e.target.value })}
                 placeholder="--verbose --max-tokens=4096"
               />
-              <p className="text-xs text-canopy-text/40">Extra CLI flags appended when launching</p>
+              <p className="text-xs text-canopy-text/40 select-text">
+                Extra CLI flags appended when launching
+              </p>
             </div>
 
             {/* Help Output */}
@@ -463,7 +465,7 @@ export function AgentSettings({
                   <div className="flex items-center justify-between">
                     <div>
                       <h5 className="text-sm font-medium text-canopy-text">Installation</h5>
-                      <p className="text-xs text-canopy-text/50">
+                      <p className="text-xs text-canopy-text/50 select-text">
                         {activeAgent.name} CLI not found
                       </p>
                     </div>
@@ -572,7 +574,7 @@ export function AgentSettings({
                         )}
 
                       <div className="px-3 py-2 rounded-[var(--radius-md)] bg-canopy-bg/50 border border-canopy-border/50">
-                        <p className="text-xs text-canopy-text/40">
+                        <p className="text-xs text-canopy-text/40 select-text">
                           ⚠️ Review commands before running them in your terminal
                         </p>
                       </div>

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -260,7 +260,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
     <div className="space-y-2">
       <div className="mb-4">
         <h3 className="text-sm font-semibold text-canopy-text/80 mb-2">Command Overrides</h3>
-        <p className="text-xs text-canopy-text/60">
+        <p className="text-xs text-canopy-text/60 select-text">
           Customize command behavior for this project. Set default argument values, define custom
           prompts, or disable commands entirely.
         </p>
@@ -366,7 +366,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                   </div>
                   <p
                     className={cn(
-                      "text-xs mt-0.5",
+                      "text-xs mt-0.5 select-text",
                       isDisabled ? "text-canopy-text/30" : "text-canopy-text/60"
                     )}
                   >
@@ -457,7 +457,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                     {/* Default Values Mode */}
                     {currentMode === "defaults" && hasArgs && (
                       <div className="space-y-3">
-                        <p className="text-xs text-canopy-text/60">
+                        <p className="text-xs text-canopy-text/60 select-text">
                           Set default values for command arguments. These values will be used when
                           the argument is not provided.
                         </p>
@@ -497,7 +497,9 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                                 }
                               />
                               {arg.description && (
-                                <p className="text-xs text-canopy-text/50">{arg.description}</p>
+                                <p className="text-xs text-canopy-text/50 select-text">
+                                  {arg.description}
+                                </p>
                               )}
                             </div>
                           );
@@ -548,7 +550,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
   return (
     <div className="space-y-3">
       <div>
-        <p className="text-xs text-canopy-text/60 mb-2">
+        <p className="text-xs text-canopy-text/60 mb-2 select-text">
           Define a custom prompt to send to the agent instead of executing the default command
           behavior. Use template variables like{" "}
           <code className="text-canopy-accent">
@@ -616,7 +618,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
       )}
 
       {value.trim() && (
-        <p className="text-xs text-canopy-text/50">
+        <p className="text-xs text-canopy-text/50 select-text">
           When this command is executed, the custom prompt will be sent to the agent instead of
           running the default command logic.
         </p>

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -183,7 +183,7 @@ export function EditorIntegrationTab() {
 
           {selectedId !== "custom" && (
             <div className="space-y-1">
-              <p className="text-xs text-canopy-text/50">Detected editors:</p>
+              <p className="text-xs text-canopy-text/50 select-text">Detected editors:</p>
               <div className="space-y-1">
                 {discoveredEditors.map((d) => (
                   <div key={d.id} className="flex items-center gap-2 text-xs text-canopy-text/60">
@@ -227,7 +227,7 @@ export function EditorIntegrationTab() {
                   placeholder="{file}:{line}:{col}"
                   className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
                 />
-                <p className="text-xs text-canopy-text/40">
+                <p className="text-xs text-canopy-text/40 select-text">
                   Use <code className="font-mono">{"{file}"}</code>,{" "}
                   <code className="font-mono">{"{line}"}</code>,{" "}
                   <code className="font-mono">{"{col}"}</code> as placeholders.

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -188,7 +188,7 @@ export function EnvironmentSettingsTab() {
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <FolderOpen className="w-10 h-10 text-canopy-text/20 mb-3" />
         <p className="text-sm text-canopy-text/60 mb-1">No project open</p>
-        <p className="text-xs text-canopy-text/40 max-w-xs">
+        <p className="text-xs text-canopy-text/40 max-w-xs select-text">
           Environment variables are project-specific. Open a project to configure its environment
           variables.
         </p>
@@ -212,7 +212,7 @@ export function EnvironmentSettingsTab() {
       id="environment-variables"
     >
       <div className="space-y-3">
-        <p className="text-xs text-canopy-text/50">
+        <p className="text-xs text-canopy-text/50 select-text">
           Variable names containing KEY, SECRET, TOKEN, or PASSWORD are stored securely using OS
           encryption <Lock className="inline h-3 w-3" />.
         </p>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -171,7 +171,7 @@ export function McpServerSettingsTab() {
                   {copied ? "Copied!" : "Copy MCP config"}
                 </button>
 
-                <p className="text-xs text-canopy-text/50 leading-relaxed">
+                <p className="text-xs text-canopy-text/50 leading-relaxed select-text">
                   Paste the copied config into your MCP client (e.g. Claude Code, Cursor,{" "}
                   <code className="text-canopy-text/70">~/.canopy/mcp.json</code>).
                   {status.apiKey && " The config includes the authorization header."}
@@ -216,7 +216,7 @@ export function McpServerSettingsTab() {
               </button>
             </div>
             {status.port && status.configuredPort && status.port !== status.configuredPort && (
-              <p className="text-xs text-status-warning/80 mt-2">
+              <p className="text-xs text-status-warning/80 mt-2 select-text">
                 Configured port {status.configuredPort} was in use — bound to {status.port} instead.
               </p>
             )}

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -189,13 +189,15 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                   </div>
                   <div>
                     <div className="text-sm font-medium text-canopy-text">{option.title}</div>
-                    <div className="text-xs text-canopy-text/50 mt-0.5">{option.description}</div>
+                    <div className="text-xs text-canopy-text/50 mt-0.5 select-text">
+                      {option.description}
+                    </div>
                   </div>
                 </div>
               </button>
             ))}
           </div>
-          <p className="text-xs text-canopy-text/40 mt-2">
+          <p className="text-xs text-canopy-text/40 mt-2 select-text">
             Changes to telemetry level take effect on next app restart.
           </p>
         </SettingsSection>
@@ -247,7 +249,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                 </button>
               ))}
             </div>
-            <p className="text-xs text-canopy-text/40 mt-2">
+            <p className="text-xs text-canopy-text/40 mt-2 select-text">
               Log pruning happens at startup. Changing this setting takes effect on next launch.
             </p>
           </SettingsSection>

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -35,7 +35,7 @@ export function SettingsCheckbox({
       />
       <div className="flex-1">
         <span className="text-sm font-medium text-canopy-text">{label}</span>
-        <p className="text-xs text-canopy-text/50 mt-0.5">{description}</p>
+        <p className="text-xs text-canopy-text/50 mt-0.5 select-text">{description}</p>
       </div>
     </label>
   );

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -38,7 +38,7 @@ export function SettingsSection({
             </span>
           )}
         </h4>
-        <p className="text-xs text-canopy-text/50">{description}</p>
+        <p className="text-xs text-canopy-text/50 select-text">{description}</p>
       </div>
       {children}
     </div>

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -298,7 +298,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
           />
 
           {performanceMode && (
-            <p className="text-xs text-status-warning/80 flex items-center gap-1.5">
+            <p className="text-xs text-status-warning/80 flex items-center gap-1.5 select-text">
               <AlertTriangle className="w-3 h-3" />
               New terminals will use reduced scrollback. Existing terminals are unchanged until
               respawned.
@@ -385,7 +385,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 disabled={panelLimits.warningsDisabled}
                 className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
               />
-              <p className="text-xs text-canopy-text/40">
+              <p className="text-xs text-canopy-text/40 select-text">
                 Show a dismissible banner when panel count reaches this number.
               </p>
             </div>
@@ -407,7 +407,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 disabled={panelLimits.warningsDisabled}
                 className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
               />
-              <p className="text-xs text-canopy-text/40">
+              <p className="text-xs text-canopy-text/40 select-text">
                 Require explicit confirmation before adding panels beyond this count.
               </p>
             </div>
@@ -429,7 +429,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
               }}
               className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
             />
-            <p className="text-xs text-canopy-text/40">
+            <p className="text-xs text-canopy-text/40 select-text">
               Absolute maximum number of panels. Cannot be bypassed.
             </p>
           </div>
@@ -581,7 +581,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                     {Math.round((1 - twoPaneSplitConfig.defaultRatio) * 100)}
                   </span>
                 </div>
-                <p className="text-xs text-canopy-text/40">
+                <p className="text-xs text-canopy-text/40 select-text">
                   Default split ratio when no worktree-specific ratio is saved.
                 </p>
               </div>
@@ -642,7 +642,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   onChange={(e) => handleValueChange(e.target.value)}
                   className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
                 />
-                <p className="text-xs text-canopy-text/40">
+                <p className="text-xs text-canopy-text/40 select-text">
                   {layoutConfig.strategy === "fixed-columns"
                     ? "Terminals will stack vertically when this many columns are filled."
                     : "Terminals will expand horizontally when this many rows are filled."}
@@ -650,7 +650,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
               </div>
             )}
 
-            <p className="text-xs text-canopy-text/40 leading-relaxed">
+            <p className="text-xs text-canopy-text/40 leading-relaxed select-text">
               {layoutConfig.strategy === "automatic" &&
                 "Uses a balanced square grid that adapts to the number of terminals (1-4 terminals use 2 columns, 5+ use up to 4 columns)."}
               {layoutConfig.strategy === "fixed-columns" &&
@@ -789,7 +789,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
             ))}
           </div>
 
-          <p className="text-xs text-canopy-text/50 leading-relaxed">
+          <p className="text-xs text-canopy-text/50 leading-relaxed select-text">
             Screen reader mode adds an accessible DOM overlay to each terminal, which has a
             performance cost. For best results, only enable when using a screen reader.
           </p>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -162,7 +162,7 @@ function SortableButtonItem({ buttonId, isVisible, onToggle }: SortableButtonIte
         <div className="text-canopy-text">{metadata.icon}</div>
         <div className="flex-1">
           <div className="text-sm font-medium text-canopy-text">{metadata.label}</div>
-          <div className="text-xs text-canopy-text/50">{metadata.description}</div>
+          <div className="text-xs text-canopy-text/50 select-text">{metadata.description}</div>
         </div>
       </div>
       <input
@@ -334,7 +334,7 @@ export function ToolbarSettingsTab() {
               <option value="browser">Browser</option>
               <option value="dev-server">Dev Server</option>
             </select>
-            <p className="text-xs text-canopy-text/40">
+            <p className="text-xs text-canopy-text/40 select-text">
               Default option to highlight when opening the launcher palette
             </p>
           </div>

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -407,7 +407,7 @@ export function TroubleshootingTab() {
           <h5 className="text-xs font-medium text-canopy-text mb-2">
             Advanced: Persistent Verbose Logging
           </h5>
-          <p className="text-xs text-canopy-text/60 mb-2">
+          <p className="text-xs text-canopy-text/60 mb-2 select-text">
             Use the toggle above for quick debugging. For persistent verbose logs across restarts,
             launch the app with environment variables:
           </p>
@@ -419,7 +419,7 @@ export function TroubleshootingTab() {
 
       <div className="space-y-2">
         <h4 className="text-sm font-medium text-canopy-text">Keyboard Shortcuts</h4>
-        <p className="text-xs text-canopy-text/50">
+        <p className="text-xs text-canopy-text/50 select-text">
           Use Cmd+Option+I (Mac) or Ctrl+Shift+I (Windows/Linux) to open DevTools.
         </p>
       </div>

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -683,7 +683,7 @@ function ParagraphingStrategyRow({
           <option value="manual">Manual Enter only</option>
         </select>
       </SettingsRow>
-      <p className="text-xs text-canopy-text/40 ml-[22px]">
+      <p className="text-xs text-canopy-text/40 ml-[22px] select-text">
         {isNonEnglish
           ? "Spoken commands require English. Manual Enter will be used for the selected language."
           : value === "spoken-command"
@@ -768,7 +768,7 @@ function DictionarySection({
           ))}
         </div>
       ) : (
-        <p className="text-xs text-canopy-text/40">
+        <p className="text-xs text-canopy-text/40 select-text">
           Domain-specific terms sent to Deepgram to boost recognition accuracy.
         </p>
       )}
@@ -796,7 +796,7 @@ function CustomInstructionsRow({
         className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-2 text-xs font-mono text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors resize-y"
         spellCheck={false}
       />
-      <p className="text-xs text-canopy-text/40">
+      <p className="text-xs text-canopy-text/40 select-text">
         Project-specific rules appended to the core correction prompt.
       </p>
     </div>

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -271,7 +271,10 @@ export function RecipeEditor({
             />
             <span className="text-sm font-medium text-canopy-text">Show in Empty State</span>
           </label>
-          <p id="show-in-empty-state-help" className="text-xs text-text-muted mt-1 ml-6">
+          <p
+            id="show-in-empty-state-help"
+            className="text-xs text-text-muted mt-1 ml-6 select-text"
+          >
             Display this recipe as a primary launcher when the worktree has no active terminals
           </p>
         </div>
@@ -291,7 +294,7 @@ export function RecipeEditor({
             <option value="prompt">Ask before assigning</option>
             <option value="never">Never assign</option>
           </select>
-          <p id="auto-assign-help" className="text-xs text-text-muted mt-1">
+          <p id="auto-assign-help" className="text-xs text-text-muted mt-1 select-text">
             Controls whether the linked GitHub issue is automatically assigned to you during quick
             worktree creation
           </p>
@@ -428,7 +431,7 @@ export function RecipeEditor({
                       </select>
                       <p
                         id={`terminal-exit-behavior-help-${index}`}
-                        className="text-xs text-text-muted mt-1"
+                        className="text-xs text-text-muted mt-1 select-text"
                       >
                         Failures always preserve terminal for debugging
                       </p>
@@ -458,7 +461,7 @@ export function RecipeEditor({
                       />
                       <p
                         id={`terminal-initial-prompt-help-${index}`}
-                        className="text-xs text-text-muted mt-1"
+                        className="text-xs text-text-muted mt-1 select-text"
                       >
                         This prompt will be sent to the agent when it starts. Variables:{" "}
                         <code className="text-canopy-text/70">{"{{issue_number}}"}</code>,{" "}
@@ -493,7 +496,7 @@ export function RecipeEditor({
                       </select>
                       <p
                         id={`terminal-agent-exit-behavior-help-${index}`}
-                        className="text-xs text-text-muted mt-1"
+                        className="text-xs text-text-muted mt-1 select-text"
                       >
                         Failures always preserve terminal for debugging
                       </p>
@@ -521,7 +524,7 @@ export function RecipeEditor({
                       />
                       <p
                         id={`terminal-dev-command-help-${index}`}
-                        className="text-xs text-text-muted mt-1"
+                        className="text-xs text-text-muted mt-1 select-text"
                       >
                         Leave empty to use project default or auto-detect from package.json
                       </p>
@@ -552,7 +555,7 @@ export function RecipeEditor({
                       </select>
                       <p
                         id={`terminal-dev-exit-behavior-help-${index}`}
-                        className="text-xs text-text-muted mt-1"
+                        className="text-xs text-text-muted mt-1 select-text"
                       >
                         Failures always preserve terminal for debugging
                       </p>

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -882,7 +882,7 @@ export function NewWorktreeDialog({
                     </div>
                   </PopoverContent>
                 </Popover>
-                <p className="text-xs text-canopy-text/60">
+                <p className="text-xs text-canopy-text/60 select-text">
                   {parsedBranch.hasPrefix ? (
                     <>
                       <span className="font-mono text-canopy-accent">{parsedBranch.prefix}/</span>


### PR DESCRIPTION
## Summary

- Description and help text throughout the settings UI had implicit `user-select: none` inherited from parent containers, making them impossible to select or copy
- Fixed `RecipeEditor.tsx` to use `select-text` on description/help paragraphs, and audited all other settings components for the same issue
- Applied `select-text` consistently to `<p>`, `<span>`, and similar descriptive text across 14 settings and dialog files

Resolves #4435

## Changes

- `src/components/TerminalRecipe/RecipeEditor.tsx` — primary fix for recipe editor description text
- `src/components/Settings/` — sweep of `AgentSettings`, `CommandOverridesTab`, `EditorIntegrationTab`, `EnvironmentSettingsTab`, `McpServerSettingsTab`, `PrivacyDataTab`, `SettingsCheckbox`, `SettingsSection`, `TerminalSettingsTab`, `ToolbarSettingsTab`, `TroubleshootingTab`, `VoiceInputSettingsTab`, `AgentHelpOutput`
- `src/components/Worktree/NewWorktreeDialog.tsx` — description text in dialog

## Testing

- Verified all changed files pass Prettier and ESLint (warnings only, no errors)
- Typecheck passes cleanly on the branch