### PR TITLE
perf(compiler): switch React Compiler to infer mode

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig(({ mode }) => ({
   plugins: [
     react(),
     babel({
-      presets: [reactCompilerPreset({ compilationMode: "annotation" })],
+      presets: [reactCompilerPreset({ compilationMode: "infer" })],
     }),
     tailwindcss(),
     cspTransformPlugin(),


### PR DESCRIPTION
## Summary

- Switches React Compiler `compilationMode` from `"annotation"` to `"infer"` in `vite.config.ts`
- Under `"annotation"` mode only 4 files had any compiler benefit (those with `"use memo"` directives); the rest of the app got nothing
- `"infer"` is the default and most-tested mode, auto-memoising all compatible components and hooks without manual annotation

Resolves #4805

## Changes

- `vite.config.ts`: `compilationMode: "annotation"` → `compilationMode: "infer"`

The 4 existing `"use memo"` directives in `WorktreeCard.tsx`, `TerminalSettingsTab.tsx`, `ContentGrid.tsx`, and `TerminalPane.tsx` are harmless to leave in place. The `eslint-plugin-react-compiler` is already set to `"warn"` and will surface any silent bailouts.

## Testing

Codebase compatibility was audited prior to this change: no render-phase ref reads, clean Zustand selectors with `useShallow`, minimal framer-motion usage with no problematic patterns, and no dynamic ref forwarding issues with Radix `asChild`. Type checks and lint pass cleanly.