### PR TITLE
fix(github): improve toolbar button UX when token not configured

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -8,6 +8,7 @@ import {
   nextGeneration,
   getGeneration,
 } from "@/lib/githubResourceCache";
+import { isTokenRelatedError } from "@/lib/githubErrors";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -530,16 +531,6 @@ export function GitHubResourceList({
       selection,
     ]
   );
-
-  const isTokenRelatedError = (msg: string | null | undefined): boolean => {
-    if (!msg) return false;
-    return (
-      msg.includes("GitHub token not configured") ||
-      msg.includes("Invalid GitHub token") ||
-      msg.includes("Token lacks required permissions") ||
-      msg.includes("SSO authorization required")
-    );
-  };
 
   const isTokenError = isTokenRelatedError(error);
 

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -121,6 +121,14 @@ export const GitHubStatsToolbarButton = memo(
       return `${days}d ago`;
     }, []);
 
+    const openSettingsForToken = useCallback(() => {
+      void actionService.dispatch(
+        "app.settings.openTab",
+        { tab: "github", sectionId: "github-token" },
+        { source: "user" }
+      );
+    }, []);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -129,12 +137,24 @@ export const GitHubStatsToolbarButton = memo(
           setPrsOpen(false);
           setCommitsOpen(false);
         },
-        openIssues: () => setIssuesOpen((p) => !p),
-        openPrs: () => setPrsOpen((p) => !p),
+        openIssues: () => {
+          if (isTokenError) {
+            openSettingsForToken();
+            return;
+          }
+          setIssuesOpen((p) => !p);
+        },
+        openPrs: () => {
+          if (isTokenError) {
+            openSettingsForToken();
+            return;
+          }
+          setPrsOpen((p) => !p);
+        },
         openCommits: () => setCommitsOpen((p) => !p),
         stats,
       }),
-      [stats]
+      [stats, isTokenError, openSettingsForToken]
     );
 
     if (!currentProject) return null;
@@ -177,7 +197,7 @@ export const GitHubStatsToolbarButton = memo(
                   "h-full gap-2 rounded-none px-3 text-canopy-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
                   isTokenError && "opacity-40",
                   !isTokenError && stats?.issueCount === 0 && "opacity-50",
-                  isStale && "opacity-60",
+                  !isTokenError && isStale && "opacity-60",
                   issuesOpen &&
                     "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-open/20"
                 )}
@@ -267,7 +287,7 @@ export const GitHubStatsToolbarButton = memo(
                   "h-full gap-2 rounded-none px-3 text-canopy-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
                   isTokenError && "opacity-40",
                   !isTokenError && stats?.prCount === 0 && "opacity-50",
-                  isStale && "opacity-60",
+                  !isTokenError && isStale && "opacity-60",
                   prsOpen &&
                     "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-merged/20"
                 )}

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -14,6 +14,7 @@ import { FixedDropdown } from "@/components/ui/fixed-dropdown";
 import { CircleDot, GitPullRequest, GitCommit } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { actionService } from "@/services/ActionService";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useGitHubFilterStore } from "@/store/githubFilterStore";
