### PR TITLE
fix(terminal): reinstall agent listeners after hibernation wake

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -8,6 +8,7 @@ import { isNonKeyboardInput } from "./inputUtils";
 import { reduceScrollback } from "./TerminalScrollbackController";
 import { logDebug, logError } from "@/utils/logger";
 import { SCROLLBACK_BACKGROUND } from "@shared/config/scrollback";
+import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 
 export interface HibernationManagerDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
@@ -27,6 +28,7 @@ export interface HibernationManagerDeps {
   setCachedSelection: (id: string, selection: string) => void;
   clearDirectingState: (id: string) => void;
   onUserInput: (id: string, data: string) => void;
+  onEnterPressed: (id: string) => void;
 }
 
 export class TerminalHibernationManager {
@@ -235,9 +237,100 @@ export class TerminalHibernationManager {
           this.deps.onUserInput(id, data);
         }
         terminalClient.write(id, data);
+        if (managed.onInput) {
+          managed.onInput(data);
+        }
       }
     });
     managed.listeners.push(() => inputDisposable.dispose());
+
+    // Reinstall title-state listener for agent terminals
+    if (managed.agentId) {
+      const agentConfig = getEffectiveAgentConfig(managed.agentId);
+      const titlePatterns = agentConfig?.detection?.titleStatePatterns;
+      if (titlePatterns) {
+        let lastReportedTitleState: "working" | "waiting" | undefined;
+
+        const titleDisposable = terminal.onTitleChange((title: string) => {
+          let matched: "working" | "waiting" | undefined;
+          for (const pattern of titlePatterns.working) {
+            if (title.includes(pattern)) {
+              matched = "working";
+              break;
+            }
+          }
+          if (!matched) {
+            for (const pattern of titlePatterns.waiting) {
+              if (title.includes(pattern)) {
+                matched = "waiting";
+                break;
+              }
+            }
+          }
+          if (!matched) {
+            if (managed.titleReportTimer !== undefined) {
+              clearTimeout(managed.titleReportTimer);
+              managed.titleReportTimer = undefined;
+              managed.pendingTitleState = undefined;
+            }
+            return;
+          }
+
+          if (matched === "working") {
+            if (managed.titleReportTimer !== undefined) {
+              clearTimeout(managed.titleReportTimer);
+              managed.titleReportTimer = undefined;
+              managed.pendingTitleState = undefined;
+            }
+            if (lastReportedTitleState !== "working") {
+              lastReportedTitleState = "working";
+              window.electron.terminal.reportTitleState(id, "working");
+            }
+          } else {
+            managed.pendingTitleState = "waiting";
+            if (managed.titleReportTimer !== undefined) {
+              clearTimeout(managed.titleReportTimer);
+            }
+            managed.titleReportTimer = window.setTimeout(() => {
+              managed.titleReportTimer = undefined;
+              if (managed.pendingTitleState === "waiting") {
+                managed.pendingTitleState = undefined;
+                if (lastReportedTitleState !== "waiting") {
+                  lastReportedTitleState = "waiting";
+                  window.electron.terminal.reportTitleState(id, "waiting");
+                }
+              }
+            }, 250);
+          }
+        });
+        managed.listeners.push(() => {
+          titleDisposable.dispose();
+          if (managed.titleReportTimer !== undefined) {
+            clearTimeout(managed.titleReportTimer);
+            managed.titleReportTimer = undefined;
+            managed.pendingTitleState = undefined;
+          }
+        });
+      }
+    }
+
+    // Reinstall agent Enter key listener
+    if (managed.kind === "agent") {
+      const keyDisposable = terminal.onKey(({ domEvent }) => {
+        if (
+          !managed.isInputLocked &&
+          domEvent.key === "Enter" &&
+          !domEvent.isComposing &&
+          !domEvent.shiftKey &&
+          !domEvent.ctrlKey &&
+          !domEvent.altKey &&
+          !domEvent.metaKey
+        ) {
+          this.deps.onEnterPressed(id);
+        }
+      });
+      managed.listeners.push(() => keyDisposable.dispose());
+    }
 
     // Reset restore state
     managed.writeChain = Promise.resolve();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -108,6 +108,7 @@ class TerminalInstanceService {
       setCachedSelection: (id, selection) => this.cachedSelections.set(id, selection),
       clearDirectingState: (id) => this.agentStateController.clearDirectingState(id),
       onUserInput: (id, data) => this.onUserInput(id, data),
+      onEnterPressed: (id) => this.onEnterPressed(id),
     });
 
     this.wakeManager = new TerminalWakeManager({
@@ -509,6 +510,7 @@ class TerminalInstanceService {
     const existing = this.instances.get(id);
     if (existing) {
       existing.getRefreshTier = getRefreshTier;
+      existing.onInput = onInput;
       if (getCwd) {
         this.cwdProviders.set(id, getCwd);
       }
@@ -606,6 +608,7 @@ class TerminalInstanceService {
       isAltBuffer: false,
       altBufferListeners: new Set(),
       ipcListenerCount: listeners.length,
+      onInput,
     };
 
     managed.parserHandler = new TerminalParserHandler(managed, () => {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -127,6 +127,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     setCachedSelection: vi.fn(),
     clearDirectingState: vi.fn(),
     onUserInput: vi.fn(),
+    onEnterPressed: vi.fn(),
   };
 }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -41,6 +41,15 @@ vi.mock("@xterm/addon-webgl", () => ({
   })),
 }));
 
+const mockGetEffectiveAgentConfig = vi.fn();
+vi.mock("@shared/config/agentRegistry", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getEffectiveAgentConfig: (...args: unknown[]) => mockGetEffectiveAgentConfig(...args),
+  };
+});
+
 vi.mock("../TerminalAddonManager", () => ({
   setupTerminalAddons: vi.fn(() => ({
     fitAddon: { fit: vi.fn() },
@@ -165,6 +174,13 @@ describe("TerminalInstanceService - Hibernation", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+
+    // Mock window.electron for title state reporting
+    (window as Record<string, unknown>).electron = {
+      terminal: {
+        reportTitleState: vi.fn(),
+      },
+    };
 
     ({ terminalInstanceService: service } =
       (await import("../TerminalInstanceService")) as unknown as {
@@ -588,6 +604,139 @@ describe("TerminalInstanceService - Hibernation", () => {
       expect(managed.isHibernated).toBe(false);
 
       expect(service.instances.has("t1")).toBe(true);
+    });
+  });
+
+  describe("Agent listener reinstallation after unhibernate", () => {
+    it("should install more listeners for agent terminals with titleStatePatterns than non-agent", () => {
+      mockGetEffectiveAgentConfig.mockReturnValue({
+        detection: {
+          titleStatePatterns: {
+            working: ["\u2726"],
+            waiting: ["\u25C7"],
+          },
+        },
+      });
+
+      // Non-agent terminal
+      const nonAgent = makeMockManaged({
+        isHibernated: true,
+        isOpened: false,
+        kind: "terminal",
+        type: "terminal",
+        ipcListenerCount: 0,
+      });
+      nonAgent.listeners = [];
+      service.instances.set("t1", nonAgent as unknown as Record<string, unknown>);
+      service.unhibernate("t1");
+      const nonAgentListenerCount = nonAgent.listeners.length;
+
+      // Agent terminal
+      const agent = makeMockManaged({
+        isHibernated: true,
+        isOpened: false,
+        kind: "agent",
+        type: "claude",
+        agentId: "claude",
+        ipcListenerCount: 0,
+      });
+      agent.listeners = [];
+      service.instances.set("t2", agent as unknown as Record<string, unknown>);
+      service.unhibernate("t2");
+      const agentListenerCount = agent.listeners.length;
+
+      // Agent should have 2 more listeners: title-state + enter-key
+      expect(agentListenerCount).toBe(nonAgentListenerCount + 2);
+    });
+
+    it("should install enter-key listener but not title listener when no titleStatePatterns", () => {
+      mockGetEffectiveAgentConfig.mockReturnValue(undefined);
+
+      // Non-agent baseline
+      const nonAgent = makeMockManaged({
+        isHibernated: true,
+        isOpened: false,
+        kind: "terminal",
+        type: "terminal",
+        ipcListenerCount: 0,
+      });
+      nonAgent.listeners = [];
+      service.instances.set("t1", nonAgent as unknown as Record<string, unknown>);
+      service.unhibernate("t1");
+      const nonAgentListenerCount = nonAgent.listeners.length;
+
+      // Agent without title patterns
+      const agent = makeMockManaged({
+        isHibernated: true,
+        isOpened: false,
+        kind: "agent",
+        type: "claude",
+        agentId: "claude",
+        ipcListenerCount: 0,
+      });
+      agent.listeners = [];
+      service.instances.set("t2", agent as unknown as Record<string, unknown>);
+      service.unhibernate("t2");
+      const agentListenerCount = agent.listeners.length;
+
+      // Agent should have 1 more listener: enter-key only (no title-state)
+      expect(agentListenerCount).toBe(nonAgentListenerCount + 1);
+    });
+
+    it("should preserve onInput callback on ManagedTerminal through unhibernate", () => {
+      const onInputMock = vi.fn();
+      const managed = makeMockManaged({
+        isHibernated: true,
+        isOpened: false,
+        onInput: onInputMock,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.unhibernate("t1");
+
+      // onInput should still be on the managed instance
+      expect((managed as Record<string, unknown>).onInput).toBe(onInputMock);
+    });
+
+    it("should not grow listeners across hibernate/unhibernate cycles for agent terminals", () => {
+      mockGetEffectiveAgentConfig.mockReturnValue({
+        detection: {
+          titleStatePatterns: {
+            working: ["\u2726"],
+            waiting: ["\u25C7"],
+          },
+        },
+      });
+
+      const managed = makeMockManaged({
+        ipcListenerCount: 2,
+        kind: "agent",
+        type: "claude",
+        agentId: "claude",
+        canonicalAgentState: "completed",
+        onInput: vi.fn(),
+      });
+      managed.listeners = [vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn(), vi.fn()];
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.hibernate("t1");
+      expect(managed.listeners.length).toBe(2);
+
+      service.unhibernate("t1");
+      const afterFirstCycle = managed.listeners.length;
+      // Agent terminals should have more listeners than just IPC (title + key + standard)
+      expect(afterFirstCycle).toBeGreaterThan(2);
+
+      service.hibernate("t1");
+      expect(managed.listeners.length).toBe(2);
+
+      service.unhibernate("t1");
+      expect(managed.listeners.length).toBe(afterFirstCycle);
+
+      // Third cycle
+      service.hibernate("t1");
+      service.unhibernate("t1");
+      expect(managed.listeners.length).toBe(afterFirstCycle);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -176,7 +176,7 @@ describe("TerminalInstanceService - Hibernation", () => {
     vi.clearAllMocks();
 
     // Mock window.electron for title state reporting
-    (window as Record<string, unknown>).electron = {
+    (window as unknown as Record<string, unknown>).electron = {
       terminal: {
         reportTitleState: vi.fn(),
       },

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -92,6 +92,9 @@ export interface ManagedTerminal {
   // Input lock state (read-only monitor mode)
   isInputLocked?: boolean;
 
+  // Caller-supplied input callback (stored for reinstallation after hibernation wake)
+  onInput?: (data: string) => void;
+
   // Incremental restore state
   writeChain: Promise<void>;
   restoreGeneration: number;


### PR DESCRIPTION
## Summary

- Agent terminals that hibernate and wake up were silently losing three categories of listeners: the title-state listener (agent working/waiting detection), the Enter key listener (command submission), and `onInput` callback forwarding (clear-command and last-command tracking).
- The root cause was drift between the `getOrCreate()` creation path and the `unhibernate()` wake path in `TerminalHibernationManager` — the wake path had no access to `kind`, `agentId`, or the original `onInput` callback, so agent-conditional listeners were simply omitted.
- The fix stores `kind`, `agentId`, and `onInput` on the hibernated record so `unhibernate()` can reinstall all three listener categories correctly.

Resolves #4842

## Changes

- `TerminalHibernationManager.ts` — `unhibernate()` now reinstalls the title-state listener, agent Enter key listener, and `onInput` forwarding for agent terminals
- `TerminalInstanceService.ts` — passes `kind`, `agentId`, and `onInput` through to the hibernation record
- `types.ts` — adds `kind`, `agentId`, and `onInput` fields to the hibernated terminal record type
- `TerminalHibernationManager.test.ts` / `TerminalInstanceService.hibernation.test.ts` — 4 new tests covering all three missing listener categories and their absence on non-agent terminals

## Testing

All four new tests pass. The fix was verified against the creation path to confirm parity between `getOrCreate()` and `unhibernate()` for agent terminals.