### PR TITLE
fix(e2e): propagate SKIP_FIRST_RUN_DIALOGS flag to sandboxed renderer

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2889,3 +2889,13 @@ if (process.env.CANOPY_E2E_FAULT_MODE === "1") {
 if (process.env.CANOPY_E2E_MODE === "1") {
   contextBridge.exposeInMainWorld("__CANOPY_E2E_MODE__", true);
 }
+
+// E2E test bridge: expose the "skip first-run dialogs" flag to the renderer at
+// runtime. This cannot travel through `import.meta.env` because that is baked
+// at Vite build time, and CI builds do not set the var at build time — it is
+// only set when the E2E harness launches Electron. The sandboxed renderer
+// cannot read `process.env` directly, so the preload (which does have a
+// polyfilled `process.env` even under sandbox: true) is the propagation point.
+if (process.env.CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS === "1") {
+  contextBridge.exposeInMainWorld("__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__", true);
+}

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -58,10 +58,10 @@ vi.stubGlobal("window", {
 });
 
 const { isCanopyEnvEnabledMock } = vi.hoisted(() => ({
-  isCanopyEnvEnabledMock: vi.fn(() => false),
+  isCanopyEnvEnabledMock: vi.fn((_key: string): boolean => false),
 }));
 vi.mock("@/utils/env", () => ({
-  isCanopyEnvEnabled: (...args: unknown[]) => isCanopyEnvEnabledMock(...(args as [never])),
+  isCanopyEnvEnabled: (key: string) => isCanopyEnvEnabledMock(key),
 }));
 
 vi.mock("@/components/Setup/AgentSetupWizard", () => ({

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -57,8 +57,11 @@ vi.stubGlobal("window", {
   removeEventListener: vi.fn(),
 });
 
+const { isCanopyEnvEnabledMock } = vi.hoisted(() => ({
+  isCanopyEnvEnabledMock: vi.fn(() => false),
+}));
 vi.mock("@/utils/env", () => ({
-  isCanopyEnvEnabled: () => false,
+  isCanopyEnvEnabled: (...args: unknown[]) => isCanopyEnvEnabledMock(...(args as [never])),
 }));
 
 vi.mock("@/components/Setup/AgentSetupWizard", () => ({
@@ -281,6 +284,34 @@ describe("OnboardingFlow resume and legacy steps", () => {
     await vi.waitFor(() => {
       expect(getByTestId("agent-setup-wizard")).toBeTruthy();
     });
+  });
+
+  it("renders nothing and skips hydration when CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS is enabled", async () => {
+    // The component reads SKIP_FIRST_RUN_DIALOGS at module load, so we flip
+    // the mock, reset the module cache, and re-import.
+    isCanopyEnvEnabledMock.mockReturnValue(true);
+    try {
+      vi.resetModules();
+      const { OnboardingFlow: IsolatedOnboardingFlow } = await import("../OnboardingFlow");
+      const { baseElement } = await act(async () => {
+        return render(<IsolatedOnboardingFlow {...defaultProps} />);
+      });
+
+      // No dialog, no progress indicator — nothing should render
+      expect(
+        baseElement.ownerDocument.querySelector('[data-testid="agent-setup-wizard"]')
+      ).toBeNull();
+      expect(baseElement.ownerDocument.querySelector('[data-testid="welcome-step"]')).toBeNull();
+      expect(
+        baseElement.ownerDocument.querySelector('[data-testid="onboarding-progress"]')
+      ).toBeNull();
+
+      // IPC hydration should be skipped entirely
+      expect(onboardingMock.get).not.toHaveBeenCalled();
+    } finally {
+      isCanopyEnvEnabledMock.mockReturnValue(false);
+      vi.resetModules();
+    }
   });
 });
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -25,6 +25,7 @@ declare global {
       getRendererListenerCount: (channel: string) => number;
     };
     __CANOPY_E2E_MODE__?: boolean;
+    __CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
   }
 }
 

--- a/src/utils/__tests__/env.test.ts
+++ b/src/utils/__tests__/env.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getCanopyEnv, isCanopyEnvEnabled } from "../env";
+
+type WindowWithBridge = Window &
+  typeof globalThis & {
+    __CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
+  };
+
+describe("getCanopyEnv / isCanopyEnvEnabled", () => {
+  const originalViteEnv = { ...import.meta.env };
+
+  beforeEach(() => {
+    delete (window as WindowWithBridge).__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__;
+    vi.stubEnv("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS", "");
+    vi.stubEnv("CANOPY_VERBOSE", "");
+    vi.stubEnv("CANOPY_PERF_CAPTURE", "");
+  });
+
+  afterEach(() => {
+    delete (window as WindowWithBridge).__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__;
+    vi.unstubAllEnvs();
+    Object.assign(import.meta.env, originalViteEnv);
+  });
+
+  it("returns true for CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS when the runtime window bridge is set", () => {
+    (window as WindowWithBridge).__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__ = true;
+    expect(isCanopyEnvEnabled("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe(true);
+    expect(getCanopyEnv("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe("1");
+  });
+
+  it("runtime window bridge takes precedence over import.meta.env", () => {
+    (window as WindowWithBridge).__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__ = true;
+    vi.stubEnv("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS", "0");
+    expect(isCanopyEnvEnabled("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe(true);
+  });
+
+  it("falls back to import.meta.env when the bridge is absent", () => {
+    vi.stubEnv("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS", "1");
+    expect(isCanopyEnvEnabled("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe(true);
+  });
+
+  it("returns false when neither the bridge nor import.meta.env is set to '1'", () => {
+    expect(isCanopyEnvEnabled("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe(false);
+  });
+
+  it("ignores a bridge value that is not literal true", () => {
+    (window as unknown as Record<string, unknown>).__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__ = "1";
+    expect(isCanopyEnvEnabled("CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS")).toBe(false);
+  });
+
+  it("does not consult the runtime bridge for other keys", () => {
+    // Even if someone set a bridge-like global, non-E2E keys must not read it.
+    (window as unknown as Record<string, unknown>).__CANOPY_VERBOSE__ = true;
+    vi.stubEnv("CANOPY_VERBOSE", "1");
+    expect(isCanopyEnvEnabled("CANOPY_VERBOSE")).toBe(true);
+
+    vi.stubEnv("CANOPY_VERBOSE", "");
+    expect(isCanopyEnvEnabled("CANOPY_VERBOSE")).toBe(false);
+  });
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -9,7 +9,25 @@ function getProcessEnv(): Record<string, string | undefined> | undefined {
   return maybeProcess?.env;
 }
 
+// Some Canopy env keys are set at Electron launch time (not Vite build time)
+// and cannot reach the sandboxed renderer through `import.meta.env` or
+// `process.env`. For those keys, `electron/preload.cts` exposes the value on
+// `window` via `contextBridge`, and we consult that bridge first. Other keys
+// remain build-time only (dev-workflow flags baked by Vite).
+function getRuntimeBridgeValue(key: CanopyEnvKey): string | undefined {
+  if (typeof window === "undefined") return undefined;
+  if (key === "CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS") {
+    return window.__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__ === true ? "1" : undefined;
+  }
+  return undefined;
+}
+
 export function getCanopyEnv(key: CanopyEnvKey): string | undefined {
+  const runtimeValue = getRuntimeBridgeValue(key);
+  if (runtimeValue !== undefined) {
+    return runtimeValue;
+  }
+
   const viteValue = import.meta.env[key];
   if (typeof viteValue === "string") {
     return viteValue;


### PR DESCRIPTION
## Summary

- `CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS` was read in the renderer via `import.meta.env`, which Vite bakes at build time. CI builds don't set the var at build time (only at Electron launch), so it always evaluated to `false`, leaving the AgentSetupWizard free to block Playwright clicks on the welcome screen.
- Mirrors the existing `CANOPY_E2E_FAULT_MODE` pattern: the preload now exposes the flag via `contextBridge.exposeInMainWorld` at runtime, and `src/utils/env.ts` checks the window bridge first for this key via a new `getRuntimeBridgeValue()` helper.
- Components are unchanged. The fix is purely in how the flag reaches the renderer.

Resolves #5066

## Changes

- `electron/preload.cts` — exposes `__CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS__` on `window` when the env var is set at launch time
- `src/types/electron.d.ts` — adds the window global declaration alongside the existing E2E globals
- `src/utils/env.ts` — adds `getRuntimeBridgeValue()` helper; `isCanopyEnvEnabled` checks the bridge first for `CANOPY_E2E_SKIP_FIRST_RUN_DIALOGS`
- `src/utils/__tests__/env.test.ts` — 6 new unit tests covering bridge precedence, fallback behaviour, and the helper itself
- `src/components/Onboarding/__tests__/OnboardingFlow.test.tsx` — adds a skip-path test and typed env mock; resolves conflict with the `maps legacy 'welcome' step` test added on develop

## Testing

23/23 unit tests pass. Typecheck clean, lint ratchet holds at 398 warnings (0 errors), format clean. Online E2E tests can't be run locally without the Claude/opencode CLIs — verification defers to CI.