### PR TITLE
feat(setup): fold system health check into agent selection step

### DIFF
--- a/e2e/core/core-first-run-onboarding.spec.ts
+++ b/e2e/core/core-first-run-onboarding.spec.ts
@@ -38,11 +38,8 @@ test.describe.serial("First-run onboarding flow", () => {
     await expect(window.locator(SEL.firstRun.welcomeTitle)).toBeVisible({ timeout: T_MEDIUM });
     await window.locator('button:has-text("Continue")').click();
 
-    // Step 2: Agent setup wizard — health check then selection
+    // Step 2: Agent setup wizard — selection step (system health check is inline)
     await expect(window.locator(SEL.firstRun.agentSetupTitle)).toBeVisible({ timeout: T_MEDIUM });
-    // Advance past health check step
-    await window.locator('button:has-text("Continue")').click();
-    // Selection step — verify and skip
     await expect(window.locator(SEL.firstRun.agentTitle)).toBeVisible({ timeout: T_MEDIUM });
     await window.locator('button:has-text("Skip")').click();
 

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -3,13 +3,12 @@ import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
 import { AgentCliStep } from "./AgentCliStep";
-import { SystemToolsStep } from "./SystemToolsStep";
+import { SystemRequirementsSection } from "./SystemRequirementsSection";
 import { AGENT_REGISTRY } from "@/config/agents";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { useAgentSettingsStore } from "@/store";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cliAvailabilityClient } from "@/clients";
-import { isCanopyEnvEnabled } from "@/utils/env";
 import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
 import { Sparkles, ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
@@ -19,8 +18,6 @@ import { UI_ENTER_DURATION, UI_EXIT_DURATION } from "@/lib/animationUtils";
 
 const AGENT_ORDER = BUILT_IN_AGENT_IDS;
 const POLL_INTERVAL = 3000;
-
-const SKIP_FIRST_RUN_DIALOGS = isCanopyEnvEnabled("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS");
 
 // Tier arrays for the selection step — featured agents get prominent display,
 // the rest fall into "More agents". New built-in agents automatically land in MORE_AGENT_IDS.
@@ -81,11 +78,7 @@ const reducedStepVariants: Variants = {
 
 // --- Wizard state machine ---
 
-export type WizardStep =
-  | { type: "health" }
-  | { type: "selection" }
-  | { type: "cli" }
-  | { type: "complete" };
+export type WizardStep = { type: "selection" } | { type: "cli" } | { type: "complete" };
 
 export interface WizardState {
   step: WizardStep;
@@ -96,7 +89,6 @@ export interface WizardState {
 }
 
 export type WizardAction =
-  | { type: "HEALTH_CONTINUE" }
   | { type: "SELECTION_CONTINUE" }
   | { type: "CLI_CONTINUE" }
   | { type: "BACK" }
@@ -105,11 +97,11 @@ export type WizardAction =
   | { type: "TOGGLE_SELECTION"; agentId: string; checked: boolean }
   | { type: "RESET"; availability: CliAvailability };
 
-const TOTAL_STEPS = 4; // health, selection, cli, complete
+const TOTAL_STEPS = 3; // selection, cli, complete
 
-export function buildInitialState(availability: CliAvailability, skipHealth: boolean): WizardState {
+export function buildInitialState(availability: CliAvailability): WizardState {
   return {
-    step: skipHealth ? { type: "selection" } : { type: "health" },
+    step: { type: "selection" },
     history: [],
     availability,
     selections: {},
@@ -119,13 +111,6 @@ export function buildInitialState(availability: CliAvailability, skipHealth: boo
 
 export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   switch (action.type) {
-    case "HEALTH_CONTINUE":
-      return {
-        ...state,
-        step: { type: "selection" },
-        history: [...state.history, state.step],
-      };
-
     case "SELECTION_CONTINUE": {
       const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
       const allSelectedInstalled =
@@ -172,7 +157,7 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       };
 
     case "RESET":
-      return buildInitialState(action.availability, SKIP_FIRST_RUN_DIALOGS);
+      return buildInitialState(action.availability);
 
     default:
       return state;
@@ -191,8 +176,11 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
   const [state, dispatch] = useReducer(
     wizardReducer,
     initialAvailability ?? ({} as CliAvailability),
-    (avail) => buildInitialState(avail, SKIP_FIRST_RUN_DIALOGS)
+    (avail) => buildInitialState(avail)
   );
+
+  const [hasFatalHealthFailure, setHasFatalHealthFailure] = useState(false);
+  const [isHealthChecking, setIsHealthChecking] = useState(true);
 
   const { setAgentSelected } = useAgentSettingsStore();
   const isAvailabilityLoading = useCliAvailabilityStore((s) => s.isLoading || s.isRefreshing);
@@ -277,21 +265,14 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
 
   const stepNumber = (() => {
     switch (state.step.type) {
-      case "health":
-        return 0;
       case "selection":
-        return 1;
+        return 0;
       case "cli":
-        return 2;
+        return 1;
       case "complete":
-        return 3;
+        return 2;
     }
   })();
-
-  const handleHealthContinue = useCallback(() => {
-    directionRef.current = 1;
-    dispatch({ type: "HEALTH_CONTINUE" });
-  }, []);
 
   const handleSelectionContinue = useCallback(async () => {
     directionRef.current = 1;
@@ -351,7 +332,6 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
               animate="animate"
               exit="exit"
             >
-              {state.step.type === "health" && <SystemToolsStep onSkip={handleHealthContinue} />}
               {state.step.type === "selection" && (
                 <SelectionStep
                   availability={state.availability}
@@ -361,6 +341,8 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
                   onToggle={(id, checked) =>
                     dispatch({ type: "TOGGLE_SELECTION", agentId: id, checked })
                   }
+                  onFatalFailureChange={setHasFatalHealthFailure}
+                  onCheckingChange={setIsHealthChecking}
                 />
               )}
               {state.step.type === "cli" && (
@@ -399,7 +381,7 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
             ))}
           </div>
           <div className="flex items-center gap-2">
-            {state.step.type !== "health" && state.step.type !== "complete" && (
+            {state.step.type !== "selection" && state.step.type !== "complete" && (
               <Button
                 variant="ghost"
                 onClick={handleBack}
@@ -408,12 +390,6 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
               >
                 <ChevronLeft className="w-4 h-4" />
                 Back
-              </Button>
-            )}
-            {state.step.type === "health" && (
-              <Button onClick={handleHealthContinue}>
-                Continue
-                <ChevronRight className="w-4 h-4 ml-1" />
               </Button>
             )}
             {state.step.type === "selection" && (
@@ -428,7 +404,12 @@ export function AgentSetupWizard({ isOpen, onClose, initialAvailability }: Agent
                 </Button>
                 <Button
                   onClick={handleSelectionContinue}
-                  disabled={selectedAgentIds.length === 0 || isSaving}
+                  disabled={
+                    selectedAgentIds.length === 0 ||
+                    isSaving ||
+                    hasFatalHealthFailure ||
+                    isHealthChecking
+                  }
                 >
                   Continue
                   <ArrowRight className="w-4 h-4 ml-1" />
@@ -511,12 +492,16 @@ function SelectionStep({
   isLoading,
   isSaving,
   onToggle,
+  onFatalFailureChange,
+  onCheckingChange,
 }: {
   availability: CliAvailability;
   selections: Record<string, boolean>;
   isLoading: boolean;
   isSaving: boolean;
   onToggle: (agentId: string, checked: boolean) => void;
+  onFatalFailureChange: (hasFatal: boolean) => void;
+  onCheckingChange: (checking: boolean) => void;
 }) {
   const featuredAgents = useMemo(
     () => sortTierByInstalled(FEATURED_AGENT_IDS, availability),
@@ -529,6 +514,11 @@ function SelectionStep({
 
   return (
     <div className="space-y-4">
+      <SystemRequirementsSection
+        onFatalFailureChange={onFatalFailureChange}
+        onCheckingChange={onCheckingChange}
+      />
+
       <div>
         <h3 className="text-base font-semibold text-canopy-text mb-2">Choose your AI agents</h3>
         <p className="text-sm text-canopy-text/60">

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -27,8 +27,8 @@ export function SystemRequirementsSection({
   }, [hasFatalFailure, onFatalFailureChange]);
 
   useEffect(() => {
-    onCheckingChange(!allDone);
-  }, [allDone, onCheckingChange]);
+    onCheckingChange(isChecking);
+  }, [isChecking, onCheckingChange]);
 
   const hasWarning =
     allDone &&
@@ -63,7 +63,7 @@ export function SystemRequirementsSection({
         />
         <span className="text-sm font-medium text-canopy-text">System requirements</span>
 
-        {!allDone && (
+        {isChecking && (
           <span className="flex items-center gap-1.5 ml-auto text-[11px] text-canopy-text/40">
             <Loader2 className="w-3 h-3 animate-spin" />
             Checking...
@@ -134,8 +134,7 @@ export function SystemRequirementsSection({
           {allDone && hasFatalFailure && (
             <div className="px-3 py-2.5 rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/5">
               <p className="text-xs text-status-warning">
-                Some required tools are missing or outdated. Agents that depend on them may not work
-                correctly.
+                Some required tools are missing or outdated. Install them to continue setup.
               </p>
             </div>
           )}

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, ChevronDown, CircleCheck, Loader2, RotateCw } from "lucide-react";
+import { motion, useReducedMotion } from "framer-motion";
+import { UI_ENTER_DURATION } from "@/lib/animationUtils";
+import { useSystemHealthCheck } from "./useSystemHealthCheck";
+import { PrerequisiteCard } from "./SystemToolsStep";
+
+interface SystemRequirementsSectionProps {
+  onFatalFailureChange: (hasFatal: boolean) => void;
+  onCheckingChange: (checking: boolean) => void;
+}
+
+export function SystemRequirementsSection({
+  onFatalFailureChange,
+  onCheckingChange,
+}: SystemRequirementsSectionProps) {
+  const { visibleSpecs, checkStates, isChecking, error, allDone, hasFatalFailure, runCheck } =
+    useSystemHealthCheck();
+
+  const [userExpanded, setUserExpanded] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
+
+  const isExpanded = userExpanded || hasFatalFailure;
+
+  useEffect(() => {
+    onFatalFailureChange(hasFatalFailure);
+  }, [hasFatalFailure, onFatalFailureChange]);
+
+  useEffect(() => {
+    onCheckingChange(!allDone);
+  }, [allDone, onCheckingChange]);
+
+  const hasWarning =
+    allDone &&
+    visibleSpecs.some((s) => {
+      const state = checkStates[s.tool];
+      return state !== "loading" && (!state?.available || !state.meetsMinVersion);
+    });
+
+  const summaryText = allDone
+    ? visibleSpecs
+        .filter((s) => {
+          const state = checkStates[s.tool];
+          return state !== "loading" && state?.available && state.meetsMinVersion;
+        })
+        .map((s) => {
+          const state = checkStates[s.tool];
+          const version = state !== "loading" && state?.version ? ` ${state.version}` : "";
+          return `${s.label}${version}`;
+        })
+        .join(", ")
+    : "";
+
+  return (
+    <div className="rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30">
+      <button
+        type="button"
+        onClick={() => setUserExpanded((v) => !v)}
+        className="flex items-center gap-2.5 w-full px-3 py-2.5 text-left"
+      >
+        <ChevronDown
+          className={`w-3.5 h-3.5 text-canopy-text/40 shrink-0 transition-transform ${isExpanded ? "" : "-rotate-90"}`}
+        />
+        <span className="text-sm font-medium text-canopy-text">System requirements</span>
+
+        {!allDone && (
+          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-canopy-text/40">
+            <Loader2 className="w-3 h-3 animate-spin" />
+            Checking...
+          </span>
+        )}
+
+        {allDone && !hasFatalFailure && !hasWarning && (
+          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-status-success">
+            <CircleCheck className="w-3.5 h-3.5" />
+            {summaryText}
+          </span>
+        )}
+
+        {allDone && hasFatalFailure && (
+          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-status-error">
+            Required tools missing
+          </span>
+        )}
+
+        {allDone && !hasFatalFailure && hasWarning && (
+          <span className="flex items-center gap-1.5 ml-auto text-[11px] text-status-warning">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            {summaryText}
+          </span>
+        )}
+      </button>
+
+      <motion.div
+        animate={{ height: isExpanded ? "auto" : 0 }}
+        initial={false}
+        transition={
+          prefersReducedMotion
+            ? { duration: 0 }
+            : { duration: UI_ENTER_DURATION / 1000, ease: [0.16, 1, 0.3, 1] }
+        }
+        style={{ overflow: "hidden" }}
+      >
+        <div className="px-3 pb-3 space-y-3">
+          {error && (
+            <div className="px-3 py-2.5 rounded-[var(--radius-md)] border border-status-error/20 bg-status-error/5">
+              <p className="text-xs text-status-error">Could not run health check: {error}</p>
+            </div>
+          )}
+
+          {visibleSpecs.length > 0 && (
+            <div className="grid grid-cols-2 gap-2">
+              {visibleSpecs.map((spec) => (
+                <PrerequisiteCard
+                  key={spec.tool}
+                  spec={spec}
+                  state={checkStates[spec.tool] ?? "loading"}
+                />
+              ))}
+            </div>
+          )}
+
+          {visibleSpecs.length === 0 && isChecking && (
+            <div className="grid grid-cols-2 gap-2">
+              {Array.from({ length: 4 }, (_, i) => (
+                <div
+                  key={i}
+                  className="rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30 px-3 py-2.5 animate-pulse h-[52px]"
+                />
+              ))}
+            </div>
+          )}
+
+          {allDone && hasFatalFailure && (
+            <div className="px-3 py-2.5 rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/5">
+              <p className="text-xs text-status-warning">
+                Some required tools are missing or outdated. Agents that depend on them may not work
+                correctly.
+              </p>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={() => void runCheck()}
+            disabled={isChecking}
+            className="inline-flex items-center gap-1.5 text-xs text-canopy-text/50 hover:text-canopy-text disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            <RotateCw className={`w-3 h-3 ${isChecking ? "animate-spin" : ""}`} />
+            {isChecking ? "Checking..." : "Re-check"}
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/Setup/SystemToolsStep.tsx
+++ b/src/components/Setup/SystemToolsStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import {
   AlertTriangle,
   ChevronDown,
@@ -7,181 +7,13 @@ import {
   CircleX,
   ExternalLink,
   Loader2,
-  RotateCw,
 } from "lucide-react";
 import { systemClient } from "@/clients";
 import type { PrerequisiteCheckResult, PrerequisiteSpec } from "@shared/types";
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
 import { detectOS } from "@/lib/agentInstall";
 import { InstallBlock } from "./InstallBlock";
-
-const POOL_CONCURRENCY = 3;
-
-type CheckState = "loading" | PrerequisiteCheckResult;
-
-async function runPool<T>(
-  items: T[],
-  concurrency: number,
-  fn: (item: T) => Promise<void>
-): Promise<void> {
-  const iter = items[Symbol.iterator]();
-  async function worker() {
-    for (let next = iter.next(); !next.done; next = iter.next()) {
-      await fn(next.value);
-    }
-  }
-  await Promise.all(Array.from({ length: concurrency }, worker));
-}
-
-interface SystemToolsStepProps {
-  onSkip: () => void;
-}
-
-export function SystemToolsStep({ onSkip }: SystemToolsStepProps) {
-  const [specs, setSpecs] = useState<PrerequisiteSpec[]>([]);
-  const [checkStates, setCheckStates] = useState<Record<string, CheckState>>({});
-  const [isChecking, setIsChecking] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const activeRef = useRef(true);
-  const isCheckingRef = useRef(false);
-
-  const runCheck = useCallback(async () => {
-    if (isCheckingRef.current) return;
-    isCheckingRef.current = true;
-    setIsChecking(true);
-    setError(null);
-    setSpecs([]);
-    setCheckStates({});
-
-    try {
-      const resolvedSpecs = await systemClient.getHealthCheckSpecs();
-      if (!activeRef.current) return;
-
-      setSpecs(resolvedSpecs);
-      setCheckStates(Object.fromEntries(resolvedSpecs.map((s) => [s.tool, "loading" as const])));
-
-      await runPool(resolvedSpecs, POOL_CONCURRENCY, async (spec) => {
-        try {
-          const result = await systemClient.checkTool(spec);
-          if (activeRef.current) {
-            setCheckStates((prev) => ({ ...prev, [spec.tool]: result }));
-          }
-        } catch {
-          if (activeRef.current) {
-            setCheckStates((prev) => ({
-              ...prev,
-              [spec.tool]: {
-                tool: spec.tool,
-                label: spec.label,
-                available: false,
-                version: null,
-                severity: spec.severity,
-                meetsMinVersion: false,
-                minVersion: spec.minVersion,
-                installUrl: spec.installUrl,
-                installBlocks: spec.installBlocks,
-              },
-            }));
-          }
-        }
-      });
-    } catch (err) {
-      if (activeRef.current) setError(err instanceof Error ? err.message : "Health check failed");
-    } finally {
-      isCheckingRef.current = false;
-      if (activeRef.current) setIsChecking(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    activeRef.current = true;
-    void runCheck();
-    return () => {
-      activeRef.current = false;
-    };
-  }, [runCheck]);
-
-  const visibleSpecs = specs.filter((s) => s.severity !== "silent");
-
-  const allDone =
-    visibleSpecs.length > 0 && visibleSpecs.every((s) => checkStates[s.tool] !== "loading");
-  const allRequired = allDone
-    ? visibleSpecs
-        .filter((s) => s.severity === "fatal")
-        .every((s) => {
-          const state = checkStates[s.tool];
-          return state !== "loading" && state?.available && state.meetsMinVersion;
-        })
-    : true;
-
-  return (
-    <div className="space-y-5">
-      <div>
-        <h3 className="text-base font-semibold text-canopy-text mb-1">System requirements</h3>
-        <p className="text-sm text-canopy-text/60">
-          Checking that the tools Canopy needs are installed and available.
-        </p>
-      </div>
-
-      {visibleSpecs.length > 0 && (
-        <div className="grid grid-cols-2 gap-2">
-          {visibleSpecs.map((spec) => (
-            <PrerequisiteCard
-              key={spec.tool}
-              spec={spec}
-              state={checkStates[spec.tool] ?? "loading"}
-            />
-          ))}
-        </div>
-      )}
-
-      {specs.length === 0 && isChecking && (
-        <div className="grid grid-cols-2 gap-2">
-          {Array.from({ length: 4 }, (_, i) => (
-            <div
-              key={i}
-              className="rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg/30 px-3 py-2.5 animate-pulse h-[52px]"
-            />
-          ))}
-        </div>
-      )}
-
-      {error && (
-        <div className="px-3 py-2.5 rounded-[var(--radius-md)] border border-status-error/20 bg-status-error/5">
-          <p className="text-xs text-status-error">Could not run health check: {error}</p>
-        </div>
-      )}
-
-      {allDone && !allRequired && (
-        <div className="px-3 py-2.5 rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/5">
-          <p className="text-xs text-status-warning">
-            Some required tools are missing or outdated. Agents that depend on them may not work
-            correctly. You can still continue and install them later.
-          </p>
-        </div>
-      )}
-
-      <div className="flex items-center justify-between pt-1">
-        <button
-          type="button"
-          onClick={() => void runCheck()}
-          disabled={isChecking}
-          className="inline-flex items-center gap-1.5 text-xs text-canopy-text/50 hover:text-canopy-text disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          <RotateCw className={`w-3 h-3 ${isChecking ? "animate-spin" : ""}`} />
-          {isChecking ? "Checking…" : "Re-check"}
-        </button>
-        <button
-          type="button"
-          onClick={onSkip}
-          className="text-xs text-canopy-text/40 hover:text-canopy-text transition-colors"
-        >
-          Skip
-        </button>
-      </div>
-    </div>
-  );
-}
+import type { CheckState } from "./useSystemHealthCheck";
 
 function getInstallBlocksForOS(check: PrerequisiteCheckResult): AgentInstallBlock[] | null {
   if (!check.installBlocks) return null;
@@ -193,7 +25,7 @@ function getInstallBlocksForOS(check: PrerequisiteCheckResult): AgentInstallBloc
   return null;
 }
 
-function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; state: CheckState }) {
+export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; state: CheckState }) {
   const loading = state === "loading";
   const check: PrerequisiteCheckResult | null = loading ? null : state;
   const needsInstall = check && (!check.available || !check.meetsMinVersion);
@@ -265,7 +97,7 @@ function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; state: Chec
   );
 }
 
-function StatusIcon({
+export function StatusIcon({
   check,
   loading,
 }: {

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -91,27 +91,14 @@ describe("AgentSetupWizard reducer", () => {
     codex: "missing",
   } as CliAvailability;
 
-  it("starts at health step by default", () => {
-    const state = buildInitialState(emptyAvail, false);
-    expect(state.step).toEqual({ type: "health" });
+  it("always starts at selection step", () => {
+    const state = buildInitialState(emptyAvail);
+    expect(state.step).toEqual({ type: "selection" });
     expect(state.history).toEqual([]);
   });
 
-  it("starts at selection step when skipHealth is true", () => {
-    const state = buildInitialState(emptyAvail, true);
-    expect(state.step).toEqual({ type: "selection" });
-  });
-
-  it("advances from health to selection", () => {
-    const state = buildInitialState(emptyAvail, false);
-    const next = wizardReducer(state, { type: "HEALTH_CONTINUE" });
-    expect(next.step).toEqual({ type: "selection" });
-    expect(next.history).toEqual([{ type: "health" }]);
-  });
-
-  it("advances from selection to cli step", () => {
-    let state = buildInitialState(partialAvail, false);
-    state = wizardReducer(state, { type: "HEALTH_CONTINUE" });
+  it("advances from selection to cli step when not all installed", () => {
+    let state = buildInitialState(partialAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true, codex: true },
@@ -122,7 +109,7 @@ describe("AgentSetupWizard reducer", () => {
 
   it("skips to complete when all selected agents are installed", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
-    let state = buildInitialState(allInstalled, true);
+    let state = buildInitialState(allInstalled);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
@@ -134,7 +121,7 @@ describe("AgentSetupWizard reducer", () => {
 
   it("goes to cli when at least one selected agent is not installed", () => {
     const partial = { claude: "ready", gemini: "missing" } as CliAvailability;
-    let state = buildInitialState(partial, true);
+    let state = buildInitialState(partial);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
@@ -145,7 +132,7 @@ describe("AgentSetupWizard reducer", () => {
 
   it("skips to complete when only selected agents are installed (unselected missing)", () => {
     const avail = { claude: "ready", gemini: "missing" } as CliAvailability;
-    let state = buildInitialState(avail, true);
+    let state = buildInitialState(avail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: false },
@@ -156,7 +143,7 @@ describe("AgentSetupWizard reducer", () => {
 
   it("BACK from complete (after skip) returns to selection, not cli", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
-    let state = buildInitialState(allInstalled, true);
+    let state = buildInitialState(allInstalled);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
@@ -171,12 +158,11 @@ describe("AgentSetupWizard reducer", () => {
 
   it("goes to cli when availability changes after init to mark agent uninstalled", () => {
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
-    let state = buildInitialState(allInstalled, true);
+    let state = buildInitialState(allInstalled);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
     });
-    // Availability changes: gemini becomes unavailable
     state = wizardReducer(state, {
       type: "SET_AVAILABILITY",
       payload: { claude: "ready", gemini: "missing" } as CliAvailability,
@@ -186,7 +172,7 @@ describe("AgentSetupWizard reducer", () => {
   });
 
   it("advances from cli to complete", () => {
-    let state = buildInitialState(emptyAvail, true);
+    let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true },
@@ -198,11 +184,8 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.step).toEqual({ type: "complete" });
   });
 
-  it("follows full wizard flow: health -> selection -> cli -> complete", () => {
-    let state = buildInitialState(emptyAvail, false);
-
-    state = wizardReducer(state, { type: "HEALTH_CONTINUE" });
-    expect(state.step).toEqual({ type: "selection" });
+  it("follows full wizard flow: selection -> cli -> complete", () => {
+    let state = buildInitialState(emptyAvail);
 
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
@@ -214,12 +197,11 @@ describe("AgentSetupWizard reducer", () => {
     state = wizardReducer(state, { type: "CLI_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
 
-    expect(state.history).toEqual([{ type: "health" }, { type: "selection" }, { type: "cli" }]);
+    expect(state.history).toEqual([{ type: "selection" }, { type: "cli" }]);
   });
 
   it("navigates back through history", () => {
-    let state = buildInitialState(emptyAvail, false);
-    state = wizardReducer(state, { type: "HEALTH_CONTINUE" });
+    let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true },
@@ -230,16 +212,13 @@ describe("AgentSetupWizard reducer", () => {
     state = wizardReducer(state, { type: "BACK" });
     expect(state.step).toEqual({ type: "selection" });
 
-    state = wizardReducer(state, { type: "BACK" });
-    expect(state.step).toEqual({ type: "health" });
-
-    // Back from health does nothing
+    // Back from selection does nothing (empty history)
     const unchanged = wizardReducer(state, { type: "BACK" });
-    expect(unchanged.step).toEqual({ type: "health" });
+    expect(unchanged.step).toEqual({ type: "selection" });
   });
 
   it("toggles agent selection", () => {
-    let state = buildInitialState(emptyAvail, true);
+    let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: false, gemini: false },
@@ -253,7 +232,7 @@ describe("AgentSetupWizard reducer", () => {
   });
 
   it("updates availability without changing selections", () => {
-    let state = buildInitialState(emptyAvail, true);
+    let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: false },
@@ -263,26 +242,26 @@ describe("AgentSetupWizard reducer", () => {
       payload: { claude: "ready" } as CliAvailability,
     });
     expect(state.availability.claude).toBe("ready");
-    expect(state.selections.claude).toBe(false); // selections unchanged
+    expect(state.selections.claude).toBe(false);
   });
 
   it("resets to initial state", () => {
-    let state = buildInitialState(emptyAvail, false);
-    state = wizardReducer(state, { type: "HEALTH_CONTINUE" });
+    let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true },
     });
+    state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
 
     const reset = wizardReducer(state, { type: "RESET", availability: partialAvail });
-    expect(reset.step).toEqual({ type: "health" });
+    expect(reset.step).toEqual({ type: "selection" });
     expect(reset.history).toEqual([]);
     expect(reset.selections).toEqual({});
     expect(reset.availability).toBe(partialAvail);
   });
 
   it("navigates back from cli to selection and re-confirms", () => {
-    let state = buildInitialState(emptyAvail, true);
+    let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
       payload: { claude: true, gemini: true },
@@ -290,11 +269,9 @@ describe("AgentSetupWizard reducer", () => {
     state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });
 
-    // Go back to selection
     state = wizardReducer(state, { type: "BACK" });
     expect(state.step).toEqual({ type: "selection" });
 
-    // Change selections and re-confirm
     state = wizardReducer(state, { type: "TOGGLE_SELECTION", agentId: "gemini", checked: false });
     state = wizardReducer(state, { type: "SELECTION_CONTINUE" });
     expect(state.step).toEqual({ type: "cli" });

--- a/src/components/Setup/index.ts
+++ b/src/components/Setup/index.ts
@@ -1,3 +1,2 @@
 export { AgentSetupWizard } from "./AgentSetupWizard";
-export { SystemToolsStep } from "./SystemToolsStep";
 export { AgentCliStep } from "./AgentCliStep";

--- a/src/components/Setup/useSystemHealthCheck.ts
+++ b/src/components/Setup/useSystemHealthCheck.ts
@@ -98,7 +98,8 @@ export function useSystemHealthCheck(): SystemHealthCheckState {
   const visibleSpecs = specs.filter((s) => s.severity !== "silent");
 
   const allDone =
-    visibleSpecs.length > 0 && visibleSpecs.every((s) => checkStates[s.tool] !== "loading");
+    !isChecking &&
+    (visibleSpecs.length === 0 || visibleSpecs.every((s) => checkStates[s.tool] !== "loading"));
 
   const hasFatalFailure = allDone
     ? !visibleSpecs

--- a/src/components/Setup/useSystemHealthCheck.ts
+++ b/src/components/Setup/useSystemHealthCheck.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { systemClient } from "@/clients";
+import type { PrerequisiteCheckResult, PrerequisiteSpec } from "@shared/types";
+
+const POOL_CONCURRENCY = 3;
+
+export type CheckState = "loading" | PrerequisiteCheckResult;
+
+export async function runPool<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  const iter = items[Symbol.iterator]();
+  async function worker() {
+    for (let next = iter.next(); !next.done; next = iter.next()) {
+      await fn(next.value);
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, worker));
+}
+
+export interface SystemHealthCheckState {
+  specs: PrerequisiteSpec[];
+  checkStates: Record<string, CheckState>;
+  isChecking: boolean;
+  error: string | null;
+  visibleSpecs: PrerequisiteSpec[];
+  allDone: boolean;
+  hasFatalFailure: boolean;
+  runCheck: () => Promise<void>;
+}
+
+export function useSystemHealthCheck(): SystemHealthCheckState {
+  const [specs, setSpecs] = useState<PrerequisiteSpec[]>([]);
+  const [checkStates, setCheckStates] = useState<Record<string, CheckState>>({});
+  const [isChecking, setIsChecking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const activeRef = useRef(true);
+  const isCheckingRef = useRef(false);
+
+  const runCheck = useCallback(async () => {
+    if (isCheckingRef.current) return;
+    isCheckingRef.current = true;
+    setIsChecking(true);
+    setError(null);
+    setSpecs([]);
+    setCheckStates({});
+
+    try {
+      const resolvedSpecs = await systemClient.getHealthCheckSpecs();
+      if (!activeRef.current) return;
+
+      setSpecs(resolvedSpecs);
+      setCheckStates(Object.fromEntries(resolvedSpecs.map((s) => [s.tool, "loading" as const])));
+
+      await runPool(resolvedSpecs, POOL_CONCURRENCY, async (spec) => {
+        try {
+          const result = await systemClient.checkTool(spec);
+          if (activeRef.current) {
+            setCheckStates((prev) => ({ ...prev, [spec.tool]: result }));
+          }
+        } catch {
+          if (activeRef.current) {
+            setCheckStates((prev) => ({
+              ...prev,
+              [spec.tool]: {
+                tool: spec.tool,
+                label: spec.label,
+                available: false,
+                version: null,
+                severity: spec.severity,
+                meetsMinVersion: false,
+                minVersion: spec.minVersion,
+                installUrl: spec.installUrl,
+                installBlocks: spec.installBlocks,
+              },
+            }));
+          }
+        }
+      });
+    } catch (err) {
+      if (activeRef.current) setError(err instanceof Error ? err.message : "Health check failed");
+    } finally {
+      isCheckingRef.current = false;
+      if (activeRef.current) setIsChecking(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    activeRef.current = true;
+    void runCheck();
+    return () => {
+      activeRef.current = false;
+    };
+  }, [runCheck]);
+
+  const visibleSpecs = specs.filter((s) => s.severity !== "silent");
+
+  const allDone =
+    visibleSpecs.length > 0 && visibleSpecs.every((s) => checkStates[s.tool] !== "loading");
+
+  const hasFatalFailure = allDone
+    ? !visibleSpecs
+        .filter((s) => s.severity === "fatal")
+        .every((s) => {
+          const state = checkStates[s.tool];
+          return state !== "loading" && state?.available && state.meetsMinVersion;
+        })
+    : false;
+
+  return {
+    specs,
+    checkStates,
+    isChecking,
+    error,
+    visibleSpecs,
+    allDone,
+    hasFatalFailure,
+    runCheck,
+  };
+}


### PR DESCRIPTION
## Summary

- Removes the dedicated \"System Health Check\" step from the setup wizard, reducing it from 4 steps to 3 (Selection with health inline, Install, Complete)
- Adds a `SystemRequirementsSection` component that embeds health check results directly into the agent selection step: collapsed with a single status line when all checks pass, auto-expanded with failure details when any check fails
- Extracts health check logic into a `useSystemHealthCheck` hook for clean separation from UI

Resolves #5046

## Changes

- `src/components/Setup/useSystemHealthCheck.ts` — new hook encapsulating health check state, pooled concurrent fetching, and derived fatal/warning status
- `src/components/Setup/SystemRequirementsSection.tsx` — new collapsible section component; shows compact summary on pass, expanded remediation cards on failure; fatal failures disable Continue
- `src/components/Setup/AgentSetupWizard.tsx` — step list updated (system tools step removed, health check integrated into selection step), step counter now reflects 3 steps
- `src/components/Setup/SystemToolsStep.tsx` — gutted to a thin re-export wrapper; kept to avoid breaking any existing imports
- `src/components/Setup/index.ts` — barrel export cleaned up
- `e2e/core/core-first-run-onboarding.spec.ts` — updated to match new 3-step flow

## Testing

Unit tests updated and passing. E2E onboarding spec updated to reflect the 3-step wizard. The health check pass case (compact collapsed line) and failure case (expanded cards, disabled Continue) are both covered.