### PR TITLE
fix(terminal): remove lastKnownProjectId fallback causing phantom agent terminals

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -738,8 +738,6 @@ export class PtyManager extends EventEmitter {
       }
     }
 
-    this.registry.setLastKnownProjectId(newProjectId);
-
     logInfo(`Project switch complete: ${foregrounded} foregrounded, ${backgrounded} backgrounded`);
   }
 

--- a/electron/services/pty/TerminalRegistry.ts
+++ b/electron/services/pty/TerminalRegistry.ts
@@ -18,7 +18,6 @@ export class TerminalRegistry {
   private terminals: Map<string, TerminalProcess> = new Map();
   private trashTimeouts: Map<string, NodeJS.Timeout> = new Map();
   private trashExpiryTimes: Map<string, number> = new Map();
-  private lastKnownProjectId: string | null = null;
   private projectIdCandidatesByTerminalId: Map<string, ProjectIdCandidates> = new Map();
 
   constructor(private readonly trashTtlMs: number = TRASH_TTL_MS) {}
@@ -128,24 +127,8 @@ export class TerminalRegistry {
 
   getForProject(projectId: string): string[] {
     const result: string[] = [];
-    const allTerminals = Array.from(this.terminals.entries());
-
-    console.log(
-      `[TerminalRegistry] getForProject(${projectId.slice(0, 8)}): checking ${allTerminals.length} total terminals`
-    );
-
-    for (const [id, terminal] of allTerminals) {
-      const info = terminal.getInfo();
-      const matches = this.terminalMatchesProject(terminal, projectId);
-      const inTrash = this.isInTrash(id);
-
-      if (!matches || inTrash) {
-        console.log(
-          `[TerminalRegistry] Terminal ${id.slice(0, 12)} NOT included: matches=${matches}, inTrash=${inTrash}, terminalProjectId=${info.projectId?.slice(0, 8)}`
-        );
-      }
-
-      if (matches && !inTrash) {
+    for (const [id, terminal] of this.terminals.entries()) {
+      if (this.terminalMatchesProject(terminal, projectId) && !this.isInTrash(id)) {
         result.push(id);
       }
     }
@@ -234,18 +217,7 @@ export class TerminalRegistry {
   }
 
   /**
-   * Set the last known project ID for legacy terminal handling.
-   */
-  setLastKnownProjectId(projectId: string): void {
-    this.lastKnownProjectId = projectId;
-  }
-
-  getLastKnownProjectId(): string | null {
-    return this.lastKnownProjectId;
-  }
-
-  /**
-   * Check if terminal belongs to a project (using fallback logic).
+   * Check if terminal belongs to a project via explicit projectId or filesystem inference.
    */
   terminalBelongsToProject(terminal: TerminalProcess, projectId: string): boolean {
     const info = terminal.getInfo();
@@ -260,11 +232,6 @@ export class TerminalRegistry {
     if (matches) {
       info.projectId = projectId;
       return true;
-    }
-
-    // Only fallback to lastKnownProjectId if we couldn't infer anything from the filesystem.
-    if (!candidates.mainProjectId && !candidates.worktreeProjectId) {
-      return this.lastKnownProjectId === projectId;
     }
 
     return false;
@@ -415,40 +382,6 @@ export class TerminalRegistry {
     if (matches) {
       info.projectId = projectId;
       return true;
-    }
-
-    // Fallback to lastKnownProjectId if we couldn't infer anything from the filesystem.
-    // This ensures getForProject() finds terminals even when inference fails (e.g., dev-preview
-    // terminals that may have changed cwd), aligning with terminalBelongsToProject behavior.
-    if (!candidates.mainProjectId && !candidates.worktreeProjectId) {
-      const fallbackMatches = this.lastKnownProjectId === projectId;
-      if (process.env.CANOPY_VERBOSE && fallbackMatches) {
-        console.log(
-          `[TerminalRegistry] Matching ${info.id.slice(0, 8)} to project ${projectId.slice(0, 8)}:`,
-          {
-            directMatch: false,
-            infoProjectId: info.projectId?.slice(0, 8),
-            candidates,
-            lastKnownProjectId: this.lastKnownProjectId?.slice(0, 8),
-            fallbackMatches,
-          }
-        );
-      }
-      if (fallbackMatches) {
-        // Persist the fallback match to prevent terminal from following future project switches
-        info.projectId = projectId;
-      }
-      return fallbackMatches;
-    }
-
-    if (process.env.CANOPY_VERBOSE && !matches) {
-      console.log(
-        `[TerminalRegistry] Terminal ${info.id.slice(0, 8)} does not match project ${projectId.slice(0, 8)}:`,
-        {
-          candidates,
-          lastKnownProjectId: this.lastKnownProjectId?.slice(0, 8),
-        }
-      );
     }
 
     return false;

--- a/electron/services/pty/__tests__/TerminalRegistry.projectIdInference.test.ts
+++ b/electron/services/pty/__tests__/TerminalRegistry.projectIdInference.test.ts
@@ -159,6 +159,54 @@ describe("TerminalRegistry projectId inference", () => {
     expect(stats.terminalTypes).toEqual({ terminal: 1 });
   });
 
+  it("does not match terminal with no projectId and non-git cwd to any project", () => {
+    const registry = new TerminalRegistry();
+    const terminal = createMockTerminalProcess({
+      id: "t-orphan",
+      cwd: "/tmp/not-a-git-repo-" + Date.now(),
+    });
+
+    registry.add("t-orphan", terminal);
+
+    expect(registry.getForProject("project-a")).toEqual([]);
+    expect(registry.getForProject("project-b")).toEqual([]);
+    expect(registry.terminalBelongsToProject(terminal, "project-a")).toBe(false);
+    expect(registry.terminalBelongsToProject(terminal, "project-b")).toBe(false);
+  });
+
+  it("does not leak terminals across projects after repeated getForProject calls", () => {
+    const registry = new TerminalRegistry();
+    const projectA = "project-aaa";
+    const projectB = "project-bbb";
+
+    const terminalA = createMockTerminalProcess({
+      id: "t-a",
+      cwd: "/tmp",
+      projectId: projectA,
+    });
+
+    const terminalNoProject = createMockTerminalProcess({
+      id: "t-no-project",
+      cwd: "/tmp/random-" + Date.now(),
+    });
+
+    registry.add("t-a", terminalA);
+    registry.add("t-no-project", terminalNoProject);
+
+    // Query for project A — should only find t-a
+    expect(registry.getForProject(projectA)).toEqual(["t-a"]);
+
+    // Query for project B — should find nothing (t-no-project must NOT leak here)
+    expect(registry.getForProject(projectB)).toEqual([]);
+
+    // Query project A again — still only t-a
+    expect(registry.getForProject(projectA)).toEqual(["t-a"]);
+
+    // t-no-project should not have been assigned to any project
+    const info = terminalNoProject.getInfo();
+    expect(info.projectId).toBeUndefined();
+  });
+
   it("clears trash timeout when terminal is deleted", () => {
     const registry = new TerminalRegistry(120000);
     const projectId = "project-123";

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -612,8 +612,7 @@ export async function hydrateAppState(
 
         // Restore any orphaned backend terminals not in saved state (append at end).
         // When no panels were saved (brand-new project), skip the startup "default"
-        // terminal — its projectId may have been backfilled by TerminalRegistry's
-        // lastKnownProjectId fallback, incorrectly attributing it to the new project.
+        // terminal — it belongs to the previous project's bootstrap sequence, not this one.
         // In safe mode, skip orphan reconnection entirely to ensure a clean slate.
         const hasSavedPanels = appState.terminals && appState.terminals.length > 0;
         const orphanedTerminals = hydrateResult.safeMode


### PR DESCRIPTION
## Summary

- Removes the `lastKnownProjectId` fallback from `TerminalRegistry` that allowed agent terminals to match against a stale project ID after a project switch, causing them to appear in the wrong project's terminal list.
- Cleans up the setter/getter methods and both fallback branches in `terminalMatchesProject()` and `terminalBelongsToProject()`, along with the call site in `PtyManager.onProjectSwitch()`.
- Adds 2 regression tests covering the scenarios where this fallback was doing damage.

Resolves #4874

## Changes

- `electron/services/pty/TerminalRegistry.ts` — removed `lastKnownProjectId` field, setter/getter, and all fallback branches from the two project-matching methods
- `electron/services/PtyManager.ts` — removed the `setLastKnownProjectId()` call in `onProjectSwitch()`
- `electron/services/pty/TerminalRegistry.projectIdInference.test.ts` — new regression tests
- `src/utils/stateHydration/index.ts` — updated stale comment

## Testing

Regression tests added and passing. The removed fallback was the only mechanism by which terminals could match a project they no longer belonged to, so no other test changes were needed.