### PR TITLE
fix(quickrun): prevent duplicate terminal spawn on directory change

### DIFF
--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -100,6 +100,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [focusedSuggestionIndex, setFocusedSuggestionIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isRunningRef = useRef(false);
 
   useEffect(() => {
     const saved = localStorage.getItem(`${HISTORY_KEY_PREFIX}${projectId}`);
@@ -281,28 +282,31 @@ export function QuickRun({ projectId }: QuickRunProps) {
 
     if (!cwd) return;
 
-    // Apply stored preferences for saved items, fall back to global state
-    const useDock =
-      item.type === "saved" && item.preferredLocation !== undefined
-        ? item.preferredLocation === "dock"
-        : runAsDocked;
-    const useAutoRestart =
-      item.type === "saved" && item.preferredAutoRestart !== undefined
-        ? item.preferredAutoRestart
-        : autoRestart;
-
-    // Update visible toggles to reflect the preferences being used
-    if (item.type === "saved") {
-      if (item.preferredLocation !== undefined) setRunAsDocked(useDock);
-      if (item.preferredAutoRestart !== undefined) setAutoRestart(useAutoRestart);
-    }
-
-    saveHistory(cmd);
-    setShowSuggestions(false);
-    setInput("");
-    setFocusedSuggestionIndex(-1);
+    if (isRunningRef.current) return;
+    isRunningRef.current = true;
 
     try {
+      // Apply stored preferences for saved items, fall back to global state
+      const useDock =
+        item.type === "saved" && item.preferredLocation !== undefined
+          ? item.preferredLocation === "dock"
+          : runAsDocked;
+      const useAutoRestart =
+        item.type === "saved" && item.preferredAutoRestart !== undefined
+          ? item.preferredAutoRestart
+          : autoRestart;
+
+      // Update visible toggles to reflect the preferences being used
+      if (item.type === "saved") {
+        if (item.preferredLocation !== undefined) setRunAsDocked(useDock);
+        if (item.preferredAutoRestart !== undefined) setAutoRestart(useAutoRestart);
+      }
+
+      saveHistory(cmd);
+      setShowSuggestions(false);
+      setInput("");
+      setFocusedSuggestionIndex(-1);
+
       const terminalType = detectTerminalTypeFromCommand(cmd);
       await addTerminal({
         type: terminalType,
@@ -316,6 +320,8 @@ export function QuickRun({ projectId }: QuickRunProps) {
       });
     } catch (error) {
       console.error("Failed to spawn terminal:", error);
+    } finally {
+      isRunningRef.current = false;
     }
   };
 
@@ -352,6 +358,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
     <div className="flex min-h-0 shrink-0 flex-col border-t border-border-divider bg-surface-sidebar/95 text-xs">
       {/* Header */}
       <button
+        type="button"
         onClick={() => setIsExpanded(!isExpanded)}
         className={cn(
           "flex w-full items-center justify-between px-4 py-2 font-sans",
@@ -425,6 +432,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button
+                          type="button"
                           onClick={handleToggleAutoRestart}
                           className={cn(
                             "p-1.5 rounded-[var(--radius-sm)] transition-all",
@@ -449,6 +457,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button
+                          type="button"
                           onClick={() => setRunAsDocked(!runAsDocked)}
                           className={cn(
                             "p-1.5 rounded-[var(--radius-sm)] transition-all",
@@ -483,6 +492,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                       <TooltipTrigger asChild>
                         <span className="inline-flex">
                           <button
+                            type="button"
                             onClick={() => handleRun(input)}
                             disabled={!input.trim()}
                             className={cn(
@@ -515,6 +525,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                     <div className="overflow-y-auto flex-1">
                       {suggestions.map((item, index) => (
                         <button
+                          type="button"
                           key={`${item.value}-${index}`}
                           role="option"
                           aria-selected={index === focusedSuggestionIndex}

--- a/src/components/Project/__tests__/QuickRun.test.tsx
+++ b/src/components/Project/__tests__/QuickRun.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+// Provide localStorage stub for jsdom
+const storageMap = new Map<string, string>();
+Object.defineProperty(globalThis, "localStorage", {
+  value: {
+    getItem: (key: string) => storageMap.get(key) ?? null,
+    setItem: (key: string, value: string) => storageMap.set(key, value),
+    removeItem: (key: string) => storageMap.delete(key),
+    clear: () => storageMap.clear(),
+  },
+  configurable: true,
+});
+
+const mockAddTerminal = vi.fn();
+let addTerminalResolver: (() => void) | null = null;
+let addTerminalRejecter: ((err: Error) => void) | null = null;
+
+vi.mock("@/hooks/useProjectSettings", () => ({
+  useProjectSettings: () => ({
+    allDetectedRunners: [],
+    settings: { runCommands: [] },
+    promoteToSaved: vi.fn(),
+    removeFromSaved: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/terminalStore", () => ({
+  useTerminalStore: (
+    selector: (s: { addTerminal: typeof mockAddTerminal; terminals: never[] }) => unknown
+  ) => selector({ addTerminal: mockAddTerminal, terminals: [] }),
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string }) => unknown) =>
+    selector({ activeWorktreeId: "wt-1" }),
+}));
+
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({
+    worktreeMap: new Map([["wt-1", { name: "main", path: "/tmp/test-worktree" }]]),
+  }),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/utils/terminalType", () => ({
+  detectTerminalTypeFromCommand: () => "terminal",
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Project/RunningTaskList", () => ({
+  RunningTaskList: () => null,
+}));
+
+import { QuickRun } from "../QuickRun";
+
+function setupPendingTerminal() {
+  const promise = new Promise<void>((resolve, reject) => {
+    addTerminalResolver = resolve;
+    addTerminalRejecter = reject;
+  });
+  mockAddTerminal.mockReturnValue(promise);
+}
+
+function resolveTerminal() {
+  addTerminalResolver?.();
+  addTerminalResolver = null;
+}
+
+function rejectTerminal(err: Error) {
+  addTerminalRejecter?.(err);
+  addTerminalRejecter = null;
+}
+
+describe("QuickRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    addTerminalResolver = null;
+    addTerminalRejecter = null;
+  });
+
+  function typeAndEnter(text: string) {
+    const input = screen.getByPlaceholderText("Execute command...");
+    fireEvent.change(input, { target: { value: text } });
+    fireEvent.keyDown(input, { key: "Enter" });
+  }
+
+  it("prevents duplicate terminal spawn on rapid double Enter", async () => {
+    setupPendingTerminal();
+    render(<QuickRun projectId="test-project" />);
+
+    const input = screen.getByPlaceholderText("Execute command...");
+    fireEvent.change(input, { target: { value: "npm test" } });
+
+    // Fire Enter twice before the first addTerminal resolves
+    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockAddTerminal).toHaveBeenCalledTimes(1);
+
+    // Resolve and clean up
+    await act(async () => resolveTerminal());
+  });
+
+  it("prevents duplicate spawn from Enter + run button click", async () => {
+    setupPendingTerminal();
+    render(<QuickRun projectId="test-project" />);
+
+    const input = screen.getByPlaceholderText("Execute command...");
+    fireEvent.change(input, { target: { value: "npm test" } });
+
+    // Enter via keyboard
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Then click the run button before addTerminal resolves
+    const runButton = screen.getByLabelText("Run command");
+    fireEvent.click(runButton);
+
+    expect(mockAddTerminal).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolveTerminal());
+  });
+
+  it("allows a second run after the first completes", async () => {
+    setupPendingTerminal();
+    render(<QuickRun projectId="test-project" />);
+
+    typeAndEnter("npm test");
+    expect(mockAddTerminal).toHaveBeenCalledTimes(1);
+
+    // Resolve first run
+    await act(async () => resolveTerminal());
+
+    // Set up a new pending terminal for the second run
+    setupPendingTerminal();
+
+    // Second run should work
+    typeAndEnter("npm start");
+    expect(mockAddTerminal).toHaveBeenCalledTimes(2);
+
+    await act(async () => resolveTerminal());
+  });
+
+  it("releases the guard when addTerminal throws", async () => {
+    setupPendingTerminal();
+    render(<QuickRun projectId="test-project" />);
+
+    typeAndEnter("npm test");
+    expect(mockAddTerminal).toHaveBeenCalledTimes(1);
+
+    // Reject first run
+    await act(async () => rejectTerminal(new Error("spawn failed")));
+
+    // Set up new terminal for retry
+    setupPendingTerminal();
+
+    // Should be able to run again after error
+    typeAndEnter("npm test");
+    expect(mockAddTerminal).toHaveBeenCalledTimes(2);
+
+    await act(async () => resolveTerminal());
+  });
+
+  it("does not call addTerminal for blank input", () => {
+    render(<QuickRun projectId="test-project" />);
+
+    const input = screen.getByPlaceholderText("Execute command...");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(mockAddTerminal).not.toHaveBeenCalled();
+  });
+
+  it("renders all main buttons with type='button'", () => {
+    render(<QuickRun projectId="test-project" />);
+
+    const allButtons = screen.getAllByRole("button");
+    for (const button of allButtons) {
+      expect(button.getAttribute("type")).toBe("button");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `handleRunItem` in `QuickRun.tsx` had a race condition where a rapid Enter keypress (or a `cd` command completing and re-triggering the handler) could fire twice before the first async terminal spawn finished, creating a duplicate tab
- Added a `useRef` reentrancy guard that blocks re-entry while a spawn is in flight
- Added `type="button"` to five buttons in the component to prevent accidental form submission behaviour

Resolves #4457

## Changes

- `src/components/Project/QuickRun.tsx` — reentrancy guard via `isRunningRef`, `type="button"` on buttons
- `src/components/Project/__tests__/QuickRun.test.tsx` — regression tests covering rapid double-Enter, concurrent invocations, and normal single-run behaviour

## Testing

Unit tests added and passing. The guard is tested directly: rapid double-Enter now results in a single terminal spawn, not two.