### PR TITLE
fix(background): preserve tab group structure when backgrounding panels

### DIFF
--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
-import { Eclipse } from "lucide-react";
+import { useState, useMemo } from "react";
+import { Eclipse, Layers, ChevronDown, ChevronRight } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { useTerminalStore } from "@/store/terminalStore";
+import { useTerminalStore, type TerminalInstance } from "@/store";
+import type { TrashedTerminalGroupMetadata } from "@/store/slices";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useBackgroundedTerminals } from "@/hooks/useTerminalSelectors";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -13,16 +14,33 @@ interface BackgroundContainerProps {
   compact?: boolean;
 }
 
+interface BackgroundDisplaySingle {
+  type: "single";
+  terminal: TerminalInstance;
+}
+
+interface BackgroundDisplayGroup {
+  type: "group";
+  groupRestoreId: string;
+  groupMetadata: TrashedTerminalGroupMetadata;
+  terminals: TerminalInstance[];
+}
+
+type BackgroundDisplayItem = BackgroundDisplaySingle | BackgroundDisplayGroup;
+
 export function BackgroundContainer({ compact = false }: BackgroundContainerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const terminals = useBackgroundedTerminals();
-  const { restoreBackgroundTerminal, activateTerminal, pingTerminal } = useTerminalStore(
-    useShallow((state) => ({
-      restoreBackgroundTerminal: state.restoreBackgroundTerminal,
-      activateTerminal: state.activateTerminal,
-      pingTerminal: state.pingTerminal,
-    }))
-  );
+  const backgroundedTerminals = useTerminalStore((state) => state.backgroundedTerminals);
+  const { restoreBackgroundTerminal, restoreBackgroundGroup, activateTerminal, pingTerminal } =
+    useTerminalStore(
+      useShallow((state) => ({
+        restoreBackgroundTerminal: state.restoreBackgroundTerminal,
+        restoreBackgroundGroup: state.restoreBackgroundGroup,
+        activateTerminal: state.activateTerminal,
+        pingTerminal: state.pingTerminal,
+      }))
+    );
   const { activeWorktreeId, selectWorktree, trackTerminalFocus } = useWorktreeSelectionStore(
     useShallow((state) => ({
       activeWorktreeId: state.activeWorktreeId,
@@ -31,9 +49,88 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
     }))
   );
 
+  const displayItems = useMemo((): BackgroundDisplayItem[] => {
+    const groups = new Map<
+      string,
+      {
+        metadata: TrashedTerminalGroupMetadata | undefined;
+        terminals: TerminalInstance[];
+      }
+    >();
+    const singles: TerminalInstance[] = [];
+
+    for (const terminal of terminals) {
+      const bgInfo = backgroundedTerminals.get(terminal.id);
+      if (bgInfo?.groupRestoreId) {
+        const existing = groups.get(bgInfo.groupRestoreId);
+        if (existing) {
+          existing.terminals.push(terminal);
+          if (bgInfo.groupMetadata) {
+            existing.metadata = bgInfo.groupMetadata;
+          }
+        } else {
+          groups.set(bgInfo.groupRestoreId, {
+            metadata: bgInfo.groupMetadata,
+            terminals: [terminal],
+          });
+        }
+      } else {
+        singles.push(terminal);
+      }
+    }
+
+    const items: BackgroundDisplayItem[] = [];
+
+    for (const [groupRestoreId, group] of groups) {
+      if (group.metadata && group.terminals.length > 1) {
+        items.push({
+          type: "group",
+          groupRestoreId,
+          groupMetadata: group.metadata,
+          terminals: group.terminals,
+        });
+      } else {
+        for (const terminal of group.terminals) {
+          items.push({ type: "single", terminal });
+        }
+      }
+    }
+
+    for (const terminal of singles) {
+      items.push({ type: "single", terminal });
+    }
+
+    return items;
+  }, [terminals, backgroundedTerminals]);
+
   if (terminals.length === 0) return null;
 
   const count = terminals.length;
+
+  const handleRestoreSingle = (terminal: TerminalInstance) => {
+    const worktreeId = terminal.worktreeId?.trim();
+    if (worktreeId && worktreeId !== activeWorktreeId) {
+      trackTerminalFocus(worktreeId, terminal.id);
+      selectWorktree(worktreeId);
+    }
+    restoreBackgroundTerminal(terminal.id);
+    activateTerminal(terminal.id);
+    pingTerminal(terminal.id);
+    setIsOpen(false);
+  };
+
+  const handleRestoreGroup = (
+    groupRestoreId: string,
+    groupMetadata: TrashedTerminalGroupMetadata
+  ) => {
+    restoreBackgroundGroup(groupRestoreId);
+    const activeId = groupMetadata.activeTabId;
+    if (activeId) {
+      activateTerminal(activeId);
+      pingTerminal(activeId);
+    }
+    setIsOpen(false);
+  };
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -80,44 +177,148 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
           </div>
 
           <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
-            {terminals.map((terminal) => (
-              <button
-                key={terminal.id}
-                type="button"
-                onClick={() => {
-                  const worktreeId = terminal.worktreeId?.trim();
-                  if (worktreeId && worktreeId !== activeWorktreeId) {
-                    trackTerminalFocus(worktreeId, terminal.id);
-                    selectWorktree(worktreeId);
-                  }
-                  restoreBackgroundTerminal(terminal.id);
-                  activateTerminal(terminal.id);
-                  pingTerminal(terminal.id);
-                  setIsOpen(false);
-                }}
-                className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-none hover:bg-tint/5 focus:bg-tint/5"
-              >
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
-                    <TerminalIcon
-                      type={terminal.type}
-                      kind={terminal.kind}
-                      agentId={terminal.agentId}
-                      detectedProcessId={terminal.detectedProcessId}
-                      className="h-3 w-3"
-                    />
+            {displayItems.map((item) => {
+              if (item.type === "group") {
+                return (
+                  <BackgroundGroupItem
+                    key={item.groupRestoreId}
+                    groupRestoreId={item.groupRestoreId}
+                    groupMetadata={item.groupMetadata}
+                    terminals={item.terminals}
+                    onRestoreGroup={handleRestoreGroup}
+                    onRestoreSingle={handleRestoreSingle}
+                  />
+                );
+              }
+              return (
+                <button
+                  key={item.terminal.id}
+                  type="button"
+                  onClick={() => handleRestoreSingle(item.terminal)}
+                  className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-none hover:bg-tint/5 focus:bg-tint/5"
+                >
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
+                      <TerminalIcon
+                        type={item.terminal.type}
+                        kind={item.terminal.kind}
+                        agentId={item.terminal.agentId}
+                        detectedProcessId={item.terminal.detectedProcessId}
+                        className="h-3 w-3"
+                      />
+                    </div>
+                    <span className="text-xs truncate font-medium text-canopy-text/70 group-hover:text-canopy-text transition-colors">
+                      {item.terminal.title}
+                    </span>
                   </div>
-                  <span className="text-xs truncate font-medium text-canopy-text/70 group-hover:text-canopy-text transition-colors">
-                    {terminal.title}
-                  </span>
-                </div>
-
-                <span className="text-[10px] text-canopy-text/40 shrink-0">Restore</span>
-              </button>
-            ))}
+                  <span className="text-[10px] text-canopy-text/40 shrink-0">Restore</span>
+                </button>
+              );
+            })}
           </div>
         </div>
       </PopoverContent>
     </Popover>
+  );
+}
+
+function BackgroundGroupItem({
+  groupRestoreId,
+  groupMetadata,
+  terminals,
+  onRestoreGroup,
+  onRestoreSingle,
+}: {
+  groupRestoreId: string;
+  groupMetadata: TrashedTerminalGroupMetadata;
+  terminals: TerminalInstance[];
+  onRestoreGroup: (groupRestoreId: string, metadata: TrashedTerminalGroupMetadata) => void;
+  onRestoreSingle: (terminal: TerminalInstance) => void;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const tabCount = terminals.length;
+  const groupName = `Tab Group (${tabCount} ${tabCount === 1 ? "tab" : "tabs"})`;
+
+  return (
+    <div className="rounded-[var(--radius-sm)] bg-transparent hover:bg-tint/5 transition-colors">
+      <div className="flex items-center gap-2 px-2.5 py-1.5 group">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0 h-4 w-4 p-0 hover:bg-transparent"
+          onClick={() => setIsExpanded(!isExpanded)}
+          aria-label={isExpanded ? "Collapse group" : "Expand group"}
+          aria-expanded={isExpanded}
+          aria-controls={`bg-group-${groupRestoreId}`}
+        >
+          {isExpanded ? (
+            <ChevronDown className="w-3 h-3 text-canopy-text/60" />
+          ) : (
+            <ChevronRight className="w-3 h-3 text-canopy-text/60" />
+          )}
+        </Button>
+
+        <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
+          <Layers className="w-3 h-3 text-canopy-text/70" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-medium text-canopy-text/70 group-hover:text-canopy-text truncate transition-colors">
+            {groupName}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          className="text-[10px] text-canopy-text/40 shrink-0 hover:text-canopy-text transition-colors"
+          onClick={() => onRestoreGroup(groupRestoreId, groupMetadata)}
+        >
+          Restore All
+        </button>
+      </div>
+
+      {isExpanded && (
+        <div
+          id={`bg-group-${groupRestoreId}`}
+          role="region"
+          aria-label="Group panels"
+          className="pl-6 pr-2 pb-1.5 space-y-0.5"
+        >
+          {terminals
+            .sort((a, b) => {
+              const aIndex = groupMetadata.panelIds.indexOf(a.id);
+              const bIndex = groupMetadata.panelIds.indexOf(b.id);
+              if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+              return 0;
+            })
+            .map((terminal) => {
+              const isActiveTab = groupMetadata.activeTabId === terminal.id;
+              return (
+                <button
+                  key={terminal.id}
+                  type="button"
+                  onClick={() => onRestoreSingle(terminal)}
+                  className="flex items-center gap-2 w-full px-2 py-1 text-[11px] rounded hover:bg-tint/5 text-left"
+                >
+                  <TerminalIcon
+                    type={terminal.type}
+                    kind={terminal.kind}
+                    agentId={terminal.agentId}
+                    detectedProcessId={terminal.detectedProcessId}
+                    className="w-2.5 h-2.5 opacity-60"
+                  />
+                  <span
+                    className={`truncate flex-1 ${isActiveTab ? "text-canopy-text/70 font-medium" : "text-canopy-text/50"}`}
+                  >
+                    {terminal.title}
+                    {isActiveTab && <span className="ml-1 text-canopy-text/40">(active)</span>}
+                  </span>
+                  <span className="text-[10px] text-canopy-text/30 shrink-0">Restore</span>
+                </button>
+              );
+            })}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -123,9 +123,16 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
     groupRestoreId: string,
     groupMetadata: TrashedTerminalGroupMetadata
   ) => {
+    const worktreeId = groupMetadata.worktreeId?.trim();
+    if (worktreeId && worktreeId !== activeWorktreeId) {
+      selectWorktree(worktreeId);
+    }
     restoreBackgroundGroup(groupRestoreId);
     const activeId = groupMetadata.activeTabId;
     if (activeId) {
+      if (worktreeId) {
+        trackTerminalFocus(worktreeId, activeId);
+      }
       activateTerminal(activeId);
       pingTerminal(activeId);
     }
@@ -284,7 +291,7 @@ function BackgroundGroupItem({
           aria-label="Group panels"
           className="pl-6 pr-2 pb-1.5 space-y-0.5"
         >
-          {terminals
+          {[...terminals]
             .sort((a, b) => {
               const aIndex = groupMetadata.panelIds.indexOf(a.id);
               const bIndex = groupMetadata.panelIds.indexOf(b.id);

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -66,7 +66,12 @@ export function registerTerminalLifecycleActions(
       const state = useTerminalStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        state.backgroundTerminal(targetId);
+        const group = state.getPanelGroup(targetId);
+        if (group) {
+          state.backgroundPanelGroup(targetId);
+        } else {
+          state.backgroundTerminal(targetId);
+        }
       }
     },
   }));

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -7,6 +7,7 @@ export {
   type TerminalRegistryMiddleware,
   type TrashedTerminal,
   type TrashedTerminalGroupMetadata,
+  type BackgroundedTerminal,
 } from "./terminalRegistrySlice";
 
 export {

--- a/src/store/slices/terminalRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/terminalRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Tests for background system preserving tab group structure
+ * Issue #4843: Backgrounding grouped panel permanently loses tab group structure
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { TabGroup } from "@/types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+  },
+}));
+
+const { useTerminalStore } = await import("../../../terminalStore");
+
+function makeTerminal(id: string, location: "grid" | "dock" = "grid") {
+  return {
+    id,
+    type: "terminal" as const,
+    title: `Shell ${id}`,
+    cwd: "/test",
+    cols: 80,
+    rows: 24,
+    location,
+  };
+}
+
+describe("backgroundTerminal group metadata", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should save groupRestoreId and groupMetadata when backgrounding a grouped panel", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t1",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    useTerminalStore.getState().backgroundTerminal("t1");
+
+    const state = useTerminalStore.getState();
+    const bgInfo = state.backgroundedTerminals.get("t1");
+    expect(bgInfo).toBeDefined();
+    expect(bgInfo!.groupRestoreId).toBeDefined();
+    expect(bgInfo!.groupMetadata).toBeDefined();
+    expect(bgInfo!.groupMetadata!.panelIds).toEqual(["t1", "t2", "t3"]);
+    expect(bgInfo!.groupMetadata!.activeTabId).toBe("t1");
+    expect(bgInfo!.groupMetadata!.location).toBe("grid");
+  });
+
+  it("should not save group metadata for ungrouped panels", () => {
+    useTerminalStore.setState({
+      terminals: [makeTerminal("t1")],
+      tabGroups: new Map(),
+    });
+
+    useTerminalStore.getState().backgroundTerminal("t1");
+
+    const bgInfo = useTerminalStore.getState().backgroundedTerminals.get("t1");
+    expect(bgInfo).toBeDefined();
+    expect(bgInfo!.groupRestoreId).toBeUndefined();
+    expect(bgInfo!.groupMetadata).toBeUndefined();
+  });
+
+  it("should dissolve group correctly when backgrounding one panel from a 3-panel group", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t2",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    useTerminalStore.getState().backgroundTerminal("t1");
+
+    const state = useTerminalStore.getState();
+    const updatedGroup = state.tabGroups.get("group-1");
+    expect(updatedGroup).toBeDefined();
+    expect(updatedGroup!.panelIds).toEqual(["t2", "t3"]);
+    expect(updatedGroup!.activeTabId).toBe("t2");
+  });
+});
+
+describe("backgroundPanelGroup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should background all panels in a group atomically", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t2",
+      location: "grid",
+    };
+
+    useTerminalStore.setState({
+      terminals: [makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    useTerminalStore.getState().backgroundPanelGroup("t1");
+
+    const state = useTerminalStore.getState();
+
+    // All panels should be backgrounded
+    expect(state.terminals.find((t) => t.id === "t1")!.location).toBe("background");
+    expect(state.terminals.find((t) => t.id === "t2")!.location).toBe("background");
+    expect(state.terminals.find((t) => t.id === "t3")!.location).toBe("background");
+
+    // All should have same groupRestoreId
+    const bg1 = state.backgroundedTerminals.get("t1")!;
+    const bg2 = state.backgroundedTerminals.get("t2")!;
+    const bg3 = state.backgroundedTerminals.get("t3")!;
+    expect(bg1.groupRestoreId).toBeDefined();
+    expect(bg1.groupRestoreId).toBe(bg2.groupRestoreId);
+    expect(bg2.groupRestoreId).toBe(bg3.groupRestoreId);
+
+    // Only anchor (first) gets groupMetadata
+    expect(bg1.groupMetadata).toBeDefined();
+    expect(bg1.groupMetadata!.panelIds).toEqual(["t1", "t2", "t3"]);
+    expect(bg1.groupMetadata!.activeTabId).toBe("t2");
+    expect(bg2.groupMetadata).toBeUndefined();
+    expect(bg3.groupMetadata).toBeUndefined();
+
+    // Tab group should be deleted
+    expect(state.tabGroups.has("group-1")).toBe(false);
+  });
+
+  it("should fall back to backgroundTerminal when panel is not in a group", () => {
+    useTerminalStore.setState({
+      terminals: [makeTerminal("t1")],
+      tabGroups: new Map(),
+    });
+
+    useTerminalStore.getState().backgroundPanelGroup("t1");
+
+    const state = useTerminalStore.getState();
+    expect(state.terminals.find((t) => t.id === "t1")!.location).toBe("background");
+    expect(state.backgroundedTerminals.has("t1")).toBe(true);
+  });
+});
+
+describe("restoreBackgroundGroup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should reconstruct the tab group with correct order and active tab", () => {
+    const groupRestoreId = "group-test-123";
+
+    useTerminalStore.setState({
+      terminals: [
+        { ...makeTerminal("t1"), location: "background" as const },
+        { ...makeTerminal("t2"), location: "background" as const },
+        { ...makeTerminal("t3"), location: "background" as const },
+      ],
+      backgroundedTerminals: new Map([
+        [
+          "t1",
+          {
+            id: "t1",
+            originalLocation: "grid" as const,
+            groupRestoreId,
+            groupMetadata: {
+              panelIds: ["t1", "t2", "t3"],
+              activeTabId: "t2",
+              location: "grid" as const,
+              worktreeId: null,
+            },
+          },
+        ],
+        ["t2", { id: "t2", originalLocation: "grid" as const, groupRestoreId }],
+        ["t3", { id: "t3", originalLocation: "grid" as const, groupRestoreId }],
+      ]),
+    });
+
+    useTerminalStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    const state = useTerminalStore.getState();
+
+    // All panels restored
+    expect(state.terminals.find((t) => t.id === "t1")!.location).toBe("grid");
+    expect(state.terminals.find((t) => t.id === "t2")!.location).toBe("grid");
+    expect(state.terminals.find((t) => t.id === "t3")!.location).toBe("grid");
+
+    // Backgrounded entries cleared
+    expect(state.backgroundedTerminals.size).toBe(0);
+
+    // Tab group recreated
+    expect(state.tabGroups.size).toBe(1);
+    const group = [...state.tabGroups.values()][0];
+    expect(group.panelIds).toEqual(["t1", "t2", "t3"]);
+    expect(group.activeTabId).toBe("t2");
+    expect(group.location).toBe("grid");
+  });
+
+  it("should filter out panels that no longer exist", () => {
+    const groupRestoreId = "group-test-456";
+
+    // t2 was removed while backgrounded
+    useTerminalStore.setState({
+      terminals: [
+        { ...makeTerminal("t1"), location: "background" as const },
+        { ...makeTerminal("t3"), location: "background" as const },
+      ],
+      backgroundedTerminals: new Map([
+        [
+          "t1",
+          {
+            id: "t1",
+            originalLocation: "grid" as const,
+            groupRestoreId,
+            groupMetadata: {
+              panelIds: ["t1", "t2", "t3"],
+              activeTabId: "t2",
+              location: "grid" as const,
+              worktreeId: null,
+            },
+          },
+        ],
+        ["t3", { id: "t3", originalLocation: "grid" as const, groupRestoreId }],
+      ]),
+    });
+
+    useTerminalStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.size).toBe(1);
+    const group = [...state.tabGroups.values()][0];
+    // t2 should be filtered out
+    expect(group.panelIds).toEqual(["t1", "t3"]);
+    // activeTabId falls back since t2 is gone
+    expect(group.activeTabId).toBe("t1");
+  });
+
+  it("should be a no-op when groupRestoreId is not found", () => {
+    useTerminalStore.setState({
+      terminals: [makeTerminal("t1")],
+      backgroundedTerminals: new Map(),
+    });
+
+    useTerminalStore.getState().restoreBackgroundGroup("nonexistent");
+
+    const state = useTerminalStore.getState();
+    expect(state.tabGroups.size).toBe(0);
+  });
+});
+
+describe("restoreBackgroundTerminal with groupRestoreId", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should delegate to restoreBackgroundGroup when panel has groupRestoreId", () => {
+    const groupRestoreId = "group-test-789";
+
+    useTerminalStore.setState({
+      terminals: [
+        { ...makeTerminal("t1"), location: "background" as const },
+        { ...makeTerminal("t2"), location: "background" as const },
+      ],
+      backgroundedTerminals: new Map([
+        [
+          "t1",
+          {
+            id: "t1",
+            originalLocation: "grid" as const,
+            groupRestoreId,
+            groupMetadata: {
+              panelIds: ["t1", "t2"],
+              activeTabId: "t1",
+              location: "grid" as const,
+              worktreeId: null,
+            },
+          },
+        ],
+        ["t2", { id: "t2", originalLocation: "grid" as const, groupRestoreId }],
+      ]),
+    });
+
+    // Restore via single-panel API — should restore the whole group
+    useTerminalStore.getState().restoreBackgroundTerminal("t1");
+
+    const state = useTerminalStore.getState();
+    expect(state.terminals.find((t) => t.id === "t1")!.location).toBe("grid");
+    expect(state.terminals.find((t) => t.id === "t2")!.location).toBe("grid");
+    expect(state.backgroundedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(1);
+  });
+
+  it("should restore standalone panel without group reconstruction", () => {
+    useTerminalStore.setState({
+      terminals: [{ ...makeTerminal("t1"), location: "background" as const }],
+      backgroundedTerminals: new Map([["t1", { id: "t1", originalLocation: "dock" as const }]]),
+    });
+
+    useTerminalStore.getState().restoreBackgroundTerminal("t1");
+
+    const state = useTerminalStore.getState();
+    expect(state.terminals.find((t) => t.id === "t1")!.location).toBe("dock");
+    expect(state.backgroundedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(0);
+  });
+});
+
+describe("round-trip: backgroundPanelGroup → restoreBackgroundGroup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const { reset } = useTerminalStore.getState();
+    reset();
+    useTerminalStore.setState({
+      terminals: [],
+      tabGroups: new Map(),
+      trashedTerminals: new Map(),
+      backgroundedTerminals: new Map(),
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("should fully reconstruct the group after background and restore", () => {
+    const group: TabGroup = {
+      id: "group-1",
+      panelIds: ["t1", "t2", "t3"],
+      activeTabId: "t2",
+      location: "dock",
+      worktreeId: "wt-1",
+    };
+
+    useTerminalStore.setState({
+      terminals: [
+        makeTerminal("t1", "dock"),
+        makeTerminal("t2", "dock"),
+        makeTerminal("t3", "dock"),
+      ],
+      tabGroups: new Map([["group-1", group]]),
+    });
+
+    // Background the group
+    useTerminalStore.getState().backgroundPanelGroup("t1");
+
+    let state = useTerminalStore.getState();
+    expect(state.tabGroups.size).toBe(0);
+    expect(state.backgroundedTerminals.size).toBe(3);
+
+    // Get the groupRestoreId
+    const groupRestoreId = state.backgroundedTerminals.get("t1")!.groupRestoreId!;
+
+    // Restore the group
+    useTerminalStore.getState().restoreBackgroundGroup(groupRestoreId);
+
+    state = useTerminalStore.getState();
+    expect(state.backgroundedTerminals.size).toBe(0);
+    expect(state.tabGroups.size).toBe(1);
+
+    const restoredGroup = [...state.tabGroups.values()][0];
+    expect(restoredGroup.panelIds).toEqual(["t1", "t2", "t3"]);
+    expect(restoredGroup.activeTabId).toBe("t2");
+    expect(restoredGroup.location).toBe("dock");
+
+    // All panels restored to dock
+    for (const id of ["t1", "t2", "t3"]) {
+      expect(state.terminals.find((t) => t.id === id)!.location).toBe("dock");
+    }
+  });
+});

--- a/src/store/slices/terminalRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
+++ b/src/store/slices/terminalRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts
@@ -437,9 +437,9 @@ describe("round-trip: backgroundPanelGroup → restoreBackgroundGroup", () => {
 
     useTerminalStore.setState({
       terminals: [
-        makeTerminal("t1", "dock"),
-        makeTerminal("t2", "dock"),
-        makeTerminal("t3", "dock"),
+        { ...makeTerminal("t1", "dock"), worktreeId: "wt-1" },
+        { ...makeTerminal("t2", "dock"), worktreeId: "wt-1" },
+        { ...makeTerminal("t3", "dock"), worktreeId: "wt-1" },
       ],
       tabGroups: new Map([["group-1", group]]),
     });
@@ -465,10 +465,13 @@ describe("round-trip: backgroundPanelGroup → restoreBackgroundGroup", () => {
     expect(restoredGroup.panelIds).toEqual(["t1", "t2", "t3"]);
     expect(restoredGroup.activeTabId).toBe("t2");
     expect(restoredGroup.location).toBe("dock");
+    expect(restoredGroup.worktreeId).toBe("wt-1");
 
-    // All panels restored to dock
+    // All panels restored to dock with correct worktreeId
     for (const id of ["t1", "t2", "t3"]) {
-      expect(state.terminals.find((t) => t.id === id)!.location).toBe("dock");
+      const t = state.terminals.find((t) => t.id === id)!;
+      expect(t.location).toBe("dock");
+      expect(t.worktreeId).toBe("wt-1");
     }
   });
 });

--- a/src/store/slices/terminalRegistry/background.ts
+++ b/src/store/slices/terminalRegistry/background.ts
@@ -13,7 +13,11 @@ export const createBackgroundActions = (
   get: Get
 ): Pick<
   TerminalRegistrySlice,
-  "backgroundTerminal" | "restoreBackgroundTerminal" | "isInBackground"
+  | "backgroundTerminal"
+  | "backgroundPanelGroup"
+  | "restoreBackgroundTerminal"
+  | "restoreBackgroundGroup"
+  | "isInBackground"
 > => ({
   backgroundTerminal: (id) => {
     const terminal = get().terminals.find((t) => t.id === id);
@@ -22,27 +26,46 @@ export const createBackgroundActions = (
 
     const originalLocation: "dock" | "grid" = terminal.location === "dock" ? "dock" : "grid";
 
+    // Capture group metadata BEFORE set() dissolves the group
+    const group = get().getPanelGroup(id);
+    let groupRestoreId: string | undefined;
+    let groupMetadata: import("./types").TrashedTerminalGroupMetadata | undefined;
+
+    if (group) {
+      groupRestoreId = `group-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      groupMetadata = {
+        panelIds: [...group.panelIds],
+        activeTabId: group.activeTabId ?? group.panelIds[0] ?? "",
+        location: group.location,
+        worktreeId: group.worktreeId ?? null,
+      };
+    }
+
     set((state) => {
       const newTerminals = state.terminals.map((t) =>
         t.id === id ? { ...t, location: "background" as const } : t
       );
       const newBackgrounded = new Map(state.backgroundedTerminals);
-      newBackgrounded.set(id, { id, originalLocation });
+      newBackgrounded.set(id, {
+        id,
+        originalLocation,
+        ...(groupRestoreId && { groupRestoreId }),
+        ...(groupMetadata && { groupMetadata }),
+      });
 
       // Remove panel from tab group (same dissolve logic as trashTerminal)
       let newTabGroups = state.tabGroups;
-      for (const group of state.tabGroups.values()) {
-        if (group.panelIds.includes(id)) {
+      for (const g of state.tabGroups.values()) {
+        if (g.panelIds.includes(id)) {
           newTabGroups = new Map(state.tabGroups);
-          const newPanelIds = group.panelIds.filter((pid) => pid !== id);
+          const newPanelIds = g.panelIds.filter((pid) => pid !== id);
 
           if (newPanelIds.length <= 1) {
-            newTabGroups.delete(group.id);
+            newTabGroups.delete(g.id);
           } else {
-            const newActiveTabId =
-              group.activeTabId === id ? (newPanelIds[0] ?? "") : group.activeTabId;
-            newTabGroups.set(group.id, {
-              ...group,
+            const newActiveTabId = g.activeTabId === id ? (newPanelIds[0] ?? "") : g.activeTabId;
+            newTabGroups.set(g.id, {
+              ...g,
               panelIds: newPanelIds,
               activeTabId: newActiveTabId,
             });
@@ -66,9 +89,94 @@ export const createBackgroundActions = (
     }
   },
 
+  backgroundPanelGroup: (panelId) => {
+    const group = get().getPanelGroup(panelId);
+
+    // If no group, fall back to single panel background
+    if (!group) {
+      get().backgroundTerminal(panelId);
+      return;
+    }
+
+    const groupRestoreId = `group-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    const panelIds = [...group.panelIds];
+    const activeTabId = group.activeTabId ?? panelIds[0] ?? "";
+    const terminals = get().terminals;
+
+    const existingPanelIds = panelIds.filter((id) => terminals.some((t) => t.id === id));
+    if (existingPanelIds.length === 0) {
+      set((state) => {
+        const newTabGroups = new Map(state.tabGroups);
+        newTabGroups.delete(group.id);
+        saveTabGroups(newTabGroups);
+        return { tabGroups: newTabGroups };
+      });
+      return;
+    }
+
+    const bgPanelIds = existingPanelIds;
+    const resolvedActiveTabId = bgPanelIds.includes(activeTabId)
+      ? activeTabId
+      : (bgPanelIds[0] ?? "");
+    const originalLocation: "dock" | "grid" = group.location === "dock" ? "dock" : "grid";
+    const worktreeId = group.worktreeId ?? null;
+
+    set((state) => {
+      const newTerminals = state.terminals.map((t) =>
+        bgPanelIds.includes(t.id) ? { ...t, location: "background" as const } : t
+      );
+
+      const newBackgrounded = new Map(state.backgroundedTerminals);
+      for (let i = 0; i < bgPanelIds.length; i++) {
+        const id = bgPanelIds[i];
+        const isAnchor = i === 0;
+        newBackgrounded.set(id, {
+          id,
+          originalLocation,
+          groupRestoreId,
+          ...(isAnchor && {
+            groupMetadata: {
+              panelIds: bgPanelIds,
+              activeTabId: resolvedActiveTabId,
+              location: group.location,
+              worktreeId,
+            },
+          }),
+        });
+      }
+
+      const newTabGroups = new Map(state.tabGroups);
+      newTabGroups.delete(group.id);
+      saveTabGroups(newTabGroups);
+
+      saveTerminals(newTerminals);
+      return {
+        terminals: newTerminals,
+        backgroundedTerminals: newBackgrounded,
+        tabGroups: newTabGroups,
+      };
+    });
+
+    // Apply background renderer policy for PTY-backed panels
+    for (const id of bgPanelIds) {
+      const terminal = terminals.find((t) => t.id === id);
+      if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+        terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.BACKGROUND);
+      }
+    }
+  },
+
   restoreBackgroundTerminal: (id, targetWorktreeId) => {
     const backgroundedInfo = get().backgroundedTerminals.get(id);
-    const restoreLocation = backgroundedInfo?.originalLocation ?? "grid";
+    if (!backgroundedInfo) return;
+
+    // If panel has a group, delegate to restoreBackgroundGroup
+    if (backgroundedInfo.groupRestoreId) {
+      get().restoreBackgroundGroup(backgroundedInfo.groupRestoreId, targetWorktreeId);
+      return;
+    }
+
+    const restoreLocation = backgroundedInfo.originalLocation ?? "grid";
     const terminal = get().terminals.find((t) => t.id === id);
 
     set((state) => {
@@ -93,6 +201,101 @@ export const createBackgroundActions = (
         optimizeForDock(id);
       } else {
         terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+      }
+    }
+  },
+
+  restoreBackgroundGroup: (groupRestoreId, targetWorktreeId) => {
+    const backgroundedTerminals = get().backgroundedTerminals;
+
+    const groupPanels: Array<{
+      id: string;
+      backgrounded: NonNullable<ReturnType<typeof backgroundedTerminals.get>>;
+    }> = [];
+    let anchorPanel: NonNullable<ReturnType<typeof backgroundedTerminals.get>> | undefined;
+
+    for (const [id, backgrounded] of backgroundedTerminals.entries()) {
+      if (backgrounded.groupRestoreId === groupRestoreId) {
+        groupPanels.push({ id, backgrounded });
+        if (backgrounded.groupMetadata) {
+          anchorPanel = backgrounded;
+        }
+      }
+    }
+
+    if (groupPanels.length === 0) return;
+
+    const restoreLocation =
+      anchorPanel?.groupMetadata?.location ??
+      groupPanels[0]?.backgrounded?.originalLocation ??
+      "grid";
+    const worktreeId =
+      targetWorktreeId !== undefined
+        ? targetWorktreeId
+        : (anchorPanel?.groupMetadata?.worktreeId ?? undefined);
+
+    set((state) => {
+      const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));
+      const newTerminals = state.terminals.map((t) =>
+        panelIdsInGroup.has(t.id)
+          ? {
+              ...t,
+              location: restoreLocation as "dock" | "grid",
+              worktreeId: worktreeId ?? t.worktreeId,
+            }
+          : t
+      );
+
+      const newBackgrounded = new Map(state.backgroundedTerminals);
+      for (const { id } of groupPanels) {
+        newBackgrounded.delete(id);
+      }
+
+      saveTerminals(newTerminals);
+      return { terminals: newTerminals, backgroundedTerminals: newBackgrounded };
+    });
+
+    // Recreate the tab group if we have multiple valid panels
+    const restoredPanelIds = groupPanels.map(({ id }) => id);
+    const existingIds = new Set(get().terminals.map((t) => t.id));
+    const validPanelIds = restoredPanelIds.filter((id) => existingIds.has(id));
+
+    if (validPanelIds.length > 1) {
+      let orderedPanelIds = validPanelIds;
+      let activeTabId = validPanelIds[0];
+
+      if (anchorPanel?.groupMetadata) {
+        const { panelIds, activeTabId: metadataActiveTabId } = anchorPanel.groupMetadata;
+        orderedPanelIds = panelIds.filter((id) => validPanelIds.includes(id));
+        for (const id of validPanelIds) {
+          if (!orderedPanelIds.includes(id)) {
+            orderedPanelIds.push(id);
+          }
+        }
+        activeTabId = orderedPanelIds.includes(metadataActiveTabId)
+          ? metadataActiveTabId
+          : orderedPanelIds[0];
+      }
+
+      if (orderedPanelIds.length > 1) {
+        get().createTabGroup(
+          restoreLocation as "dock" | "grid",
+          worktreeId,
+          orderedPanelIds,
+          activeTabId
+        );
+      }
+    }
+
+    // Apply renderer policies for PTY-backed panels
+    for (const { id } of groupPanels) {
+      const terminal = get().terminals.find((t) => t.id === id);
+      if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+        if (restoreLocation === "dock") {
+          optimizeForDock(id);
+        } else {
+          terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+        }
       }
     }
   },

--- a/src/store/slices/terminalRegistry/types.ts
+++ b/src/store/slices/terminalRegistry/types.ts
@@ -110,6 +110,10 @@ export interface TrashedTerminal {
 export interface BackgroundedTerminal {
   id: string;
   originalLocation: "dock" | "grid";
+  /** Shared ID for panels backgrounded together as a group */
+  groupRestoreId?: string;
+  /** Present on the "anchor" panel of a backgrounded group, holds metadata for recreation */
+  groupMetadata?: TrashedTerminalGroupMetadata;
 }
 
 export interface TerminalRegistrySlice {
@@ -160,7 +164,11 @@ export interface TerminalRegistrySlice {
   isInTrash: (id: string) => boolean;
 
   backgroundTerminal: (id: string) => void;
+  /** Background all panels in a group together, storing group metadata for restoration */
+  backgroundPanelGroup: (panelId: string) => void;
   restoreBackgroundTerminal: (id: string, targetWorktreeId?: string) => void;
+  /** Restore all panels with the given groupRestoreId, recreating the tab group */
+  restoreBackgroundGroup: (groupRestoreId: string, targetWorktreeId?: string) => void;
   isInBackground: (id: string) => boolean;
 
   reorderTerminals: (

--- a/src/store/slices/terminalRegistrySlice.ts
+++ b/src/store/slices/terminalRegistrySlice.ts
@@ -12,6 +12,7 @@ export type {
   AddTerminalOptions,
   TrashedTerminal,
   TrashedTerminalGroupMetadata,
+  BackgroundedTerminal,
   TerminalRegistrySlice,
   TerminalRegistryMiddleware,
   TerminalRegistryStoreApi,


### PR DESCRIPTION
## Summary

- When a panel belonging to a tab group is backgrounded, the group metadata (member IDs, active tab, location, worktree) is now captured and stored alongside the backgrounded panel record.
- On restore, if the group still exists the panel is reinserted at its original position; if the group was dissolved it is fully recreated from the stored metadata.
- The implementation mirrors the existing trash system's `groupRestoreId`/`groupMetadata` pattern, keeping both code paths consistent.

Resolves #4843

## Changes

- `src/store/slices/terminalRegistry/types.ts` — added `groupRestoreId` and `groupMetadata` fields to `BackgroundedTerminal`
- `src/store/slices/terminalRegistry/background.ts` — `backgroundTerminal` captures group metadata before removal; `restoreBackgroundTerminal` reconstructs or rejoins the group on restore
- `src/components/Layout/BackgroundContainer.tsx` — updated restore UI path to handle group-aware restoration
- `src/services/actions/definitions/terminalLifecycleActions.ts` — minor action wiring update
- `src/store/slices/terminalRegistry/__tests__/backgroundTerminalGroupCleanup.test.ts` — 477-line test suite covering background/restore across single-member dissolution, multi-member groups, active-tab preservation, and ordering

## Testing

Unit tests added in `backgroundTerminalGroupCleanup.test.ts` cover the full matrix of scenarios: backgrounding the only member, backgrounding one of several members, restoring into an existing group, restoring and recreating a dissolved group, and active-tab tracking through a round trip. All existing tests continue to pass.