### PR TITLE
feat(notes): auto-create first note when palette opens on empty project

### DIFF
--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -67,6 +67,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
   const {
     notes,
     isLoading,
+    isInitialized,
     initialize,
     createNote,
     deleteNote,
@@ -134,6 +135,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
     notes,
     visibleNotes: search.visibleNotes,
     isLoading,
+    isInitialized,
     isSearching: search.isSearching,
     lastSelectedNoteId,
     setLastSelectedNoteId,

--- a/src/hooks/__tests__/useNoteActions.test.ts
+++ b/src/hooks/__tests__/useNoteActions.test.ts
@@ -24,6 +24,7 @@ function defaultProps(overrides: Record<string, unknown> = {}) {
     notes: [defaultNote],
     visibleNotes: [defaultNote],
     isLoading: false,
+    isInitialized: true,
     isSearching: false,
     lastSelectedNoteId: null as string | null,
     setLastSelectedNoteId: vi.fn(),
@@ -188,6 +189,119 @@ describe("useNoteActions", () => {
       renderHook(() => useNoteActions(props));
 
       expect(props.setSelectedNote).toHaveBeenCalledWith(emptyTitleNote);
+    });
+  });
+
+  describe("auto-create first note", () => {
+    it("auto-creates when palette opens with no notes and store is initialized", () => {
+      const createNote = vi.fn().mockResolvedValue({
+        metadata: { id: "new1", title: "", scope: "project", createdAt: Date.now(), tags: [] },
+        content: "",
+        path: "/notes/new1.md",
+        lastModified: Date.now(),
+      });
+      const props = defaultProps({
+        notes: [],
+        visibleNotes: [],
+        isInitialized: true,
+        isLoading: false,
+        createNote,
+      });
+
+      renderHook(() => useNoteActions(props));
+
+      expect(createNote).toHaveBeenCalledWith("", "project");
+    });
+
+    it("does not auto-create when isInitialized is false", () => {
+      const createNote = vi.fn();
+      const props = defaultProps({
+        notes: [],
+        visibleNotes: [],
+        isInitialized: false,
+        isLoading: true,
+        createNote,
+      });
+
+      renderHook(() => useNoteActions(props));
+
+      expect(createNote).not.toHaveBeenCalled();
+    });
+
+    it("does not auto-create when notes exist", () => {
+      const createNote = vi.fn();
+      const props = defaultProps({
+        notes: [defaultNote],
+        visibleNotes: [defaultNote],
+        isInitialized: true,
+        isLoading: false,
+        createNote,
+      });
+
+      renderHook(() => useNoteActions(props));
+
+      expect(createNote).not.toHaveBeenCalled();
+    });
+
+    it("does not auto-create when palette is closed", () => {
+      const createNote = vi.fn();
+      const props = defaultProps({
+        isOpen: false,
+        notes: [],
+        visibleNotes: [],
+        isInitialized: true,
+        isLoading: false,
+        createNote,
+      });
+
+      renderHook(() => useNoteActions(props));
+
+      expect(createNote).not.toHaveBeenCalled();
+    });
+
+    it("does not auto-create when search hides all notes but notes exist", () => {
+      const createNote = vi.fn();
+      const props = defaultProps({
+        notes: [defaultNote],
+        visibleNotes: [],
+        isInitialized: true,
+        isLoading: false,
+        isSearching: true,
+        createNote,
+      });
+
+      renderHook(() => useNoteActions(props));
+
+      expect(createNote).not.toHaveBeenCalled();
+    });
+
+    it("re-creates when palette is closed and reopened with zero notes", () => {
+      const createNote = vi.fn().mockResolvedValue({
+        metadata: { id: "new1", title: "", scope: "project", createdAt: Date.now(), tags: [] },
+        content: "",
+        path: "/notes/new1.md",
+        lastModified: Date.now(),
+      });
+      const props = defaultProps({
+        notes: [],
+        visibleNotes: [],
+        isInitialized: true,
+        isLoading: false,
+        createNote,
+      });
+
+      const { rerender } = renderHook(({ hookProps }) => useNoteActions(hookProps), {
+        initialProps: { hookProps: props },
+      });
+
+      expect(createNote).toHaveBeenCalledTimes(1);
+
+      // Close palette
+      rerender({ hookProps: { ...props, isOpen: false } });
+      // Reopen palette
+      rerender({ hookProps: { ...props, isOpen: true } });
+
+      expect(createNote).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/hooks/useNoteActions.ts
+++ b/src/hooks/useNoteActions.ts
@@ -6,6 +6,7 @@ interface UseNoteActionsOptions {
   notes: NoteListItem[];
   visibleNotes: NoteListItem[];
   isLoading: boolean;
+  isInitialized: boolean;
   isSearching: boolean;
   lastSelectedNoteId: string | null;
   setLastSelectedNoteId: (id: string | null) => void;
@@ -62,8 +63,10 @@ export interface UseNoteActionsReturn {
 
 export function useNoteActions({
   isOpen,
+  notes,
   visibleNotes,
   isLoading,
+  isInitialized,
   isSearching,
   lastSelectedNoteId,
   setLastSelectedNoteId,
@@ -95,11 +98,13 @@ export function useNoteActions({
   const [deleteConfirmNote, setDeleteConfirmNote] = useState<NoteListItem | null>(null);
 
   const hasRestoredRef = useRef(false);
+  const autoCreatedRef = useRef(false);
 
   // Initialize notes on open
   useEffect(() => {
     if (isOpen) {
       hasRestoredRef.current = false;
+      autoCreatedRef.current = false;
       initialize();
       setQuery("");
       setSelectedIndex(0);
@@ -267,6 +272,14 @@ export function useNoteActions({
       setSelectedNote,
     ]
   );
+
+  // Auto-create first note when palette opens on a project with no notes
+  useEffect(() => {
+    if (!isOpen || !isInitialized || isLoading || notes.length > 0) return;
+    if (autoCreatedRef.current) return;
+    autoCreatedRef.current = true;
+    handleCreateNote();
+  }, [isOpen, isInitialized, isLoading, notes.length, handleCreateNote]);
 
   const handleDeleteNote = useCallback((note: NoteListItem, e: React.MouseEvent) => {
     e.stopPropagation();


### PR DESCRIPTION
## Summary

- When the Notes palette opens and the project has no notes, automatically creates and opens the first note so the user lands in an editable state immediately
- Avoids the empty-state dead end where users had to manually trigger note creation before doing anything useful

Resolves #4129

## Changes

- **`src/hooks/useNoteActions.ts`**: Added `isInitialized` to options interface, `autoCreatedRef` guard (reset on palette reopen), and a `useEffect` that auto-creates a note when `isOpen && isInitialized && !isLoading && notes.length === 0`
- **`src/components/Notes/NotesPalette.tsx`**: Extract `isInitialized` from `useNotesStore()` and pass to `useNoteActions`
- **`src/hooks/__tests__/useNoteActions.test.ts`**: 6 new test cases covering auto-create behavior, guard conditions, and reopen cycles

## Test plan

- [x] Unit tests pass (15/15 including 6 new auto-create tests)
- [x] Typecheck clean
- [x] Lint clean (405 warnings, all pre-existing)
- [x] Format clean