### PR TITLE
fix(preload): prevent tsc from overwriting esbuild-bundled preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint:ci": "eslint . --max-warnings 0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.preload.json electron/tsconfig.json",
+    "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json",
     "check": "npm run typecheck && npm run lint:ratchet && npm run format:check",
     "fix": "npm run format && npm run lint:fix",
     "test:smoke": "node scripts/run-smoke.mjs",


### PR DESCRIPTION
## Summary

- The `typecheck` script was using `tsc -b` for the preload tsconfig, which emits a `.cjs` output file and overwrites the esbuild-bundled preload in `dist-electron/`. This left the preload without its bundled dependencies, causing `module not found: ../shared/utils/trustedRenderer.js` on subsequent `WebContentsView` loads in dev mode.
- Fixed by switching the preload typecheck step to `tsc --noEmit -p` so it only type-checks without emitting, leaving the esbuild output intact.
- The main electron tsconfig still uses `tsc -b` (build mode is correct there), but the preload compile is now check-only.

Resolves #4887

## Changes

- `package.json`: `typecheck` script now runs `tsc --noEmit -p electron/tsconfig.preload.json` instead of `tsc -b electron/tsconfig.preload.json ...`

## Testing

Typecheck passes cleanly. The preload no longer gets overwritten during a type-check run, so project switches in dev mode no longer hit the missing `trustedRenderer` error.