### PR TITLE
fix(browser): route screenshot clipboard write through Electron IPC on Linux

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -419,6 +419,7 @@ export const CHANNELS = {
 
   CLIPBOARD_SAVE_IMAGE: "clipboard:save-image",
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",
+  CLIPBOARD_WRITE_IMAGE: "clipboard:write-image",
 
   APP_THEME_GET: "app-theme:get",
   APP_THEME_SET_COLOR_SCHEME: "app-theme:set-color-scheme",

--- a/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const clipboardMock = vi.hoisted(() => ({
+  writeImage: vi.fn(),
+  readImage: vi.fn(),
+}));
+
+const nativeImageMock = vi.hoisted(() => ({
+  createFromBuffer: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  clipboard: clipboardMock,
+  nativeImage: nativeImageMock,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn(() => Promise.resolve()),
+  readdir: vi.fn(() => Promise.resolve([])),
+  stat: vi.fn(),
+  unlink: vi.fn(),
+  writeFile: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("node:crypto", () => ({
+  randomBytes: vi.fn(() => ({ toString: () => "abc123" })),
+}));
+
+import { ipcMain } from "electron";
+import { registerClipboardHandlers } from "../clipboard.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(channel: string): Handler {
+  const calls = vi.mocked(ipcMain.handle).mock.calls;
+  const match = calls.find(([ch]) => ch === channel);
+  if (!match) throw new Error(`No handler registered for ${channel}`);
+  return match[1] as Handler;
+}
+
+const fakeEvent = {} as Electron.IpcMainInvokeEvent;
+
+describe("clipboard:write-image handler", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("registers the clipboard:write-image handler", () => {
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map(([ch]) => ch);
+    expect(channels).toContain("clipboard:write-image");
+  });
+
+  it("writes valid PNG data to clipboard and returns ok", async () => {
+    const fakeImage = { isEmpty: () => false };
+    nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
+
+    const pngData = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const handler = getHandler("clipboard:write-image");
+    const result = await handler(fakeEvent, pngData);
+
+    expect(nativeImageMock.createFromBuffer).toHaveBeenCalledTimes(1);
+    const bufferArg = nativeImageMock.createFromBuffer.mock.calls[0][0];
+    expect(Buffer.isBuffer(bufferArg)).toBe(true);
+    expect([...bufferArg]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+
+    expect(clipboardMock.writeImage).toHaveBeenCalledWith(fakeImage);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("handles Uint8Array subarray with non-zero byteOffset correctly", async () => {
+    const fakeImage = { isEmpty: () => false };
+    nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
+
+    const fullBuffer = new Uint8Array([0x00, 0x00, 0x89, 0x50, 0x4e, 0x47]);
+    const subarray = fullBuffer.subarray(2);
+
+    const handler = getHandler("clipboard:write-image");
+    await handler(fakeEvent, subarray);
+
+    const bufferArg = nativeImageMock.createFromBuffer.mock.calls[0][0];
+    expect([...bufferArg]).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("returns error for empty/invalid image data", async () => {
+    const fakeImage = { isEmpty: () => true };
+    nativeImageMock.createFromBuffer.mockReturnValue(fakeImage);
+
+    const handler = getHandler("clipboard:write-image");
+    const result = await handler(fakeEvent, new Uint8Array([]));
+
+    expect(clipboardMock.writeImage).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: "Invalid image data" });
+  });
+
+  it("returns error when nativeImage.createFromBuffer throws", async () => {
+    nativeImageMock.createFromBuffer.mockImplementation(() => {
+      throw new Error("Corrupt buffer");
+    });
+
+    const handler = getHandler("clipboard:write-image");
+    const result = await handler(fakeEvent, new Uint8Array([0xff]));
+
+    expect(result).toEqual({ ok: false, error: "Corrupt buffer" });
+  });
+
+  it("cleanup removes the handler", () => {
+    cleanup();
+    const removedChannels = vi.mocked(ipcMain.removeHandler).mock.calls.map(([ch]) => ch);
+    expect(removedChannels).toContain("clipboard:write-image");
+  });
+});

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -117,11 +117,31 @@ export function registerClipboardHandlers(): () => void {
     }
   };
 
+  const handleWriteImage = async (
+    _event: Electron.IpcMainInvokeEvent,
+    pngData: Uint8Array
+  ): Promise<{ ok: true } | { ok: false; error: string }> => {
+    try {
+      const buffer = Buffer.from(pngData.buffer, pngData.byteOffset, pngData.byteLength);
+      const image = nativeImage.createFromBuffer(buffer);
+      if (image.isEmpty()) {
+        return { ok: false, error: "Invalid image data" };
+      }
+      clipboard.writeImage(image);
+      return { ok: true };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  };
+
   ipcMain.handle(CHANNELS.CLIPBOARD_SAVE_IMAGE, handleSaveImage);
   ipcMain.handle(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, handleThumbnailFromPath);
+  ipcMain.handle(CHANNELS.CLIPBOARD_WRITE_IMAGE, handleWriteImage);
 
   return () => {
     ipcMain.removeHandler(CHANNELS.CLIPBOARD_SAVE_IMAGE);
     ipcMain.removeHandler(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH);
+    ipcMain.removeHandler(CHANNELS.CLIPBOARD_WRITE_IMAGE);
   };
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -827,6 +827,7 @@ const CHANNELS = {
   // Clipboard channels
   CLIPBOARD_SAVE_IMAGE: "clipboard:save-image",
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",
+  CLIPBOARD_WRITE_IMAGE: "clipboard:write-image",
 
   // App Theme channels
   APP_THEME_GET: "app-theme:get",
@@ -2417,6 +2418,7 @@ const api: ElectronAPI = {
     saveImage: () => _unwrappingInvoke(CHANNELS.CLIPBOARD_SAVE_IMAGE),
     thumbnailFromPath: (filePath: string) =>
       _unwrappingInvoke(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, filePath),
+    writeImage: (pngData: Uint8Array) => _unwrappingInvoke(CHANNELS.CLIPBOARD_WRITE_IMAGE, pngData),
   },
 
   // Web Utils API

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1025,6 +1025,7 @@ export interface ElectronAPI {
     ): Promise<
       { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
     >;
+    writeImage(pngData: Uint8Array): Promise<{ ok: true } | { ok: false; error: string }>;
   };
   webUtils: {
     getPathForFile(file: File): string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1354,6 +1354,10 @@ export interface IpcInvokeMap {
     args: [filePath: string];
     result: { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string };
   };
+  "clipboard:write-image": {
+    args: [pngData: Uint8Array];
+    result: { ok: true } | { ok: false; error: string };
+  };
 
   // Notification settings channels
   "notification:settings-get": {

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -466,19 +466,17 @@ export function BrowserPane({
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
-    // Check webviewRef directly to avoid stale closure over isWebviewReady state
-    if (!webview) return;
+    if (!webview || !isWebviewReady) return;
     try {
       const url = webview.getURL();
       if (!url || url === "about:blank") return;
       const image = await webview.capturePage();
       const pngData = new Uint8Array(image.toPNG());
-      const blob = new Blob([pngData], { type: "image/png" });
-      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+      await window.electron.clipboard.writeImage(pngData);
     } catch (err) {
       console.error("[BrowserPane] Screenshot capture failed:", err);
     }
-  }, []);
+  }, [isWebviewReady]);
 
   const handleToggleDevTools = useCallback(() => {
     const webview = webviewRef.current;

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -11,6 +11,7 @@ type MockWebviewElement = HTMLElement & {
   getURL: ReturnType<typeof vi.fn>;
   isLoading: ReturnType<typeof vi.fn>;
   getWebContentsId: ReturnType<typeof vi.fn>;
+  capturePage: ReturnType<typeof vi.fn>;
   setMockLoading: (value: boolean) => void;
 };
 
@@ -38,6 +39,9 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
   });
   webview.isLoading = vi.fn(() => loading);
   webview.getWebContentsId = vi.fn(() => 42);
+  webview.capturePage = vi.fn(() =>
+    Promise.resolve({ toPNG: () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]) })
+  );
   webview.setMockLoading = (value: boolean) => {
     loading = value;
   };
@@ -186,6 +190,9 @@ describe("BrowserPane webview lifecycle regression", () => {
     (globalThis as any).window = globalThis.window ?? {};
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).electron = {
+      clipboard: {
+        writeImage: vi.fn(() => Promise.resolve({ ok: true })),
+      },
       webview: {
         startConsoleCapture: vi.fn(() => Promise.resolve()),
         stopConsoleCapture: vi.fn(() => Promise.resolve()),
@@ -491,6 +498,78 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).not.toContain("blocked.com");
+    });
+  });
+
+  describe("screenshot capture via IPC", () => {
+    it("calls clipboard.writeImage with Uint8Array after dom-ready", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent("canopy:browser-capture-screenshot", {
+            detail: { id: "browser-panel-1" },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = (window as any).electron.clipboard.writeImage;
+      expect(mock).toHaveBeenCalledTimes(1);
+      const arg = mock.mock.calls[0][0];
+      expect(arg).toBeInstanceOf(Uint8Array);
+    });
+
+    it("does not call writeImage when webview is not ready", async () => {
+      const { container } = render(<BrowserPane {...baseProps} initialUrl="about:blank" />);
+      const webview = getWebviewElement(container);
+      webview.getURL.mockReturnValue("about:blank");
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent("canopy:browser-capture-screenshot", {
+            detail: { id: "browser-panel-1" },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = (window as any).electron.clipboard.writeImage;
+      expect(mock).not.toHaveBeenCalled();
+    });
+
+    it("does not call writeImage when URL is about:blank", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      webview.getURL.mockReturnValue("about:blank");
+
+      await act(async () => {
+        window.dispatchEvent(
+          new CustomEvent("canopy:browser-capture-screenshot", {
+            detail: { id: "browser-panel-1" },
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = (window as any).electron.clipboard.writeImage;
+      expect(mock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- `navigator.clipboard.write()` with a `ClipboardItem` containing binary PNG data crashes the renderer process on Linux (X11/Wayland) in Electron 41. The crash bypasses JS error handling and kills the entire window.
- Replaced the clipboard write with an IPC call to the main process, which uses `electron.clipboard.writeImage()` via a new `clipboard:write-image` handler. This is stable on all platforms.
- Added an `isWebviewReady` guard inside `handleCaptureScreenshot` to protect against programmatic dispatch (e.g., via `ActionService`) on a not-yet-ready webview.

Resolves #4891

## Changes

- `electron/ipc/channels.ts` — new `CLIPBOARD_WRITE_IMAGE` channel constant
- `electron/ipc/handlers/clipboard.ts` — `clipboard:write-image` handler using `nativeImage.createFromBuffer()` + `clipboard.writeImage()`
- `electron/preload.cts` — expose `window.electron.clipboard.writeImage(pngData)` via contextBridge
- `shared/types/ipc/api.ts` / `shared/types/ipc/maps.ts` — types for the new channel
- `src/components/Browser/BrowserPane.tsx` — replace `navigator.clipboard.write()` with `window.electron.clipboard.writeImage()`, add `isWebviewReady` guard
- Tests for both the new IPC handler and the updated `BrowserPane` screenshot path

## Testing

Unit tests cover the new handler (success path, error propagation) and the updated `BrowserPane` component (IPC called instead of clipboard API, `isWebviewReady` guard respected). All existing tests pass.