### PR TITLE
feat(setup): auto-skip install step when all selected agents are installed

### DIFF
--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -99,12 +99,16 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
         history: [...state.history, state.step],
       };
 
-    case "SELECTION_CONTINUE":
+    case "SELECTION_CONTINUE": {
+      const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
+      const allSelectedInstalled =
+        selectedIds.length > 0 && selectedIds.every((id) => isAgentReady(state.availability[id]));
       return {
         ...state,
-        step: { type: "cli" },
+        step: allSelectedInstalled ? { type: "complete" } : { type: "cli" },
         history: [...state.history, state.step],
       };
+    }
 
     case "CLI_CONTINUE":
       return {

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -120,7 +120,7 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.step).toEqual({ type: "cli" });
   });
 
-  it("advances from selection to cli even when all agents installed", () => {
+  it("skips to complete when all selected agents are installed", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled, true);
     state = wizardReducer(state, {
@@ -128,7 +128,45 @@ describe("AgentSetupWizard reducer", () => {
       payload: { claude: true, gemini: true },
     });
     state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    expect(state.step).toEqual({ type: "complete" });
+    expect(state.history).toEqual([{ type: "selection" }]);
+  });
+
+  it("goes to cli when at least one selected agent is not installed", () => {
+    const partial = { claude: "ready", gemini: "missing" } as CliAvailability;
+    let state = buildInitialState(partial, true);
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
+  });
+
+  it("skips to complete when only selected agents are installed (unselected missing)", () => {
+    const avail = { claude: "ready", gemini: "missing" } as CliAvailability;
+    let state = buildInitialState(avail, true);
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: false },
+    });
+    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    expect(state.step).toEqual({ type: "complete" });
+  });
+
+  it("BACK from complete (after skip) returns to selection, not cli", () => {
+    const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
+    let state = buildInitialState(allInstalled, true);
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    expect(state.step).toEqual({ type: "complete" });
+
+    state = wizardReducer(state, { type: "BACK" });
+    expect(state.step).toEqual({ type: "selection" });
+    expect(state.history).toEqual([]);
   });
 
   it("advances from cli to complete", () => {

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -169,6 +169,22 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.history).toEqual([]);
   });
 
+  it("goes to cli when availability changes after init to mark agent uninstalled", () => {
+    const allInstalled: Record<string, boolean> = { claude: true, gemini: true };
+    let state = buildInitialState(allInstalled, true);
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    // Availability changes: gemini becomes unavailable
+    state = wizardReducer(state, {
+      type: "SET_AVAILABILITY",
+      payload: { claude: true, gemini: false },
+    });
+    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
+    expect(state.step).toEqual({ type: "cli" });
+  });
+
   it("advances from cli to complete", () => {
     let state = buildInitialState(emptyAvail, true);
     state = wizardReducer(state, {

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -170,7 +170,7 @@ describe("AgentSetupWizard reducer", () => {
   });
 
   it("goes to cli when availability changes after init to mark agent uninstalled", () => {
-    const allInstalled: Record<string, boolean> = { claude: true, gemini: true };
+    const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled, true);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
@@ -179,7 +179,7 @@ describe("AgentSetupWizard reducer", () => {
     // Availability changes: gemini becomes unavailable
     state = wizardReducer(state, {
       type: "SET_AVAILABILITY",
-      payload: { claude: true, gemini: false },
+      payload: { claude: "ready", gemini: "missing" } as CliAvailability,
     });
     state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });


### PR DESCRIPTION
## Summary

- When a user advances past the selection step and every selected agent is already detected as available, the wizard now skips straight to the complete step rather than showing an install screen full of green checkmarks
- Applies to both first-run and returning-user flows, including the case where a developer has pre-installed all their tools before opening Canopy
- If availability changes between wizard init and continue (e.g. polling updates a status), the decision is made at the moment the user clicks Continue, so the right step is always shown

Resolves #5050

## Changes

- `SELECTION_CONTINUE` reducer case in `AgentSetupWizard.tsx` checks `state.availability` at transition time and routes to `{ type: "complete" }` when all selected agents are installed, `{ type: "cli" }` otherwise
- Updated existing test that previously asserted the old (always-cli) behaviour
- Added four new reducer tests covering: partial installation, unselected-but-missing agents, BACK navigation after a skip, and availability changes between init and continue

## Testing

All new and updated reducer tests pass. The BACK action correctly pops history back to selection (not cli) after a skip, since the history only contains the steps the user actually visited.