### PR TITLE
fix(help): use full canopyide.com URLs for doc links

### DIFF
--- a/help/AGENTS.md
+++ b/help/AGENTS.md
@@ -70,3 +70,5 @@ The `canopy-docs` MCP server is your only documentation source — use it for al
 - **`list_pages`** — List all indexed documentation pages. Use to discover available content or browse by section.
 - **`get_site_structure`** — Returns the hierarchical page tree. Use to understand how documentation is organized.
 - **`get_related_pages`** — Find pages related to a given page by URL. Use to suggest further reading.
+
+**URL construction:** MCP tools return page paths (e.g., `/docs/getting-started`). Always prepend `https://canopyide.com` to form the full URL before linking — never present bare paths to users.

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -82,3 +82,5 @@ The `canopy-docs` MCP server is your only documentation source — use it for al
 - **`list_pages`** — List all indexed documentation pages. Use to discover available content or browse by section.
 - **`get_site_structure`** — Returns the hierarchical page tree. Use to understand how documentation is organized.
 - **`get_related_pages`** — Find pages related to a given page by URL. Use to suggest further reading.
+
+**URL construction:** MCP tools return page paths (e.g., `/docs/getting-started`). Always prepend `https://canopyide.com` to form the full URL before linking — never present bare paths to users.

--- a/help/GEMINI.md
+++ b/help/GEMINI.md
@@ -82,3 +82,5 @@ The `canopy-docs` MCP server is your only documentation source — use it for al
 - **`list_pages`** — List all indexed documentation pages. Use to discover available content or browse by section.
 - **`get_site_structure`** — Returns the hierarchical page tree. Use to understand how documentation is organized.
 - **`get_related_pages`** — Find pages related to a given page by URL. Use to suggest further reading.
+
+**URL construction:** MCP tools return page paths (e.g., `/docs/getting-started`). Always prepend `https://canopyide.com` to form the full URL before linking — never present bare paths to users.


### PR DESCRIPTION
## Summary

- The `canopy-docs` MCP returns relative page paths (e.g. `/docs/getting-started`) rather than full URLs. Without explicit instruction, help agents were surfacing these bare paths in responses, which aren't clickable or useful.
- Added a short instruction to `help/CLAUDE.md`, `help/AGENTS.md`, and `help/GEMINI.md` telling agents to prepend `https://canopyide.com` to any path returned by the MCP before linking it.

Resolves #4982

## Changes

- `help/CLAUDE.md` — added URL construction instruction
- `help/AGENTS.md` — added URL construction instruction
- `help/GEMINI.md` — added URL construction instruction

## Testing

Markdown-only change. No build or runtime impact. Verified the wording is consistent across all three agent instruction files.