### PR TITLE
feat(voice): handle spoken paragraph commands in AI text correction

### DIFF
--- a/shared/config/__tests__/voiceCorrection.test.ts
+++ b/shared/config/__tests__/voiceCorrection.test.ts
@@ -49,6 +49,25 @@ describe("CORE_CORRECTION_PROMPT", () => {
   it("is identified as a speech-to-text correction engine", () => {
     expect(CORE_CORRECTION_PROMPT).toContain("speech-to-text correction engine");
   });
+
+  it("instructs LLM to convert standalone paragraph voice commands to newlines", () => {
+    expect(CORE_CORRECTION_PROMPT).toContain("new paragraph");
+    expect(CORE_CORRECTION_PROMPT).toContain("next paragraph");
+    expect(CORE_CORRECTION_PROMPT).toContain("start a new paragraph");
+    expect(CORE_CORRECTION_PROMPT).toContain("\\n\\n");
+  });
+
+  it("instructs LLM to convert standalone line break voice commands to newlines", () => {
+    expect(CORE_CORRECTION_PROMPT).toContain("new line");
+    expect(CORE_CORRECTION_PROMPT).toContain("next line");
+    expect(CORE_CORRECTION_PROMPT).toContain("line break");
+    expect(CORE_CORRECTION_PROMPT).toContain("\\n");
+  });
+
+  it("scopes voice commands to standalone formatting instructions only", () => {
+    expect(CORE_CORRECTION_PROMPT).toContain("standalone");
+    expect(CORE_CORRECTION_PROMPT).toMatch(/not.+part of a.+sentence/i);
+  });
 });
 
 describe("buildCorrectionSystemPrompt", () => {
@@ -160,6 +179,12 @@ describe("MICRO_CORRECTION_PROMPT", () => {
   it("describes adjacent word merging", () => {
     expect(MICRO_CORRECTION_PROMPT).toContain("zoo stand");
     expect(MICRO_CORRECTION_PROMPT).toContain("Zustand");
+  });
+
+  it("does not contain paragraph voice command handling", () => {
+    expect(MICRO_CORRECTION_PROMPT).not.toContain("standalone");
+    expect(MICRO_CORRECTION_PROMPT).not.toContain("next paragraph");
+    expect(MICRO_CORRECTION_PROMPT).not.toContain("line break");
   });
 });
 

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -20,7 +20,10 @@ CONFIDENCE TAGS: Words wrapped in <uncertain>word</uncertain> inside <target> we
 CORRECTION PRIORITY:
 1. REQUIRED TERMS / CUSTOM DICTIONARY — Always map phonetically similar words to their exact canonical form.
 2. TECHNICAL TERMS — Correct misheard programming terms using the <terms> dictionary below.
-3. PARAGRAPHS & PUNCTUATION — Add natural paragraph breaks, sentence punctuation, and casing.
+3. PARAGRAPHS & PUNCTUATION — Add natural paragraph breaks, sentence punctuation, and casing. When the speaker uses a standalone voice formatting command (a phrase whose sole purpose is to insert a break, not part of a grammatical sentence), remove the command text and insert the corresponding characters:
+   - Paragraph break (\\n\\n): "new paragraph", "next paragraph", "start a new paragraph", "start new paragraph"
+   - Line break (\\n): "new line", "next line", "line break"
+   Only treat these as commands when spoken as isolated formatting instructions between sentences, not when they appear naturally in speech (e.g. "explain the new paragraph feature" should NOT trigger a break).
 4. FILLER REMOVAL — Remove um, uh, like, you know only when clearly filler, not meaningful.
 5. HOMOPHONES — Fix their/there, its/it's, your/you're when context makes the correct form unambiguous.
 


### PR DESCRIPTION
## Summary

- Expanded `CORE_CORRECTION_PROMPT` priority #3 in `shared/config/voiceCorrection.ts` to explicitly recognize spoken paragraph/line-break voice commands ("new paragraph", "next paragraph", "start a new paragraph", "new line", "line break") and convert them to `\n\n` or `\n` in the corrected output
- The voice commands are removed from the corrected text rather than left as literal words
- `MICRO_CORRECTION_PROMPT` is intentionally unchanged — paragraph handling is a passage-level concern, not a word-cluster concern

Resolves #4064

## Changes

- `shared/config/voiceCorrection.ts` — added explicit spoken-command paragraph detection to `CORE_CORRECTION_PROMPT`
- `shared/config/__tests__/voiceCorrection.test.ts` — added test cases verifying the prompt includes paragraph command handling and the correct newline substitution rules

## Testing

Unit tests added and passing. The existing paragraph boundary flow (Deepgram `speech_final`, manual Enter via `commitParagraphBoundary()`) is unchanged.