### PR TITLE
feat(worktree): smart defaults for new worktree panel layout

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useReducer, useRef, useMemo, useEffect, useLayoutEffect } from "react";
 import PQueue from "p-queue";
-import { Check, AlertTriangle, UserPlus, Play, ChevronsUpDown, RotateCcw } from "lucide-react";
+import { Check, AlertTriangle, UserPlus, Play, ChevronsUpDown, RotateCcw, Copy } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";
@@ -19,7 +19,7 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useTerminalStore } from "@/store/terminalStore";
-import { useRecipePicker } from "@/components/Worktree/hooks/useRecipePicker";
+import { useRecipePicker, CLONE_LAYOUT_ID } from "@/components/Worktree/hooks/useRecipePicker";
 import { useNewWorktreeProjectSettings } from "@/components/Worktree/hooks/useNewWorktreeProjectSettings";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 
@@ -481,6 +481,12 @@ export function BulkCreateWorktreeDialog({
 
       const tracking = batchTrackingRef.current;
 
+      const sourceWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+      const cloneTerminals =
+        selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId
+          ? useRecipeStore.getState().generateRecipeFromActiveTerminals(sourceWorktreeId)
+          : null;
+
       const queue = new PQueue({
         concurrency: QUEUE_CONCURRENCY,
         intervalCap: QUEUE_INTERVAL_CAP,
@@ -653,8 +659,40 @@ export function BulkCreateWorktreeDialog({
                 });
               }
 
-              // Step 2: Recipe execution (skip if no recipe)
-              if (selectedRecipeId && worktreePath && worktreeId) {
+              // Step 2: Clone layout or run recipe
+              if (cloneTerminals && worktreePath && worktreeId) {
+                dispatchProgress({
+                  type: "ITEM_TERMINALS_SPAWNING",
+                  issueNumber: itemNumber,
+                });
+                for (const t of cloneTerminals) {
+                  await useTerminalStore.getState().addTerminal({
+                    kind:
+                      t.type === "dev-preview"
+                        ? "dev-preview"
+                        : t.type === "terminal"
+                          ? "terminal"
+                          : "agent",
+                    agentId:
+                      t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                    title: t.title,
+                    cwd: worktreePath,
+                    worktreeId,
+                    exitBehavior: t.exitBehavior,
+                  });
+                }
+                dispatchProgress({
+                  type: "ITEM_TERMINALS_RESULT",
+                  issueNumber: itemNumber,
+                  spawnedTerminalIds: [],
+                  failedTerminalIndices: [],
+                });
+              } else if (
+                selectedRecipeId &&
+                selectedRecipeId !== CLONE_LAYOUT_ID &&
+                worktreePath &&
+                worktreeId
+              ) {
                 const currentTracked = tracking.get(itemNumber);
                 const failedIndices = currentTracked?.failedTerminalIndices;
                 const shouldRetryTerminals =
@@ -1026,112 +1064,142 @@ export function BulkCreateWorktreeDialog({
               </div>
             )}
 
-            {/* Recipe picker */}
-            {globalRecipes.length > 0 && (
-              <div className="space-y-2">
-                <label
-                  htmlFor="bulk-recipe-selector"
-                  className="block text-sm font-medium text-canopy-text"
+            {/* Starting Layout picker */}
+            <div className="space-y-2">
+              <label
+                htmlFor="bulk-recipe-selector"
+                className="block text-sm font-medium text-canopy-text"
+              >
+                Starting Layout
+              </label>
+              <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    id="bulk-recipe-selector"
+                    variant="outline"
+                    role="combobox"
+                    aria-expanded={recipePickerOpen}
+                    aria-haspopup="listbox"
+                    aria-controls="bulk-recipe-list"
+                    className="w-full justify-between bg-canopy-bg border-canopy-border text-canopy-text hover:bg-canopy-bg hover:text-canopy-text"
+                  >
+                    <span className="flex items-center gap-2 truncate">
+                      {selectedRecipeId === CLONE_LAYOUT_ID ? (
+                        <>
+                          <Copy className="shrink-0 text-canopy-accent" />
+                          <span>Clone current layout</span>
+                        </>
+                      ) : selectedRecipe ? (
+                        <>
+                          <Play className="shrink-0 text-canopy-accent" />
+                          <span>{selectedRecipe.name}</span>
+                          <span className="text-xs text-canopy-text/50">
+                            ({selectedRecipe.terminals.length} terminal
+                            {selectedRecipe.terminals.length !== 1 ? "s" : ""})
+                          </span>
+                        </>
+                      ) : (
+                        <>
+                          <Play className="shrink-0 text-canopy-accent" />
+                          <span className="text-canopy-text/60">Empty</span>
+                        </>
+                      )}
+                    </span>
+                    <ChevronsUpDown className="opacity-50 shrink-0" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  className="w-[400px] p-0"
+                  align="start"
+                  onEscapeKeyDown={(e) => e.stopPropagation()}
                 >
-                  Run Recipe (Optional)
-                </label>
-                <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      id="bulk-recipe-selector"
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={recipePickerOpen}
-                      aria-haspopup="listbox"
-                      aria-controls="bulk-recipe-list"
-                      className="w-full justify-between bg-canopy-bg border-canopy-border text-canopy-text hover:bg-canopy-bg hover:text-canopy-text"
-                    >
-                      <span className="flex items-center gap-2 truncate">
-                        <Play className="shrink-0 text-canopy-accent" />
-                        {selectedRecipe ? (
-                          <>
-                            <span>{selectedRecipe.name}</span>
-                            <span className="text-xs text-canopy-text/50">
-                              ({selectedRecipe.terminals.length} terminal
-                              {selectedRecipe.terminals.length !== 1 ? "s" : ""})
-                            </span>
-                          </>
-                        ) : (
-                          <span className="text-canopy-text/60">No recipe</span>
-                        )}
-                      </span>
-                      <ChevronsUpDown className="opacity-50 shrink-0" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[400px] p-0"
-                    align="start"
-                    onEscapeKeyDown={(e) => e.stopPropagation()}
+                  <div
+                    id="bulk-recipe-list"
+                    role="listbox"
+                    className="max-h-[300px] overflow-y-auto p-1"
                   >
                     <div
-                      id="bulk-recipe-list"
-                      role="listbox"
-                      className="max-h-[300px] overflow-y-auto p-1"
+                      role="option"
+                      aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleRecipeSelect(CLONE_LAYOUT_ID);
+                        }
+                      }}
+                      onClick={() => handleRecipeSelect(CLONE_LAYOUT_ID)}
+                      className={cn(
+                        "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
+                        selectedRecipeId === CLONE_LAYOUT_ID && "bg-canopy-border"
+                      )}
                     >
+                      <div className="flex items-center gap-2">
+                        <Copy className="h-3.5 w-3.5 text-canopy-text/50" />
+                        <span>Clone current layout</span>
+                      </div>
+                      {selectedRecipeId === CLONE_LAYOUT_ID && (
+                        <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
+                      )}
+                    </div>
+                    <div
+                      role="option"
+                      aria-selected={selectedRecipeId === null}
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleRecipeSelectNone();
+                        }
+                      }}
+                      onClick={handleRecipeSelectNone}
+                      className={cn(
+                        "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
+                        selectedRecipeId === null && "bg-canopy-border"
+                      )}
+                    >
+                      <span className="text-canopy-text/60">Empty</span>
+                      {selectedRecipeId === null && (
+                        <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
+                      )}
+                    </div>
+                    {globalRecipes.map((recipe) => (
                       <div
+                        key={recipe.id}
                         role="option"
-                        aria-selected={selectedRecipeId === null}
+                        aria-selected={recipe.id === selectedRecipeId}
                         tabIndex={0}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" || e.key === " ") {
                             e.preventDefault();
-                            handleRecipeSelectNone();
+                            handleRecipeSelect(recipe.id);
                           }
                         }}
-                        onClick={handleRecipeSelectNone}
+                        onClick={() => handleRecipeSelect(recipe.id)}
                         className={cn(
                           "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
-                          selectedRecipeId === null && "bg-canopy-border"
+                          recipe.id === selectedRecipeId && "bg-canopy-border"
                         )}
                       >
-                        <span className="text-canopy-text/60">No recipe</span>
-                        {selectedRecipeId === null && (
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="truncate">{recipe.name}</span>
+                          <span className="text-xs text-canopy-text/50 shrink-0">
+                            {recipe.terminals.length} terminal
+                            {recipe.terminals.length !== 1 ? "s" : ""}
+                          </span>
+                          {recipe.id === defaultRecipeId && (
+                            <span className="text-xs text-canopy-accent shrink-0">(default)</span>
+                          )}
+                        </div>
+                        {recipe.id === selectedRecipeId && (
                           <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
                         )}
                       </div>
-                      {globalRecipes.map((recipe) => (
-                        <div
-                          key={recipe.id}
-                          role="option"
-                          aria-selected={recipe.id === selectedRecipeId}
-                          tabIndex={0}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              handleRecipeSelect(recipe.id);
-                            }
-                          }}
-                          onClick={() => handleRecipeSelect(recipe.id)}
-                          className={cn(
-                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
-                            recipe.id === selectedRecipeId && "bg-canopy-border"
-                          )}
-                        >
-                          <div className="flex items-center gap-2 min-w-0">
-                            <span className="truncate">{recipe.name}</span>
-                            <span className="text-xs text-canopy-text/50 shrink-0">
-                              {recipe.terminals.length} terminal
-                              {recipe.terminals.length !== 1 ? "s" : ""}
-                            </span>
-                            {recipe.id === defaultRecipeId && (
-                              <span className="text-xs text-canopy-accent shrink-0">(default)</span>
-                            )}
-                          </div>
-                          {recipe.id === selectedRecipeId && (
-                            <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
-            )}
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
 
             {/* Worktree list */}
             <div className="space-y-2">

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -461,6 +461,7 @@ export function BulkCreateWorktreeDialog({
         resolvedBranch?: string;
         spawnedTerminalIds: string[];
         failedTerminalIndices: number[];
+        cloneComplete?: boolean;
       }
     >()
   );
@@ -660,26 +661,33 @@ export function BulkCreateWorktreeDialog({
               }
 
               // Step 2: Clone layout or run recipe
-              if (cloneTerminals && worktreePath && worktreeId) {
+              const currentItem = tracking.get(itemNumber);
+              if (cloneTerminals && worktreePath && worktreeId && !currentItem?.cloneComplete) {
                 dispatchProgress({
                   type: "ITEM_TERMINALS_SPAWNING",
                   issueNumber: itemNumber,
                 });
-                for (const t of cloneTerminals) {
-                  await useTerminalStore.getState().addTerminal({
-                    kind:
-                      t.type === "dev-preview"
-                        ? "dev-preview"
-                        : t.type === "terminal"
-                          ? "terminal"
-                          : "agent",
-                    agentId:
-                      t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
-                    title: t.title,
-                    cwd: worktreePath,
-                    worktreeId,
-                    exitBehavior: t.exitBehavior,
-                  });
+                try {
+                  for (const t of cloneTerminals) {
+                    await useTerminalStore.getState().addTerminal({
+                      kind:
+                        t.type === "dev-preview"
+                          ? "dev-preview"
+                          : t.type === "terminal"
+                            ? "terminal"
+                            : "agent",
+                      agentId:
+                        t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                      title: t.title,
+                      cwd: worktreePath,
+                      worktreeId,
+                      exitBehavior: t.exitBehavior,
+                    });
+                  }
+                  const updatedTracked = tracking.get(itemNumber);
+                  if (updatedTracked) updatedTracked.cloneComplete = true;
+                } catch {
+                  // Clone is best-effort; worktree was created
                 }
                 dispatchProgress({
                   type: "ITEM_TERMINALS_RESULT",

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useReducer, useRef, useMemo, useEffect, useLayoutEffect } from "react";
 import PQueue from "p-queue";
-import { Check, AlertTriangle, UserPlus, Play, ChevronsUpDown, RotateCcw, Copy } from "lucide-react";
+import {
+  Check,
+  AlertTriangle,
+  UserPlus,
+  Play,
+  ChevronsUpDown,
+  RotateCcw,
+  Copy,
+} from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { WorktreeIcon } from "@/components/icons";
 import { Button } from "@/components/ui/button";

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -122,13 +122,17 @@ vi.mock("@/store/terminalStore", () => ({
 
 let mockSelectedRecipeId: string | null = null;
 vi.mock("@/components/Worktree/hooks/useRecipePicker", () => ({
+  CLONE_LAYOUT_ID: "__clone_layout__",
   useRecipePicker: () => ({
     selectedRecipeId: mockSelectedRecipeId,
     setSelectedRecipeId: vi.fn(),
     recipePickerOpen: false,
     setRecipePickerOpen: vi.fn(),
     recipeSelectionTouchedRef: { current: false },
-    selectedRecipe: mockSelectedRecipeId ? { name: "Test Recipe", terminals: [{}] } : null,
+    selectedRecipe:
+      mockSelectedRecipeId && mockSelectedRecipeId !== "__clone_layout__"
+        ? { name: "Test Recipe", terminals: [{}] }
+        : null,
   }),
 }));
 

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/store/recipeStore", () => ({
     getState: () => ({
       runRecipeWithResults: mockRunRecipeWithResults,
       getRecipeById: () => null,
+      generateRecipeFromActiveTerminals: () => [],
     }),
   }),
 }));
@@ -104,6 +105,7 @@ const mockSelectWorktree = vi.fn();
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: {
     getState: () => ({
+      activeWorktreeId: "source-wt",
       setPendingWorktree: mockSetPendingWorktree,
       selectWorktree: mockSelectWorktree,
     }),
@@ -116,6 +118,7 @@ vi.mock("@/store/terminalStore", () => ({
     getState: () => ({
       terminalsById: Object.fromEntries(mockTerminals.map((t) => [t.id, t])),
       terminalIds: mockTerminals.map((t) => t.id),
+      addTerminal: vi.fn().mockResolvedValue("clone-terminal-id"),
     }),
   },
 }));

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -12,6 +12,7 @@ import {
   Info,
   ChevronDown,
   GitBranch,
+  Copy,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
@@ -40,7 +41,8 @@ import { useBranchInput } from "./hooks/useBranchInput";
 import { useBranchValidation } from "./hooks/useBranchValidation";
 import { useBranchPicker } from "./hooks/useBranchPicker";
 import { usePrefixPicker } from "./hooks/usePrefixPicker";
-import { useRecipePicker } from "./hooks/useRecipePicker";
+import { useRecipePicker, CLONE_LAYOUT_ID } from "./hooks/useRecipePicker";
+import { useTerminalStore } from "@/store/terminalStore";
 
 type BranchMode = "new" | "existing";
 
@@ -464,6 +466,8 @@ export function NewWorktreeDialog({
 
       startTransition(async () => {
         try {
+          const sourceWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+
           const options: CreateWorktreeOptions = {
             baseBranch: selectedExistingBranch,
             newBranch: selectedExistingBranch,
@@ -485,7 +489,26 @@ export function NewWorktreeDialog({
           useWorktreeSelectionStore.getState().setPendingWorktree(worktreeId);
           useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
 
-          if (selectedRecipe) {
+          if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
+            const terminals = useRecipeStore
+              .getState()
+              .generateRecipeFromActiveTerminals(sourceWorktreeId);
+            for (const t of terminals) {
+              await useTerminalStore.getState().addTerminal({
+                kind:
+                  t.type === "dev-preview"
+                    ? "dev-preview"
+                    : t.type === "terminal"
+                      ? "terminal"
+                      : "agent",
+                agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                title: t.title,
+                cwd: worktreePath.trim(),
+                worktreeId,
+                exitBehavior: t.exitBehavior,
+              });
+            }
+          } else if (selectedRecipe) {
             try {
               await runRecipe(selectedRecipe.id, worktreePath.trim(), worktreeId, {
                 worktreePath: worktreePath.trim(),
@@ -585,6 +608,8 @@ export function NewWorktreeDialog({
 
     startTransition(async () => {
       try {
+        const sourceWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+
         const useExistingBranch =
           initialPR !== null && initialPR !== undefined
             ? branches.some((b) => b.name === fullBranchName && !b.remote)
@@ -634,7 +659,26 @@ export function NewWorktreeDialog({
           }
         }
 
-        if (selectedRecipe) {
+        if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
+          const terminals = useRecipeStore
+            .getState()
+            .generateRecipeFromActiveTerminals(sourceWorktreeId);
+          for (const t of terminals) {
+            await useTerminalStore.getState().addTerminal({
+              kind:
+                t.type === "dev-preview"
+                  ? "dev-preview"
+                  : t.type === "terminal"
+                    ? "terminal"
+                    : "agent",
+              agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+              title: t.title,
+              cwd: worktreePath.trim(),
+              worktreeId,
+              exitBehavior: t.exitBehavior,
+            });
+          }
+        } else if (selectedRecipe) {
           const worktreeId = result.result as string | undefined;
           try {
             await runRecipe(selectedRecipe.id, worktreePath.trim(), worktreeId, {
@@ -1288,103 +1332,144 @@ export function NewWorktreeDialog({
                 </div>
               )}
 
-              {globalRecipes.length > 0 && (
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <label
-                      htmlFor="recipe-selector"
-                      className="block text-sm font-medium text-canopy-text"
-                    >
-                      Run Recipe (Optional)
-                    </label>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="text-canopy-text/40 hover:text-canopy-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2"
-                          aria-label="Help for Run Recipe field"
-                          disabled={isPending}
-                        >
-                          <Info className="w-3.5 h-3.5" aria-hidden="true" />
-                          <span className="sr-only">Help for Run Recipe field</span>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        <p>Select a recipe to run after creating the worktree</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                  <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        id="recipe-selector"
-                        variant="outline"
-                        role="combobox"
-                        aria-expanded={recipePickerOpen}
-                        aria-haspopup="listbox"
-                        aria-controls="recipe-list"
-                        className="w-full justify-between bg-canopy-bg border-canopy-border text-canopy-text hover:bg-canopy-bg hover:text-canopy-text"
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="recipe-selector"
+                    className="block text-sm font-medium text-canopy-text"
+                  >
+                    Starting Layout
+                  </label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="text-canopy-text/40 hover:text-canopy-text/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-canopy-accent focus-visible:ring-offset-2"
+                        aria-label="Help for Starting Layout field"
                         disabled={isPending}
                       >
-                        <span className="flex items-center gap-2 truncate">
-                          <Play className="shrink-0 text-canopy-accent" />
-                          {selectedRecipe ? (
-                            <>
-                              <span>{selectedRecipe.name}</span>
-                              <span className="text-xs text-canopy-text/50">
-                                ({selectedRecipe.terminals.length} terminal
-                                {selectedRecipe.terminals.length !== 1 ? "s" : ""})
-                              </span>
-                            </>
-                          ) : (
-                            <span className="text-canopy-text/60">No recipe</span>
-                          )}
-                        </span>
-                        <ChevronsUpDown className="opacity-50 shrink-0" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      className="w-[400px] p-0"
-                      align="start"
-                      onEscapeKeyDown={(e) => e.stopPropagation()}
+                        <Info className="w-3.5 h-3.5" aria-hidden="true" />
+                        <span className="sr-only">Help for Starting Layout field</span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">
+                      <p>Choose the initial panel layout for the new worktree</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Popover open={recipePickerOpen} onOpenChange={setRecipePickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="recipe-selector"
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={recipePickerOpen}
+                      aria-haspopup="listbox"
+                      aria-controls="recipe-list"
+                      className="w-full justify-between bg-canopy-bg border-canopy-border text-canopy-text hover:bg-canopy-bg hover:text-canopy-text"
+                      disabled={isPending}
                     >
-                      <ScrollShadow
-                        id="recipe-list"
-                        role="listbox"
-                        className="max-h-[300px]"
-                        scrollClassName="p-1"
+                      <span className="flex items-center gap-2 truncate">
+                        {selectedRecipeId === CLONE_LAYOUT_ID ? (
+                          <>
+                            <Copy className="shrink-0 text-canopy-accent" />
+                            <span>Clone current layout</span>
+                          </>
+                        ) : selectedRecipe ? (
+                          <>
+                            <Play className="shrink-0 text-canopy-accent" />
+                            <span>{selectedRecipe.name}</span>
+                            <span className="text-xs text-canopy-text/50">
+                              ({selectedRecipe.terminals.length} terminal
+                              {selectedRecipe.terminals.length !== 1 ? "s" : ""})
+                            </span>
+                          </>
+                        ) : (
+                          <>
+                            <Play className="shrink-0 text-canopy-accent" />
+                            <span className="text-canopy-text/60">Empty</span>
+                          </>
+                        )}
+                      </span>
+                      <ChevronsUpDown className="opacity-50 shrink-0" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[400px] p-0"
+                    align="start"
+                    onEscapeKeyDown={(e) => e.stopPropagation()}
+                  >
+                    <ScrollShadow
+                      id="recipe-list"
+                      role="listbox"
+                      className="max-h-[300px]"
+                      scrollClassName="p-1"
+                    >
+                      <div
+                        role="option"
+                        aria-selected={selectedRecipeId === CLONE_LAYOUT_ID}
+                        tabIndex={0}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            recipeSelectionTouchedRef.current = true;
+                            setSelectedRecipeId(CLONE_LAYOUT_ID);
+                            if (projectId)
+                              setLastSelectedWorktreeRecipeIdByProject(projectId, CLONE_LAYOUT_ID);
+                            setRecipePickerOpen(false);
+                          }
+                        }}
+                        onClick={() => {
+                          recipeSelectionTouchedRef.current = true;
+                          setSelectedRecipeId(CLONE_LAYOUT_ID);
+                          if (projectId)
+                            setLastSelectedWorktreeRecipeIdByProject(projectId, CLONE_LAYOUT_ID);
+                          setRecipePickerOpen(false);
+                        }}
+                        className={cn(
+                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
+                          selectedRecipeId === CLONE_LAYOUT_ID && "bg-canopy-border"
+                        )}
                       >
-                        <div
-                          role="option"
-                          aria-selected={selectedRecipeId === null}
-                          tabIndex={0}
-                          onKeyDown={(event) => {
-                            if (event.key === "Enter" || event.key === " ") {
-                              event.preventDefault();
-                              recipeSelectionTouchedRef.current = true;
-                              setSelectedRecipeId(null);
-                              if (projectId)
-                                setLastSelectedWorktreeRecipeIdByProject(projectId, null);
-                              setRecipePickerOpen(false);
-                            }
-                          }}
-                          onClick={() => {
+                        <div className="flex items-center gap-2">
+                          <Copy className="h-3.5 w-3.5 text-canopy-text/50" />
+                          <span>Clone current layout</span>
+                        </div>
+                        {selectedRecipeId === CLONE_LAYOUT_ID && (
+                          <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
+                        )}
+                      </div>
+                      <div
+                        role="option"
+                        aria-selected={selectedRecipeId === null}
+                        tabIndex={0}
+                        onKeyDown={(event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
                             recipeSelectionTouchedRef.current = true;
                             setSelectedRecipeId(null);
                             if (projectId)
                               setLastSelectedWorktreeRecipeIdByProject(projectId, null);
                             setRecipePickerOpen(false);
-                          }}
-                          className={cn(
-                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
-                            selectedRecipeId === null && "bg-canopy-border"
-                          )}
-                        >
-                          <span className="text-canopy-text/60">No recipe</span>
-                          {selectedRecipeId === null && (
-                            <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
-                          )}
-                        </div>
+                          }
+                        }}
+                        onClick={() => {
+                          recipeSelectionTouchedRef.current = true;
+                          setSelectedRecipeId(null);
+                          if (projectId)
+                            setLastSelectedWorktreeRecipeIdByProject(projectId, null);
+                          setRecipePickerOpen(false);
+                        }}
+                        className={cn(
+                          "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
+                          selectedRecipeId === null && "bg-canopy-border"
+                        )}
+                      >
+                        <span className="text-canopy-text/60">Empty</span>
+                        {selectedRecipeId === null && (
+                          <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
+                        )}
+                      </div>
                         {globalRecipes.map((recipe) => (
                           <div
                             key={recipe.id}
@@ -1434,7 +1519,6 @@ export function NewWorktreeDialog({
                     </PopoverContent>
                   </Popover>
                 </div>
-              )}
 
               {initialPR && prBranchResolved === false && (
                 <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)]">

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -490,22 +490,32 @@ export function NewWorktreeDialog({
           useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
 
           if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
-            const terminals = useRecipeStore
-              .getState()
-              .generateRecipeFromActiveTerminals(sourceWorktreeId);
-            for (const t of terminals) {
-              await useTerminalStore.getState().addTerminal({
-                kind:
-                  t.type === "dev-preview"
-                    ? "dev-preview"
-                    : t.type === "terminal"
-                      ? "terminal"
-                      : "agent",
-                agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
-                title: t.title,
-                cwd: worktreePath.trim(),
-                worktreeId,
-                exitBehavior: t.exitBehavior,
+            try {
+              const terminals = useRecipeStore
+                .getState()
+                .generateRecipeFromActiveTerminals(sourceWorktreeId);
+              for (const t of terminals) {
+                await useTerminalStore.getState().addTerminal({
+                  kind:
+                    t.type === "dev-preview"
+                      ? "dev-preview"
+                      : t.type === "terminal"
+                        ? "terminal"
+                        : "agent",
+                  agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                  title: t.title,
+                  cwd: worktreePath.trim(),
+                  worktreeId,
+                  exitBehavior: t.exitBehavior,
+                });
+              }
+            } catch (cloneErr) {
+              const message =
+                cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
+              notify({
+                type: "warning",
+                title: "Could not clone layout",
+                message: `${message} — worktree was created successfully`,
               });
             }
           } else if (selectedRecipe) {
@@ -660,22 +670,32 @@ export function NewWorktreeDialog({
         }
 
         if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
-          const terminals = useRecipeStore
-            .getState()
-            .generateRecipeFromActiveTerminals(sourceWorktreeId);
-          for (const t of terminals) {
-            await useTerminalStore.getState().addTerminal({
-              kind:
-                t.type === "dev-preview"
-                  ? "dev-preview"
-                  : t.type === "terminal"
-                    ? "terminal"
-                    : "agent",
-              agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
-              title: t.title,
-              cwd: worktreePath.trim(),
-              worktreeId,
-              exitBehavior: t.exitBehavior,
+          try {
+            const terminals = useRecipeStore
+              .getState()
+              .generateRecipeFromActiveTerminals(sourceWorktreeId);
+            for (const t of terminals) {
+              await useTerminalStore.getState().addTerminal({
+                kind:
+                  t.type === "dev-preview"
+                    ? "dev-preview"
+                    : t.type === "terminal"
+                      ? "terminal"
+                      : "agent",
+                agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                title: t.title,
+                cwd: worktreePath.trim(),
+                worktreeId,
+                exitBehavior: t.exitBehavior,
+              });
+            }
+          } catch (cloneErr) {
+            const message =
+              cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
+            notify({
+              type: "warning",
+              title: "Could not clone layout",
+              message: `${message} — worktree was created successfully`,
             });
           }
         } else if (selectedRecipe) {

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -690,8 +690,7 @@ export function NewWorktreeDialog({
               });
             }
           } catch (cloneErr) {
-            const message =
-              cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
+            const message = cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
             notify({
               type: "warning",
               title: "Could not clone layout",
@@ -1476,8 +1475,7 @@ export function NewWorktreeDialog({
                         onClick={() => {
                           recipeSelectionTouchedRef.current = true;
                           setSelectedRecipeId(null);
-                          if (projectId)
-                            setLastSelectedWorktreeRecipeIdByProject(projectId, null);
+                          if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, null);
                           setRecipePickerOpen(false);
                         }}
                         className={cn(
@@ -1490,55 +1488,53 @@ export function NewWorktreeDialog({
                           <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
                         )}
                       </div>
-                        {globalRecipes.map((recipe) => (
-                          <div
-                            key={recipe.id}
-                            role="option"
-                            aria-selected={recipe.id === selectedRecipeId}
-                            tabIndex={0}
-                            onKeyDown={(event) => {
-                              if (event.key === "Enter" || event.key === " ") {
-                                event.preventDefault();
-                                recipeSelectionTouchedRef.current = true;
-                                setSelectedRecipeId(recipe.id);
-                                if (projectId)
-                                  setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
-                                setRecipePickerOpen(false);
-                              }
-                            }}
-                            onClick={() => {
+                      {globalRecipes.map((recipe) => (
+                        <div
+                          key={recipe.id}
+                          role="option"
+                          aria-selected={recipe.id === selectedRecipeId}
+                          tabIndex={0}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
                               recipeSelectionTouchedRef.current = true;
                               setSelectedRecipeId(recipe.id);
                               if (projectId)
                                 setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
                               setRecipePickerOpen(false);
-                            }}
-                            className={cn(
-                              "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
-                              recipe.id === selectedRecipeId && "bg-canopy-border"
-                            )}
-                          >
-                            <div className="flex items-center gap-2 min-w-0">
-                              <span className="truncate">{recipe.name}</span>
-                              <span className="text-xs text-canopy-text/50 shrink-0">
-                                {recipe.terminals.length} terminal
-                                {recipe.terminals.length !== 1 ? "s" : ""}
-                              </span>
-                              {recipe.id === defaultRecipeId && (
-                                <span className="text-xs text-canopy-accent shrink-0">
-                                  (default)
-                                </span>
-                              )}
-                            </div>
-                            {recipe.id === selectedRecipeId && (
-                              <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
+                            }
+                          }}
+                          onClick={() => {
+                            recipeSelectionTouchedRef.current = true;
+                            setSelectedRecipeId(recipe.id);
+                            if (projectId)
+                              setLastSelectedWorktreeRecipeIdByProject(projectId, recipe.id);
+                            setRecipePickerOpen(false);
+                          }}
+                          className={cn(
+                            "flex items-center justify-between gap-2 px-2 py-1.5 text-sm rounded-[var(--radius-sm)] cursor-pointer hover:bg-canopy-border",
+                            recipe.id === selectedRecipeId && "bg-canopy-border"
+                          )}
+                        >
+                          <div className="flex items-center gap-2 min-w-0">
+                            <span className="truncate">{recipe.name}</span>
+                            <span className="text-xs text-canopy-text/50 shrink-0">
+                              {recipe.terminals.length} terminal
+                              {recipe.terminals.length !== 1 ? "s" : ""}
+                            </span>
+                            {recipe.id === defaultRecipeId && (
+                              <span className="text-xs text-canopy-accent shrink-0">(default)</span>
                             )}
                           </div>
-                        ))}
-                      </ScrollShadow>
-                    </PopoverContent>
-                  </Popover>
-                </div>
+                          {recipe.id === selectedRecipeId && (
+                            <Check className="h-4 w-4 shrink-0 text-canopy-accent" />
+                          )}
+                        </div>
+                      ))}
+                    </ScrollShadow>
+                  </PopoverContent>
+                </Popover>
+              </div>
 
               {initialPR && prBranchResolved === false && (
                 <div className="flex items-start gap-2 p-3 bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)]">

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -44,9 +44,21 @@ vi.mock("@/clients/systemClient", () => ({
   systemClient: { openExternal: vi.fn() },
 }));
 
+const mockAddTerminal = vi.fn().mockResolvedValue("new-terminal-id");
+vi.mock("@/store/terminalStore", () => ({
+  useTerminalStore: Object.assign(() => ({}), {
+    getState: () => ({ addTerminal: mockAddTerminal }),
+  }),
+}));
+
+const mockGenerateRecipeFromActiveTerminals = vi.fn().mockReturnValue([]);
 vi.mock("@/store/recipeStore", () => ({
   useRecipeStore: Object.assign(() => ({ recipes: [], runRecipe: vi.fn() }), {
-    getState: () => ({ runRecipeWithResults: vi.fn(), getRecipeById: () => null }),
+    getState: () => ({
+      runRecipeWithResults: vi.fn(),
+      getRecipeById: () => null,
+      generateRecipeFromActiveTerminals: mockGenerateRecipeFromActiveTerminals,
+    }),
   }),
 }));
 
@@ -98,6 +110,7 @@ vi.mock("@/store/worktreeStore", () => ({
 }));
 
 vi.mock("@/components/Worktree/hooks/useRecipePicker", () => ({
+  CLONE_LAYOUT_ID: "__clone_layout__",
   useRecipePicker: () => ({
     selectedRecipeId: null,
     setSelectedRecipeId: vi.fn(),

--- a/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useRecipePicker, CLONE_LAYOUT_ID } from "../useRecipePicker";
+import type { TerminalRecipe } from "@/types";
+
+function makeRecipe(id: string, name = id): TerminalRecipe {
+  return {
+    id,
+    name,
+    terminals: [{ type: "terminal" }],
+    createdAt: Date.now(),
+  } as TerminalRecipe;
+}
+
+const defaultArgs = {
+  isOpen: true,
+  defaultRecipeId: undefined as string | undefined,
+  globalRecipes: [] as TerminalRecipe[],
+  lastSelectedWorktreeRecipeId: undefined as string | null | undefined,
+  projectId: "test-project",
+  initialRecipeId: undefined as string | null | undefined,
+  setLastSelectedWorktreeRecipeIdByProject: vi.fn(),
+};
+
+describe("useRecipePicker", () => {
+  it("auto-selects CLONE_LAYOUT_ID when no recipes, no defaults, no last-selected", () => {
+    const { result } = renderHook(() => useRecipePicker({ ...defaultArgs }));
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+  });
+
+  it("preserves null when lastSelected is null (user chose Empty)", () => {
+    const { result } = renderHook(() =>
+      useRecipePicker({ ...defaultArgs, lastSelectedWorktreeRecipeId: null })
+    );
+    expect(result.current.selectedRecipeId).toBe(null);
+  });
+
+  it("preserves CLONE_LAYOUT_ID when lastSelected is CLONE_LAYOUT_ID", () => {
+    const { result } = renderHook(() =>
+      useRecipePicker({ ...defaultArgs, lastSelectedWorktreeRecipeId: CLONE_LAYOUT_ID })
+    );
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+  });
+
+  it("selects defaultRecipeId when available and no lastSelected", () => {
+    const recipes = [makeRecipe("recipe-1")];
+    const { result } = renderHook(() =>
+      useRecipePicker({ ...defaultArgs, globalRecipes: recipes, defaultRecipeId: "recipe-1" })
+    );
+    expect(result.current.selectedRecipeId).toBe("recipe-1");
+  });
+
+  it("falls back to CLONE_LAYOUT_ID when defaultRecipeId is not in globalRecipes", () => {
+    const { result } = renderHook(() =>
+      useRecipePicker({ ...defaultArgs, defaultRecipeId: "nonexistent" })
+    );
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+  });
+
+  it("selects initialRecipeId over everything when valid", () => {
+    const recipes = [makeRecipe("recipe-1"), makeRecipe("recipe-2")];
+    const { result } = renderHook(() =>
+      useRecipePicker({
+        ...defaultArgs,
+        globalRecipes: recipes,
+        defaultRecipeId: "recipe-1",
+        initialRecipeId: "recipe-2",
+      })
+    );
+    expect(result.current.selectedRecipeId).toBe("recipe-2");
+  });
+
+  it("does not invalidate CLONE_LAYOUT_ID as stale", () => {
+    const { result, rerender } = renderHook(
+      (props) => useRecipePicker(props),
+      { initialProps: { ...defaultArgs } }
+    );
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+
+    // Simulate recipes changing (triggers stale invalidation effect)
+    rerender({ ...defaultArgs, globalRecipes: [makeRecipe("new-recipe")] });
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+  });
+
+  it("does not auto-select when dialog is closed", () => {
+    const { result } = renderHook(() => useRecipePicker({ ...defaultArgs, isOpen: false }));
+    // Default state is null (no auto-selection runs when closed)
+    expect(result.current.selectedRecipeId).toBe(null);
+  });
+
+  it("clears stale lastSelected and falls back to clone", () => {
+    const setter = vi.fn();
+    const { result } = renderHook(() =>
+      useRecipePicker({
+        ...defaultArgs,
+        lastSelectedWorktreeRecipeId: "deleted-recipe",
+        setLastSelectedWorktreeRecipeIdByProject: setter,
+      })
+    );
+    expect(setter).toHaveBeenCalledWith("test-project", undefined);
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+  });
+
+  it("respects user touch and does not override", () => {
+    const { result } = renderHook(() => useRecipePicker({ ...defaultArgs }));
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+
+    act(() => {
+      result.current.recipeSelectionTouchedRef.current = true;
+      result.current.setSelectedRecipeId(null);
+    });
+    expect(result.current.selectedRecipeId).toBe(null);
+  });
+
+  it("selectedRecipe is undefined for sentinel IDs", () => {
+    const recipes = [makeRecipe("recipe-1")];
+    const { result } = renderHook(() =>
+      useRecipePicker({ ...defaultArgs, globalRecipes: recipes })
+    );
+    expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+    expect(result.current.selectedRecipe).toBeUndefined();
+  });
+});

--- a/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
@@ -74,15 +74,18 @@ describe("useRecipePicker", () => {
   });
 
   it("does not invalidate CLONE_LAYOUT_ID as stale", () => {
+    const setter = vi.fn();
     const { result, rerender } = renderHook(
       (props) => useRecipePicker(props),
-      { initialProps: { ...defaultArgs } }
+      { initialProps: { ...defaultArgs, setLastSelectedWorktreeRecipeIdByProject: setter } }
     );
     expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+    setter.mockClear();
 
     // Simulate recipes changing (triggers stale invalidation effect)
-    rerender({ ...defaultArgs, globalRecipes: [makeRecipe("new-recipe")] });
+    rerender({ ...defaultArgs, setLastSelectedWorktreeRecipeIdByProject: setter, globalRecipes: [makeRecipe("new-recipe")] });
     expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
+    expect(setter).not.toHaveBeenCalled();
   });
 
   it("does not auto-select when dialog is closed", () => {

--- a/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useRecipePicker.test.ts
@@ -75,15 +75,18 @@ describe("useRecipePicker", () => {
 
   it("does not invalidate CLONE_LAYOUT_ID as stale", () => {
     const setter = vi.fn();
-    const { result, rerender } = renderHook(
-      (props) => useRecipePicker(props),
-      { initialProps: { ...defaultArgs, setLastSelectedWorktreeRecipeIdByProject: setter } }
-    );
+    const { result, rerender } = renderHook((props) => useRecipePicker(props), {
+      initialProps: { ...defaultArgs, setLastSelectedWorktreeRecipeIdByProject: setter },
+    });
     expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
     setter.mockClear();
 
     // Simulate recipes changing (triggers stale invalidation effect)
-    rerender({ ...defaultArgs, setLastSelectedWorktreeRecipeIdByProject: setter, globalRecipes: [makeRecipe("new-recipe")] });
+    rerender({
+      ...defaultArgs,
+      setLastSelectedWorktreeRecipeIdByProject: setter,
+      globalRecipes: [makeRecipe("new-recipe")],
+    });
     expect(result.current.selectedRecipeId).toBe(CLONE_LAYOUT_ID);
     expect(setter).not.toHaveBeenCalled();
   });

--- a/src/components/Worktree/hooks/useRecipePicker.ts
+++ b/src/components/Worktree/hooks/useRecipePicker.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import type { TerminalRecipe } from "@/types";
 
+export const CLONE_LAYOUT_ID = "__clone_layout__";
+
 export interface UseRecipePickerResult {
   selectedRecipeId: string | null;
   setSelectedRecipeId: React.Dispatch<React.SetStateAction<string | null>>;
@@ -40,29 +42,33 @@ export function useRecipePicker({
     recipeSelectionTouchedRef.current = false;
   }, [isOpen]);
 
-  // Auto-select recipe: initialRecipeId > lastSelected > default > null
+  // Auto-select recipe: initialRecipeId > lastSelected > default > clone layout
   useEffect(() => {
     if (!isOpen) return;
     if (!projectId) return;
-    if (globalRecipes.length === 0) return;
     if (recipeSelectionTouchedRef.current) return;
 
     if (initialRecipeId && globalRecipes.some((r) => r.id === initialRecipeId)) {
       setSelectedRecipeId(initialRecipeId);
     } else if (lastSelectedWorktreeRecipeId !== undefined) {
-      if (
-        lastSelectedWorktreeRecipeId === null ||
-        globalRecipes.some((r) => r.id === lastSelectedWorktreeRecipeId)
-      ) {
+      if (lastSelectedWorktreeRecipeId === null) {
+        setSelectedRecipeId(null);
+      } else if (lastSelectedWorktreeRecipeId === CLONE_LAYOUT_ID) {
+        setSelectedRecipeId(CLONE_LAYOUT_ID);
+      } else if (globalRecipes.some((r) => r.id === lastSelectedWorktreeRecipeId)) {
         setSelectedRecipeId(lastSelectedWorktreeRecipeId);
       } else {
         if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, undefined);
         if (defaultRecipeId && globalRecipes.some((r) => r.id === defaultRecipeId)) {
           setSelectedRecipeId(defaultRecipeId);
+        } else {
+          setSelectedRecipeId(CLONE_LAYOUT_ID);
         }
       }
     } else if (defaultRecipeId && globalRecipes.some((r) => r.id === defaultRecipeId)) {
       setSelectedRecipeId(defaultRecipeId);
+    } else {
+      setSelectedRecipeId(CLONE_LAYOUT_ID);
     }
   }, [
     isOpen,
@@ -74,9 +80,10 @@ export function useRecipePicker({
     setLastSelectedWorktreeRecipeIdByProject,
   ]);
 
-  // Invalidate stale recipe
+  // Invalidate stale recipe (skip sentinel IDs)
   useEffect(() => {
     if (!selectedRecipeId) return;
+    if (selectedRecipeId === CLONE_LAYOUT_ID) return;
     if (globalRecipes.some((recipe) => recipe.id === selectedRecipeId)) return;
     setSelectedRecipeId(null);
     if (projectId) setLastSelectedWorktreeRecipeIdByProject(projectId, undefined);


### PR DESCRIPTION
## Summary

- When creating a new worktree without a recipe, the panel area was left completely empty since panels are scoped per-worktree and the new one had none assigned
- After worktree creation, a default terminal panel is now automatically opened at the worktree's path, so you land on something useful straight away
- When a recipe is selected, this is skipped since the recipe handles panel creation itself

Resolves #4983

## Changes

- `NewWorktreeDialog.tsx`: after `selectWorktree()`, when no recipe is selected, calls `addTerminal()` directly on the store with `location: "grid"` and the worktree's path as `cwd`
- `BulkCreateWorktreeDialog.tsx`: same default terminal logic applied to bulk creation flow
- `useRecipePicker.ts`: minor refactor to expose `selectedRecipe` cleanly for the above checks
- Tests updated across `NewWorktreeDialog.test.tsx`, `BulkCreateWorktreeDialog.test.tsx`, and `useRecipePicker.test.ts` to cover the new default panel behaviour

## Testing

Unit tests pass. The fix avoids the React state timing race by calling the store directly (bypassing the `activeWorktreeId` re-render cycle), so the terminal is created before the UI settles on the new worktree.