### PR TITLE
fix(settings): hide uninstalled agents in System Status

### DIFF
--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -4,7 +4,6 @@ import {
   ChevronRight,
   Moon,
   CheckCircle,
-  AlertCircle,
   Wrench,
   LayoutGrid,
   PanelBottom,
@@ -28,7 +27,7 @@ import type {
   CliAvailability,
   AgentSettings,
 } from "@shared/types";
-import { isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
 import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
@@ -441,7 +440,7 @@ export function GeneralTab({
           <SettingsSection
             icon={Info}
             title="System Status"
-            description="Agent CLI availability. Agents must be installed and accessible in your PATH."
+            description="Agents ready to use on your system."
             id="general-system-status"
           >
             {cliCheckFailed ? (
@@ -449,57 +448,93 @@ export function GeneralTab({
             ) : !cliAvailability || !agentSettings ? (
               <div className="text-sm text-text-muted">Loading agent status...</div>
             ) : (
-              <div className="space-y-2">
-                {getAgentIds().map((id) => {
-                  const config = getAgentConfig(id);
-                  const agentEntry = getAgentSettingsEntry(agentSettings, id);
-                  const isSelected = agentEntry.selected !== false;
-                  const isAvailable = isAgentReady(cliAvailability[id]);
-                  const name = config?.name ?? id;
-                  const isUnavailable = isSelected && !isAvailable;
+              (() => {
+                const allAgentIds = getAgentIds();
+                const installedAgentIds = allAgentIds.filter(
+                  (id) =>
+                    isAgentInstalled(cliAvailability[id]) &&
+                    getAgentSettingsEntry(agentSettings, id).selected !== false
+                );
+                const hiddenCount = allAgentIds.length - installedAgentIds.length;
 
+                if (installedAgentIds.length === 0) {
                   return (
-                    <button
-                      type="button"
-                      key={id}
-                      className={cn(
-                        "flex items-center justify-between text-sm px-3 py-2 rounded-[var(--radius-md)] border w-full text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2",
-                        isUnavailable
-                          ? "border-[color-mix(in_oklab,var(--color-status-warning)_30%,transparent)] bg-[color-mix(in_oklab,var(--color-status-warning)_6%,transparent)] hover:bg-[color-mix(in_oklab,var(--color-status-warning)_10%,transparent)]"
-                          : "settings-list-item border-canopy-border hover:bg-[var(--settings-nav-hover-bg,var(--theme-overlay-hover))]"
-                      )}
-                      aria-label={`Go to ${name} agent settings`}
-                      onClick={() => onNavigateToAgents?.(id)}
-                    >
-                      <span className="text-text-secondary">{name}</span>
-                      <span className="flex items-center gap-2">
-                        {!isSelected ? (
-                          <span className="text-text-muted text-xs">Disabled</span>
-                        ) : isAvailable ? (
-                          <>
-                            <CheckCircle className="w-3.5 h-3.5 text-status-success" />
-                            <span className="text-status-success text-xs">Ready</span>
-                          </>
-                        ) : (
-                          <>
-                            <AlertCircle className="w-3.5 h-3.5 text-status-warning" />
-                            <span className="text-status-warning text-xs">CLI not found</span>
-                          </>
+                    <div className="space-y-2">
+                      <p className="text-sm text-text-muted">No agents installed yet.</p>
+                      <div className="flex items-center gap-3">
+                        <button
+                          type="button"
+                          className="text-xs text-canopy-accent hover:underline"
+                          onClick={() =>
+                            window.dispatchEvent(
+                              new CustomEvent("canopy:open-agent-setup-wizard")
+                            )
+                          }
+                        >
+                          Run setup wizard
+                        </button>
+                        {onNavigateToAgents && (
+                          <button
+                            type="button"
+                            className="text-xs text-canopy-accent hover:underline"
+                            onClick={() => onNavigateToAgents?.()}
+                          >
+                            Browse available agents
+                          </button>
                         )}
-                      </span>
-                    </button>
+                      </div>
+                    </div>
                   );
-                })}
+                }
 
-                {onNavigateToAgents && (
-                  <button
-                    onClick={() => onNavigateToAgents?.()}
-                    className="text-xs text-canopy-accent hover:underline"
-                  >
-                    Configure agents →
-                  </button>
-                )}
-              </div>
+                return (
+                  <div className="space-y-2">
+                    {installedAgentIds.map((id) => {
+                      const config = getAgentConfig(id);
+                      const name = config?.name ?? id;
+                      const ready = isAgentReady(cliAvailability[id]);
+
+                      return (
+                        <button
+                          type="button"
+                          key={id}
+                          className="settings-list-item border-canopy-border hover:bg-[var(--settings-nav-hover-bg,var(--theme-overlay-hover))] flex items-center justify-between text-sm px-3 py-2 rounded-[var(--radius-md)] border w-full text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-canopy-accent focus-visible:outline-offset-2"
+                          aria-label={`Go to ${name} agent settings`}
+                          onClick={() => onNavigateToAgents?.(id)}
+                        >
+                          <span className="text-text-secondary">{name}</span>
+                          <span className="flex items-center gap-2">
+                            <CheckCircle
+                              className={cn(
+                                "w-3.5 h-3.5",
+                                ready ? "text-status-success" : "text-status-warning"
+                              )}
+                            />
+                            <span
+                              className={cn(
+                                "text-xs",
+                                ready ? "text-status-success" : "text-status-warning"
+                              )}
+                            >
+                              {ready ? "Ready" : "Needs setup"}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    })}
+
+                    {hiddenCount > 0 && onNavigateToAgents && (
+                      <button
+                        type="button"
+                        onClick={() => onNavigateToAgents?.()}
+                        className="text-xs text-canopy-accent hover:underline"
+                      >
+                        {`Canopy supports ${hiddenCount} more ${hiddenCount === 1 ? "agent" : "agents"} →`}
+                      </button>
+                    )}
+                  </div>
+                );
+              })()
             )}
           </SettingsSection>
 

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -466,9 +466,7 @@ export function GeneralTab({
                           type="button"
                           className="text-xs text-canopy-accent hover:underline"
                           onClick={() =>
-                            window.dispatchEvent(
-                              new CustomEvent("canopy:open-agent-setup-wizard")
-                            )
+                            window.dispatchEvent(new CustomEvent("canopy:open-agent-setup-wizard"))
                           }
                         >
                           Run setup wizard

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { CliAvailability, AgentSettings, HibernationConfig } from "@shared/types";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("../SettingsSection", () => ({
+  SettingsSection: ({
+    children,
+    title,
+    description,
+  }: {
+    children: React.ReactNode;
+    title: string;
+    description?: string;
+  }) => (
+    <section data-testid={`section-${title}`}>
+      <h3>{title}</h3>
+      {description && <p data-testid={`section-desc-${title}`}>{description}</p>}
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock("../SettingsSubtabBar", () => ({
+  SettingsSubtabBar: () => null,
+}));
+
+vi.mock("@/components/Settings/SettingsSwitchCard", () => ({
+  SettingsSwitchCard: () => null,
+}));
+
+vi.mock("@/components/icons", () => ({
+  CanopyIcon: () => null,
+  ProjectPulseIcon: () => null,
+}));
+
+vi.mock("@/store", () => ({
+  usePreferencesStore: (selector: (state: Record<string, boolean>) => unknown) =>
+    selector({
+      showProjectPulse: true,
+      showDeveloperTools: false,
+      showGridAgentHighlights: true,
+      showDockAgentHighlights: true,
+    }),
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    subscribe: vi.fn(() => () => {}),
+    loadOverrides: vi.fn(() => Promise.resolve()),
+    getBinding: vi.fn(() => null),
+    getEffectiveCombo: vi.fn(() => null),
+    formatComboForDisplay: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentIds: () => ["claude", "gemini", "codex", "opencode", "cursor"],
+  getAgentConfig: (id: string) => ({
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+  }),
+}));
+
+const mockDispatch = vi.fn();
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (actionId: string, ...rest: unknown[]) => mockDispatch(actionId, ...rest),
+  },
+}));
+
+function setupDispatchMock(cliAvailability: CliAvailability, agentSettings: AgentSettings) {
+  mockDispatch.mockImplementation(async (actionId: string) => {
+    if (actionId === "cliAvailability.get") {
+      return { ok: true, result: cliAvailability };
+    }
+    if (actionId === "agentSettings.get") {
+      return { ok: true, result: agentSettings };
+    }
+    if (actionId === "hibernation.getConfig") {
+      return {
+        ok: true,
+        result: { enabled: false, inactiveThresholdHours: 24 } as HibernationConfig,
+      };
+    }
+    return { ok: true, result: undefined };
+  });
+}
+
+function setupElectron() {
+  (window as unknown as { electron: unknown }).electron = {
+    update: {
+      getChannel: vi.fn().mockResolvedValue("stable"),
+      setChannel: vi.fn().mockResolvedValue("stable"),
+    },
+  };
+}
+
+async function renderGeneralTab() {
+  const { GeneralTab } = await import("../GeneralTab");
+  return render(
+    <GeneralTab
+      appVersion="1.0.0"
+      onNavigateToAgents={vi.fn()}
+      activeSubtab="overview"
+      onSubtabChange={vi.fn()}
+    />
+  );
+}
+
+describe("GeneralTab — System Status filtering (issue #5072)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectron();
+  });
+
+  it("renders only installed, enabled agents (hides uninstalled)", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Claude")).toBeTruthy();
+      expect(screen.getByText("Gemini")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Codex")).toBeNull();
+    expect(screen.queryByText("Opencode")).toBeNull();
+    expect(screen.queryByText("Cursor")).toBeNull();
+    // No orange warning labels anywhere
+    expect(screen.queryByText("CLI not found")).toBeNull();
+  });
+
+  it("hides installed but user-disabled agents", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "ready", opencode: "missing", cursor: "missing" },
+      { agents: { gemini: { selected: false } } } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Claude")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Gemini")).toBeNull();
+    expect(screen.getByText("Codex")).toBeTruthy();
+  });
+
+  it("shows summary for hidden agents with correct count and pluralization", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Canopy supports 3 more agents/)).toBeTruthy();
+    });
+  });
+
+  it("uses singular 'agent' when hiddenCount is 1", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "ready", opencode: "ready", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Canopy supports 1 more agent →/)).toBeTruthy();
+    });
+  });
+
+  it("hides summary when all agents installed", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "ready", opencode: "ready", cursor: "ready" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Claude")).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/Canopy supports/)).toBeNull();
+  });
+
+  it("shows 'Needs setup' label for installed-but-not-ready agents", async () => {
+    setupDispatchMock(
+      { claude: "installed", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Claude")).toBeTruthy();
+      expect(screen.getByText("Gemini")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Needs setup")).toBeTruthy();
+    expect(screen.getByText("Ready")).toBeTruthy();
+  });
+
+  it("renders empty-state CTA when no agents installed", async () => {
+    setupDispatchMock(
+      { claude: "missing", gemini: "missing", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("No agents installed yet.")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Run setup wizard")).toBeTruthy();
+    expect(screen.getByText("Browse available agents")).toBeTruthy();
+    // Should NOT list any agent rows
+    expect(screen.queryByText("Claude")).toBeNull();
+  });
+
+  it("setup wizard button dispatches canopy:open-agent-setup-wizard CustomEvent", async () => {
+    setupDispatchMock(
+      { claude: "missing", gemini: "missing", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Run setup wizard")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Run setup wizard"));
+
+    const wizardEvent = dispatchSpy.mock.calls.find(
+      ([event]) => event instanceof CustomEvent && event.type === "canopy:open-agent-setup-wizard"
+    );
+    expect(wizardEvent).toBeTruthy();
+
+    dispatchSpy.mockRestore();
+  });
+
+  it("summary link calls onNavigateToAgents without an agent id", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    const onNavigate = vi.fn();
+    const { GeneralTab } = await import("../GeneralTab");
+    render(
+      <GeneralTab
+        appVersion="1.0.0"
+        onNavigateToAgents={onNavigate}
+        activeSubtab="overview"
+        onSubtabChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Canopy supports 3 more agents/)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText(/Canopy supports 3 more agents/));
+    expect(onNavigate).toHaveBeenCalledWith();
+  });
+
+  it("shows neutral section description, not dependency-check framing", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      { agents: {} } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      const desc = screen.getByTestId("section-desc-System Status");
+      expect(desc.textContent).toBe("Agents ready to use on your system.");
+    });
+  });
+});

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -117,7 +117,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("renders only installed, enabled agents (hides uninstalled)", async () => {
     setupDispatchMock(
-      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "ready",
+        gemini: "ready",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 
@@ -153,7 +159,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("shows summary for hidden agents with correct count and pluralization", async () => {
     setupDispatchMock(
-      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "ready",
+        gemini: "ready",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 
@@ -194,7 +206,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("shows 'Needs setup' label for installed-but-not-ready agents", async () => {
     setupDispatchMock(
-      { claude: "installed", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "installed",
+        gemini: "ready",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 
@@ -211,7 +229,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("renders empty-state CTA when no agents installed", async () => {
     setupDispatchMock(
-      { claude: "missing", gemini: "missing", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "missing",
+        gemini: "missing",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 
@@ -229,7 +253,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("setup wizard button dispatches canopy:open-agent-setup-wizard CustomEvent", async () => {
     setupDispatchMock(
-      { claude: "missing", gemini: "missing", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "missing",
+        gemini: "missing",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 
@@ -253,7 +283,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("summary link calls onNavigateToAgents without an agent id", async () => {
     setupDispatchMock(
-      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "ready",
+        gemini: "ready",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 
@@ -278,7 +314,13 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
 
   it("shows neutral section description, not dependency-check framing", async () => {
     setupDispatchMock(
-      { claude: "ready", gemini: "ready", codex: "missing", opencode: "missing", cursor: "missing" },
+      {
+        claude: "ready",
+        gemini: "ready",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
       { agents: {} } as unknown as AgentSettings
     );
 

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -131,8 +131,8 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     expect(screen.queryByText("Codex")).toBeNull();
     expect(screen.queryByText("Opencode")).toBeNull();
     expect(screen.queryByText("Cursor")).toBeNull();
-    // No orange warning labels anywhere
-    expect(screen.queryByText("CLI not found")).toBeNull();
+    // Both visible rows render the "Ready" badge
+    expect(screen.getAllByText("Ready")).toHaveLength(2);
   });
 
   it("hides installed but user-disabled agents", async () => {
@@ -173,7 +173,7 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     await renderGeneralTab();
 
     await waitFor(() => {
-      expect(screen.getByText(/Canopy supports 1 more agent →/)).toBeTruthy();
+      expect(screen.getByText(/Canopy supports 1 more agent\b/)).toBeTruthy();
     });
   });
 

--- a/src/components/Settings/settingsSearchIndex.ts
+++ b/src/components/Settings/settingsSearchIndex.ts
@@ -218,7 +218,7 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
     subtabLabel: "Overview",
     section: "System Status",
     title: "System Status",
-    description: "CLI agent availability — Claude, Gemini, Codex, OpenCode, Cursor status",
+    description: "Installed agents and their operational status",
     keywords: ["agents", "cli", "available", "status", "check", "ready"],
   },
   {


### PR DESCRIPTION
## Summary

- System Status in Settings > General now only shows agents that are actually installed on the user's system. Uninstalled agents were previously rendered as orange \"CLI not found\" warning rows, which made the app look broken when the user simply hadn't installed agents they don't use.
- Agents in the `installed` state (present but needing auth/setup) are included in the list with a \"Needs setup\" label rather than \"Ready\", since their operational status genuinely matters.
- A summary line below the list shows \"Canopy supports N more agent(s)\" for discoverability, and an empty-state CTA points to the setup wizard or agent browser if nothing is installed.

Resolves #5072

## Changes

- `src/components/Settings/GeneralTab.tsx` — Filter System Status to installed+enabled agents only using `isAgentInstalled`. Per-agent status badge now differentiates `ready` vs `installed` states. Empty-state CTA dispatches `canopy:open-agent-setup-wizard` CustomEvent. Section description reworded to \"Agents ready to use on your system.\"
- `src/components/Settings/settingsSearchIndex.ts` — Removed hard-coded agent names from the search index description.
- `src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx` — 10 tests covering filter behaviour, `installed` vs `ready` state labels, summary count and pluralisation, empty-state CTA, and setup wizard CustomEvent dispatch. Updated fixtures to use the three-state `AgentAvailabilityState` model (`\"ready\"` / `\"installed\"` / `\"missing\"`) introduced in the develop branch after this branch was cut.

## Testing

10 new tests passing. Rebased cleanly onto develop, picking up the three-state CLI availability model and the GitHub Copilot addition. Typecheck and lint clean (0 errors).