### PR TITLE
fix(voice): handle Windows backslash paths in voice correction

### DIFF
--- a/shared/config/__tests__/voiceCorrection.test.ts
+++ b/shared/config/__tests__/voiceCorrection.test.ts
@@ -177,6 +177,23 @@ describe("buildCorrectionSystemPrompt", () => {
     const projectSection = prompt.split("CURRENT PROJECT:")[1]?.split("\n\n")[0] ?? "";
     expect(projectSection).not.toContain("Repository:");
   });
+
+  it("handles trailing separators in project path", () => {
+    const prompt = buildCorrectionSystemPrompt({
+      projectName: "My App",
+      projectPath: "C:\\Users\\dev\\my-repo\\",
+    });
+    expect(prompt).toContain("my-repo");
+    expect(prompt).not.toContain("C:\\Users\\dev\\my-repo\\");
+  });
+
+  it("handles mixed separators in project path", () => {
+    const prompt = buildCorrectionSystemPrompt({
+      projectName: "My App",
+      projectPath: "C:\\Users/dev\\my-repo",
+    });
+    expect(prompt).toContain("my-repo");
+  });
 });
 
 describe("MICRO_CORRECTION_PROMPT", () => {
@@ -270,5 +287,14 @@ describe("buildMicroCorrectionSystemPrompt", () => {
     });
     const projectSection = prompt.split("CURRENT PROJECT:")[1]?.split("\n\n")[0] ?? "";
     expect(projectSection).not.toContain("Repository:");
+  });
+
+  it("handles trailing separators in project path", () => {
+    const prompt = buildMicroCorrectionSystemPrompt({
+      projectName: "My App",
+      projectPath: "/Users/dev/my-repo/",
+    });
+    expect(prompt).toContain("my-repo");
+    expect(prompt).not.toContain("/Users/dev/my-repo/");
   });
 });

--- a/shared/config/__tests__/voiceCorrection.test.ts
+++ b/shared/config/__tests__/voiceCorrection.test.ts
@@ -159,6 +159,24 @@ describe("buildCorrectionSystemPrompt", () => {
     });
     expect(prompt).toContain("my-app-repo");
   });
