### PR TITLE
fix(worktree): differentiate card hover and selected states

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -659,6 +659,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
               <WorktreeHeader
                 worktree={worktree}
                 isActive={isActive}
+                variant={variant}
                 isMuted={isMuted}
                 isMainWorktree={isMainWorktree}
                 isMainOnStandardBranch={isMainOnStandardBranch}

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -103,7 +103,8 @@ const IssueBadge = memo(function IssueBadge({
           />
           <span
             className={cn(
-              "truncate flex-1 min-w-0 hover:underline",
+              "truncate flex-1 min-w-0",
+              isActive && "hover:underline",
               isHeadline
                 ? isActive
                   ? "text-text-primary font-medium"
@@ -187,7 +188,9 @@ const PRBadge = memo(function PRBadge({
             <CornerDownRight className="w-3 h-3 text-text-muted shrink-0" aria-hidden="true" />
           )}
           <GitPullRequest className={cn("w-3 h-3 shrink-0", prStateColor)} aria-hidden="true" />
-          <span className={cn("font-mono hover:underline", prStateColor)}>#{prNumber}</span>
+          <span className={cn("font-mono", isActive && "hover:underline", prStateColor)}>
+            #{prNumber}
+          </span>
         </button>
       </TooltipTrigger>
       <TooltipContent side="right" align="start" className="p-3">
@@ -692,7 +695,9 @@ export function WorktreeHeader({
                 aria-label="View agent plan file"
               >
                 <FileText className="w-3 h-3 shrink-0 text-canopy-accent/70" aria-hidden="true" />
-                <span className="font-mono hover:underline">{worktree.planFilePath ?? "Plan"}</span>
+                <span className={cn("font-mono", isActive && "hover:underline")}>
+                  {worktree.planFilePath ?? "Plan"}
+                </span>
               </button>
             )}
           </div>

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -53,6 +53,7 @@ interface IssueBadgeProps {
   onOpen?: () => void;
   isHeadline?: boolean;
   isActive?: boolean;
+  underlineOnHover?: boolean;
 }
 
 const IssueBadge = memo(function IssueBadge({
@@ -62,6 +63,7 @@ const IssueBadge = memo(function IssueBadge({
   onOpen,
   isHeadline,
   isActive,
+  underlineOnHover,
 }: IssueBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { data, loading, error, fetchTooltip, reset } = useIssueTooltip(worktreePath, issueNumber);
@@ -104,7 +106,7 @@ const IssueBadge = memo(function IssueBadge({
           <span
             className={cn(
               "truncate flex-1 min-w-0",
-              isActive && "hover:underline",
+              underlineOnHover && "hover:underline",
               isHeadline
                 ? isActive
                   ? "text-text-primary font-medium"
@@ -138,6 +140,7 @@ interface PRBadgeProps {
   worktreePath: string;
   onOpen?: () => void;
   isActive?: boolean;
+  underlineOnHover?: boolean;
 }
 
 const PRBadge = memo(function PRBadge({
@@ -147,6 +150,7 @@ const PRBadge = memo(function PRBadge({
   worktreePath,
   onOpen,
   isActive,
+  underlineOnHover,
 }: PRBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
   const { data, loading, error, fetchTooltip, reset } = usePRTooltip(worktreePath, prNumber);
@@ -188,7 +192,7 @@ const PRBadge = memo(function PRBadge({
             <CornerDownRight className="w-3 h-3 text-text-muted shrink-0" aria-hidden="true" />
           )}
           <GitPullRequest className={cn("w-3 h-3 shrink-0", prStateColor)} aria-hidden="true" />
-          <span className={cn("font-mono", isActive && "hover:underline", prStateColor)}>
+          <span className={cn("font-mono", underlineOnHover && "hover:underline", prStateColor)}>
             #{prNumber}
           </span>
         </button>
@@ -211,6 +215,7 @@ const PRBadge = memo(function PRBadge({
 export interface WorktreeHeaderProps {
   worktree: WorktreeState;
   isActive: boolean;
+  variant?: "sidebar" | "grid";
   isMuted?: boolean;
   isMainWorktree: boolean;
   isMainOnStandardBranch?: boolean;
@@ -277,6 +282,7 @@ export interface WorktreeHeaderProps {
 export function WorktreeHeader({
   worktree,
   isActive,
+  variant = "sidebar",
   isMuted,
   isMainWorktree,
   isMainOnStandardBranch,
@@ -306,6 +312,10 @@ export function WorktreeHeader({
 
   const hasIssueTitle = !!(worktree.issueNumber && worktree.issueTitle);
   const hasPlanFile = Boolean(worktree.hasPlanFile);
+  // In sidebar variant, badges only become actionable when the card is selected,
+  // so the hover underline is misleading on unselected cards. Grid variant has no
+  // such two-step ambiguity, so preserve its always-on hover affordance.
+  const underlineOnHover = variant !== "sidebar" || isActive;
   const hasUpstreamDelta =
     (worktree.aheadCount !== undefined && worktree.aheadCount > 0) ||
     (worktree.behindCount !== undefined && worktree.behindCount > 0);
@@ -348,6 +358,7 @@ export function WorktreeHeader({
               onOpen={badges.onOpenIssue}
               isHeadline
               isActive={isActive}
+              underlineOnHover={underlineOnHover}
             />
           ) : isMainStandardLayout ? (
             <span
@@ -630,6 +641,7 @@ export function WorktreeHeader({
                 worktreePath={worktree.path}
                 onOpen={badges.onOpenIssue}
                 isActive={isActive}
+                underlineOnHover={underlineOnHover}
               />
             )}
             {worktree.prNumber && worktree.prState !== "closed" && (
@@ -640,6 +652,7 @@ export function WorktreeHeader({
                 worktreePath={worktree.path}
                 onOpen={badges.onOpenPR}
                 isActive={isActive}
+                underlineOnHover={underlineOnHover}
               />
             )}
             {hasUpstreamDelta && (
@@ -695,7 +708,7 @@ export function WorktreeHeader({
                 aria-label="View agent plan file"
               >
                 <FileText className="w-3 h-3 shrink-0 text-canopy-accent/70" aria-hidden="true" />
-                <span className={cn("font-mono", isActive && "hover:underline")}>
+                <span className={cn("font-mono", underlineOnHover && "hover:underline")}>
                   {worktree.planFilePath ?? "Plan"}
                 </span>
               </button>

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -663,7 +663,13 @@ describe("WorktreeHeader hover:underline on badges", () => {
 
   it("grid variant: badges keep hover:underline regardless of active state", () => {
     const { container, unmount } = renderHeader({
-      worktree: { ...issueWt, prNumber: 101, prState: "open", hasPlanFile: true, planFilePath: "TODO.md" },
+      worktree: {
+        ...issueWt,
+        prNumber: 101,
+        prState: "open",
+        hasPlanFile: true,
+        planFilePath: "TODO.md",
+      },
       badges: { onOpenIssue: noop, onOpenPR: noop, onOpenPlan: noop },
       variant: "grid",
     });
@@ -673,7 +679,13 @@ describe("WorktreeHeader hover:underline on badges", () => {
     unmount();
 
     const { container: activeContainer } = renderHeader({
-      worktree: { ...issueWt, prNumber: 101, prState: "open", hasPlanFile: true, planFilePath: "TODO.md" },
+      worktree: {
+        ...issueWt,
+        prNumber: 101,
+        prState: "open",
+        hasPlanFile: true,
+        planFilePath: "TODO.md",
+      },
       badges: { onOpenIssue: noop, onOpenPR: noop, onOpenPlan: noop },
       variant: "grid",
       isActive: true,

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -623,32 +623,76 @@ describe("WorktreeHeader decorative elements", () => {
 });
 
 describe("WorktreeHeader hover:underline on badges", () => {
-  it("issue badge text span has hover:underline", () => {
-    const { container } = renderHeader({
+  it("issue badge text span has hover:underline only when card is active", () => {
+    const { container, rerender } = renderHeader({
       worktree: { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" },
       badges: { onOpenIssue: noop },
     });
-    const textSpan = container.querySelector('button[aria-label*="Open issue"] .truncate');
-    expect(textSpan).toBeDefined();
-    expect(textSpan!.className).toContain("hover:underline");
+    const inactiveSpan = container.querySelector('button[aria-label*="Open issue"] .truncate');
+    expect(inactiveSpan).toBeDefined();
+    expect(inactiveSpan!.className).not.toContain("hover:underline");
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeHeader
+          worktree={{ ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" }}
+          isActive={true}
+          isMainWorktree={false}
+          isPinned={false}
+          branchLabel="feature/test"
+          badges={{ onOpenIssue: noop }}
+          menu={baseMenu}
+        />
+      </TooltipProvider>
+    );
+    const activeSpan = container.querySelector('button[aria-label*="Open issue"] .truncate');
+    expect(activeSpan!.className).toContain("hover:underline");
   });
 
-  it("PR badge number span has hover:underline", () => {
-    renderHeader({
+  it("PR badge number span has hover:underline only when card is active", () => {
+    const { rerender } = renderHeader({
       worktree: { ...baseWorktree, prNumber: 101, prState: "open" },
       badges: { onOpenPR: noop },
     });
-    const prSpan = screen.getByText("#101");
-    expect(prSpan.className).toContain("hover:underline");
+    expect(screen.getByText("#101").className).not.toContain("hover:underline");
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeHeader
+          worktree={{ ...baseWorktree, prNumber: 101, prState: "open" }}
+          isActive={true}
+          isMainWorktree={false}
+          isPinned={false}
+          branchLabel="feature/test"
+          badges={{ onOpenPR: noop }}
+          menu={baseMenu}
+        />
+      </TooltipProvider>
+    );
+    expect(screen.getByText("#101").className).toContain("hover:underline");
   });
 
-  it("plan badge text span has hover:underline", () => {
-    renderHeader({
+  it("plan badge text span has hover:underline only when card is active", () => {
+    const { rerender } = renderHeader({
       worktree: { ...baseWorktree, hasPlanFile: true, planFilePath: "TODO.md" },
       badges: { onOpenPlan: noop },
     });
-    const planSpan = screen.getByText("TODO.md");
-    expect(planSpan.className).toContain("hover:underline");
+    expect(screen.getByText("TODO.md").className).not.toContain("hover:underline");
+
+    rerender(
+      <TooltipProvider>
+        <WorktreeHeader
+          worktree={{ ...baseWorktree, hasPlanFile: true, planFilePath: "TODO.md" }}
+          isActive={true}
+          isMainWorktree={false}
+          isPinned={false}
+          branchLabel="feature/test"
+          badges={{ onOpenPlan: noop }}
+          menu={baseMenu}
+        />
+      </TooltipProvider>
+    );
+    expect(screen.getByText("TODO.md").className).toContain("hover:underline");
   });
 });
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -623,76 +623,62 @@ describe("WorktreeHeader decorative elements", () => {
 });
 
 describe("WorktreeHeader hover:underline on badges", () => {
-  it("issue badge text span has hover:underline only when card is active", () => {
-    const { container, rerender } = renderHeader({
-      worktree: { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" },
-      badges: { onOpenIssue: noop },
-    });
-    const inactiveSpan = container.querySelector('button[aria-label*="Open issue"] .truncate');
-    expect(inactiveSpan).toBeDefined();
-    expect(inactiveSpan!.className).not.toContain("hover:underline");
+  const issueWt = { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" };
+  const prWt = { ...baseWorktree, prNumber: 101, prState: "open" as const };
+  const planWt = { ...baseWorktree, hasPlanFile: true, planFilePath: "TODO.md" };
 
-    rerender(
-      <TooltipProvider>
-        <WorktreeHeader
-          worktree={{ ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" }}
-          isActive={true}
-          isMainWorktree={false}
-          isPinned={false}
-          branchLabel="feature/test"
-          badges={{ onOpenIssue: noop }}
-          menu={baseMenu}
-        />
-      </TooltipProvider>
-    );
-    const activeSpan = container.querySelector('button[aria-label*="Open issue"] .truncate');
-    expect(activeSpan!.className).toContain("hover:underline");
+  function getIssueSpan(container: HTMLElement) {
+    return container.querySelector('button[aria-label*="Open issue"] .truncate');
+  }
+
+  it("sidebar variant: issue badge underline only when active", () => {
+    const { container } = renderHeader({ worktree: issueWt, badges: { onOpenIssue: noop } });
+    expect(getIssueSpan(container)!.className).not.toContain("hover:underline");
+
+    const { container: activeContainer } = renderHeader({
+      worktree: issueWt,
+      badges: { onOpenIssue: noop },
+      isActive: true,
+    });
+    expect(getIssueSpan(activeContainer)!.className).toContain("hover:underline");
   });
 
-  it("PR badge number span has hover:underline only when card is active", () => {
-    const { rerender } = renderHeader({
-      worktree: { ...baseWorktree, prNumber: 101, prState: "open" },
-      badges: { onOpenPR: noop },
-    });
+  it("sidebar variant: PR badge underline only when active", () => {
+    const { unmount } = renderHeader({ worktree: prWt, badges: { onOpenPR: noop } });
     expect(screen.getByText("#101").className).not.toContain("hover:underline");
+    unmount();
 
-    rerender(
-      <TooltipProvider>
-        <WorktreeHeader
-          worktree={{ ...baseWorktree, prNumber: 101, prState: "open" }}
-          isActive={true}
-          isMainWorktree={false}
-          isPinned={false}
-          branchLabel="feature/test"
-          badges={{ onOpenPR: noop }}
-          menu={baseMenu}
-        />
-      </TooltipProvider>
-    );
+    renderHeader({ worktree: prWt, badges: { onOpenPR: noop }, isActive: true });
     expect(screen.getByText("#101").className).toContain("hover:underline");
   });
 
-  it("plan badge text span has hover:underline only when card is active", () => {
-    const { rerender } = renderHeader({
-      worktree: { ...baseWorktree, hasPlanFile: true, planFilePath: "TODO.md" },
-      badges: { onOpenPlan: noop },
-    });
+  it("sidebar variant: plan badge underline only when active", () => {
+    const { unmount } = renderHeader({ worktree: planWt, badges: { onOpenPlan: noop } });
     expect(screen.getByText("TODO.md").className).not.toContain("hover:underline");
+    unmount();
 
-    rerender(
-      <TooltipProvider>
-        <WorktreeHeader
-          worktree={{ ...baseWorktree, hasPlanFile: true, planFilePath: "TODO.md" }}
-          isActive={true}
-          isMainWorktree={false}
-          isPinned={false}
-          branchLabel="feature/test"
-          badges={{ onOpenPlan: noop }}
-          menu={baseMenu}
-        />
-      </TooltipProvider>
-    );
+    renderHeader({ worktree: planWt, badges: { onOpenPlan: noop }, isActive: true });
     expect(screen.getByText("TODO.md").className).toContain("hover:underline");
+  });
+
+  it("grid variant: badges keep hover:underline regardless of active state", () => {
+    const { container, unmount } = renderHeader({
+      worktree: { ...issueWt, prNumber: 101, prState: "open", hasPlanFile: true, planFilePath: "TODO.md" },
+      badges: { onOpenIssue: noop, onOpenPR: noop, onOpenPlan: noop },
+      variant: "grid",
+    });
+    expect(getIssueSpan(container)!.className).toContain("hover:underline");
+    expect(screen.getByText("#101").className).toContain("hover:underline");
+    expect(screen.getByText("TODO.md").className).toContain("hover:underline");
+    unmount();
+
+    const { container: activeContainer } = renderHeader({
+      worktree: { ...issueWt, prNumber: 101, prState: "open", hasPlanFile: true, planFilePath: "TODO.md" },
+      badges: { onOpenIssue: noop, onOpenPR: noop, onOpenPlan: noop },
+      variant: "grid",
+      isActive: true,
+    });
+    expect(getIssueSpan(activeContainer)!.className).toContain("hover:underline");
   });
 });
 

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -1,6 +1,8 @@
 .sidebar-worktree-card[data-active="true"] {
-  background: var(--theme-overlay-selected);
-  box-shadow: var(--theme-shadow-ambient);
+  background: var(--theme-overlay-active);
+  box-shadow:
+    inset 2px 0 0 var(--theme-accent-primary),
+    var(--theme-shadow-ambient);
 }
 
 .sidebar-worktree-card[data-hoverable="true"]:hover,


### PR DESCRIPTION
## Summary

- Worktree cards in the sidebar now show a visually distinct selected state: stronger `overlay-active` background plus a 2px inset `accent-primary` box-shadow. Hovering an unselected card still gets the existing hover treatment, but the active card is clearly different at a glance.
- Issue/PR/plan badges in `WorktreeHeader` now gate `hover:underline` on whether the worktree is active. Hovering an unselected card no longer shows link-like affordances on text that isn't actually clickable yet.
- The sidebar variant gating is scoped correctly: grid-variant cards (the worktree grid view) keep their existing always-on hover underline behaviour unchanged.

Resolves #5065

## Changes

- `sidebar.css`: active card background uses `overlay-active` token; 2px inset accent-primary box-shadow added to selected state
- `WorktreeHeader.tsx`: `isActive` and `variant` props gate `hover:underline` on issue, PR, and plan links; sidebar variant only shows underline on active cards
- `WorktreeCard.tsx`: passes `variant="sidebar"` to `WorktreeHeader`
- `WorktreeCard/__tests__/WorktreeHeader.test.tsx`: 55 tests covering active/inactive hover gating for both sidebar and grid variants

## Testing

All 55 `WorktreeHeader` unit tests pass. Typecheck, lint ratchet, and Prettier are clean. Hover/selected states verified against the design described in the issue.