### PR TITLE
feat(agent-detection): three-state CLI availability (missing, installed, ready)

### DIFF
--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { getAgentIds } from "../../../shared/config/agentRegistry.js";
+import type { AgentAvailabilityState } from "../../../shared/types/ipc/system.js";
 import type { HandlerDependencies } from "../types.js";
 
 export function registerAgentCliHandlers(deps: HandlerDependencies): () => void {
@@ -10,7 +11,9 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   const handleSystemGetCliAvailability = async () => {
     if (!cliAvailabilityService) {
       console.warn("[IPC] CliAvailabilityService not available");
-      return Object.fromEntries(getAgentIds().map((id) => [id, false]));
+      return Object.fromEntries(
+        getAgentIds().map((id) => [id, "missing" as AgentAvailabilityState])
+      );
     }
 
     const cached = cliAvailabilityService.getAvailability();
@@ -26,7 +29,9 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   const handleSystemRefreshCliAvailability = async () => {
     if (!cliAvailabilityService) {
       console.warn("[IPC] CliAvailabilityService not available");
-      return Object.fromEntries(getAgentIds().map((id) => [id, false]));
+      return Object.fromEntries(
+        getAgentIds().map((id) => [id, "missing" as AgentAvailabilityState])
+      );
     }
 
     return await cliAvailabilityService.refresh();

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -3,6 +3,7 @@ import { projectStore } from "./services/ProjectStore.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { getEffectiveRegistry } from "../shared/config/agentRegistry.js";
 import type { CliAvailabilityService } from "./services/CliAvailabilityService.js";
+import { isAgentInstalled } from "../shared/utils/agentAvailability.js";
 import * as CliInstallService from "./services/CliInstallService.js";
 import { getWindowRegistry, getProjectViewManager } from "./window/windowRef.js";
 import { autoUpdaterService } from "./services/AutoUpdaterService.js";
@@ -58,9 +59,7 @@ export function createApplicationMenu(
     const items: Electron.MenuItemConstructorOptions[] = [];
 
     Object.values(getEffectiveRegistry()).forEach((agent) => {
-      const isAvailable = availability?.[agent.id] ?? false;
-
-      if (isAvailable) {
+      if (isAgentInstalled(availability?.[agent.id])) {
         items.push({
           label: `New ${agent.name}`,
           accelerator: agent.shortcut ? convertShortcutToAccelerator(agent.shortcut) : undefined,

--- a/electron/services/AgentVersionService.ts
+++ b/electron/services/AgentVersionService.ts
@@ -8,6 +8,7 @@ import {
 import type { AgentVersionInfo } from "../../shared/types/ipc/system.js";
 import type { AgentId } from "../../shared/types/agent.js";
 import { CliAvailabilityService } from "./CliAvailabilityService.js";
+import { isAgentInstalled } from "../../shared/utils/agentAvailability.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -130,8 +131,7 @@ export class AgentVersionService {
     }
 
     const availability = await this.cliAvailabilityService.checkAvailability();
-    const isAvailable = availability[agentId];
-    if (!isAvailable) {
+    if (!isAgentInstalled(availability[agentId])) {
       return {
         agentId,
         installedVersion: null,

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -1,10 +1,18 @@
 import { execFileSync } from "child_process";
-import type { CliAvailability } from "../../shared/types/ipc.js";
-import { getEffectiveRegistry } from "../../shared/config/agentRegistry.js";
+import { access, constants } from "fs/promises";
+import { join } from "path";
+import { homedir } from "os";
+import type { CliAvailability, AgentAvailabilityState } from "../../shared/types/ipc.js";
+import {
+  getEffectiveRegistry,
+  type AgentConfig,
+  type AgentAuthCheck,
+} from "../../shared/config/agentRegistry.js";
 import { refreshPath } from "../setup/environment.js";
 
 export class CliAvailabilityService {
   private static readonly CHECK_TIMEOUT_MS = 10_000;
+  private static readonly AUTH_CHECK_TIMEOUT_MS = 3_000;
 
   private availability: CliAvailability | null = null;
   private inFlightCheck: Promise<CliAvailability> | null = null;
@@ -27,8 +35,8 @@ export class CliAvailabilityService {
 
         const checksPromise = Promise.allSettled(
           entries.map(async ([id, config]) => {
-            const available = await this.checkCommand(config.command);
-            return [id, available] as [string, boolean];
+            const state = await this.checkAgent(config);
+            return [id, state] as [string, AgentAvailabilityState];
           })
         );
 
@@ -40,7 +48,7 @@ export class CliAvailabilityService {
           );
         });
 
-        let availabilityEntries: [string, boolean][];
+        let availabilityEntries: [string, AgentAvailabilityState][];
         try {
           const results = await Promise.race([checksPromise, timeoutPromise]);
           availabilityEntries = results.map((result, index) => {
@@ -51,12 +59,14 @@ export class CliAvailabilityService {
                 `[CliAvailabilityService] Check failed for ${entries[index][0]}:`,
                 result.reason
               );
-              return [entries[index][0], false] as [string, boolean];
+              return [entries[index][0], "missing"] as [string, AgentAvailabilityState];
             }
           });
         } catch (error) {
           console.warn("[CliAvailabilityService]", error instanceof Error ? error.message : error);
-          availabilityEntries = entries.map(([id]) => [id, false]);
+          availabilityEntries = entries.map(
+            ([id]) => [id, "missing"] as [string, AgentAvailabilityState]
+          );
         } finally {
           if (timeoutHandle) {
             clearTimeout(timeoutHandle);
@@ -89,6 +99,65 @@ export class CliAvailabilityService {
     this.checkId++;
     this.inFlightCheck = null;
     return this.checkAvailability();
+  }
+
+  private async checkAgent(config: AgentConfig): Promise<AgentAvailabilityState> {
+    const binaryFound = await this.checkCommand(config.command);
+    if (!binaryFound) return "missing";
+
+    if (!config.authCheck) return "ready";
+
+    return this.checkAuth(config.authCheck);
+  }
+
+  private async checkAuth(authCheck: AgentAuthCheck): Promise<AgentAvailabilityState> {
+    const timeoutPromise = new Promise<AgentAvailabilityState>((resolve) => {
+      setTimeout(
+        () => resolve(authCheck.fallback ?? "installed"),
+        CliAvailabilityService.AUTH_CHECK_TIMEOUT_MS
+      );
+    });
+
+    const checkPromise = (async (): Promise<AgentAvailabilityState> => {
+      // Check environment variable first (positive signal only)
+      if (authCheck.envVar && process.env[authCheck.envVar]) {
+        return "ready";
+      }
+
+      const home = homedir();
+
+      // Check platform-specific config paths
+      const platform = process.platform as "darwin" | "linux" | "win32";
+      const platformPaths = authCheck.configPaths?.[platform];
+      if (platformPaths) {
+        for (const relPath of platformPaths) {
+          const fullPath = join(home, relPath);
+          try {
+            await access(fullPath, constants.R_OK);
+            return "ready";
+          } catch {
+            // File not found, continue
+          }
+        }
+      }
+
+      // Check platform-independent config paths
+      if (authCheck.configPathsAll) {
+        for (const relPath of authCheck.configPathsAll) {
+          const fullPath = join(home, relPath);
+          try {
+            await access(fullPath, constants.R_OK);
+            return "ready";
+          } catch {
+            // File not found, continue
+          }
+        }
+      }
+
+      return authCheck.fallback ?? "installed";
+    })();
+
+    return Promise.race([checkPromise, timeoutPromise]);
   }
 
   private async checkCommand(command: string): Promise<boolean> {

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -16,6 +16,12 @@ vi.mock("../../setup/environment.js", () => ({
   refreshPath: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock fs/promises for auth checks
+vi.mock("fs/promises", () => ({
+  access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  constants: { R_OK: 4 },
+}));
+
 describe("CliAvailabilityService", () => {
   let service: CliAvailabilityService;
   const mockedExecFileSync = vi.mocked(execFileSync);
@@ -30,20 +36,17 @@ describe("CliAvailabilityService", () => {
   });
 
   describe("checkAvailability", () => {
-    it("checks all CLIs and returns availability status", async () => {
-      // Mock all CLIs as available
+    it("returns 'installed' when binary found but no auth file (default)", async () => {
+      // Mock all CLIs as available (binary found)
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       const result = await service.checkAvailability();
 
-      expect(result).toEqual({
-        claude: true,
-        gemini: true,
-        codex: true,
-        opencode: true,
-        cursor: true,
-        kiro: true,
-      });
+      // All agents have authCheck config, so without auth files they return "installed"
+      // (cursor has fallback: "installed" explicitly)
+      for (const state of Object.values(result)) {
+        expect(state).toBe("installed");
+      }
 
       // Should have called execFileSync 6 times (once for each CLI)
       expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
@@ -56,28 +59,23 @@ describe("CliAvailabilityService", () => {
       );
     });
 
-    it("detects when some CLIs are not available", async () => {
-      // Mock claude as available, gemini/codex/opencode as not available
-      mockedExecFileSync.mockImplementation((_file, args) => {
-        if (args?.[0] === "claude") {
-          return Buffer.from("/usr/local/bin/claude");
-        }
-        throw new Error("Command not found");
-      });
+    it("returns 'ready' when binary found and auth file exists", async () => {
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      // Binary found
+      mockedExecFileSync.mockImplementation(() => Buffer.from(""));
+      // Auth file found
+      mockedAccess.mockResolvedValue(undefined);
 
       const result = await service.checkAvailability();
 
-      expect(result).toEqual({
-        claude: true,
-        gemini: false,
-        codex: false,
-        opencode: false,
-        cursor: false,
-        kiro: false,
-      });
+      for (const state of Object.values(result)) {
+        expect(state).toBe("ready");
+      }
     });
 
-    it("detects when all CLIs are not available", async () => {
+    it("returns 'missing' when binary not found", async () => {
       // Mock all CLIs as not available
       mockedExecFileSync.mockImplementation(() => {
         throw new Error("Command not found");
@@ -86,17 +84,41 @@ describe("CliAvailabilityService", () => {
       const result = await service.checkAvailability();
 
       expect(result).toEqual({
-        claude: false,
-        gemini: false,
-        codex: false,
-        opencode: false,
-        cursor: false,
-        kiro: false,
+        claude: "missing",
+        gemini: "missing",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+        kiro: "missing",
       });
     });
 
+    it("returns mixed states for different agents", async () => {
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      // Only claude binary found
+      mockedExecFileSync.mockImplementation((_file, args) => {
+        if (args?.[0] === "claude") {
+          return Buffer.from("/usr/local/bin/claude");
+        }
+        throw new Error("Command not found");
+      });
+
+      // Auth file found (for claude)
+      mockedAccess.mockResolvedValue(undefined);
+
+      const result = await service.checkAvailability();
+
+      expect(result.claude).toBe("ready");
+      expect(result.gemini).toBe("missing");
+      expect(result.codex).toBe("missing");
+      expect(result.opencode).toBe("missing");
+      expect(result.cursor).toBe("missing");
+      expect(result.kiro).toBe("missing");
+    });
+
     it("uses which on Unix-like systems", async () => {
-      // Save original platform
       const originalPlatform = process.platform;
 
       try {
@@ -109,14 +131,12 @@ describe("CliAvailabilityService", () => {
 
         await service.checkAvailability();
 
-        // Should use 'which' command on Unix
         expect(mockedExecFileSync).toHaveBeenCalledWith(
           "which",
           expect.any(Array),
           expect.any(Object)
         );
       } finally {
-        // Restore original platform even if test fails
         Object.defineProperty(process, "platform", {
           value: originalPlatform,
           writable: true,
@@ -125,7 +145,6 @@ describe("CliAvailabilityService", () => {
     });
 
     it("uses where on Windows", async () => {
-      // Save original platform
       const originalPlatform = process.platform;
 
       try {
@@ -138,14 +157,12 @@ describe("CliAvailabilityService", () => {
 
         await service.checkAvailability();
 
-        // Should use 'where' command on Windows
         expect(mockedExecFileSync).toHaveBeenCalledWith(
           "where",
           expect.any(Array),
           expect.any(Object)
         );
       } finally {
-        // Restore original platform even if test fails
         Object.defineProperty(process, "platform", {
           value: originalPlatform,
           writable: true,
@@ -167,14 +184,9 @@ describe("CliAvailabilityService", () => {
       await service.checkAvailability();
       vi.mocked(refreshPath).mockClear();
 
-      // Second check — cache is warm, should not call refreshPath
       await service.refresh();
-      // refresh() calls refreshPath explicitly, so clear again
       vi.mocked(refreshPath).mockClear();
 
-      // Force a new check via the service's own checkAvailability
-      // After refresh completes, inFlightCheck is cleared and availability is set
-      // A subsequent checkAvailability should NOT call refreshPath since availability !== null
       await service.checkAvailability();
       expect(refreshPath).not.toHaveBeenCalled();
     });
@@ -188,8 +200,6 @@ describe("CliAvailabilityService", () => {
         service.checkAvailability(),
       ]);
 
-      // All concurrent calls share the same in-flight promise,
-      // so refreshPath should only be called once
       expect(refreshPath).toHaveBeenCalledOnce();
     });
 
@@ -201,6 +211,30 @@ describe("CliAvailabilityService", () => {
 
       expect(result1).toEqual(result2);
       expect(result2).not.toBeNull();
+    });
+  });
+
+  describe("auth check with env var", () => {
+    it("returns ready when OPENAI_API_KEY is set for codex", async () => {
+      const origKey = process.env.OPENAI_API_KEY;
+      process.env.OPENAI_API_KEY = "sk-test-key";
+
+      try {
+        // Only codex binary found
+        mockedExecFileSync.mockImplementation((_file, args) => {
+          if (args?.[0] === "codex") return Buffer.from("");
+          throw new Error("not found");
+        });
+
+        const result = await service.checkAvailability();
+        expect(result.codex).toBe("ready");
+      } finally {
+        if (origKey === undefined) {
+          delete process.env.OPENAI_API_KEY;
+        } else {
+          process.env.OPENAI_API_KEY = origKey;
+        }
+      }
     });
   });
 
@@ -216,14 +250,11 @@ describe("CliAvailabilityService", () => {
       await service.checkAvailability();
       const cached = service.getAvailability();
 
-      expect(cached).toEqual({
-        claude: true,
-        gemini: true,
-        codex: true,
-        opencode: true,
-        cursor: true,
-        kiro: true,
-      });
+      expect(cached).not.toBeNull();
+      // All agents should have some state (not null)
+      for (const state of Object.values(cached!)) {
+        expect(["missing", "installed", "ready"]).toContain(state);
+      }
     });
   });
 
@@ -237,23 +268,12 @@ describe("CliAvailabilityService", () => {
     });
 
     it("re-checks availability and updates cache", async () => {
-      // Initial check - all available
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
       await service.checkAvailability();
 
-      expect(service.getAvailability()).toEqual({
-        claude: true,
-        gemini: true,
-        codex: true,
-        opencode: true,
-        cursor: true,
-        kiro: true,
-      });
-
-      // Clear mocks
       vi.clearAllMocks();
 
-      // Refresh with changed availability - only claude available now
+      // Only claude available now
       mockedExecFileSync.mockImplementation((_file, args) => {
         if (args?.[0] === "claude") {
           return Buffer.from("/usr/local/bin/claude");
@@ -263,39 +283,23 @@ describe("CliAvailabilityService", () => {
 
       const refreshed = await service.refresh();
 
-      expect(refreshed).toEqual({
-        claude: true,
-        gemini: false,
-        codex: false,
-        opencode: false,
-        cursor: false,
-        kiro: false,
-      });
+      expect(refreshed.claude).not.toBe("missing");
+      expect(refreshed.gemini).toBe("missing");
+      expect(refreshed.codex).toBe("missing");
 
       expect(service.getAvailability()).toEqual(refreshed);
-
-      // Should have called execFileSync again (6 times for refresh)
       expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
     });
 
     it("works on cold start before initial check", async () => {
-      // Fresh service, no prior checkAvailability call
       const freshService = new CliAvailabilityService();
-
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
-      // refresh() should still populate cache even on first call
       const result = await freshService.refresh();
 
-      expect(result).toEqual({
-        claude: true,
-        gemini: true,
-        codex: true,
-        opencode: true,
-        cursor: true,
-        kiro: true,
-      });
-
+      for (const state of Object.values(result)) {
+        expect(["missing", "installed", "ready"]).toContain(state);
+      }
       expect(freshService.getAvailability()).toEqual(result);
     });
   });
@@ -313,7 +317,6 @@ describe("CliAvailabilityService", () => {
 
       await service.checkAvailability();
 
-      // All six CLIs should have been checked
       expect(executionOrder).toHaveLength(6);
       expect(executionOrder).toContain("claude");
       expect(executionOrder).toContain("gemini");
@@ -326,46 +329,34 @@ describe("CliAvailabilityService", () => {
     it("deduplicates concurrent checkAvailability calls", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
-      // Start multiple checks concurrently
       const [result1, result2, result3] = await Promise.all([
         service.checkAvailability(),
         service.checkAvailability(),
         service.checkAvailability(),
       ]);
 
-      // All should return the same result
       expect(result1).toEqual(result2);
       expect(result2).toEqual(result3);
-
-      // Should only have called execFileSync 6 times total (not 18)
-      // because concurrent calls share the same in-flight promise
       expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
     });
 
     it("concurrent refresh calls each trigger a new check", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
-      // Start multiple refresh calls concurrently
       const [result1, result2] = await Promise.all([service.refresh(), service.refresh()]);
 
-      // Both should return the same result (mocked)
       expect(result1).toEqual(result2);
-
-      // Should call execFileSync 12 times total (6 for each refresh)
-      // Refresh intentionally breaks deduplication to ensure freshness
       expect(mockedExecFileSync).toHaveBeenCalledTimes(12);
     });
 
     it("allows sequential checks after first completes", async () => {
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
-      // First check
       await service.checkAvailability();
       expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
 
       vi.clearAllMocks();
 
-      // Second check after first completes should trigger new checks
       await service.refresh();
       expect(mockedExecFileSync).toHaveBeenCalledTimes(6);
     });
@@ -373,20 +364,13 @@ describe("CliAvailabilityService", () => {
 
   describe("security - command validation", () => {
     it("rejects commands with invalid characters in private checkCommand", async () => {
-      // This test verifies the internal security validation
-      // We can't directly test the private method, but we can verify
-      // that the public API never attempts to execute unsafe commands
-
-      // Try to check availability normally (safe commands)
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
       await service.checkAvailability();
 
-      // Verify that execFileSync was called with safe, expected commands
       const calls = mockedExecFileSync.mock.calls;
       calls.forEach((call) => {
         const args = call[1] as string[];
         const command = args[0];
-        // All commands should match safe pattern: alphanumeric, dash, underscore, dot
         expect(command).toMatch(/^[a-zA-Z0-9._-]+$/);
       });
     });

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -125,6 +125,17 @@ export interface AgentModelConfig {
   shortLabel: string;
 }
 
+export interface AgentAuthCheck {
+  /** Platform-specific config file paths to check (relative to os.homedir()) */
+  configPaths?: Partial<Record<"darwin" | "linux" | "win32", string[]>>;
+  /** Platform-independent config file paths (relative to os.homedir()) */
+  configPathsAll?: string[];
+  /** Environment variable that indicates auth when present */
+  envVar?: string;
+  /** Fallback state when binary found but auth check is inconclusive */
+  fallback?: "installed" | "ready";
+}
+
 export interface AgentConfig {
   id: string;
   name: string;
@@ -232,6 +243,11 @@ export interface AgentConfig {
    * Merged with baseline prerequisites during health checks.
    */
   prerequisites?: PrerequisiteSpec[];
+  /**
+   * Authentication check configuration.
+   * Used by CliAvailabilityService to distinguish "installed" from "ready".
+   */
+  authCheck?: AgentAuthCheck;
 }
 
 export const AGENT_REGISTRY: Record<string, AgentConfig> = {
@@ -368,6 +384,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     },
     help: {
       args: [],
+    },
+    authCheck: {
+      configPathsAll: [".claude/config.json"],
     },
     prerequisites: [
       {
@@ -512,6 +531,14 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     help: {
       args: [],
     },
+    authCheck: {
+      configPaths: {
+        darwin: ["Library/Application Support/gemini/credentials.json"],
+        linux: [".config/gemini/credentials.json"],
+        win32: [".config/gemini/credentials.json"],
+      },
+      envVar: "GEMINI_API_KEY",
+    },
     prerequisites: [
       {
         tool: "gemini",
@@ -651,6 +678,10 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     },
     help: {
       args: [],
+    },
+    authCheck: {
+      configPathsAll: [".config/openai/auth.json", ".openai/auth.json"],
+      envVar: "OPENAI_API_KEY",
     },
     prerequisites: [
       {
@@ -820,6 +851,13 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     resume: {
       args: (sessionId: string) => ["-s", sessionId],
     },
+    authCheck: {
+      configPaths: {
+        darwin: ["Library/Application Support/opencode/config.json"],
+        linux: [".config/opencode/config.json"],
+        win32: [".config/opencode/config.json"],
+      },
+    },
     prerequisites: [
       {
         tool: "opencode",
@@ -915,6 +953,16 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       },
       maxConcurrent: 2,
       enabled: true,
+    },
+    authCheck: {
+      // Cursor may store tokens in OS Keychain on newer versions;
+      // file check is best-effort, default to "installed" if inconclusive.
+      configPaths: {
+        darwin: ["Library/Application Support/Cursor/User/globalStorage/storage.json"],
+        linux: [".config/Cursor/User/globalStorage/storage.json"],
+        win32: ["AppData/Roaming/Cursor/User/globalStorage/storage.json"],
+      },
+      fallback: "installed",
     },
     prerequisites: [
       {
@@ -1046,6 +1094,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
     },
     help: {
       args: [],
+    },
+    authCheck: {
+      configPathsAll: [".kiro/credentials", ".kiro/config.json"],
     },
     prerequisites: [
       {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -121,6 +121,7 @@ export type {
   SystemOpenExternalPayload,
   SystemOpenPathPayload,
   AppMetricsSummary,
+  AgentAvailabilityState,
   CliAvailability,
   AgentVersionInfo,
   AgentUpdateSettings,

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -26,8 +26,11 @@ export interface SystemWakePayload {
   timestamp: number;
 }
 
+/** Three-state availability for an individual agent CLI */
+export type AgentAvailabilityState = "missing" | "installed" | "ready";
+
 /** CLI availability status for AI agents */
-export type CliAvailability = Record<AgentId, boolean>;
+export type CliAvailability = Record<AgentId, AgentAvailabilityState>;
 
 /** Version information for an agent */
 export interface AgentVersionInfo {

--- a/shared/utils/agentAvailability.ts
+++ b/shared/utils/agentAvailability.ts
@@ -1,0 +1,13 @@
+import type { AgentAvailabilityState } from "../types/ipc/system.js";
+
+export function isAgentReady(state: AgentAvailabilityState | undefined): boolean {
+  return state === "ready";
+}
+
+export function isAgentInstalled(state: AgentAvailabilityState | undefined): boolean {
+  return state === "installed" || state === "ready";
+}
+
+export function isAgentMissing(state: AgentAvailabilityState | undefined): boolean {
+  return state === "missing" || state === undefined;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,7 @@ import {
   usePaletteStore,
   useNotificationSettingsStore,
 } from "./store";
+import { isAgentReady } from "../shared/utils/agentAvailability";
 import { useShallow } from "zustand/react/shallow";
 import { useMacroFocusStore } from "./store/macroFocusStore";
 import { useSafeModeStore } from "./store/safeModeStore";
@@ -328,7 +329,7 @@ function App() {
       : [];
     const primaryAgent = defaultAgent ?? selected[0];
 
-    if (primaryAgent && availability[primaryAgent]) {
+    if (primaryAgent && isAgentReady(availability[primaryAgent])) {
       launchAgent(primaryAgent, {
         worktreeId: activeWorktreeId ?? undefined,
       }).catch(() => {});

--- a/src/components/HelpPanel/HelpAgentPicker.tsx
+++ b/src/components/HelpPanel/HelpAgentPicker.tsx
@@ -7,6 +7,7 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { actionService } from "@/services/ActionService";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { isAgentMissing } from "../../../shared/utils/agentAvailability";
 
 interface HelpAgentPickerProps {
   onSelectAgent: (agentId: string) => void;
@@ -19,7 +20,7 @@ export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
   const enabledAgents = useMemo(() => {
     return BUILT_IN_AGENT_IDS.filter((id) => {
       if (settings?.agents && settings.agents[id]?.selected === false) return false;
-      if (availability[id] === false) return false;
+      if (isAgentMissing(availability[id])) return false;
       return true;
     });
   }, [settings, availability]);

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -18,12 +18,14 @@ import {
 } from "@/components/ui/context-menu";
 
 import type { BuiltInAgentId } from "@shared/config/agentIds";
+import type { AgentAvailabilityState } from "@shared/types";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
 
 type AgentType = BuiltInAgentId;
 
 interface AgentButtonProps {
   type: AgentType;
-  availability?: boolean;
+  availability?: AgentAvailabilityState;
   "data-toolbar-item"?: string;
 }
 
@@ -41,7 +43,7 @@ export function AgentButton({
   const tooltipDetails = config.tooltip ? ` — ${config.tooltip}` : "";
   const shortcut = displayCombo ? ` (${displayCombo})` : "";
   const isLoading = availability === undefined;
-  const isAvailable = availability ?? false;
+  const isAvailable = isAgentReady(availability);
 
   const tooltip = isLoading
     ? `Checking ${config.name} CLI availability...`

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -5,6 +5,8 @@ import { Spinner } from "@/components/ui/Spinner";
 import { agentHelpClient } from "@/clients";
 import { cliAvailabilityClient } from "@/clients";
 import type { AgentHelpResult } from "@shared/types/ipc/agent";
+import type { AgentAvailabilityState } from "@shared/types";
+import { isAgentInstalled, isAgentMissing } from "../../../shared/utils/agentAvailability";
 
 interface AgentHelpOutputProps {
   agentId: string;
@@ -24,7 +26,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
   const [helpResult, setHelpResult] = useState<AgentHelpResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isCliAvailable, setIsCliAvailable] = useState<boolean | null>(null);
+  const [isCliAvailable, setIsCliAvailable] = useState<AgentAvailabilityState | null>(null);
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isMountedRef = useRef(true);
@@ -32,9 +34,9 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
   const checkCliAvailability = useCallback(async () => {
     try {
       const availability = await cliAvailabilityClient.get();
-      return availability[agentId] ?? false;
+      return availability[agentId] ?? "missing";
     } catch {
-      return false;
+      return "missing";
     }
   }, [agentId]);
 
@@ -70,7 +72,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
       const available = await checkCliAvailability();
       setIsCliAvailable(available);
 
-      if (!available) {
+      if (!isAgentInstalled(available)) {
         setIsLoading(false);
         return;
       }
@@ -165,7 +167,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
           </p>
         </div>
 
-        {isCliAvailable && (
+        {isAgentInstalled(isCliAvailable ?? undefined) && (
           <div className="flex items-center gap-2">
             <Button
               size="sm"
@@ -200,7 +202,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
         </div>
       )}
 
-      {!isLoading && isCliAvailable === false && (
+      {!isLoading && isAgentMissing(isCliAvailable ?? undefined) && isCliAvailable !== null && (
         <div className="px-4 py-6 rounded-[var(--radius-md)] border border-canopy-border bg-surface text-center space-y-2">
           <p className="text-sm text-canopy-text/60">CLI not found</p>
           <p className="text-xs text-canopy-text/40 select-text">

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -485,7 +485,7 @@ export function AgentSettings({
               const installBlocks = agentConfig ? getInstallBlocksForCurrentOS(agentConfig) : null;
               const hasInstallConfig = agentConfig?.install;
 
-              if (isCliAvailable === true) {
+              if (isCliAvailable === "ready") {
                 return null;
               }
 
@@ -504,9 +504,13 @@ export function AgentSettings({
                 >
                   <div className="flex items-center justify-between">
                     <div>
-                      <h5 className="text-sm font-medium text-canopy-text">Installation</h5>
+                      <h5 className="text-sm font-medium text-canopy-text">
+                        {isCliAvailable === "installed" ? "Authentication" : "Installation"}
+                      </h5>
                       <p className="text-xs text-canopy-text/50 select-text">
-                        {activeAgent.name} CLI not found
+                        {isCliAvailable === "installed"
+                          ? `${activeAgent.name} CLI found but not authenticated`
+                          : `${activeAgent.name} CLI not found`}
                       </p>
                     </div>
                     <Button

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -23,6 +23,7 @@ import { getAgentIds, getAgentConfig } from "@/config/agents";
 import { DEFAULT_AGENT_SETTINGS, getAgentSettingsEntry } from "@shared/types";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import type { HibernationConfig, CliAvailability, AgentSettings } from "@shared/types";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
 import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
@@ -377,7 +378,7 @@ export function GeneralTab({
                   const config = getAgentConfig(id);
                   const agentEntry = getAgentSettingsEntry(agentSettings, id);
                   const isSelected = agentEntry.selected !== false;
-                  const isAvailable = cliAvailability[id] ?? false;
+                  const isAvailable = isAgentReady(cliAvailability[id]);
                   const name = config?.name ?? id;
                   const isUnavailable = isSelected && !isAvailable;
 

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -7,6 +7,7 @@ import { terminalClient, systemClient } from "@/clients";
 import { EmbeddedTerminal } from "./EmbeddedTerminal";
 import { AGENT_DESCRIPTIONS } from "./AgentSetupWizard";
 import type { CliAvailability } from "@shared/types";
+import { isAgentInstalled, isAgentMissing } from "@shared/utils/agentAvailability";
 
 const AGENT_ORDER = BUILT_IN_AGENT_IDS;
 
@@ -34,8 +35,8 @@ export function AgentCliStep({ availability, selections }: AgentCliStepProps) {
   useEffect(() => {
     if (
       installingAgentId &&
-      availability[installingAgentId] !== "missing" &&
-      prevAvailabilityRef.current[installingAgentId] === "missing"
+      isAgentInstalled(availability[installingAgentId]) &&
+      isAgentMissing(prevAvailabilityRef.current[installingAgentId])
     ) {
       setInstallingAgentId(null);
       if (installTimeoutRef.current) {
@@ -119,7 +120,7 @@ export function AgentCliStep({ availability, selections }: AgentCliStepProps) {
           const config = AGENT_REGISTRY[agentId];
           if (!config) return null;
 
-          const isInstalled = availability[agentId] !== "missing";
+          const isInstalled = isAgentInstalled(availability[agentId]);
           const isInstalling = installingAgentId === agentId;
           const isDisabled = isInstalled || !!installingAgentId || !terminalId;
           const blocks = getInstallBlocksForCurrentOS(config);

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -34,8 +34,8 @@ export function AgentCliStep({ availability, selections }: AgentCliStepProps) {
   useEffect(() => {
     if (
       installingAgentId &&
-      availability[installingAgentId] === true &&
-      prevAvailabilityRef.current[installingAgentId] !== true
+      availability[installingAgentId] !== "missing" &&
+      prevAvailabilityRef.current[installingAgentId] === "missing"
     ) {
       setInstallingAgentId(null);
       if (installTimeoutRef.current) {
@@ -119,7 +119,7 @@ export function AgentCliStep({ availability, selections }: AgentCliStepProps) {
           const config = AGENT_REGISTRY[agentId];
           if (!config) return null;
 
-          const isInstalled = availability[agentId] === true;
+          const isInstalled = availability[agentId] !== "missing";
           const isInstalling = installingAgentId === agentId;
           const isDisabled = isInstalled || !!installingAgentId || !terminalId;
           const blocks = getInstallBlocksForCurrentOS(config);

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -11,6 +11,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cliAvailabilityClient } from "@/clients";
 import { isCanopyEnvEnabled } from "@/utils/env";
 import type { CliAvailability } from "@shared/types";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
 import { CanopyAgentIcon } from "@/components/icons";
 
@@ -196,13 +197,13 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
     initRef.current = true;
     const initial: Record<string, boolean> = {};
     for (const agentId of AGENT_ORDER) {
-      initial[agentId] = state.availability[agentId] === true;
+      initial[agentId] = isAgentReady(state.availability[agentId]);
     }
     dispatch({ type: "INIT_SELECTIONS", payload: initial });
   }, [isOpen, isAvailabilityLoading, state.availability, state.selectionsInitialized]);
 
   const installedAgents = useMemo(
-    () => AGENT_ORDER.filter((id) => state.availability[id] === true),
+    () => AGENT_ORDER.filter((id) => isAgentReady(state.availability[id])),
     [state.availability]
   );
 
@@ -394,7 +395,8 @@ function SelectionStep({
           {AGENT_ORDER.map((agentId) => {
             const config = AGENT_REGISTRY[agentId];
             if (!config) return null;
-            const isInstalled = availability[agentId] === true;
+            const agentState = availability[agentId];
+            const isInstalled = agentState !== "missing";
             const isChecked = selections[agentId] ?? false;
             const Icon = config.icon;
             const description = AGENT_DESCRIPTIONS[agentId] ?? config.tooltip ?? "";
@@ -423,9 +425,13 @@ function SelectionStep({
                     <div className="text-[11px] text-canopy-text/40 truncate">{description}</div>
                   )}
                 </div>
-                {isInstalled ? (
+                {agentState === "ready" ? (
                   <span className="text-[11px] text-status-success font-medium shrink-0">
-                    Installed
+                    Ready
+                  </span>
+                ) : isInstalled ? (
+                  <span className="text-[11px] text-status-warning font-medium shrink-0">
+                    Needs login
                   </span>
                 ) : (
                   <span className="text-[11px] text-canopy-text/30 shrink-0">Not installed</span>

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { buildInitialState, wizardReducer } from "../AgentSetupWizard";
+import type { CliAvailability } from "@shared/types";
 
 describe("AgentSetupWizard reducer", () => {
-  const emptyAvail: Record<string, string> = {};
-  const partialAvail: Record<string, string> = {
+  const emptyAvail = {} as CliAvailability;
+  const partialAvail = {
     claude: "ready",
     gemini: "missing",
     codex: "missing",
-  };
+  } as CliAvailability;
 
   it("starts at health step by default", () => {
     const state = buildInitialState(emptyAvail, false);
@@ -39,7 +40,7 @@ describe("AgentSetupWizard reducer", () => {
   });
 
   it("advances from selection to cli even when all agents installed", () => {
-    const allInstalled: Record<string, string> = { claude: "ready", gemini: "ready" };
+    const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled, true);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
@@ -124,7 +125,7 @@ describe("AgentSetupWizard reducer", () => {
     });
     state = wizardReducer(state, {
       type: "SET_AVAILABILITY",
-      payload: { claude: "ready" },
+      payload: { claude: "ready" } as CliAvailability,
     });
     expect(state.availability.claude).toBe("ready");
     expect(state.selections.claude).toBe(false); // selections unchanged

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "vitest";
 import { buildInitialState, wizardReducer } from "../AgentSetupWizard";
 
 describe("AgentSetupWizard reducer", () => {
-  const emptyAvail: Record<string, boolean> = {};
-  const partialAvail: Record<string, boolean> = { claude: true, gemini: false, codex: false };
+  const emptyAvail: Record<string, string> = {};
+  const partialAvail: Record<string, string> = {
+    claude: "ready",
+    gemini: "missing",
+    codex: "missing",
+  };
 
   it("starts at health step by default", () => {
     const state = buildInitialState(emptyAvail, false);
@@ -35,7 +39,7 @@ describe("AgentSetupWizard reducer", () => {
   });
 
   it("advances from selection to cli even when all agents installed", () => {
-    const allInstalled: Record<string, boolean> = { claude: true, gemini: true };
+    const allInstalled: Record<string, string> = { claude: "ready", gemini: "ready" };
     let state = buildInitialState(allInstalled, true);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
@@ -120,9 +124,9 @@ describe("AgentSetupWizard reducer", () => {
     });
     state = wizardReducer(state, {
       type: "SET_AVAILABILITY",
-      payload: { claude: true },
+      payload: { claude: "ready" },
     });
-    expect(state.availability.claude).toBe(true);
+    expect(state.availability.claude).toBe("ready");
     expect(state.selections.claude).toBe(false); // selections unchanged
   });
 

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -651,7 +651,7 @@ export function ContentGrid({
       .map((id) => {
         const agentConfig = getEffectiveAgentConfig(id);
         const canLaunch =
-          id === "terminal" ? true : !agentAvailability || agentAvailability[id] === true;
+          id === "terminal" ? true : !agentAvailability || isAgentReady(agentAvailability[id]);
         return { id, name: agentConfig?.name ?? id, canLaunch };
       });
   }, [agentAvailability, gridSelectedAgentIds]);

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -13,6 +13,7 @@ import {
   type TerminalInstance,
 } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
 import { GridPanel } from "./GridPanel";
 import { GridTabGroup } from "./GridTabGroup";
 import { GridNotificationBar } from "./GridNotificationBar";
@@ -196,7 +197,10 @@ function RotatingTip() {
 
   const filteredTips = useMemo(
     () =>
-      TIPS.filter((tip) => !tip.requiredAgents || tip.requiredAgents.some((a) => availability[a])),
+      TIPS.filter(
+        (tip) =>
+          !tip.requiredAgents || tip.requiredAgents.some((a) => isAgentReady(availability[a]))
+      ),
     [availability]
   );
 

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -19,6 +19,7 @@ import { cn } from "../../lib/utils";
 import { getAgentConfig, getAgentIds } from "@/config/agents";
 import { getAgentSettingsEntry } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
 import { WorktreeDetailsSection } from "./WorktreeCard/WorktreeDetailsSection";
 import { WorktreeDialogs } from "./WorktreeCard/WorktreeDialogs";
 import { WorktreeHeader } from "./WorktreeCard/WorktreeHeader";
@@ -487,7 +488,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
       })
       .map((agentId) => {
         const config = getAgentConfig(agentId);
-        const available = agentAvailability?.[agentId] ?? false;
+        const available = isAgentReady(agentAvailability?.[agentId]);
 
         return {
           id: agentId,

--- a/src/components/Worktree/WorktreeCard/__tests__/worktreeCardPropsAreEqual.test.ts
+++ b/src/components/Worktree/WorktreeCard/__tests__/worktreeCardPropsAreEqual.test.ts
@@ -123,20 +123,20 @@ describe("worktreeCardPropsAreEqual", () => {
   });
 
   it("returns false when agentAvailability values change", () => {
-    const prev = baseProps({ agentAvailability: { claude: true, codex: false } as never });
-    const next = baseProps({ agentAvailability: { claude: true, codex: true } as never });
+    const prev = baseProps({ agentAvailability: { claude: "ready", codex: "missing" } as never });
+    const next = baseProps({ agentAvailability: { claude: "ready", codex: "ready" } as never });
     expect(worktreeCardPropsAreEqual(prev, next)).toBe(false);
   });
 
   it("returns true when agentAvailability has same values (different reference)", () => {
-    const prev = baseProps({ agentAvailability: { claude: true } as never });
-    const next = baseProps({ agentAvailability: { claude: true } as never });
+    const prev = baseProps({ agentAvailability: { claude: "ready" } as never });
+    const next = baseProps({ agentAvailability: { claude: "ready" } as never });
     expect(worktreeCardPropsAreEqual(prev, next)).toBe(true);
   });
 
   it("returns false when agentAvailability key count changes", () => {
-    const prev = baseProps({ agentAvailability: { claude: true } as never });
-    const next = baseProps({ agentAvailability: { claude: true, codex: false } as never });
+    const prev = baseProps({ agentAvailability: { claude: "ready" } as never });
+    const next = baseProps({ agentAvailability: { claude: "ready", codex: "missing" } as never });
     expect(worktreeCardPropsAreEqual(prev, next)).toBe(false);
   });
 

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -17,7 +17,7 @@ const {
   getEffectiveAgentIdsMock: vi.fn(),
   getEffectiveAgentConfigMock: vi.fn(),
   cliAvailabilityState: {
-    availability: { claude: true, gemini: false } as Record<string, boolean>,
+    availability: { claude: "ready", gemini: "missing" } as Record<string, string>,
     isInitialized: true,
     isLoading: false,
     isRefreshing: false,
@@ -107,7 +107,7 @@ describe("usePanelPalette", () => {
       }
       return undefined;
     });
-    cliAvailabilityState.availability = { claude: true, gemini: false };
+    cliAvailabilityState.availability = { claude: "ready", gemini: "missing" };
     cliAvailabilityState.isInitialized = true;
     cliAvailabilityState.lastCheckedAt = Date.now();
 
@@ -305,7 +305,7 @@ describe("usePanelPalette", () => {
   describe("agent availability", () => {
     it("sets installed=true for available agents", () => {
       getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
-      cliAvailabilityState.availability = { claude: true };
+      cliAvailabilityState.availability = { claude: "ready" };
 
       const { result } = renderHook(() => usePanelPalette());
 
@@ -321,7 +321,7 @@ describe("usePanelPalette", () => {
         color: "#4285f4",
         tooltip: "Gemini agent",
       });
-      cliAvailabilityState.availability = { gemini: false };
+      cliAvailabilityState.availability = { gemini: "missing" };
 
       const { result } = renderHook(() => usePanelPalette());
 
@@ -362,7 +362,7 @@ describe("usePanelPalette", () => {
         color: "#4285f4",
         tooltip: "Gemini agent",
       });
-      cliAvailabilityState.availability = { gemini: false };
+      cliAvailabilityState.availability = { gemini: "missing" };
 
       const { result } = renderHook(() => usePanelPalette());
 
@@ -383,7 +383,7 @@ describe("usePanelPalette", () => {
 
     it("handleSelect returns option for installed agent", () => {
       getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
-      cliAvailabilityState.availability = { claude: true };
+      cliAvailabilityState.availability = { claude: "ready" };
 
       const { result } = renderHook(() => usePanelPalette());
 

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -30,6 +30,7 @@ export type UsePanelPaletteReturn = UseSearchablePaletteReturn<PanelKindOption> 
 };
 
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
 
@@ -121,7 +122,9 @@ export function usePanelPalette(): UsePanelPaletteReturn {
           color: agentConfig.color,
           description: displayCombo || agentConfig.shortcut || agentConfig.tooltip,
           category: "agent" as const,
-          installed: isAvailabilityInitialized ? (availability[agentId] ?? false) : undefined,
+          installed: isAvailabilityInitialized
+            ? isAgentInstalled(availability[agentId])
+            : undefined,
         };
       })
       .filter((agent): agent is PanelKindOption => agent !== null);

--- a/src/lib/__tests__/projectExplanationPrompt.test.ts
+++ b/src/lib/__tests__/projectExplanationPrompt.test.ts
@@ -20,114 +20,114 @@ describe("PROJECT_EXPLANATION_PROMPT", () => {
 describe("getDefaultAgentId", () => {
   it("should return default agent when it matches an available agent", () => {
     const availability: CliAvailability = {
-      claude: true,
-      gemini: false,
-      codex: false,
-      opencode: false,
+      claude: "ready",
+      gemini: "missing",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId("claude", undefined, availability)).toBe("claude");
   });
 
   it("should prioritize default agent over default selection", () => {
     const availability: CliAvailability = {
-      claude: true,
-      gemini: true,
-      codex: false,
-      opencode: false,
+      claude: "ready",
+      gemini: "ready",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId("gemini", "claude", availability)).toBe("gemini");
   });
 
   it("should fall back to default selection when default agent is not available", () => {
     const availability: CliAvailability = {
-      claude: true,
-      gemini: false,
-      codex: false,
-      opencode: false,
+      claude: "ready",
+      gemini: "missing",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId("gemini", "claude", availability)).toBe("claude");
   });
 
   it("should fall back to first available agent when neither default is available", () => {
     const availability: CliAvailability = {
-      claude: true,
-      gemini: false,
-      codex: false,
-      opencode: false,
+      claude: "ready",
+      gemini: "missing",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId("gemini", "codex", availability)).toBe("claude");
   });
 
   it("should fall back to first available agent when no defaults", () => {
     const availability: CliAvailability = {
-      claude: false,
-      gemini: true,
-      codex: false,
-      opencode: false,
+      claude: "missing",
+      gemini: "ready",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId(undefined, undefined, availability)).toBe("gemini");
   });
 
   it("should return null when no agents are available", () => {
     const availability: CliAvailability = {
-      claude: false,
-      gemini: false,
-      codex: false,
-      opencode: false,
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId(undefined, undefined, availability)).toBeNull();
   });
 
   it("should prioritize agents in order: claude, gemini, codex, opencode", () => {
     const availability1: CliAvailability = {
-      claude: true,
-      gemini: true,
-      codex: true,
-      opencode: true,
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+      opencode: "ready",
     };
     expect(getDefaultAgentId(undefined, undefined, availability1)).toBe("claude");
 
     const availability2: CliAvailability = {
-      claude: false,
-      gemini: true,
-      codex: true,
-      opencode: true,
+      claude: "missing",
+      gemini: "ready",
+      codex: "ready",
+      opencode: "ready",
     };
     expect(getDefaultAgentId(undefined, undefined, availability2)).toBe("gemini");
 
     const availability3: CliAvailability = {
-      claude: false,
-      gemini: false,
-      codex: true,
-      opencode: true,
+      claude: "missing",
+      gemini: "missing",
+      codex: "ready",
+      opencode: "ready",
     };
     expect(getDefaultAgentId(undefined, undefined, availability3)).toBe("codex");
 
     const availability4: CliAvailability = {
-      claude: false,
-      gemini: false,
-      codex: false,
-      opencode: true,
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+      opencode: "ready",
     };
     expect(getDefaultAgentId(undefined, undefined, availability4)).toBe("opencode");
   });
 
   it("should ignore default agent if it's not a valid agent", () => {
     const availability: CliAvailability = {
-      claude: true,
-      gemini: false,
-      codex: false,
-      opencode: false,
+      claude: "ready",
+      gemini: "missing",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId("invalid-agent" as any, undefined, availability)).toBe("claude");
   });
 
   it("should handle terminal and browser in default selection gracefully", () => {
     const availability: CliAvailability = {
-      claude: false,
-      gemini: true,
-      codex: false,
-      opencode: false,
+      claude: "missing",
+      gemini: "ready",
+      codex: "missing",
+      opencode: "missing",
     };
     expect(getDefaultAgentId(undefined, "terminal", availability)).toBe("gemini");
     expect(getDefaultAgentId(undefined, "browser", availability)).toBe("gemini");

--- a/src/lib/resolveAgentId.ts
+++ b/src/lib/resolveAgentId.ts
@@ -1,5 +1,6 @@
 import type { CliAvailability } from "@shared/types";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import { isAgentReady } from "../../shared/utils/agentAvailability";
 
 /**
  * Resolve which agent to use given a user preference, an optional secondary
@@ -13,7 +14,8 @@ export function getDefaultAgentId(
   selectedAgents?: Set<string>
 ): BuiltInAgentId | null {
   const isUsable = (id: string) =>
-    availability[id as keyof CliAvailability] && (!selectedAgents || selectedAgents.has(id));
+    isAgentReady(availability[id as keyof CliAvailability]) &&
+    (!selectedAgents || selectedAgents.has(id));
 
   if (
     defaultAgent &&

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -43,10 +43,10 @@ const stubCtx: ActionContext = {};
 
 function allAvailability(override?: Partial<CliAvailability>): CliAvailability {
   return {
-    claude: true,
-    gemini: true,
-    codex: true,
-    opencode: true,
+    claude: "ready",
+    gemini: "ready",
+    codex: "ready",
+    opencode: "ready",
     ...override,
   } as CliAvailability;
 }
@@ -159,7 +159,7 @@ describe("help.launchAgent", () => {
     );
     mockGetAgentPrefsState.mockReturnValue({ defaultAgent: "gemini" });
     mockGetCliAvailabilityState.mockReturnValue({
-      availability: allAvailability({ gemini: false }),
+      availability: allAvailability({ gemini: "missing" }),
       isInitialized: true,
     });
 
@@ -178,7 +178,7 @@ describe("help.launchAgent", () => {
     );
     mockGetAgentPrefsState.mockReturnValue({ defaultAgent: undefined });
     mockGetCliAvailabilityState.mockReturnValue({
-      availability: allAvailability({ claude: false, gemini: false }),
+      availability: allAvailability({ claude: "missing", gemini: "missing" }),
       isInitialized: true,
     });
 
@@ -198,10 +198,10 @@ describe("help.launchAgent", () => {
     mockGetAgentPrefsState.mockReturnValue({ defaultAgent: undefined });
     mockGetCliAvailabilityState.mockReturnValue({
       availability: allAvailability({
-        claude: false,
-        gemini: false,
-        codex: false,
-        opencode: false,
+        claude: "missing",
+        gemini: "missing",
+        codex: "missing",
+        opencode: "missing",
       }),
       isInitialized: false,
     });

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -23,8 +23,20 @@ vi.mock("@/config/agents", () => ({
 
 import { useCliAvailabilityStore, cleanupCliAvailabilityStore } from "../cliAvailabilityStore";
 
-const defaultAvail = { claude: false, gemini: false, codex: false, opencode: false, cursor: false };
-const installedAvail = { claude: true, gemini: false, codex: true, opencode: false, cursor: false };
+const defaultAvail = {
+  claude: "missing",
+  gemini: "missing",
+  codex: "missing",
+  opencode: "missing",
+  cursor: "missing",
+};
+const installedAvail = {
+  claude: "ready",
+  gemini: "missing",
+  codex: "ready",
+  opencode: "missing",
+  cursor: "installed",
+};
 
 describe("cliAvailabilityStore", () => {
   beforeEach(() => {

--- a/src/store/__tests__/normalizeAgentSelection.test.ts
+++ b/src/store/__tests__/normalizeAgentSelection.test.ts
@@ -16,11 +16,11 @@ describe("normalizeAgentSelection", () => {
   });
 
   const availability: CliAvailability = {
-    claude: true,
-    gemini: false,
-    codex: true,
-    opencode: false,
-    cursor: false,
+    claude: "ready",
+    gemini: "missing",
+    codex: "ready",
+    opencode: "missing",
+    cursor: "installed",
   } as CliAvailability;
 
   it("fills selected: undefined using CLI availability", () => {
@@ -65,6 +65,15 @@ describe("normalizeAgentSelection", () => {
     });
     const result = normalizeAgentSelection(settings, availability);
     expect(result.agents.claude.selected).toBe(true);
+  });
+
+  it("does not auto-select agents with 'installed' state", () => {
+    const settings = makeSettings({
+      cursor: {},
+    });
+    const result = normalizeAgentSelection(settings, availability);
+    // cursor is "installed" (not "ready"), so should not be auto-selected
+    expect(result.agents.cursor.selected).toBe(false);
   });
 
   it("returns same reference when no changes are needed", () => {

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -3,6 +3,7 @@ import type { AgentSettings, AgentSettingsEntry, CliAvailability } from "@shared
 import { agentSettingsClient } from "@/clients";
 import { DEFAULT_AGENT_SETTINGS } from "@shared/types";
 import { getEffectiveAgentIds } from "../../shared/config/agentRegistry";
+import { isAgentReady } from "../../shared/utils/agentAvailability";
 
 /**
  * In-memory normalization: fills `selected: undefined` entries using CLI availability
@@ -25,7 +26,7 @@ export function normalizeAgentSelection(
       agents[id] = { ...entry, selected: false };
       changed = true;
     } else if (entry.selected === undefined) {
-      agents[id] = { ...entry, selected: availability[id] === true };
+      agents[id] = { ...entry, selected: isAgentReady(availability[id]) };
       changed = true;
     }
   }
@@ -156,7 +157,7 @@ export async function migrateAgentSelection(availability: CliAvailability): Prom
     try {
       // First: migrate agents without `selected` (existing migration)
       for (const agentId of agentsNeedingMigration) {
-        const selected = availability[agentId] === true;
+        const selected = isAgentReady(availability[agentId]);
         await agentSettingsClient.set(agentId, { selected });
       }
 

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -21,7 +21,7 @@ interface CliAvailabilityActions {
 type CliAvailabilityStore = CliAvailabilityState & CliAvailabilityActions;
 
 function defaultAvailability(): CliAvailability {
-  return Object.fromEntries(getAgentIds().map((id) => [id, false])) as CliAvailability;
+  return Object.fromEntries(getAgentIds().map((id) => [id, "missing"])) as CliAvailability;
 }
 
 let epoch = 0;


### PR DESCRIPTION
## Summary

- Replaces the binary boolean `CliAvailability` type with a three-state `CliAvailabilityState` union: `missing`, `installed`, and `ready`. Each agent in the registry now declares an `authCheck` (config path or lightweight command) so the service can distinguish a binary that's present but unauthenticated from one that's fully set up.
- The new state flows through the wizard's agent selection step, the CLI install step, the completion step, and Settings > Agents, surfacing an amber "Needs login" state rather than a false green "Ready" when auth is still outstanding.
- All existing tests have been updated; 200-line test suite for `CliAvailabilityService` covers all three states per agent.

Resolves #5043

## Changes

- `shared/config/agentRegistry.ts` — added `authCheck` declarations per built-in agent (config path or command)
- `shared/types/ipc/system.ts` — `CliAvailability` type changed from `Record<AgentId, boolean>` to `Record<AgentId, CliAvailabilityState>`
- `shared/utils/agentAvailability.ts` — new utility for deriving display state from `CliAvailabilityState`
- `electron/services/CliAvailabilityService.ts` — auth check logic added; returns three-state result per agent
- UI components updated: `AgentButton`, `AgentSettings`, `AgentHelpOutput`, `GeneralTab`, `AgentCliStep`, `AgentSetupWizard`, `WorktreeCard`, `HelpAgentPicker`, `ContentGrid`

## Testing

`npm run check` passes cleanly (0 errors). Unit tests cover all three detection states across every built-in agent. Wizard flow manually verified: agents with missing binaries show gray, installed-but-unauthenticated show amber, fully ready show green.