### PR TITLE
fix(dock): restore dock visibility and click handlers

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -69,8 +69,15 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     const groups = getTabGroups("dock", activeWorktreeId ?? undefined);
     if (!helpTerminalId) return groups;
     return groups.filter((g) => !(g.panelIds.length === 1 && g.panelIds[0] === helpTerminalId));
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- storeTerminalIds/trashedTerminals are intentional trigger deps
-  }, [getTabGroups, activeWorktreeId, storeTerminalIds, trashedTerminals, helpTerminalId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- storeTerminalIds/terminalsById/trashedTerminals are intentional trigger deps
+  }, [
+    getTabGroups,
+    activeWorktreeId,
+    storeTerminalIds,
+    terminalsById,
+    trashedTerminals,
+    helpTerminalId,
+  ]);
 
   const { worktrees } = useWorktrees();
 

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -392,6 +392,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
+              if (e.detail >= 2) return;
               if (isOpen) {
                 closeDockTerminal();
               } else {

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -87,15 +87,6 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Derive isOpen from store state - open if ANY panel in this group is active
   const isOpen = panels.some((p) => p.id === activeDockTerminalId);
 
-  // Click/double-click arbitration: defer single-click action to distinguish from double-click.
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
-    };
-  }, []);
-
   // Track when popover was just programmatically opened
   const wasJustOpenedRef = useRef(false);
   const prevIsOpenRef = useRef(isOpen);
@@ -401,22 +392,17 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              if (clickTimerRef.current) {
-                clearTimeout(clickTimerRef.current);
-                clickTimerRef.current = null;
+              if (isOpen) {
+                closeDockTerminal();
+              } else {
+                openDockTerminal(activeTabId);
               }
-              if (e.detail >= 2) {
-                moveTerminalToGrid(activePanel.id);
-                return;
-              }
-              clickTimerRef.current = setTimeout(() => {
-                clickTimerRef.current = null;
-                if (isOpen) {
-                  closeDockTerminal();
-                } else {
-                  openDockTerminal(activeTabId);
-                }
-              }, 250);
+            }}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              const moved = moveTerminalToGrid(activePanel.id);
+              if (moved) closeDockTerminal();
             }}
             aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
           >

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -223,6 +223,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
+              if (e.detail >= 2) return;
               if (isOpen) {
                 closeDockTerminal();
               } else {

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -42,15 +42,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   // Derive isOpen from store state
   const isOpen = activeDockTerminalId === terminal.id;
 
-  // Click/double-click arbitration: defer single-click action to distinguish from double-click.
-  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
-    };
-  }, []);
-
   // Track when popover was just programmatically opened to ignore immediate close events
   const wasJustOpenedRef = useRef(false);
   const prevIsOpenRef = useRef(isOpen);
@@ -232,25 +223,17 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              if (clickTimerRef.current) {
-                clearTimeout(clickTimerRef.current);
-                clickTimerRef.current = null;
+              if (isOpen) {
+                closeDockTerminal();
+              } else {
+                openDockTerminal(terminal.id);
               }
-              if (e.detail >= 2) {
-                // Double-click: move to grid. moveTerminalToGrid in the store
-                // atomically clears activeDockTerminalId so no separate close needed.
-                moveTerminalToGrid(terminal.id);
-                return;
-              }
-              // Single-click: defer to distinguish from double-click
-              clickTimerRef.current = setTimeout(() => {
-                clickTimerRef.current = null;
-                if (isOpen) {
-                  closeDockTerminal();
-                } else {
-                  openDockTerminal(terminal.id);
-                }
-              }, 250);
+            }}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              const moved = moveTerminalToGrid(terminal.id);
+              if (moved) closeDockTerminal();
             }}
             aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
           >

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -441,8 +441,8 @@ export function ContentGrid({
   // Get tab groups for the active worktree
   const tabGroups = useMemo(() => {
     return getTabGroups("grid", activeWorktreeId ?? undefined);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- storeTerminalIds/trashedTerminals are intentional trigger deps
-  }, [getTabGroups, activeWorktreeId, storeTerminalIds, trashedTerminals]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- storeTerminalIds/terminalsById/trashedTerminals are intentional trigger deps
+  }, [getTabGroups, activeWorktreeId, storeTerminalIds, terminalsById, trashedTerminals]);
 
   // Handler for adding a new tab to a single panel (creates a tab group)
   const handleAddTabForPanel = useCallback(

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -337,7 +337,7 @@ function TerminalPaneComponent({
 
     observer.observe(containerRef.current);
     return () => observer.disconnect();
-  }, [id, updateVisibility]);
+  }, [id, restartKey, updateVisibility]);
 
   // Separate unmount cleanup — only update store visibility.
   // The service-level setVisible(false) is handled by XtermAdapter's own

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -314,9 +314,13 @@ function TerminalPaneComponent({
     isDraggingRef.current = isDragging;
   }, [isDragging]);
 
