### PR TITLE
fix(terminal): prevent terminal opening in home dir during worktree init race

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -10,11 +10,13 @@ vi.mock("electron", () => ({
   },
 }));
 
-const { mockGetCurrentProject, mockGetProjectById, mockGetProjectSettings } = vi.hoisted(() => ({
-  mockGetCurrentProject: vi.fn(),
-  mockGetProjectById: vi.fn(),
-  mockGetProjectSettings: vi.fn(),
-}));
+const { mockGetCurrentProject, mockGetProjectById, mockGetProjectSettings, mockGetMonitorAsync } =
+  vi.hoisted(() => ({
+    mockGetCurrentProject: vi.fn(),
+    mockGetProjectById: vi.fn(),
+    mockGetProjectSettings: vi.fn(),
+    mockGetMonitorAsync: vi.fn(),
+  }));
 
 vi.mock("../../../../services/ProjectStore.js", () => ({
   projectStore: {
@@ -183,5 +185,103 @@ describe("terminal spawn handler - projectId resolution", () => {
     expect(mockGetProjectSettings).toHaveBeenCalledWith("project-a-id");
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.shell).toBe("/bin/bash");
+  });
+});
+
+describe("terminal spawn handler - worktree cwd fallback (issue #4888)", () => {
+  let ptyClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    hasTerminal: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ptyClient = {
+      spawn: vi.fn(),
+      hasTerminal: vi.fn(() => false),
+      write: vi.fn(),
+    };
+    mockGetCurrentProject.mockReturnValue(null);
+    mockGetProjectById.mockReturnValue(null);
+    mockGetProjectSettings.mockResolvedValue({});
+    mockGetMonitorAsync.mockResolvedValue(null);
+  });
+
+  it("falls back to worktree path when cwd is inaccessible and worktreeId is provided", async () => {
+    const os = await import("os");
+    const tmpDir = os.tmpdir();
+    mockGetMonitorAsync.mockResolvedValue({ path: tmpDir });
+
+    const worktreeService = { getMonitorAsync: mockGetMonitorAsync };
+    const deps = { ptyClient, worktreeService } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cwd: "/nonexistent/path",
+      worktreeId: "wt-123",
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(mockGetMonitorAsync).toHaveBeenCalledWith("wt-123");
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.cwd).toBe(tmpDir);
+  });
+
+  it("falls back to homedir when worktreeService returns null", async () => {
+    mockGetMonitorAsync.mockResolvedValue(null);
+
+    const worktreeService = { getMonitorAsync: mockGetMonitorAsync };
+    const deps = { ptyClient, worktreeService } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    const os = await import("os");
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cwd: "/nonexistent/path",
+      worktreeId: "wt-123",
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(mockGetMonitorAsync).toHaveBeenCalledWith("wt-123");
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.cwd).toBe(os.homedir());
+  });
+
+  it("does not call worktreeService when cwd is valid", async () => {
+    const worktreeService = { getMonitorAsync: mockGetMonitorAsync };
+    const deps = { ptyClient, worktreeService } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    const os = await import("os");
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cwd: os.homedir(),
+      worktreeId: "wt-123",
+      cols: 80,
+      rows: 24,
+    });
+
+    expect(mockGetMonitorAsync).not.toHaveBeenCalled();
+  });
+
+  it("works when worktreeService is not available on deps", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    const os = await import("os");
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cwd: "/nonexistent/path",
+      worktreeId: "wt-123",
+      cols: 80,
+      rows: 24,
+    });
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.cwd).toBe(os.homedir());
   });
 });

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -113,6 +113,19 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           // ignore
         }
       }
+
+      if (worktreeId && deps.worktreeService) {
+        try {
+          const snapshot = await deps.worktreeService.getMonitorAsync(worktreeId);
+          if (snapshot?.path && path.isAbsolute(snapshot.path)) {
+            await fs.promises.access(snapshot.path);
+            return snapshot.path;
+          }
+        } catch {
+          // ignore — worktree path inaccessible or service unavailable
+        }
+      }
+
       return os.homedir();
     };
 

