### PR TITLE
fix(github): update token creation URL description to 'Canopy'

### DIFF
--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -141,7 +141,7 @@ export function GitHubSettingsTab() {
     void actionService.dispatch(
       "system.openExternal",
       {
-        url: "https://github.com/settings/tokens/new?scopes=repo,read:org&description=Canopy%20Command%20Center",
+        url: "https://github.com/settings/tokens/new?scopes=repo,read:org&description=Canopy",
       },
       { source: "user" }
     );

--- a/src/components/Settings/__tests__/GitHubSettingsTab.a11y.test.tsx
+++ b/src/components/Settings/__tests__/GitHubSettingsTab.a11y.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 import { useGitHubConfigStore } from "@/store";
+import { actionService } from "@/services/ActionService";
 
 const mockedUseGitHubConfigStore = vi.mocked(useGitHubConfigStore);
 
@@ -30,6 +31,7 @@ function setupStore(overrides: Record<string, unknown> = {}) {
 
 describe("GitHubSettingsTab accessibility", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.useFakeTimers();
     setupStore();
   });
@@ -104,5 +106,19 @@ describe("GitHubSettingsTab accessibility", () => {
     for (const svg of spinnerSvgs) {
       expect(svg.getAttribute("aria-hidden")).toBe("true");
     }
+  });
+
+  it("Create Token button opens GitHub with correct description", () => {
+    render(<GitHubSettingsTab />);
+    const btn = screen.getByRole("button", { name: /create token on github/i });
+    fireEvent.click(btn);
+
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      {
+        url: "https://github.com/settings/tokens/new?scopes=repo,read:org&description=Canopy",
+      },
+      { source: "user" }
+    );
   });
 });


### PR DESCRIPTION
## Summary

- The GitHub token creation URL in Settings had the description pre-filled as `Canopy%20Command%20Center`, which references old branding we've moved away from
- Updated the description parameter to `Canopy` to match current naming
- Added a regression test to catch this kind of stale URL value in future

Resolves #5025

## Changes

- `src/components/Settings/GitHubSettingsTab.tsx`: changed `description=Canopy%20Command%20Center` to `description=Canopy` in the `openGitHubTokenPage` URL
- `src/components/Settings/__tests__/GitHubSettingsTab.a11y.test.tsx`: added test asserting the generated URL contains `description=Canopy` and not the old `Command+Center` variant

## Testing

Unit tests pass. The new test specifically checks for the correct description value in the constructed URL.