### PR TITLE
fix(window): clamp oversized window to display before centering on restore

### DIFF
--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -136,33 +136,39 @@ describe("createWindowWithState", () => {
   });
 
   describe("recovery", () => {
-    it("clamps oversized window and calls setSize before center when off-screen", () => {
-      // Simulate a window saved on a 2560×1440 external monitor, now on 1920×1080
+    it("clamps oversized window at origin and calls setSize before center (#4710)", () => {
+      // Exact #4710 scenario: window saved on 2560×1440 external monitor, reopened at origin on 1920×1080
       const oversizedBounds = { x: 0, y: 0, width: 2560, height: 1440, isMaximized: false };
       storeMock.get.mockImplementation((key: string) => {
         if (key === "windowStates") return { "/home/user/project": oversizedBounds };
         return {};
       });
 
-      // getBounds returns the oversized dimensions (window created with saved state)
       winInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 2560, height: 1440 });
-
-      // workArea is 1920×1080 — window is fully visible but oversized
-      // visibleArea = min(2560,1920)*min(1440,1080) = 1920*1080 = 2073600
-      // totalArea = 2560*1440 = 3686400
-      // 2073600 < 3686400*0.5 = 1843200? No — so we need the window to be OFF-screen
-      // Let's place it at coordinates that put it mostly off-screen
-      winInstance.getBounds.mockReturnValue({ x: 1800, y: 900, width: 2560, height: 1440 });
 
       createWindowWithState({ show: false }, "/home/user/project");
 
       expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
       expect(winInstance.center).toHaveBeenCalled();
 
-      // Verify setSize was called before center
       const setSizeOrder = winInstance.setSize.mock.invocationCallOrder[0];
       const centerOrder = winInstance.center.mock.invocationCallOrder[0];
       expect(setSizeOrder).toBeLessThan(centerOrder);
+    });
+
+    it("clamps oversized window and centers when mostly off-screen", () => {
+      const oversizedBounds = { x: 1800, y: 900, width: 2560, height: 1440, isMaximized: false };
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "windowStates") return { "/home/user/project": oversizedBounds };
+        return {};
+      });
+
+      winInstance.getBounds.mockReturnValue({ x: 1800, y: 900, width: 2560, height: 1440 });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
+      expect(winInstance.center).toHaveBeenCalled();
     });
 
     it("does not call setSize when window is fully visible on current display", () => {

--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -23,6 +23,7 @@ const winInstance = {
   isDestroyed: vi.fn(() => false),
   maximize: vi.fn(),
   center: vi.fn(),
+  setSize: vi.fn(),
   on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
     eventHandlers.set(event, handler);
   }),
@@ -131,6 +132,68 @@ describe("createWindowWithState", () => {
       createWindowWithState({ show: false }, "/home/user/new-project");
 
       expect(winInstance.maximize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recovery", () => {
+    it("clamps oversized window and calls setSize before center when off-screen", () => {
+      // Simulate a window saved on a 2560×1440 external monitor, now on 1920×1080
+      const oversizedBounds = { x: 0, y: 0, width: 2560, height: 1440, isMaximized: false };
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "windowStates") return { "/home/user/project": oversizedBounds };
+        return {};
+      });
+
+      // getBounds returns the oversized dimensions (window created with saved state)
+      winInstance.getBounds.mockReturnValue({ x: 0, y: 0, width: 2560, height: 1440 });
+
+      // workArea is 1920×1080 — window is fully visible but oversized
+      // visibleArea = min(2560,1920)*min(1440,1080) = 1920*1080 = 2073600
+      // totalArea = 2560*1440 = 3686400
+      // 2073600 < 3686400*0.5 = 1843200? No — so we need the window to be OFF-screen
+      // Let's place it at coordinates that put it mostly off-screen
+      winInstance.getBounds.mockReturnValue({ x: 1800, y: 900, width: 2560, height: 1440 });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      expect(winInstance.setSize).toHaveBeenCalledWith(1920, 1080);
+      expect(winInstance.center).toHaveBeenCalled();
+
+      // Verify setSize was called before center
+      const setSizeOrder = winInstance.setSize.mock.invocationCallOrder[0];
+      const centerOrder = winInstance.center.mock.invocationCallOrder[0];
+      expect(setSizeOrder).toBeLessThan(centerOrder);
+    });
+
+    it("does not call setSize when window is fully visible on current display", () => {
+      const normalBounds = { x: 100, y: 100, width: 1200, height: 800, isMaximized: false };
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "windowStates") return { "/home/user/project": normalBounds };
+        return {};
+      });
+
+      winInstance.getBounds.mockReturnValue({ x: 100, y: 100, width: 1200, height: 800 });
+
+      createWindowWithState({ show: false }, "/home/user/project");
+
+      expect(winInstance.setSize).not.toHaveBeenCalled();
+      expect(winInstance.center).not.toHaveBeenCalled();
+    });
+
+    it("clamps MRU-cascaded oversized bounds via clampToDisplay", () => {
+      // MRU has oversized dimensions from external monitor
+      const oversizedMru = { x: 100, y: 100, width: 2560, height: 1440, isMaximized: false };
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "windowStates") return { "/home/user/other": oversizedMru };
+        return {};
+      });
+
+      createWindowWithState({ show: false }, "/home/user/new-project");
+
+      // clampToDisplay should have clamped width/height to workArea (1920×1080)
+      const opts = constructorCalls[0] as Record<string, number>;
+      expect(opts.width).toBeLessThanOrEqual(1920);
+      expect(opts.height).toBeLessThanOrEqual(1080);
     });
   });
 

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -154,7 +154,11 @@ export function createWindowWithState(
     const visibleArea = Math.max(0, visibleWidth) * Math.max(0, visibleHeight);
     const totalArea = bounds.width * bounds.height;
 
-    if (visibleArea < totalArea * 0.5) {
+    if (
+      visibleArea < totalArea * 0.5 ||
+      bounds.width > workArea.width ||
+      bounds.height > workArea.height
+    ) {
       const clampedWidth = Math.round(Math.min(bounds.width, workArea.width));
       const clampedHeight = Math.round(Math.min(bounds.height, workArea.height));
       win.setSize(clampedWidth, clampedHeight);

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -63,11 +63,13 @@ function clampToDisplay(bounds: { x: number; y: number; width: number; height: n
   const display = screen.getDisplayMatching(bounds as Electron.Rectangle);
   if (!display) return bounds;
   const wa = display.workArea;
+  const clampedWidth = Math.round(Math.min(bounds.width, wa.width));
+  const clampedHeight = Math.round(Math.min(bounds.height, wa.height));
   return {
-    x: Math.max(wa.x, Math.min(bounds.x, wa.x + wa.width - bounds.width)),
-    y: Math.max(wa.y, Math.min(bounds.y, wa.y + wa.height - bounds.height)),
-    width: bounds.width,
-    height: bounds.height,
+    x: Math.max(wa.x, Math.min(bounds.x, wa.x + wa.width - clampedWidth)),
+    y: Math.max(wa.y, Math.min(bounds.y, wa.y + wa.height - clampedHeight)),
+    width: clampedWidth,
+    height: clampedHeight,
   };
 }
 
@@ -153,6 +155,9 @@ export function createWindowWithState(
     const totalArea = bounds.width * bounds.height;
 
     if (visibleArea < totalArea * 0.5) {
+      const clampedWidth = Math.round(Math.min(bounds.width, workArea.width));
+      const clampedHeight = Math.round(Math.min(bounds.height, workArea.height));
+      win.setSize(clampedWidth, clampedHeight);
       win.center();
     }
   }


### PR DESCRIPTION
## Summary

- When Canopy is closed on an external monitor and reopened without it, the saved window dimensions can exceed the current display's work area. Electron/macOS then collapses the window to its minimum size on `center()`.
- `clampToDisplay()` now clamps `width` and `height` to the display's work area (not just `x`/`y`), so position clamping uses the corrected dimensions.
- The off-screen recovery path in `createWindowWithState` calls `win.setSize()` before `win.center()` whenever the window is either mostly off-screen or larger than the current display.

Resolves #4710

## Changes

- `electron/windowState.ts`: `clampToDisplay` now reduces `width`/`height` to fit the work area, and the off-screen recovery condition also triggers when the window is oversized regardless of visibility.
- `electron/__tests__/windowState.test.ts`: Four new tests covering the exact #4710 scenario (oversized at origin), off-screen oversized, normal window (no-op), and MRU cascade with oversized bounds.

## Testing

Unit tests pass. The four new recovery tests cover the scenarios described in the issue, including the exact case (2560×1440 window restored on a 1920×1080 display at the origin).