### PR TITLE
feat(theme-picker): track recently used themes in picker

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -260,6 +260,7 @@ export const CHANNELS = {
   TERMINAL_CONFIG_SET_HYBRID_INPUT_AUTO_FOCUS: "terminal-config:set-hybrid-input-auto-focus",
   TERMINAL_CONFIG_SET_COLOR_SCHEME: "terminal-config:set-color-scheme",
   TERMINAL_CONFIG_SET_CUSTOM_SCHEMES: "terminal-config:set-custom-schemes",
+  TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS: "terminal-config:set-recent-scheme-ids",
   TERMINAL_CONFIG_IMPORT_COLOR_SCHEME: "terminal-config:import-color-scheme",
   TERMINAL_CONFIG_SET_SCREEN_READER_MODE: "terminal-config:set-screen-reader-mode",
   TERMINAL_CONFIG_SET_RESOURCE_MONITORING: "terminal-config:set-resource-monitoring",
@@ -449,6 +450,7 @@ export const CHANNELS = {
   APP_THEME_SET_FOLLOW_SYSTEM: "app-theme:set-follow-system",
   APP_THEME_SET_PREFERRED_DARK_SCHEME: "app-theme:set-preferred-dark-scheme",
   APP_THEME_SET_PREFERRED_LIGHT_SCHEME: "app-theme:set-preferred-light-scheme",
+  APP_THEME_SET_RECENT_SCHEME_IDS: "app-theme:set-recent-scheme-ids",
   APP_THEME_SYSTEM_APPEARANCE_CHANGED: "app-theme:system-appearance-changed",
 
   TELEMETRY_GET: "telemetry:get",

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -159,6 +159,84 @@ describe("appTheme handlers", () => {
     );
   });
 
+  describe("setRecentSchemeIds", () => {
+    it("persists a valid string array", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
+      await handler({}, ["bondi", "dracula", "serengeti"]);
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ recentSchemeIds: ["bondi", "dracula", "serengeti"] })
+      );
+    });
+
+    it("ignores non-array input without throwing", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
+      await handler({}, "not-an-array");
+      await handler({}, null);
+      await handler({}, 42);
+
+      const recentCalls = storeMock.set.mock.calls.filter(
+        (c: unknown[]) => (c[1] as { recentSchemeIds?: unknown }).recentSchemeIds !== undefined
+      );
+      expect(recentCalls).toHaveLength(0);
+    });
+
+    it("filters out non-string and empty entries, trims whitespace", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
+      await handler({}, ["bondi", "", "  ", 42, null, undefined, " dracula "]);
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ recentSchemeIds: ["bondi", "dracula"] })
+      );
+    });
+
+    it("caps the persisted list at 5 entries", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
+      await handler({}, ["a", "b", "c", "d", "e", "f", "g"]);
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ recentSchemeIds: ["a", "b", "c", "d", "e"] })
+      );
+    });
+
+    it("preserves other appTheme fields when persisting", async () => {
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        followSystem: true,
+        preferredDarkSchemeId: "custom-dark",
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS);
+      await handler({}, ["bondi"]);
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({
+          colorSchemeId: "daintree",
+          followSystem: true,
+          preferredDarkSchemeId: "custom-dark",
+          recentSchemeIds: ["bondi"],
+        })
+      );
+    });
+  });
+
   it("nativeTheme updated does nothing when followSystem is false", () => {
     storeState.data.appTheme = { colorSchemeId: "daintree", followSystem: false };
     registerAppThemeHandlers();

--- a/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
@@ -243,4 +243,54 @@ describe("terminalConfig handlers", () => {
     await fontSizeHandler({}, 16);
     expect(storeState.data.terminalConfig).toEqual({ fontSize: 16 });
   });
+
+  describe("setRecentSchemeIds", () => {
+    it("persists a valid string array", async () => {
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS);
+
+      await handler({}, ["dracula", "monokai"]);
+
+      expect(storeState.data.terminalConfig).toMatchObject({
+        recentSchemeIds: ["dracula", "monokai"],
+      });
+    });
+
+    it("ignores non-array input without mutating store", async () => {
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS);
+
+      const before = storeState.data.terminalConfig;
+      await handler({}, "not-an-array");
+      await handler({}, null);
+      await handler({}, 123);
+
+      expect(storeState.data.terminalConfig).toEqual(before);
+    });
+
+    it("filters non-string entries, trims whitespace, caps at 5", async () => {
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS);
+
+      await handler({}, ["a", "", "  ", 42, null, " b ", "c", "d", "e", "f", "g"]);
+
+      expect(storeState.data.terminalConfig).toMatchObject({
+        recentSchemeIds: ["a", "b", "c", "d", "e"],
+      });
+    });
+
+    it("preserves other terminalConfig fields when persisting", async () => {
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS);
+
+      await handler({}, ["dracula"]);
+
+      expect(storeState.data.terminalConfig).toMatchObject({
+        scrollbackLines: 1000,
+        fontSize: 12,
+        fontFamily: "JetBrains Mono",
+        recentSchemeIds: ["dracula"],
+      });
+    });
+  });
 });

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -210,10 +210,10 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
       console.warn("Invalid app theme recentSchemeIds:", ids);
       return;
     }
-    const sanitized = ids
+    const trimmed = ids
       .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
-      .map((id) => id.trim())
-      .slice(0, 5);
+      .map((id) => id.trim());
+    const sanitized = Array.from(new Set(trimmed)).slice(0, 5);
     const current = getAppThemeConfig();
     store.set("appTheme", {
       ...current,

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -205,6 +205,24 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
   ipcMain.handle(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME, handleSetPreferredLightScheme);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME));
 
+  const handleSetRecentSchemeIds = async (_event: Electron.IpcMainInvokeEvent, ids: unknown) => {
+    if (!Array.isArray(ids)) {
+      console.warn("Invalid app theme recentSchemeIds:", ids);
+      return;
+    }
+    const sanitized = ids
+      .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      .map((id) => id.trim())
+      .slice(0, 5);
+    const current = getAppThemeConfig();
+    store.set("appTheme", {
+      ...current,
+      recentSchemeIds: sanitized,
+    } satisfies AppThemeConfig);
+  };
+  ipcMain.handle(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS, handleSetRecentSchemeIds);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS));
+
   // nativeTheme listener for auto-switching
   let appearanceTimer: ReturnType<typeof setTimeout> | null = null;
 

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -162,10 +162,10 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       console.warn("Invalid terminal recentSchemeIds:", ids);
       return;
     }
