### PR TITLE
feat(bulk): include main worktree in bulk operations

### DIFF
--- a/src/components/BulkCommandCenter/BulkCommandPalette.tsx
+++ b/src/components/BulkCommandCenter/BulkCommandPalette.tsx
@@ -97,7 +97,6 @@ function useWorktreeRows(): WorktreeRow[] {
   return useMemo(() => {
     const rows: WorktreeRow[] = [];
     for (const wt of worktrees.values()) {
-      if (wt.isMainWorktree) continue;
       const eligible = getEligibleTerminals(terminals, wt.id);
       const dominantState = getDominantAgentState(eligible.map((t) => t.agentState));
       rows.push({
@@ -620,7 +619,7 @@ function BulkCommandPaletteInner() {
             {/* Worktree list */}
             {rows.length === 0 ? (
               <div className="px-3 py-8 text-center text-canopy-text/50 text-sm">
-                No non-main worktrees available
+                No worktrees available
               </div>
             ) : (
               <>

--- a/src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx
+++ b/src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx
@@ -313,12 +313,20 @@ describe("BulkCommandPalette", () => {
     expect(screen.queryByRole("dialog")).toBeNull();
   });
 
-  it("renders worktree rows excluding main worktree when open", () => {
+  it("renders worktree rows including main worktree when open", () => {
     render(<BulkCommandPalette />);
     openPalette();
     expect(screen.getByText("feature/a")).toBeTruthy();
     expect(screen.getByText("feature/b")).toBeTruthy();
-    expect(screen.queryByText("main")).toBeNull();
+    expect(screen.getByText("main")).toBeTruthy();
+  });
+
+  it("renders main worktree as disabled when it has no agent terminals", () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    const mainRow = screen.getByText("main").closest("button")!;
+    const checkbox = mainRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.disabled).toBe(true);
   });
 
   it("shows agent terminal count per worktree", () => {


### PR DESCRIPTION
## Summary

- Removed the `isMainWorktree` guard in `useWorktreeRows()` so the main worktree now appears as a selectable row in the bulk command palette alongside sub-worktrees.
- Updated the empty-state message to reflect that all worktrees (not just feature worktrees) are covered.
- Updated tests to cover the main worktree inclusion and verify it respects the same eligibility filtering as other worktrees.

Resolves #4771

## Changes

- `src/components/BulkCommandCenter/BulkCommandPalette.tsx` — removed `if (wt.isMainWorktree) continue` guard; updated empty-state string
- `src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx` — added test cases for main worktree visibility and eligibility filtering

## Testing

Unit tests updated and passing. The main worktree now appears in bulk operations when it has eligible agent terminals, and is correctly excluded when it has none.