### PR TITLE
perf(terminal): lazy-load HybridInputBar for non-agent terminals

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { AlertTriangle, RefreshCw, Settings } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
@@ -38,7 +38,10 @@ import { actionService } from "@/services/ActionService";
 import { InputTracker } from "@/services/clearCommandDetection";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { terminalClient } from "@/clients";
-import { HybridInputBar, type HybridInputBarHandle } from "./HybridInputBar";
+import type { HybridInputBarHandle } from "./HybridInputBar";
+const LazyHybridInputBar = lazy(() =>
+  import("./HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
+);
 import { getTerminalFocusTarget, shouldSuppressUnfocusedClick } from "./terminalFocus";
 import { registerPanelFocusHandler } from "./terminalFocusRegistry";
 
@@ -855,30 +858,32 @@ function TerminalPaneComponent({
         </div>
 
         {showHybridInputBar && (
-          <HybridInputBar
-            ref={inputBarRef}
-            terminalId={id}
-            disabled={isBackendDisconnected || isBackendRecovering || isInputLocked}
-            cwd={cwd}
-            agentId={effectiveAgentId}
-            agentHasLifecycleEvent={stateChangeTrigger !== undefined}
-            agentState={agentState}
-            restartKey={restartKey}
-            onActivate={handleClick}
-            onSend={({ trackerData, text }) => {
-              if (!isInputLocked) {
-                terminalInstanceService.notifyUserInput(id);
-                terminalClient.submit(id, text);
-                handleInput(trackerData);
-              }
-            }}
-            onSendKey={(key) => {
-              if (!isInputLocked) {
-                terminalInstanceService.notifyUserInput(id);
-                terminalClient.sendKey(id, key);
-              }
-            }}
-          />
+          <Suspense fallback={null}>
+            <LazyHybridInputBar
+              ref={inputBarRef}
+              terminalId={id}
+              disabled={isBackendDisconnected || isBackendRecovering || isInputLocked}
+              cwd={cwd}
+              agentId={effectiveAgentId}
+              agentHasLifecycleEvent={stateChangeTrigger !== undefined}
+              agentState={agentState}
+              restartKey={restartKey}
+              onActivate={handleClick}
+              onSend={({ trackerData, text }) => {
+                if (!isInputLocked) {
+                  terminalInstanceService.notifyUserInput(id);
+                  terminalClient.submit(id, text);
+                  handleInput(trackerData);
+                }
+              }}
+              onSendKey={(key) => {
+                if (!isInputLocked) {
+                  terminalInstanceService.notifyUserInput(id);
+                  terminalClient.sendKey(id, key);
+                }
+              }}
+            />
+          </Suspense>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Replaces the static `HybridInputBar` import in `TerminalPane` with `React.lazy()` and a dynamic import, deferring the `vendor-editor` CodeMirror chunk until an agent terminal is actually opened.
- `HybridInputBar` is only ever rendered when `isAgentTerminal && hybridInputEnabled`, so users opening plain terminal sessions were paying the full CodeMirror parse cost for a component they'd never see.
- Wraps the lazy component in a `Suspense` with `fallback={null}`, consistent with the existing `SettingsDialog` pattern. The terminal content area is already visible during the brief load window, so the null fallback is invisible in practice.

Resolves #4825

## Changes

- `src/components/Terminal/TerminalPane.tsx`: static import replaced with `React.lazy()` + `Suspense` wrapper around the conditional `HybridInputBar` render.

## Testing

- Typecheck passes clean (`tsc --noEmit`).
- ESLint passes with no errors (one pre-existing react-compiler warning unrelated to this change).
- Prettier reports no changes needed.