### PR TITLE
fix(ui): increase notification opacity to improve legibility

### DIFF
--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -93,7 +93,7 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
         className={cn(
           "pointer-events-auto relative flex flex-col w-full max-w-[360px]",
           "rounded-[var(--radius-sm)] border-l-[3px] border border-tint/[0.08]",
-          "bg-surface-panel/60 backdrop-blur-xl",
+          "bg-surface-panel/85 backdrop-blur-xl",
           "px-3 py-2.5 pr-2",
           "text-sm text-canopy-text",
           "shadow-[var(--theme-shadow-floating)]",

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -80,7 +80,7 @@ function Toast({ notification }: { notification: Notification }) {
       className={cn(
         "group pointer-events-auto relative flex w-full max-w-[360px] items-start gap-3",
         "rounded-[var(--radius-sm)] border-l-[3px] border border-tint/[0.08]",
-        "bg-surface-panel/60 backdrop-blur-xl",
+        "bg-surface-panel/85 backdrop-blur-xl",
         "px-3 py-2.5 pr-2",
         "text-sm text-canopy-text",
         "shadow-[var(--theme-shadow-floating)]",


### PR DESCRIPTION
## Summary

- Raised `bg-surface-panel` opacity from 60% to 85% in the toaster and re-entry summary components so terminal content doesn't bleed through notification backgrounds
- Fixes the legibility issue shown in the issue screenshot where background text was visibly poking through

Resolves #5040

## Changes

- `src/components/ui/toaster.tsx` — opacity `60` → `85`
- `src/components/ui/ReEntrySummary.tsx` — opacity `60` → `85`

## Testing

Verified the class change is consistent across both notification surfaces. No functional logic changed, purely a visual adjustment.