### PR TITLE
fix(store): include undefined location in getGridCount and hasGridFocus checks

### DIFF
--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -364,4 +364,83 @@ describe("Grid Capacity Enforcement", () => {
       expect(focusedId).toBe("docked-1");
     });
   });
+
+  describe("getGridCount", () => {
+    it("should return 0 when no terminals", () => {
+      useTerminalStore.setState({ terminals: [] });
+      expect(useTerminalStore.getState().getGridCount()).toBe(0);
+    });
+
+    it("should count grid-location terminals", () => {
+      useTerminalStore.setState({ terminals: createGridTerminals(5) });
+      expect(useTerminalStore.getState().getGridCount()).toBe(5);
+    });
+
+    it("should count undefined-location terminals as grid", () => {
+      const terminals = createGridTerminals(3);
+      terminals.forEach((t) => (t.location = undefined));
+      useTerminalStore.setState({ terminals });
+      expect(useTerminalStore.getState().getGridCount()).toBe(3);
+    });
+
+    it("should count mixed grid + undefined but not dock or trash", () => {
+      const grid = createGridTerminals(4);
+      const undefinedLoc = [createMockTerminal("u-1", "grid"), createMockTerminal("u-2", "grid")];
+      undefinedLoc.forEach((t) => (t.location = undefined));
+      const dock = createDockedTerminals(3);
+      const trash = [createMockTerminal("trash-1", "trash")];
+
+      useTerminalStore.setState({ terminals: [...grid, ...undefinedLoc, ...dock, ...trash] });
+      expect(useTerminalStore.getState().getGridCount()).toBe(6);
+    });
+  });
+
+  describe("hasGridFocus with undefined location", () => {
+    it("should preserve focus when focused terminal has undefined location (bulkMoveToGrid)", () => {
+      const focusedTerminal = createMockTerminal("focused-1", "grid");
+      focusedTerminal.location = undefined;
+      const dockedTerminals = createDockedTerminals(2);
+
+      useTerminalStore.setState({
+        terminals: [focusedTerminal, ...dockedTerminals],
+        focusedId: "focused-1",
+      });
+
+      useTerminalStore.getState().bulkMoveToGrid();
+
+      expect(useTerminalStore.getState().focusedId).toBe("focused-1");
+    });
+
+    it("should not treat null focused terminal as having grid focus (bulkMoveToGrid)", () => {
+      const dockedTerminals = createDockedTerminals(2);
+
+      useTerminalStore.setState({
+        terminals: dockedTerminals,
+        focusedId: null,
+      });
+
+      useTerminalStore.getState().bulkMoveToGrid();
+
+      // Focus should not be forcibly set to null — moved terminals get focus via moveTerminalToGrid
+      const { focusedId } = useTerminalStore.getState();
+      expect(focusedId).not.toBe(null);
+    });
+
+    it("should preserve focus when focused terminal has undefined location (bulkMoveToGridByWorktree)", () => {
+      const focusedTerminal = createMockTerminal("focused-1", "grid");
+      focusedTerminal.location = undefined;
+      focusedTerminal.worktreeId = "wt-1";
+      const dockedTerminal = createMockTerminal("dock-1", "dock");
+      dockedTerminal.worktreeId = "wt-1";
+
+      useTerminalStore.setState({
+        terminals: [focusedTerminal, dockedTerminal],
+        focusedId: "focused-1",
+      });
+
+      useTerminalStore.getState().bulkMoveToGridByWorktree("wt-1");
+
+      expect(useTerminalStore.getState().focusedId).toBe("focused-1");
+    });
+  });
 });

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -140,7 +140,9 @@ export const createTerminalBulkActionsSlice = (
       const currentFocusedTerminal = currentFocusId
         ? terminals.find((t) => t.id === currentFocusId)
         : null;
-      const hasGridFocus = currentFocusedTerminal?.location === "grid";
+      const hasGridFocus =
+        currentFocusedTerminal != null &&
+        (currentFocusedTerminal.location === "grid" || currentFocusedTerminal.location === undefined);
 
       terminalsToMove.forEach((t) => moveTerminalToGrid(t.id));
 
@@ -235,7 +237,9 @@ export const createTerminalBulkActionsSlice = (
       const currentFocusedTerminal = currentFocusId
         ? terminals.find((t) => t.id === currentFocusId)
         : null;
-      const hasGridFocus = currentFocusedTerminal?.location === "grid";
+      const hasGridFocus =
+        currentFocusedTerminal != null &&
+        (currentFocusedTerminal.location === "grid" || currentFocusedTerminal.location === undefined);
 
       terminalsToMove.forEach((t) => moveTerminalToGrid(t.id));
 
@@ -267,7 +271,7 @@ export const createTerminalBulkActionsSlice = (
 
     getGridCount: () => {
       const terminals = getTerminals();
-      return terminals.filter((t) => t.location === "grid").length;
+      return terminals.filter((t) => t.location === "grid" || t.location === undefined).length;
     },
 
     getDockedCount: () => {

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -142,7 +142,8 @@ export const createTerminalBulkActionsSlice = (
         : null;
       const hasGridFocus =
         currentFocusedTerminal != null &&
-        (currentFocusedTerminal.location === "grid" || currentFocusedTerminal.location === undefined);
+        (currentFocusedTerminal.location === "grid" ||
+          currentFocusedTerminal.location === undefined);
 
       terminalsToMove.forEach((t) => moveTerminalToGrid(t.id));
 
@@ -239,7 +240,8 @@ export const createTerminalBulkActionsSlice = (
         : null;
       const hasGridFocus =
         currentFocusedTerminal != null &&
-        (currentFocusedTerminal.location === "grid" || currentFocusedTerminal.location === undefined);
+        (currentFocusedTerminal.location === "grid" ||
+          currentFocusedTerminal.location === undefined);
 
       terminalsToMove.forEach((t) => moveTerminalToGrid(t.id));
 


### PR DESCRIPTION
## Summary

- `getGridCount()` was checking `location === "grid"` only, missing terminals with `undefined` location which are semantically grid panels. Six other predicates in the same file already handle this correctly with the `(t.location === "grid" || t.location === undefined)` pattern.
- The same gap existed in two `hasGridFocus` checks, which could cause focus-restore logic to be skipped incorrectly after bulk terminal operations.
- Seven new tests added to `gridCapacity.test.ts` covering the `undefined` location edge cases and null-guard paths.

Resolves #4845

## Changes

- `src/store/slices/terminalBulkActionsSlice.ts`: three predicate fixes to include `undefined` location (one in `getGridCount`, two in `hasGridFocus`)
- `src/store/slices/__tests__/gridCapacity.test.ts`: seven new tests for `getGridCount` and `hasGridFocus` with `undefined` location

## Testing

Unit tests pass. The new tests directly exercise the previously-missing code paths to prevent regression.