### PR TITLE
feat(panel-palette): show agent availability status

### DIFF
--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -100,37 +100,46 @@ export function PanelPalette({
 
   const isSearching = query.trim().length > 0;
 
-  const renderOption = (kind: PanelKindOption, index: number) => (
-    <button
-      key={kind.id}
-      id={`panel-option-${kind.id}`}
-      tabIndex={-1}
-      onPointerDown={(e) => e.preventDefault()}
-      role="option"
-      aria-selected={index === selectedIndex}
-      ref={(el) => {
-        if (el) itemsRef.current.set(kind.id, el);
-        else itemsRef.current.delete(kind.id);
-      }}
-      className={cn(
-        "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
-        index === selectedIndex
-          ? "bg-overlay-soft border-overlay text-canopy-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-canopy-accent before:content-['']"
-          : "border-transparent text-canopy-text/70 hover:bg-overlay-subtle hover:text-canopy-text"
-      )}
-      onClick={() => onSelect(kind)}
-    >
-      <div className="shrink-0">
-        <PanelKindIcon iconId={kind.iconId} color={kind.color} size={16} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-canopy-text">{kind.name}</div>
-        {kind.description && (
-          <div className="text-xs text-canopy-text/50 truncate">{kind.description}</div>
+  const renderOption = (kind: PanelKindOption, index: number) => {
+    const isUnavailable = kind.installed === false;
+    return (
+      <button
+        key={kind.id}
+        id={`panel-option-${kind.id}`}
+        tabIndex={-1}
+        onPointerDown={(e) => e.preventDefault()}
+        role="option"
+        aria-selected={index === selectedIndex}
+        ref={(el) => {
+          if (el) itemsRef.current.set(kind.id, el);
+          else itemsRef.current.delete(kind.id);
+        }}
+        className={cn(
+          "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
+          index === selectedIndex
+            ? "bg-overlay-soft border-overlay text-canopy-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-canopy-accent before:content-['']"
+            : "border-transparent text-canopy-text/70 hover:bg-overlay-subtle hover:text-canopy-text",
+          isUnavailable && "opacity-50"
         )}
-      </div>
-    </button>
-  );
+        onClick={() => onSelect(kind)}
+      >
+        <div className="shrink-0">
+          <PanelKindIcon iconId={kind.iconId} color={kind.color} size={16} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-canopy-text">{kind.name}</div>
+          {kind.description && (
+            <div className="text-xs text-canopy-text/50 truncate">{kind.description}</div>
+          )}
+        </div>
+        {isUnavailable && (
+          <span className="shrink-0 text-[10px] font-medium text-canopy-text/40">
+            Not installed
+          </span>
+        )}
+      </button>
+    );
+  };
 
   const renderSectionedList = () => {
     const agents = results.filter((r) => r.category === "agent");

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -9,12 +9,23 @@ const {
   hasPanelComponentMock,
   getEffectiveAgentIdsMock,
   getEffectiveAgentConfigMock,
+  cliAvailabilityState,
 } = vi.hoisted(() => ({
   getPanelKindIdsMock: vi.fn(),
   getPanelKindConfigMock: vi.fn(),
   hasPanelComponentMock: vi.fn(),
   getEffectiveAgentIdsMock: vi.fn(),
   getEffectiveAgentConfigMock: vi.fn(),
+  cliAvailabilityState: {
+    availability: { claude: true, gemini: false } as Record<string, boolean>,
+    isInitialized: true,
+    isLoading: false,
+    isRefreshing: false,
+    error: null,
+    lastCheckedAt: Date.now(),
+    initialize: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock("@shared/config/panelKindRegistry", () => ({
@@ -47,6 +58,13 @@ vi.mock("@/store/agentSettingsStore", () => ({
     selector({ settings: { agents: { claude: { selected: true }, gemini: { selected: true } } } }),
 }));
 
+vi.mock("@/store/cliAvailabilityStore", () => {
+  const store = (selector: (state: typeof cliAvailabilityState) => unknown) =>
+    selector(cliAvailabilityState);
+  store.getState = () => cliAvailabilityState;
+  return { useCliAvailabilityStore: store };
+});
+
 import { usePanelPalette } from "../usePanelPalette";
 
 describe("usePanelPalette", () => {
@@ -66,6 +84,10 @@ describe("usePanelPalette", () => {
         : null
     );
     hasPanelComponentMock.mockReturnValue(true);
+    cliAvailabilityState.availability = { claude: true, gemini: false };
+    cliAvailabilityState.isInitialized = true;
+    cliAvailabilityState.lastCheckedAt = Date.now();
+
     getEffectiveAgentIdsMock.mockReturnValue(["claude", "claude"]);
     getEffectiveAgentConfigMock.mockReturnValue({
       name: "Claude",
@@ -209,5 +231,109 @@ describe("usePanelPalette", () => {
       })
     );
     dispatchSpy.mockRestore();
+  });
+
+  describe("agent availability", () => {
+    it("sets installed=true for available agents", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
+      cliAvailabilityState.availability = { claude: true };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const claude = result.current.results.find((item) => item.id === "agent:claude");
+      expect(claude?.installed).toBe(true);
+    });
+
+    it("sets installed=false for unavailable agents", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["gemini"]);
+      getEffectiveAgentConfigMock.mockReturnValue({
+        name: "Gemini",
+        iconId: "gemini",
+        color: "#4285f4",
+        tooltip: "Gemini agent",
+      });
+      cliAvailabilityState.availability = { gemini: false };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const gemini = result.current.results.find((item) => item.id === "agent:gemini");
+      expect(gemini?.installed).toBe(false);
+    });
+
+    it("sets installed=undefined before availability is initialized", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
+      cliAvailabilityState.isInitialized = false;
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const claude = result.current.results.find((item) => item.id === "agent:claude");
+      expect(claude?.installed).toBeUndefined();
+    });
+
+    it("does not set installed on tool items", () => {
+      const { result } = renderHook(() => usePanelPalette());
+
+      const browser = result.current.results.find((item) => item.id === "browser");
+      expect(browser?.installed).toBeUndefined();
+    });
+
+    it("does not set installed on MORE_AGENTS entry", () => {
+      const { result } = renderHook(() => usePanelPalette());
+
+      const moreAgents = result.current.results.find((item) => item.id === MORE_AGENTS_PANEL_ID);
+      expect(moreAgents?.installed).toBeUndefined();
+    });
+
+    it("handleSelect dispatches setup wizard and returns null for uninstalled agent", () => {
+      const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+      getEffectiveAgentIdsMock.mockReturnValue(["gemini"]);
+      getEffectiveAgentConfigMock.mockReturnValue({
+        name: "Gemini",
+        iconId: "gemini",
+        color: "#4285f4",
+        tooltip: "Gemini agent",
+      });
+      cliAvailabilityState.availability = { gemini: false };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const gemini = result.current.results.find((item) => item.id === "agent:gemini");
+      expect(gemini).toBeDefined();
+      expect(gemini!.installed).toBe(false);
+
+      const selected = result.current.handleSelect(gemini!);
+      expect(selected).toBeNull();
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "canopy:open-agent-setup-wizard",
+          detail: { returnToPanelPalette: true },
+        })
+      );
+      dispatchSpy.mockRestore();
+    });
+
+    it("handleSelect returns option for installed agent", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
+      cliAvailabilityState.availability = { claude: true };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const claude = result.current.results.find((item) => item.id === "agent:claude");
+      const selected = result.current.handleSelect(claude!);
+      expect(selected).toBe(claude);
+    });
+
+    it("handleSelect allows selection when installed is undefined (before init)", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
+      cliAvailabilityState.isInitialized = false;
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const claude = result.current.results.find((item) => item.id === "agent:claude");
+      expect(claude?.installed).toBeUndefined();
+
+      const selected = result.current.handleSelect(claude!);
+      expect(selected).toBe(claude);
+    });
   });
 });

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -4,6 +4,7 @@ import { hasPanelComponent } from "@/registry/panelComponentRegistry";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { keybindingService } from "@/services/KeybindingService";
 import type { KeyAction } from "@shared/types/keymap";
@@ -16,6 +17,7 @@ export interface PanelKindOption {
   color: string;
   description?: string;
   category: "agent" | "tool" | "resume";
+  installed?: boolean;
   resumeSession?: AgentSessionRecord;
 }
 
@@ -25,6 +27,8 @@ export type UsePanelPaletteReturn = UseSearchablePaletteReturn<PanelKindOption> 
 };
 
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
 const AGENT_LAUNCH_ACTIONS: Record<string, KeyAction> = Object.fromEntries(
   BUILT_IN_AGENT_IDS.map((id) => [id, `agent.${id}` as KeyAction])
@@ -45,6 +49,8 @@ export const MORE_AGENTS_PANEL_ID = "more-agents";
 export function usePanelPalette(): UsePanelPaletteReturn {
   const userRegistry = useUserAgentRegistryStore((state) => state.registry);
   const agentSettings = useAgentSettingsStore((state) => state.settings);
+  const availability = useCliAvailabilityStore((state) => state.availability);
+  const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
   const [keybindingVersion, setKeybindingVersion] = useState(0);
   const [resumeSessions, setResumeSessions] = useState<AgentSessionRecord[]>([]);
 
@@ -102,6 +108,7 @@ export function usePanelPalette(): UsePanelPaletteReturn {
           color: agentConfig.color,
           description: displayCombo || agentConfig.shortcut || agentConfig.tooltip,
           category: "agent" as const,
+          installed: isAvailabilityInitialized ? (availability[agentId] ?? false) : undefined,
         };
       })
       .filter((agent): agent is PanelKindOption => agent !== null);
@@ -148,18 +155,38 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       ...resumeOptions,
       ...toolDedup.values(),
     ];
-  }, [userRegistry, keybindingVersion, agentSettings, resumeSessions]);
+  }, [
+    userRegistry,
+    keybindingVersion,
+    agentSettings,
+    resumeSessions,
+    availability,
+    isAvailabilityInitialized,
+  ]);
 
