### PR TITLE
fix(sidebar): suppress filter-empty state when no worktrees exist

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1118,7 +1118,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                   counts={quickStateCounts}
                 />
               )}
-              {filteredWorktrees.length === 0 && hasFilters ? (
+              {filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
                 <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
                   <FilterX className="w-10 h-10 text-canopy-text/40 mb-3" />
                   <p className="text-sm text-canopy-text/60 mb-3">


### PR DESCRIPTION
## Summary

- When all worktrees are deleted while a status filter is active, the sidebar was jumping straight to the \"No worktrees match your filters\" branch without first checking if any worktrees exist at all.
- Added a `hasNonMainWorktrees` guard to the filter-empty condition in `src/App.tsx`, mirroring the logic the overview modal already uses correctly.
- Clears up a misleading UX where users were prompted to clear a filter when there was nothing to show regardless.

Resolves #4797

## Changes

- `src/App.tsx` line 1121: added `&& hasNonMainWorktrees` to the filter-empty conditional so the normal empty state is shown when the total worktree count is zero.

## Testing

Verified the fix manually: deleting all worktrees with a filter active now shows the correct empty state rather than the filter-empty message. Existing unit tests pass.