### PR TITLE
fix(browser): reload page when pressing Enter on unchanged URL

### DIFF
--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -117,10 +117,14 @@ export function BrowserToolbar({
         setIsEditing(false);
         setIsDropdownOpen(false);
         setHighlightedIndex(-1);
-        onNavigate(result.url);
+        if (result.url === url) {
+          onReload();
+        } else {
+          onNavigate(result.url);
+        }
       }
     },
-    [inputValue, onNavigate]
+    [inputValue, url, onNavigate, onReload]
   );
 
   const handleFocus = useCallback(() => {

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { BrowserToolbar } from "../BrowserToolbar";
+
+vi.mock("@/store/urlHistoryStore", () => ({
+  useUrlHistoryStore: () => [],
+  getFrecencySuggestions: () => [],
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn(() => Promise.resolve({ ok: true })) },
+}));
+
+const defaultProps = {
+  url: "http://localhost:5173/",
+  canGoBack: false,
+  canGoForward: false,
+  isLoading: false,
+  onNavigate: vi.fn(),
+  onBack: vi.fn(),
+  onForward: vi.fn(),
+  onReload: vi.fn(),
+  onOpenExternal: vi.fn(),
+};
+
+function renderToolbar(overrides = {}) {
+  const props = { ...defaultProps, ...overrides };
+  return render(<BrowserToolbar {...props} />);
+}
+
+describe("BrowserToolbar handleSubmit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls onReload when submitting the same URL", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+
+    fireEvent.focus(input);
+    // handleFocus sets inputValue to url prop (http://localhost:5173/)
+    fireEvent.submit(input.closest("form")!);
+
+    expect(defaultProps.onReload).toHaveBeenCalledOnce();
+    expect(defaultProps.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("calls onNavigate when submitting a different URL", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "localhost:3000" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(defaultProps.onNavigate).toHaveBeenCalledWith("http://localhost:3000/");
+    expect(defaultProps.onReload).not.toHaveBeenCalled();
+  });
+
+  it("calls onReload when display-format input normalizes to same URL", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+
+    fireEvent.focus(input);
+    // Type the display format (no protocol, no trailing slash) which normalizes to the same URL
+    fireEvent.change(input, { target: { value: "localhost:5173" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(defaultProps.onReload).toHaveBeenCalledOnce();
+    expect(defaultProps.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows error for invalid URL and does not call either callback", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "not a valid url !!!" } });
+    fireEvent.submit(input.closest("form")!);
+
+    expect(defaultProps.onReload).not.toHaveBeenCalled();
+    expect(defaultProps.onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("calls onReload on consecutive same-URL submissions", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+
+    fireEvent.focus(input);
+    fireEvent.submit(input.closest("form")!);
+    // Focus again and submit again
+    fireEvent.focus(input);
+    fireEvent.submit(input.closest("form")!);
+
+    expect(defaultProps.onReload).toHaveBeenCalledTimes(2);
+    expect(defaultProps.onNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -96,4 +96,16 @@ describe("BrowserToolbar handleSubmit", () => {
     expect(defaultProps.onReload).toHaveBeenCalledTimes(2);
     expect(defaultProps.onNavigate).not.toHaveBeenCalled();
   });
+
+  it("calls onReload for URL with path, query, and hash", () => {
+    const fullUrl = "http://localhost:5173/app?tab=1#section";
+    const { getByTestId } = renderToolbar({ url: fullUrl });
+    const input = getByTestId("browser-address-bar");
+
+    fireEvent.focus(input);
+    fireEvent.submit(input.closest("form")!);
+
+    expect(defaultProps.onReload).toHaveBeenCalledOnce();
+    expect(defaultProps.onNavigate).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Pressing Enter on the URL bar now triggers a page reload even when the URL hasn't changed, matching expected browser behaviour.
- The fix detects when the submitted URL is identical to the current URL and explicitly calls `webview.reload()` instead of relying on `loadURL`, which does nothing when the URL is the same.

Resolves #5036

## Changes

- `src/components/Browser/BrowserToolbar.tsx`: added same-URL detection in the `handleNavigate` callback; calls `webview.reload()` when the URL is unchanged.
- `src/components/Browser/__tests__/BrowserToolbar.test.tsx`: new test suite covering the reload-on-Enter behaviour, including URLs with paths, query strings, and hashes.

## Testing

Unit tests pass. The new `BrowserToolbar` test suite covers the fix directly, including edge cases with complex URLs. Manually verified the fix resolves the reported behaviour where Enter on an unchanged URL had no effect.