### PR TITLE
feat(terminal): migrate context menu to ActionService

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -244,6 +244,13 @@ export type BuiltInActionId =
   | "devServer.start"
   | "devServer.openDetected"
   | "worktree.compareDiff"
+  | "terminal.copy"
+  | "terminal.paste"
+  | "terminal.copyLink"
+  | "terminal.deleteNote"
+  | "terminal.contextMenu"
+  | "terminal.sendToAgent"
+  | "terminal.bulkCommand"
   | "terminal.stashInput"
   | "terminal.popStash"
   | "terminal.restartService";

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -10,9 +10,6 @@ import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { terminalClient } from "@/clients";
-import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
-import { fireWatchNotification } from "@/lib/watchNotification";
 import {
   ArrowDownFromLine,
   Bell,
@@ -118,8 +115,6 @@ export function TerminalContextMenu({
   const { worktrees } = useWorktrees();
 
   const isWatched = useTerminalStore((state) => state.watchedPanels.has(terminalId));
-  const watchPanel = useTerminalStore((state) => state.watchPanel);
-  const unwatchPanel = useTerminalStore((state) => state.unwatchPanel);
 
   const [hasSelection, setHasSelection] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
@@ -146,7 +141,7 @@ export function TerminalContextMenu({
   const modifierKey = isMac ? "⌘" : "Ctrl";
 
   const handleAction = useCallback(
-    async (actionId: string) => {
+    (actionId: string) => {
       if (!terminal) return;
 
       if (actionId.startsWith("open-link:")) {
@@ -157,68 +152,38 @@ export function TerminalContextMenu({
 
       if (actionId.startsWith("copy-link:")) {
         const url = actionId.slice("copy-link:".length);
-        void navigator.clipboard.writeText(url);
+        void actionService.dispatch("terminal.copyLink", { url }, { source: "context-menu" });
         return;
       }
 
       if (actionId.startsWith("move-to-worktree:")) {
         const worktreeId = actionId.slice("move-to-worktree:".length);
-        const result = await actionService.dispatch(
+        void actionService.dispatch(
           "terminal.moveToWorktree",
           { terminalId, worktreeId },
           { source: "context-menu" }
         );
-        if (!result.ok) {
-          console.error("Failed to move terminal to worktree:", result.error);
-        }
         return;
       }
 
       if (actionId.startsWith("convert-to:")) {
         const targetType = actionId.slice("convert-to:".length);
         if (targetType === "terminal" || AGENT_IDS.includes(targetType)) {
-          const result = await actionService.dispatch(
+          void actionService.dispatch(
             "terminal.convertType",
             { terminalId, type: targetType as TerminalType },
             { source: "context-menu" }
           );
-          if (!result.ok) {
-            console.error("Failed to convert terminal type:", result.error);
-          }
         }
         return;
       }
 
       switch (actionId) {
-        case "copy": {
-          const managed = terminalInstanceService.get(terminalId);
-          if (managed?.terminal) {
-            const selection = managed.terminal.getSelection();
-            if (selection) {
-              void navigator.clipboard.writeText(selection);
-            }
-          }
+        case "copy":
+          void actionService.dispatch("terminal.copy", { terminalId }, { source: "context-menu" });
           break;
-        }
         case "paste":
-          if (!terminal.isInputLocked) {
-            void (async () => {
-              try {
-                const text = await navigator.clipboard.readText();
-                if (!text) return;
-                const managed = terminalInstanceService.get(terminalId);
-                if (!managed || managed.isInputLocked) return;
-                if (managed.terminal.modes.bracketedPasteMode) {
-                  terminalClient.write(terminalId, formatWithBracketedPaste(text));
-                } else {
-                  terminalClient.write(terminalId, text.replace(/\r?\n/g, "\r"));
-                }
-                terminalInstanceService.notifyUserInput(terminalId);
-              } catch {
-                // Clipboard API may be denied
-              }
-            })();
-          }
+          void actionService.dispatch("terminal.paste", { terminalId }, { source: "context-menu" });
           break;
         case "move-to-dock":
           void actionService.dispatch(
@@ -270,13 +235,7 @@ export function TerminalContextMenu({
           );
           break;
         case "toggle-watch":
-          if (isWatched) {
-            unwatchPanel(terminalId);
-          } else if (terminal.agentState === "completed" || terminal.agentState === "waiting") {
-            fireWatchNotification(terminalId, terminal.title ?? terminalId, terminal.agentState);
-          } else {
-            watchPanel(terminalId);
-          }
+          void actionService.dispatch("terminal.watch", { terminalId }, { source: "context-menu" });
           break;
         case "duplicate":
           void actionService.dispatch(
@@ -335,19 +294,15 @@ export function TerminalContextMenu({
           break;
         case "delete-note":
           if (terminal.notePath) {
-            void (async () => {
-              const result = await actionService.dispatch(
-                "notes.delete",
-                {
-                  notePath: terminal.notePath,
-                  noteTitle: terminal.title,
-                },
-                { source: "context-menu" }
-              );
-              if (result.ok) {
-                useTerminalStore.getState().removeTerminal(terminalId);
-              }
-            })();
+            void actionService.dispatch(
+              "terminal.deleteNote",
+              {
+                terminalId,
+                notePath: terminal.notePath,
+                noteTitle: terminal.title,
+              },
+              { source: "context-menu", confirmed: true }
+            );
           }
           break;
         case "reveal-in-palette":
@@ -361,7 +316,7 @@ export function TerminalContextMenu({
           break;
       }
     },
-    [terminal, terminalId, isWatched, watchPanel, unwatchPanel]
+    [terminal, terminalId]
   );
 
   if (!terminal) {

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -1,6 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
-import type { ActionId } from "@shared/types/actions";
 import { openPanelContextMenu } from "@/lib/panelContextMenu";
 import { useTerminalStore } from "@/store/terminalStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
@@ -24,6 +23,84 @@ export function registerTerminalInputActions(
     },
   }));
 
+  actions.set("terminal.copy", () => ({
+    id: "terminal.copy",
+    title: "Copy Selection",
+    description: "Copy the current terminal selection to clipboard",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
+    run: async (args: unknown) => {
+      const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
+      const state = useTerminalStore.getState();
+      const targetId = terminalId ?? state.focusedId;
+      if (!targetId) return;
+      const { terminalInstanceService } =
+        await import("@/services/terminal/TerminalInstanceService");
+      const managed = terminalInstanceService.get(targetId);
+      if (managed?.terminal) {
+        const selection = managed.terminal.getSelection();
+        if (selection) {
+          await navigator.clipboard.writeText(selection);
+        }
+      }
+    },
+  }));
+
+  actions.set("terminal.paste", () => ({
+    id: "terminal.paste",
+    title: "Paste",
+    description: "Paste clipboard content into the terminal",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
+    run: async (args: unknown) => {
+      const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
+      const state = useTerminalStore.getState();
+      const targetId = terminalId ?? state.focusedId;
+      if (!targetId) return;
+      const terminal = state.terminals.find((t) => t.id === targetId);
+      if (terminal?.isInputLocked) return;
+      const { terminalInstanceService } =
+        await import("@/services/terminal/TerminalInstanceService");
+      const managed = terminalInstanceService.get(targetId);
+      if (!managed || managed.isInputLocked) return;
+      try {
+        const text = await navigator.clipboard.readText();
+        if (!text) return;
+        const { terminalClient } = await import("@/clients");
+        const { formatWithBracketedPaste } = await import("@shared/utils/terminalInputProtocol");
+        if (managed.terminal.modes.bracketedPasteMode) {
+          terminalClient.write(targetId, formatWithBracketedPaste(text));
+        } else {
+          terminalClient.write(targetId, text.replace(/\r?\n/g, "\r"));
+        }
+        terminalInstanceService.notifyUserInput(targetId);
+      } catch {
+        // Clipboard API may be denied
+      }
+    },
+  }));
+
+  actions.set("terminal.copyLink", () => ({
+    id: "terminal.copyLink",
+    title: "Copy Link Address",
+    description: "Copy a URL to the clipboard",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ url: z.string() }),
+    run: async (args: unknown) => {
+      const { url } = args as { url: string };
+      await navigator.clipboard.writeText(url);
+    },
+  }));
+
   actions.set("terminal.contextMenu", () => ({
     id: "terminal.contextMenu",
     title: "Open Context Menu",
@@ -44,7 +121,7 @@ export function registerTerminalInputActions(
   }));
 
   actions.set("terminal.stashInput", () => ({
-    id: "terminal.stashInput" as ActionId,
+    id: "terminal.stashInput",
     title: "Stash Input",
     description: "Park the current hybrid input draft to a temporary stash slot",
     category: "terminal",
@@ -60,7 +137,7 @@ export function registerTerminalInputActions(
   }));
 
   actions.set("terminal.popStash", () => ({
-    id: "terminal.popStash" as ActionId,
+    id: "terminal.popStash",
     title: "Restore Stashed Input",
     description: "Restore the previously stashed hybrid input draft",
     category: "terminal",
@@ -76,7 +153,7 @@ export function registerTerminalInputActions(
   }));
 
   actions.set("terminal.bulkCommand", () => ({
-    id: "terminal.bulkCommand" as ActionId,
+    id: "terminal.bulkCommand",
     title: "Bulk Command Center",
     description: "Send keystrokes or commands to multiple agent terminals",
     category: "terminal",
@@ -91,7 +168,7 @@ export function registerTerminalInputActions(
   }));
 
   actions.set("terminal.sendToAgent", () => ({
-    id: "terminal.sendToAgent" as ActionId,
+    id: "terminal.sendToAgent",
     title: "Send to Agent",
     description: "Send terminal selection to another agent or terminal panel",
     category: "terminal",

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -326,23 +326,55 @@ export function registerTerminalLifecycleActions(
     kind: "command",
     danger: "safe",
     scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
     isEnabled: (ctx) => !!ctx.focusedTerminalId,
-    run: async (_args, ctx) => {
+    run: async (args: unknown, ctx) => {
+      const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
       const state = useTerminalStore.getState();
-      const targetId = ctx.focusedTerminalId ?? state.focusedId;
+      const targetId = terminalId ?? ctx.focusedTerminalId ?? state.focusedId;
       if (!targetId) return;
 
       if (state.watchedPanels.has(targetId)) {
         state.unwatchPanel(targetId);
       } else {
         const terminal = state.terminals.find((t) => t.id === targetId);
-        // Fire immediately if agent is already in a terminal attention state
         if (terminal?.agentState === "completed" || terminal?.agentState === "waiting") {
           const { fireWatchNotification } = await import("@/lib/watchNotification");
           fireWatchNotification(targetId, terminal.title ?? targetId, terminal.agentState);
         } else {
           state.watchPanel(targetId);
         }
+      }
+    },
+  }));
+
+  actions.set("terminal.deleteNote", () => ({
+    id: "terminal.deleteNote",
+    title: "Delete Note",
+    description: "Delete the note file and remove the panel",
+    category: "terminal",
+    kind: "command",
+    danger: "confirm",
+    scope: "renderer",
+    argsSchema: z.object({
+      terminalId: z.string(),
+      notePath: z.string(),
+      noteTitle: z.string().optional(),
+    }),
+    run: async (args: unknown) => {
+      const { terminalId, notePath, noteTitle } = args as {
+        terminalId: string;
+        notePath: string;
+        noteTitle?: string;
+      };
+      const { actionService } = await import("@/services/ActionService");
+      const result = await actionService.dispatch(
+        "notes.delete",
+        { notePath, noteTitle },
+        { source: "context-menu" }
+      );
+      if (result.ok) {
+        useTerminalStore.getState().removeTerminal(terminalId);
       }
     },
   }));


### PR DESCRIPTION
## Summary

- Migrates all remaining inline handlers in `TerminalContextMenu` to dispatch through `ActionService`
- Adds new action definitions: `terminal.copy`, `terminal.paste`, `terminal.copyLink`, `terminal.deleteNote`
- Extends `terminal.watch` with optional `terminalId` arg so context menu targets the right-clicked panel
- Adds 7 missing `ActionId` entries to the shared union type, removing `as ActionId` casts
- Simplifies `TerminalContextMenu.tsx` — component is now a thin dispatcher with no inline logic

Resolves #4310

## Changes

- `shared/types/actions.ts`: added `terminal.copy`, `terminal.paste`, `terminal.copyLink`, `terminal.deleteNote`, `terminal.contextMenu`, `terminal.sendToAgent`, `terminal.bulkCommand` to `ActionId` union
- `src/services/actions/definitions/terminalInputActions.ts`: new `terminal.copy`, `terminal.paste`, `terminal.copyLink` actions; removed `as ActionId` casts
- `src/services/actions/definitions/terminalLifecycleActions.ts`: extended `terminal.watch` with `terminalId` arg; added `terminal.deleteNote` composite action
- `src/components/Terminal/TerminalContextMenu.tsx`: replaced all inline handlers with `actionService.dispatch()` calls; removed unused imports

## Test plan

- [x] Existing 17 tests pass (`TerminalContextMenu.test.tsx`)
- [x] TypeScript typecheck clean
- [x] Lint ratchet clean (405 warnings, no new ones)
- [x] Prettier format clean
- [ ] Manual: right-click terminal → Copy, Paste, Watch, Copy Link all work
- [ ] Manual: right-click notes panel → Delete Note removes panel