-    const sanitized = ids
+    const trimmed = ids
       .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
-      .map((id) => id.trim())
-      .slice(0, 5);
+      .map((id) => id.trim());
+    const sanitized = Array.from(new Set(trimmed)).slice(0, 5);
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, recentSchemeIds: sanitized });
   };

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -154,6 +154,27 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
   ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, handleTerminalConfigSetCustomSchemes);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES));
 
+  const handleTerminalConfigSetRecentSchemeIds = async (
+    _event: Electron.IpcMainInvokeEvent,
+    ids: unknown
+  ) => {
+    if (!Array.isArray(ids)) {
+      console.warn("Invalid terminal recentSchemeIds:", ids);
+      return;
+    }
+    const sanitized = ids
+      .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+      .map((id) => id.trim())
+      .slice(0, 5);
+    const currentConfig = getTerminalConfigObject();
+    store.set("terminalConfig", { ...currentConfig, recentSchemeIds: sanitized });
+  };
+  ipcMain.handle(
+    CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS,
+    handleTerminalConfigSetRecentSchemeIds
+  );
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS));
+
   const handleTerminalConfigSetScreenReaderMode = async (
     _event: Electron.IpcMainInvokeEvent,
     mode: string

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2004,6 +2004,9 @@ const api: ElectronAPI = {
     setCustomSchemes: (schemesJson: string) =>
       _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, schemesJson),
 
+    setRecentSchemeIds: (ids: string[]) =>
+      _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS, ids),
+
     importColorScheme: () => _unwrappingInvoke(CHANNELS.TERMINAL_CONFIG_IMPORT_COLOR_SCHEME),
 
     setScreenReaderMode: (mode: "auto" | "on" | "off") =>
