### PR TITLE
perf(ui): replace transition-all with specific transition properties

### DIFF
--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -197,7 +197,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
       >
         <div
           className={cn(
-            "w-10 h-px rounded-full transition-all duration-150 delay-100 group-hover:h-0.5",
+            "w-10 h-px rounded-full transition-[height] duration-150 delay-100 group-hover:h-0.5",
             "bg-canopy-text/15",
             "group-hover:bg-canopy-text/30 group-focus-visible:bg-canopy-accent",
             isResizing && "bg-canopy-accent"

--- a/src/components/EventInspector/EventDetail.tsx
+++ b/src/components/EventInspector/EventDetail.tsx
@@ -33,7 +33,7 @@ function ContextPill({ label, value, filterKey, currentFilters, onToggle }: Cont
                 onToggle(filterKey, value);
               }}
               className={cn(
-                "group flex items-center gap-2 px-2 py-1 rounded text-xs font-mono text-left w-fit transition-all max-w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                "group flex items-center gap-2 px-2 py-1 rounded text-xs font-mono text-left w-fit transition max-w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 isActive
                   ? "bg-primary/15 text-primary border border-primary/30 hover:bg-primary/25"
                   : "hover:bg-muted border border-transparent hover:border-border text-foreground"

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1233,7 +1233,7 @@ export function BulkCreateWorktreeDialog({
             <div className="space-y-2">
               <div className="h-2 rounded-full bg-overlay-soft overflow-hidden">
                 <div
-                  className="h-full rounded-full bg-canopy-accent transition-all duration-300"
+                  className="h-full rounded-full bg-canopy-accent transition-[width] duration-300"
                   style={{
                     width: `${progress.items.size > 0 ? (processedCount / progress.items.size) * 100 : 0}%`,
                   }}

--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -391,7 +391,7 @@ export function GitHubListItem({
                   type="button"
                   onClick={(e) => e.stopPropagation()}
                   className={cn(
-                    "shrink-0 p-0.5 rounded hover:bg-muted transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    "shrink-0 p-0.5 rounded hover:bg-muted transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                     isActive
                       ? "opacity-100"
                       : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"

--- a/src/components/Layout/ChordIndicator.tsx
+++ b/src/components/Layout/ChordIndicator.tsx
@@ -69,7 +69,7 @@ export function ChordIndicator() {
       <div
         className={cn(
           "rounded-[var(--radius-lg)] bg-canopy-sidebar/95 border border-[var(--border-overlay)] shadow-xl",
-          "transition-all duration-150",
+          "transition duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.96]"
         )}

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -376,7 +376,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         <PopoverTrigger asChild>
           <button
             className={cn(
-              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition-all duration-150 max-w-[280px]",
+              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
               "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-canopy-text/70",
               "hover:text-canopy-text hover:bg-[var(--dock-item-bg-hover)]",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -205,7 +205,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         <PopoverTrigger asChild>
           <button
             className={cn(
-              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition-all duration-150 max-w-[280px]",
+              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
               "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-canopy-text/70",
               "hover:text-canopy-text hover:bg-[var(--dock-item-bg-hover)]",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -138,7 +138,7 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           >
             <div
               className={cn(
-                "w-px h-8 rounded-full transition-all duration-150 delay-100 group-hover:w-0.5",
+                "w-px h-8 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
                 "bg-canopy-text/20",
                 "group-hover:bg-canopy-text/35 group-focus-visible:bg-canopy-accent",
                 isResizing && "bg-canopy-accent"

--- a/src/components/Notes/NoteListItem.tsx
+++ b/src/components/Notes/NoteListItem.tsx
@@ -105,7 +105,7 @@ export function NoteListItemRow({
                 <button
                   type="button"
                   onClick={(e) => onDelete(note, e)}
-                  className="shrink-0 opacity-0 group-hover:opacity-100 p-1 rounded-[var(--radius-sm)] hover:bg-status-error/10 text-canopy-text/40 hover:text-status-error transition-all"
+                  className="shrink-0 opacity-0 group-hover:opacity-100 p-1 rounded-[var(--radius-sm)] hover:bg-status-error/10 text-canopy-text/40 hover:text-status-error transition"
                   aria-label="Delete note"
                 >
                   <Trash2 size={12} />

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -90,7 +90,7 @@ export function GettingStartedChecklist({
         {/* Collapsible body */}
         <div
           className={cn(
-            "overflow-hidden transition-all duration-300 ease-in-out",
+            "overflow-hidden transition-[height] duration-300 ease-in-out",
             collapsed ? "h-0" : "h-auto"
           )}
           {...(collapsed ? { inert: true } : {})}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -718,7 +718,7 @@ function PanelHeaderComponent({
                       onAddTab();
                     }}
                     onPointerDown={(e) => e.stopPropagation()}
-                    className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-canopy-text/10 text-canopy-text/40 hover:text-canopy-text transition-all focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1"
+                    className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-canopy-text/10 text-canopy-text/40 hover:text-canopy-text transition focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1"
                     aria-label="Duplicate panel as new tab"
                     type="button"
                   >

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -399,7 +399,7 @@ export function PortalDock() {
           >
             <div
               className={cn(
-                "w-px h-8 rounded-full transition-all duration-150 delay-100 group-hover:w-0.5",
+                "w-px h-8 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
                 "bg-canopy-text/20",
                 "group-hover:bg-canopy-text/35 group-focus:bg-canopy-accent",
                 isResizing && "bg-canopy-accent"

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -39,7 +39,7 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
                   onOpenUrl(link.url, link.title, true);
                 }
               }}
-              className="flex items-center gap-4 p-4 rounded-[var(--radius-xl)] bg-canopy-border hover:bg-canopy-border/80 border border-canopy-border hover:border-canopy-border transition-all group focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
+              className="flex items-center gap-4 p-4 rounded-[var(--radius-xl)] bg-canopy-border hover:bg-canopy-border/80 border border-canopy-border hover:border-canopy-border transition-colors group focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
             >
               <div className="w-8 h-8 flex items-center justify-center text-foreground group-hover:text-canopy-text transition-colors">
                 <PortalIcon icon={link.icon} size="launchpad" url={link.url} type={link.type} />

--- a/src/components/Portal/PortalToolbar.tsx
+++ b/src/components/Portal/PortalToolbar.tsx
@@ -98,7 +98,7 @@ const SortableTab = memo(function SortableTab({
             }
           }}
           className={cn(
-            "group relative flex items-center gap-2 px-3 py-1.5 text-xs font-medium cursor-pointer select-none transition-all",
+            "group relative flex items-center gap-2 px-3 py-1.5 text-xs font-medium cursor-pointer select-none transition",
             "rounded-full border shadow-[var(--theme-shadow-ambient)]",
             "min-w-[80px] max-w-[200px]",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
@@ -389,7 +389,7 @@ export function PortalToolbar({
                           defaultNewTabUrl,
                         });
                       }}
-                      className="flex items-center justify-center w-8 h-[26px] rounded-full bg-overlay-subtle hover:bg-overlay-soft text-canopy-text/70 hover:text-canopy-text border border-divider transition-all"
+                      className="flex items-center justify-center w-8 h-[26px] rounded-full bg-overlay-subtle hover:bg-overlay-soft text-canopy-text/70 hover:text-canopy-text border border-divider transition"
                       aria-label="New Tab"
                       aria-haspopup="menu"
                     >

--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -478,7 +478,7 @@ export function AutomationTab({
               type="text"
               value={terminalShell}
               onChange={(e) => onTerminalShellChange(e.target.value)}
-              className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+              className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
               placeholder="/bin/zsh"
               spellCheck={false}
               autoComplete="off"
@@ -498,7 +498,7 @@ export function AutomationTab({
               type="text"
               value={terminalShellArgs}
               onChange={(e) => onTerminalShellArgsChange(e.target.value)}
-              className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+              className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
               placeholder="-l"
               spellCheck={false}
               autoComplete="off"
@@ -517,7 +517,7 @@ export function AutomationTab({
               type="text"
               value={terminalDefaultCwd}
               onChange={(e) => onTerminalDefaultCwdChange(e.target.value)}
-              className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+              className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
               placeholder="/path/to/working/directory"
               spellCheck={false}
               autoComplete="off"
@@ -541,7 +541,7 @@ export function AutomationTab({
               max={SCROLLBACK_MAX}
               value={terminalScrollback}
               onChange={(e) => onTerminalScrollbackChange(e.target.value)}
-              className="w-28 bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+              className="w-28 bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
               placeholder="1000"
             />
             {terminalScrollback.trim() &&

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -290,7 +290,7 @@ export function GeneralTab({
                 type="text"
                 value={name}
                 onChange={(e) => onNameChange(e.target.value)}
-                className="w-full bg-transparent border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+                className="w-full bg-transparent border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
                 placeholder="My Awesome Project"
               />
             </div>
@@ -317,7 +317,7 @@ export function GeneralTab({
                 aria-label={`Set project color to ${PRESET_SWATCHES[i].label}`}
                 onClick={() => onColorChange(hex)}
                 className={cn(
-                  "h-7 w-7 rounded-full transition-all border-2 shrink-0",
+                  "h-7 w-7 rounded-full transition border-2 shrink-0",
                   color === hex
                     ? "border-canopy-text scale-110 shadow-sm"
                     : "border-transparent hover:border-canopy-border hover:scale-105"
@@ -356,7 +356,7 @@ export function GeneralTab({
               autoComplete="off"
               aria-label="Hex color value"
               className={cn(
-                "w-28 bg-canopy-bg border rounded px-3 py-1.5 text-sm text-canopy-text font-mono focus:outline-none focus:ring-1 transition-all placeholder:text-text-muted",
+                "w-28 bg-canopy-bg border rounded px-3 py-1.5 text-sm text-canopy-text font-mono focus:outline-none focus:ring-1 transition placeholder:text-text-muted",
                 hexInput && !isValidHexColor(hexInput)
                   ? "border-status-error/50 focus:border-status-error focus:ring-status-error/30"
                   : "border-canopy-border focus:border-canopy-accent focus:ring-canopy-accent/30"
@@ -392,7 +392,7 @@ export function GeneralTab({
           type="text"
           value={devServerCommand}
           onChange={(e) => onDevServerCommandChange(e.target.value)}
-          className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+          className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
           placeholder="npm run dev"
           spellCheck={false}
           autoCapitalize="off"
@@ -422,7 +422,7 @@ export function GeneralTab({
                 onDevServerLoadTimeoutChange(num);
               }
             }}
-            className="w-28 bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+            className="w-28 bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
             placeholder="30"
             aria-label="Dev server load timeout in seconds"
           />
@@ -537,7 +537,7 @@ export function GeneralTab({
           aria-checked={currentProject?.inRepoSettings ?? false}
           aria-label="Store settings in repository"
           className={cn(
-            "w-full flex items-center justify-between p-4 rounded-[var(--radius-lg)] border transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-canopy-accent",
+            "w-full flex items-center justify-between p-4 rounded-[var(--radius-lg)] border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-canopy-accent",
             currentProject?.inRepoSettings
               ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
               : "border-canopy-border hover:bg-tint/5 text-canopy-text/70",

--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -155,7 +155,7 @@ export function ProjectOnboardingWizard({
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
-                  className="w-full bg-transparent border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+                  className="w-full bg-transparent border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
                   placeholder="My Project"
                 />
               </div>
@@ -195,7 +195,7 @@ export function ProjectOnboardingWizard({
                     type="text"
                     value={devServerCommand}
                     onChange={(e) => setDevServerCommand(e.target.value)}
-                    className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition-all placeholder:text-text-muted"
+                    className="w-full bg-canopy-bg border border-canopy-border rounded px-3 py-2 text-sm text-canopy-text font-mono focus:outline-none focus:border-canopy-accent focus:ring-1 focus:ring-canopy-accent/30 transition placeholder:text-text-muted"
                     placeholder="npm run dev"
                     spellCheck={false}
                     autoCapitalize="off"

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -102,7 +102,7 @@ function HeapBar({ heapStats }: { heapStats: HeapStats }) {
       </div>
       <div className="h-1.5 rounded-full bg-canopy-text/5 overflow-hidden">
         <div
-          className={`h-full rounded-full transition-all ${barColor}`}
+          className={`h-full rounded-full transition-[width] ${barColor}`}
           style={{ width: `${Math.min(heapStats.percent, 100)}%` }}
         />
       </div>

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -16,7 +16,7 @@ import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 const renderIcon = (emoji: string, color?: string, sizeClass = "h-9 w-9 text-lg") => (
   <div
     className={cn(
-      "flex items-center justify-center rounded-[var(--radius-xl)] shadow-[inset_0_1px_2px_rgba(0,0,0,0.18)] shrink-0 transition-all duration-200",
+      "flex items-center justify-center rounded-[var(--radius-xl)] shadow-[inset_0_1px_2px_rgba(0,0,0,0.18)] shrink-0 transition duration-200",
       sizeClass
     )}
     style={{

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -164,7 +164,7 @@ function ProjectListItem({
 
       <div
         className={cn(
-          "flex items-center justify-center rounded-[var(--radius-lg)] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)] shrink-0 transition-all duration-200",
+          "flex items-center justify-center rounded-[var(--radius-lg)] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3)] shrink-0 transition duration-200",
           "h-8 w-8 text-base"
         )}
         style={{

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -395,7 +395,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
               <div
                 className={cn(
                   "relative flex items-center rounded-[var(--radius-md)] border border-border-subtle/50 bg-overlay-soft",
-                  "transition-all focus-within:border-canopy-accent/35 focus-within:ring-1 focus-within:ring-canopy-accent/12"
+                  "transition focus-within:border-canopy-accent/35 focus-within:ring-1 focus-within:ring-canopy-accent/12"
                 )}
               >
                 {/* Prompt Symbol */}
@@ -435,7 +435,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                           type="button"
                           onClick={handleToggleAutoRestart}
                           className={cn(
-                            "p-1.5 rounded-[var(--radius-sm)] transition-all",
+                            "p-1.5 rounded-[var(--radius-sm)] transition",
                             autoRestart
                               ? "bg-canopy-accent/20 text-canopy-accent"
                               : "text-text-muted hover:bg-overlay-soft hover:text-text-secondary"
@@ -460,7 +460,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                           type="button"
                           onClick={() => setRunAsDocked(!runAsDocked)}
                           className={cn(
-                            "p-1.5 rounded-[var(--radius-sm)] transition-all",
+                            "p-1.5 rounded-[var(--radius-sm)] transition",
                             runAsDocked
                               ? "bg-canopy-accent/20 text-canopy-accent"
                               : "text-text-muted hover:bg-overlay-soft hover:text-text-secondary"
@@ -496,7 +496,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                             onClick={() => handleRun(input)}
                             disabled={!input.trim()}
                             className={cn(
-                              "p-1.5 rounded-[var(--radius-sm)] transition-all",
+                              "p-1.5 rounded-[var(--radius-sm)] transition",
                               input.trim()
                                 ? "text-accent-primary hover:bg-accent-soft"
                                 : "cursor-not-allowed text-text-muted/50"

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -240,7 +240,7 @@ function InlineChecklist({
       {/* Progress bar */}
       <div className="w-full h-1 bg-canopy-border/50 rounded-full mb-4 overflow-hidden">
         <div
-          className="h-full bg-canopy-accent rounded-full transition-all duration-500"
+          className="h-full bg-canopy-accent rounded-full transition-[width] duration-500"
           style={{ width: `${(progressDone / progressTotal) * 100}%` }}
         />
       </div>

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -433,7 +433,7 @@ export function GeneralTab({
                   disabled={channelSaving || updateChannel === null}
                   onClick={() => void handleChannelChange(ch)}
                   className={cn(
-                    "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-all capitalize",
+                    "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
                     updateChannel === ch
                       ? "bg-canopy-accent/10 border border-canopy-accent text-canopy-accent"
                       : "border border-canopy-border hover:bg-tint/5 text-canopy-text/70"
@@ -542,7 +542,7 @@ export function GeneralTab({
                         disabled={isSaving}
                         onClick={() => handleThresholdChange(value)}
                         className={cn(
-                          "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-all",
+                          "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
                           hibernationConfig.inactiveThresholdHours === value
                             ? "bg-canopy-accent/10 border border-canopy-accent text-canopy-accent"
                             : "border border-canopy-border hover:bg-tint/5 text-canopy-text/70"

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -167,7 +167,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                 type="button"
                 onClick={() => void handleTelemetryChange(option.level)}
                 className={cn(
-                  "w-full text-left p-4 rounded-[var(--radius-lg)] border transition-all",
+                  "w-full text-left p-4 rounded-[var(--radius-lg)] border transition-colors",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
                   telemetryLevel === option.level
                     ? "border-canopy-accent/40 bg-canopy-accent/5"
@@ -238,7 +238,7 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
                   type="button"
                   onClick={() => void handleRetentionChange(option.value)}
                   className={cn(
-                    "px-3 py-2 rounded-[var(--radius-md)] text-sm font-medium transition-all",
+                    "px-3 py-2 rounded-[var(--radius-md)] text-sm font-medium transition-colors",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
                     logRetentionDays === option.value
                       ? "bg-canopy-accent/10 text-canopy-accent border border-canopy-accent/30"

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1934,7 +1934,7 @@ function SearchResults({
             )
           }
           className={cn(
-            "group w-full text-left p-3 rounded-[var(--radius-md)] border transition-all",
+            "group w-full text-left p-3 rounded-[var(--radius-md)] border transition-colors",
             index === activeIndex
               ? "bg-overlay-soft border-canopy-accent/30"
               : "border-transparent hover:bg-overlay-soft hover:border-canopy-border",
@@ -1971,7 +1971,7 @@ function SearchResults({
             </div>
             <ChevronRight
               className={cn(
-                "w-4 h-4 text-canopy-text/20 shrink-0 transition-all",
+                "w-4 h-4 text-canopy-text/20 shrink-0 transition",
                 index === activeIndex
                   ? "text-canopy-accent/60 translate-x-0.5"
                   : "group-hover:text-canopy-text/40"

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -67,7 +67,7 @@ export function SettingsSwitchCard({
       aria-checked={isEnabled}
       aria-label={ariaLabel}
       className={cn(
-        "relative w-full flex items-center justify-between transition-all focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        "relative w-full flex items-center justify-between transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
         isCard ? "p-4 rounded-[var(--radius-lg)] border hover:bg-tint/5" : "py-2",
         isEnabled ? scheme.enabled : "border-canopy-border text-canopy-text/70",
         scheme.focus,

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -582,7 +582,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 aria-checked={cachedProjectViews === value}
                 aria-label={`${label} - ${description}`}
                 className={cn(
-                  "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-all",
+                  "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
                   cachedProjectViews === value
                     ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
                     : "border-canopy-border hover:bg-tint/5 text-canopy-text/70"
@@ -756,7 +756,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                   key={id}
                   onClick={() => handleStrategyChange(id)}
                   className={cn(
-                    "flex flex-col items-center justify-center p-4 rounded-[var(--radius-md)] border transition-all",
+                    "flex flex-col items-center justify-center p-4 rounded-[var(--radius-md)] border transition-colors",
                     layoutConfig.strategy === id
                       ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
                       : "border-canopy-border hover:bg-tint/5 text-canopy-text/70"
@@ -822,7 +822,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 aria-checked={scrollbackLines === value}
                 aria-label={`${label} - ${description}`}
                 className={cn(
-                  "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-all",
+                  "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
                   performanceMode && "opacity-50 cursor-not-allowed",
                   scrollbackLines === value
                     ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
@@ -919,7 +919,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
                 aria-checked={screenReaderMode === value}
                 aria-label={`${label} - ${description}`}
                 className={cn(
-                  "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-all",
+                  "flex flex-col items-center justify-center p-3 rounded-[var(--radius-md)] border transition-colors",
                   screenReaderMode === value
                     ? "bg-canopy-accent/10 border-canopy-accent text-canopy-accent"
                     : "border-canopy-border hover:bg-tint/5 text-canopy-text/70"

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -109,7 +109,7 @@ function ArtifactItem({
         className={cn(
           "w-full flex items-center justify-between px-3 py-2 text-left",
           colorClass.split(" ")[1],
-          "hover:brightness-110 transition-all"
+          "hover:brightness-110 transition"
         )}
       >
         <div className="flex items-center gap-2 min-w-0">
@@ -327,7 +327,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
           className={cn(
             "px-3 py-2 rounded-[var(--radius-md)] shadow-lg",
             "border border-status-info/30 text-status-info hover:bg-status-info/10",
-            "text-sm font-medium transition-all",
+            "text-sm font-medium transition-colors",
             "flex items-center gap-2"
           )}
         >

--- a/src/components/Terminal/GridFullOverlay.tsx
+++ b/src/components/Terminal/GridFullOverlay.tsx
@@ -24,7 +24,7 @@ export function GridFullOverlay({ maxTerminals, show }: GridFullOverlayProps) {
       <div
         className={cn(
           "flex flex-col items-center gap-3 text-center px-6 py-4 rounded-[var(--radius-xl)] bg-canopy-bg/90 border border-canopy-border/40 shadow-[var(--theme-shadow-dialog)]",
-          "transition-all duration-150",
+          "transition duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-1 scale-[0.98]"
         )}

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -109,7 +109,7 @@ function InlineStatusBannerComponent({
         hasDescription
           ? "flex flex-col gap-2 px-3 py-2 shrink-0"
           : "flex items-center justify-between gap-3 px-3 py-2 shrink-0",
-        shouldAnimate && "transition-all duration-150",
+        shouldAnimate && "transition duration-150",
         shouldAnimate && (isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"),
         className
       )}

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -100,7 +100,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
         "flex items-center justify-between gap-4 px-4 py-3 rounded-[var(--radius-lg)]",
         "bg-[color-mix(in_oklab,var(--color-status-warning)_12%,transparent)]",
         "border border-status-warning/30",
-        "transition-all duration-200",
+        "transition duration-200",
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
         className
       )}

--- a/src/components/Terminal/TerminalScrollIndicator.tsx
+++ b/src/components/Terminal/TerminalScrollIndicator.tsx
@@ -29,7 +29,7 @@ export function TerminalScrollIndicator({ terminalId }: TerminalScrollIndicatorP
           "bg-canopy-bg/90 border border-canopy-border/40 text-canopy-text shadow-[var(--theme-shadow-floating)]",
           "text-xs font-medium cursor-pointer",
           "hover:bg-canopy-bg hover:border-canopy-border/60",
-          "transition-all duration-150",
+          "transition duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
         )}

--- a/src/components/Terminal/TwoPaneSplitDivider.tsx
+++ b/src/components/Terminal/TwoPaneSplitDivider.tsx
@@ -188,7 +188,7 @@ export function TwoPaneSplitDivider({
     >
       <div
         className={cn(
-          "w-px h-16 rounded-full transition-all duration-150 delay-100 group-hover:w-0.5",
+          "w-px h-16 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
           "bg-canopy-text/20",
           "group-hover:bg-canopy-text/35 group-focus-visible:bg-canopy-accent",
           isDragging && "bg-canopy-accent"

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -251,7 +251,7 @@ export function VoiceInputButton({
                   : "Start voice input"
         }
         className={cn(
-          "relative flex items-center justify-center rounded-full transition-all duration-200",
+          "relative flex items-center justify-center rounded-full transition duration-200",
           "h-6 w-6",
           "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-canopy-accent",
           showOrbit

--- a/src/components/Worktree/ScrollIndicator.tsx
+++ b/src/components/Worktree/ScrollIndicator.tsx
@@ -36,7 +36,7 @@ export function ScrollIndicator({ direction, count, onClick }: ScrollIndicatorPr
           "bg-canopy-bg/90 border border-canopy-border/40 text-canopy-text shadow-[var(--theme-shadow-floating)]",
           "text-xs font-medium cursor-pointer",
           "hover:bg-canopy-bg hover:border-canopy-border/60",
-          "transition-all duration-150",
+          "transition duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-1",
           isVisible

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -557,7 +557,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
         <div
           ref={droppableRef}
           className={cn(
-            "sidebar-worktree-card group/card relative transition-all duration-200",
+            "sidebar-worktree-card group/card relative transition duration-200",
             variant === "sidebar" && "border-b border-border-default",
             variant === "grid" && "rounded-lg border border-divider bg-overlay-subtle",
             isActive &&
@@ -579,7 +579,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
               "bg-[var(--sidebar-hover-bg,var(--theme-overlay-hover))]",
             isOver &&
               !isActive &&
-              "ring-2 ring-accent-primary bg-accent-primary/10 border-accent-primary/50 transition-all duration-200",
+              "ring-2 ring-accent-primary bg-accent-primary/10 border-accent-primary/50 transition-colors duration-200",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
           )}
           data-active={isActive && variant === "sidebar" ? "true" : undefined}

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -461,7 +461,7 @@ export function WorktreeOverviewModal({
                       />
                       <span
                         className={cn(
-                          "transition-all",
+                          "transition",
                           hideMainWorktree && "line-through decoration-canopy-text/30"
                         )}
                       >
@@ -566,7 +566,7 @@ export function WorktreeOverviewModal({
                             "rounded-lg overflow-hidden",
                             "border border-divider",
                             "bg-canopy-sidebar/50",
-                            "transition-all duration-200",
+                            "transition duration-200",
                             "hover:border-canopy-accent/50 hover:shadow-lg hover:shadow-canopy-accent/5",
                             worktree.id === activeWorktreeId &&
                               "border-[var(--color-state-active)]/70 shadow-md"
@@ -613,7 +613,7 @@ export function WorktreeOverviewModal({
                       "rounded-lg overflow-hidden",
                       "border border-divider",
                       "bg-canopy-sidebar/50",
-                      "transition-all duration-200",
+                      "transition duration-200",
                       "hover:border-canopy-accent/50 hover:shadow-lg hover:shadow-canopy-accent/5",
                       worktree.id === activeWorktreeId &&
                         "border-[var(--color-state-active)]/70 shadow-md"

--- a/src/components/ui/ShortcutHint.tsx
+++ b/src/components/ui/ShortcutHint.tsx
@@ -79,7 +79,7 @@ export function ShortcutHint() {
           "flex items-center gap-2 px-3 py-1.5",
           "rounded-[var(--radius-lg)] bg-canopy-sidebar/95 border border-[var(--border-overlay)] shadow-[var(--theme-shadow-floating)]",
           "text-xs text-canopy-text/70",
-          "transition-all duration-150",
+          "transition duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-1"
         )}

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -7,6 +7,13 @@ describe("buttonVariants", () => {
     expect(classes).toContain("cursor-pointer");
   });
 
+  it("uses specific transition instead of transition-all", () => {
+    const classes = buttonVariants();
+    expect(classes).not.toContain("transition-all");
+    // Should contain the base "transition" utility (word boundary check)
+    expect(classes).toMatch(/(?:^|\s)transition(?:\s|$)/);
+  });
+
   it("includes cursor-pointer across all variants", () => {
     const variants = [
       "default",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-md)] text-sm font-medium cursor-pointer select-none transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 active:scale-[0.98]",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-[var(--radius-md)] text-sm font-medium cursor-pointer select-none transition duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 active:scale-[0.98]",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

- Replaces all `transition-all` instances across the codebase with specific transition properties, so Chromium only interpolates the CSS properties that actually change on each element
- Hot paths like `DockedTerminalItem`, `DockedTabGroup`, `PanelHeader`, and `PortalToolbar` now use `transition` (Tailwind v4 base, targeting color/bg/shadow/transform) rather than transitioning every computed property on every frame
- Dimensional animations use `transition-[width]`/`transition-[height]`, color-only changes use `transition-colors`, matching the pattern already established in `toolbar.css`

Resolves #4712

## Changes

- 40 files updated, 62 instances replaced
- Added unit test for `button.tsx` to verify the correct transition class is applied
- No behaviour changes, purely a rendering performance improvement

## Testing

Full lint and format check passes clean. Unit tests pass. Verified visually that hover/active transitions on buttons, dock tabs, panel headers, and toolbar elements are unaffected.