### PR TITLE
feat(settings): add Cursor agent to settings modal

### DIFF
--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -96,6 +96,7 @@ export const DEFAULT_DANGEROUS_ARGS: Record<string, string> = {
   claude: "--dangerously-skip-permissions",
   gemini: "--yolo",
   codex: "--dangerously-bypass-approvals-and-sandbox",
+  cursor: "--force",
 };
 
 export const DEFAULT_AGENT_SETTINGS: AgentSettings = {

--- a/src/components/Settings/__tests__/AgentSettings.subtabs.test.ts
+++ b/src/components/Settings/__tests__/AgentSettings.subtabs.test.ts
@@ -9,7 +9,7 @@ const GENERAL_SUBTAB_ID = "general";
  * These tests verify the derivation logic used inside the component.
  */
 describe("AgentSettings subtab derivation logic", () => {
-  const agentIds = ["claude", "gemini", "codex", "opencode"];
+  const agentIds = ["claude", "gemini", "codex", "opencode", "cursor"];
 
   function deriveActiveState(
     activeSubtab: string | null,
@@ -44,6 +44,10 @@ describe("AgentSettings subtab derivation logic", () => {
     const codex = deriveActiveState("codex", agentIds);
     expect(codex.isGeneralActive).toBe(false);
     expect(codex.activeAgentId).toBe("codex");
+
+    const cursor = deriveActiveState("cursor", agentIds);
+    expect(cursor.isGeneralActive).toBe(false);
+    expect(cursor.activeAgentId).toBe("cursor");
   });
 
   it("falls back to General when activeSubtab is an unknown id (prevents blank screen)", () => {

--- a/src/components/Settings/settingsSearchIndex.ts
+++ b/src/components/Settings/settingsSearchIndex.ts
@@ -201,7 +201,7 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
     subtabLabel: "Overview",
     section: "System Status",
     title: "System Status",
-    description: "CLI agent availability — Claude, Gemini, Codex, OpenCode status",
+    description: "CLI agent availability — Claude, Gemini, Codex, OpenCode, Cursor status",
     keywords: ["agents", "cli", "available", "status", "check", "ready"],
   },
   {


### PR DESCRIPTION
## Summary
- Add `cursor: "--force"` to `DEFAULT_DANGEROUS_ARGS` so the skip-permissions toggle works for Cursor agent
- Add `"cursor"` to the subtab test fixture and assertions in `AgentSettings.subtabs.test.ts`
- Add "Cursor" to the system-status search index description string

Closes #4421

## Test plan
- [x] All 10 subtab derivation tests pass (including new cursor assertion)
- [x] Typecheck clean (`tsc --noEmit`)
- [x] Lint clean (405 warnings, matching baseline)
- [x] Format clean (Prettier)

🤖 Generated with [Claude Code](https://claude.ai/code)