### PR TITLE
feat(agent-state): add 'exited' state for cleanly terminated terminals

### DIFF
--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -281,7 +281,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         throw new Error("Invalid state: must be a non-empty string");
       }
 
-      const validStates = ["idle", "working", "waiting", "completed"];
+      const validStates = ["idle", "working", "waiting", "completed", "exited"];
       if (!validStates.includes(state)) {
         throw new Error(`Invalid state: must be one of ${validStates.join(", ")}`);
       }

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -499,7 +499,11 @@ events.on("agent:state-changed", (payload) => {
       sessionTokens: payload.sessionTokens,
     });
 
-    if (payload.state === "waiting" || payload.state === "completed") {
+    if (
+      payload.state === "waiting" ||
+      payload.state === "completed" ||
+      payload.state === "exited"
+    ) {
       ptyManager.flushAgentSnapshot(payload.terminalId);
     }
   }

--- a/electron/schemas/agent.ts
+++ b/electron/schemas/agent.ts
@@ -3,7 +3,14 @@ import { BUILT_IN_TERMINAL_TYPES } from "../../shared/config/agentIds.js";
 
 export const TerminalTypeSchema = z.enum(BUILT_IN_TERMINAL_TYPES);
 
-export const AgentStateSchema = z.enum(["idle", "working", "running", "waiting", "completed"]);
+export const AgentStateSchema = z.enum([
+  "idle",
+  "working",
+  "running",
+  "waiting",
+  "completed",
+  "exited",
+]);
 
 // @see shared/types/events.ts for the TypeScript interface definition.
 export const EventContextSchema = z.object({

--- a/electron/services/ActivityHeadlineGenerator.ts
+++ b/electron/services/ActivityHeadlineGenerator.ts
@@ -104,6 +104,12 @@ export class ActivityHeadlineGenerator {
           status: "success",
           type: "idle",
         };
+      case "exited":
+        return {
+          headline: "Exited",
+          status: "success",
+          type: "idle",
+        };
       case "idle":
       default:
         return {

--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -139,7 +139,11 @@ class AgentNotificationService {
 
     // Cancel any pending completion timer for this agent when it leaves "completed"
     // (must run even when master toggle is off to prevent stale timers)
-    if (previousState === "completed" && state !== "completed") {
+    if (
+      (previousState === "completed" || previousState === "exited") &&
+      state !== "completed" &&
+      state !== "exited"
+    ) {
       const timer = this.completionTimers.get(key);
       if (timer) {
         clearTimeout(timer);
@@ -190,7 +194,7 @@ class AgentNotificationService {
     const isWatched = terminalId !== undefined && this.watchedTerminals.has(terminalId);
     if (!isWatched) return;
 
-    if (state === "completed" && settings.completedEnabled) {
+    if ((state === "completed" || state === "exited") && settings.completedEnabled) {
       this.scheduleCompletionNotification(key, worktreeId, terminalId, agentId);
     } else if (
       state === "waiting" &&

--- a/electron/services/AgentStateMachine.ts
+++ b/electron/services/AgentStateMachine.ts
@@ -13,11 +13,12 @@ export type AgentEvent =
 
 const VALID_TRANSITIONS: Record<AgentState, AgentState[]> = {
   idle: ["working", "running"],
-  working: ["waiting", "completed"],
+  working: ["waiting", "completed", "exited"],
   running: ["idle"], // Shell process state - managed by TerminalProcess, not this state machine
-  waiting: ["working", "completed"],
+  waiting: ["working", "completed", "exited"],
   directing: [], // Renderer-only state, never produced by main process
-  completed: ["working", "waiting"],
+  completed: ["working", "waiting", "exited"],
+  exited: [], // Terminal state - process is gone, no transitions out
 };
 
 export function isValidTransition(from: AgentState, to: AgentState): boolean {
@@ -72,8 +73,8 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
       break;
 
     case "exit":
-      if (current === "working" || current === "waiting" || current === "completed") {
-        return "completed";
+      if (current !== "idle" && current !== "exited") {
+        return "exited";
       }
       break;
   }

--- a/electron/services/__tests__/AgentStateMachine.test.ts
+++ b/electron/services/__tests__/AgentStateMachine.test.ts
@@ -25,8 +25,12 @@ describe("AgentStateMachine", () => {
       expect(isValidTransition("waiting", "working")).toBe(true);
     });
 
-    it("should allow waiting → completed (exit while waiting)", () => {
+    it("should allow waiting → completed", () => {
       expect(isValidTransition("waiting", "completed")).toBe(true);
+    });
+
+    it("should allow waiting → exited (exit while waiting)", () => {
+      expect(isValidTransition("waiting", "exited")).toBe(true);
     });
 
     it("should allow completed → waiting (prompt after completion)", () => {
@@ -37,8 +41,18 @@ describe("AgentStateMachine", () => {
       expect(isValidTransition("completed", "working")).toBe(true);
     });
 
-    it("should not allow completed → other states", () => {
+    it("should allow completed → exited (exit from completed)", () => {
+      expect(isValidTransition("completed", "exited")).toBe(true);
+    });
+
+    it("should not allow completed → idle", () => {
       expect(isValidTransition("completed", "idle")).toBe(false);
+    });
+
+    it("should not allow exited → any state (terminal state)", () => {
+      expect(isValidTransition("exited", "idle")).toBe(false);
+      expect(isValidTransition("exited", "working")).toBe(false);
+      expect(isValidTransition("exited", "completed")).toBe(false);
     });
 
     it("should not allow invalid transitions", () => {
@@ -59,6 +73,7 @@ describe("AgentStateMachine", () => {
         expect(nextAgentState("working", event)).toBe("working");
         expect(nextAgentState("waiting", event)).toBe("waiting");
         expect(nextAgentState("completed", event)).toBe("completed");
+        expect(nextAgentState("exited", event)).toBe("exited");
       });
     });
 
@@ -139,82 +154,87 @@ describe("AgentStateMachine", () => {
     });
 
     describe("exit event", () => {
-      it("should transition working → completed on exit code 0", () => {
+      it("should transition working → exited on exit code 0", () => {
         const event: AgentEvent = { type: "exit", code: 0 };
-        expect(nextAgentState("working", event)).toBe("completed");
+        expect(nextAgentState("working", event)).toBe("exited");
       });
 
-      it("should transition working → completed on non-crash exit code", () => {
+      it("should transition working → exited on non-crash exit code", () => {
         const event: AgentEvent = { type: "exit", code: 1 };
-        expect(nextAgentState("working", event)).toBe("completed");
+        expect(nextAgentState("working", event)).toBe("exited");
       });
 
-      it("should transition working → completed on routine signal exit (SIGINT)", () => {
-        expect(nextAgentState("working", { type: "exit", code: 0, signal: 2 })).toBe("completed");
+      it("should transition working → exited on routine signal exit (SIGINT)", () => {
+        expect(nextAgentState("working", { type: "exit", code: 0, signal: 2 })).toBe("exited");
       });
 
-      it("should transition working → completed on routine exit code (130 = SIGINT)", () => {
-        expect(nextAgentState("working", { type: "exit", code: 130 })).toBe("completed");
+      it("should transition working → exited on routine exit code (130 = SIGINT)", () => {
+        expect(nextAgentState("working", { type: "exit", code: 130 })).toBe("exited");
       });
 
-      it("should transition working → completed on SIGHUP signal", () => {
-        expect(nextAgentState("working", { type: "exit", code: 0, signal: 1 })).toBe("completed");
+      it("should transition working → exited on SIGHUP signal", () => {
+        expect(nextAgentState("working", { type: "exit", code: 0, signal: 1 })).toBe("exited");
       });
 
-      it("should transition working → completed on SIGTERM exit code (143)", () => {
-        expect(nextAgentState("working", { type: "exit", code: 143 })).toBe("completed");
+      it("should transition working → exited on SIGTERM exit code (143)", () => {
+        expect(nextAgentState("working", { type: "exit", code: 143 })).toBe("exited");
       });
 
-      it("should transition working → completed on crash signal (SIGSEGV)", () => {
-        expect(nextAgentState("working", { type: "exit", code: 139 })).toBe("completed");
+      it("should transition working → exited on crash signal (SIGSEGV)", () => {
+        expect(nextAgentState("working", { type: "exit", code: 139 })).toBe("exited");
       });
 
-      it("should transition waiting → completed on exit code 0", () => {
+      it("should transition waiting → exited on exit code 0", () => {
         const event: AgentEvent = { type: "exit", code: 0 };
-        expect(nextAgentState("waiting", event)).toBe("completed");
+        expect(nextAgentState("waiting", event)).toBe("exited");
       });
 
-      it("should transition waiting → completed on non-crash exit code", () => {
+      it("should transition waiting → exited on non-crash exit code", () => {
         const event: AgentEvent = { type: "exit", code: 1 };
-        expect(nextAgentState("waiting", event)).toBe("completed");
+        expect(nextAgentState("waiting", event)).toBe("exited");
       });
 
-      it("should transition waiting → completed on routine exit (SIGTERM)", () => {
-        expect(nextAgentState("waiting", { type: "exit", code: 143 })).toBe("completed");
+      it("should transition waiting → exited on routine exit (SIGTERM)", () => {
+        expect(nextAgentState("waiting", { type: "exit", code: 143 })).toBe("exited");
       });
 
-      it("should transition waiting → completed on crash signal exit (SIGSEGV)", () => {
-        expect(nextAgentState("waiting", { type: "exit", code: 139 })).toBe("completed");
+      it("should transition waiting → exited on crash signal exit (SIGSEGV)", () => {
+        expect(nextAgentState("waiting", { type: "exit", code: 139 })).toBe("exited");
       });
 
-      it("should stay completed on non-crash exit from completed", () => {
+      it("should transition completed → exited on exit", () => {
         const event: AgentEvent = { type: "exit", code: 1 };
-        expect(nextAgentState("completed", event)).toBe("completed");
+        expect(nextAgentState("completed", event)).toBe("exited");
       });
 
-      it("should transition working → completed on crash signal exit (SIGABRT)", () => {
-        expect(nextAgentState("working", { type: "exit", code: 134 })).toBe("completed");
+      it("should transition working → exited on crash signal exit (SIGABRT)", () => {
+        expect(nextAgentState("working", { type: "exit", code: 134 })).toBe("exited");
       });
 
-      it("should transition completed → completed on crash signal exit (SIGABRT)", () => {
-        expect(nextAgentState("completed", { type: "exit", code: 134 })).toBe("completed");
+      it("should transition completed → exited on crash signal exit (SIGABRT)", () => {
+        expect(nextAgentState("completed", { type: "exit", code: 134 })).toBe("exited");
       });
 
-      it("should stay completed on zero exit from completed", () => {
+      it("should transition completed → exited on zero exit", () => {
         const event: AgentEvent = { type: "exit", code: 0 };
-        expect(nextAgentState("completed", event)).toBe("completed");
+        expect(nextAgentState("completed", event)).toBe("exited");
       });
 
-      it("should not transition from other states on exit", () => {
+      it("should not transition from idle on exit", () => {
         const event: AgentEvent = { type: "exit", code: 0 };
         expect(nextAgentState("idle", event)).toBe("idle");
+      });
+
+      it("should not transition from exited on exit (terminal state)", () => {
+        const event: AgentEvent = { type: "exit", code: 0 };
+        expect(nextAgentState("exited", event)).toBe("exited");
       });
     });
 
     describe("kill event", () => {
       it("should transition to idle from any state", () => {
         const event: AgentEvent = { type: "kill" };
-        const states: AgentState[] = ["idle", "working", "waiting", "completed"];
+        const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
 
         for (const state of states) {
           expect(nextAgentState(state, event)).toBe("idle");
@@ -225,7 +245,7 @@ describe("AgentStateMachine", () => {
     describe("error event (no-op)", () => {
       it("should not change state on error event", () => {
         const event: AgentEvent = { type: "error", error: "Something went wrong" };
-        const states: AgentState[] = ["idle", "working", "waiting", "completed"];
+        const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
 
         for (const state of states) {
           expect(nextAgentState(state, event)).toBe(state);

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -180,8 +180,12 @@ export class AgentStateService {
       trigger: inferredTrigger,
       confidence: inferredConfidence,
       ...(newState === "waiting" && waitingReason ? { waitingReason } : {}),
-      ...(newState === "completed" && sessionCost != null ? { sessionCost } : {}),
-      ...(newState === "completed" && sessionTokens != null ? { sessionTokens } : {}),
+      ...((newState === "completed" || newState === "exited") && sessionCost != null
+        ? { sessionCost }
+        : {}),
+      ...((newState === "completed" || newState === "exited") && sessionTokens != null
+        ? { sessionTokens }
+        : {}),
     };
 
     const validatedStateChange = AgentStateChangedSchema.safeParse(stateChangePayload);

--- a/electron/services/pty/__tests__/AgentStateService.test.ts
+++ b/electron/services/pty/__tests__/AgentStateService.test.ts
@@ -69,7 +69,7 @@ describe("AgentStateService", () => {
     expect(terminal.agentState).toBe("idle");
   });
 
-  it("transitions working → completed on crash-signal exit (no failed state)", () => {
+  it("transitions working → exited on crash-signal exit (no failed state)", () => {
     const service = new AgentStateService();
     const terminal = createTerminal({ agentState: "working" });
 
@@ -77,17 +77,17 @@ describe("AgentStateService", () => {
     const changed = service.updateAgentState(terminal, { type: "exit", code: 139 });
 
     expect(changed).toBe(true);
-    expect(terminal.agentState).toBe("completed");
+    expect(terminal.agentState).toBe("exited");
   });
 
-  it("transitions working → completed on routine exit", () => {
+  it("transitions working → exited on routine exit", () => {
     const service = new AgentStateService();
     const terminal = createTerminal({ agentState: "working" });
 
     const changed = service.updateAgentState(terminal, { type: "exit", code: 0 });
 
     expect(changed).toBe(true);
-    expect(terminal.agentState).toBe("completed");
+    expect(terminal.agentState).toBe("exited");
   });
 
   it("error event is a no-op and does not change state", () => {

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -1,5 +1,12 @@
-/** Agent lifecycle state: idle | working | running | waiting | directing | completed */
-export type AgentState = "idle" | "working" | "running" | "waiting" | "directing" | "completed";
+/** Agent lifecycle state: idle | working | running | waiting | directing | completed | exited */
+export type AgentState =
+  | "idle"
+  | "working"
+  | "running"
+  | "waiting"
+  | "directing"
+  | "completed"
+  | "exited";
 
 /** Classification of why an agent is in the "waiting" state */
 export type WaitingReason = "prompt" | "question";

--- a/shared/types/ipc/agent.ts
+++ b/shared/types/ipc/agent.ts
@@ -28,7 +28,7 @@ export type AgentStateChangeTrigger =
   | "title";
 
 /** Agent state */
-export type AgentState = "idle" | "working" | "running" | "waiting" | "completed";
+export type AgentState = "idle" | "working" | "running" | "waiting" | "completed" | "exited";
 
 /** Payload for agent state change events */
 export interface AgentStateChangePayload {
@@ -52,9 +52,9 @@ export interface AgentStateChangePayload {
   confidence: number;
   /** Why the agent is waiting (only present when state is "waiting") */
   waitingReason?: WaitingReason;
-  /** Extracted session cost in dollars (only present when state is "completed") */
+  /** Extracted session cost in dollars (only present when state is "completed" or "exited") */
   sessionCost?: number;
-  /** Extracted session token count (only present when state is "completed" and legacy format is used) */
+  /** Extracted session token count (only present when state is "completed" or "exited" and legacy format is used) */
   sessionTokens?: number;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -560,6 +560,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       let hasRunningAgent = false;
       let hasWaitingAgent = false;
       let hasCompletedAgent = false;
+      let hasExitedAgent = false;
 
       for (const id of terminalIds) {
         const t = terminalsById[id];
@@ -572,6 +573,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           waitingTerminalCount++;
         }
         if (t.agentState === "completed") hasCompletedAgent = true;
+        if (t.agentState === "exited") hasExitedAgent = true;
       }
 
       // chipState logic mirrors useWorktreeStatus.ts — keep in sync
@@ -604,6 +606,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         hasRunningAgent,
         hasWaitingAgent,
         hasCompletedAgent,
+        hasExitedAgent,
         hasMergeConflict:
           worktree.worktreeChanges?.changes.some((c) => c.status === "conflicted") ?? false,
         chipState,
@@ -675,6 +678,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         hasRunningAgent: false,
         hasWaitingAgent: false,
         hasCompletedAgent: false,
+        hasExitedAgent: false,
         hasMergeConflict: false,
         chipState: null,
       };

--- a/src/components/BulkCommandCenter/BulkCommandPalette.tsx
+++ b/src/components/BulkCommandCenter/BulkCommandPalette.tsx
@@ -74,6 +74,7 @@ const STATE_PRESETS: StatePreset[] = [
   { label: "Waiting", match: (r) => r.dominantState === "waiting" },
   { label: "Idle", match: (r) => r.dominantState === null && !r.disabled },
   { label: "Completed", match: (r) => r.dominantState === "completed" },
+  { label: "Exited", match: (r) => r.dominantState === "exited" },
 ];
 
 function getEligibleTerminals(

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -201,7 +201,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   // Use shortened title without command summary for dock items
   const displayTitle = getBaseTitle(terminal.title);
   // Only show icon for non-idle, non-completed states (reduce noise)
-  const showStateIcon = agentState && agentState !== "idle" && agentState !== "completed";
+  const showStateIcon =
+    agentState && agentState !== "idle" && agentState !== "completed" && agentState !== "exited";
   const StateIcon = showStateIcon
     ? getEffectiveStateIcon(agentState, terminal.waitingReason)
     : null;

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -206,7 +206,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     ? getEffectiveStateIcon(agentState, terminal.waitingReason)
     : null;
   const isDeprioritized =
-    !isOpen && (!agentState || agentState === "idle" || agentState === "completed");
+    !isOpen &&
+    (!agentState || agentState === "idle" || agentState === "completed" || agentState === "exited");
 
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>

--- a/src/components/Layout/useDockBlockedState.ts
+++ b/src/components/Layout/useDockBlockedState.ts
@@ -75,6 +75,10 @@ export function getGroupAmbientAgentState(
 export function isGroupDeprioritized(panels: ReadonlyArray<{ agentState?: AgentState }>): boolean {
   if (panels.length === 0) return false;
   return panels.every(
-    (p) => !p.agentState || p.agentState === "idle" || p.agentState === "completed"
+    (p) =>
+      !p.agentState ||
+      p.agentState === "idle" ||
+      p.agentState === "completed" ||
+      p.agentState === "exited"
   );
 }

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -278,7 +278,11 @@ function PanelHeaderComponent({
   const handleWatchToggle = useCallback(() => {
     if (isWatched) {
       unwatchPanel(id);
-    } else if (terminal?.agentState === "completed" || terminal?.agentState === "waiting") {
+    } else if (
+      terminal?.agentState === "completed" ||
+      terminal?.agentState === "waiting" ||
+      terminal?.agentState === "exited"
+    ) {
       fireWatchNotification(id, terminal.title ?? id, terminal.agentState);
     } else {
       watchPanel(id);

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -19,7 +19,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
         const t = state.terminalsById[id];
         if (t && t.location !== "trash") {
           active++;
-          if (t.agentState === "completed") completed++;
+          if (t.agentState === "completed" || t.agentState === "exited") completed++;
         }
       }
       return { activeCount: active, completedCount: completed };
@@ -86,7 +86,11 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       const { terminalsById, terminalIds } = useTerminalStore.getState();
       for (const id of terminalIds) {
         const t = terminalsById[id];
-        if (t && t.agentState === "completed" && t.location !== "trash") {
+        if (
+          t &&
+          (t.agentState === "completed" || t.agentState === "exited") &&
+          t.location !== "trash"
+        ) {
           useTerminalStore.getState().trashTerminal(t.id);
         }
       }

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -137,8 +137,8 @@ function TerminalHeaderContentComponent({
       return null;
     }
 
-    // Show completed chip only when there's a cost to display
-    if (agentState === "completed" && sessionCost == null) {
+    // Show completed/exited chip only when there's a cost to display
+    if ((agentState === "completed" || agentState === "exited") && sessionCost == null) {
       return null;
     }
 
@@ -156,9 +156,11 @@ function TerminalHeaderContentComponent({
             ? "bg-[color-mix(in_oklab,var(--color-status-info)_15%,transparent)] border-status-info/40"
             : agentState === "completed"
               ? "bg-[color-mix(in_oklab,var(--color-status-success)_15%,transparent)] border-status-success/40"
-              : agentState === "waiting" && waitingReason === "prompt"
-                ? "bg-[color-mix(in_oklab,var(--color-status-warning)_15%,transparent)] border-status-warning/40"
-                : "bg-[color-mix(in_oklab,var(--color-state-waiting)_15%,transparent)] border-state-waiting/40";
+              : agentState === "exited"
+                ? "bg-overlay-soft border-divider"
+                : agentState === "waiting" && waitingReason === "prompt"
+                  ? "bg-[color-mix(in_oklab,var(--color-status-warning)_15%,transparent)] border-status-warning/40"
+                  : "bg-[color-mix(in_oklab,var(--color-state-waiting)_15%,transparent)] border-state-waiting/40";
 
     const headline = activity?.headline?.trim() || `Agent ${agentState}`;
     const showConfidence = stateChangeConfidence != null && stateChangeConfidence < 1;
@@ -195,7 +197,7 @@ function TerminalHeaderContentComponent({
                   />
                 )}
               </div>
-              {agentState === "completed" && sessionCost != null && (
+              {(agentState === "completed" || agentState === "exited") && sessionCost != null && (
                 <span
                   className="text-[11px] text-canopy-text/50 font-mono shrink-0"
                   style={{ fontVariantNumeric: "tabular-nums" }}

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -104,12 +104,12 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
 }
 
 const STATE_PRIORITY: Record<AgentState, number> = {
-  working: 6,
-  directing: 5,
-  running: 4,
-  completed: 3,
-  waiting: 2,
-  exited: 1,
+  working: 7,
+  directing: 6,
+  running: 5,
+  completed: 4,
+  waiting: 3,
+  exited: 2,
   idle: 1,
 };
 

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -51,6 +51,13 @@ const STATE_CONFIG: Record<
     label: "completed",
     tooltip: "Agent finished this task",
   },
+  exited: {
+    icon: "–",
+    color: "text-canopy-text/40",
+    pulse: false,
+    label: "exited",
+    tooltip: "Process exited",
+  },
   directing: {
     icon: "✎",
     color: "text-status-info",
@@ -102,6 +109,7 @@ const STATE_PRIORITY: Record<AgentState, number> = {
   running: 4,
   completed: 3,
   waiting: 2,
+  exited: 1,
   idle: 1,
 };
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -271,7 +271,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
   const pingTerminal = useTerminalStore((state) => state.pingTerminal);
   const openDockTerminal = useTerminalStore((state) => state.openDockTerminal);
   const getCountByWorktree = useTerminalStore((state) => state.getCountByWorktree);
-  const completedCount = terminalCounts.byState.completed;
+  const completedCount = terminalCounts.byState.completed + terminalCounts.byState.exited;
   const totalTerminalCount = terminalCounts.total;
   const allTerminalCount = getCountByWorktree(worktree.id);
   const gridCount = worktreeTerminals.filter(

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -659,6 +659,7 @@ const allZeroStates = {
   directing: 0,
   idle: 0,
   completed: 0,
+  exited: 0,
 } as const;
 
 describe("WorktreeHeader collapsed session indicators", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -66,7 +66,7 @@ function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstan
 
 const baseCounts: WorktreeTerminalSectionProps["counts"] = {
   total: 2,
-  byState: { idle: 2, working: 0, running: 0, waiting: 0, directing: 0, completed: 0 },
+  byState: { idle: 2, working: 0, running: 0, waiting: 0, directing: 0, completed: 0, exited: 0 },
 };
 
 function renderSection(overrides: Partial<WorktreeTerminalSectionProps> = {}) {

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -109,6 +109,7 @@ const SESSION_OPTIONS: { value: SessionFilter; label: string }[] = [
   { value: "running", label: "Running" },
   { value: "waiting", label: "Waiting" },
   { value: "completed", label: "Completed" },
+  { value: "exited", label: "Exited" },
 ];
 
 const ACTIVITY_OPTIONS: { value: ActivityFilter; label: string }[] = [

--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -221,6 +221,7 @@ export function WorktreeOverviewModal({
       let hasRunningAgent = false;
       let hasWaitingAgent = false;
       let hasCompletedAgent = false;
+      let hasExitedAgent = false;
       for (const id of terminalIds) {
         const t = terminalsById[id];
         if (!t || t.worktreeId !== worktree.id || t.location === "trash") continue;
@@ -229,6 +230,7 @@ export function WorktreeOverviewModal({
         if (t.agentState === "running") hasRunningAgent = true;
         if (t.agentState === "waiting") hasWaitingAgent = true;
         if (t.agentState === "completed") hasCompletedAgent = true;
+        if (t.agentState === "exited") hasExitedAgent = true;
       }
       map.set(worktree.id, {
         terminalCount,
@@ -236,6 +238,7 @@ export function WorktreeOverviewModal({
         hasRunningAgent,
         hasWaitingAgent,
         hasCompletedAgent,
+        hasExitedAgent,
         hasMergeConflict:
           worktree.worktreeChanges?.changes.some((c) => c.status === "conflicted") ?? false,
         chipState: null,
@@ -296,6 +299,7 @@ export function WorktreeOverviewModal({
         hasRunningAgent: false,
         hasWaitingAgent: false,
         hasCompletedAgent: false,
+        hasExitedAgent: false,
         hasMergeConflict: false,
         chipState: null,
       };

--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -5,6 +5,7 @@ import {
   SpinnerCircle,
   HollowCircle,
   InteractingCircle,
+  ExitedCircle,
   PromptCircle,
   QuestionCircle,
 } from "@/components/icons/AgentStateCircles";
@@ -16,6 +17,7 @@ export const STATE_ICONS: Record<AgentState, React.ComponentType<{ className?: s
   directing: InteractingCircle,
   idle: Circle,
   completed: CheckCircle2,
+  exited: ExitedCircle,
 };
 
 export const STATE_COLORS: Record<AgentState, string> = {
@@ -25,6 +27,7 @@ export const STATE_COLORS: Record<AgentState, string> = {
   directing: "text-category-blue",
   idle: "text-canopy-text/40",
   completed: "text-status-success",
+  exited: "text-canopy-text/40",
 };
 
 export const STATE_LABELS: Record<AgentState, string> = {
@@ -34,6 +37,7 @@ export const STATE_LABELS: Record<AgentState, string> = {
   waiting: "waiting",
   directing: "directing",
   completed: "done",
+  exited: "exited",
 };
 
 export const STATE_PRIORITY: AgentState[] = [
@@ -42,6 +46,7 @@ export const STATE_PRIORITY: AgentState[] = [
   "waiting",
   "running",
   "completed",
+  "exited",
   "idle",
 ];
 
@@ -52,6 +57,7 @@ export const STATE_SORT_PRIORITY: Record<AgentState, number> = {
   running: 3,
   idle: 4,
   completed: 5,
+  exited: 6,
 };
 
 export function getEffectiveStateIcon(

--- a/src/components/icons/AgentStateCircles.tsx
+++ b/src/components/icons/AgentStateCircles.tsx
@@ -95,6 +95,23 @@ export function PromptCircle({ className, ...props }: CircleProps) {
   );
 }
 
+export function ExitedCircle({ className, ...props }: CircleProps) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className={className} {...props}>
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" />
+      <line
+        x1="5"
+        y1="8"
+        x2="11"
+        y2="8"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
 export function QuestionCircle({ className, ...props }: CircleProps) {
   return (
     <svg viewBox="0 0 16 16" fill="none" className={className} {...props}>

--- a/src/hooks/__tests__/useWorktreeTerminals.test.ts
+++ b/src/hooks/__tests__/useWorktreeTerminals.test.ts
@@ -51,6 +51,7 @@ describe("useWorktreeTerminals logic", () => {
       waiting: 0,
       directing: 0,
       completed: 0,
+      exited: 0,
     });
   });
 

--- a/src/hooks/__tests__/useWorktreeTerminals.test.ts
+++ b/src/hooks/__tests__/useWorktreeTerminals.test.ts
@@ -21,6 +21,7 @@ function calculateWorktreeCounts(terminals: TerminalInstance[], worktreeId: stri
     waiting: 0,
     directing: 0,
     completed: 0,
+    exited: 0,
   };
 
   worktreeTerminals.forEach((terminal) => {

--- a/src/hooks/app/useOrchestrationMilestones.ts
+++ b/src/hooks/app/useOrchestrationMilestones.ts
@@ -44,7 +44,10 @@ const TOAST_STAGGER = 5500;
 
 function checkAgentCompleted(): boolean {
   const { terminalsById, terminalIds } = useTerminalStore.getState();
-  return terminalIds.some((id) => terminalsById[id]?.agentState === "completed");
+  return terminalIds.some((id) => {
+    const state = terminalsById[id]?.agentState;
+    return state === "completed" || state === "exited";
+  });
 }
 
 function checkConcurrentAgents(): boolean {
@@ -148,12 +151,14 @@ export function useOrchestrationMilestones(isStateLoaded: boolean): void {
         unsubs.push(
           useTerminalStore.subscribe((state, prev) => {
             if (!shown["first-agent-completed"]) {
-              const had = prev.terminalIds.some(
-                (id) => prev.terminalsById[id]?.agentState === "completed"
-              );
-              const has = state.terminalIds.some(
-                (id) => state.terminalsById[id]?.agentState === "completed"
-              );
+              const had = prev.terminalIds.some((id) => {
+                const s = prev.terminalsById[id]?.agentState;
+                return s === "completed" || s === "exited";
+              });
+              const has = state.terminalIds.some((id) => {
+                const s = state.terminalsById[id]?.agentState;
+                return s === "completed" || s === "exited";
+              });
               if (!had && has) showToast("first-agent-completed");
             }
 

--- a/src/hooks/useWatchedPanelNotifications.ts
+++ b/src/hooks/useWatchedPanelNotifications.ts
@@ -59,7 +59,9 @@ export function useWatchedPanelNotifications(): void {
         const previousState = prevAgentStates.get(panelId);
 
         if (
-          (currentState === "completed" || currentState === "waiting") &&
+          (currentState === "completed" ||
+            currentState === "waiting" ||
+            currentState === "exited") &&
           currentState !== previousState
         ) {
           const terminal = terminalsById[panelId];

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -57,6 +57,7 @@ export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsRe
       waiting: 0,
       directing: 0,
       completed: 0,
+      exited: 0,
     };
 
     const agentStates: (AgentState | undefined)[] = [];

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -42,6 +42,7 @@ const createEmptyMeta = (): DerivedWorktreeMeta => ({
   hasRunningAgent: false,
   hasWaitingAgent: false,
   hasCompletedAgent: false,
+  hasExitedAgent: false,
   hasMergeConflict: false,
   chipState: null,
 });

--- a/src/lib/watchNotification.ts
+++ b/src/lib/watchNotification.ts
@@ -8,9 +8,28 @@ export function fireWatchNotification(
   agentState: string
 ): void {
   const label = panelTitle || panelId;
-  const isWaiting = agentState === "waiting";
 
-  if (isWaiting) {
+  if (agentState === "exited") {
+    notify({
+      type: "info",
+      priority: "high",
+      title: "Process exited",
+      message: `${label} process has exited`,
+      duration: 5000,
+      correlationId: panelId,
+      action: {
+        label: "Go to terminal",
+        onClick: () => {
+          useTerminalStore.getState().setFocused(panelId, true);
+        },
+        actionId: "panel.focus",
+        actionArgs: { panelId },
+      },
+    });
+    return;
+  }
+
+  if (agentState === "waiting") {
     notify({
       type: "warning",
       priority: "high",

--- a/src/lib/worktreeFilters.ts
+++ b/src/lib/worktreeFilters.ts
@@ -17,6 +17,7 @@ export interface DerivedWorktreeMeta {
   hasRunningAgent: boolean;
   hasWaitingAgent: boolean;
   hasCompletedAgent: boolean;
+  hasExitedAgent: boolean;
   hasMergeConflict: boolean;
   chipState: ChipState;
 }
@@ -193,6 +194,7 @@ export function matchesFilters(
     if (filters.sessionFilters.has("running") && derived.hasRunningAgent) hasMatch = true;
     if (filters.sessionFilters.has("waiting") && derived.hasWaitingAgent) hasMatch = true;
     if (filters.sessionFilters.has("completed") && derived.hasCompletedAgent) hasMatch = true;
+    if (filters.sessionFilters.has("exited") && derived.hasExitedAgent) hasMatch = true;
 
     if (!hasMatch) return false;
   }

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -343,7 +343,11 @@ export function registerTerminalLifecycleActions(
         state.unwatchPanel(targetId);
       } else {
         const terminal = state.terminalsById[targetId];
-        if (terminal?.agentState === "completed" || terminal?.agentState === "waiting") {
+        if (
+          terminal?.agentState === "completed" ||
+          terminal?.agentState === "waiting" ||
+          terminal?.agentState === "exited"
+        ) {
           const { fireWatchNotification } = await import("@/lib/watchNotification");
           fireWatchNotification(targetId, terminal.title ?? targetId, terminal.agentState);
         } else {

--- a/src/services/actions/definitions/worktreeSessionActions.ts
+++ b/src/services/actions/definitions/worktreeSessionActions.ts
@@ -95,7 +95,9 @@ export function registerWorktreeSessionActions(
       const { worktreeId } = args as { worktreeId?: string };
       const targetWorktreeId = worktreeId ?? ctx.activeWorktreeId;
       if (!targetWorktreeId) return;
-      useTerminalStore.getState().bulkCloseByWorktree(targetWorktreeId, "completed");
+      const store = useTerminalStore.getState();
+      store.bulkCloseByWorktree(targetWorktreeId, "completed");
+      store.bulkCloseByWorktree(targetWorktreeId, "exited");
     },
   }));
 

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -43,7 +43,9 @@ export class TerminalHibernationManager {
     if (
       !managed ||
       managed.isHibernated ||
-      (managed.kind === "agent" && managed.canonicalAgentState !== "completed")
+      (managed.kind === "agent" &&
+        managed.canonicalAgentState !== "completed" &&
+        managed.canonicalAgentState !== "exited")
     )
       return;
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -144,7 +144,9 @@ class TerminalInstanceService {
         // Hibernation timer management
         if (
           tier === TerminalRefreshTier.BACKGROUND &&
-          (managed.kind !== "agent" || managed.canonicalAgentState === "completed")
+          (managed.kind !== "agent" ||
+            managed.canonicalAgentState === "completed" ||
+            managed.canonicalAgentState === "exited")
         ) {
           if (!managed.hibernationTimer && !managed.isHibernated) {
             managed.hibernationTimer = setTimeout(() => {
@@ -1561,7 +1563,12 @@ class TerminalInstanceService {
     for (const managed of this.instances.values()) {
       if (managed.isHibernated) continue;
       if (managed.isFocused) continue;
-      if (managed.kind === "agent" && managed.canonicalAgentState !== "completed") continue;
+      if (
+        managed.kind === "agent" &&
+        managed.canonicalAgentState !== "completed" &&
+        managed.canonicalAgentState !== "exited"
+      )
+        continue;
       reduceScrollback(managed, targetLines);
     }
   }

--- a/src/store/slices/terminalRegistry/core.ts
+++ b/src/store/slices/terminalRegistry/core.ts
@@ -669,13 +669,13 @@ export const createCorePanelActions = (
             stateChangeConfidence: confidence,
             waitingReason: agentState === "waiting" ? waitingReason : undefined,
             sessionCost:
-              agentState === "completed" && sessionCost != null
+              (agentState === "completed" || agentState === "exited") && sessionCost != null
                 ? sessionCost
                 : agentState === "working"
                   ? undefined
                   : terminal.sessionCost,
             sessionTokens:
-              agentState === "completed" && sessionTokens != null
+              (agentState === "completed" || agentState === "exited") && sessionTokens != null
                 ? sessionTokens
                 : agentState === "working"
                   ? undefined

--- a/src/store/terminalStore.ts
+++ b/src/store/terminalStore.ts
@@ -61,7 +61,8 @@ export function getTerminalRefreshTier(
   // Completed agents drop to BACKGROUND so they can be hibernated to free memory.
   if (
     isAgentTerminal(terminal.kind ?? terminal.type, terminal.agentId) &&
-    terminal.agentState !== "completed"
+    terminal.agentState !== "completed" &&
+    terminal.agentState !== "exited"
   ) {
     return TerminalRefreshTierEnum.VISIBLE;
   }

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -22,7 +22,13 @@ export type TypeFilter =
   | "detached"
   | "other";
 export type GitHubFilter = "hasIssue" | "hasPR" | "prOpen" | "prMerged" | "prClosed";
-export type SessionFilter = "hasTerminals" | "working" | "running" | "waiting" | "completed";
+export type SessionFilter =
+  | "hasTerminals"
+  | "working"
+  | "running"
+  | "waiting"
+  | "completed"
+  | "exited";
 export type ActivityFilter = "last15m" | "last1h" | "last24h" | "last7d";
 
 interface WorktreeFilterState {

--- a/src/workers/WorkerAgentStateService.ts
+++ b/src/workers/WorkerAgentStateService.ts
@@ -61,11 +61,8 @@ function nextAgentState(current: AgentState, event: AgentEvent): AgentState {
       break;
 
     case "exit":
-      if (current === "working" || current === "waiting") {
-        return "completed";
-      }
-      if (current === "completed") {
-        return "completed";
+      if (current !== "idle" && current !== "exited") {
+        return "exited";
       }
       break;
   }

--- a/src/workers/__tests__/WorkerAgentStateService.test.ts
+++ b/src/workers/__tests__/WorkerAgentStateService.test.ts
@@ -84,42 +84,43 @@ describe("WorkerAgentStateService", () => {
     });
 
     describe("exit event", () => {
-      it("should transition working → completed on exit code 0", () => {
-        expect(calcState("working", { type: "exit", code: 0 })).toBe("completed");
+      it("should transition working → exited on exit code 0", () => {
+        expect(calcState("working", { type: "exit", code: 0 })).toBe("exited");
       });
 
-      it("should transition working → completed on non-zero exit code", () => {
-        expect(calcState("working", { type: "exit", code: 1 })).toBe("completed");
+      it("should transition working → exited on non-zero exit code", () => {
+        expect(calcState("working", { type: "exit", code: 1 })).toBe("exited");
       });
 
-      it("should transition waiting → completed on exit code 0", () => {
-        expect(calcState("waiting", { type: "exit", code: 0 })).toBe("completed");
+      it("should transition waiting → exited on exit code 0", () => {
+        expect(calcState("waiting", { type: "exit", code: 0 })).toBe("exited");
       });
 
-      it("should transition waiting → completed on non-zero exit code", () => {
-        expect(calcState("waiting", { type: "exit", code: 1 })).toBe("completed");
+      it("should transition waiting → exited on non-zero exit code", () => {
+        expect(calcState("waiting", { type: "exit", code: 1 })).toBe("exited");
       });
 
-      it("should stay completed on non-zero exit from completed", () => {
-        expect(calcState("completed", { type: "exit", code: 1 })).toBe("completed");
+      it("should transition completed → exited on exit", () => {
+        expect(calcState("completed", { type: "exit", code: 1 })).toBe("exited");
       });
 
-      it("should return null (no-op) on zero exit from completed", () => {
-        const state = createTerminalState("t1", "agent1");
-        state.agentState = "completed";
-        const result = calculateStateChange(state, { type: "exit", code: 0 });
-        expect(result).toBeNull();
+      it("should transition completed → exited on zero exit", () => {
+        expect(calcState("completed", { type: "exit", code: 0 })).toBe("exited");
       });
 
-      it("should not transition from other states on exit", () => {
+      it("should not transition from idle on exit", () => {
         expect(calcState("idle", { type: "exit", code: 0 })).toBe("idle");
+      });
+
+      it("should not transition from exited on exit (terminal state)", () => {
+        expect(calcState("exited", { type: "exit", code: 0 })).toBe("exited");
       });
     });
 
     describe("error event", () => {
       it("should not change state on error (error events are no-ops)", () => {
         const event: AgentEvent = { type: "error", error: "Something went wrong" };
-        const states: AgentState[] = ["idle", "working", "waiting", "completed"];
+        const states: AgentState[] = ["idle", "working", "waiting", "completed", "exited"];
 
         for (const state of states) {
           expect(calcState(state, event)).toBe(state);
@@ -196,12 +197,13 @@ describe("WorkerAgentStateService", () => {
       expect(r.trigger).toBe("activity");
     });
 
-    it("should return null on non-zero exit from completed (no state change)", () => {
+    it("should return exited on exit from completed", () => {
       const state = createTerminalState("t1", "agent1");
       state.agentState = "completed";
       const result = calculateStateChange(state, { type: "exit", code: 1 });
 
-      expect(result).toBeNull();
+      expect(result).not.toBeNull();
+      expect(result!.state).toBe("exited");
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a new `exited` agent state that fires when a terminal process terminates cleanly, distinguishing "process is gone" from "agent completed its task"
- The `exited` state renders as a gray circle with a solid minus icon, clearly separating it from `completed` (green checkmark) and `idle` (dim circle)
- All downstream consumers updated: state machine, worktree filter, notification service, activity headline generator, panel header, docked terminal, bulk command palette, and the `AgentStateCircles` icon component

Resolves #4998

## Changes

- `shared/types/agent.ts` — added `'exited'` to the `AgentState` union
- `electron/services/AgentStateMachine.ts` — transitions to `exited` on process exit instead of falling through to `completed`
- `electron/services/AgentNotificationService.ts` / `ActivityHeadlineGenerator.ts` — handle `exited` state without triggering task-complete notifications
- `src/components/Worktree/terminalStateConfig.tsx` — icon and colour config for `exited`
- `src/components/icons/AgentStateCircles.tsx` — new `MinusCircle` variant for the exited state
- Tests updated across `AgentStateMachine.test.ts`, `WorkerAgentStateService.test.ts`, and worktree filter/hook tests

## Testing

Unit tests updated and passing. The exited state was manually verified to appear correctly in the panel header and worktree card after a process exits with code 0.