--- a/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
+++ b/src/hooks/app/__tests__/useActiveWorktreeSync.test.ts
@@ -17,12 +17,20 @@ describe("useActiveWorktreeSync homeDir fallback (issue #4254)", () => {
 
   it("uses homeDir as fallback before empty string in defaultTerminalCwd", async () => {
     const content = await readFile(HOOK_PATH, "utf-8");
-    // The fallback chain should be: worktree path → project path → homeDir → ""
+    // When initialized: worktree path → project path → homeDir → ""
     expect(content).toContain('activeWorktree?.path ?? currentProject?.path ?? homeDir ?? ""');
+    // When not initialized: project path → homeDir → "" (skips worktree which hasn't loaded)
+    expect(content).toContain('currentProject?.path ?? homeDir ?? ""');
   });
 
-  it("includes homeDir in useMemo dependency array", async () => {
+  it("gates defaultTerminalCwd on isInitialized to prevent race condition", async () => {
     const content = await readFile(HOOK_PATH, "utf-8");
-    expect(content).toContain("[activeWorktree, currentProject, homeDir]");
+    expect(content).toContain("isInitialized");
+    expect(content).toContain("const { worktrees, isInitialized } = useWorktrees()");
+  });
+
+  it("includes homeDir and isInitialized in useMemo dependency array", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("[activeWorktree, currentProject, homeDir, isInitialized]");
   });
 });

--- a/src/hooks/app/useActiveWorktreeSync.ts
+++ b/src/hooks/app/useActiveWorktreeSync.ts
@@ -5,7 +5,7 @@ import { useProjectStore } from "@/store";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 
 export function useActiveWorktreeSync() {
-  const { worktrees } = useWorktrees();
+  const { worktrees, isInitialized } = useWorktrees();
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
   const currentProject = useProjectStore((s) => s.currentProject);
@@ -66,8 +66,11 @@ export function useActiveWorktreeSync() {
   }, [activeWorktreeId, currentProject?.id, worktrees]);
 
   const defaultTerminalCwd = useMemo(
-    () => activeWorktree?.path ?? currentProject?.path ?? homeDir ?? "",
-    [activeWorktree, currentProject, homeDir]
+    () =>
+      isInitialized
+        ? (activeWorktree?.path ?? currentProject?.path ?? homeDir ?? "")
+        : (currentProject?.path ?? homeDir ?? ""),
+    [activeWorktree, currentProject, homeDir, isInitialized]
   );
 
   return { activeWorktree, defaultTerminalCwd };

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -33,7 +33,7 @@ export interface UseAgentLauncherReturn {
 
 export function useAgentLauncher(): UseAgentLauncherReturn {
   const addTerminal = useTerminalStore((state) => state.addTerminal);
-  const { worktreeMap } = useWorktrees();
+  const { worktreeMap, isInitialized } = useWorktrees();
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
   const currentProject = useProjectStore((state) => state.currentProject);
   const { homeDir } = useHomeDir();
@@ -89,7 +89,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
       const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
       const targetWorktree = targetWorktreeId ? worktreeMap.get(targetWorktreeId) : null;
 
-      if (targetWorktreeId && !targetWorktree) {
+      if (targetWorktreeId && !targetWorktree && isInitialized) {
         console.warn(`Worktree ${targetWorktreeId} not found, cannot launch agent`);
         return null;
       }
@@ -191,7 +191,15 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         return null;
       }
     },
-    [activeWorktreeId, worktreeMap, addTerminal, currentProject, agentSettings, homeDir]
+    [
+      activeWorktreeId,
+      worktreeMap,
+      isInitialized,
+      addTerminal,
+      currentProject,
+      agentSettings,
+      homeDir,
+    ]
   );
 
   return {

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -7,6 +7,7 @@ export interface UseWorktreesReturn {
   worktreeMap: Map<string, WorktreeState>;
   activeId: string | null;
   isLoading: boolean;
+  isInitialized: boolean;
   error: string | null;
   refresh: () => Promise<void>;
   setActive: (id: string) => void;
@@ -23,6 +24,7 @@ function normalizeSnapshot(s: WorktreeSnapshot): WorktreeState {
 export function useWorktrees(): UseWorktreesReturn {
   const worktreeMap = useWorktreeStore((state) => state.worktrees);
   const isLoading = useWorktreeStore((state) => state.isLoading);
+  const isInitialized = useWorktreeStore((state) => state.isInitialized);
   const error = useWorktreeStore((state) => state.error);
 
   const refresh = useCallback(async () => {
@@ -61,6 +63,7 @@ export function useWorktrees(): UseWorktreesReturn {
     worktreeMap: normalizedMap,
     activeId: worktrees.length > 0 ? worktrees[0].id : null,
     isLoading,
+    isInitialized,
     error,
     refresh,
     setActive,


### PR DESCRIPTION
## Summary

- Renderer guard: `useActiveWorktreeSync` now tracks an `isInitialized` flag and skips emitting a worktree path until the worktrees list has loaded, preventing a stale `homeDir` value from being used as cwd during session restore
- Main-process fallback: `lifecycle.ts` now calls `worktreeService.getMonitorAsync(worktreeId)` when a `worktreeId` is present in spawn options, resolving the stored worktree path before falling through to `os.homedir()`
- `useAgentLauncher` and `useWorktrees` updated to propagate the `isInitialized` state correctly

Resolves #4888

## Changes

- `src/hooks/app/useActiveWorktreeSync.ts` — added `isInitialized` guard; cwd only emits after worktrees are loaded
- `src/hooks/useAgentLauncher.ts` — passes `isInitialized` through to dependent hooks
- `src/hooks/useWorktrees.ts` — exposes `isInitialized` from the worktrees store slice
- `electron/ipc/handlers/terminal/lifecycle.ts` — worktree path resolution via `worktreeService.getMonitorAsync` before `os.homedir()` fallback
- Tests added for both the renderer race condition and the main-process fallback path

## Testing

Unit tests cover the race condition scenario (worktrees empty at spawn time) and the main-process `getMonitorAsync` fallback. Both the renderer guard and main-process fallback were verified via the existing test suite with `npm run check` passing clean.