+
+  it("extracts directory name from Windows backslash path", () => {
+    const prompt = buildCorrectionSystemPrompt({
+      projectName: "My App",
+      projectPath: "C:\\Users\\dev\\my-repo",
+    });
+    expect(prompt).toContain("my-repo");
+    expect(prompt).not.toContain("C:\\Users\\dev\\my-repo");
+  });
+
+  it("omits Repository line when Windows path directory matches project name", () => {
+    const prompt = buildCorrectionSystemPrompt({
+      projectName: "canopy",
+      projectPath: "C:\\Users\\dev\\canopy",
+    });
+    const projectSection = prompt.split("CURRENT PROJECT:")[1]?.split("\n\n")[0] ?? "";
+    expect(projectSection).not.toContain("Repository:");
+  });
 });
 
 describe("MICRO_CORRECTION_PROMPT", () => {
@@ -234,5 +252,23 @@ describe("buildMicroCorrectionSystemPrompt", () => {
     });
     const guardrailIdx = prompt.lastIndexOf("Return a JSON object");
     expect(guardrailIdx).toBeGreaterThan(prompt.length - 300);
+  });
+
+  it("extracts directory name from Windows backslash path", () => {
+    const prompt = buildMicroCorrectionSystemPrompt({
+      projectName: "My App",
+      projectPath: "C:\\Users\\dev\\my-repo",
+    });
+    expect(prompt).toContain("my-repo");
+    expect(prompt).not.toContain("C:\\Users\\dev\\my-repo");
+  });
+
+  it("omits Repository line when Windows path directory matches project name", () => {
+    const prompt = buildMicroCorrectionSystemPrompt({
+      projectName: "canopy",
+      projectPath: "C:\\Users\\dev\\canopy",
+    });
+    const projectSection = prompt.split("CURRENT PROJECT:")[1]?.split("\n\n")[0] ?? "";
+    expect(projectSection).not.toContain("Repository:");
   });
 });

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -149,7 +149,8 @@ export function buildCorrectionSystemPrompt(context: CorrectionPromptContext): s
       projectParts.push(`Project: ${context.projectName}`);
     }
     if (context.projectPath) {
-      const dirName = context.projectPath.split(/[/\\]/).filter(Boolean).pop() || context.projectPath;
+      const dirName =
+        context.projectPath.split(/[/\\]/).filter(Boolean).pop() || context.projectPath;
       if (dirName !== context.projectName) {
         projectParts.push(`Repository: ${dirName}`);
       }
@@ -185,7 +186,8 @@ export function buildMicroCorrectionSystemPrompt(context: CorrectionPromptContex
       projectParts.push(`Project: ${context.projectName}`);
     }
     if (context.projectPath) {
-      const dirName = context.projectPath.split(/[/\\]/).filter(Boolean).pop() || context.projectPath;
+      const dirName =
+        context.projectPath.split(/[/\\]/).filter(Boolean).pop() || context.projectPath;
       if (dirName !== context.projectName) {
         projectParts.push(`Repository: ${dirName}`);
       }

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -149,7 +149,7 @@ export function buildCorrectionSystemPrompt(context: CorrectionPromptContext): s
       projectParts.push(`Project: ${context.projectName}`);
     }
     if (context.projectPath) {
-      const dirName = context.projectPath.split(/[/\\]/).pop() || context.projectPath;
+      const dirName = context.projectPath.split(/[/\\]/).filter(Boolean).pop() || context.projectPath;
       if (dirName !== context.projectName) {
         projectParts.push(`Repository: ${dirName}`);
       }
@@ -185,7 +185,7 @@ export function buildMicroCorrectionSystemPrompt(context: CorrectionPromptContex
       projectParts.push(`Project: ${context.projectName}`);
     }
     if (context.projectPath) {
-      const dirName = context.projectPath.split(/[/\\]/).pop() || context.projectPath;
+      const dirName = context.projectPath.split(/[/\\]/).filter(Boolean).pop() || context.projectPath;
       if (dirName !== context.projectName) {
         projectParts.push(`Repository: ${dirName}`);
       }

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -149,7 +149,7 @@ export function buildCorrectionSystemPrompt(context: CorrectionPromptContext): s
       projectParts.push(`Project: ${context.projectName}`);
     }
     if (context.projectPath) {
-      const dirName = context.projectPath.split("/").pop() || context.projectPath;
+      const dirName = context.projectPath.split(/[/\\]/).pop() || context.projectPath;
       if (dirName !== context.projectName) {
         projectParts.push(`Repository: ${dirName}`);
       }
@@ -185,7 +185,7 @@ export function buildMicroCorrectionSystemPrompt(context: CorrectionPromptContex
       projectParts.push(`Project: ${context.projectName}`);
     }
     if (context.projectPath) {
-      const dirName = context.projectPath.split("/").pop() || context.projectPath;
+      const dirName = context.projectPath.split(/[/\\]/).pop() || context.projectPath;
       if (dirName !== context.projectName) {
         projectParts.push(`Repository: ${dirName}`);
       }

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -143,7 +143,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   }));
 
   useEffect(() => {
-    const basename = filePath.split(/[/\\]/).pop() ?? filePath;
+    const basename = filePath.split(/[/\\]/).filter(Boolean).pop() ?? filePath;
     const desc = LanguageDescription.matchFilename(languages, basename);
     if (!desc) {
       setLangExtension(null);

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -143,7 +143,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   }));
 
   useEffect(() => {
-    const basename = filePath.split("/").pop() ?? filePath;
+    const basename = filePath.split(/[/\\]/).pop() ?? filePath;
     const desc = LanguageDescription.matchFilename(languages, basename);
     if (!desc) {
       setLangExtension(null);

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -201,7 +201,7 @@ export function FileViewerModal({
     }
   }, [hasDiff, diff]);
 
-  const fileName = filePath.split(/[/\\]/).pop() || filePath;
+  const fileName = filePath.split(/[/\\]/).filter(Boolean).pop() || filePath;
 
   // Compute relative path by stripping rootPath prefix; guard against empty root
   const displayRoot = rootPath ? (rootPath.endsWith("/") ? rootPath : rootPath + "/") : null;

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -201,7 +201,7 @@ export function FileViewerModal({
     }
   }, [hasDiff, diff]);
 
-  const fileName = filePath.split("/").pop() || filePath;
+  const fileName = filePath.split(/[/\\]/).pop() || filePath;
 
   // Compute relative path by stripping rootPath prefix; guard against empty root
   const displayRoot = rootPath ? (rootPath.endsWith("/") ? rootPath : rootPath + "/") : null;

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -234,7 +234,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                   </span>
                   <FileIcon className="w-3 h-3 shrink-0 text-text-muted" />
                   <span className="text-text-secondary truncate min-w-0" title={file.path}>
-                    {file.path.split(/[/\\]/).pop()}
+                    {file.path.split(/[/\\]/).filter(Boolean).pop()}
                   </span>
                 </button>
               );

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -234,7 +234,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
                   </span>
                   <FileIcon className="w-3 h-3 shrink-0 text-text-muted" />
                   <span className="text-text-secondary truncate min-w-0" title={file.path}>
-                    {file.path.split("/").pop()}
+                    {file.path.split(/[/\\]/).pop()}
                   </span>
                 </button>
               );

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -614,7 +614,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                           </span>
                           <FileIcon className="w-3 h-3 shrink-0 text-canopy-text/40" />
                           <span className="text-canopy-text/80 truncate min-w-0" title={file.path}>
