### PR TITLE
docs(demo): rewrite demo-video-creator skill for the overhauled demo system

### DIFF
--- a/.claude/skills/demo-video-creator/SKILL.md
+++ b/.claude/skills/demo-video-creator/SKILL.md
@@ -13,7 +13,7 @@ Create polished demo videos of Canopy by writing scenario scripts and recording 
 2. **Create a scene file** — Add `demo/scenes/<name>.ts`. Export a default `ScenarioConfig` object.
 3. **Write scenes** — Each scene is an async function receiving a `Stage` instance. Compose primitives to script the interaction.
 4. **Configure output** — Set `outputFile`, `preset`, and `fps` in your `ScenarioConfig`.
-5. **Test interactively** — Run `npm run demo` to launch Electron in demo mode and verify your scenario visually.
+5. **Test interactively** — Run `npm run demo` to launch Electron in demo mode for manual visual inspection of the app state before recording.
 6. **Record** — Run `npm run demo:record -- --scenario <name>` to capture a video. Override defaults with `--output <path>`, `--preset <preset>`, `--fps <n>`.
 
 ## Key Files

--- a/.claude/skills/demo-video-creator/SKILL.md
+++ b/.claude/skills/demo-video-creator/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: demo-video-creator
+description: Guide for writing and recording Canopy demo videos. Use when creating demo scenarios, working with the Stage DSL, or recording screen captures.
+---
+
+# Demo Video Creator
+
+Create polished demo videos of Canopy by writing scenario scripts and recording them with the built-in capture pipeline.
+
+## Workflow
+
+1. **Find selectors** — Browse `e2e/helpers/selectors.ts` for the `SEL` registry. Every UI element you interact with needs a selector from this registry.
+2. **Create a scene file** — Add `demo/scenes/<name>.ts`. Export a default `ScenarioConfig` object.
+3. **Write scenes** — Each scene is an async function receiving a `Stage` instance. Compose primitives to script the interaction.
+4. **Configure output** — Set `outputFile`, `preset`, and `fps` in your `ScenarioConfig`.
+5. **Test interactively** — Run `npm run demo` to launch Electron in demo mode and verify your scenario visually.
+6. **Record** — Run `npm run demo:record -- --scenario <name>` to capture a video. Override defaults with `--output <path>`, `--preset <preset>`, `--fps <n>`.
+
+## Key Files
+
+| Purpose                    | Path                                |
+| -------------------------- | ----------------------------------- |
+| Stage DSL (all primitives) | `demo/stage.ts`                     |
+| CLI runner                 | `demo/runner.ts`                    |
+| Scene definitions          | `demo/scenes/`                      |
+| Selector registry          | `e2e/helpers/selectors.ts`          |
+| IPC type contracts         | `shared/types/ipc/demo.ts`          |
+| Preload wiring             | `electron/preload.cts` (demo block) |
+| IPC handlers               | `electron/ipc/handlers/demo.ts`     |
+
+## Scenario Config
+
+```typescript
+import type { ScenarioConfig, Scene } from "../stage.js";
+
+const myScene: Scene = async (stage) => {
+  // ... use stage primitives
+};
+
+export default {
+  outputFile: "demo-output/my-video.mp4",
+  preset: "youtube-1080p",
+  fps: 30,
+  scenes: [myScene],
+} satisfies ScenarioConfig;
+```
+
+## Stage DSL Reference
+
+### Cursor
+
+```typescript
+stage.cursor.moveTo(selector, { durationMs?, offsetX?, offsetY? })
+stage.cursor.click(selector?)  // moveTo + click; omit selector for click-in-place
+```
+
+### Keyboard
+
+```typescript
+stage.keyboard.type(selector, text, { cps? })  // type into a focused element
+stage.pressKey(key, code?, modifiers?, selector?)  // press a single key
+// modifiers: "mod" | "ctrl" | "shift" | "alt" | "meta"
+```
+
+### Camera
+
+```typescript
+stage.camera.zoom(factor, { durationMs? })
+```
+
+### Scroll & Drag
+
+```typescript
+stage.scroll(selector)  // scroll element into view
+stage.drag(fromSelector, toSelector, durationMs?)
+```
+
+### Spotlight & Annotate
+
+```typescript
+stage.spotlight(selector, padding?)      // highlight an element
+stage.dismissSpotlight()
+
+const { id } = await stage.annotate(selector, text, position?, id?)
+// position: "top" | "bottom" | "left" | "right"
+stage.dismissAnnotation(id?)  // dismiss specific or all annotations
+```
+
+### Wait & Timing
+
+```typescript
+stage.wait.forSelector(selector, { timeoutMs? })
+stage.waitForIdle(settleMs?, timeoutMs?)  // wait for UI to settle
+stage.sleep(ms)
+```
+
+### Capture
+
+The capture pipeline encodes directly to the output file via ffmpeg — there is no intermediate frame directory.
+
+```typescript
+const capture = await stage.startCapture({ fps, outputPath, preset });
+// ... run scenes ...
+const result = await stage.stopCapture();
+// result.outputPath — path to the final video
+// result.frameCount — number of frames captured
+```
+
+The runner handles capture automatically. You only need these methods if building a custom recording flow.
+
+## Encode Presets
+
+| Preset          | Format                | Use case                      |
+| --------------- | --------------------- | ----------------------------- |
+| `youtube-4k`    | MP4, H.264, 3840x2160 | YouTube uploads, high quality |
+| `youtube-1080p` | MP4, H.264, 1920x1080 | YouTube uploads, standard     |
+| `web-webm`      | WebM, VP9             | Web embedding, smaller files  |
+
+## Tips
+
+- Keep scenes short and focused — one interaction sequence per scene
+- Use `stage.sleep()` between actions for natural pacing (500-1500ms typical)
+- Use `stage.wait.forSelector()` before interacting with elements that load asynchronously
+- Use `stage.spotlight()` to draw attention to a specific element before interacting with it
+- Use `stage.annotate()` to add text labels explaining what's happening
+- Selectors from `SEL` are data-testid based — add new ones in `e2e/helpers/selectors.ts` if needed
+
+$ARGUMENTS

