### PR TITLE
perf(hydration): fire-and-forget recipe loading on initial hydration

### DIFF
--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -992,7 +992,7 @@ describe("hydrateAppState", () => {
     await pendingRecipes;
   });
 
-  it("waits for recipe loading during initial hydration", async () => {
+  it("does not block initial hydration on recipe loading", async () => {
     let resolveRecipes!: () => void;
     const pendingRecipes = new Promise<void>((resolve) => {
       resolveRecipes = resolve;
@@ -1008,22 +1008,20 @@ describe("hydrateAppState", () => {
       agentSettings,
     });
 
-    let hydrationComplete = false;
-    const hydratePromise = hydrateAppState({
-      addTerminal: vi.fn().mockResolvedValue("terminal-id"),
-      setActiveWorktree: vi.fn(),
-      loadRecipes: vi.fn().mockReturnValue(pendingRecipes),
-      openDiagnosticsDock: vi.fn(),
-    }).then(() => {
-      hydrationComplete = true;
-    });
+    const hydratePromise = hydrateAppState(
+      {
+        addTerminal: vi.fn().mockResolvedValue("terminal-id"),
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockReturnValue(pendingRecipes),
+        openDiagnosticsDock: vi.fn(),
+      },
+      undefined,
+      () => true
+    );
 
-    await Promise.resolve();
-    expect(hydrationComplete).toBe(false);
-
+    await expect(hydratePromise).resolves.toBeUndefined();
     resolveRecipes();
-    await hydratePromise;
-    expect(hydrationComplete).toBe(true);
+    await pendingRecipes;
   });
 
   it("loads and hydrates persisted tab groups after terminal restore", async () => {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -801,13 +801,9 @@ export async function hydrateAppState(
     // If no worktrees exist, we don't set any active worktree (handled gracefully)
 
     // Recipe load starts earlier to overlap with hydration work.
-    // During project switch we don't block switch completion on recipes.
+    // Recipes are non-critical for first paint; fire-and-forget on both initial load and project switch.
     if (recipeLoadPromise) {
-      if (_switchId) {
-        void recipeLoadPromise;
-      } else {
-        await recipeLoadPromise;
-      }
+      void recipeLoadPromise;
     }
 
     if (appState.developerMode?.enabled && appState.developerMode.autoOpenDiagnostics) {


### PR DESCRIPTION
## Summary

- Initial app hydration was `await`ing `recipeLoadPromise` before flipping `isStateLoaded`, adding 50-160ms of blank-screen time on every cold start
- Project switch already treated recipe loading as fire-and-forget — this makes initial hydration consistent with that behaviour
- No additional safety mechanisms needed: the recipe store already handles concurrent requests via `loadRecipesRequestId` tracking and discards stale responses

Resolves #4839

## Changes

- `src/utils/stateHydration/index.ts`: removed the `await` on `recipeLoadPromise` during initial hydration so it fires in the background like project switch already does
- `src/utils/__tests__/stateHydration.test.ts`: updated the stale test that was asserting blocking behaviour to assert fire-and-forget instead

## Testing

Unit test updated and passing. The recipe store's existing stale-response protection means there's no correctness risk — recipes populate in the background as before, just no longer on the critical path for first paint.