### PR TITLE
perf(project-switcher): remove hover prefetch and workspace host prewarming

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -227,8 +227,6 @@ export const CHANNELS = {
   PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
   PROJECT_CHECK_MISSING: "project:check-missing",
   PROJECT_LOCATE: "project:locate",
-  PROJECT_PREWARM: "project:prewarm",
-
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",
   AGENT_SETTINGS_RESET: "agent-settings:reset",

--- a/electron/ipc/handlers/projectCrud.ts
+++ b/electron/ipc/handlers/projectCrud.ts
@@ -1040,15 +1040,6 @@ Thumbs.db
   ipcMain.handle(CHANNELS.PROJECT_CHECK_MISSING, handleProjectCheckMissing);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_CHECK_MISSING));
 
-  const handleProjectPrewarm = (_event: Electron.IpcMainInvokeEvent, projectId: string) => {
-    if (typeof projectId !== "string" || !projectId) return;
-    const project = projectStore.getProjectById(projectId);
-    if (!project) return;
-    deps.worktreeService?.prewarmProject(project.path);
-  };
-  ipcMain.handle(CHANNELS.PROJECT_PREWARM, handleProjectPrewarm);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_PREWARM));
-
   const handleProjectLocate = async (
     _event: Electron.IpcMainInvokeEvent,
     projectId: string

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -639,8 +639,6 @@ const CHANNELS = {
   PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
   PROJECT_CHECK_MISSING: "project:check-missing",
   PROJECT_LOCATE: "project:locate",
-  PROJECT_PREWARM: "project:prewarm",
-
   // Agent settings channels
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",
@@ -1638,9 +1636,6 @@ const api: ElectronAPI = {
 
     locate: (projectId: string): Promise<Project | null> =>
       _unwrappingInvoke(CHANNELS.PROJECT_LOCATE, projectId),
-
-    prewarmHost: (projectId: string): Promise<void> =>
-      _unwrappingInvoke(CHANNELS.PROJECT_PREWARM, projectId),
   },
 
   // Global Recipes API

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -504,7 +504,6 @@ export interface ElectronAPI {
      * Returns the updated Project, or null if the user cancelled.
      */
     locate(projectId: string): Promise<Project | null>;
-    prewarmHost(projectId: string): Promise<void>;
   };
   globalRecipes: {
     getRecipes(): Promise<TerminalRecipe[]>;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1733,7 +1733,6 @@ function App() {
         onRemoveConfirmClose={() => projectSwitcherPalette.setRemoveConfirmProject(null)}
         onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
         isRemovingProject={projectSwitcherPalette.isRemovingProject}
-        onHoverProject={projectSwitcherPalette.prefetchProject}
         onSelectNewWindow={(project) => {
           projectSwitcherPalette.close();
           void actionService.dispatch(

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -265,8 +265,4 @@ export const projectClient = {
   locate: (projectId: string): Promise<Project | null> => {
     return window.electron.project.locate(projectId);
   },
-
-  prewarmHost: (projectId: string): Promise<void> => {
-    return window.electron.project.prewarmHost(projectId);
-  },
 } as const;

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -169,7 +169,6 @@ export function ProjectSwitcher() {
             onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
             onConfirmRemove={projectSwitcher.confirmRemoveProject}
             isRemovingProject={projectSwitcher.isRemovingProject}
-            onHoverProject={projectSwitcher.prefetchProject}
           >
             <Button
               variant="outline"
@@ -228,7 +227,6 @@ export function ProjectSwitcher() {
         onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
         onConfirmRemove={projectSwitcher.confirmRemoveProject}
         isRemovingProject={projectSwitcher.isRemovingProject}
-        onHoverProject={projectSwitcher.prefetchProject}
       >
         <TooltipProvider>
           <Tooltip>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -61,7 +61,6 @@ export interface ProjectSwitcherPaletteProps {
   onRemoveConfirmClose?: () => void;
   onConfirmRemove?: () => void;
   isRemovingProject?: boolean;
-  onHoverProject?: (project: SearchableProject) => void;
 }
 
 interface ProjectListItemProps {
@@ -72,7 +71,6 @@ interface ProjectListItemProps {
   onCloseProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
-  onHoverProject?: (project: SearchableProject) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
 }
@@ -119,7 +117,6 @@ const ProjectListItem = memo(function ProjectListItem({
   onCloseProject,
   onLocateProject,
   onTogglePinProject,
-  onHoverProject,
   onCopyPath,
   onSelectNewWindow,
 }: ProjectListItemProps) {
@@ -131,7 +128,6 @@ const ProjectListItem = memo(function ProjectListItem({
       role="option"
       aria-selected={isSelected}
       aria-disabled={project.isMissing || undefined}
-      onMouseEnter={onHoverProject ? () => onHoverProject(project) : undefined}
       className={cn(
         "group relative w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border border-transparent",
         project.isActive
@@ -414,7 +410,6 @@ interface ProjectListContentProps {
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
-  onHoverProject?: (project: SearchableProject) => void;
 }
 
 function ProjectListContent({
@@ -429,7 +424,6 @@ function ProjectListContent({
   onTogglePinProject,
   onCopyPath,
   onSelectNewWindow,
-  onHoverProject,
 }: ProjectListContentProps) {
   const isSearching = query.trim().length > 0;
 
@@ -489,7 +483,6 @@ function ProjectListContent({
           onLocateProject={onLocateProject}
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
-          onHoverProject={onHoverProject}
           onSelectNewWindow={onSelectNewWindow}
         />
       </div>
@@ -544,7 +537,6 @@ function ProjectListContent({
                   onLocateProject={onLocateProject}
                   onTogglePinProject={onTogglePinProject}
                   onCopyPath={onCopyPath}
-                  onHoverProject={onHoverProject}
                   onSelectNewWindow={onSelectNewWindow}
                 />
               </div>
@@ -610,7 +602,6 @@ interface ProjectPaletteInnerProps {
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
-  onHoverProject?: (project: SearchableProject) => void;
 }
 
 function ProjectPaletteInner({
@@ -634,7 +625,6 @@ function ProjectPaletteInner({
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
-  onHoverProject,
 }: ProjectPaletteInnerProps) {
   const projectSwitcherShortcut = useKeybindingDisplay("project.switcherPalette");
 
@@ -751,7 +741,6 @@ function ProjectPaletteInner({
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
           onSelectNewWindow={onSelectNewWindow}
-          onHoverProject={onHoverProject}
         />
       </AppPaletteDialog.Body>
 
@@ -910,7 +899,6 @@ function ModalContent({
           onCopyPath={innerProps.onCopyPath}
           onSelectBackground={innerProps.onSelectBackground}
           onSelectNewWindow={innerProps.onSelectNewWindow}
-          onHoverProject={innerProps.onHoverProject}
         />
       </div>
     </div>,
@@ -986,7 +974,6 @@ function DropdownContent({
           onCopyPath={innerProps.onCopyPath}
           onSelectBackground={innerProps.onSelectBackground}
           onSelectNewWindow={innerProps.onSelectNewWindow}
-          onHoverProject={innerProps.onHoverProject}
         />
       </PopoverContent>
     </Popover>
@@ -1020,7 +1007,6 @@ export function ProjectSwitcherPalette({
   onRemoveConfirmClose,
   onConfirmRemove,
   isRemovingProject = false,
-  onHoverProject,
 }: ProjectSwitcherPaletteProps) {
   const hasRunningProcesses = removeConfirmProject
     ? removeConfirmProject.processCount > 0 ||
@@ -1051,7 +1037,6 @@ export function ProjectSwitcherPalette({
         onSelectNewWindow={onSelectNewWindow}
         onOpenProjectSettings={onOpenProjectSettings}
         dropdownAlign={dropdownAlign}
-        onHoverProject={onHoverProject}
       >
         {children}
       </DropdownContent>
@@ -1076,7 +1061,6 @@ export function ProjectSwitcherPalette({
         onSelectBackground={onSelectBackground}
         onSelectNewWindow={onSelectNewWindow}
         onOpenProjectSettings={onOpenProjectSettings}
-        onHoverProject={onHoverProject}
       />
     );
 

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -5,7 +5,6 @@ import { usePaletteStore } from "@/store/paletteStore";
 import { notify } from "@/lib/notify";
 import type { Project, BulkProjectStatsEntry } from "@shared/types";
 import { projectClient } from "@/clients";
-import { warmSettingsCache } from "@/store/projectSettingsStore";
 
 export type ProjectSwitcherMode = "modal" | "dropdown";
 
@@ -55,14 +54,9 @@ export interface UseProjectSwitcherPaletteReturn {
   confirmRemoveProject: () => Promise<void>;
   isRemovingProject: boolean;
   backgroundWaitingCount: number;
-  prefetchProject: (project: SearchableProject) => void;
 }
 
 const MAX_RESULTS = 15;
-const PREFETCH_DEBOUNCE_MS = 150;
-
-const prefetchedProjects = new Set<string>();
-let prefetchTimerRef: ReturnType<typeof setTimeout> | null = null;
 
 export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const modalIsOpen = usePaletteStore((state) => state.activePaletteId === "project-switcher");
@@ -283,11 +277,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     }
     setQuery("");
     setSelectedIndex(0);
-    if (prefetchTimerRef) {
-      clearTimeout(prefetchTimerRef);
-      prefetchTimerRef = null;
-    }
-    prefetchedProjects.clear();
   }, [mode]);
 
   const toggle = useCallback(
@@ -472,39 +461,6 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     }
   }, [removeConfirmProject, isRemovingProject, closeActiveProject, removeProject]);
 
-  const prefetchProject = useCallback((project: SearchableProject) => {
-    if (project.isActive || project.isMissing) return;
-    if (prefetchedProjects.has(project.id)) return;
-
-    void projectClient.prewarmHost(project.id).catch(() => {});
-
-    if (prefetchTimerRef) {
-      clearTimeout(prefetchTimerRef);
-    }
-
-    prefetchTimerRef = setTimeout(() => {
-      prefetchTimerRef = null;
-      if (prefetchedProjects.has(project.id)) return;
-
-      void (async () => {
-        try {
-          const [data, detected] = await Promise.all([
-            projectClient.getSettings(project.id),
-            projectClient.detectRunners(project.id),
-          ]);
-
-          const savedCommandStrings = new Set(data.runCommands?.map((c) => c.command) || []);
-          const newDetected = detected.filter((d) => !savedCommandStrings.has(d.command));
-
-          warmSettingsCache(project.id, data, newDetected, detected);
-          prefetchedProjects.add(project.id);
-        } catch {
-          // Prefetch failures are non-critical
-        }
-      })();
-    }, PREFETCH_DEBOUNCE_MS);
-  }, []);
-
   return {
     isOpen,
     mode,
@@ -533,6 +489,5 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     confirmRemoveProject,
     isRemovingProject,
     backgroundWaitingCount,
-    prefetchProject,
   };
 }

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -44,7 +44,6 @@ const createMockProjectClient = () => ({
   disableInRepoSettings: vi.fn().mockResolvedValue({}),
   checkMissing: vi.fn().mockResolvedValue([]),
   locate: vi.fn().mockResolvedValue(null),
-  prewarmHost: vi.fn().mockResolvedValue(undefined),
   cloneRepo: vi.fn().mockResolvedValue({ success: true }),
   onCloneProgress: vi.fn().mockReturnValue(() => {}),
   exportRecipeToFile: vi.fn().mockResolvedValue(true),

--- a/src/store/persistence/__tests__/terminalPersistence.test.ts
+++ b/src/store/persistence/__tests__/terminalPersistence.test.ts
@@ -50,7 +50,6 @@ const createMockProjectClient = () => ({
   disableInRepoSettings: vi.fn().mockResolvedValue({}),
   checkMissing: vi.fn().mockResolvedValue([]),
   locate: vi.fn().mockResolvedValue(null),
-  prewarmHost: vi.fn().mockResolvedValue(undefined),
   cloneRepo: vi.fn().mockResolvedValue({ success: true }),
   onCloneProgress: vi.fn().mockReturnValue(() => {}),
   exportRecipeToFile: vi.fn().mockResolvedValue(true),


### PR DESCRIPTION
## Summary

- Removes the `onMouseEnter` hover handler from `ProjectSwitcherPalette` that was triggering `prewarmHost()` and a debounced `getSettings()` + `detectRunners()` fetch on every hovered project item
- Drops the `prefetchedProjects` module-level Set and associated `prefetchProject` / `clearPrefetchedProjects` logic from `useProjectSwitcherPalette`
- Removes the `prewarmHost` call wired into `App.tsx` at startup

Hovering over 5 projects was spawning 5 UtilityProcess workspace hosts with a 3-minute cleanup grace period each. Canopy's multi-view architecture already makes the actual switch fast, so the prefetch bought nothing and just burned memory and CPU in the background.

Resolves #4726

## Changes

- `src/hooks/useProjectSwitcherPalette.ts` — removed `prefetchProject`, `clearPrefetchedProjects`, `prefetchedProjects` Set, and the `prewarmHost` IPC call (45 lines deleted)
- `src/components/Project/ProjectSwitcherPalette.tsx` — removed `onMouseEnter` hover handler wired to prefetch
- `src/components/Project/ProjectSwitcher.tsx` — removed `onClose` prop passing `clearPrefetchedProjects`
- `src/App.tsx` — removed `prewarmHost` startup call

## Testing

Ran `npm run check` (typecheck + lint + format) — clean. No unit tests affected. Manually verified the project switcher opens, navigates, and switches projects correctly without the prefetch in place.