### PR TITLE
fix(meta): update stale GitHub URLs and dynamic copyright year

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -13,8 +13,8 @@ app.setAboutPanelOptions({
   applicationName: "Canopy",
   applicationVersion: app.getVersion(),
   version: "Beta",
-  copyright: "© 2025 Canopy Team",
-  website: "https://github.com/gregpriday/canopy-electron",
+  copyright: `© ${new Date().getFullYear()} Canopy Team`,
+  website: "https://github.com/canopyide/canopy",
 });
 
 function convertShortcutToAccelerator(shortcut: string): string {
@@ -302,7 +302,7 @@ export function createApplicationMenu(
         {
           label: "Learn More",
           click: async () => {
-            await shell.openExternal("https://github.com/gregpriday/canopy-electron");
+            await shell.openExternal("https://github.com/canopyide/canopy");
           },
         },
         ...(process.platform !== "darwin" && app.isPackaged

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -131,7 +131,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         `**Component Stack:**\n\`\`\`\n${errorInfo?.componentStack || "No component stack"}\n\`\`\``
     );
 
-    const issueUrl = `https://github.com/gregpriday/canopy-electron/issues/new?title=${encodeURIComponent(`Component Error: ${error?.message || "Unknown"}`)}&body=${issueBody}`;
+    const issueUrl = `https://github.com/canopyide/canopy/issues/new?title=${encodeURIComponent(`Component Error: ${error?.message || "Unknown"}`)}&body=${issueBody}`;
 
     if (window.electron?.system?.openExternal) {
       actionService

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -245,7 +245,7 @@ function EmptyState({
   const handleOpenHelp = () => {
     void actionService.dispatch(
       "system.openExternal",
-      { url: "https://github.com/gregpriday/canopy-electron#readme" },
+      { url: "https://github.com/canopyide/canopy#readme" },
       { source: "user" }
     );
   };


### PR DESCRIPTION
## Summary

- Replaced 4 stale `gregpriday/canopy-electron` URLs with the correct `canopyide/canopy` across `electron/menu.ts`, `ErrorBoundary.tsx`, and `ContentGrid.tsx`
- Made the About panel copyright year dynamic using `new Date().getFullYear()` so it won't go stale again

Resolves #4791

## Changes

- `electron/menu.ts` — updated `website` field and the Help → Learn More `shell.openExternal` URL; copyright year now generated at runtime
- `src/components/ErrorBoundary/ErrorBoundary.tsx` — corrected the GitHub issue report URL
- `src/components/Terminal/ContentGrid.tsx` — corrected the help link pointing to the README

## Testing

Ran `npm run check` (typecheck + lint + format) — clean. All four affected call sites verified against the correct `canopyide/canopy` repo.