### PR TITLE
feat(icons): unify agent group icon to CanopyAgentIcon

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -21,7 +21,6 @@ import {
 } from "@/store";
 import {
   X,
-  TreeDeciduous,
   Code,
   Github,
   LayoutGrid,
@@ -40,7 +39,7 @@ import {
   KeyRound,
   Shield,
 } from "lucide-react";
-import { WorktreeIcon } from "@/components/icons";
+import { WorktreeIcon, CanopyAgentIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { useVerticalScrollShadows } from "@/hooks/useVerticalScrollShadows";
 import { appClient } from "@/clients";
@@ -447,7 +446,7 @@ export function SettingsDialog({
     terminal: <LayoutGrid className="w-5 h-5 text-text-secondary" />,
     terminalAppearance: <SquareTerminal className="w-5 h-5 text-text-secondary" />,
     worktree: <WorktreeIcon className="w-5 h-5 text-text-secondary" />,
-    agents: <TreeDeciduous className="w-5 h-5 text-text-secondary" />,
+    agents: <CanopyAgentIcon className="w-5 h-5 text-text-secondary" />,
     github: <Github className="w-5 h-5 text-text-secondary" />,
     portal: <PanelRight className="w-5 h-5 text-text-secondary" />,
     toolbar: <SettingsIcon className="w-5 h-5 text-text-secondary" />,
@@ -624,7 +623,7 @@ export function SettingsDialog({
               <NavGroup label="Integrations">
                 <NavItem
                   tab="agents"
-                  icon={<TreeDeciduous className="w-4 h-4" />}
+                  icon={<CanopyAgentIcon className="w-4 h-4" />}
                   label="CLI Agents"
                   activeTab={activeTab}
                   isSearching={isSearching}


### PR DESCRIPTION
## Summary

- Replaces `TreeDeciduous` (Lucide) with `CanopyAgentIcon` (custom botanical SVG) in all places that represent AI agents as a group concept
- Affected surfaces: Settings tab icon, Settings nav item ("CLI Agents"), and the agent selection dialog header
- `AgentSetupWizard`, toolbar button, onboarding checklist, context menu, and worktree overview already used `CanopyAgentIcon` — this change makes Settings consistent with the rest of the app

Resolves #4257

## Changes

- `src/components/Settings/SettingsDialog.tsx` — removed `TreeDeciduous` import, added `CanopyAgentIcon` import, replaced both icon usages (tab icon and nav item)
- `src/components/Setup/AgentSelectionStep.tsx` was also updated, but that file was removed upstream in the setup wizard restructure (PR #4514); the new wizard already uses `CanopyAgentIcon`

## Testing

- No logic changes, purely visual icon swap
- Existing unit and E2E tests pass — no snapshot or component tests reference these specific icon components