### PR TITLE
feat(settings): add random theme cycling button to app theme picker

### DIFF
--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -268,6 +268,9 @@ export function AppThemePicker() {
     const otherIds = allSchemes.map((s) => s.id).filter((id) => id !== selectedSchemeId);
     if (otherIds.length === 0) return;
 
+    // Filter out current theme in case it was manually selected mid-cycle
+    shuffleQueueRef.current = shuffleQueueRef.current.filter((id) => id !== selectedSchemeId);
+
     if (shuffleQueueRef.current.length === 0) {
       shuffleQueueRef.current = shuffleArray(otherIds);
     }

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -116,9 +116,9 @@ describe("AppThemePicker shuffle button", () => {
     fireEvent.click(shuffleBtn);
 
     expect(setSelectedSchemeId).toHaveBeenCalledTimes(2);
-    const ids = setSelectedSchemeId.mock.calls.map((call: unknown[]) => call[0]);
+    const ids = setSelectedSchemeId.mock.calls.map((call: unknown[]) => call[0] as string);
     // Both should be from the other themes
-    expect(ids.every((id: string) => id !== "theme-a")).toBe(true);
+    expect(ids.every((id) => id !== "theme-a")).toBe(true);
     // Both IDs in the first cycle should be unique (both b and c)
     expect(new Set(ids).size).toBe(2);
   });


### PR DESCRIPTION
## Summary

- Adds a shuffle button to `AppThemePicker` that cycles through all available themes (built-in + custom) in a pseudo-random order
- Implements a stateful shuffle queue: themes are shuffled once per session, each press applies the next theme, and the queue reshuffles automatically when exhausted
- The current theme is always excluded from the shuffle pool so each press guarantees a different theme

Resolves #4144

## Changes

- `src/components/Settings/AppThemePicker.tsx` — added shuffle state (`useRef` queue + index), shuffle icon button in the header, and `handleShuffle` logic that skips the active theme and re-shuffles on exhaustion
- `src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx` — unit tests covering first-press shuffle, sequential cycling, re-shuffle on exhaustion, hiding button when only one theme available, and manual theme change mid-cycle

## Testing

Unit test suite added covering all acceptance criteria and edge cases. Ran `npm run check` clean.