### PR TITLE
refactor(toolbar): derive agent buttons dynamically from BUILT_IN_AGENT_IDS

### DIFF
--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -1,4 +1,4 @@
-import type { BuiltInAgentId } from "../config/agentIds.js";
+import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "../config/agentIds.js";
 
 /** Identifier for plugin-contributed toolbar buttons (namespaced as plugin.name.buttonId) */
 export type PluginToolbarButtonId = `plugin.${string}`;
@@ -6,15 +6,17 @@ export type PluginToolbarButtonId = `plugin.${string}`;
 /** Identifier for any toolbar button (built-in or plugin-contributed) */
 export type AnyToolbarButtonId = ToolbarButtonId | PluginToolbarButtonId;
 
-/** Unique identifier for built-in toolbar buttons */
+/**
+ * Unique identifier for built-in toolbar buttons.
+ *
+ * Agent button IDs are derived from `BUILT_IN_AGENT_IDS` so that adding a new
+ * agent to the registry automatically makes it a valid toolbar button ID
+ * without touching this union.
+ */
 export type ToolbarButtonId =
   | "sidebar-toggle"
   | "agent-setup"
-  | "claude"
-  | "gemini"
-  | "codex"
-  | "opencode"
-  | "cursor"
+  | BuiltInAgentId
   | "terminal"
   | "browser"
   | "dev-server"
@@ -43,15 +45,7 @@ export interface LauncherDefaults {
   /** Always show dev server option in palette, even if devServerCommand not configured */
   alwaysShowDevServer: boolean;
   /** Default panel type to highlight when palette opens */
-  defaultSelection?:
-    | "terminal"
-    | "claude"
-    | "gemini"
-    | "codex"
-    | "opencode"
-    | "cursor"
-    | "browser"
-    | "dev-server";
+  defaultSelection?: "terminal" | BuiltInAgentId | "browser" | "dev-server";
   /** Default agent for automated workflows like "What's Next?" */
   defaultAgent?: BuiltInAgentId;
 }
@@ -65,11 +59,9 @@ export const TOOLBAR_BUTTON_PRIORITIES: Record<ToolbarButtonId, ToolbarButtonPri
   "github-stats": 1,
   "voice-recording": 1,
   "agent-setup": 2,
-  claude: 2,
-  gemini: 2,
-  codex: 2,
-  opencode: 2,
-  cursor: 2,
+  ...(Object.fromEntries(
+    BUILT_IN_AGENT_IDS.map((id) => [id, 2 as ToolbarButtonPriority])
+  ) as Record<BuiltInAgentId, ToolbarButtonPriority>),
   terminal: 3,
   browser: 3,
   "dev-server": 3,

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -60,21 +60,23 @@ import { ToolbarSettingsButton } from "./ToolbarSettingsButton";
 import { ToolbarProblemsButton } from "./ToolbarProblemsButton";
 import { ToolbarPortalButton } from "./ToolbarPortalButton";
 
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import { getAgentConfig } from "@/config/agents";
 
 const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
   "agent-setup",
   ...(BUILT_IN_AGENT_IDS as unknown as ToolbarButtonId[]),
 ]);
 
