### PR TITLE
feat(palette): action-oriented empty states with shortcut hints

### DIFF
--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -71,7 +71,7 @@ export function QuickSwitcher({
       searchAriaLabel="Search terminals, agents, and worktrees"
       listId="quick-switcher-list"
       itemIdPrefix="qs-option"
-      emptyMessage="No items available"
+      emptyMessage="No panels open"
       noMatchMessage={`No items match "${query}"`}
       totalResults={totalResults}
       emptyContent={

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useEffectEvent, useRef, useMemo } from "react";
 import { X, FilterX } from "lucide-react";
 import { WorktreeOverviewIcon, CanopyAgentIcon } from "@/components/icons";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { cn } from "@/lib/utils";
 import { useShallow } from "zustand/react/shallow";
 import { WorktreeCard } from "./WorktreeCard";
@@ -114,6 +115,30 @@ export interface WorktreeOverviewModalProps {
   agentAvailability?: UseAgentLauncherReturn["availability"];
   agentSettings?: UseAgentLauncherReturn["agentSettings"];
   homeDir?: string;
+}
+
+function EmptyWorktreeState() {
+  const createWorktreeShortcut = useKeybindingDisplay("worktree.createDialog.open");
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-3 text-canopy-text/50">
+      <WorktreeOverviewIcon className="w-8 h-8 text-canopy-text/30" />
+      <p className="text-sm font-medium text-canopy-text/70">No worktrees yet</p>
+      <p className="text-xs text-canopy-text/40">
+        {createWorktreeShortcut ? (
+          <>
+            Press{" "}
+            <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+              {createWorktreeShortcut}
+            </kbd>{" "}
+            to create a worktree.
+          </>
+        ) : (
+          "Create a worktree to get started."
+        )}
+      </p>
+    </div>
+  );
 }
 
 export function WorktreeOverviewModal({
@@ -482,9 +507,7 @@ export function WorktreeOverviewModal({
           {/* Content */}
           <div className="flex-1 overflow-y-auto p-6">
             {worktrees.length === 0 ? (
-              <div className="flex items-center justify-center h-full text-canopy-text/50">
-                No worktrees available
-              </div>
+              <EmptyWorktreeState />
             ) : filteredWorktrees.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-full gap-4 text-canopy-text/50">
                 <FilterX className="w-12 h-12 text-canopy-text/30" />

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import type { WorktreeState } from "@/types";
 
 interface WorktreeListItemProps {
@@ -73,6 +74,8 @@ export function WorktreePalette({
   onConfirm,
   onClose,
 }: WorktreePaletteProps) {
+  const createWorktreeShortcut = useKeybindingDisplay("worktree.createDialog.open");
+
   return (
     <SearchablePalette<WorktreeState>
       isOpen={isOpen}
@@ -101,9 +104,24 @@ export function WorktreePalette({
       searchAriaLabel="Search worktrees"
       listId="worktree-palette-list"
       itemIdPrefix="worktree-option"
-      emptyMessage="No worktrees available"
+      emptyMessage="No worktrees yet"
       noMatchMessage={`No worktrees match "${query}"`}
       totalResults={totalResults}
+      emptyContent={
+        <p className="mt-2 text-xs text-canopy-text/40">
+          {createWorktreeShortcut ? (
+            <>
+              Press{" "}
+              <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-canopy-border text-canopy-text/60">
+                {createWorktreeShortcut}
+              </kbd>{" "}
+              to create a worktree.
+            </>
+          ) : (
+            "Create a worktree to get started."
+          )}
+        </p>
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary

- Palette empty states now show contextual messages with keyboard shortcut hints instead of generic "No items available" text
- Quick Switcher, Worktree Palette, and Worktree Overview all updated to display the relevant keybinding for the next action
- Shortcut hints resolve dynamically from the user's actual keybinding config via `useKeybinding`, so custom keymaps are respected

Resolves #4317

## Changes

- `QuickSwitcher.tsx` — empty state message updated to "No panels open" with a hint to open a new terminal (resolved from keybinding)
- `WorktreePalette.tsx` — empty state updated to "No worktrees yet" with a shortcut hint to create one
- `WorktreeOverviewModal.tsx` — empty state upgraded to match the Notes palette pattern: icon, contextual message, and shortcut hint

## Testing

- Ran `npm run fix` — no formatting or lint changes required
- Typecheck and lint pass cleanly
- Verified keybinding resolution uses `useKeybinding` hook so custom keymaps are respected; no hardcoded shortcut strings
- "No match" state for search queries is unchanged as specified