### PR TITLE
fix(e2e): fix non-deterministic panel count in core-terminal-layout-operations

### DIFF
--- a/e2e/core/core-terminal-layout-operations.spec.ts
+++ b/e2e/core/core-terminal-layout-operations.spec.ts
@@ -8,10 +8,10 @@ import {
   getGridPanelIds,
   getDockPanelIds,
   getFirstGridPanel,
-  openTerminal,
 } from "../helpers/panels";
 import { SEL } from "../helpers/selectors";
-import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
+import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
+import { spawnTerminalAndVerify } from "../helpers/workflows";
 
 let ctx: AppContext;
 let fixtureDir: string;
@@ -47,11 +47,9 @@ test.describe.serial("Core: Terminal Layout Operations", () => {
   test.describe.serial("Grid Panel Reordering", () => {
     test("open 3 terminals for reorder tests", async () => {
       const { window } = ctx;
-      for (let i = 0; i < 3; i++) {
-        await openTerminal(window);
-        await window.waitForTimeout(T_SETTLE);
-      }
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(3);
+      await spawnTerminalAndVerify(window);
+      await spawnTerminalAndVerify(window);
+      await spawnTerminalAndVerify(window);
     });
 
     test("move focused panel right changes order", async () => {

--- a/e2e/helpers/panels.ts
+++ b/e2e/helpers/panels.ts
@@ -17,7 +17,7 @@ export async function clickToolbarButton(
 
   // Try direct click first — Playwright auto-waits for visibility
   try {
-    await button.click({ timeout: 3000 });
+    await button.click({ timeout: 3000, noWaitAfter: true });
     return;
   } catch {
     // Button not clickable — might be in overflow menu
@@ -38,7 +38,7 @@ export async function clickToolbarButton(
   }
 
   // Last resort: try clicking with longer timeout
-  await button.click({ timeout });
+  await button.click({ timeout, noWaitAfter: true });
 }
 
 /**


### PR DESCRIPTION
## Summary

- The "open 3 terminals" setup test was using fixed `T_SETTLE` waits between spawns, which caused races on Windows where the panel count landed at 2 or 4 instead of 3.
- Replaced the loop with three sequential `spawnTerminalAndVerify()` calls, which poll until each terminal is confirmed registered before spawning the next.
- Added `noWaitAfter: true` to `clickToolbarButton` to prevent Playwright's post-click network/navigation wait from racing with the button's action handler and triggering a double-dispatch.

Resolves #4912

## Changes

- `e2e/core/core-terminal-layout-operations.spec.ts`: replaced `openTerminal` + `T_SETTLE` loop with three `spawnTerminalAndVerify()` calls
- `e2e/helpers/panels.ts`: added `noWaitAfter: true` to both `clickToolbarButton` click paths

## Testing

The test is deterministic by construction now rather than relying on timing. The existing `spawnTerminalAndVerify` helper already polls the grid panel count, so each spawn completes before the next begins.