### PR TITLE
fix(browser): surface blocked cross-origin navigations to the user

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -281,6 +281,7 @@ export const CHANNELS = {
   WEBVIEW_DIALOG_REQUEST: "webview:dialog-request",
   WEBVIEW_DIALOG_RESPONSE: "webview:dialog-response",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
+  WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
   WEBVIEW_START_CONSOLE_CAPTURE: "webview:start-console-capture",
   WEBVIEW_STOP_CONSOLE_CAPTURE: "webview:stop-console-capture",
   WEBVIEW_CLEAR_CONSOLE_CAPTURE: "webview:clear-console-capture",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -475,6 +475,7 @@ const CHANNELS = {
   WEBVIEW_DIALOG_REQUEST: "webview:dialog-request",
   WEBVIEW_DIALOG_RESPONSE: "webview:dialog-response",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
+  WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
   WEBVIEW_START_CONSOLE_CAPTURE: "webview:start-console-capture",
   WEBVIEW_STOP_CONSOLE_CAPTURE: "webview:stop-console-capture",
   WEBVIEW_CLEAR_CONSOLE_CAPTURE: "webview:clear-console-capture",
@@ -1749,6 +1750,9 @@ const api: ElectronAPI = {
     onFindShortcut: (
       callback: (payload: { panelId: string; shortcut: "find" | "next" | "prev" | "close" }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_FIND_SHORTCUT, callback),
+    onNavigationBlocked: (
+      callback: (payload: { panelId: string; url: string }) => void
+    ): (() => void) => _typedOn(CHANNELS.WEBVIEW_NAVIGATION_BLOCKED, callback),
     startConsoleCapture: (webContentsId: number, paneId: string): Promise<void> =>
       _unwrappingInvoke(CHANNELS.WEBVIEW_START_CONSOLE_CAPTURE, webContentsId, paneId),
     stopConsoleCapture: (webContentsId: number, paneId: string): Promise<void> =>

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -43,8 +43,10 @@ vi.mock("../../utils/webviewCsp.js", () => ({
   isDevPreviewPartition: vi.fn(() => false),
 }));
 
+const mockCanOpenExternalUrl = vi.fn<(url: string) => boolean>(() => false);
+
 vi.mock("../../utils/openExternal.js", () => ({
-  canOpenExternalUrl: vi.fn(() => false),
+  canOpenExternalUrl: (url: string) => mockCanOpenExternalUrl(url),
   openExternalUrl: vi.fn(),
 }));
 
@@ -54,19 +56,30 @@ vi.mock("../../utils/appProtocol.js", () => ({
   buildHeaders: vi.fn(),
 }));
 
+const mockGetPanelId = vi.fn<(id: number) => string | undefined>(() => undefined);
+
 vi.mock("../../services/WebviewDialogService.js", () => ({
   getWebviewDialogService: vi.fn(() => ({
     registerDialog: vi.fn(),
-    getPanelId: vi.fn(),
+    getPanelId: mockGetPanelId,
   })),
 }));
 
+const mockMainWindowSend = vi.fn();
+const mockMainWindow = {
+  isDestroyed: () => false,
+  webContents: { send: mockMainWindowSend },
+};
+
 vi.mock("../../window/windowRef.js", () => ({
-  getMainWindow: vi.fn(() => null),
+  getMainWindow: vi.fn(() => mockMainWindow),
 }));
 
 vi.mock("../../ipc/channels.js", () => ({
-  CHANNELS: { WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut" },
+  CHANNELS: {
+    WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
+    WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
+  },
 }));
 
 import { setupWebviewCSP } from "../protocols.js";
@@ -101,6 +114,9 @@ function getEventHandlers(
 describe("setupWebviewCSP — webview guest navigation restriction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCanOpenExternalUrl.mockReturnValue(false);
+    mockGetPanelId.mockReturnValue(undefined);
+    mockMainWindowSend.mockClear();
     webContentsCreatedListeners.length = 0;
   });
 
@@ -264,6 +280,74 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       const handlers = getEventHandlers(contents, "will-redirect");
       expect(handlers.length).toBe(0);
+    });
+  });
+
+  describe("blocked navigation notification", () => {
+    it("sends WEBVIEW_NAVIGATION_BLOCKED for blocked http/https URLs", () => {
+      mockCanOpenExternalUrl.mockReturnValue(true);
+      mockGetPanelId.mockReturnValue("panel-123");
+      const contents = createMockWebContents("webview");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "https://auth.example.com/authorize");
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockMainWindowSend).toHaveBeenCalledWith("webview:navigation-blocked", {
+        panelId: "panel-123",
+        url: "https://auth.example.com/authorize",
+      });
+    });
+
+    it("sends notification for blocked redirects", () => {
+      mockCanOpenExternalUrl.mockReturnValue(true);
+      mockGetPanelId.mockReturnValue("panel-456");
+      const contents = createMockWebContents("webview");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-redirect")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "https://accounts.google.com/o/oauth2/auth");
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockMainWindowSend).toHaveBeenCalledWith("webview:navigation-blocked", {
+        panelId: "panel-456",
+        url: "https://accounts.google.com/o/oauth2/auth",
+      });
+    });
+
+    it("does not send notification for non-web URLs (javascript:, data:, etc.)", () => {
+      mockGetPanelId.mockReturnValue("panel-789");
+      const contents = createMockWebContents("webview");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "javascript:alert(1)");
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockMainWindowSend).not.toHaveBeenCalledWith(
+        "webview:navigation-blocked",
+        expect.anything()
+      );
+    });
+
+    it("does not send notification when panelId is not registered", () => {
+      mockGetPanelId.mockReturnValue(undefined);
+      const contents = createMockWebContents("webview");
+      simulateWebContentsCreated(contents);
+
+      const handler = getEventHandlers(contents, "will-navigate")[0];
+      const event = { preventDefault: vi.fn() };
+      handler(event, "https://example.com");
+
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockMainWindowSend).not.toHaveBeenCalledWith(
+        "webview:navigation-blocked",
+        expect.anything()
+      );
     });
   });
 });

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -170,10 +170,26 @@ export function setupWebviewCSP(): void {
       // Block webview guest navigations to non-localhost URLs (closes TOCTOU gap
       // where will-attach-webview validates src at attachment but the guest can
       // navigate away afterwards).
+      // When a navigable URL is blocked, notify the renderer so the user can
+      // choose to open it in their system browser instead.
+      const notifyBlockedNavigation = (url: string): void => {
+        if (!canOpenExternalUrl(url)) return;
+        const panelId = getWebviewDialogService().getPanelId(contents.id);
+        if (!panelId) return;
+        const mainWindow = getMainWindow();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send(CHANNELS.WEBVIEW_NAVIGATION_BLOCKED, {
+            panelId,
+            url,
+          });
+        }
+      };
+
       contents.on("will-navigate", (event, navigationUrl) => {
         if (!isLocalhostUrl(navigationUrl)) {
           console.warn(`[MAIN] Blocked webview navigation to non-localhost URL: ${navigationUrl}`);
           event.preventDefault();
+          notifyBlockedNavigation(navigationUrl);
         }
       });
 
