### PR TITLE
fix(main): remove global disable-renderer-backgrounding flags

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -88,9 +88,8 @@ app.commandLine.appendSwitch(
   "--max-old-space-size=768 --max-semi-space-size=64 --expose-gc"
 );
 
-// Keep the renderer process at full priority and prevent AudioContext suspension
-app.commandLine.appendSwitch("disable-renderer-backgrounding");
-app.commandLine.appendSwitch("disable-background-timer-throttling");
+// Allow autoplay without user gesture (voice input, media panels).
+// Per-view throttling is managed by ProjectViewManager.setBackgroundThrottling().
 app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 // Disable unused Chromium features: BackForwardCache wastes memory (no browser navigation),
 // CalculateNativeWinOcclusion causes unnecessary power usage on macOS

--- a/src/hooks/useWebviewThrottle.ts
+++ b/src/hooks/useWebviewThrottle.ts
@@ -7,8 +7,8 @@ import { useTerminalStore } from "@/store";
  * becomes visible (dock popover opened or restored to grid).
  *
  * Uses `Page.setWebLifecycleState` via the main process CDP debugger because
- * `webContents.setBackgroundThrottling` is overridden by the parent window's
- * `disable-renderer-backgrounding` app switch flag.
+ * it provides a full JS lifecycle freeze — stronger than the timer/frame
+ * throttling that `webContents.setBackgroundThrottling` applies.
  */
 export function useWebviewThrottle(
   panelId: string,


### PR DESCRIPTION
## Summary

- Removes `disable-renderer-backgrounding` and `disable-background-timer-throttling` global Chromium flags that were overriding per-view throttling set by `ProjectViewManager`
- Cached WebContentsViews now receive proper CPU/timer throttling when deactivated, reducing idle CPU load and memory pressure from JIT/GC
- Updates the `useWebviewThrottle` JSDoc to accurately explain why CDP `Page.setWebLifecycleState` is used (the global flag previously prevented standard throttling APIs from working)

Resolves #4675

## Changes

- `electron/main.ts`: Removed the two `app.commandLine.appendSwitch` calls for `disable-renderer-backgrounding` and `disable-background-timer-throttling`; updated adjacent comment to note throttling is now handled per-view via `ProjectViewManager`
- `src/hooks/useWebviewThrottle.ts`: Corrected JSDoc — the CDP freeze approach is still valid for direct webview lifecycle control, but the comment no longer implies the global flag forces us to use it

## Testing

- Typecheck, lint, and format all pass clean
- `ProjectViewManager.deactivateCurrentView()` calls `setBackgroundThrottling(true)` which will now take effect on cached views; voice input via `VoiceRecordingService` only runs in the active view so AudioContext suspension in cached views is not a concern