### PR TITLE
fix(menu): replace role menu items with correct webContents targets

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockWebContents = vi.hoisted(() => ({
+  toggleDevTools: vi.fn(),
+  reload: vi.fn(),
+  reloadIgnoringCache: vi.fn(),
+  setZoomLevel: vi.fn(),
+  getZoomLevel: vi.fn(() => 1.0),
+  isDestroyed: vi.fn(() => false),
+  send: vi.fn(),
+  undo: vi.fn(),
+  redo: vi.fn(),
+  cut: vi.fn(),
+  copy: vi.fn(),
+  paste: vi.fn(),
+  selectAll: vi.fn(),
+}));
+
+const mockFocusedWebContents = vi.hoisted(() => ({
+  undo: vi.fn(),
+  redo: vi.fn(),
+  cut: vi.fn(),
+  copy: vi.fn(),
+  paste: vi.fn(),
+  selectAll: vi.fn(),
+  isDestroyed: vi.fn(() => false),
+}));
+
+const mockBrowserWindow = vi.hoisted(() => ({
+  isDestroyed: vi.fn(() => false),
+  id: 1,
+}));
+
+let capturedTemplate: Electron.MenuItemConstructorOptions[] = [];
+
+vi.mock("electron", () => ({
+  Menu: {
+    buildFromTemplate: vi.fn((template: Electron.MenuItemConstructorOptions[]) => {
+      capturedTemplate = template;
+      return {};
+    }),
+    setApplicationMenu: vi.fn(),
+  },
+  dialog: { showOpenDialog: vi.fn() },
+  BrowserWindow: vi.fn(),
+  shell: { openExternal: vi.fn() },
+  app: {
+    isPackaged: false,
+    getVersion: vi.fn(() => "1.0.0"),
+    setAboutPanelOptions: vi.fn(),
+  },
+  webContents: {
+    getFocusedWebContents: vi.fn(() => mockFocusedWebContents),
+  },
+}));
+
+vi.mock("../services/ProjectStore.js", () => ({
+  projectStore: {
+    getAllProjects: vi.fn(() => []),
+    getCurrentProjectId: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../ipc/channels.js", () => ({
+  CHANNELS: { MENU_ACTION: "menu-action" },
+}));
+
+vi.mock("../../shared/config/agentRegistry.js", () => ({
+  getEffectiveRegistry: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/CliAvailabilityService.js", () => ({}));
+vi.mock("../services/CliInstallService.js", () => ({}));
+
+vi.mock("../window/windowRef.js", () => ({
+  getWindowRegistry: vi.fn(() => null),
+  getProjectViewManager: vi.fn(() => null),
+}));
+
+vi.mock("../services/AutoUpdaterService.js", () => ({
+  autoUpdaterService: { checkForUpdatesManually: vi.fn() },
+}));
+
+vi.mock("../services/pluginMenuRegistry.js", () => ({
+  getPluginMenuItems: vi.fn(() => []),
+}));
+
+vi.mock("../window/webContentsRegistry.js", () => ({
+  getAppWebContents: vi.fn(() => mockWebContents),
+}));
+
+import { createApplicationMenu } from "../menu.js";
+import { webContents } from "electron";
+
+function findMenuItem(
+  template: Electron.MenuItemConstructorOptions[],
+  menuLabel: string,
+  itemLabel: string
+): Electron.MenuItemConstructorOptions | undefined {
+  const menu = template.find((m) => m.label === menuLabel);
+  if (!menu || !Array.isArray(menu.submenu)) return undefined;
+  return (menu.submenu as Electron.MenuItemConstructorOptions[]).find((i) => i.label === itemLabel);
+}
+
+describe("createApplicationMenu", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTemplate = [];
+    mockWebContents.getZoomLevel.mockReturnValue(1.0);
+    createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+  });
+
+  describe("zoom items target getAppWebContents", () => {
+    it("Actual Size resets zoom to 0", () => {
+      const item = findMenuItem(capturedTemplate, "View", "Actual Size");
+      expect(item).toBeDefined();
+      expect(item!.accelerator).toBe("CommandOrControl+0");
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(mockWebContents.setZoomLevel).toHaveBeenCalledWith(0);
+    });
+
+    it("Zoom In increments zoom by 0.5", () => {
+      const item = findMenuItem(capturedTemplate, "View", "Zoom In");
+      expect(item).toBeDefined();
+      expect(item!.accelerator).toBe("CommandOrControl+=");
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(mockWebContents.setZoomLevel).toHaveBeenCalledWith(1.5);
+    });
+
+    it("Zoom Out decrements zoom by 0.5", () => {
+      const item = findMenuItem(capturedTemplate, "View", "Zoom Out");
+      expect(item).toBeDefined();
+      expect(item!.accelerator).toBe("CommandOrControl+-");
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(mockWebContents.setZoomLevel).toHaveBeenCalledWith(0.5);
+    });
+  });
+
+  describe("toggleDevTools targets getAppWebContents", () => {
+    it("calls toggleDevTools on app webContents", () => {
+      const item = findMenuItem(capturedTemplate, "View", "Toggle Developer Tools");
+      expect(item).toBeDefined();
+      expect(item!.accelerator).toBe("Alt+CommandOrControl+I");
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(mockWebContents.toggleDevTools).toHaveBeenCalled();
+    });
+  });
+
+  describe("edit commands route to focused webContents", () => {
+    const editItems = [
+      { label: "Undo", method: "undo", accelerator: "CommandOrControl+Z" },
+      { label: "Redo", method: "redo", accelerator: "CommandOrControl+Shift+Z" },
+      { label: "Cut", method: "cut", accelerator: "CommandOrControl+X" },
+      { label: "Copy", method: "copy", accelerator: "CommandOrControl+C" },
+      { label: "Paste", method: "paste", accelerator: "CommandOrControl+V" },
+      { label: "Select All", method: "selectAll", accelerator: "CommandOrControl+A" },
+    ] as const;
+
+    for (const { label, method, accelerator } of editItems) {
+      it(`${label} calls ${method} on focused webContents`, () => {
+        const item = findMenuItem(capturedTemplate, "Edit", label);
+        expect(item).toBeDefined();
+        expect(item!.accelerator).toBe(accelerator);
+        item!.click!(
+          {} as Electron.MenuItem,
+          mockBrowserWindow as unknown as Electron.BaseWindow,
+          {} as Electron.KeyboardEvent
+        );
+        expect(mockFocusedWebContents[method]).toHaveBeenCalled();
+      });
+    }
+
+    it("no-ops when getFocusedWebContents returns null", () => {
+      vi.mocked(webContents.getFocusedWebContents).mockReturnValueOnce(null as never);
+      const item = findMenuItem(capturedTemplate, "Edit", "Copy");
+      expect(() => {
+        item!.click!(
+          {} as Electron.MenuItem,
+          mockBrowserWindow as unknown as Electron.BaseWindow,
+          {} as Electron.KeyboardEvent
+        );
+      }).not.toThrow();
+      expect(mockFocusedWebContents.copy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("zoom items fallback to mainWindow when browserWindow is undefined", () => {
+    it("Zoom In still works via mainWindow fallback", () => {
+      mockWebContents.setZoomLevel.mockClear();
+      const item = findMenuItem(capturedTemplate, "View", "Zoom In");
+      item!.click!({} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent);
+      expect(mockWebContents.setZoomLevel).toHaveBeenCalledWith(1.5);
+    });
+  });
+});

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, dialog, BrowserWindow, shell, app } from "electron";
+import { Menu, dialog, BrowserWindow, shell, app, webContents } from "electron";
 import { projectStore } from "./services/ProjectStore.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { getEffectiveRegistry } from "../shared/config/agentRegistry.js";
@@ -144,13 +144,55 @@ export function createApplicationMenu(
     {
       label: "Edit",
       submenu: [
-        { role: "undo" },
-        { role: "redo" },
+        {
+          label: "Undo",
+          accelerator: "CommandOrControl+Z",
+          click: () => {
+            const focused = webContents.getFocusedWebContents();
+            if (focused && !focused.isDestroyed()) focused.undo();
+          },
+        },
+        {
+          label: "Redo",
+          accelerator: "CommandOrControl+Shift+Z",
+          click: () => {
+            const focused = webContents.getFocusedWebContents();
+            if (focused && !focused.isDestroyed()) focused.redo();
+          },
+        },
         { type: "separator" },
-        { role: "cut" },
-        { role: "copy" },
-        { role: "paste" },
-        { role: "selectAll" },
+        {
+          label: "Cut",
+          accelerator: "CommandOrControl+X",
+          click: () => {
+            const focused = webContents.getFocusedWebContents();
+            if (focused && !focused.isDestroyed()) focused.cut();
+          },
+        },
+        {
+          label: "Copy",
+          accelerator: "CommandOrControl+C",
+          click: () => {
+            const focused = webContents.getFocusedWebContents();
+            if (focused && !focused.isDestroyed()) focused.copy();
+          },
+        },
+        {
+          label: "Paste",
+          accelerator: "CommandOrControl+V",
+          click: () => {
+            const focused = webContents.getFocusedWebContents();
+            if (focused && !focused.isDestroyed()) focused.paste();
+          },
+        },
+        {
+          label: "Select All",
+          accelerator: "CommandOrControl+A",
+          click: () => {
+            const focused = webContents.getFocusedWebContents();
+            if (focused && !focused.isDestroyed()) focused.selectAll();
+          },
+        },
       ],
     },
     {
@@ -179,11 +221,52 @@ export function createApplicationMenu(
             getAppWebContents(win).reloadIgnoringCache();
           },
         },
-        ...(app.isPackaged ? [] : [{ role: "toggleDevTools" as const }]),
+        ...(app.isPackaged
+          ? []
+          : [
+              {
+                label: "Toggle Developer Tools",
+                accelerator: "Alt+CommandOrControl+I",
+                click: (
+                  _item: Electron.MenuItem,
+                  browserWindow: Electron.BaseWindow | undefined
+                ) => {
+                  const win = getTargetBrowserWindow(browserWindow);
+                  if (!win) return;
+                  getAppWebContents(win).toggleDevTools();
+                },
+              },
+            ]),
         { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn" },
-        { role: "zoomOut" },
+        {
+          label: "Actual Size",
+          accelerator: "CommandOrControl+0",
+          click: (_item: Electron.MenuItem, browserWindow: Electron.BaseWindow | undefined) => {
+            const win = getTargetBrowserWindow(browserWindow);
+            if (!win) return;
+            getAppWebContents(win).setZoomLevel(0);
+          },
+        },
+        {
+          label: "Zoom In",
+          accelerator: "CommandOrControl+=",
+          click: (_item: Electron.MenuItem, browserWindow: Electron.BaseWindow | undefined) => {
+            const win = getTargetBrowserWindow(browserWindow);
+            if (!win) return;
+            const wc = getAppWebContents(win);
+            wc.setZoomLevel(wc.getZoomLevel() + 0.5);
+          },
+        },
+        {
+          label: "Zoom Out",
+          accelerator: "CommandOrControl+-",
+          click: (_item: Electron.MenuItem, browserWindow: Electron.BaseWindow | undefined) => {
+            const win = getTargetBrowserWindow(browserWindow);
+            if (!win) return;
+            const wc = getAppWebContents(win);
+            wc.setZoomLevel(wc.getZoomLevel() - 0.5);
+          },
+        },
         { type: "separator" },
         {
           label: "Toggle Full Screen",


### PR DESCRIPTION
## Summary

After the WebContentsView migration, menu items using Electron's built-in `role` property dispatch to `BrowserWindow.webContents`, which is now an empty shell. The actual app UI lives in a child `WebContentsView`, so these roles were silently no-opping.

- Replaced zoom roles (`resetZoom`, `zoomIn`, `zoomOut`) and `toggleDevTools` with explicit `click` handlers that resolve the correct webContents via `getAppWebContents(win)`
- Replaced edit roles (`undo`, `redo`, `cut`, `copy`, `paste`, `selectAll`) with `click` handlers using `webContents.getFocusedWebContents()` so they route to whichever webContents has focus (app view, portal webview, or browser panel)
- Added explicit labels and accelerators for all 10 replaced items to preserve OS-level menu integration
- Added unit tests covering all replaced items

Resolves #4790

## Changes

- `electron/menu.ts` — replaced 10 role-based items with explicit click handlers
- `electron/__tests__/menu.test.ts` — new test suite with 211 lines covering all replaced menu items

## Testing

All 10 replaced items have unit tests. The existing `npm run check` suite passes cleanly with no new errors.