### PR TITLE
feat(dnd): add CSS layout containment to grid cell wrappers

### DIFF
--- a/src/components/DragDrop/GridPlaceholder.tsx
+++ b/src/components/DragDrop/GridPlaceholder.tsx
@@ -73,7 +73,7 @@ export function SortableGridPlaceholder() {
       style={style}
       {...attributes}
       {...listeners}
-      className="h-full"
+      className="h-full contain-layout contain-style"
       data-placeholder-id={GRID_PLACEHOLDER_ID}
     >
       <GridPlaceholder />

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -51,7 +51,7 @@ export function SortableTerminal({
       style={style}
       data-terminal-id={terminal.id}
       className={cn(
-        "h-full min-w-0 contain-layout",
+        "h-full min-w-0 contain-layout contain-style",
         isDragging && "opacity-40 ring-2 ring-canopy-accent/50 rounded"
       )}
       {...attributes}

--- a/src/components/DragDrop/__tests__/GridPlaceholder.test.tsx
+++ b/src/components/DragDrop/__tests__/GridPlaceholder.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { SortableGridPlaceholder } from "../GridPlaceholder";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: { role: "button" },
+    listeners: undefined,
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+  }),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: {
+    Transform: {
+      toString: () => undefined,
+    },
+  },
+}));
+
+vi.mock("../DndProvider", () => ({
+  GRID_PLACEHOLDER_ID: "__grid-placeholder__",
+  useDndPlaceholder: () => ({ activeTerminal: null }),
+}));
+
+describe("SortableGridPlaceholder", () => {
+  it("renders contain-layout and contain-style on the wrapper", () => {
+    const { container } = render(<SortableGridPlaceholder />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("contain-layout");
+    expect(wrapper.className).toContain("contain-style");
+  });
+
+  it("sets data-placeholder-id on the wrapper", () => {
+    const { container } = render(<SortableGridPlaceholder />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute("data-placeholder-id")).toBe("__grid-placeholder__");
+  });
+});

--- a/src/components/DragDrop/__tests__/SortableTerminal.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableTerminal.test.tsx
@@ -38,7 +38,7 @@ const terminal: TerminalInstance = {
 };
 
 describe("SortableTerminal", () => {
-  it("always renders contain-layout on the wrapper", () => {
+  it("always renders contain-layout and contain-style on the wrapper", () => {
     mockIsDragging = false;
     const { container } = render(
       <SortableTerminal terminal={terminal} sourceLocation="grid" sourceIndex={0}>
@@ -47,9 +47,10 @@ describe("SortableTerminal", () => {
     );
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain("contain-layout");
+    expect(wrapper.className).toContain("contain-style");
   });
 
-  it("includes contain-layout alongside drag-state classes when dragging", () => {
+  it("includes contain-layout contain-style alongside drag-state classes when dragging", () => {
     mockIsDragging = true;
     const { container } = render(
       <SortableTerminal terminal={terminal} sourceLocation="grid" sourceIndex={0}>
@@ -58,6 +59,7 @@ describe("SortableTerminal", () => {
     );
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.className).toContain("contain-layout");
+    expect(wrapper.className).toContain("contain-style");
     expect(wrapper.className).toContain("opacity-40");
   });
 


### PR DESCRIPTION
## Summary

- Adds `contain: layout style` to `SortableGridPlaceholder` grid cell wrappers, isolating each panel's layout and style recalculations from the rest of the grid
- Adds `contain: style` to `SortableTerminal` wrappers for style isolation without clipping absolutely positioned children
- Layout containment is the safe level here: no `paint` or `strict`, so tooltips, context menus, and overlays continue to work correctly

Resolves #4713

## Changes

- `src/components/DragDrop/GridPlaceholder.tsx` — `contain: layout style` on the grid cell wrapper div
- `src/components/DragDrop/SortableTerminal.tsx` — `contain: style` on the sortable wrapper
- Updated/added unit tests for both components verifying the containment styles are applied

## Testing

Existing unit tests updated and passing. The change targets layout recalculation isolation during heavy terminal output — profiling with DevTools Performance panel during agent activity should show reduced "Recalculate Style" and "Layout" times per the issue constraints.