-                            {file.path.split(/[/\\]/).pop()}
+                            {file.path.split(/[/\\]/).filter(Boolean).pop()}
                           </span>
                           <span className="text-canopy-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
                             {/[/\\]/.test(file.path)

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -618,7 +618,10 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                           </span>
                           <span className="text-canopy-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
                             {/[/\\]/.test(file.path)
-                              ? file.path.substring(0, Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\")))
+                              ? file.path.substring(
+                                  0,
+                                  Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\"))
+                                )
                               : ""}
                           </span>
                         </button>

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -614,11 +614,11 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                           </span>
                           <FileIcon className="w-3 h-3 shrink-0 text-canopy-text/40" />
                           <span className="text-canopy-text/80 truncate min-w-0" title={file.path}>
-                            {file.path.split("/").pop()}
+                            {file.path.split(/[/\\]/).pop()}
                           </span>
                           <span className="text-canopy-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
-                            {file.path.includes("/")
-                              ? file.path.substring(0, file.path.lastIndexOf("/"))
+                            {/[/\\]/.test(file.path)
+                              ? file.path.substring(0, Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\")))
                               : ""}
                           </span>
                         </button>


### PR DESCRIPTION
## Summary

- `voiceCorrection.ts` was splitting `projectPath` on `"/"` only, which fails on Windows where paths use backslashes. The full path (e.g. `C:\Users\deven\Desktop\canopy`) was being sent as the repository name in the AI prompt instead of just `canopy`.
- Fixed both occurrences (lines 152 and 188) by switching to `split(/[/\\]/).filter(Boolean)` which handles forward slashes, backslashes, and trailing separators correctly.
- Applied the same cross-platform split to four renderer components that extract directory names from paths for display purposes.

Resolves #4942

## Changes

- `shared/config/voiceCorrection.ts` — replace `split("/")` with `split(/[/\\]/).filter(Boolean)` in both `buildMicroCorrectionSystemPrompt` and `buildCorrectionSystemPrompt`
- `src/components/FileViewer/CodeViewer.tsx`, `FileViewerModal.tsx`, `Worktree/CrossWorktreeDiff.tsx`, `Worktree/ReviewHub/ReviewHub.tsx` — same fix for path display

## Testing

Added 7 regression tests in `shared/config/__tests__/voiceCorrection.test.ts` covering Windows paths with backslashes, POSIX paths, trailing separators, mixed separators, and root-level paths. All tests pass.