-  const { results, selectedIndex, close, ...paletteRest } = useSearchablePalette<PanelKindOption>({
-    items: availableKinds,
-    filterFn: filterPanelKinds,
-    maxResults: 20,
-    paletteId: "panel",
-  });
+  const { results, selectedIndex, close, isOpen, ...paletteRest } =
+    useSearchablePalette<PanelKindOption>({
+      items: availableKinds,
+      filterFn: filterPanelKinds,
+      maxResults: 20,
+      paletteId: "panel",
+    });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const { lastCheckedAt, refresh, isInitialized, initialize } =
+      useCliAvailabilityStore.getState();
+    if (!isInitialized) {
+      void initialize();
+      return;
+    }
+    const isStale = !lastCheckedAt || Date.now() - lastCheckedAt > STALE_THRESHOLD_MS;
+    if (isStale) void refresh().catch(() => {});
+  }, [isOpen]);
 
   const handleSelect = useCallback(
     (option: PanelKindOption): PanelKindOption | null => {
-      if (option.id === MORE_AGENTS_PANEL_ID) {
+      if (option.id === MORE_AGENTS_PANEL_ID || option.installed === false) {
         close();
         window.dispatchEvent(
           new CustomEvent("canopy:open-agent-setup-wizard", {
@@ -179,14 +206,14 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     const selected = results[selectedIndex];
     if (!selected) return null;
 
-    if (selected.id === MORE_AGENTS_PANEL_ID) {
+    if (selected.id === MORE_AGENTS_PANEL_ID || selected.installed === false) {
       close();
       window.dispatchEvent(
         new CustomEvent("canopy:open-agent-setup-wizard", {
           detail: { returnToPanelPalette: true },
         })
       );
-      return selected;
+      return null;
     }
     close();
     return selected;
@@ -196,6 +223,7 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     results,
     selectedIndex,
     close,
+    isOpen,
     ...paletteRest,
     handleSelect,
     confirmSelection,

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -71,6 +71,25 @@ describe("cliAvailabilityStore", () => {
       expect(refreshMock).toHaveBeenCalledTimes(1);
     });
 
+    it("sets lastCheckedAt on successful initialize", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      const before = Date.now();
+
+      await useCliAvailabilityStore.getState().initialize();
+
+      const state = useCliAvailabilityStore.getState();
+      expect(state.lastCheckedAt).toBeGreaterThanOrEqual(before);
+      expect(state.lastCheckedAt).toBeLessThanOrEqual(Date.now());
+    });
+
+    it("does not set lastCheckedAt on failed initialize", async () => {
+      refreshMock.mockRejectedValueOnce(new Error("IPC failed"));
+
+      await useCliAvailabilityStore.getState().initialize();
+
+      expect(useCliAvailabilityStore.getState().lastCheckedAt).toBeNull();
+    });
+
     it("sets error state when refresh fails", async () => {
       refreshMock.mockRejectedValueOnce(new Error("IPC failed"));
 
@@ -105,6 +124,28 @@ describe("cliAvailabilityStore", () => {
       expect(state.availability).toEqual(installedAvail);
       expect(state.isRefreshing).toBe(false);
       expect(state.error).toBeNull();
+    });
+
+    it("sets lastCheckedAt on successful refresh", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      const before = Date.now();
+
+      await useCliAvailabilityStore.getState().refresh();
+
+      const state = useCliAvailabilityStore.getState();
+      expect(state.lastCheckedAt).toBeGreaterThanOrEqual(before);
+      expect(state.lastCheckedAt).toBeLessThanOrEqual(Date.now());
+    });
+
+    it("does not set lastCheckedAt on failed refresh", async () => {
+      refreshMock.mockRejectedValueOnce(new Error("Network error"));
+
+      await useCliAvailabilityStore
+        .getState()
+        .refresh()
+        .catch(() => {});
+
+      expect(useCliAvailabilityStore.getState().lastCheckedAt).toBeNull();
     });
 
     it("deduplicates concurrent refresh calls", async () => {
@@ -166,6 +207,7 @@ describe("cliAvailabilityStore", () => {
       const state = useCliAvailabilityStore.getState();
       expect(state.isInitialized).toBe(false);
       expect(state.isLoading).toBe(true);
+      expect(state.lastCheckedAt).toBeNull();
       expect(state.availability).toEqual(defaultAvail);
 
       refreshMock.mockResolvedValueOnce(installedAvail);

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -10,6 +10,7 @@ interface CliAvailabilityState {
   isRefreshing: boolean;
   error: string | null;
   isInitialized: boolean;
+  lastCheckedAt: number | null;
 }
 
 interface CliAvailabilityActions {
@@ -33,6 +34,7 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get)
   isRefreshing: false,
   error: null,
   isInitialized: false,
+  lastCheckedAt: null,
 
   initialize: () => {
     if (get().isInitialized) return Promise.resolve();
@@ -49,7 +51,7 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get)
         set({ isLoading: true, error: null });
         const availability = await cliAvailabilityClient.refresh();
         if (epoch === myEpoch) {
-          set({ availability, isLoading: false, isInitialized: true });
+          set({ availability, isLoading: false, isInitialized: true, lastCheckedAt: Date.now() });
         }
       } catch (e) {
         if (epoch === myEpoch) {
@@ -82,7 +84,7 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get)
         set({ isRefreshing: true, error: null });
         const availability = await cliAvailabilityClient.refresh();
         if (epoch === myEpoch) {
-          set({ availability, isRefreshing: false, error: null });
+          set({ availability, isRefreshing: false, error: null, lastCheckedAt: Date.now() });
         }
       } catch (e) {
         if (epoch === myEpoch) {
@@ -113,5 +115,6 @@ export function cleanupCliAvailabilityStore() {
     isRefreshing: false,
     error: null,
     isInitialized: false,
+    lastCheckedAt: null,
   });
 }


### PR DESCRIPTION
## Summary

- Uninstalled agents now appear in the panel palette visually dimmed with a "Not installed" badge, so they're discoverable without being misleadingly launchable
- Selecting an uninstalled agent redirects to the AgentSetupWizard instead of opening a broken terminal
- Availability is rendered immediately from the cache, with a background refresh triggered if the last check is older than 5 minutes

Resolves #4915

## Changes

- `cliAvailabilityStore.ts` — added `lastCheckedAt` timestamp for staleness tracking
- `usePanelPalette.ts` — subscribed to availability store, maps `installed` field onto `PanelKindOption`, triggers background refresh on palette open if stale (>5 min), redirects uninstalled agent selections to AgentSetupWizard
- `PanelPalette.tsx` — visual dimming and "Not installed" badge for unavailable agents
- `usePanelPalette.test.tsx` — coverage for installed/uninstalled rendering, redirect behaviour, staleness refresh
- `cliAvailabilityStore.test.ts` — coverage for `lastCheckedAt` staleness logic

## Testing

Unit tests pass. The installed/uninstalled paths, redirect behaviour, and stale-refresh trigger all have explicit test coverage. Manually verified the badge and dimming render correctly in the palette for an agent with a missing CLI.