### PR TITLE
feat(electron): upgrade from v40 to v41

### DIFF
--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -184,7 +184,7 @@ export function setupWebviewCSP(): void {
       });
 
       // Intercept JavaScript dialogs (alert/confirm/prompt) from webview guests.
-      // Electron 40 emits "js-dialog" but its TS types omit it from the overload union.
+      // Electron 40+ emits "js-dialog" but its TS types omit it from the overload union.
       (contents as { on: (event: string, listener: (...args: unknown[]) => void) => void }).on(
         "js-dialog",
         (

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -163,7 +163,7 @@ function logPermissionDenial(
   );
 }
 
-// Electron 40 permission types (from electron.d.ts) — kept as reference for auditing.
+// Electron 41 permission types (from electron.d.ts) — kept as reference for auditing.
 // setPermissionRequestHandler: clipboard-read, clipboard-sanitized-write, display-capture,
 //   fullscreen, geolocation, idle-detection, media, mediaKeySystem, midi, midiSysex,
 //   notifications, pointerLock, keyboardLock, openExternal, speaker-selection,

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "cross-env": "^10.1.0",
         "drizzle-kit": "^0.31.9",
         "drizzle-orm": "^0.45.1",
-        "electron": "^40.8.5",
+        "electron": "^41.1.0",
         "electron-builder": "^26.8.1",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.3.0",
@@ -9422,9 +9422,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.8.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.8.5.tgz",
-      "integrity": "sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==",
+      "version": "41.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.1.0.tgz",
+      "integrity": "sha512-0XRFyxRqetmqtkkBvV++wGbHYJ7bD++f6EgJW8y9kX4pPRagwlmKDtzqXZhKiu0DIQppm3sXxzHWK9GYP91OKQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "cross-env": "^10.1.0",
     "drizzle-kit": "^0.31.9",
     "drizzle-orm": "^0.45.1",
-    "electron": "^40.8.5",
+    "electron": "^41.1.0",
     "electron-builder": "^26.8.1",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.3.0",


### PR DESCRIPTION
## Summary

- Bumps `electron` from `^40.8.5` to `^41.1.0` (Chromium 146, Node.js 24.14)
- Updates two stale version comments in `protocols.ts` and `security.ts` that still referenced v40
- `package-lock.json` updated to reflect the new resolution

Resolves #3485

## Changes

- `package.json`: `electron` version constraint updated to `^41.1.0`
- `electron/setup/protocols.ts`: version comment updated to reflect Electron 41
- `electron/setup/security.ts`: version comment updated to reflect Electron 41
- `package-lock.json`: lockfile updated

## Testing

- `npm run check` (typecheck + lint + format) passes clean
- Unit tests pass
- Native modules (`node-pty`) rebuild successfully via postinstall
- App starts and IPC channels function correctly