--- a/demo/runner.ts
+++ b/demo/runner.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { launchApp, closeApp } from "../e2e/helpers/launch.js";
 import { Stage } from "./stage.js";
 import type { ScenarioConfig } from "./stage.js";
-import type { DemoEncodePayload } from "../shared/types/ipc/demo.js";
+import type { DemoEncodePreset } from "../shared/types/ipc/demo.js";
 
 const { values } = parseArgs({
   args: process.argv.slice(2),
@@ -32,7 +32,7 @@ async function run(): Promise<void> {
   const config = mod.default;
 
   const outputPath = values.output ?? config.outputFile;
-  const preset = (values.preset ?? config.preset) as DemoEncodePayload["preset"];
+  const preset = (values.preset ?? config.preset) as DemoEncodePreset;
   const parsedFps = values.fps ? parseInt(values.fps, 10) : (config.fps ?? 30);
   const fps = Number.isFinite(parsedFps) && parsedFps > 0 ? parsedFps : 30;
 
@@ -41,12 +41,14 @@ async function run(): Promise<void> {
     extraArgs: ["--demo-mode"],
   });
 
+  let stage: Stage | undefined;
   try {
-    const stage = await Stage.create(window);
+    stage = await Stage.create(window);
     console.log(`Stage ready. Running ${config.scenes.length} scene(s)...`);
 
-    const capture = await stage.startCapture({ fps });
-    console.log(`Capturing at ${fps} fps → ${capture.outputDir}`);
+    const resolvedOutput = path.resolve(outputPath);
+    const capture = await stage.startCapture({ fps, outputPath: resolvedOutput, preset });
+    console.log(`Capturing at ${fps} fps → ${capture.outputPath}`);
 
     for (let i = 0; i < config.scenes.length; i++) {
       console.log(`  Scene ${i + 1}/${config.scenes.length}...`);
@@ -57,25 +59,16 @@ async function run(): Promise<void> {
     console.log(`Captured ${stopResult.frameCount} frames.`);
 
     if (stopResult.frameCount === 0) {
-      console.error("No frames captured — skipping encode.");
+      console.error("No frames captured.");
       process.exitCode = 1;
       return;
     }
 
-    const resolvedOutput = path.resolve(outputPath);
-    console.log(`Encoding → ${resolvedOutput} (preset: ${preset})...`);
-    const result = await stage.encode({
-      framesDir: stopResult.outputDir,
-      outputPath: resolvedOutput,
-      preset,
-      fps,
-    });
-    console.log(`Done in ${(result.durationMs / 1000).toFixed(1)}s → ${result.outputPath}`);
+    console.log(`Done → ${stopResult.outputPath}`);
   } catch (err) {
     console.error("Scene failed:", err);
-    // Stop capture to free timer if still running
     try {
-      await Stage.create(window).then((s) => s.stopCapture());
+      await stage?.stopCapture();
     } catch {
       // Already stopped or app crashed
     }

--- a/demo/stage.ts
+++ b/demo/stage.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- page.evaluate() runs in browser context where window.electron is untyped */
 import type { Page } from "@playwright/test";
 import type {
+  DemoAnnotateResult,
   DemoEncodePayload,
   DemoEncodeResult,
   DemoStartCapturePayload,
@@ -98,5 +99,66 @@ export class Stage {
 
   async encode(payload: DemoEncodePayload): Promise<DemoEncodeResult> {
     return this.page.evaluate((p) => (window as any).electron.demo.encode(p), payload);
+  }
+
+  async scroll(selector: string): Promise<void> {
+    await this.page.evaluate((sel) => (window as any).electron.demo.scroll(sel), selector);
+  }
+
+  async drag(fromSelector: string, toSelector: string, durationMs?: number): Promise<void> {
+    await this.page.evaluate(
+      ([from, to, dur]) => (window as any).electron.demo.drag(from, to, dur),
+      [fromSelector, toSelector, durationMs] as const
+    );
+  }
+
+  async pressKey(
+    key: string,
+    code?: string,
+    modifiers?: Array<"mod" | "ctrl" | "shift" | "alt" | "meta">,
+    selector?: string
+  ): Promise<void> {
+    await this.page.evaluate(
+      ([k, c, mods, sel]) => (window as any).electron.demo.pressKey(k, c, mods, sel),
+      [key, code, modifiers, selector] as const
+    );
+  }
+
+  async spotlight(selector: string, padding?: number): Promise<void> {
+    await this.page.evaluate(([sel, pad]) => (window as any).electron.demo.spotlight(sel, pad), [
+      selector,
+      padding,
+    ] as const);
+  }
+
+  async dismissSpotlight(): Promise<void> {
+    await this.page.evaluate(() => (window as any).electron.demo.dismissSpotlight());
+  }
+
+  async annotate(
+    selector: string,
+    text: string,
+    position?: "top" | "bottom" | "left" | "right",
+    id?: string
+  ): Promise<DemoAnnotateResult> {
+    return this.page.evaluate(
+      ([sel, txt, pos, annotationId]) =>
+        (window as any).electron.demo.annotate(sel, txt, pos, annotationId),
+      [selector, text, position, id] as const
+    );
+  }
+
+  async dismissAnnotation(id?: string): Promise<void> {
+    await this.page.evaluate(
+      (annotationId) => (window as any).electron.demo.dismissAnnotation(annotationId),
+      id
+    );
+  }
+
+  async waitForIdle(settleMs?: number, timeoutMs?: number): Promise<void> {
+    await this.page.evaluate(
+      ([settle, timeout]) => (window as any).electron.demo.waitForIdle(settle, timeout),
+      [settleMs, timeoutMs] as const
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Rewrites `.claude/skills/demo-video-creator/SKILL.md` from scratch to reflect the Scene/Stage DSL, demo runner, and recording pipeline introduced in the preceding issues
- Adds 8 missing Stage primitive wrappers to `demo/stage.ts`: `scroll`, `drag`, `pressKey`, `spotlight`, `dismissSpotlight`, `annotate`, `dismissAnnotation`, and `waitForIdle`
- Fixes `demo/runner.ts` to use the current capture pipeline API (`outputPath` + `preset` in `startCapture`, removes the stale `encode()` call)

Resolves #4780

## Changes

- `.claude/skills/demo-video-creator/SKILL.md` — full rewrite; workflow-oriented rather than API reference, covers scene authoring, Stage primitives, capture config, and the `npm run demo:record` flow
- `demo/stage.ts` — 8 new primitive wrappers that were present in the type definitions but missing from the Stage class
- `demo/runner.ts` — capture pipeline call updated to match the actual API shape

## Testing

Type-checked cleanly. The new Stage methods align with the `DemoCapture.startCapture` signature in the capture service. Manual inspection confirmed the runner no longer references the removed `encode()` method.