### PR TITLE
perf(terminal): use replaceChildren() to clear hibernated terminal DOM

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -138,9 +138,7 @@ export class TerminalHibernationManager {
 
     // Reuse existing hostElement — clear old xterm DOM nodes to prevent ghosting
     const hostElement = managed.hostElement;
-    while (hostElement.firstChild) {
-      hostElement.removeChild(hostElement.firstChild);
-    }
+    hostElement.replaceChildren();
 
     // Re-create parser handler
     managed.parserHandler = new TerminalParserHandler(managed, () => {


### PR DESCRIPTION
## Summary

- Replaces the `while (el.firstChild) el.removeChild(el.firstChild)` loop in `TerminalHibernationManager.unhibernate()` with a single `hostElement.replaceChildren()` call.
- `replaceChildren()` batches all child removal into one internal `ContainerNode::RemoveChildren` call with a single layout invalidation pass, rather than crossing the JS-to-C++ boundary on each iteration.
- Chromium 86+ supports this API; Electron 41 ships Chromium 146, so there are no compatibility concerns.

Resolves #4820

## Changes

- `src/services/terminal/TerminalHibernationManager.ts`: three-line loop replaced with one-liner.

## Testing

Existing test suite passes. The change is mechanical and safe — `terminal.dispose()` is called during the hibernate step, so WebGL contexts and event listeners are already cleaned up before this code runs.