@@ -2547,6 +2550,9 @@ const api: ElectronAPI = {
 
     setPreferredLightScheme: (schemeId: string) =>
       _unwrappingInvoke(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME, schemeId),
+
+    setRecentSchemeIds: (ids: string[]) =>
+      _unwrappingInvoke(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS, ids),
 
     onSystemAppearanceChanged: (
       callback: (payload: { isDark: boolean; schemeId: string }) => void

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -675,6 +675,7 @@ const CHANNELS = {
   TERMINAL_CONFIG_SET_HYBRID_INPUT_AUTO_FOCUS: "terminal-config:set-hybrid-input-auto-focus",
   TERMINAL_CONFIG_SET_COLOR_SCHEME: "terminal-config:set-color-scheme",
   TERMINAL_CONFIG_SET_CUSTOM_SCHEMES: "terminal-config:set-custom-schemes",
+  TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS: "terminal-config:set-recent-scheme-ids",
   TERMINAL_CONFIG_IMPORT_COLOR_SCHEME: "terminal-config:import-color-scheme",
   TERMINAL_CONFIG_SET_SCREEN_READER_MODE: "terminal-config:set-screen-reader-mode",
   TERMINAL_CONFIG_SET_RESOURCE_MONITORING: "terminal-config:set-resource-monitoring",
@@ -859,6 +860,7 @@ const CHANNELS = {
   APP_THEME_SET_FOLLOW_SYSTEM: "app-theme:set-follow-system",
   APP_THEME_SET_PREFERRED_DARK_SCHEME: "app-theme:set-preferred-dark-scheme",
   APP_THEME_SET_PREFERRED_LIGHT_SCHEME: "app-theme:set-preferred-light-scheme",
+  APP_THEME_SET_RECENT_SCHEME_IDS: "app-theme:set-recent-scheme-ids",
   APP_THEME_SYSTEM_APPEARANCE_CHANGED: "app-theme:system-appearance-changed",
 
   // Telemetry channels

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -212,6 +212,8 @@ export interface AppThemeConfig {
   followSystem?: boolean;
   preferredDarkSchemeId?: string;
   preferredLightSchemeId?: string;
+  /** IDs of the most recently selected themes (LRU, newest first, capped at 5) */
+  recentSchemeIds?: string[];
 }
 
 export interface AppThemeValidationWarning {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -757,6 +757,7 @@ export interface ElectronAPI {
     setHybridInputAutoFocus(enabled: boolean): Promise<void>;
     setColorScheme(schemeId: string): Promise<void>;
     setCustomSchemes(schemesJson: string): Promise<void>;
+    setRecentSchemeIds(ids: string[]): Promise<void>;
     importColorScheme(): Promise<
       | {
           ok: true;
@@ -1083,6 +1084,7 @@ export interface ElectronAPI {
     setFollowSystem(enabled: boolean): Promise<void>;
     setPreferredDarkScheme(schemeId: string): Promise<void>;
     setPreferredLightScheme(schemeId: string): Promise<void>;
+    setRecentSchemeIds(ids: string[]): Promise<void>;
     onSystemAppearanceChanged(
       callback: (payload: { isDark: boolean; schemeId: string }) => void
     ): () => void;

--- a/shared/types/ipc/config.ts
+++ b/shared/types/ipc/config.ts
@@ -20,6 +20,8 @@ export interface TerminalConfig {
   colorSchemeId?: string;
   /** Custom imported color schemes (serialized) */
   customSchemes?: string;
+  /** IDs of the most recently selected terminal color schemes (LRU, newest first, capped at 5) */
+  recentSchemeIds?: string[];
   /** Screen reader mode: 'auto' (follow OS), 'on', or 'off' (default: 'auto') */
   screenReaderMode?: "auto" | "on" | "off";
   /** Show per-terminal CPU and memory usage in panel headers (default: false) */

--- a/src/clients/appThemeClient.ts
+++ b/src/clients/appThemeClient.ts
@@ -36,4 +36,8 @@ export const appThemeClient = {
   setPreferredLightScheme: (schemeId: string): Promise<void> => {
     return window.electron.appTheme.setPreferredLightScheme(schemeId);
   },
+
+  setRecentSchemeIds: (ids: string[]): Promise<void> => {
+    return window.electron.appTheme.setRecentSchemeIds(ids);
+  },
 } as const;

--- a/src/clients/terminalConfigClient.ts
+++ b/src/clients/terminalConfigClient.ts
@@ -37,6 +37,10 @@ export const terminalConfigClient = {
     return window.electron.terminalConfig.setCustomSchemes(schemesJson);
   },
 
+  setRecentSchemeIds: (ids: string[]): Promise<void> => {
+    return window.electron.terminalConfig.setRecentSchemeIds(ids);
+  },
+
   importColorScheme: () => {
     return window.electron.terminalConfig.importColorScheme();
   },

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -191,14 +191,12 @@ export function AppThemePicker() {
 
       try {
         await appThemeClient.setColorScheme(id);
+        // Only persist the updated recents once the selection itself was saved.
+        // Read back from the store so we capture the post-LRU-update state.
+        await appThemeClient.setRecentSchemeIds(useAppThemeStore.getState().recentSchemeIds);
       } catch (error) {
         console.error("Failed to persist app theme:", error);
       }
-
-      // Persist the updated recently-used list (read from store after the LRU update)
-      appThemeClient
-        .setRecentSchemeIds(useAppThemeStore.getState().recentSchemeIds)
-        .catch((error) => console.error("Failed to persist recent themes:", error));
 
       const scheme = allSchemes.find((s) => s.id === id);
       if (scheme?.heroVideo && id !== prev && !prefersReducedMotion()) {

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -131,6 +131,7 @@ export function AppThemePicker() {
   const customSchemes = useAppThemeStore((s) => s.customSchemes);
   const setSelectedSchemeId = useAppThemeStore((s) => s.setSelectedSchemeId);
   const addCustomScheme = useAppThemeStore((s) => s.addCustomScheme);
+  const recentSchemeIds = useAppThemeStore((s) => s.recentSchemeIds);
   const followSystem = useAppThemeStore((s) => s.followSystem);
   const setFollowSystem = useAppThemeStore((s) => s.setFollowSystem);
   const preferredDarkSchemeId = useAppThemeStore((s) => s.preferredDarkSchemeId);
@@ -146,8 +147,26 @@ export function AppThemePicker() {
   const shuffleQueueRef = useRef<string[]>([]);
 
   const allSchemes = useMemo(() => [...BUILT_IN_APP_SCHEMES, ...customSchemes], [customSchemes]);
-  const darkSchemes = useMemo(() => allSchemes.filter((s) => s.type !== "light"), [allSchemes]);
-  const lightSchemes = useMemo(() => allSchemes.filter((s) => s.type === "light"), [allSchemes]);
+  const recentSchemes = useMemo(
+    () =>
+      recentSchemeIds
+        .map((id) => allSchemes.find((s) => s.id === id))
+        .filter((s): s is AppColorScheme => Boolean(s)),
+    [recentSchemeIds, allSchemes]
+  );
+  const recentIdSet = useMemo(() => new Set(recentSchemes.map((s) => s.id)), [recentSchemes]);
+  const darkSchemes = useMemo(
+    () => allSchemes.filter((s) => s.type !== "light" && !recentIdSet.has(s.id)),
+    [allSchemes, recentIdSet]
+  );
+  const lightSchemes = useMemo(
+    () => allSchemes.filter((s) => s.type === "light" && !recentIdSet.has(s.id)),
+    [allSchemes, recentIdSet]
+  );
+  // Unfiltered dark/light lists — used for follow-system preferred pickers that
+  // should not hide recently-used themes.
+  const allDarkSchemes = useMemo(() => allSchemes.filter((s) => s.type !== "light"), [allSchemes]);
+  const allLightSchemes = useMemo(() => allSchemes.filter((s) => s.type === "light"), [allSchemes]);
   const selectedScheme = useMemo(
     () => allSchemes.find((s) => s.id === selectedSchemeId) ?? allSchemes[0],
     [allSchemes, selectedSchemeId]
@@ -175,6 +194,11 @@ export function AppThemePicker() {
       } catch (error) {
         console.error("Failed to persist app theme:", error);
       }
+
+      // Persist the updated recently-used list (read from store after the LRU update)
+      appThemeClient
+        .setRecentSchemeIds(useAppThemeStore.getState().recentSchemeIds)
+        .catch((error) => console.error("Failed to persist recent themes:", error));
 
       const scheme = allSchemes.find((s) => s.id === id);
       if (scheme?.heroVideo && id !== prev && !prefersReducedMotion()) {
@@ -261,9 +285,8 @@ export function AppThemePicker() {
       }
 
       addCustomScheme(result.scheme);
-      setSelectedSchemeId(result.scheme.id);
-      await appThemeClient.setColorScheme(result.scheme.id);
       await persistCustomSchemes();
+      await handleSelect(result.scheme.id);
 
       if (result.warnings.length > 0) {
         setImportWarnings(result.warnings);
@@ -277,7 +300,7 @@ export function AppThemePicker() {
       console.error("Failed to import app theme:", error);
       setImportMessage("Failed to import app theme.");
     }
-  }, [addCustomScheme, setSelectedSchemeId]);
+  }, [addCustomScheme, handleSelect]);
 
   const handleExport = useCallback(async () => {
     if (!selectedScheme) return;
@@ -307,13 +330,13 @@ export function AppThemePicker() {
         <div className="space-y-2 pl-1">
           <PreferredSchemePicker
             label="Preferred dark theme"
-            schemes={darkSchemes}
+            schemes={allDarkSchemes}
             selectedId={preferredDarkSchemeId}
             onSelect={handlePreferredDarkChange}
           />
           <PreferredSchemePicker
             label="Preferred light theme"
-            schemes={lightSchemes}
+            schemes={allLightSchemes}
             selectedId={preferredLightSchemeId}
             onSelect={handlePreferredLightChange}
           />
@@ -408,6 +431,9 @@ export function AppThemePicker() {
         <AppDialog.BodyScroll>
           <ThemeSelector<AppColorScheme>
             groups={[
+              ...(recentSchemes.length > 0
+                ? [{ label: "Recently Used", items: recentSchemes }]
+                : []),
               ...(darkSchemes.length > 0 ? [{ label: "Dark", items: darkSchemes }] : []),
               ...(lightSchemes.length > 0 ? [{ label: "Light", items: lightSchemes }] : []),
             ]}

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -95,12 +95,12 @@ export function ColorSchemePicker() {
       setSelectedSchemeId(id);
       try {
         await terminalConfigClient.setColorScheme(id);
+        await terminalConfigClient.setRecentSchemeIds(
+          useTerminalColorSchemeStore.getState().recentSchemeIds
+        );
       } catch (error) {
         console.error("Failed to persist color scheme:", error);
       }
-      terminalConfigClient
-        .setRecentSchemeIds(useTerminalColorSchemeStore.getState().recentSchemeIds)
-        .catch((error) => console.error("Failed to persist recent terminal schemes:", error));
     },
     [setSelectedSchemeId]
   );

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import {
   BUILT_IN_SCHEMES,
   DEFAULT_SCHEME_ID,
@@ -73,9 +73,22 @@ export function ColorSchemePicker() {
   const customSchemes = useTerminalColorSchemeStore((s) => s.customSchemes);
   const setSelectedSchemeId = useTerminalColorSchemeStore((s) => s.setSelectedSchemeId);
   const addCustomScheme = useTerminalColorSchemeStore((s) => s.addCustomScheme);
+  const recentSchemeIds = useTerminalColorSchemeStore((s) => s.recentSchemeIds);
   const appThemeId = useAppThemeStore((s) => s.selectedSchemeId);
 
-  const allSchemes = [...BUILT_IN_SCHEMES, ...customSchemes];
+  const allSchemes = useMemo(() => [...BUILT_IN_SCHEMES, ...customSchemes], [customSchemes]);
+  const recentSchemes = useMemo(
+    () =>
+      recentSchemeIds
+        .map((id) => allSchemes.find((s) => s.id === id))
+        .filter((s): s is TerminalColorScheme => Boolean(s)),
+    [recentSchemeIds, allSchemes]
+  );
+  const recentIdSet = useMemo(() => new Set(recentSchemes.map((s) => s.id)), [recentSchemes]);
+  const otherSchemes = useMemo(
+    () => allSchemes.filter((s) => !recentIdSet.has(s.id)),
+    [allSchemes, recentIdSet]
+  );
 
   const handleSelect = useCallback(
     async (id: string) => {
@@ -85,6 +98,9 @@ export function ColorSchemePicker() {
       } catch (error) {
         console.error("Failed to persist color scheme:", error);
       }
+      terminalConfigClient
+        .setRecentSchemeIds(useTerminalColorSchemeStore.getState().recentSchemeIds)
+        .catch((error) => console.error("Failed to persist recent terminal schemes:", error));
     },
     [setSelectedSchemeId]
   );
@@ -100,36 +116,61 @@ export function ColorSchemePicker() {
         colors: result.scheme.colors,
       };
       addCustomScheme(scheme);
-      setSelectedSchemeId(scheme.id);
-      await terminalConfigClient.setColorScheme(scheme.id);
       await persistCustomSchemes();
+      await handleSelect(scheme.id);
     } catch (error) {
       console.error("Failed to import color scheme:", error);
     }
-  }, [addCustomScheme, setSelectedSchemeId]);
+  }, [addCustomScheme, handleSelect]);
 
   return (
     <div className="space-y-3">
-      <ThemeSelector<TerminalColorScheme>
-        items={allSchemes}
-        selectedId={selectedSchemeId}
-        onSelect={handleSelect}
-        renderPreview={(scheme) => (
-          <SchemePreview scheme={resolveSchemeForPreview(scheme, appThemeId)} />
-        )}
-        renderMeta={(scheme) => {
-          const resolved = resolveSchemeForPreview(scheme, appThemeId);
-          return (
-            <div className="flex items-center gap-1.5">
-              <span className="text-xs text-canopy-text truncate">{scheme.name}</span>
-              {resolved.type === "light" && (
-                <span className="text-[10px] text-canopy-text/50 shrink-0">light</span>
-              )}
-            </div>
-          );
-        }}
-        getName={(s) => s.name}
-      />
+      {recentSchemes.length > 0 ? (
+        <ThemeSelector<TerminalColorScheme>
+          groups={[
+            { label: "Recently Used", items: recentSchemes },
+            ...(otherSchemes.length > 0 ? [{ label: "All schemes", items: otherSchemes }] : []),
+          ]}
+          selectedId={selectedSchemeId}
+          onSelect={handleSelect}
+          renderPreview={(scheme) => (
+            <SchemePreview scheme={resolveSchemeForPreview(scheme, appThemeId)} />
+          )}
+          renderMeta={(scheme) => {
+            const resolved = resolveSchemeForPreview(scheme, appThemeId);
+            return (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-canopy-text truncate">{scheme.name}</span>
+                {resolved.type === "light" && (
+                  <span className="text-[10px] text-canopy-text/50 shrink-0">light</span>
+                )}
+              </div>
+            );
+          }}
+          getName={(s) => s.name}
+        />
+      ) : (
+        <ThemeSelector<TerminalColorScheme>
+          items={allSchemes}
+          selectedId={selectedSchemeId}
+          onSelect={handleSelect}
+          renderPreview={(scheme) => (
+            <SchemePreview scheme={resolveSchemeForPreview(scheme, appThemeId)} />
+          )}
+          renderMeta={(scheme) => {
+            const resolved = resolveSchemeForPreview(scheme, appThemeId);
+            return (
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-canopy-text truncate">{scheme.name}</span>
+                {resolved.type === "light" && (
+                  <span className="text-[10px] text-canopy-text/50 shrink-0">light</span>
+                )}
+              </div>
+            );
+          }}
+          getName={(s) => s.name}
+        />
+      )}
       <button
         onClick={handleImport}
         className="text-xs text-canopy-accent hover:text-canopy-accent/80 transition-colors"

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@/clients/appThemeClient", () => ({
     setColorScheme: vi.fn().mockResolvedValue(undefined),
     setFollowSystem: vi.fn().mockResolvedValue(undefined),
     setCustomSchemes: vi.fn().mockResolvedValue(undefined),
+    setRecentSchemeIds: vi.fn().mockResolvedValue(undefined),
     importTheme: vi.fn().mockResolvedValue({ ok: false, errors: ["Import cancelled"] }),
   },
 }));
@@ -87,13 +88,16 @@ describe("AppThemePicker shuffle button", () => {
     Object.assign(storeState, {
       selectedSchemeId: "theme-a",
       customSchemes: [],
+      recentSchemeIds: [],
       followSystem: false,
       preferredDarkSchemeId: "theme-a",
       preferredLightSchemeId: "theme-a",
       setSelectedSchemeId: vi.fn(),
+      setSelectedSchemeIdSilent: vi.fn(),
       setFollowSystem: vi.fn(),
       setPreferredDarkSchemeId: vi.fn(),
       setPreferredLightSchemeId: vi.fn(),
+      setRecentSchemeIds: vi.fn(),
       addCustomScheme: vi.fn(),
     });
   });

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -335,6 +335,7 @@ export function AgentSetupWizard({
   // Theme state (first-run only)
   const selectedSchemeId = useAppThemeStore((s) => s.selectedSchemeId);
   const setSelectedSchemeId = useAppThemeStore((s) => s.setSelectedSchemeId);
+  const setSelectedSchemeIdSilent = useAppThemeStore((s) => s.setSelectedSchemeIdSilent);
   const hasAutoSelected = useRef(false);
 
   // Telemetry state (first-run only)
@@ -416,10 +417,12 @@ export function AgentSetupWizard({
     const prefersLight = window.matchMedia("(prefers-color-scheme: light)").matches;
     const targetId = prefersLight ? "bondi" : "daintree";
     if (selectedSchemeId !== targetId) {
-      setSelectedSchemeId(targetId);
+      // Auto-select mirrors OS appearance — not a direct user pick, so use the
+      // silent setter to avoid polluting the recently-used list.
+      setSelectedSchemeIdSilent(targetId);
       appThemeClient.setColorScheme(targetId).catch(console.error);
     }
-  }, [isFirstRun, isOpen, state.step.type, selectedSchemeId, setSelectedSchemeId]);
+  }, [isFirstRun, isOpen, state.step.type, selectedSchemeId, setSelectedSchemeIdSilent]);
 
   const handleThemeSelect = useCallback(
     async (id: string) => {

--- a/src/hooks/useAppThemeConfig.ts
+++ b/src/hooks/useAppThemeConfig.ts
@@ -8,12 +8,13 @@ import type { ColorVisionMode } from "@shared/types";
 const VALID_COLOR_VISION_MODES: ColorVisionMode[] = ["default", "red-green", "blue-yellow"];
 
 export function useAppThemeConfig() {
-  const setSelectedSchemeId = useAppThemeStore((state) => state.setSelectedSchemeId);
+  const setSelectedSchemeIdSilent = useAppThemeStore((state) => state.setSelectedSchemeIdSilent);
   const addCustomScheme = useAppThemeStore((state) => state.addCustomScheme);
   const setColorVisionMode = useAppThemeStore((state) => state.setColorVisionMode);
   const setFollowSystem = useAppThemeStore((state) => state.setFollowSystem);
   const setPreferredDarkSchemeId = useAppThemeStore((state) => state.setPreferredDarkSchemeId);
   const setPreferredLightSchemeId = useAppThemeStore((state) => state.setPreferredLightSchemeId);
+  const setRecentSchemeIds = useAppThemeStore((state) => state.setRecentSchemeIds);
 
   useEffect(() => {
     let cancelled = false;
@@ -37,7 +38,15 @@ export function useAppThemeConfig() {
         }
 
         if (typeof config.colorSchemeId === "string" && config.colorSchemeId.trim()) {
-          setSelectedSchemeId(config.colorSchemeId.trim());
+          setSelectedSchemeIdSilent(config.colorSchemeId.trim());
+        }
+
+        if (Array.isArray(config.recentSchemeIds)) {
+          const sanitized = config.recentSchemeIds
+            .filter((id: unknown): id is string => typeof id === "string" && id.trim().length > 0)
+            .map((id) => id.trim())
+            .slice(0, 5);
+          setRecentSchemeIds(sanitized);
         }
 
         if (
@@ -71,17 +80,19 @@ export function useAppThemeConfig() {
       cancelled = true;
     };
   }, [
-    setSelectedSchemeId,
+    setSelectedSchemeIdSilent,
     addCustomScheme,
     setColorVisionMode,
     setFollowSystem,
     setPreferredDarkSchemeId,
     setPreferredLightSchemeId,
+    setRecentSchemeIds,
   ]);
 
   useEffect(() => {
     return window.electron.appTheme.onSystemAppearanceChanged(({ schemeId }) => {
-      setSelectedSchemeId(schemeId);
+      // OS-driven follow-system changes must not populate the recently-used list
+      setSelectedSchemeIdSilent(schemeId);
     });
-  }, [setSelectedSchemeId]);
+  }, [setSelectedSchemeIdSilent]);
 }

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -17,8 +17,8 @@ export function useTerminalConfig() {
 
   const selectedSchemeId = useTerminalColorSchemeStore((state) => state.selectedSchemeId);
   const customSchemes = useTerminalColorSchemeStore((state) => state.customSchemes);
-  const setSelectedSchemeId = useTerminalColorSchemeStore((state) => state.setSelectedSchemeId);
   const addCustomScheme = useTerminalColorSchemeStore((state) => state.addCustomScheme);
+  const setRecentSchemeIds = useTerminalColorSchemeStore((state) => state.setRecentSchemeIds);
 
   useEffect(() => {
     let cancelled = false;
@@ -34,7 +34,8 @@ export function useTerminalConfig() {
           setFontFamily(config.fontFamily);
         }
         if (typeof config.colorSchemeId === "string" && config.colorSchemeId.trim()) {
-          setSelectedSchemeId(config.colorSchemeId);
+          // Hydrate directly to avoid polluting the recently-used list on startup
+          useTerminalColorSchemeStore.setState({ selectedSchemeId: config.colorSchemeId.trim() });
         }
         if (typeof config.customSchemes === "string" && config.customSchemes.trim()) {
           try {
@@ -48,6 +49,13 @@ export function useTerminalConfig() {
             // ignore malformed custom schemes
           }
         }
+        if (Array.isArray(config.recentSchemeIds)) {
+          const sanitized = config.recentSchemeIds
+            .filter((id: unknown): id is string => typeof id === "string" && id.trim().length > 0)
+            .map((id) => id.trim())
+            .slice(0, 5);
+          setRecentSchemeIds(sanitized);
+        }
       })
       .catch((error) => {
         console.error("Failed to load terminal config:", error);
@@ -56,7 +64,7 @@ export function useTerminalConfig() {
     return () => {
       cancelled = true;
     };
-  }, [setFontSize, setFontFamily, setSelectedSchemeId, addCustomScheme]);
+  }, [setFontSize, setFontFamily, addCustomScheme, setRecentSchemeIds]);
 
   const screenReaderEnabled = useScreenReaderStore((s) => s.resolvedScreenReaderEnabled());
 

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -86,4 +86,25 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
     useAppThemeStore.getState().setRecentSchemeIds(["a", "b", "c", "d", "e", "f", "g"]);
     expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["a", "b", "c", "d", "e"]);
   });
+
+  it("setRecentSchemeIds deduplicates incoming entries", () => {
+    useAppThemeStore.getState().setRecentSchemeIds(["a", "b", "a", "c", "b", "d"]);
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("removeCustomScheme strips the removed id from recentSchemeIds", () => {
+    const customScheme = {
+      id: "custom-app-theme",
+      name: "Custom",
+      type: "dark" as const,
+      tokens: {} as never,
+    };
+    useAppThemeStore.getState().addCustomScheme(customScheme);
+    useAppThemeStore.getState().setSelectedSchemeId("custom-app-theme");
+    useAppThemeStore.getState().setSelectedSchemeId("svalbard");
+    expect(useAppThemeStore.getState().recentSchemeIds).toContain("custom-app-theme");
+
+    useAppThemeStore.getState().removeCustomScheme("custom-app-theme");
+    expect(useAppThemeStore.getState().recentSchemeIds).not.toContain("custom-app-theme");
+  });
 });

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -97,6 +97,7 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
       id: "custom-app-theme",
       name: "Custom",
       type: "dark" as const,
+      builtin: false,
       tokens: {} as never,
     };
     useAppThemeStore.getState().addCustomScheme(customScheme);

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
+import { useAppThemeStore } from "../appThemeStore";
+
+describe("appThemeStore.recentSchemeIds LRU", () => {
+  beforeEach(() => {
+    useAppThemeStore.setState({
+      selectedSchemeId: DEFAULT_APP_SCHEME_ID,
+      customSchemes: [],
+      colorVisionMode: "default",
+      followSystem: false,
+      preferredDarkSchemeId: "daintree",
+      preferredLightSchemeId: "bondi",
+      recentSchemeIds: [],
+    });
+  });
+
+  it("starts empty", () => {
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual([]);
+  });
+
+  it("setSelectedSchemeId prepends the id to recentSchemeIds", () => {
+    useAppThemeStore.getState().setSelectedSchemeId("svalbard");
+    expect(useAppThemeStore.getState().recentSchemeIds[0]).toBe("svalbard");
+
+    useAppThemeStore.getState().setSelectedSchemeId("bondi");
+    const recent = useAppThemeStore.getState().recentSchemeIds;
+    expect(recent[0]).toBe("bondi");
+    expect(recent[1]).toBe("svalbard");
+  });
+
+  it("deduplicates when re-selecting an existing id (moves to front)", () => {
+    const store = useAppThemeStore.getState();
+    store.setSelectedSchemeId("daintree");
+    store.setSelectedSchemeId("bondi");
+    store.setSelectedSchemeId("serengeti");
+    store.setSelectedSchemeId("daintree");
+
+    const recent = useAppThemeStore.getState().recentSchemeIds;
+    expect(recent[0]).toBe("daintree");
+    expect(recent.filter((id) => id === "daintree")).toHaveLength(1);
+    expect(recent).toHaveLength(3);
+  });
+
+  it("caps the list at 5 entries, evicting the oldest", () => {
+    const store = useAppThemeStore.getState();
+    const ids = ["daintree", "bondi", "serengeti", "hokkaido", "namib", "arashiyama", "atacama"];
+    for (const id of ids) store.setSelectedSchemeId(id);
+
+    const recent = useAppThemeStore.getState().recentSchemeIds;
+    expect(recent).toHaveLength(5);
+    // Newest first, oldest two evicted
+    expect(recent[0]).toBe("atacama");
+    expect(recent).not.toContain("daintree");
+    expect(recent).not.toContain("bondi");
+  });
+
+  it("setSelectedSchemeIdSilent does NOT mutate recentSchemeIds", () => {
+    useAppThemeStore.getState().setSelectedSchemeId("svalbard");
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["svalbard"]);
+
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("bondi");
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe("bondi");
+    // recentSchemeIds unchanged — silent path does not record usage
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["svalbard"]);
+  });
+
+  it("injectTheme does NOT mutate recentSchemeIds (hover preview)", () => {
+    useAppThemeStore.getState().setSelectedSchemeId("daintree");
+    const before = useAppThemeStore.getState().recentSchemeIds;
+
+    const someScheme = { id: "hover-target", tokens: {} } as unknown as Parameters<
+      ReturnType<typeof useAppThemeStore.getState>["injectTheme"]
+    >[0];
+    try {
+      useAppThemeStore.getState().injectTheme(someScheme);
+    } catch {
+      // jsdom may throw on unknown tokens — irrelevant to this assertion
+    }
+
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(before);
+  });
+
+  it("setRecentSchemeIds replaces the list and caps at 5", () => {
+    useAppThemeStore.getState().setRecentSchemeIds(["a", "b", "c", "d", "e", "f", "g"]);
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["a", "b", "c", "d", "e"]);
+  });
+});

--- a/src/store/__tests__/terminalColorSchemeStore.test.ts
+++ b/src/store/__tests__/terminalColorSchemeStore.test.ts
@@ -211,7 +211,7 @@ describe("terminalColorSchemeStore", () => {
       ]);
     });
 
-    it("removing a custom scheme does not eagerly scrub its id from the recents list", () => {
+    it("removing a custom scheme strips its id from the recents list", () => {
       const store = useTerminalColorSchemeStore.getState();
       store.addCustomScheme(CUSTOM_SCHEME);
       store.setSelectedSchemeId("custom-test");
@@ -219,8 +219,8 @@ describe("terminalColorSchemeStore", () => {
       expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toContain("custom-test");
 
       useTerminalColorSchemeStore.getState().removeCustomScheme("custom-test");
-      // Stale id is preserved — UI filters via .find().filter(Boolean)
-      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toContain("custom-test");
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).not.toContain("custom-test");
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toEqual(["dracula"]);
     });
   });
 

--- a/src/store/__tests__/terminalColorSchemeStore.test.ts
+++ b/src/store/__tests__/terminalColorSchemeStore.test.ts
@@ -46,6 +46,7 @@ describe("terminalColorSchemeStore", () => {
     useTerminalColorSchemeStore.setState({
       selectedSchemeId: DEFAULT_SCHEME_ID,
       customSchemes: [],
+      recentSchemeIds: [],
     });
     useAppThemeStore.setState({
       selectedSchemeId: "daintree",
@@ -155,6 +156,72 @@ describe("terminalColorSchemeStore", () => {
     const theme = useTerminalColorSchemeStore.getState().getEffectiveTheme();
 
     expect(theme).toEqual(CANOPY_TERMINAL_THEME);
+  });
+
+  describe("recentSchemeIds LRU", () => {
+    it("starts empty", () => {
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toEqual([]);
+    });
+
+    it("prepends the newly selected scheme id", () => {
+      useTerminalColorSchemeStore.getState().setSelectedSchemeId("dracula");
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toEqual(["dracula"]);
+
+      useTerminalColorSchemeStore.getState().setSelectedSchemeId("solarized-dark");
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toEqual([
+        "solarized-dark",
+        "dracula",
+      ]);
+    });
+
+    it("deduplicates when re-selecting an existing id (moves to front)", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      store.setSelectedSchemeId("solarized-dark");
+      store.setSelectedSchemeId("monokai");
+      store.setSelectedSchemeId("dracula");
+
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toEqual([
+        "dracula",
+        "monokai",
+        "solarized-dark",
+      ]);
+    });
+
+    it("caps the list at 5 entries", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      const ids = ["a", "b", "c", "d", "e", "f", "g"];
+      for (const id of ids) store.setSelectedSchemeId(id);
+
+      const recent = useTerminalColorSchemeStore.getState().recentSchemeIds;
+      expect(recent).toHaveLength(5);
+      expect(recent).toEqual(["g", "f", "e", "d", "c"]);
+    });
+
+    it("setRecentSchemeIds replaces the list and respects the 5-cap", () => {
+      useTerminalColorSchemeStore
+        .getState()
+        .setRecentSchemeIds(["a", "b", "c", "d", "e", "f", "g"]);
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toEqual([
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+      ]);
+    });
+
+    it("removing a custom scheme does not eagerly scrub its id from the recents list", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.addCustomScheme(CUSTOM_SCHEME);
+      store.setSelectedSchemeId("custom-test");
+      store.setSelectedSchemeId("dracula");
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toContain("custom-test");
+
+      useTerminalColorSchemeStore.getState().removeCustomScheme("custom-test");
+      // Stale id is preserved — UI filters via .find().filter(Boolean)
+      expect(useTerminalColorSchemeStore.getState().recentSchemeIds).toContain("custom-test");
+    });
   });
 
   describe("selectWrapperBackground", () => {

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -80,6 +80,7 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     set((state) => ({
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: needsFallback ? DEFAULT_APP_SCHEME_ID : state.selectedSchemeId,
+      recentSchemeIds: state.recentSchemeIds.filter((x) => x !== id),
     }));
     if (needsFallback) {
       const defaultScheme = BUILT_IN_APP_SCHEMES.find((s) => s.id === DEFAULT_APP_SCHEME_ID)!;
@@ -99,7 +100,8 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   setFollowSystem: (enabled) => set({ followSystem: enabled }),
   setPreferredDarkSchemeId: (id) => set({ preferredDarkSchemeId: id }),
   setPreferredLightSchemeId: (id) => set({ preferredLightSchemeId: id }),
-  setRecentSchemeIds: (ids) => set({ recentSchemeIds: ids.slice(0, RECENT_SCHEMES_LIMIT) }),
+  setRecentSchemeIds: (ids) =>
+    set({ recentSchemeIds: Array.from(new Set(ids)).slice(0, RECENT_SCHEMES_LIMIT) }),
 }));
 
 export { injectSchemeToDOM };

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -4,6 +4,8 @@ import { resolveAppTheme, type AppColorScheme } from "@shared/theme";
 import type { ColorVisionMode } from "@shared/types";
 import { applyAppThemeToRoot, applyColorVisionMode } from "@/theme/applyAppTheme";
 
+const RECENT_SCHEMES_LIMIT = 5;
+
 interface AppThemeState {
   selectedSchemeId: string;
   customSchemes: AppColorScheme[];
@@ -11,7 +13,14 @@ interface AppThemeState {
   followSystem: boolean;
   preferredDarkSchemeId: string;
   preferredLightSchemeId: string;
+  recentSchemeIds: string[];
   setSelectedSchemeId: (id: string) => void;
+  /**
+   * Like setSelectedSchemeId, but does NOT update recentSchemeIds. Used for
+   * OS-driven follow-system changes and startup hydration, where the change
+   * does not reflect direct user intent.
+   */
+  setSelectedSchemeIdSilent: (id: string) => void;
   addCustomScheme: (scheme: AppColorScheme) => void;
   removeCustomScheme: (id: string) => void;
   injectTheme: (scheme: AppColorScheme) => void;
@@ -19,6 +28,7 @@ interface AppThemeState {
   setFollowSystem: (enabled: boolean) => void;
   setPreferredDarkSchemeId: (id: string) => void;
   setPreferredLightSchemeId: (id: string) => void;
+  setRecentSchemeIds: (ids: string[]) => void;
 }
 
 function injectSchemeToDOM(scheme: AppColorScheme): void {
@@ -37,8 +47,22 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   followSystem: false,
   preferredDarkSchemeId: "daintree",
   preferredLightSchemeId: "bondi",
+  recentSchemeIds: [],
 
   setSelectedSchemeId: (id) => {
+    const { customSchemes } = useAppThemeStore.getState();
+    const scheme = resolveAppTheme(id, customSchemes);
+    set((state) => ({
+      selectedSchemeId: scheme.id,
+      recentSchemeIds: [scheme.id, ...state.recentSchemeIds.filter((x) => x !== scheme.id)].slice(
+        0,
+        RECENT_SCHEMES_LIMIT
+      ),
+    }));
+    injectSchemeToDOM(scheme);
+  },
+
+  setSelectedSchemeIdSilent: (id) => {
     const { customSchemes } = useAppThemeStore.getState();
     const scheme = resolveAppTheme(id, customSchemes);
     set({ selectedSchemeId: scheme.id });
@@ -75,6 +99,7 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   setFollowSystem: (enabled) => set({ followSystem: enabled }),
   setPreferredDarkSchemeId: (id) => set({ preferredDarkSchemeId: id }),
   setPreferredLightSchemeId: (id) => set({ preferredLightSchemeId: id }),
+  setRecentSchemeIds: (ids) => set({ recentSchemeIds: ids.slice(0, RECENT_SCHEMES_LIMIT) }),
 }));
 
 export { injectSchemeToDOM };

--- a/src/store/terminalColorSchemeStore.ts
+++ b/src/store/terminalColorSchemeStore.ts
@@ -112,9 +112,11 @@ export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((s
     set((state) => ({
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: state.selectedSchemeId === id ? DEFAULT_SCHEME_ID : state.selectedSchemeId,
+      recentSchemeIds: state.recentSchemeIds.filter((x) => x !== id),
     })),
 
-  setRecentSchemeIds: (ids) => set({ recentSchemeIds: ids.slice(0, RECENT_SCHEMES_LIMIT) }),
+  setRecentSchemeIds: (ids) =>
+    set({ recentSchemeIds: Array.from(new Set(ids)).slice(0, RECENT_SCHEMES_LIMIT) }),
 
   getEffectiveTheme: (): ITheme => {
     const { selectedSchemeId, customSchemes } = get();

--- a/src/store/terminalColorSchemeStore.ts
+++ b/src/store/terminalColorSchemeStore.ts
@@ -10,12 +10,16 @@ import {
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { getTerminalThemeFromCSS } from "@/utils/terminalTheme";
 
+const RECENT_SCHEMES_LIMIT = 5;
+
 interface TerminalColorSchemeState {
   selectedSchemeId: string;
   customSchemes: TerminalColorScheme[];
+  recentSchemeIds: string[];
   setSelectedSchemeId: (id: string) => void;
   addCustomScheme: (scheme: TerminalColorScheme) => void;
   removeCustomScheme: (id: string) => void;
+  setRecentSchemeIds: (ids: string[]) => void;
   getEffectiveTheme: () => ITheme;
 }
 
@@ -88,8 +92,16 @@ export function selectEffectiveTheme(state: TerminalColorSchemeState): ITheme {
 export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((set, get) => ({
   selectedSchemeId: DEFAULT_SCHEME_ID,
   customSchemes: [],
+  recentSchemeIds: [],
 
-  setSelectedSchemeId: (id) => set({ selectedSchemeId: id }),
+  setSelectedSchemeId: (id) =>
+    set((state) => ({
+      selectedSchemeId: id,
+      recentSchemeIds: [id, ...state.recentSchemeIds.filter((x) => x !== id)].slice(
+        0,
+        RECENT_SCHEMES_LIMIT
+      ),
+    })),
 
   addCustomScheme: (scheme) =>
     set((state) => ({
@@ -101,6 +113,8 @@ export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((s
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: state.selectedSchemeId === id ? DEFAULT_SCHEME_ID : state.selectedSchemeId,
     })),
+
+  setRecentSchemeIds: (ids) => set({ recentSchemeIds: ids.slice(0, RECENT_SCHEMES_LIMIT) }),
 
   getEffectiveTheme: (): ITheme => {
     const { selectedSchemeId, customSchemes } = get();


### PR DESCRIPTION
## Summary

- Adds LRU tracking of the last 5 selected themes to both `appThemeStore` and `terminalColorSchemeStore`, surfaced as a "Recently Used" group above Dark/Light in `AppThemePicker` and `ColorSchemePicker`
- LRU updates on commit (user-confirmed selection), not on hover or preview. OS follow-system changes, startup hydration, and the AgentSetupWizard auto-select all use a new `setSelectedSchemeIdSilent` setter so they don't pollute the recents list with non-user-intent selections
- Persisted via two new IPC channels (`APP_THEME_SET_RECENT_SCHEME_IDS`, `TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS`) with sanitisation (trim, dedupe, cap 5). `removeCustomScheme` strips deleted IDs from recents in both stores

Resolves #5071

## Changes

- `appThemeStore` / `terminalColorSchemeStore`: new `recentSchemeIds` state, `setRecentSchemeIds`, and `setSelectedSchemeIdSilent`
- `AppThemePicker`: "Recently Used" group rendered above Dark/Light, deduped from those groups
- `ColorSchemePicker`: grouped "Recently Used" section when non-empty
- `AgentSetupWizard`: OS-preference auto-select now uses `setSelectedSchemeIdSilent` (WelcomeStep was consolidated here in develop)
- `useAppThemeConfig` / `useTerminalConfig`: hydrate recents on startup, use silent setter for follow-system changes
- IPC: two new channels, handlers with dedup/cap sanitisation, preload exposure, client methods, type definitions

## Testing

91 targeted unit tests pass across stores, IPC handlers, and picker components. Typecheck and lint clean. Rebased onto current develop after the WelcomeStep consolidation landed.