### PR TITLE
fix(settings): improve dark mode button visibility

### DIFF
--- a/src/components/Settings/AgentSelectorDropdown.tsx
+++ b/src/components/Settings/AgentSelectorDropdown.tsx
@@ -102,7 +102,7 @@ export function AgentSelectorDropdown({
           aria-haspopup="listbox"
           className={cn(
             "flex items-center gap-2 w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
-            "border border-canopy-border bg-canopy-bg text-canopy-text",
+            "border border-border-interactive bg-canopy-bg text-canopy-text",
             "hover:border-canopy-accent/50 transition-colors",
             "focus:outline-none focus:ring-2 focus:ring-canopy-accent/50"
           )}

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -235,7 +235,7 @@ export function AgentSettings({
         {isGeneralActive && (
           <div
             id="agents-general"
-            className="rounded-[var(--radius-lg)] border border-canopy-border bg-surface p-4 space-y-4"
+            className="rounded-[var(--radius-lg)] border border-border-interactive bg-surface p-4 space-y-4"
           >
             <div className="pb-3 border-b border-canopy-border">
               <h4 className="text-sm font-medium text-canopy-text">Global Agent Settings</h4>
@@ -251,7 +251,7 @@ export function AgentSettings({
                 onChange={(e) =>
                   setDefaultAgent(e.target.value ? (e.target.value as DefaultAgentId) : undefined)
                 }
-                className="w-full px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
+                className="w-full px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
               >
                 <option value="">None (first available)</option>
                 {agentOptions.map((agent) => (
@@ -271,7 +271,7 @@ export function AgentSettings({
 
         {/* Agent Configuration Card */}
         {!isGeneralActive && activeAgent && agentOptions.some((a) => a.id === activeAgent.id) && (
-          <div className="rounded-[var(--radius-lg)] border border-canopy-border bg-surface p-4 space-y-4">
+          <div className="rounded-[var(--radius-lg)] border border-border-interactive bg-surface p-4 space-y-4">
             {/* Header with agent info */}
             <div className="flex items-center justify-between pb-3 border-b border-canopy-border">
               <div className="flex items-center gap-3">
@@ -420,7 +420,7 @@ export function AgentSettings({
             <div id="agents-custom-args" className="space-y-2 pt-2 border-t border-canopy-border">
               <label className="text-sm font-medium text-canopy-text">Custom Arguments</label>
               <input
-                className="w-full rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-canopy-accent/50 placeholder:text-text-muted"
+                className="w-full rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-canopy-accent/50 placeholder:text-text-muted"
                 value={activeEntry.customFlags ?? ""}
                 onChange={(e) => updateAgent(activeAgent.id, { customFlags: e.target.value })}
                 placeholder="--verbose --max-tokens=4096"
@@ -497,7 +497,7 @@ export function AgentSettings({
                       {installBlocks.map((block, blockIndex) => (
                         <div
                           key={blockIndex}
-                          className="rounded-[var(--radius-md)] border border-canopy-border bg-surface p-3 space-y-2"
+                          className="rounded-[var(--radius-md)] border border-border-interactive bg-surface p-3 space-y-2"
                         >
                           {block.label && (
                             <div className="text-xs font-medium text-canopy-text/70">
@@ -521,7 +521,7 @@ export function AgentSettings({
                               {block.commands.map((command, cmdIndex) => (
                                 <div
                                   key={cmdIndex}
-                                  className="flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-canopy-bg border border-canopy-border"
+                                  className="flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] bg-canopy-bg border border-border-interactive"
                                 >
                                   <code className="flex-1 text-xs font-mono text-canopy-text">
                                     {command}

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -111,7 +111,7 @@ function PreferredSchemePicker({
               "flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] border text-xs transition-colors",
               selectedId === scheme.id
                 ? "border-canopy-accent/30 bg-canopy-accent/10 text-canopy-text"
-                : "border-canopy-border text-canopy-text/70 hover:bg-surface-hover"
+                : "border-border-interactive text-canopy-text/70 hover:bg-surface-hover"
             )}
           >
             <div
@@ -382,7 +382,7 @@ export function AppThemePicker() {
             }}
             className={cn(
               "w-full flex items-center gap-3 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
-              "border-canopy-border bg-canopy-bg hover:border-canopy-text/30",
+              "border-border-interactive bg-canopy-bg hover:border-canopy-text/30",
               open && "border-canopy-accent"
             )}
           >
@@ -432,7 +432,7 @@ export function AppThemePicker() {
             <div
               ref={listRef}
               onMouseDown={(e) => e.preventDefault()}
-              className="absolute z-50 left-0 right-0 mt-1 max-h-[280px] overflow-y-auto rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg shadow-[var(--theme-shadow-floating)]"
+              className="absolute z-50 left-0 right-0 mt-1 max-h-[280px] overflow-y-auto rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg shadow-[var(--theme-shadow-floating)]"
             >
               <ThemeSelector<AppColorScheme>
                 groups={[

--- a/src/components/Settings/ColorVisionPicker.tsx
+++ b/src/components/Settings/ColorVisionPicker.tsx
@@ -79,7 +79,7 @@ export function ColorVisionPicker() {
         value={colorVisionMode}
         onChange={(e) => handleChange(e.target.value)}
         className={cn(
-          "bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+          "bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
         )}
         aria-label="Color vision mode"
       >

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -280,7 +280,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
             placeholder="Search commands..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 bg-canopy-bg border border-canopy-border rounded text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent"
+            className="w-full pl-9 pr-3 py-2 bg-canopy-bg border border-border-interactive rounded text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent"
             aria-label="Search commands"
           />
         </div>
@@ -491,7 +491,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                                 onChange={(e) =>
                                   updateDefault(command.id, arg.name, e.target.value)
                                 }
-                                className="w-full bg-canopy-sidebar border border-canopy-border rounded px-2 py-1.5 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
+                                className="w-full bg-canopy-sidebar border border-border-interactive rounded px-2 py-1.5 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
                                 placeholder={
                                   arg.default ? `Default: ${arg.default}` : `Enter ${arg.name}`
                                 }
@@ -573,7 +573,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
                           "text-[11px] px-2 py-0.5 rounded font-mono transition-colors",
                           usedVariables.includes(arg.name)
                             ? "bg-canopy-accent/20 text-canopy-accent border border-canopy-accent/30"
-                            : "bg-canopy-sidebar text-canopy-text/70 hover:bg-canopy-border border border-canopy-border"
+                            : "bg-canopy-sidebar text-canopy-text/70 hover:bg-canopy-border border border-border-interactive"
                         )}
                       >
                         {"{"}
@@ -604,7 +604,7 @@ function PromptEditor({ commandId, args, value, onChange }: PromptEditorProps) {
             "w-full bg-canopy-sidebar border rounded px-2 py-1.5 text-sm text-canopy-text font-mono focus:outline-none focus:ring-1 min-h-[120px] resize-y",
             validation && !validation.valid
               ? "border-status-error/50 focus:border-status-error focus:ring-status-error/30"
-              : "border-canopy-border focus:border-canopy-accent focus:ring-canopy-accent/30"
+              : "border-border-interactive focus:border-canopy-accent focus:ring-canopy-accent/30"
           )}
           placeholder={`Example: Work on issue {issueNumber}...\n\nUse {variableName} to include argument values.`}
         />

--- a/src/components/Settings/DockDensityPicker.tsx
+++ b/src/components/Settings/DockDensityPicker.tsx
@@ -23,7 +23,7 @@ export function DockDensityPicker() {
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
             dockDensity === option.id
               ? "border-canopy-accent bg-canopy-accent/10 text-canopy-text"
-              : "border-canopy-border bg-canopy-bg text-text-secondary hover:border-canopy-text/30 hover:text-canopy-text"
+              : "border-border-interactive bg-canopy-bg text-text-secondary hover:border-canopy-text/30 hover:text-canopy-text"
           )}
           aria-pressed={dockDensity === option.id}
         >

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -157,7 +157,7 @@ export function EditorIntegrationTab() {
               <select
                 value={selectedId}
                 onChange={(e) => setSelectedId(e.target.value as KnownEditorId)}
-                className="flex-1 bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
+                className="flex-1 bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
               >
                 {ORDERED_KNOWN_IDS.map((id) => {
                   const disc = availabilityMap.get(id);
@@ -174,7 +174,7 @@ export function EditorIntegrationTab() {
                 onClick={handleRescan}
                 disabled={isRescanning}
                 title="Re-scan for installed editors"
-                className="p-2 rounded-[var(--radius-md)] border border-canopy-border hover:bg-tint/5 text-canopy-text/60 hover:text-canopy-text transition-colors disabled:opacity-40"
+                className="p-2 rounded-[var(--radius-md)] border border-border-interactive hover:bg-tint/5 text-canopy-text/60 hover:text-canopy-text transition-colors disabled:opacity-40"
               >
                 <RefreshCw className={cn("w-4 h-4", isRescanning && "animate-spin")} />
               </button>
@@ -215,7 +215,7 @@ export function EditorIntegrationTab() {
                   value={customCommand}
                   onChange={(e) => setCustomCommand(e.target.value)}
                   placeholder="e.g. code, nvim, subl"
-                  className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
+                  className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
                 />
               </div>
               <div className="space-y-1">
@@ -225,7 +225,7 @@ export function EditorIntegrationTab() {
                   value={customTemplate}
                   onChange={(e) => setCustomTemplate(e.target.value)}
                   placeholder="{file}:{line}:{col}"
-                  className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
+                  className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
                 />
                 <p className="text-xs text-canopy-text/40 select-text">
                   Use <code className="font-mono">{"{file}"}</code>,{" "}
@@ -248,7 +248,7 @@ export function EditorIntegrationTab() {
             <button
               onClick={handleTest}
               disabled={isTesting}
-              className="px-4 py-2 rounded-[var(--radius-md)] border border-canopy-border text-sm text-canopy-text/70 hover:text-canopy-text hover:bg-tint/5 disabled:opacity-50 transition-colors flex items-center gap-1.5"
+              className="px-4 py-2 rounded-[var(--radius-md)] border border-border-interactive text-sm text-canopy-text/70 hover:text-canopy-text hover:bg-tint/5 disabled:opacity-50 transition-colors flex items-center gap-1.5"
             >
               <ExternalLink className="w-3.5 h-3.5" />
               {isTesting ? "Testing…" : "Test"}

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -278,7 +278,7 @@ export function EnvironmentSettingsTab() {
                       onChange={(e) => updateRow(index, "key", e.target.value)}
                       spellCheck={false}
                       autoCapitalize="none"
-                      className="flex-1 bg-transparent border border-canopy-border rounded px-2 py-1 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
+                      className="flex-1 bg-transparent border border-border-interactive rounded px-2 py-1 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30"
                       placeholder="VARIABLE_NAME"
                       aria-label="Environment variable name"
                     />
@@ -292,7 +292,7 @@ export function EnvironmentSettingsTab() {
                         autoCapitalize="none"
                         autoComplete={isSensitive ? "new-password" : "off"}
                         className={cn(
-                          "w-full bg-canopy-sidebar border border-canopy-border rounded px-2 py-1 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30",
+                          "w-full bg-canopy-sidebar border border-border-interactive rounded px-2 py-1 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30",
                           isSensitive && "pr-8"
                         )}
                         placeholder="value"

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -319,7 +319,7 @@ export function GeneralTab({
         <>
           <div
             id="general-about"
-            className="settings-card flex items-start gap-4 p-4 rounded-[var(--radius-md)] border border-canopy-border"
+            className="settings-card flex items-start gap-4 p-4 rounded-[var(--radius-md)] border border-border-interactive"
           >
             <div
               className="h-12 w-12 rounded-xl flex items-center justify-center shrink-0"
@@ -383,7 +383,7 @@ export function GeneralTab({
                         "flex items-center justify-between text-sm px-3 py-2 rounded-[var(--radius-md)] border w-full text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
                         isUnavailable
                           ? "border-[color-mix(in_oklab,var(--color-status-warning)_30%,transparent)] bg-[color-mix(in_oklab,var(--color-status-warning)_6%,transparent)] hover:bg-[color-mix(in_oklab,var(--color-status-warning)_10%,transparent)]"
-                          : "settings-list-item border-canopy-border hover:bg-[var(--settings-nav-hover-bg,var(--theme-overlay-hover))]"
+                          : "settings-list-item border-border-interactive hover:bg-[var(--settings-nav-hover-bg,var(--theme-overlay-hover))]"
                       )}
                       aria-label={`Go to ${name} agent settings`}
                       onClick={() => onNavigateToAgents?.(id)}
@@ -436,7 +436,7 @@ export function GeneralTab({
                     "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-all capitalize",
                     updateChannel === ch
                       ? "bg-canopy-accent/10 border border-canopy-accent text-canopy-accent"
-                      : "border border-canopy-border hover:bg-tint/5 text-canopy-text/70"
+                      : "border border-border-interactive hover:bg-tint/5 text-canopy-text/70"
                   )}
                 >
                   {ch}
@@ -545,7 +545,7 @@ export function GeneralTab({
                           "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-all",
                           hibernationConfig.inactiveThresholdHours === value
                             ? "bg-canopy-accent/10 border border-canopy-accent text-canopy-accent"
-                            : "border border-canopy-border hover:bg-tint/5 text-canopy-text/70"
+                            : "border border-border-interactive hover:bg-tint/5 text-canopy-text/70"
                         )}
                       >
                         {label}

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -210,7 +210,7 @@ export function GitHubSettingsTab() {
               }
               aria-label="GitHub personal access token"
               autoComplete="new-password"
-              className="flex-1 bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors"
+              className="flex-1 bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors"
               disabled={isValidating || isTesting}
             />
             <Button

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -156,7 +156,7 @@ export function ImageViewerTab() {
                     value={customCommand}
                     onChange={(e) => handleCommandChange(e.target.value)}
                     placeholder="e.g. open -a Photoshop, gimp"
-                    className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
+                    className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors font-mono"
                   />
                   <p className="text-xs text-canopy-text/40">
                     The file path will be appended as the last argument.

--- a/src/components/Settings/KeybindingProfileActions.tsx
+++ b/src/components/Settings/KeybindingProfileActions.tsx
@@ -78,7 +78,7 @@ export function KeybindingProfileActions({ onImportComplete }: KeybindingProfile
         onClick={handleExport}
         disabled={isLoading}
         className={cn(
-          "flex items-center gap-1.5 px-3 py-2 text-sm border border-canopy-border rounded transition-colors",
+          "flex items-center gap-1.5 px-3 py-2 text-sm border border-border-interactive rounded transition-colors",
           isLoading
             ? "opacity-50 cursor-not-allowed text-canopy-text/40"
             : "text-canopy-text/60 hover:text-canopy-text hover:border-canopy-accent"
@@ -91,7 +91,7 @@ export function KeybindingProfileActions({ onImportComplete }: KeybindingProfile
         onClick={handleImport}
         disabled={isLoading}
         className={cn(
-          "flex items-center gap-1.5 px-3 py-2 text-sm border border-canopy-border rounded transition-colors",
+          "flex items-center gap-1.5 px-3 py-2 text-sm border border-border-interactive rounded transition-colors",
           isLoading
             ? "opacity-50 cursor-not-allowed text-canopy-text/40"
             : "text-canopy-text/60 hover:text-canopy-text hover:border-canopy-accent"

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -137,7 +137,7 @@ function KeyRecorder({ onCapture, onCancel, excludeActionId }: KeyRecorderProps)
   const isChord = capturedCombos.length > 1;
 
   return (
-    <div className="bg-canopy-bg/50 border border-canopy-border rounded-[var(--radius-lg)] p-4 space-y-3">
+    <div className="bg-canopy-bg/50 border border-border-interactive rounded-[var(--radius-lg)] p-4 space-y-3">
       <div className="flex items-center gap-2">
         {recording ? (
           <div className="flex-1 px-4 py-2 border border-canopy-accent rounded bg-canopy-accent/10 text-canopy-accent animate-pulse text-center">
@@ -153,14 +153,14 @@ function KeyRecorder({ onCapture, onCancel, excludeActionId }: KeyRecorderProps)
             ) : null}
           </div>
         ) : capturedCombo ? (
-          <div className="flex-1 px-4 py-2 border border-canopy-border rounded bg-canopy-bg text-canopy-text text-center font-mono">
+          <div className="flex-1 px-4 py-2 border border-border-interactive rounded bg-canopy-bg text-canopy-text text-center font-mono">
             <span>{keybindingService.formatComboForDisplay(capturedCombo)}</span>
             {isChord && <span className="ml-2 text-xs text-canopy-text/50">(chord)</span>}
           </div>
         ) : (
           <button
             onClick={handleStartRecording}
-            className="flex-1 px-4 py-2 border border-canopy-border rounded bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:border-canopy-accent transition-colors"
+            className="flex-1 px-4 py-2 border border-border-interactive rounded bg-canopy-bg text-canopy-text/60 hover:text-canopy-text hover:border-canopy-accent transition-colors"
           >
             Click to record shortcut
           </button>
@@ -415,7 +415,7 @@ export function KeyboardShortcutsTab() {
         <div
           className={cn(
             "flex items-center gap-1.5 px-2 py-1.5 flex-1 min-w-0 rounded-[var(--radius-md)]",
-            "bg-canopy-bg border border-canopy-border",
+            "bg-canopy-bg border border-border-interactive",
             "focus-within:border-canopy-accent focus-within:ring-1 focus-within:ring-canopy-accent/20"
           )}
         >
@@ -449,7 +449,7 @@ export function KeyboardShortcutsTab() {
           onClick={handleOpenResetDialog}
           disabled={isResetting}
           className={cn(
-            "flex items-center gap-1.5 px-3 py-2 text-sm border border-canopy-border rounded transition-colors",
+            "flex items-center gap-1.5 px-3 py-2 text-sm border border-border-interactive rounded transition-colors",
             isResetting
               ? "opacity-50 cursor-not-allowed text-canopy-text/40"
               : hasOverrides

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -153,7 +153,7 @@ export function McpServerSettingsTab() {
                   <span className="text-xs text-canopy-text/60">Running on port {status.port}</span>
                 </div>
 
-                <div className="flex items-center gap-2 p-2.5 rounded-[var(--radius-md)] bg-canopy-bg border border-canopy-border font-mono text-xs text-canopy-text/80 select-all">
+                <div className="flex items-center gap-2 p-2.5 rounded-[var(--radius-md)] bg-canopy-bg border border-border-interactive font-mono text-xs text-canopy-text/80 select-all">
                   {sseUrl}
                 </div>
 
@@ -161,7 +161,7 @@ export function McpServerSettingsTab() {
                   onClick={handleCopyConfig}
                   className={cn(
                     "flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
-                    "border border-canopy-border hover:bg-overlay-soft",
+                    "border border-border-interactive hover:bg-overlay-soft",
                     copied
                       ? "text-status-success border-status-success/30"
                       : "text-canopy-text/70 hover:text-canopy-text"
@@ -199,14 +199,14 @@ export function McpServerSettingsTab() {
                   if (e.key === "Enter") handlePortSave();
                 }}
                 placeholder="45454"
-                className="w-40 bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 font-mono focus:outline-none focus:ring-1 focus:ring-canopy-accent"
+                className="w-40 bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-2 text-sm text-canopy-text placeholder:text-canopy-text/40 font-mono focus:outline-none focus:ring-1 focus:ring-canopy-accent"
               />
               <button
                 onClick={handlePortSave}
                 disabled={portInput === (status.configuredPort?.toString() ?? "")}
                 className={cn(
                   "px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] transition-colors",
-                  "border border-canopy-border",
+                  "border border-border-interactive",
                   portInput === (status.configuredPort?.toString() ?? "")
                     ? "text-canopy-text/30 cursor-not-allowed"
                     : "text-canopy-text/70 hover:text-canopy-text hover:bg-overlay-soft"
@@ -241,7 +241,7 @@ export function McpServerSettingsTab() {
                       type={showApiKey ? "text" : "password"}
                       value={status.apiKey}
                       readOnly
-                      className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-2 pr-10 font-mono text-xs text-canopy-text/80 focus:outline-none select-all"
+                      className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-2 pr-10 font-mono text-xs text-canopy-text/80 focus:outline-none select-all"
                     />
                     <button
                       type="button"
@@ -258,7 +258,7 @@ export function McpServerSettingsTab() {
                   </div>
                   <button
                     onClick={handleGenerateApiKey}
-                    className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-canopy-border text-canopy-text/70 hover:text-canopy-text hover:bg-overlay-soft transition-colors"
+                    className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-border-interactive text-canopy-text/70 hover:text-canopy-text hover:bg-overlay-soft transition-colors"
                     title="Regenerate API key"
                   >
                     <RefreshCw className="w-3.5 h-3.5" />
@@ -266,7 +266,7 @@ export function McpServerSettingsTab() {
                   </button>
                   <button
                     onClick={handleClearApiKey}
-                    className="px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-canopy-border text-status-danger hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/20 transition-colors"
+                    className="px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-border-interactive text-status-danger hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/20 transition-colors"
                   >
                     Remove
                   </button>
@@ -274,7 +274,7 @@ export function McpServerSettingsTab() {
               </div>
             ) : (
               <div className="space-y-3">
-                <div className="flex items-center gap-2 p-3 rounded-[var(--radius-md)] bg-canopy-bg border border-canopy-border">
+                <div className="flex items-center gap-2 p-3 rounded-[var(--radius-md)] bg-canopy-bg border border-border-interactive">
                   <div className="w-2 h-2 rounded-full bg-canopy-text/30" />
                   <span className="text-xs text-canopy-text/60">
                     No authentication — any local process can connect
@@ -282,7 +282,7 @@ export function McpServerSettingsTab() {
                 </div>
                 <button
                   onClick={handleGenerateApiKey}
-                  className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium border border-canopy-border text-canopy-text/70 hover:text-canopy-text hover:bg-overlay-soft transition-colors"
+                  className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium border border-border-interactive text-canopy-text/70 hover:text-canopy-text hover:bg-overlay-soft transition-colors"
                 >
                   <Key className="w-3.5 h-3.5" />
                   Generate API Key

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -149,7 +149,7 @@ export function NotificationSettingsTab() {
                     <select
                       value={settings.waitingEscalationDelayMs}
                       onChange={(e) => update({ waitingEscalationDelayMs: Number(e.target.value) })}
-                      className="px-3 py-2 text-sm rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
+                      className="px-3 py-2 text-sm rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
                     >
                       {ESCALATION_DELAY_OPTIONS.map(({ value, label }) => (
                         <option key={value} value={value}>
@@ -214,7 +214,7 @@ export function NotificationSettingsTab() {
                       <select
                         value={settings[field]}
                         onChange={(e) => update({ [field]: e.target.value })}
-                        className="flex-1 px-3 py-2 text-sm rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
+                        className="flex-1 px-3 py-2 text-sm rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
                       >
                         {AVAILABLE_SOUNDS.map(({ file, label: soundLabel }) => (
                           <option key={file} value={file}>
@@ -225,7 +225,7 @@ export function NotificationSettingsTab() {
                       <button
                         onClick={() => handlePreview(settings[field])}
                         title={`Preview ${label.toLowerCase()}`}
-                        className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg text-canopy-text hover:bg-tint/[0.06] transition-colors"
+                        className="flex items-center gap-1.5 px-3 py-2 text-sm rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg text-canopy-text hover:bg-tint/[0.06] transition-colors"
                       >
                         <Play className="h-3.5 w-3.5" />
                         Preview

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -197,20 +197,20 @@ export function PortalSettingsTab() {
       return (
         <div
           key={link.id}
-          className="flex items-center gap-2 p-3 rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30"
+          className="flex items-center gap-2 p-3 rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg/30"
         >
           <input
             type="text"
             value={editName}
             onChange={(e) => setEditName(e.target.value)}
-            className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-2 py-1 text-sm text-canopy-text w-32 focus:border-canopy-accent focus:outline-none"
+            className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-2 py-1 text-sm text-canopy-text w-32 focus:border-canopy-accent focus:outline-none"
             placeholder="Name"
           />
           <input
             type="text"
             value={editUrl}
             onChange={(e) => setEditUrl(e.target.value)}
-            className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-2 py-1 text-sm text-canopy-text flex-1 focus:border-canopy-accent focus:outline-none"
+            className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-2 py-1 text-sm text-canopy-text flex-1 focus:border-canopy-accent focus:outline-none"
             placeholder="URL"
           />
           <button
@@ -232,7 +232,7 @@ export function PortalSettingsTab() {
     return (
       <div
         key={link.id}
-        className="flex items-center justify-between p-3 rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30"
+        className="flex items-center justify-between p-3 rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg/30"
       >
         <div className="flex items-center gap-3">
           {allowDelete ? <FaviconIcon url={link.url} /> : <ServiceIcon name={link.icon} />}
@@ -325,7 +325,7 @@ export function PortalSettingsTab() {
                     : defaultNewTabUrl
             }
             onChange={(e) => handleDefaultAgentChange(e.target.value)}
-            className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
+            className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
           >
             <option value="none">None (show Launchpad)</option>
             {enabledLinks.map((link) => (
@@ -346,7 +346,7 @@ export function PortalSettingsTab() {
                   setCustomDefaultUrl(e.target.value);
                   setCustomUrlError("");
                 }}
-                className="flex-1 bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
+                className="flex-1 bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleCustomUrlSave();
                   if (e.key === "Escape") handleCustomUrlCancel();
@@ -367,7 +367,7 @@ export function PortalSettingsTab() {
                 type="button"
                 onClick={handleCustomUrlCancel}
                 aria-label="Cancel custom URL"
-                className="px-3 py-1.5 rounded-[var(--radius-md)] border border-canopy-border text-canopy-text/70 text-sm hover:bg-canopy-border/50 transition-colors"
+                className="px-3 py-1.5 rounded-[var(--radius-md)] border border-border-interactive text-canopy-text/70 text-sm hover:bg-canopy-border/50 transition-colors"
               >
                 <X className="w-4 h-4" />
               </button>
@@ -414,7 +414,7 @@ export function PortalSettingsTab() {
                 setNewLinkName(e.target.value);
                 setUrlError("");
               }}
-              className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-32 focus:border-canopy-accent focus:outline-none transition-colors"
+              className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-32 focus:border-canopy-accent focus:outline-none transition-colors"
             />
             <input
               type="text"
@@ -424,7 +424,7 @@ export function PortalSettingsTab() {
                 setNewLinkUrl(e.target.value);
                 setUrlError("");
               }}
-              className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text flex-1 focus:border-canopy-accent focus:outline-none transition-colors"
+              className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text flex-1 focus:border-canopy-accent focus:outline-none transition-colors"
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleAddLink();
               }}

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -171,7 +171,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
                   telemetryLevel === option.level
                     ? "border-canopy-accent/40 bg-canopy-accent/5"
-                    : "border-canopy-border hover:bg-tint/5"
+                    : "border-border-interactive hover:bg-tint/5"
                 )}
               >
                 <div className="flex items-center gap-3">
@@ -242,7 +242,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
                     logRetentionDays === option.value
                       ? "bg-canopy-accent/10 text-canopy-accent border border-canopy-accent/30"
-                      : "text-canopy-text/60 border border-canopy-border hover:bg-tint/5 hover:text-canopy-text"
+                      : "text-canopy-text/60 border border-border-interactive hover:bg-tint/5 hover:text-canopy-text"
                   )}
                 >
                   {option.label}

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -31,7 +31,7 @@ export function SettingsCheckbox({
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
         disabled={disabled}
-        className="w-4 h-4 mt-0.5 rounded border-canopy-border bg-canopy-bg text-canopy-accent focus:ring-canopy-accent focus:ring-2 focus:ring-offset-0 disabled:opacity-50"
+        className="w-4 h-4 mt-0.5 rounded border-border-interactive bg-canopy-bg text-canopy-accent focus:ring-canopy-accent focus:ring-2 focus:ring-offset-0 disabled:opacity-50"
       />
       <div className="flex-1">
         <span className="text-sm font-medium text-canopy-text">{label}</span>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -957,7 +957,7 @@ export function SettingsDialog({
                     handleScopeSwitch(e.target.value as SettingsScope);
                     e.target.blur();
                   }}
-                  className="appearance-none text-xs py-1 pl-2 pr-6 rounded-[var(--radius-md)] bg-transparent border border-canopy-border text-text-secondary hover:text-canopy-text hover:border-canopy-text/30 focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/20 outline-none cursor-pointer transition-colors"
+                  className="appearance-none text-xs py-1 pl-2 pr-6 rounded-[var(--radius-md)] bg-transparent border border-border-interactive text-text-secondary hover:text-canopy-text hover:border-canopy-text/30 focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/20 outline-none cursor-pointer transition-colors"
                 >
                   <option value="global">Global</option>
                   <option value="project">Project</option>
@@ -973,7 +973,7 @@ export function SettingsDialog({
           <div
             className={cn(
               "flex items-center gap-1.5 px-2 py-1.5 mb-3 rounded-[var(--radius-md)]",
-              "settings-search border border-canopy-border",
+              "settings-search border border-border-interactive",
               "focus-within:border-canopy-accent focus-within:ring-1 focus-within:ring-canopy-accent/20"
             )}
           >

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -4,19 +4,19 @@ import { cn } from "@/lib/utils";
 
 const COLOR_SCHEMES = {
   accent: {
-    enabled: "border-canopy-border text-canopy-text",
+    enabled: "border-border-interactive text-canopy-text",
     icon: "text-canopy-accent",
     toggle: "bg-canopy-accent",
     focus: "focus-visible:outline-canopy-accent",
   },
   amber: {
-    enabled: "border-canopy-border text-canopy-text",
+    enabled: "border-border-interactive text-canopy-text",
     icon: "text-status-warning",
     toggle: "bg-status-warning",
     focus: "focus-visible:outline-status-warning",
   },
   danger: {
-    enabled: "border-canopy-border text-canopy-text",
+    enabled: "border-border-interactive text-canopy-text",
     icon: "text-status-error",
     toggle: "bg-status-error",
     focus: "focus-visible:outline-status-error",
@@ -69,7 +69,7 @@ export function SettingsSwitchCard({
       className={cn(
         "relative w-full flex items-center justify-between transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
         isCard ? "p-4 rounded-[var(--radius-lg)] border hover:bg-tint/5" : "py-2",
-        isEnabled ? scheme.enabled : "border-canopy-border text-canopy-text/70",
+        isEnabled ? scheme.enabled : "border-border-interactive text-canopy-text/70",
         scheme.focus,
         disabled && "opacity-50 cursor-not-allowed"
       )}

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -188,7 +188,7 @@ export function TerminalAppearanceTab({
                     }
                   }}
                   onBlur={handleFontSizeBlur}
-                  className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-24 focus:border-canopy-accent focus:outline-none transition-colors"
+                  className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-24 focus:border-canopy-accent focus:outline-none transition-colors"
                   aria-label="Terminal font size"
                   aria-invalid={fontSizeError != null || undefined}
                   aria-describedby={fontSizeError ? fontSizeErrorId : undefined}
@@ -214,7 +214,7 @@ export function TerminalAppearanceTab({
                 value={selectedFontFamilyId}
                 onChange={(e) => handleFontFamilyChange(e.target.value)}
                 className={cn(
-                  "bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+                  "bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
                 )}
                 aria-label="Terminal font family"
               >

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -429,7 +429,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 }
               }}
               disabled={!memoryLeakDetectionEnabled || !resourceMonitoringEnabled}
-              className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+              className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
             />
             <p className="text-xs text-canopy-text/40 select-text">
               Automatically restart a terminal when its RSS exceeds this threshold. Set between
@@ -491,7 +491,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   if (!isNaN(val)) setSoftWarningLimit(val);
                 }}
                 disabled={panelLimits.warningsDisabled}
-                className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+                className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
               />
               <p className="text-xs text-canopy-text/40 select-text">
                 Show a dismissible banner when panel count reaches this number.
@@ -513,7 +513,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   if (!isNaN(val)) setConfirmationLimit(val);
                 }}
                 disabled={panelLimits.warningsDisabled}
-                className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+                className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
               />
               <p className="text-xs text-canopy-text/40 select-text">
                 Require explicit confirmation before adding panels beyond this count.
@@ -535,7 +535,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 const val = parseInt(e.target.value, 10);
                 if (!isNaN(val)) setPanelHardLimit(val);
               }}
-              className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+              className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
             />
             <p className="text-xs text-canopy-text/40 select-text">
               Absolute maximum number of panels. Cannot be bypassed.
@@ -759,7 +759,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                     "flex flex-col items-center justify-center p-4 rounded-[var(--radius-md)] border transition-all",
                     layoutConfig.strategy === id
                       ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
-                      : "border-canopy-border hover:bg-tint/5 text-canopy-text/70"
+                      : "border-border-interactive hover:bg-tint/5 text-canopy-text/70"
                   )}
                 >
                   <Icon className="w-6 h-6 mb-2" />
@@ -782,7 +782,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   max="10"
                   value={layoutConfig.value}
                   onChange={(e) => handleValueChange(e.target.value)}
-                  className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
+                  className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text w-full focus:border-canopy-accent focus:outline-none transition-colors"
                 />
                 <p className="text-xs text-canopy-text/40 select-text">
                   {layoutConfig.strategy === "fixed-columns"
@@ -826,7 +826,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   performanceMode && "opacity-50 cursor-not-allowed",
                   scrollbackLines === value
                     ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
-                    : "border-canopy-border hover:bg-tint/5 text-canopy-text/70"
+                    : "border-border-interactive hover:bg-tint/5 text-canopy-text/70"
                 )}
               >
                 <span className="text-xs font-medium">{label}</span>
@@ -922,7 +922,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-all",
                   screenReaderMode === value
                     ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
-                    : "border-canopy-border hover:bg-tint/5 text-canopy-text/70"
+                    : "border-border-interactive hover:bg-tint/5 text-canopy-text/70"
                 )}
               >
                 <span className="text-xs font-medium">{label}</span>

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -73,7 +73,7 @@ export function ThemeSelector<T extends { id: string }>({
         "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
         item.id === selectedId
           ? "border-canopy-accent bg-canopy-accent/10"
-          : "border-canopy-border bg-canopy-bg hover:border-canopy-text/30"
+          : "border-border-interactive bg-canopy-bg hover:border-canopy-text/30"
       )}
     >
       {renderPreview(item)}
@@ -102,7 +102,7 @@ export function ThemeSelector<T extends { id: string }>({
             }}
             placeholder="Filter themes..."
             aria-label="Filter themes"
-            className="w-full pl-7 pr-2 py-1.5 text-xs rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:border-canopy-accent"
+            className="w-full pl-7 pr-2 py-1.5 text-xs rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg text-canopy-text placeholder:text-canopy-text/40 focus:outline-none focus:border-canopy-accent"
           />
         </div>
       </div>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -155,7 +155,7 @@ function SortableButtonItem({
     <div
       ref={setNodeRef}
       style={style}
-      className="flex items-center gap-3 p-3 rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30"
+      className="flex items-center gap-3 p-3 rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg/30"
     >
       <div {...attributes} {...listeners} className="cursor-grab active:cursor-grabbing">
         <GripVertical className="h-4 w-4 text-canopy-text/50" />
@@ -172,7 +172,7 @@ function SortableButtonItem({
         checked={isVisible}
         onChange={() => onToggle(buttonId)}
         aria-label={`Toggle ${metadata.label} visibility`}
-        className="w-4 h-4 rounded border-canopy-border bg-canopy-bg text-canopy-accent focus:ring-canopy-accent focus:ring-2"
+        className="w-4 h-4 rounded border-border-interactive bg-canopy-bg text-canopy-accent focus:ring-canopy-accent focus:ring-2"
       />
     </div>
   );
@@ -344,7 +344,7 @@ export function ToolbarSettingsTab() {
                   e.target.value ? (e.target.value as typeof launcher.defaultSelection) : undefined
                 )
               }
-              className="w-full px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
+              className="w-full px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-interactive bg-canopy-bg text-canopy-text focus:border-canopy-accent focus:outline-none transition-colors"
             >
               <option value="">None (first available)</option>
               <option value="terminal">Terminal</option>
@@ -365,7 +365,7 @@ export function ToolbarSettingsTab() {
         <button
           onClick={reset}
           className={cn(
-            "flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-canopy-border",
+            "flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-interactive",
             "text-canopy-text/60 hover:text-canopy-text hover:bg-tint/5 transition-colors"
           )}
         >

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -240,7 +240,7 @@ export function VoiceInputSettingsTab() {
               <select
                 value={settings.language}
                 onChange={(e) => update({ language: e.target.value })}
-                className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
+                className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
               >
                 {LANGUAGES.map(({ code, label }) => (
                   <option key={code} value={code}>
@@ -256,7 +256,7 @@ export function VoiceInputSettingsTab() {
                 onChange={(e) =>
                   update({ transcriptionModel: e.target.value as VoiceTranscriptionModel })
                 }
-                className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
+                className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
               >
                 {TRANSCRIPTION_MODELS.map(({ value, label, description }) => (
                   <option key={value} value={value}>
@@ -319,7 +319,7 @@ export function VoiceInputSettingsTab() {
                   onChange={(e) =>
                     update({ correctionModel: e.target.value as VoiceCorrectionModel })
                   }
-                  className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
+                  className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
                 >
                   {CORRECTION_MODELS.map(({ value, label, description }) => (
                     <option key={value} value={value}>
@@ -486,7 +486,7 @@ function ApiKeyRow({
               }
             }}
             placeholder={value ? "Enter new key to replace" : placeholder}
-            className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 pr-8 font-mono text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors"
+            className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 pr-8 font-mono text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors"
             autoComplete="new-password"
             spellCheck={false}
             disabled={validation === "testing"}
@@ -690,7 +690,7 @@ function ParagraphingStrategyRow({
         <select
           value={value}
           onChange={(e) => onChange(e.target.value as VoiceParagraphingStrategy)}
-          className="bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
+          className="bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent transition-colors"
         >
           <option value="spoken-command">Spoken commands</option>
           <option value="manual">Manual Enter only</option>
@@ -747,7 +747,7 @@ function DictionarySection({
             }
           }}
           placeholder="Add term…"
-          className="flex-1 bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors"
+          className="flex-1 bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors"
         />
         <Button
           onClick={onAdd}
@@ -766,7 +766,7 @@ function DictionarySection({
           {words.map((word) => (
             <span
               key={word}
-              className="inline-flex items-center gap-1 rounded-full border border-canopy-border bg-canopy-bg px-2.5 py-0.5 text-xs text-canopy-text"
+              className="inline-flex items-center gap-1 rounded-full border border-border-interactive bg-canopy-bg px-2.5 py-0.5 text-xs text-canopy-text"
             >
               {word}
               <button
@@ -806,7 +806,7 @@ function CustomInstructionsRow({
         onChange={(e) => onChange(e.target.value)}
         rows={3}
         placeholder='e.g., "Always capitalize ProductName as one word"'
-        className="w-full bg-canopy-bg border border-canopy-border rounded-[var(--radius-md)] px-3 py-2 text-xs font-mono text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors resize-y"
+        className="w-full bg-canopy-bg border border-border-interactive rounded-[var(--radius-md)] px-3 py-2 text-xs font-mono text-canopy-text placeholder:text-text-muted focus:outline-none focus:border-canopy-accent transition-colors resize-y"
         spellCheck={false}
       />
       <p className="text-xs text-canopy-text/40 select-text">

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -180,7 +180,7 @@ export function WorktreeSettingsTab() {
                   <TooltipTrigger asChild>
                     <button
                       onClick={handleReset}
-                      className="px-3 py-1.5 border border-canopy-border rounded-[var(--radius-md)] text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/50 transition-colors"
+                      className="px-3 py-1.5 border border-border-interactive rounded-[var(--radius-md)] text-canopy-text/60 hover:text-canopy-text hover:bg-canopy-border/50 transition-colors"
                       aria-label="Reset to default"
                     >
                       <RotateCcw className="w-4 h-4" />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -14,15 +14,15 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none focus-visible:ring-destructive",
         outline:
-          "ring-1 ring-border-subtle bg-surface-panel-elevated/95 backdrop-blur-md text-canopy-text shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_var(--color-overlay-soft)] hover:bg-surface-panel-elevated hover:ring-border-default hover:text-canopy-text active:bg-overlay-soft active:shadow-none",
+          "ring-1 ring-border-interactive bg-surface-panel-elevated/95 backdrop-blur-md text-canopy-text shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_var(--color-overlay-soft)] hover:bg-surface-panel-elevated hover:ring-border-default hover:text-canopy-text active:bg-overlay-soft active:shadow-none",
         secondary:
           "bg-secondary text-secondary-foreground ring-1 ring-tint/[0.08] shadow-[var(--theme-shadow-ambient)] hover:bg-secondary/90 active:shadow-none",
         ghost:
           "text-text-secondary hover:bg-overlay-soft hover:text-canopy-text focus-visible:text-canopy-text",
         link: "text-primary underline-offset-4 hover:underline",
         subtle:
-          "bg-surface-panel text-text-secondary ring-1 ring-border-subtle hover:bg-surface-panel-elevated hover:ring-border-default hover:text-canopy-text",
-        pill: "rounded-full bg-surface-panel backdrop-blur-md ring-1 ring-border-subtle text-text-secondary hover:bg-surface-panel-elevated hover:ring-border-default hover:text-canopy-text",
+          "bg-surface-panel text-text-secondary ring-1 ring-border-interactive hover:bg-surface-panel-elevated hover:ring-border-default hover:text-canopy-text",
+        pill: "rounded-full bg-surface-panel backdrop-blur-md ring-1 ring-border-interactive text-text-secondary hover:bg-surface-panel-elevated hover:ring-border-default hover:text-canopy-text",
         "ghost-danger":
           "text-status-error hover:bg-status-error/10 focus-visible:ring-status-error",
         "ghost-success": "text-status-success hover:bg-status-success/10",


### PR DESCRIPTION
## Summary

- Interactive elements (buttons, inputs, selects, checkboxes) in the Settings dialog lacked sufficient border contrast in dark mode, making them hard to distinguish from the background
- Upgraded border classes from `border-canopy-border` to `border-border-interactive` across 27 Settings components and the base `button` UI primitive, using the semantic token that specifically targets interactive element borders
- No logic changes — purely a visual/accessibility improvement

Resolves #4422

## Changes

- `src/components/ui/button.tsx` — base button component uses `border-border-interactive`
- `src/components/Settings/*.tsx` — 26 settings component files updated to use `border-border-interactive` on all interactive controls (inputs, selects, dropdowns, checkboxes, switch cards, etc.)

## Testing

- TypeScript, ESLint, and Prettier all pass cleanly (`npm run check`)
- Visual change verified by reviewing the token mapping: `border-border-interactive` resolves to a higher-contrast border in dark themes compared to `border-canopy-border`