### PR TITLE
refactor(types): remove orphaned deprecated type exports

### DIFF
--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -1,5 +1,3 @@
-import type { BuiltInAgentId } from "../config/agentIds.js";
-
 /** Agent lifecycle state: idle | working | running | waiting | directing | completed */
 export type AgentState = "idle" | "working" | "running" | "waiting" | "directing" | "completed";
 
@@ -35,8 +33,6 @@ export interface RunRecord {
 }
 
 export type AgentId = string;
-/** @deprecated Use BuiltInAgentId from shared/config/agentIds.ts instead */
-export type LegacyAgentType = BuiltInAgentId;
 
 /** Valid triggers for agent state changes */
 export type AgentStateChangeTrigger =

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -28,13 +28,7 @@ export type {
 export type { NotificationType, Notification, NotificationPayload } from "./notification.js";
 
 // Agent types
-export type {
-  AgentState,
-  TaskState,
-  RunRecord,
-  LegacyAgentType,
-  AgentStateChangeTrigger,
-} from "./agent.js";
+export type { AgentState, TaskState, RunRecord, AgentStateChangeTrigger } from "./agent.js";
 
 // Panel types
 export type {

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -36,17 +36,3 @@ export interface DevPreviewSessionState {
 export interface DevPreviewStateChangedPayload {
   state: DevPreviewSessionState;
 }
-
-/** @deprecated Replaced by `dev-preview:state-changed` payload. */
-export interface DevPreviewUrlDetectedPayload {
-  terminalId: string;
-  url: string;
-  worktreeId?: string;
-}
-
-/** @deprecated Replaced by `dev-preview:state-changed` payload. */
-export interface DevPreviewErrorDetectedPayload {
-  terminalId: string;
-  error: DevServerError;
-  worktreeId?: string;
-}

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -1,10 +1,5 @@
-import type {
-  AgentState,
-  AgentStateChangeTrigger,
-  AgentId,
-  LegacyAgentType,
-  WaitingReason,
-} from "./agent.js";
+import type { AgentState, AgentStateChangeTrigger, AgentId, WaitingReason } from "./agent.js";
+import type { BuiltInAgentId } from "../config/agentIds.js";
 import type { BrowserHistory } from "./browser.js";
 
 /** Built-in panel kinds */
@@ -22,7 +17,7 @@ export type PanelKind = BuiltInPanelKind | (string & {});
 /**
  * @deprecated Use PanelKind + agentId instead. This is kept for backward compatibility/migrations.
  */
-export type TerminalType = "terminal" | LegacyAgentType;
+export type TerminalType = "terminal" | BuiltInAgentId;
 
 /** Location of a panel instance in the UI */
 export type PanelLocation = "grid" | "dock" | "trash" | "background";

--- a/shared/types/slashCommands.ts
+++ b/shared/types/slashCommands.ts
@@ -1,4 +1,4 @@
-import type { LegacyAgentType } from "./agent.js";
+import type { BuiltInAgentId } from "../config/agentIds.js";
 
 export type SlashCommandScope = "built-in" | "global" | "user" | "project";
 
@@ -7,13 +7,13 @@ export interface SlashCommand {
   label: string; // e.g. "/compact"
   description: string;
   scope: SlashCommandScope;
-  agentId: LegacyAgentType;
+  agentId: BuiltInAgentId;
   sourcePath?: string;
   kind?: "command" | "skill";
 }
 
 export interface SlashCommandListRequest {
-  agentId: LegacyAgentType;
+  agentId: BuiltInAgentId;
   projectPath?: string;
 }
 
@@ -21,8 +21,8 @@ export interface BuiltinSlashCommandEntry {
   id: string;
   label: string;
   description: string;
-  descriptions?: Partial<Record<LegacyAgentType, string>>;
-  supportedAgents: readonly LegacyAgentType[];
+  descriptions?: Partial<Record<BuiltInAgentId, string>>;
+  supportedAgents: readonly BuiltInAgentId[];
 }
 
 const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
@@ -327,7 +327,7 @@ const BUILTIN_SLASH_COMMANDS: readonly BuiltinSlashCommandEntry[] = [
 
 export { BUILTIN_SLASH_COMMANDS };
 
-export function getBuiltinSlashCommands(agentId: LegacyAgentType): SlashCommand[] {
+export function getBuiltinSlashCommands(agentId: BuiltInAgentId): SlashCommand[] {
   return BUILTIN_SLASH_COMMANDS.filter((entry) => entry.supportedAgents.includes(agentId)).map(
     (entry) => ({
       id: entry.id,

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -6,7 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { EmojiPicker } from "@/components/ui/emoji-picker";
 import { getProjectGradient, isValidHexColor } from "@/lib/colorUtils";
 import { cn } from "@/lib/utils";
-import { validateProjectSvg, sanitizeSvg, svgToDataUrl } from "@/lib/svg";
+import { sanitizeSvg, svgToDataUrl } from "@/lib/svg";
 import { GITIGNORE_SNIPPET } from "./projectSettingsConstants";
 import type { Project } from "@shared/types/project";
 
@@ -144,7 +144,7 @@ export function GeneralTab({
     }
     try {
       const text = await file.text();
-      const result = validateProjectSvg(text);
+      const result = sanitizeSvg(text);
       if (!result.ok) {
         setIconError(result.error);
         return;

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import { EditorView, drawSelection } from "@codemirror/view";
 import { EditorSelection, EditorState } from "@codemirror/state";
-import type { LegacyAgentType } from "@shared/types";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@/types";
 import { getAgentConfig } from "@/config/agents";
 import { cn } from "@/lib/utils";
@@ -98,7 +98,7 @@ export interface HybridInputBarProps {
   onSendKey?: (key: string) => void;
   onActivate?: () => void;
   cwd: string;
-  agentId?: LegacyAgentType;
+  agentId?: BuiltInAgentId;
   agentHasLifecycleEvent?: boolean;
   agentState?: AgentState;
   restartKey?: number;

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -31,7 +31,8 @@ import {
 } from "@/store";
 import { useTerminalLogic } from "@/hooks/useTerminalLogic";
 import { errorsClient } from "@/clients";
-import type { AgentState, LegacyAgentType } from "@/types";
+import type { AgentState } from "@/types";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { actionService } from "@/services/ActionService";
 import { InputTracker } from "@/services/clearCommandDetection";
@@ -210,7 +211,7 @@ function TerminalPaneComponent({
       : type && isRegisteredAgent(type)
         ? type
         : undefined
-  ) as LegacyAgentType | undefined;
+  ) as BuiltInAgentId | undefined;
   const isAgentTerminal = effectiveAgentId !== undefined;
   const showHybridInputBar = isAgentTerminal && hybridInputEnabled;
 

--- a/src/components/Terminal/hooks/useTokenResolution.ts
+++ b/src/components/Terminal/hooks/useTokenResolution.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, type Dispatch, type SetStateAction } from "react";
 import { EditorSelection } from "@codemirror/state";
-import type { LegacyAgentType } from "@shared/types";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { buildTerminalSendPayload } from "@/lib/terminalInput";
 import { useCommandHistoryStore } from "@/store/commandHistoryStore";
@@ -44,7 +44,7 @@ interface UseTokenResolutionParams {
   setSelectionContext: Dispatch<SetStateAction<AtSelectionContext | null>>;
   terminalId: string;
   cwd: string;
-  agentId?: LegacyAgentType;
+  agentId?: BuiltInAgentId;
 }
 
 export function useTokenResolution({

--- a/src/hooks/useSlashCommandAutocomplete.ts
+++ b/src/hooks/useSlashCommandAutocomplete.ts
@@ -3,12 +3,13 @@ import type { AutocompleteItem } from "@/components/Terminal/AutocompleteMenu";
 import { slashCommandsClient } from "@/clients";
 import { rankSlashCommands } from "@/lib/slashCommandMatch";
 
-import { getBuiltinSlashCommands, type LegacyAgentType, type SlashCommand } from "@shared/types";
+import { getBuiltinSlashCommands, type SlashCommand } from "@shared/types";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 
 export interface UseSlashCommandAutocompleteArgs {
   query: string;
   enabled: boolean;
-  agentId?: LegacyAgentType;
+  agentId?: BuiltInAgentId;
   projectPath?: string;
 }
 

--- a/src/hooks/useSlashCommandList.ts
+++ b/src/hooks/useSlashCommandList.ts
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { slashCommandsClient } from "@/clients";
 
-import { getBuiltinSlashCommands, type LegacyAgentType, type SlashCommand } from "@shared/types";
+import { getBuiltinSlashCommands, type SlashCommand } from "@shared/types";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
 
 export interface UseSlashCommandListArgs {
-  agentId?: LegacyAgentType;
+  agentId?: BuiltInAgentId;
   projectPath?: string;
 }
 

--- a/src/lib/__tests__/svg.test.ts
+++ b/src/lib/__tests__/svg.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { validateProjectSvg, svgToDataUrl, validateSvg } from "../svg";
+import { sanitizeSvg, svgToDataUrl, validateSvg } from "../svg";
 
-describe("validateProjectSvg (sanitizeSvg)", () => {
+describe("sanitizeSvg", () => {
   const validSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
     <circle cx="50" cy="50" r="40" fill="blue"/>
   </svg>`;
 
   it("should accept a valid SVG", () => {
-    const result = validateProjectSvg(validSvg);
+    const result = sanitizeSvg(validSvg);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).toBe(validSvg.trim());
@@ -20,12 +20,12 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       <path d="M10 10 L90 90" stroke="black"/>
       <text x="50" y="50">Hello</text>
     </svg>`;
-    const result = validateProjectSvg(svg);
+    const result = sanitizeSvg(svg);
     expect(result.ok).toBe(true);
   });
 
   it("should reject empty input", () => {
-    const result = validateProjectSvg("");
+    const result = sanitizeSvg("");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("required");
@@ -33,7 +33,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
   });
 
   it("should reject null/undefined input", () => {
-    const result = validateProjectSvg(null as unknown as string);
+    const result = sanitizeSvg(null as unknown as string);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("required");
@@ -41,7 +41,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
   });
 
   it("should reject non-SVG content", () => {
-    const result = validateProjectSvg("<html><body>Hello</body></html>");
+    const result = sanitizeSvg("<html><body>Hello</body></html>");
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("valid SVG");
@@ -53,7 +53,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       <script>alert('xss')</script>
       <circle cx="50" cy="50" r="40"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithScript);
+    const result = sanitizeSvg(svgWithScript);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("script");
@@ -69,7 +69,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       </foreignObject>
       <circle cx="50" cy="50" r="40"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithForeignObject);
+    const result = sanitizeSvg(svgWithForeignObject);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("foreignObject");
@@ -82,7 +82,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
     const svgWithOnclick = `<svg xmlns="http://www.w3.org/2000/svg">
       <circle cx="50" cy="50" r="40" onclick="alert('xss')"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithOnclick);
+    const result = sanitizeSvg(svgWithOnclick);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("onclick");
@@ -95,7 +95,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
     const svgWithOnload = `<svg xmlns="http://www.w3.org/2000/svg" onload="alert('xss')">
       <circle cx="50" cy="50" r="40"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithOnload);
+    const result = sanitizeSvg(svgWithOnload);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("onload");
@@ -110,7 +110,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
         <circle cx="50" cy="50" r="40"/>
       </a>
     </svg>`;
-    const result = validateProjectSvg(svgWithJsUrl);
+    const result = sanitizeSvg(svgWithJsUrl);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("javascript:");
@@ -124,7 +124,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       <image href="https://evil.com/image.svg"/>
       <circle cx="50" cy="50" r="40"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithExternal);
+    const result = sanitizeSvg(svgWithExternal);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("https://evil.com");
@@ -138,7 +138,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       <use xlink:href="https://evil.com/sprites.svg#icon"/>
       <circle cx="50" cy="50" r="40"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithXlink);
+    const result = sanitizeSvg(svgWithXlink);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("https://evil.com");
@@ -152,7 +152,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       <rect style="fill: url(https://evil.com/pattern)" width="100" height="100"/>
       <circle cx="50" cy="50" r="40"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithUrlFunc);
+    const result = sanitizeSvg(svgWithUrlFunc);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.svg).not.toContain("https://evil.com");
@@ -165,7 +165,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
     const largeSvg = `<svg xmlns="http://www.w3.org/2000/svg">
       <text>${"x".repeat(300 * 1024)}</text>
     </svg>`;
-    const result = validateProjectSvg(largeSvg);
+    const result = sanitizeSvg(largeSvg);
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toContain("too large");
@@ -181,7 +181,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       </defs>
       <rect fill="url(#grad1)" width="100" height="100"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithInternalUrl);
+    const result = sanitizeSvg(svgWithInternalUrl);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.modified).toBe(false);
@@ -197,7 +197,7 @@ describe("validateProjectSvg (sanitizeSvg)", () => {
       </defs>
       <use href="#icon"/>
     </svg>`;
-    const result = validateProjectSvg(svgWithLocalHref);
+    const result = sanitizeSvg(svgWithLocalHref);
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.modified).toBe(false);

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -13,13 +13,6 @@ export type SvgValidationResult = { ok: true; svg: string };
 export type SvgValidationError = { ok: false; error: string };
 export type SvgValidationOutcome = SvgValidationResult | SvgValidationError;
 
-/**
- * Validate project SVG - returns sanitized SVG if valid.
- * This is used by the file upload UI to provide immediate feedback.
- * @deprecated Use sanitizeSvg from @shared/utils/svgSanitizer instead
- */
-export { sanitizeSvg as validateProjectSvg } from "@shared/utils/svgSanitizer";
-
 export function svgToDataUrl(svgText: string): string {
   const encoded = encodeURIComponent(svgText).replace(/'/g, "%27").replace(/"/g, "%22");
   return `data:image/svg+xml,${encoded}`;

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -30,7 +30,7 @@ export const SettingsNavTargetSchema = z.object({
 
 export const TerminalTypeSchema = z.enum(BUILT_IN_TERMINAL_TYPES);
 
-export const LegacyAgentTypeSchema = z.enum(BUILT_IN_AGENT_IDS);
+export const BuiltInAgentIdSchema = z.enum(BUILT_IN_AGENT_IDS);
 
 export const GitStatusSchema = z.enum([
   "modified",

--- a/src/services/actions/definitions/systemActions.ts
+++ b/src/services/actions/definitions/systemActions.ts
@@ -1,5 +1,5 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
-import { CopyTreeOptionsSchema, FileSearchPayloadSchema, LegacyAgentTypeSchema } from "./schemas";
+import { CopyTreeOptionsSchema, FileSearchPayloadSchema, BuiltInAgentIdSchema } from "./schemas";
 import { z } from "zod";
 import {
   artifactClient,
@@ -134,7 +134,7 @@ export function registerSystemActions(actions: ActionRegistry, _callbacks: Actio
     kind: "query",
     danger: "safe",
     scope: "renderer",
-    argsSchema: z.object({ agentId: LegacyAgentTypeSchema, projectPath: z.string().optional() }),
+    argsSchema: z.object({ agentId: BuiltInAgentIdSchema, projectPath: z.string().optional() }),
     run: async (args: unknown) => {
       const payload = args as {
         agentId: "claude" | "gemini" | "codex" | "opencode";


### PR DESCRIPTION
## Summary

- Deleted `DevPreviewUrlDetectedPayload` and `DevPreviewErrorDetectedPayload` from `shared/types/ipc/devPreview.ts` — both were marked deprecated, replaced by `DevPreviewStateChangedPayload`, and imported nowhere
- Removed the `validateProjectSvg` alias in `src/lib/svg.ts` and updated its two consumers (`GeneralTab.tsx` and `svg.test.ts`) to use `sanitizeSvg` directly
- Replaced `LegacyAgentType` (a pure `type LegacyAgentType = BuiltInAgentId` alias) with `BuiltInAgentId` across 11 files, and renamed `LegacyAgentTypeSchema` to `BuiltInAgentIdSchema` in the action schemas

Resolves #4794

## Changes

- `shared/types/ipc/devPreview.ts` — removed 2 deprecated interfaces
- `shared/types/agent.ts` — removed `LegacyAgentType` alias
- `shared/types/index.ts` — removed deprecated re-exports
- `shared/types/panel.ts` — updated `AgentPanelData` and related types to use `BuiltInAgentId`
- `shared/types/slashCommands.ts` — updated agent type references
- `src/lib/svg.ts` — removed `validateProjectSvg` alias
- `src/lib/__tests__/svg.test.ts` — updated test imports
- `src/components/Project/GeneralTab.tsx` — updated to use `sanitizeSvg` directly
- `src/components/Terminal/HybridInputBar.tsx`, `TerminalPane.tsx`, `hooks/useTokenResolution.ts` — updated agent type references
- `src/hooks/useSlashCommandAutocomplete.ts`, `useSlashCommandList.ts` — updated agent type references
- `src/services/actions/definitions/schemas.ts`, `systemActions.ts` — renamed schema and updated type references

## Testing

Typechecks clean. No logic changes — purely mechanical symbol renaming and dead code removal.