### PR TITLE
fix(terminal): add restoreGeneration check to small restore path

### DIFF
--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -28,6 +28,7 @@ export class TerminalRestoreController {
         return true;
       }
 
+      const restoreGeneration = ++managed.restoreGeneration;
       managed.isSerializedRestoreInProgress = true;
 
       const scrollBackOffset = managed.isUserScrolledBack
@@ -37,7 +38,7 @@ export class TerminalRestoreController {
       managed.terminal.reset();
       managed.terminal.write(serializedState, () => {
         const current = this.deps.getInstance(id);
-        if (current !== managed) return;
+        if (current !== managed || managed.restoreGeneration !== restoreGeneration) return;
 
         if (scrollBackOffset > 0) {
           const newBaseY = current.terminal.buffer.active.baseY;

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -148,6 +148,44 @@ describe("TerminalRestoreController", () => {
       expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred2");
     });
 
+    it("does not apply callback when destroyed mid-write", async () => {
+      const managed = makeManagedTerminal({
+        deferredOutput: ["should-not-flush"],
+      });
+      instances.set("t1", managed);
+
+      controller.restoreFromSerialized("t1", "small-state");
+
+      // Destroy between write() and callback firing
+      controller.destroy("t1");
+      await flushMicrotasks();
+
+      expect(writeDataSpy).not.toHaveBeenCalled();
+      expect(managed.isSerializedRestoreInProgress).toBe(false);
+      expect(mockTerminal.scrollToLine).not.toHaveBeenCalled();
+    });
+
+    it("does not apply first callback when a second restore starts before callback fires", async () => {
+      const managed = makeManagedTerminal({
+        deferredOutput: ["first-deferred"],
+      });
+      instances.set("t1", managed);
+
+      // First restore — callback queued but not yet fired
+      controller.restoreFromSerialized("t1", "first-state");
+
+      // Second restore before first callback fires
+      managed.deferredOutput = ["second-deferred"];
+      controller.restoreFromSerialized("t1", "second-state");
+
+      await flushMicrotasks();
+
+      // Only the second restore's deferred output should have been flushed
+      expect(writeDataSpy).toHaveBeenCalledTimes(1);
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "second-deferred");
+      expect(managed.restoreGeneration).toBe(2);
+    });
+
     it("preserves scroll position when user is scrolled back", async () => {
       const managed = makeManagedTerminal({ isUserScrolledBack: true });
       instances.set("t1", managed);


### PR DESCRIPTION
## Summary

- The small restore path in `TerminalRestoreController.restoreFromSerialized()` only checked object identity in its write callback, not `restoreGeneration`. If unhibernation fires between scheduling the write and the callback running, the stale callback passes the identity check and applies a scroll offset calculated from the old terminal buffer against the new one.
- The incremental restore path already guards against this correctly. This brings the small path into consistency by capturing and validating `restoreGeneration` the same way.

Resolves #4844

## Changes

- `TerminalRestoreController.ts`: capture `++managed.restoreGeneration` before the write, check it alongside identity in the write callback
- `TerminalRestoreController.test.ts`: 2 new tests covering the race condition on the small restore path (stale callback bails out, non-stale callback proceeds normally)

## Testing

Existing test suite passes. New unit tests cover both the stale and non-stale cases for the small restore path race condition.