-  // Visibility observation - stable observer, ref-gated callback
+  // Visibility observation - stable observer, ref-gated callback.
+  // Capture attach generation so stale IntersectionObserver callbacks from a
+  // previous mount site don't hide a terminal that has already been re-attached.
   useEffect(() => {
     if (!containerRef.current) return;
+
+    const gen = terminalInstanceService.getAttachGeneration(id);
 
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -324,7 +328,7 @@ function TerminalPaneComponent({
         if (isDraggingRef.current) return;
 
         updateVisibility(id, entry.isIntersecting);
-        terminalInstanceService.setVisible(id, entry.isIntersecting);
+        terminalInstanceService.setVisible(id, entry.isIntersecting, gen);
       },
       {
         threshold: 0.1,
@@ -335,14 +339,15 @@ function TerminalPaneComponent({
     return () => observer.disconnect();
   }, [id, updateVisibility]);
 
-  // Separate unmount cleanup - only runs on actual unmount, not on drag changes.
-  // Capture attach generation so stale dock unmounts don't background a terminal
-  // that has already been re-attached to the grid.
+  // Separate unmount cleanup — only update store visibility.
+  // The service-level setVisible(false) is handled by XtermAdapter's own
+  // useLayoutEffect cleanup, which has the correct attachGeneration guard.
+  // Calling it here too is redundant and breaks in React StrictMode (dev),
+  // where the effect's cleanup captures the same generation as the active
+  // mount, bypassing the stale-generation guard and hiding the terminal.
   useEffect(() => {
-    const gen = terminalInstanceService.getAttachGeneration(id);
     return () => {
       updateVisibility(id, false);
-      terminalInstanceService.setVisible(id, false, gen);
     };
   }, [id, updateVisibility]);
 

--- a/src/store/slices/terminalRegistry/tabGroups.ts
+++ b/src/store/slices/terminalRegistry/tabGroups.ts
@@ -237,7 +237,9 @@ export const createTabGroupActions = (
       if (group.location === location && (group.worktreeId ?? undefined) === worktreeId) {
         const validPanelIds = group.panelIds.filter((id) => {
           const panel = state.terminalsById[id];
-          return panel && panel.location !== "trash" && !trashedTerminals.has(id);
+          if (!panel || trashedTerminals.has(id)) return false;
+          const panelLocation = panel.location ?? "grid";
+          return panelLocation === location;
         });
 
         if (validPanelIds.length > 0) {


### PR DESCRIPTION
## Summary

Fixes #4995 — dock interactions broken: terminals disappear when docked, click handlers unresponsive.

- **Restore split onClick/onDoubleClick handlers** in DockedTerminalItem and DockedTabGroup, reverting the 250ms setTimeout arbitration from 7b71ccb3f that broke single-click responsiveness and double-click cleanup
- **Add `terminalsById` to useMemo deps** in ContentDock and ContentGrid so tab groups recompute when a terminal's location changes (root cause of docked terminals not appearing)
- **Filter explicit tab group panels by location** in `getTabGroups` so a panel moved to dock doesn't leave a ghost outline in the grid
- **Guard IntersectionObserver setVisible with attachGeneration** to prevent stale callbacks from hiding re-attached terminals
- **Remove redundant setVisible(false) from TerminalPane unmount** — XtermAdapter's cleanup already handles this, and the duplicate breaks React StrictMode

## Test plan

- [ ] Dock a single agent terminal → appears in dock immediately
- [ ] Dock one of two grid terminals → docked one disappears from grid, appears in dock; remaining terminal fills grid
- [ ] Single-click docked item → popover opens instantly (no 250ms delay)
- [ ] Click again → popover closes
- [ ] Double-click docked item → moves back to grid with content visible
- [ ] Dock→expand→collapse cycle → terminal stays consistent in dock