### PR TITLE
fix(settings): skip fixPath in dev mode and refresh PATH before first CLI check

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -19,6 +19,10 @@ export class CliAvailabilityService {
 
     this.inFlightCheck = (async () => {
       try {
+        if (this.availability === null) {
+          await refreshPath();
+        }
+
         const entries = Object.entries(getEffectiveRegistry());
 
         const checksPromise = Promise.allSettled(

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -150,6 +150,46 @@ describe("CliAvailabilityService", () => {
       }
     });
 
+    it("calls refreshPath on first check (cold start)", async () => {
+      mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+
+      await service.checkAvailability();
+
+      expect(refreshPath).toHaveBeenCalledOnce();
+    });
+
+    it("does not call refreshPath on subsequent checks (warm cache)", async () => {
+      mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+
+      await service.checkAvailability();
+      vi.mocked(refreshPath).mockClear();
+
+      // Second check — cache is warm, should not call refreshPath
+      await service.refresh();
+      // refresh() calls refreshPath explicitly, so clear again
+      vi.mocked(refreshPath).mockClear();
+
+      // Force a new check via the service's own checkAvailability
+      // After refresh completes, inFlightCheck is cleared and availability is set
+      // A subsequent checkAvailability should NOT call refreshPath since availability !== null
+      await service.checkAvailability();
+      expect(refreshPath).not.toHaveBeenCalled();
+    });
+
+    it("deduplicates refreshPath across concurrent cold-start calls", async () => {
+      mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+
+      await Promise.all([
+        service.checkAvailability(),
+        service.checkAvailability(),
+        service.checkAvailability(),
+      ]);
+
+      // All concurrent calls share the same in-flight promise,
+      // so refreshPath should only be called once
+      expect(refreshPath).toHaveBeenCalledOnce();
+    });
+
     it("caches results after first check", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -7,18 +7,7 @@ const fsMock = vi.hoisted(() => ({
   rmSync: vi.fn(),
 }));
 
-vi.mock("fs", () => ({
-  default: {
-    existsSync: fsMock.existsSync,
-    readdirSync: fsMock.readdirSync,
-    rmSync: fsMock.rmSync,
-  },
-  existsSync: fsMock.existsSync,
-  readdirSync: fsMock.readdirSync,
-  rmSync: fsMock.rmSync,
-}));
-
-vi.mock("electron", () => ({
+const electronMock = vi.hoisted(() => ({
   app: {
     isPackaged: false,
     getPath: vi.fn(() => "/tmp/test-appdata"),
@@ -30,9 +19,24 @@ vi.mock("electron", () => ({
   },
 }));
 
-vi.mock("fix-path", () => ({
+const fixPathMock = vi.hoisted(() => ({
   default: vi.fn(),
 }));
+
+vi.mock("fs", () => ({
+  default: {
+    existsSync: fsMock.existsSync,
+    readdirSync: fsMock.readdirSync,
+    rmSync: fsMock.rmSync,
+  },
+  existsSync: fsMock.existsSync,
+  readdirSync: fsMock.readdirSync,
+  rmSync: fsMock.rmSync,
+}));
+
+vi.mock("electron", () => electronMock);
+
+vi.mock("fix-path", () => fixPathMock);
 
 vi.mock("node:v8", () => ({
   default: { setFlagsFromString: vi.fn() },
@@ -427,5 +431,38 @@ describe("reset-data", () => {
     await import("../environment.js");
 
     expect(fsMock.readdirSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("fixPath packaging guard", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+    process.argv = ["electron", "main.js"];
+  });
+
+  afterEach(() => {
+    electronMock.app.isPackaged = false;
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    process.argv = originalArgv;
+  });
+
+  it("does not call fixPath in dev mode (isPackaged=false)", async () => {
+    electronMock.app.isPackaged = false;
+    fsMock.existsSync.mockReturnValue(false);
+
+    await import("../environment.js");
+
+    expect(fixPathMock.default).not.toHaveBeenCalled();
+  });
+
+  it("calls fixPath in packaged mode (isPackaged=true)", async () => {
+    electronMock.app.isPackaged = true;
+    fsMock.existsSync.mockReturnValue(false);
+
+    await import("../environment.js");
+
+    expect(fixPathMock.default).toHaveBeenCalledOnce();
   });
 });

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -29,7 +29,9 @@ try {
   // GC exposure not available — non-critical
 }
 
-fixPath();
+if (app.isPackaged) {
+  fixPath();
+}
 
 // In development, use a separate userData directory so the dev instance
 // doesn't conflict with the production app's single-instance lock or storage.


### PR DESCRIPTION
## Summary

- In dev mode (`npm run dev`), `fixPath()` was running unnecessarily and could overwrite the PATH that Electron inherited from the launch chain. Now guarded with `app.isPackaged` so it only runs in production builds.
- `CliAvailabilityService` was checking CLI availability using whatever PATH was current at module load time. Added a one-shot `refreshPath()` call before the first `checkAvailability()` run so the login shell's PATH is always loaded before any `which`/`where` lookups happen.

Resolves #4698

## Changes

- `electron/setup/environment.ts` — guard `fixPath()` behind `app.isPackaged`
- `electron/services/CliAvailabilityService.ts` — call `refreshPath()` once before the first availability check
- `electron/services/__tests__/CliAvailabilityService.test.ts` — new tests covering the lazy refresh behaviour
- `electron/setup/__tests__/environment.test.ts` — expanded tests for the `isPackaged` guard
- `public/skeleton-heatmap.js` — pre-existing lint fix (global `document` directive)

## Testing

Unit tests added for both changes and passing. The `isPackaged` guard is verified to skip `fixPath()` in dev and call it in production. The lazy `refreshPath()` is verified to run exactly once before the first check and not on subsequent calls.