### PR TITLE
fix(terminal): resolve Windows blank terminal from fit/resize race

### DIFF
--- a/e2e/core/core-panel-tab-groups.spec.ts
+++ b/e2e/core/core-panel-tab-groups.spec.ts
@@ -31,6 +31,11 @@ test.describe.serial("Core: Panel Tab Groups", () => {
       const panel = getFirstGridPanel(window);
       await expect(panel).toBeVisible({ timeout: T_LONG });
 
+      // Ensure xterm-screen has non-zero dimensions (regression guard for #4913:
+      // Windows blank terminal caused by fit/resize race during transient hidden state)
+      const xtermScreen = panel.locator(SEL.terminal.xtermRows);
+      await expect(xtermScreen).toBeVisible({ timeout: T_LONG });
+
       await runTerminalCommand(window, panel, "node -e \"console.log('TAB_ORIGINAL_MARKER')\"");
       await waitForTerminalText(panel, "TAB_ORIGINAL_MARKER", T_LONG);
     });

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -442,8 +442,11 @@ function XtermAdapterComponent({
     }
   }, [terminalId, stableRefreshTierProvider, currentTier]);
 
-  // Refit terminal when window becomes visible again after being hidden
-  useEffect(() => {
+  // Refit terminal when window becomes visible again after being hidden.
+  // useLayoutEffect ensures the listener is registered synchronously before
+  // paint, closing a race on Windows where the hidden→visible transition fires
+  // before a useEffect listener would be attached (see #4913).
+  useLayoutEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible" && pendingFitRef.current) {
         pendingFitRef.current = false;
@@ -451,6 +454,14 @@ function XtermAdapterComponent({
       }
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    // Defense-in-depth: if the hidden→visible transition already fired before
+    // this listener was registered, recover immediately.
+    if (pendingFitRef.current && document.visibilityState === "visible") {
+      pendingFitRef.current = false;
+      performFit();
+    }
+
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
   }, [performFit]);
 
@@ -479,17 +490,14 @@ function XtermAdapterComponent({
           if (instance?.isAttaching) continue;
 
           const rect = entry.contentRect;
-          if (
-            rect.width >= MIN_CONTAINER_SIZE &&
-            rect.height >= MIN_CONTAINER_SIZE &&
-            document.visibilityState === "visible"
-          ) {
+          if (rect.width >= MIN_CONTAINER_SIZE && rect.height >= MIN_CONTAINER_SIZE) {
             const dims = terminalInstanceService.resize(terminalId, rect.width, rect.height, {
               immediate: true,
             });
             if (dims) {
               prevDimensionsRef.current = dims;
               initialFitDoneRef.current = true;
+              pendingFitRef.current = false;
               // Cancel any pending debounce/rAF from earlier zero-dim observations
               if (resizeDebounceRef.current !== null) {
                 clearTimeout(resizeDebounceRef.current);


### PR DESCRIPTION
## Summary

- Removes the `document.visibilityState === "visible"` guard from the `ResizeObserver` initial fit path so layout dimensions are captured even when the panel is briefly hidden during tab switching
- Moves the `visibilitychange` listener from `useEffect` to `useLayoutEffect`, closing the race on Windows where the hidden-to-visible transition can fire before a `useEffect` listener is attached
- Adds a defence-in-depth immediate recovery check: if the transition already fired before the listener registered, `performFit()` is called synchronously

Resolves #4913

## Changes

- `src/components/Terminal/XtermAdapter.tsx` — three-part fix: removed `visibilityState` guard from `ResizeObserver`, `useEffect` → `useLayoutEffect` for the `visibilitychange` handler, added immediate recovery + `pendingFitRef` clear in the fit path
- `e2e/core/core-panel-tab-groups.spec.ts` — regression guard asserting `xterm-screen` has non-zero dimensions after panel open

## Testing

Existing E2E suite passes on Linux. The regression guard in `core-panel-tab-groups.spec.ts` will catch any recurrence on Windows in the nightly run. The root cause (Windows rendering pipeline timing differences with `ResizeObserver` and `useEffect`) is addressed by moving to `useLayoutEffect` and removing the visibility precondition from the initial fit.