### PR TITLE
feat(activity-monitor): make prompt fast-path quiet threshold per-agent configurable

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -61,6 +61,7 @@ export interface ActivityMonitorOptions {
   promptScanLineCount?: number;
   promptConfidence?: number;
   idleDebounceMs?: number;
+  promptFastPathMinQuietMs?: number;
   inputConfirmMs?: number;
   maxNoPromptIdleMs?: number;
   lineRewriteDetection?: {
@@ -86,6 +87,7 @@ export class ActivityMonitor {
   private isDisposed = false;
   private debounceTimer: NodeJS.Timeout | null = null;
   private readonly IDLE_DEBOUNCE_MS: number;
+  private readonly PROMPT_FAST_PATH_MIN_QUIET_MS: number;
   private readonly PROMPT_DEBOUNCE_MS = 500;
   private readonly PROMPT_QUIET_MS = 200;
   private readonly PROMPT_HISTORY_FALLBACK_MS = 3000;
@@ -151,6 +153,7 @@ export class ActivityMonitor {
     options?: ActivityMonitorOptions
   ) {
     this.IDLE_DEBOUNCE_MS = options?.idleDebounceMs ?? 4000;
+    this.PROMPT_FAST_PATH_MIN_QUIET_MS = options?.promptFastPathMinQuietMs ?? 3000;
     this.POLLING_MAX_BOOT_MS = options?.pollingMaxBootMs ?? 15000;
     this.MAX_WORKING_SILENCE_MS = options?.maxWorkingSilenceMs ?? 180000;
 
@@ -623,16 +626,15 @@ export class ActivityMonitor {
     // exit busy immediately rather than waiting the full IDLE_DEBOUNCE_MS. This keeps
     // the idle transition snappy after the prompt appears, even when IDLE_DEBOUNCE_MS
     // has been raised to cover LLM API call silence gaps.
-    // Require at least 3 seconds of quiet to avoid premature idle during inter-tool-call
-    // gaps (Claude bursts with 1-3s pauses, Codex has 3-5s gaps). This prevents the
-    // working↔waiting jitter that occurs when brief output pauses trigger idle transitions
-    // that immediately flip back to working (Issue #3606).
-    const PROMPT_FAST_PATH_MIN_QUIET_MS = 3000;
+    // Default: 3s quiet to avoid premature idle during inter-tool-call gaps (Claude
+    // bursts with 1-3s pauses, Codex has 3-5s gaps — Issue #3606). Agents with
+    // deterministic completion markers (e.g. Cursor, 700ms) can use a lower value
+    // via promptFastPathMinQuietMs in AgentDetectionConfig.
     if (
       this.state === "busy" &&
       !this.completionTimer.emitted &&
       shouldPreferPrompt &&
-      quietForMs >= PROMPT_FAST_PATH_MIN_QUIET_MS &&
+      quietForMs >= this.PROMPT_FAST_PATH_MIN_QUIET_MS &&
       now >= this.workingHoldUntil &&
       !(this.inputTracker.pendingInputUntil > 0 && now < this.inputTracker.pendingInputUntil)
     ) {

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -199,6 +199,21 @@ describe("buildActivityMonitorOptions", () => {
     expect(result.promptHintPatterns).toBeUndefined();
   });
 
+  it("sets promptFastPathMinQuietMs for cursor agent", () => {
+    const result = buildActivityMonitorOptions("cursor", {});
+    expect(result.promptFastPathMinQuietMs).toBe(700);
+  });
+
+  it("leaves promptFastPathMinQuietMs undefined for claude agent", () => {
+    const result = buildActivityMonitorOptions("claude", {});
+    expect(result.promptFastPathMinQuietMs).toBeUndefined();
+  });
+
+  it("leaves promptFastPathMinQuietMs undefined for non-agent terminals", () => {
+    const result = buildActivityMonitorOptions(undefined, {});
+    expect(result.promptFastPathMinQuietMs).toBeUndefined();
+  });
+
   it("populates pattern config fields for a known agent", () => {
     const result = buildActivityMonitorOptions("claude", {});
     expect(result.outputActivityDetection).toEqual({

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -205,5 +205,6 @@ export function buildActivityMonitorOptions(
     promptScanLineCount: detection?.promptScanLineCount,
     promptConfidence: detection?.promptConfidence,
     idleDebounceMs: effectiveAgentId ? (detection?.debounceMs ?? 4000) : undefined,
+    promptFastPathMinQuietMs: detection?.promptFastPathMinQuietMs,
   };
 }

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -74,6 +74,15 @@ export interface AgentDetectionConfig {
   debounceMs?: number;
 
   /**
+   * Minimum quiet-output ms before the prompt fast-path can fire (default: 3000).
+   * Lower values make the busy→idle transition snappier when a prompt is detected.
+   * Agents with deterministic completion markers (e.g. Cursor) can use shorter
+   * values; agents with silent inter-tool-call gaps (Claude/Codex) need the
+   * default to avoid working↔waiting jitter (Issue #3606).
+   */
+  promptFastPathMinQuietMs?: number;
+
+  /**
    * Confidence level when primary pattern matches (default: 0.95).
    */
   primaryConfidence?: number;
@@ -822,6 +831,7 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       fallbackConfidence: 0.7,
       promptConfidence: 0.85,
       debounceMs: 4000,
+      promptFastPathMinQuietMs: 700,
     },
     routing: {
       capabilities: ["javascript", "typescript", "python", "react", "node", "general-purpose"],


### PR DESCRIPTION
## Summary

Closes #4058

The prompt fast-path in `ActivityMonitor` used a hardcoded 3000ms quiet threshold (`PROMPT_FAST_PATH_MIN_QUIET_MS`) before transitioning `busy → idle` when a prompt is detected. This caused a noticeable delay for the Cursor agent, whose `→` prompt is detected immediately via cursor-line match but still had to wait 3 seconds.

- Add `promptFastPathMinQuietMs` to `AgentDetectionConfig` (defaults to 3000ms, preserving existing behavior for Claude/Codex jitter protection from Issue #3606)
- Set Cursor agent to 700ms — safe because `shouldPreferPrompt` already requires 200ms quiet + 500ms prompt stability, and Cursor doesn't have silent inter-tool-call gaps
- Wire through `buildActivityMonitorOptions` → `ActivityMonitorOptions` → `ActivityMonitor` constructor
- Replace hardcoded local const with configurable instance field

## Test plan

- [x] 3 new unit tests in `terminalActivityPatterns.test.ts` verify wiring (cursor=700, claude=undefined, non-agent=undefined)
- [x] All 23 existing tests pass
- [x] `npm run check` passes (typecheck + lint + format)
- [ ] Manual: launch Cursor agent, confirm idle transition is noticeably faster after agent responds