-const OVERFLOW_MENU_META: Partial<
-  Record<AnyToolbarButtonId, { label: string; icon: React.ComponentType<{ className?: string }> }>
-> = {
-  claude: { label: "Claude", icon: SquareTerminal },
-  gemini: { label: "Gemini", icon: SquareTerminal },
-  codex: { label: "Codex", icon: SquareTerminal },
-  opencode: { label: "OpenCode", icon: SquareTerminal },
-  cursor: { label: "Cursor", icon: SquareTerminal },
+type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
+
+export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> = {
+  ...(Object.fromEntries(
+    BUILT_IN_AGENT_IDS.map((id) => [
+      id,
+      { label: getAgentConfig(id)?.name ?? id, icon: SquareTerminal },
+    ])
+  ) as unknown as Record<BuiltInAgentId, OverflowMenuMeta>),
   terminal: { label: "Terminal", icon: SquareTerminal },
   browser: { label: "Browser", icon: Globe },
   "dev-server": { label: "Dev Preview", icon: Monitor },
@@ -358,61 +360,22 @@ export function Toolbar({
         render: () => <AgentSetupButton key="agent-setup" data-toolbar-item="" />,
         isAvailable: !hasAnySelectedAgent,
       },
-      claude: {
-        render: () => (
-          <AgentButton
-            key="claude"
-            type="claude"
-            availability={agentAvailability?.claude}
-            data-toolbar-item=""
-          />
-        ),
-        isAvailable: agentSettings != null && agentSettings.agents?.claude?.selected !== false,
-      },
-      gemini: {
-        render: () => (
-          <AgentButton
-            key="gemini"
-            type="gemini"
-            availability={agentAvailability?.gemini}
-            data-toolbar-item=""
-          />
-        ),
-        isAvailable: agentSettings != null && agentSettings.agents?.gemini?.selected !== false,
-      },
-      codex: {
-        render: () => (
-          <AgentButton
-            key="codex"
-            type="codex"
-            availability={agentAvailability?.codex}
-            data-toolbar-item=""
-          />
-        ),
-        isAvailable: agentSettings != null && agentSettings.agents?.codex?.selected !== false,
-      },
-      opencode: {
-        render: () => (
-          <AgentButton
-            key="opencode"
-            type="opencode"
-            availability={agentAvailability?.opencode}
-            data-toolbar-item=""
-          />
-        ),
-        isAvailable: agentSettings != null && agentSettings.agents?.opencode?.selected !== false,
-      },
-      cursor: {
-        render: () => (
-          <AgentButton
-            key="cursor"
-            type="cursor"
-            availability={agentAvailability?.cursor}
-            data-toolbar-item=""
-          />
-        ),
-        isAvailable: agentSettings != null && agentSettings.agents?.cursor?.selected !== false,
-      },
+      ...Object.fromEntries(
+        BUILT_IN_AGENT_IDS.map((id) => [
+          id,
+          {
+            render: () => (
+              <AgentButton
+                key={id}
+                type={id}
+                availability={agentAvailability?.[id]}
+                data-toolbar-item=""
+              />
+            ),
+            isAvailable: !agentSettings || agentSettings.agents?.[id]?.selected !== false,
+          },
+        ])
+      ),
       terminal: {
         render: () => (
           <ToolbarLauncherButton
@@ -776,11 +739,7 @@ export function Toolbar({
 
   const overflowActions = useMemo<Partial<Record<AnyToolbarButtonId, () => void>>>(
     () => ({
-      claude: () => onLaunchAgent("claude"),
-      gemini: () => onLaunchAgent("gemini"),
-      codex: () => onLaunchAgent("codex"),
-      opencode: () => onLaunchAgent("opencode"),
-      cursor: () => onLaunchAgent("cursor"),
+      ...Object.fromEntries(BUILT_IN_AGENT_IDS.map((id) => [id, () => onLaunchAgent(id)])),
       terminal: () => onLaunchAgent("terminal"),
       browser: () => onLaunchAgent("browser"),
       "dev-server": () => {

--- a/src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts
@@ -14,6 +14,14 @@ describe("Toolbar — agent registry zero-touch guarantee (issue #5070)", () => 
     source = await fs.readFile(TOOLBAR_PATH, "utf-8");
   });
 
+  describe("BUILT_IN_AGENT_IDS invariants", () => {
+    it("contains no duplicate ids", () => {
+      // A duplicate would silently collapse in Object.fromEntries and cause
+      // React key collisions in the dynamic toolbar maps.
+      expect(new Set(BUILT_IN_AGENT_IDS).size).toBe(BUILT_IN_AGENT_IDS.length);
+    });
+  });
+
   describe("OVERFLOW_MENU_META", () => {
     it("has an entry for every built-in agent", () => {
       for (const id of BUILT_IN_AGENT_IDS) {

--- a/src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { TOOLBAR_BUTTON_PRIORITIES } from "@shared/types/toolbar";
+import { OVERFLOW_MENU_META } from "../Toolbar";
+
+const TOOLBAR_PATH = path.resolve(__dirname, "../Toolbar.tsx");
+
+describe("Toolbar — agent registry zero-touch guarantee (issue #5070)", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(TOOLBAR_PATH, "utf-8");
+  });
+
+  describe("OVERFLOW_MENU_META", () => {
+    it("has an entry for every built-in agent", () => {
+      for (const id of BUILT_IN_AGENT_IDS) {
+        expect(
+          OVERFLOW_MENU_META[id],
+          `missing OVERFLOW_MENU_META entry for agent "${id}"`
+        ).toBeDefined();
+      }
+    });
+
+    it("uses non-empty labels for every agent entry", () => {
+      for (const id of BUILT_IN_AGENT_IDS) {
+        const meta = OVERFLOW_MENU_META[id];
+        expect(meta?.label, `empty label for agent "${id}"`).toBeTruthy();
+      }
+    });
+  });
+
+  describe("TOOLBAR_BUTTON_PRIORITIES", () => {
+    it("has a priority entry for every built-in agent", () => {
+      for (const id of BUILT_IN_AGENT_IDS) {
+        expect(
+          TOOLBAR_BUTTON_PRIORITIES[id],
+          `missing TOOLBAR_BUTTON_PRIORITIES entry for agent "${id}"`
+        ).toBeDefined();
+      }
+    });
+
+    it("assigns agent buttons priority 2 (grouped with agent-setup)", () => {
+      for (const id of BUILT_IN_AGENT_IDS) {
+        expect(TOOLBAR_BUTTON_PRIORITIES[id]).toBe(2);
+      }
+    });
+  });
+
+  describe("dynamic registration pattern in Toolbar.tsx", () => {
+    it("does not hardcode per-agent buttonRegistry entries", () => {
+      // Hardcoded agent entries would take the form `claude: { render:` etc.
+      // After the refactor these should be spread from BUILT_IN_AGENT_IDS.
+      for (const id of BUILT_IN_AGENT_IDS) {
+        expect(
+          source,
+          `Toolbar.tsx should not contain a hardcoded "${id}:" buttonRegistry entry`
+        ).not.toMatch(new RegExp(`\\b${id}:\\s*\\{\\s*\\n\\s*render:`));
+      }
+    });
+
+    it("does not hardcode per-agent overflow action closures", () => {
+      for (const id of BUILT_IN_AGENT_IDS) {
+        expect(
+          source,
+          `Toolbar.tsx should not contain a hardcoded "${id}: () => onLaunchAgent" closure`
+        ).not.toMatch(new RegExp(`${id}:\\s*\\(\\)\\s*=>\\s*onLaunchAgent\\("${id}"\\)`));
+      }
+    });
+
+    it("maps BUILT_IN_AGENT_IDS when building buttonRegistry", () => {
+      expect(source).toMatch(
+        /BUILT_IN_AGENT_IDS\.map\(\(id\)\s*=>\s*\[\s*\n?\s*id,\s*\n?\s*\{\s*\n?\s*render:/
+      );
+    });
+
+    it("maps BUILT_IN_AGENT_IDS when building overflow actions", () => {
+      expect(source).toMatch(
+        /BUILT_IN_AGENT_IDS\.map\(\(id\)\s*=>\s*\[id,\s*\(\)\s*=>\s*onLaunchAgent\(id\)\]\)/
+      );
+    });
+  });
+});

--- a/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
@@ -90,9 +90,16 @@ describe("Toolbar keyboard navigation — issue #2814", () => {
 
   describe("Sub-component integration", () => {
     it("passes data-toolbar-item to AgentButton components", () => {
+      // After the dynamic registry refactor (issue #5070), AgentButton is
+      // rendered once inside a BUILT_IN_AGENT_IDS.map(...), so a single
+      // <AgentButton ... data-toolbar-item="" /> site is expected.
       const agentButtonMatches = source.match(/<AgentButton[\s\S]*?data-toolbar-item=""/g);
       expect(agentButtonMatches).not.toBeNull();
-      expect(agentButtonMatches!.length).toBeGreaterThanOrEqual(4);
+      expect(agentButtonMatches!.length).toBeGreaterThanOrEqual(1);
+      // And that single site must be inside a map over BUILT_IN_AGENT_IDS
+      expect(source).toMatch(
+        /BUILT_IN_AGENT_IDS\.map[\s\S]*?<AgentButton[\s\S]*?data-toolbar-item=""/
+      );
     });
 
     it("passes data-toolbar-item to AgentSetupButton", () => {

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -30,16 +30,11 @@ import {
   RotateCcw,
   StickyNote,
 } from "lucide-react";
-import {
-  ClaudeIcon,
-  GeminiIcon,
-  CodexIcon,
-  OpenCodeIcon,
-  CanopyAgentIcon,
-  CopyTreeIcon,
-} from "@/components/icons";
+import { CanopyAgentIcon, CopyTreeIcon } from "@/components/icons";
 import { useToolbarPreferencesStore } from "@/store";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
@@ -54,26 +49,21 @@ const BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ButtonMetadata>> = {
     icon: <CanopyAgentIcon className="h-4 w-4" />,
     description: "Shown only when no agents are enabled in Agent Settings",
   },
-  claude: {
-    label: "Claude Agent",
-    icon: <ClaudeIcon className="h-4 w-4" />,
-    description: "Launch Claude AI agent",
-  },
-  gemini: {
-    label: "Gemini Agent",
-    icon: <GeminiIcon className="h-4 w-4" />,
-    description: "Launch Gemini AI agent",
-  },
-  codex: {
-    label: "Codex Agent",
-    icon: <CodexIcon className="h-4 w-4" />,
-    description: "Launch Codex AI agent",
-  },
-  opencode: {
-    label: "OpenCode Agent",
-    icon: <OpenCodeIcon className="h-4 w-4" />,
-    description: "Launch OpenCode AI agent",
-  },
+  ...Object.fromEntries(
+    BUILT_IN_AGENT_IDS.map((id) => {
+      const cfg = getAgentConfig(id);
+      const Icon = cfg?.icon;
+      const name = cfg?.name ?? id;
+      return [
+        id,
+        {
+          label: `${name} Agent`,
+          icon: Icon ? <Icon className="h-4 w-4" /> : <SquareTerminal className="h-4 w-4" />,
+          description: `Launch ${name} AI agent`,
+        },
+      ];
+    })
+  ),
   terminal: {
     label: "Terminal",
     icon: <SquareTerminal className="h-4 w-4" />,
@@ -360,10 +350,11 @@ export function ToolbarSettingsTab() {
             >
               <option value="">None (first available)</option>
               <option value="terminal">Terminal</option>
-              <option value="claude">Claude</option>
-              <option value="gemini">Gemini</option>
-              <option value="codex">Codex</option>
-              <option value="opencode">OpenCode</option>
+              {BUILT_IN_AGENT_IDS.map((id) => (
+                <option key={id} value={id}>
+                  {getAgentConfig(id)?.name ?? id}
+                </option>
+              ))}
               <option value="browser">Browser</option>
               <option value="dev-server">Dev Preview</option>
             </select>


### PR DESCRIPTION
## Summary

- Toolbar agent buttons now derive programmatically from `BUILT_IN_AGENT_IDS` instead of being hardcoded across four separate locations. Adding a new agent to the registry automatically gives it a toolbar button, overflow menu entry, and overflow action with zero additional changes.
- `ToolbarButtonId` union type now derives agent entries from `BuiltInAgentId` rather than duplicating them, so the two can't drift out of sync.
- `TOOLBAR_BUTTON_PRIORITIES` defaults all agents to priority 2 via a computed spread, removing the need to list each one explicitly.

Resolves #5070

## Changes

- `shared/types/toolbar.ts`: `ToolbarButtonId` derives agent entries from `BuiltInAgentId`; `TOOLBAR_BUTTON_PRIORITIES` computes agent priorities from the registry
- `src/components/Layout/Toolbar.tsx`: `buttonRegistry`, `OVERFLOW_MENU_META`, and `overflowActions` all use `BUILT_IN_AGENT_IDS.map(...)` instead of hardcoded per-agent entries
- `src/components/Settings/ToolbarSettingsTab.tsx`: agent sections derive from registry, matching the same pattern
- `src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts`: new test asserting `BUILT_IN_AGENT_IDS` has no duplicates and that every agent ID appears in the toolbar config

## Testing

Type-checks and lints clean. The new invariant test covers the uniqueness constraint on `BUILT_IN_AGENT_IDS`. Manually verified kiro and copilot (the two agents that were silently missing) now render correctly in the toolbar.