@@ -181,6 +197,7 @@ export function setupWebviewCSP(): void {
         if (!isLocalhostUrl(redirectUrl)) {
           console.warn(`[MAIN] Blocked webview redirect to non-localhost URL: ${redirectUrl}`);
           event.preventDefault();
+          notifyBlockedNavigation(redirectUrl);
         }
       });
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -774,6 +774,8 @@ export interface ElectronAPI {
     onFindShortcut(
       callback: (payload: { panelId: string; shortcut: "find" | "next" | "prev" | "close" }) => void
     ): () => void;
+    /** Subscribe to blocked cross-origin navigation attempts from webview guests */
+    onNavigationBlocked(callback: (payload: { panelId: string; url: string }) => void): () => void;
     /** Start CDP console capture for a webview panel */
     startConsoleCapture(webContentsId: number, paneId: string): Promise<void>;
     /** Stop CDP console capture for a webview panel */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1878,6 +1878,10 @@ export interface IpcEventMap {
     panelId: string;
     shortcut: "find" | "next" | "prev" | "close";
   };
+  "webview:navigation-blocked": {
+    panelId: string;
+    url: string;
+  };
 
   // Voice input events
   "voice-input:transcription-delta": string;

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -28,6 +28,7 @@ import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { useNavigationBlockedNotification } from "@/hooks/useNavigationBlockedNotification";
 
 export interface BrowserPaneProps extends BasePanelProps {
   initialUrl: string;
@@ -601,6 +602,7 @@ export function BrowserPane({
     isWebviewReady && !isEvicted,
     isFocused
   );
+  useNavigationBlockedNotification(id);
 
   const handleOpenExternal = useCallback(() => {
     if (!hasValidUrl) return;

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -31,6 +31,7 @@ import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { useNavigationBlockedNotification } from "@/hooks/useNavigationBlockedNotification";
 
 const scrollCache = new Map<string, { url: string; scrollY: number }>();
 
@@ -565,6 +566,7 @@ export function DevPreviewPane({
     isWebviewReady && !isEvicted,
     isFocused
   );
+  useNavigationBlockedNotification(id);
 
   return (
     <ContentPanel

--- a/src/hooks/__tests__/useNavigationBlockedNotification.test.tsx
+++ b/src/hooks/__tests__/useNavigationBlockedNotification.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNavigationBlockedNotification } from "../useNavigationBlockedNotification";
+import type { NotifyPayload } from "@/lib/notify";
+
+const notifyMock = vi.fn<(payload: NotifyPayload) => string>().mockReturnValue("toast-id");
+
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: [NotifyPayload]) => notifyMock(...args),
+}));
+
+type BlockedCallback = (payload: { panelId: string; url: string }) => void;
+
+let capturedCallback: BlockedCallback | null = null;
+const cleanupFn = vi.fn();
+
+describe("useNavigationBlockedNotification", () => {
+  beforeEach(() => {
+    capturedCallback = null;
+    cleanupFn.mockClear();
+    notifyMock.mockClear();
+
+    window.electron = {
+      webview: {
+        onNavigationBlocked: vi.fn((cb: BlockedCallback) => {
+          capturedCallback = cb;
+          return cleanupFn;
+        }),
+      },
+      system: {
+        openExternal: vi.fn(),
+      },
+    } as unknown as typeof window.electron;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electron;
+  });
+
+  it("subscribes on mount and cleans up on unmount", () => {
+    const { unmount } = renderHook(() => useNavigationBlockedNotification("panel-1"));
+
+    expect(window.electron.webview.onNavigationBlocked).toHaveBeenCalledTimes(1);
+    expect(capturedCallback).toBeInstanceOf(Function);
+
+    unmount();
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a warning notification with Open in browser action", () => {
+    renderHook(() => useNavigationBlockedNotification("panel-1"));
+
+    act(() => {
+      capturedCallback!({
+        panelId: "panel-1",
+        url: "https://auth.example.com/authorize",
+      });
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "warning",
+        title: "Navigation blocked",
+        action: expect.objectContaining({ label: "Open in browser" }),
+        duration: 8000,
+      })
+    );
+  });
+
+  it("action button calls openExternal with the blocked URL", () => {
+    renderHook(() => useNavigationBlockedNotification("panel-1"));
+
+    act(() => {
+      capturedCallback!({
+        panelId: "panel-1",
+        url: "https://accounts.google.com/o/oauth2/auth",
+      });
+    });
+
+    const call = notifyMock.mock.calls[0][0];
+    call.action!.onClick!();
+    expect(window.electron.system.openExternal).toHaveBeenCalledWith(
+      "https://accounts.google.com/o/oauth2/auth"
+    );
+  });
+
+  it("ignores events for other panels", () => {
+    renderHook(() => useNavigationBlockedNotification("panel-1"));
+
+    act(() => {
+      capturedCallback!({
+        panelId: "panel-other",
+        url: "https://example.com",
+      });
+    });
+
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates rapid-fire notifications for the same URL", () => {
+    renderHook(() => useNavigationBlockedNotification("panel-1"));
+
+    act(() => {
+      capturedCallback!({ panelId: "panel-1", url: "https://example.com" });
+      capturedCallback!({ panelId: "panel-1", url: "https://example.com" });
+      capturedCallback!({ panelId: "panel-1", url: "https://example.com" });
+    });
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash when window.electron is undefined", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electron;
+    expect(() => renderHook(() => useNavigationBlockedNotification("panel-1"))).not.toThrow();
+  });
+});

--- a/src/hooks/useNavigationBlockedNotification.ts
+++ b/src/hooks/useNavigationBlockedNotification.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import { notify } from "@/lib/notify";
+
+const COALESCE_MS = 3000;
+
+export function useNavigationBlockedNotification(panelId: string): void {
+  const lastNotifiedRef = useRef<{ url: string; ts: number } | null>(null);
+
+  useEffect(() => {
+    if (!window.electron?.webview?.onNavigationBlocked) return;
+
+    const cleanup = window.electron.webview.onNavigationBlocked((payload) => {
+      if (payload.panelId !== panelId) return;
+
+      // Deduplicate rapid-fire notifications for the same URL (e.g. redirect chains)
+      const now = Date.now();
+      const last = lastNotifiedRef.current;
+      if (last && last.url === payload.url && now - last.ts < COALESCE_MS) return;
+      lastNotifiedRef.current = { url: payload.url, ts: now };
+
+      const displayUrl = payload.url.length > 60 ? payload.url.slice(0, 57) + "..." : payload.url;
+
+      notify({
+        type: "warning",
+        title: "Navigation blocked",
+        message: `Cross-origin navigation to ${displayUrl} is not allowed in the integrated browser.`,
+        inboxMessage: `Blocked navigation to ${payload.url}`,
+        action: {
+          label: "Open in browser",
+          onClick: () => {
+            window.electron.system.openExternal(payload.url);
+          },
+        },
+        duration: 8000,
+      });
+    });
+
+    return cleanup;
+  }, [panelId]);
+}


### PR DESCRIPTION
## Summary

- When the integrated browser blocks a cross-origin navigation (e.g. OAuth redirect), the user now sees a warning toast with an **"Open in browser"** button instead of silent failure
- Preserves the intentional localhost-only security boundary (PR #3727, RFC 8252)
- Notifications are deduplicated (3s window) to prevent toast spam from redirect chains
- Wired into both `BrowserPane` and `DevPreviewPane`

Closes #4563
Closes #4559

## Test plan

- [x] `npm run check` passes (typecheck, lint, format)
- [x] Full test suite passes (546 files, 8212 tests, 0 failures)
- [x] 10 new tests: 4 in `protocols.test.ts` (IPC emission), 6 in `useNavigationBlockedNotification.test.tsx` (hook behavior)
- [ ] Manual: open a localhost app in the integrated browser that triggers a cross-origin navigation (e.g. OAuth login) — verify toast appears with "Open in browser" action
- [ ] Manual: verify clicking "Open in browser" opens the URL in the system browser
- [ ] Manual: verify `javascript:`, `data:`, `file:` URLs are still silently blocked (no toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)