### PR TITLE
feat(theme): add pulse-heat-color to Bondi theme for punchier pulse

### DIFF
--- a/shared/theme/builtInThemes/bondi.ts
+++ b/shared/theme/builtInThemes/bondi.ts
@@ -126,6 +126,7 @@ export const theme: BuiltInThemeSource = {
     "pulse-heat-high-opacity": "0.85",
     "pulse-heat-low-opacity": "0.38",
     "pulse-heat-medium-opacity": "0.62",
+    "pulse-heat-color": "#0C9AB4",
     "pulse-missed-bg": "rgba(142,52,44,0.08)",
     "pulse-range-bg": "#F5F6F8",
     "pulse-ring-offset": "#FDFDFE",


### PR DESCRIPTION
## Summary

- Adds `pulse-heat-color` token (`#0C9AB4`, ocean teal) to Bondi theme extensions so the project pulse component has more visual impact
- The color draws from Bondi's coastal rock pool palette — deeper, saturated teal that reads clearly against the theme's background
- Everything else in the Bondi theme is left unchanged; this is a surgical single-token addition

Resolves #4102

## Changes

- `shared/theme/builtInThemes/bondi.ts` — added `pulse-heat-color: '#0C9AB4'` to the theme extensions object

## Testing

Type-checks and lint pass clean. The token feeds directly into the pulse component via the theme extension system — no component changes required.