### PR TITLE
fix(worktree): sync focusedWorktreeId in setActiveWorktree to prevent stale highlights

### DIFF
--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -260,6 +260,35 @@ describe("worktreeStore", () => {
     ]);
   });
 
+  it("setActiveWorktree syncs focusedWorktreeId to clear stale focus", () => {
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: "wt-a",
+      focusedWorktreeId: "wt-b",
+      expandedTerminals: new Set(["t1"]),
+    });
+
+    useWorktreeSelectionStore.getState().setActiveWorktree("wt-a");
+
+    const state = useWorktreeSelectionStore.getState();
+    expect(state.activeWorktreeId).toBe("wt-a");
+    expect(state.focusedWorktreeId).toBe("wt-a");
+    // Same-ID path preserves expandedTerminals
+    expect(state.expandedTerminals.has("t1")).toBe(true);
+  });
+
+  it("setActiveWorktree(null) clears both activeWorktreeId and focusedWorktreeId", () => {
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: "wt-a",
+      focusedWorktreeId: "wt-a",
+    });
+
+    useWorktreeSelectionStore.getState().setActiveWorktree(null);
+
+    const state = useWorktreeSelectionStore.getState();
+    expect(state.activeWorktreeId).toBeNull();
+    expect(state.focusedWorktreeId).toBeNull();
+  });
+
   it("does not restore stale terminal focus after a newer worktree selection wins", async () => {
     terminalStoreState.terminals = [
       { id: "term-a", worktreeId: "wt-a", location: "grid" },

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -256,6 +256,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // Auto-collapse terminals accordion when switching worktrees
     const updates: Partial<WorktreeSelectionState> = {
       activeWorktreeId: id,
+      focusedWorktreeId: id,
       _policyGeneration: generation,
     };
 


### PR DESCRIPTION
## Summary

- `setActiveWorktree()` was only updating `activeWorktreeId`, leaving `focusedWorktreeId` stale from the previous project. On project switch (via hydration), this caused two worktree cards to appear highlighted simultaneously.
- Fixed by adding `focusedWorktreeId: id` to the atomic `set()` call in `setActiveWorktree`, matching the existing behaviour of `selectWorktree()`.
- Added 2 regression tests covering the stale highlight scenario and confirming the store sets both fields atomically.

Resolves #4877

## Changes

- `src/store/worktreeStore.ts`: sync `focusedWorktreeId` alongside `activeWorktreeId` in `setActiveWorktree`
- `src/store/__tests__/worktreeStore.test.ts`: 2 new regression tests

## Testing

Unit tests added and passing. The fix is a one-line change to the Zustand store that aligns `setActiveWorktree` with `selectWorktree`.