@@ -57,6 +58,7 @@ export const GitHubStatsToolbarButton = memo(
       stats,
       loading: statsLoading,
       error: statsError,
+      isTokenError,
       refresh: refreshStats,
       isStale,
       lastUpdated,
@@ -95,10 +97,10 @@ export const GitHubStatsToolbarButton = memo(
 
     const getGitHubIndicatorStatus = useCallback((): GitHubStatusIndicatorStatus => {
       if (statsLoading) return "loading";
-      if (statsError) return "error";
+      if (statsError && !isTokenError) return "error";
       if (statsJustUpdated) return "success";
       return "idle";
-    }, [statsLoading, statsError, statsJustUpdated]);
+    }, [statsLoading, statsError, isTokenError, statsJustUpdated]);
 
     const handleGitHubStatusTransitionEnd = useCallback(() => {
       setStatsJustUpdated(false);
@@ -156,6 +158,16 @@ export const GitHubStatsToolbarButton = memo(
                   setPrsOpen(false);
                   setPrSearchQuery("");
                   setCommitsOpen(false);
+                  if (isTokenError) {
+                    setIssuesOpen(false);
+                    setIssueSearchQuery("");
+                    void actionService.dispatch(
+                      "app.settings.openTab",
+                      { tab: "github", sectionId: "github-token" },
+                      { source: "user" }
+                    );
+                    return;
+                  }
                   const willOpen = !issuesOpen;
                   setIssuesOpen(willOpen);
                   if (!willOpen) setIssueSearchQuery("");
@@ -163,23 +175,35 @@ export const GitHubStatsToolbarButton = memo(
                 }}
                 className={cn(
                   "h-full gap-2 rounded-none px-3 text-canopy-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
-                  stats?.issueCount === 0 && "opacity-50",
+                  isTokenError && "opacity-40",
+                  !isTokenError && stats?.issueCount === 0 && "opacity-50",
                   isStale && "opacity-60",
                   issuesOpen &&
                     "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-open/20"
                 )}
-                aria-label={`${stats?.issueCount ?? "\u2014"} open issues${isStale ? " (cached)" : ""}`}
+                aria-label={
+                  isTokenError
+                    ? "Configure GitHub token to see issues"
+                    : `${stats?.issueCount ?? "\u2014"} open issues${isStale ? " (cached)" : ""}`
+                }
               >
-                <CircleDot className="h-4 w-4 text-github-open" />
+                <CircleDot
+                  className={cn(
+                    "h-4 w-4",
+                    isTokenError ? "text-muted-foreground" : "text-github-open"
+                  )}
+                />
                 <span className="text-xs font-medium tabular-nums">
                   {stats?.issueCount ?? "\u2014"}
                 </span>
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
-              {isStale
-                ? `${stats?.issueCount ?? "\u2014"} open issues (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
-                : "Browse GitHub Issues"}
+              {isTokenError
+                ? "Configure GitHub token to see issues"
+                : isStale
+                  ? `${stats?.issueCount ?? "\u2014"} open issues (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
+                  : "Browse GitHub Issues"}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
@@ -224,6 +248,16 @@ export const GitHubStatsToolbarButton = memo(
                   setIssuesOpen(false);
                   setIssueSearchQuery("");
                   setCommitsOpen(false);
+                  if (isTokenError) {
+                    setPrsOpen(false);
+                    setPrSearchQuery("");
+                    void actionService.dispatch(
+                      "app.settings.openTab",
+                      { tab: "github", sectionId: "github-token" },
+                      { source: "user" }
+                    );
+                    return;
+                  }
                   const willOpen = !prsOpen;
                   setPrsOpen(willOpen);
                   if (!willOpen) setPrSearchQuery("");
@@ -231,23 +265,35 @@ export const GitHubStatsToolbarButton = memo(
                 }}
                 className={cn(
                   "h-full gap-2 rounded-none px-3 text-canopy-text hover:bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] hover:text-text-primary",
-                  stats?.prCount === 0 && "opacity-50",
+                  isTokenError && "opacity-40",
+                  !isTokenError && stats?.prCount === 0 && "opacity-50",
                   isStale && "opacity-60",
                   prsOpen &&
                     "bg-[var(--toolbar-stats-hover-bg,var(--theme-overlay-hover))] text-text-primary ring-1 ring-github-merged/20"
                 )}
-                aria-label={`${stats?.prCount ?? "\u2014"} open pull requests${isStale ? " (cached)" : ""}`}
+                aria-label={
+                  isTokenError
+                    ? "Configure GitHub token to see pull requests"
+                    : `${stats?.prCount ?? "\u2014"} open pull requests${isStale ? " (cached)" : ""}`
+                }
               >
-                <GitPullRequest className="h-4 w-4 text-github-merged" />
+                <GitPullRequest
+                  className={cn(
+                    "h-4 w-4",
+                    isTokenError ? "text-muted-foreground" : "text-github-merged"
+                  )}
+                />
                 <span className="text-xs font-medium tabular-nums">
                   {stats?.prCount ?? "\u2014"}
                 </span>
               </Button>
             </TooltipTrigger>
             <TooltipContent side="bottom">
-              {isStale
-                ? `${stats?.prCount ?? "\u2014"} open PRs (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
-                : "Browse GitHub Pull Requests"}
+              {isTokenError
+                ? "Configure GitHub token to see pull requests"
+                : isStale
+                  ? `${stats?.prCount ?? "\u2014"} open PRs (last updated ${getTimeSinceUpdate(lastUpdated)} - offline)`
+                  : "Browse GitHub Pull Requests"}
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/src/components/Layout/__tests__/Toolbar.githubDropdowns.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.githubDropdowns.test.ts
@@ -129,6 +129,52 @@ describe("Toolbar Suspense skeleton fallbacks — issue #3593", () => {
   });
 });
 
+describe("Toolbar GitHub token error UX — issue #5024", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(GITHUB_STATS_PATH, "utf-8");
+  });
+
+  it("consumes isTokenError from useRepositoryStats", () => {
+    expect(source).toContain("isTokenError");
+    expect(source).toContain("useRepositoryStats");
+  });
+
+  it("redirects to GitHub settings on token error click", () => {
+    expect(source).toContain("app.settings.openTab");
+    expect(source).toContain("github-token");
+  });
+
+  it("dims Issues and PR buttons with opacity-40 on token error", () => {
+    const issuesButton = source.slice(
+      source.indexOf("ref={issuesButtonRef}"),
+      source.indexOf("ref={issuesButtonRef}") + 1500
+    );
+    expect(issuesButton).toContain("isTokenError");
+    expect(issuesButton).toContain("opacity-40");
+
+    const prsButton = source.slice(
+      source.indexOf("ref={prsButtonRef}"),
+      source.indexOf("ref={prsButtonRef}") + 1500
+    );
+    expect(prsButton).toContain("isTokenError");
+    expect(prsButton).toContain("opacity-40");
+  });
+
+  it("does not apply token error handling to the Commits button", () => {
+    const commitsButton = source.slice(
+      source.indexOf("ref={commitsButtonRef}"),
+      source.indexOf("ref={commitsButtonRef}") + 500
+    );
+    expect(commitsButton).not.toContain("isTokenError");
+  });
+
+  it("suppresses error indicator status for token errors", () => {
+    expect(source).toContain("statsError && !isTokenError");
+  });
+});
+
 describe("Toolbar persistThroughChildOverlays — issue #3556", () => {
   let source: string;
 

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -68,6 +68,95 @@ describe("useRepositoryStats", () => {
     });
   });
 
+  describe("isTokenError", () => {
+    const tokenErrorMessages = [
+      "GitHub token not configured. Set it in Settings.",
+      "Invalid GitHub token",
+      "Token lacks required permissions",
+      "SSO authorization required for this organization",
+    ];
+
+    it.each(tokenErrorMessages)("returns isTokenError=true for ghError: %s", async (errorMsg) => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: null,
+        ghError: errorMsg,
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.isTokenError).toBe(true);
+        expect(result.current.error).toBe(errorMsg);
+      });
+    });
+
+    it("returns isTokenError=false for non-token errors", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: null,
+        ghError: "Network timeout",
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.isTokenError).toBe(false);
+        expect(result.current.error).toBe("Network timeout");
+      });
+    });
+
+    it("resets isTokenError when error clears on successful fetch", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValueOnce({
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: null,
+        ghError: "GitHub token not configured. Set it in Settings.",
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.isTokenError).toBe(true);
+      });
+
+      getRepoStatsMock.mockResolvedValueOnce({
+        commitCount: 5,
+        issueCount: 2,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 2000,
+      });
+
+      await act(async () => {
+        await result.current.refresh({ force: true });
+      });
+
+      await waitFor(() => {
+        expect(result.current.isTokenError).toBe(false);
+        expect(result.current.error).toBeNull();
+      });
+    });
+  });
+
   it("queues a refetch on project switch when an earlier fetch is still in flight", async () => {
     let currentProject = { id: "project-a", path: "/repo/a" };
     getCurrentMock.mockImplementation(async () => currentProject);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { RepositoryStats } from "../types";
 import { githubClient, projectClient } from "@/clients";
+import { isTokenRelatedError } from "@/lib/githubErrors";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
@@ -10,6 +11,7 @@ export interface UseRepositoryStatsReturn {
   stats: RepositoryStats | null;
   loading: boolean;
   error: string | null;
+  isTokenError: boolean;
   isStale: boolean;
   lastUpdated: number | null;
   refresh: (options?: { force?: boolean }) => Promise<void>;
@@ -291,10 +293,13 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     return cleanup;
   }, [fetchStats, scheduleNextPoll]);
 
+  const isTokenError = isTokenRelatedError(error);
+
   return {
     stats,
     loading,
     error,
+    isTokenError,
     isStale,
     lastUpdated,
     refresh,

--- a/src/lib/githubErrors.ts
+++ b/src/lib/githubErrors.ts
@@ -1,0 +1,9 @@
+export function isTokenRelatedError(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  return (
+    msg.includes("GitHub token not configured") ||
+    msg.includes("Invalid GitHub token") ||
+    msg.includes("Token lacks required permissions") ||
+    msg.includes("SSO authorization required")
+  );
+}


### PR DESCRIPTION
## Summary

- When no GitHub token is configured, Issues and PR toolbar buttons now dim to 40% opacity and redirect clicks straight to GitHub Settings rather than opening an empty dropdown that fails with an error
- The error pulse indicator is suppressed for token errors (shows idle state instead) so the toolbar doesn't look broken when it's just unconfigured
- `isTokenRelatedError` extracted into `src/lib/githubErrors.ts` so both the toolbar button and `GitHubResourceList` share the same detection logic

Resolves #5024

## Changes

- `src/lib/githubErrors.ts` — new shared utility, extracted from `GitHubResourceList`
- `src/hooks/useRepositoryStats.ts` — exposes `isTokenError` flag from hook return value
- `src/components/Layout/GitHubStatsToolbarButton.tsx` — dims buttons on token error, redirects clicks to settings, suppresses stale/error pulse, guards imperative `openIssues`/`openPrs` handles
- `src/components/GitHub/GitHubResourceList.tsx` — updated to use shared `isTokenRelatedError` from `githubErrors.ts`

## Testing

Unit tests added in `src/hooks/__tests__/useRepositoryStats.test.tsx` and `src/components/__tests__/Toolbar.githubDropdowns.test.ts` covering the token error detection and toolbar redirect behaviour.