### PR TITLE
fix(e2e): stabilize worktree delete context menu click on Windows

### DIFF
--- a/e2e/core/core-worktree-lifecycle.spec.ts
+++ b/e2e/core/core-worktree-lifecycle.spec.ts
@@ -7,6 +7,7 @@ import { spawnTerminalAndVerify } from "../helpers/workflows";
 import { runTerminalCommand, waitForTerminalText } from "../helpers/terminal";
 import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
+import { ensureWindowFocused } from "../helpers/focus";
 
 let ctx: AppContext;
 let mainBranch: string;
@@ -102,10 +103,12 @@ test.describe.serial("Core: Worktree Lifecycle", () => {
 
     const newCard = window.locator(SEL.worktree.card(BRANCH));
     const actionsBtn = newCard.locator(SEL.worktree.actionsMenu);
+    await ensureWindowFocused(ctx.app);
     await actionsBtn.click();
 
     const deleteItem = window.getByRole("menuitem", { name: /delete/i });
     await expect(deleteItem).toBeVisible({ timeout: T_SHORT });
+    await deleteItem.hover();
     await deleteItem.click();
 
     const confirmBtn = window.locator(SEL.worktree.deleteConfirm);


### PR DESCRIPTION
## Summary

- The `delete active worktree` E2E test was failing consistently on Windows because the Radix UI dropdown dismissed before Playwright's click event landed on the menu item
- Added `ensureWindowFocused` before opening the context menu to stabilize window focus state on Windows, preventing a spurious `onOpenChange` dismissal triggered by focus events during click synthesis
- Added an explicit `hover()` before `click()` on the delete menu item so the element is fully interactive before the click fires

Resolves #4418

## Changes

- `e2e/core/core-worktree-lifecycle.spec.ts` — added `ensureWindowFocused(ctx.app)` before the actions button click, and `deleteItem.hover()` before `deleteItem.click()`

## Testing

- Existing E2E core suite on Linux/macOS continues to pass (the additions are no-ops on those platforms)
- Fix targets the Windows-specific focus/click timing issue described in the issue; uses the `ensureWindowFocused` helper already in the test helpers