### PR TITLE
theme(highlands): add secondary amber accent and brighten success green

### DIFF
--- a/shared/theme/builtInThemes/highlands.ts
+++ b/shared/theme/builtInThemes/highlands.ts
@@ -24,9 +24,9 @@ export const theme: BuiltInThemeSource = {
     },
     border: "#3C3742",
     accent: "#9B86AE",
-    accentSecondary: "#758C73",
+    accentSecondary: "#C48A4A",
     status: {
-      success: "#758C73",
+      success: "#84B882",
       warning: "#A88554",
       danger: "#AB6B63",
       info: "#848C96",


### PR DESCRIPTION
## Summary

- Adds a warm amber secondary accent (`#C48A4A`) to the Highlands theme, drawing from the autumn bracken tones in the hero image
- Brightens the success state green from the muted original to `#84B882` so it reads clearly against the theme's surfaces
- Both changes land in `shared/theme/builtInThemes/highlands.ts` — no structural changes, just two hex value updates

Resolves #4105

## Changes

- `accentSecondary`: set to warm amber `#C48A4A` (replaces placeholder/default)
- `status.success`: updated to `#84B882` (brighter, more saturated while still fitting the Highland aesthetic)

## Testing

Formatting and linting pass clean (403 pre-existing warnings, 0 errors). No logic changes — visual token updates only.