### PR TITLE
fix(store): panel split ratios key by panel pair instead of worktree

### DIFF
--- a/src/store/__tests__/twoPaneSplitStore.test.ts
+++ b/src/store/__tests__/twoPaneSplitStore.test.ts
@@ -191,15 +191,19 @@ describe("resolveEffectiveRatio", () => {
     expect(resolveEffectiveRatio(entry(0.35, [null, null]), "b", "a")).toBe(0.35);
   });
 
-  it("returns raw ratio when only left panel is null", () => {
-    expect(resolveEffectiveRatio(entry(0.35, [null, "b"]), "b", "a")).toBe(0.35);
+  it("returns undefined when only left panel is null (partial-null)", () => {
+    expect(resolveEffectiveRatio(entry(0.35, [null, "b"]), "b", "a")).toBeUndefined();
   });
 
-  it("returns raw ratio when panels are completely different (stale IDs)", () => {
-    expect(resolveEffectiveRatio(entry(0.35, ["x", "y"]), "a", "b")).toBe(0.35);
+  it("returns undefined when panels are completely different (stale IDs)", () => {
+    expect(resolveEffectiveRatio(entry(0.35, ["x", "y"]), "a", "b")).toBeUndefined();
   });
 
-  it("returns raw ratio when only one panel matches (partial match)", () => {
-    expect(resolveEffectiveRatio(entry(0.35, ["a", "x"]), "b", "a")).toBe(0.35);
+  it("returns undefined when only one panel matches (partial match)", () => {
+    expect(resolveEffectiveRatio(entry(0.35, ["a", "x"]), "b", "a")).toBeUndefined();
+  });
+
+  it("returns undefined when one panel is replaced (partial ID reuse)", () => {
+    expect(resolveEffectiveRatio(entry(0.6, ["a", "b"]), "a", "c")).toBeUndefined();
   });
 });

--- a/src/store/twoPaneSplitStore.ts
+++ b/src/store/twoPaneSplitStore.ts
@@ -20,16 +20,21 @@ export function resolveEffectiveRatio(
 ): number | undefined {
   if (!entry) return undefined;
   const [storedLeft, storedRight] = entry.panels;
-  if (
-    storedLeft !== null &&
-    storedRight !== null &&
-    storedLeft !== currentLeft &&
-    storedLeft === currentRight &&
-    storedRight === currentLeft
-  ) {
-    return 1 - entry.ratio;
-  }
-  return entry.ratio;
+
+  // Legacy migration entries — no panel IDs recorded yet
+  if (storedLeft === null && storedRight === null) return entry.ratio;
+
+  // Partial-null is invalid data — treat as no match
+  if (storedLeft === null || storedRight === null) return undefined;
+
+  // Exact match — same panel pair in same order
+  if (storedLeft === currentLeft && storedRight === currentRight) return entry.ratio;
+
+  // Exact reverse — same pair, swapped positions
+  if (storedLeft === currentRight && storedRight === currentLeft) return 1 - entry.ratio;
+
+  // Different panel pair — stale ratio, use default
+  return undefined;
 }
 
 interface TwoPaneSplitState {


### PR DESCRIPTION
## Summary

- `resolveEffectiveRatio()` was returning stale ratios for mismatched panel pairs. Any two panels on the same worktree shared a single stored ratio, regardless of whether they were the panels that were originally resized.
- The fix returns `undefined` when the stored ratio's panel IDs don't match the current pair (in either order), causing the caller to fall back to the default 0.5 split.
- Ratios now persist correctly for the specific panel pair that was resized. Open A+B, resize to 60/40, close and reopen A+B and you get 60/40 back. Open A+C and you get 50/50.

Resolves #4901

## Changes

- `src/store/twoPaneSplitStore.ts` — `resolveEffectiveRatio()` returns `undefined` for panel ID mismatches instead of returning whatever ratio was last stored for the worktree
- `src/store/__tests__/twoPaneSplitStore.test.ts` — tests covering the mismatch case, the swap case (panels in reversed order should still restore the ratio), and fresh-pair defaults

## Testing

Unit tests added for all three scenarios: same pair (ratio restored), swapped order (ratio restored), mismatched pair (falls back to default). All pass.