### PR TITLE
fix(worktree): use smaller batches with shorter cooldowns for rate limiting

### DIFF
--- a/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
@@ -110,7 +110,7 @@ describe("worktree rate limiting", () => {
         options: { baseBranch: "main", newBranch: "feat-1", path: "/test/worktrees/feat-1" },
       });
 
-      expect(waitForRateLimitSlotMock).toHaveBeenCalledWith("worktreeCreate", 20, 30_000);
+      expect(waitForRateLimitSlotMock).toHaveBeenCalledWith("worktreeCreate", 2, 2_000);
       expect(mockWorktreeService.createWorktree).toHaveBeenCalled();
     });
 
@@ -138,7 +138,7 @@ describe("worktree rate limiting", () => {
         description: "Test task",
       });
 
-      expect(waitForRateLimitSlotMock).toHaveBeenCalledWith("worktreeCreate", 20, 30_000);
+      expect(waitForRateLimitSlotMock).toHaveBeenCalledWith("worktreeCreate", 2, 2_000);
     });
 
     it("rejects without calling createWorktree when rate limit slot rejects", async () => {

--- a/electron/ipc/handlers/worktree.ts
+++ b/electron/ipc/handlers/worktree.ts
@@ -22,8 +22,8 @@ import { soundService } from "../../services/SoundService.js";
 import { checkRateLimit, waitForRateLimitSlot } from "../utils.js";
 
 const WORKTREE_RATE_LIMIT_KEY = "worktreeCreate";
-const WORKTREE_RATE_LIMIT_MAX = 20;
-const WORKTREE_RATE_LIMIT_WINDOW_MS = 30_000;
+const WORKTREE_RATE_LIMIT_MAX = 2;
+const WORKTREE_RATE_LIMIT_WINDOW_MS = 2_000;
 import { resolveWorktreePattern } from "../../utils/worktreePattern.js";
 import { taskWorktreeService } from "../../services/TaskWorktreeService.js";
 


### PR DESCRIPTION
## Summary

- Changed worktree creation rate limit from 20 ops/30s to 2 ops/2s for smoother, more predictable pacing
- The overall throughput stays similar, but the cadence shifts from feast-or-famine to a steady rhythm
- Bulk worktree creation naturally paces itself rather than blasting through a budget then stalling

Resolves #4952

## Changes

- `electron/ipc/handlers/worktree.ts`: Updated `RateLimiter` config from `{ max: 20, window: 30000 }` to `{ max: 2, window: 2000 }`
- `electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts`: Updated test expectations to match new rate limit values

## Testing

Unit tests updated to reflect the new parameters and pass. The rate limiter logic itself is unchanged; only the configuration values were adjusted.