### PR TITLE
feat(bulk): allow targeting specific agent terminals in bulk operations

### DIFF
--- a/src/components/BulkCommandCenter/BulkCommandPalette.tsx
+++ b/src/components/BulkCommandCenter/BulkCommandPalette.tsx
@@ -486,15 +486,7 @@ function BulkCommandPaletteInner() {
     } else {
       handlePreview();
     }
-  }, [
-    mode,
-    keystrokePreset,
-    pendingDestructive,
-    selectedIds,
-    resolveTargetIds,
-    closePalette,
-    handlePreview,
-  ]);
+  }, [mode, keystrokePreset, pendingDestructive, resolveTargetIds, closePalette, handlePreview]);
 
   const canSend = useMemo(() => {
     if (selectedIds.size === 0 || isSending) return false;

--- a/src/components/BulkCommandCenter/BulkCommandPalette.tsx
+++ b/src/components/BulkCommandCenter/BulkCommandPalette.tsx
@@ -490,7 +490,7 @@ function BulkCommandPaletteInner() {
     mode,
     keystrokePreset,
     pendingDestructive,
-    selectedIds.size,
+    selectedIds,
     resolveTargetIds,
     closePalette,
     handlePreview,

--- a/src/components/BulkCommandCenter/BulkCommandPalette.tsx
+++ b/src/components/BulkCommandCenter/BulkCommandPalette.tsx
@@ -10,8 +10,9 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { useShallow } from "zustand/react/shallow";
 import { useEscapeStack } from "@/hooks";
 import { isAgentTerminal } from "@/utils/terminalType";
+import { ChevronRight } from "lucide-react";
 import { getDominantAgentState } from "@/components/Worktree/AgentStatusIndicator";
-import { STATE_ICONS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
+import { STATE_ICONS, STATE_COLORS, STATE_LABELS } from "@/components/Worktree/terminalStateConfig";
 import {
   replaceRecipeVariables,
   detectUnresolvedVariables,
@@ -33,12 +34,19 @@ type BulkMode = "keystroke" | "text" | "recipe";
 type BulkStep = "select" | "preview";
 type KeystrokePreset = "escape" | "enter" | "ctrl+c" | "double-escape";
 
+interface WorktreeTerminalRow {
+  id: string;
+  label: string;
+  agentState: AgentState | null;
+}
+
 interface WorktreeRow {
   id: string;
   branch: string;
   path: string;
   issueNumber?: number;
   prNumber?: number;
+  terminals: WorktreeTerminalRow[];
   agentTerminalCount: number;
   dominantState: AgentState | null;
   disabled: boolean;
@@ -63,18 +71,18 @@ const BULK_HISTORY_KEY = "bulk-commands";
 
 interface StatePreset {
   label: string;
-  match: (row: WorktreeRow) => boolean;
+  match: (terminal: WorktreeTerminalRow) => boolean;
 }
 
 const STATE_PRESETS: StatePreset[] = [
   {
     label: "Active",
-    match: (r) => r.dominantState === "working" || r.dominantState === "running",
+    match: (t) => t.agentState === "working" || t.agentState === "running",
   },
-  { label: "Waiting", match: (r) => r.dominantState === "waiting" },
-  { label: "Idle", match: (r) => r.dominantState === null && !r.disabled },
-  { label: "Completed", match: (r) => r.dominantState === "completed" },
-  { label: "Exited", match: (r) => r.dominantState === "exited" },
+  { label: "Waiting", match: (t) => t.agentState === "waiting" },
+  { label: "Idle", match: (t) => t.agentState === null || t.agentState === "idle" },
+  { label: "Completed", match: (t) => t.agentState === "completed" },
+  { label: "Exited", match: (t) => t.agentState === "exited" },
 ];
 
 function getEligibleTerminals(
@@ -102,15 +110,21 @@ function useWorktreeRows(): WorktreeRow[] {
     for (const wt of worktrees.values()) {
       const eligible = getEligibleTerminals(terminals, wt.id);
       const dominantState = getDominantAgentState(eligible.map((t) => t.agentState));
+      const terminalRows: WorktreeTerminalRow[] = eligible.map((t) => ({
+        id: t.id,
+        label: t.title?.trim() || t.agentId || t.id,
+        agentState: (t.agentState as AgentState | undefined) ?? null,
+      }));
       rows.push({
         id: wt.id,
         branch: wt.branch ?? wt.name,
         path: wt.path,
         issueNumber: wt.issueNumber,
         prNumber: wt.prNumber,
-        agentTerminalCount: eligible.length,
+        terminals: terminalRows,
+        agentTerminalCount: terminalRows.length,
         dominantState,
-        disabled: eligible.length === 0,
+        disabled: terminalRows.length === 0,
       });
     }
     return rows;
@@ -142,7 +156,9 @@ function BulkCommandPaletteInner() {
   const closePalette = useCallback(() => usePaletteStore.getState().closePalette(PALETTE_ID), []);
 
   const rows = useWorktreeRows();
+  // selectedIds now holds terminal IDs (was worktree IDs).
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [mode, setMode] = useState<BulkMode>("keystroke");
   const [step, setStep] = useState<BulkStep>("select");
   const [keystrokePreset, setKeystrokePreset] = useState<KeystrokePreset>("escape");
@@ -187,32 +203,106 @@ function BulkCommandPaletteInner() {
   }, [keystrokePreset]);
 
   const enabledRows = useMemo(() => rows.filter((r) => !r.disabled), [rows]);
-  const allEnabledSelected =
-    enabledRows.length > 0 && enabledRows.every((r) => selectedIds.has(r.id));
 
+  // Prune stale selection/expansion ids when the rows collection changes (e.g.,
+  // a terminal exits or a worktree is removed while the palette is open).
+  useEffect(() => {
+    const validTerminalIds = new Set<string>();
+    const validWorktreeIds = new Set<string>();
+    for (const row of rows) {
+      validWorktreeIds.add(row.id);
+      for (const t of row.terminals) validTerminalIds.add(t.id);
+    }
+    setSelectedIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (validTerminalIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setExpandedIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (validWorktreeIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [rows]);
+
+  const rowAllSelected = useCallback(
+    (row: WorktreeRow) =>
+      row.terminals.length > 0 && row.terminals.every((t) => selectedIds.has(t.id)),
+    [selectedIds]
+  );
+  const rowSomeSelected = useCallback(
+    (row: WorktreeRow) => row.terminals.some((t) => selectedIds.has(t.id)),
+    [selectedIds]
+  );
+
+  const allEnabledSelected = useMemo(
+    () => enabledRows.length > 0 && enabledRows.every(rowAllSelected),
+    [enabledRows, rowAllSelected]
+  );
+
+  // Worktrees with at least one selected terminal — feeds preview UI,
+  // recipe broadcast, and the footer worktree count.
   const selectedRows = useMemo(
-    () => rows.filter((r) => selectedIds.has(r.id)),
+    () => rows.filter((r) => r.terminals.some((t) => selectedIds.has(t.id))),
     [rows, selectedIds]
   );
 
   const presetCounts = useMemo(
     () =>
       Object.fromEntries(
-        STATE_PRESETS.map((p) => [p.label, rows.filter((r) => !r.disabled && p.match(r)).length])
+        STATE_PRESETS.map((p) => [
+          p.label,
+          rows
+            .filter((r) => !r.disabled)
+            .flatMap((r) => r.terminals)
+            .filter((t) => p.match(t)).length,
+        ])
       ),
     [rows]
   );
 
-  const selectedAgentCount = useMemo(
-    () => selectedRows.reduce((sum, r) => sum + r.agentTerminalCount, 0),
-    [selectedRows]
-  );
+  const selectedTerminalCount = selectedIds.size;
+  const selectedWorktreeCount = selectedRows.length;
 
-  const toggleWorktree = useCallback((id: string) => {
+  const toggleTerminal = useCallback((terminalId: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
+      if (next.has(terminalId)) next.delete(terminalId);
+      else next.add(terminalId);
+      return next;
+    });
+  }, []);
+
+  const toggleWorktree = useCallback(
+    (row: WorktreeRow) => {
+      if (row.terminals.length === 0) return;
+      const allSelected = row.terminals.every((t) => selectedIds.has(t.id));
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (allSelected) {
+          for (const t of row.terminals) next.delete(t.id);
+        } else {
+          for (const t of row.terminals) next.add(t.id);
+        }
+        return next;
+      });
+    },
+    [selectedIds]
+  );
+
+  const toggleExpand = useCallback((worktreeId: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(worktreeId)) next.delete(worktreeId);
+      else next.add(worktreeId);
       return next;
     });
   }, []);
@@ -221,7 +311,11 @@ function BulkCommandPaletteInner() {
     if (allEnabledSelected) {
       setSelectedIds(new Set());
     } else {
-      setSelectedIds(new Set(enabledRows.map((r) => r.id)));
+      const all = new Set<string>();
+      for (const row of enabledRows) {
+        for (const t of row.terminals) all.add(t.id);
+      }
+      setSelectedIds(all);
     }
   }, [allEnabledSelected, enabledRows]);
 
@@ -230,8 +324,9 @@ function BulkCommandPaletteInner() {
       setSelectedIds((prev) => {
         const next = new Set(prev);
         for (const row of rows) {
-          if (!row.disabled && preset.match(row)) {
-            next.add(row.id);
+          if (row.disabled) continue;
+          for (const t of row.terminals) {
+            if (preset.match(t)) next.add(t.id);
           }
         }
         return next;
@@ -253,15 +348,23 @@ function BulkCommandPaletteInner() {
   }, [step, mode, selectedRows, commandText]);
 
   const resolveTargetIds = useCallback((): string[] => {
+    // selectedIds are terminal IDs. Filter against the current panel store
+    // so we drop anything that has exited or been trashed since selection.
     const { panelsById: tById, panelIds: tIds } = usePanelStore.getState();
+    const liveEligible = new Set<string>();
     const allTerminals = tIds.map((id) => tById[id]).filter(Boolean);
-    const ids: string[] = [];
-    for (const worktreeId of selectedIds) {
-      for (const t of getEligibleTerminals(allTerminals, worktreeId)) {
-        ids.push(t.id);
+    for (const t of allTerminals) {
+      if (!t.worktreeId) continue;
+      if (
+        isAgentTerminal(t.kind ?? t.type, t.agentId) &&
+        t.location !== "trash" &&
+        t.location !== "background" &&
+        t.hasPty !== false
+      ) {
+        liveEligible.add(t.id);
       }
     }
-    return ids;
+    return [...selectedIds].filter((id) => liveEligible.has(id));
   }, [selectedIds]);
 
   const handleInsertVariable = useCallback(
@@ -289,17 +392,20 @@ function BulkCommandPaletteInner() {
     let failures = 0;
 
     if (mode === "text") {
-      const { panelsById: tById, panelIds: tIds } = usePanelStore.getState();
-      const allTerminals = tIds.map((id) => tById[id]).filter(Boolean);
+      // Build a terminal-id → parent worktree lookup so recipe variables
+      // resolve from the correct worktree context.
+      const terminalToRow = new Map<string, WorktreeRow>();
+      for (const row of rows) {
+        for (const t of row.terminals) terminalToRow.set(t.id, row);
+      }
+      const targetIds = resolveTargetIds();
       const promises: Promise<unknown>[] = [];
-      for (const row of selectedRows) {
-        const ctx = buildRecipeContext(row);
-        const resolved = replaceRecipeVariables(commandText, ctx);
+      for (const terminalId of targetIds) {
+        const row = terminalToRow.get(terminalId);
+        if (!row) continue;
+        const resolved = replaceRecipeVariables(commandText, buildRecipeContext(row));
         if (!resolved.trim()) continue;
-        const eligible = getEligibleTerminals(allTerminals, row.id);
-        for (const t of eligible) {
-          promises.push(terminalClient.submit(t.id, resolved));
-        }
+        promises.push(terminalClient.submit(terminalId, resolved));
       }
       totalTargets = promises.length;
       const results = await Promise.allSettled(promises);
@@ -338,7 +444,7 @@ function BulkCommandPaletteInner() {
 
     setIsSending(false);
     closePalette();
-  }, [mode, selectedRows, commandText, selectedRecipeId, closePalette]);
+  }, [mode, rows, selectedRows, commandText, selectedRecipeId, resolveTargetIds, closePalette]);
 
   const handleSend = useCallback(async () => {
     if (mode === "keystroke") {
@@ -351,6 +457,7 @@ function BulkCommandPaletteInner() {
       if (targetIds.length === 0) return;
       setIsSending(true);
 
+      const sentCount = targetIds.length;
       if (keystrokePreset === "double-escape") {
         targetIds.forEach((id) => terminalClient.sendKey(id, "escape"));
         doubleEscapeTimerRef.current = setTimeout(() => {
@@ -361,7 +468,7 @@ function BulkCommandPaletteInner() {
           useNotificationStore.getState().addNotification({
             type: "success",
             priority: "low",
-            message: `Sent ${KEYSTROKE_LABELS[keystrokePreset]} to ${selectedIds.size} worktree${selectedIds.size !== 1 ? "s" : ""}`,
+            message: `Sent ${KEYSTROKE_LABELS[keystrokePreset]} to ${sentCount} agent${sentCount !== 1 ? "s" : ""}`,
           });
           closePalette();
         }, 1000);
@@ -372,7 +479,7 @@ function BulkCommandPaletteInner() {
         useNotificationStore.getState().addNotification({
           type: "success",
           priority: "low",
-          message: `Sent ${KEYSTROKE_LABELS[keystrokePreset]} to ${selectedIds.size} worktree${selectedIds.size !== 1 ? "s" : ""}`,
+          message: `Sent ${KEYSTROKE_LABELS[keystrokePreset]} to ${sentCount} agent${sentCount !== 1 ? "s" : ""}`,
         });
         closePalette();
       }
@@ -482,8 +589,8 @@ function BulkCommandPaletteInner() {
                 pendingDestructive ? (
                   <div className="flex items-center gap-2 py-1">
                     <span className="text-xs text-amber-400 flex-1">
-                      Send {KEYSTROKE_LABELS[keystrokePreset]} to {selectedIds.size} worktree
-                      {selectedIds.size !== 1 ? "s" : ""}?
+                      Send {KEYSTROKE_LABELS[keystrokePreset]} to {selectedTerminalCount} agent
+                      {selectedTerminalCount !== 1 ? "s" : ""}?
                     </span>
                     <button
                       onClick={() => {
@@ -654,38 +761,156 @@ function BulkCommandPaletteInner() {
                     );
                   })}
                 </div>
-                {rows.map((row) => {
-                  const StateIcon = row.dominantState ? STATE_ICONS[row.dominantState] : null;
-                  const stateColor = row.dominantState ? STATE_COLORS[row.dominantState] : "";
-                  return (
-                    <button
-                      key={row.id}
-                      onClick={() => !row.disabled && toggleWorktree(row.id)}
-                      disabled={row.disabled}
-                      className={`w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border transition-colors flex items-center gap-2 ${
-                        row.disabled
-                          ? "opacity-40 cursor-not-allowed border-transparent"
-                          : selectedIds.has(row.id)
-                            ? "border-canopy-accent/40 bg-canopy-accent/10"
-                            : "border-transparent hover:bg-tint/[0.06]"
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedIds.has(row.id)}
-                        disabled={row.disabled}
-                        onChange={() => {}}
-                        className="pointer-events-none shrink-0"
-                        tabIndex={-1}
-                      />
-                      <span className="flex-1 text-sm text-canopy-text truncate">{row.branch}</span>
-                      {StateIcon && <StateIcon className={`w-3.5 h-3.5 shrink-0 ${stateColor}`} />}
-                      <span className="text-xs text-canopy-text/40 shrink-0">
-                        {row.agentTerminalCount} {row.agentTerminalCount === 1 ? "agent" : "agents"}
-                      </span>
-                    </button>
-                  );
-                })}
+                <div
+                  role="treegrid"
+                  aria-multiselectable="true"
+                  aria-label="Worktrees and agent terminals"
+                >
+                  {rows.map((row, rowIndex) => {
+                    const StateIcon = row.dominantState ? STATE_ICONS[row.dominantState] : null;
+                    const stateColor = row.dominantState ? STATE_COLORS[row.dominantState] : "";
+                    const allSelected = rowAllSelected(row);
+                    const someSelected = rowSomeSelected(row);
+                    const isPartial = someSelected && !allSelected;
+                    const isExpanded = expandedIds.has(row.id);
+                    const canExpand = !row.disabled && row.terminals.length > 0;
+                    return (
+                      <div
+                        key={row.id}
+                        role="row"
+                        aria-level={1}
+                        aria-posinset={rowIndex + 1}
+                        aria-setsize={rows.length}
+                        aria-expanded={canExpand ? isExpanded : undefined}
+                        data-testid={`bulk-worktree-row-${row.id}`}
+                        className={`rounded-[var(--radius-lg)] border ${
+                          row.disabled
+                            ? "opacity-40 cursor-not-allowed border-transparent"
+                            : allSelected
+                              ? "border-canopy-accent/40 bg-canopy-accent/10"
+                              : someSelected
+                                ? "border-canopy-accent/20 bg-canopy-accent/5"
+                                : "border-transparent hover:bg-tint/[0.06]"
+                        }`}
+                      >
+                        <div role="gridcell" className="flex items-center gap-2 px-3 py-2">
+                          <button
+                            type="button"
+                            onClick={() => canExpand && toggleExpand(row.id)}
+                            disabled={!canExpand}
+                            aria-label={isExpanded ? "Collapse terminals" : "Expand terminals"}
+                            data-testid={`bulk-worktree-expand-${row.id}`}
+                            className={`shrink-0 w-4 h-4 flex items-center justify-center text-canopy-text/50 hover:text-canopy-text transition-colors ${
+                              canExpand ? "" : "invisible"
+                            }`}
+                          >
+                            <ChevronRight
+                              className={`w-3.5 h-3.5 transition-transform ${
+                                isExpanded ? "rotate-90" : ""
+                              }`}
+                            />
+                          </button>
+                          <input
+                            type="checkbox"
+                            checked={allSelected}
+                            disabled={row.disabled}
+                            onChange={() => toggleWorktree(row)}
+                            ref={(el) => {
+                              if (el) el.indeterminate = isPartial;
+                            }}
+                            aria-checked={isPartial ? "mixed" : allSelected}
+                            aria-label={`Select all agents in ${row.branch}`}
+                            data-testid={`bulk-worktree-checkbox-${row.id}`}
+                            className="shrink-0"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => !row.disabled && toggleWorktree(row)}
+                            disabled={row.disabled}
+                            className="flex-1 min-w-0 text-left text-sm text-canopy-text truncate"
+                          >
+                            {row.branch}
+                          </button>
+                          {StateIcon && (
+                            <StateIcon className={`w-3.5 h-3.5 shrink-0 ${stateColor}`} />
+                          )}
+                          <span className="text-xs text-canopy-text/40 shrink-0">
+                            {row.agentTerminalCount}{" "}
+                            {row.agentTerminalCount === 1 ? "agent" : "agents"}
+                          </span>
+                        </div>
+                        {canExpand && (
+                          <div
+                            className={`grid transition-[grid-template-rows] duration-200 ${
+                              isExpanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+                            }`}
+                          >
+                            <div className="overflow-hidden">
+                              <div className="pb-1.5 pl-7 pr-3 space-y-0.5">
+                                {row.terminals.map((terminal, tIndex) => {
+                                  const TStateIcon = terminal.agentState
+                                    ? STATE_ICONS[terminal.agentState]
+                                    : null;
+                                  const tStateColor = terminal.agentState
+                                    ? STATE_COLORS[terminal.agentState]
+                                    : "";
+                                  const tStateLabel = terminal.agentState
+                                    ? STATE_LABELS[terminal.agentState]
+                                    : "idle";
+                                  const isSelected = selectedIds.has(terminal.id);
+                                  return (
+                                    <div
+                                      key={terminal.id}
+                                      role="row"
+                                      aria-level={2}
+                                      aria-posinset={tIndex + 1}
+                                      aria-setsize={row.terminals.length}
+                                      data-testid={`bulk-terminal-row-${terminal.id}`}
+                                      className={`px-2 py-1 rounded-[var(--radius-md)] flex items-center gap-2 ${
+                                        isSelected ? "bg-canopy-accent/10" : "hover:bg-tint/[0.04]"
+                                      }`}
+                                    >
+                                      <div
+                                        role="gridcell"
+                                        className="flex items-center gap-2 flex-1 min-w-0"
+                                      >
+                                        <input
+                                          type="checkbox"
+                                          checked={isSelected}
+                                          onChange={() => toggleTerminal(terminal.id)}
+                                          aria-label={`Select agent ${terminal.label}`}
+                                          data-testid={`bulk-terminal-checkbox-${terminal.id}`}
+                                          className="shrink-0"
+                                          tabIndex={isExpanded ? 0 : -1}
+                                        />
+                                        <button
+                                          type="button"
+                                          onClick={() => toggleTerminal(terminal.id)}
+                                          tabIndex={isExpanded ? 0 : -1}
+                                          className="flex-1 min-w-0 text-left text-xs text-canopy-text/80 truncate"
+                                        >
+                                          {terminal.label}
+                                        </button>
+                                        {TStateIcon && (
+                                          <TStateIcon
+                                            className={`w-3 h-3 shrink-0 ${tStateColor}`}
+                                          />
+                                        )}
+                                        <span className="text-[10px] text-canopy-text/40 shrink-0">
+                                          {tStateLabel}
+                                        </span>
+                                      </div>
+                                    </div>
+                                  );
+                                })}
+                              </div>
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
               </>
             )}
           </>
@@ -699,8 +924,8 @@ function BulkCommandPaletteInner() {
           </span>
           <div className="flex items-center gap-3">
             <span className="text-xs text-canopy-text/50">
-              {selectedIds.size} worktree{selectedIds.size !== 1 ? "s" : ""}, {selectedAgentCount}{" "}
-              agent{selectedAgentCount !== 1 ? "s" : ""}
+              {selectedWorktreeCount} worktree{selectedWorktreeCount !== 1 ? "s" : ""},{" "}
+              {selectedTerminalCount} agent{selectedTerminalCount !== 1 ? "s" : ""}
             </span>
             <button
               onClick={step === "preview" ? handleConfirm : handleSend}

--- a/src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx
+++ b/src/components/BulkCommandCenter/__tests__/BulkCommandPalette.test.tsx
@@ -55,27 +55,44 @@ vi.mock("@/components/Worktree/AgentStatusIndicator", () => ({
   },
 }));
 
-vi.mock("@/components/Worktree/terminalStateConfig", () => ({
-  STATE_ICONS: {
-    working: ({ className }: { className?: string }) =>
-      `<span data-testid="state-icon-working" class="${className}">W</span>`,
-    idle: ({ className }: { className?: string }) =>
-      `<span data-testid="state-icon-idle" class="${className}">I</span>`,
-    waiting: ({ className }: { className?: string }) =>
-      `<span data-testid="state-icon-waiting" class="${className}">WA</span>`,
-    completed: ({ className }: { className?: string }) =>
-      `<span data-testid="state-icon-completed" class="${className}">C</span>`,
-    failed: ({ className }: { className?: string }) =>
-      `<span data-testid="state-icon-failed" class="${className}">F</span>`,
-  },
-  STATE_COLORS: {
-    working: "text-state-working",
-    idle: "text-canopy-text/40",
-    waiting: "text-state-waiting",
-    completed: "text-state-completed",
-    failed: "text-state-failed",
-  },
-}));
+vi.mock("@/components/Worktree/terminalStateConfig", () => {
+  const Icon =
+    (name: string) =>
+    ({ className }: { className?: string }) => (
+      <span data-testid={`state-icon-${name}`} className={className}>
+        {name[0]}
+      </span>
+    );
+  return {
+    STATE_ICONS: {
+      working: Icon("working"),
+      running: Icon("running"),
+      waiting: Icon("waiting"),
+      directing: Icon("directing"),
+      idle: Icon("idle"),
+      completed: Icon("completed"),
+      exited: Icon("exited"),
+    },
+    STATE_COLORS: {
+      working: "text-state-working",
+      running: "text-status-info",
+      waiting: "text-state-waiting",
+      directing: "text-category-blue",
+      idle: "text-canopy-text/40",
+      completed: "text-state-completed",
+      exited: "text-canopy-text/40",
+    },
+    STATE_LABELS: {
+      working: "working",
+      running: "running",
+      waiting: "waiting",
+      directing: "directing",
+      idle: "idle",
+      completed: "done",
+      exited: "exited",
+    },
+  };
+});
 
 vi.mock("@/utils/terminalType", () => ({
   isAgentTerminal: (kindOrType?: string, agentId?: string) => kindOrType === "agent" || !!agentId,
@@ -335,8 +352,7 @@ describe("BulkCommandPalette", () => {
   it("renders main worktree as disabled when it has no agent terminals", () => {
     render(<BulkCommandPalette />);
     openPalette();
-    const mainRow = screen.getByText("main").closest("button")!;
-    const checkbox = mainRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    const checkbox = screen.getByTestId("bulk-worktree-checkbox-wt-main") as HTMLInputElement;
     expect(checkbox.disabled).toBe(true);
   });
 
@@ -347,23 +363,73 @@ describe("BulkCommandPalette", () => {
     expect(screen.getAllByText("1 agent").length).toBeGreaterThanOrEqual(1); // wt-2 and wt-3 each have 1
   });
 
-  it("toggles worktree selection via checkbox row click", () => {
+  it("toggles worktree selection via branch click (selects all child terminals)", () => {
     render(<BulkCommandPalette />);
     openPalette();
-    const row = screen.getByText("feature/a").closest("button")!;
-    fireEvent.click(row);
-    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
-    expect(checkbox.checked).toBe(true);
-    fireEvent.click(row);
-    expect(checkbox.checked).toBe(false);
+    fireEvent.click(screen.getByText("feature/a").closest("button")!);
+    const wtCheckbox = screen.getByTestId("bulk-worktree-checkbox-wt-1") as HTMLInputElement;
+    const t1Checkbox = screen.getByTestId("bulk-terminal-checkbox-t1") as HTMLInputElement;
+    const t2Checkbox = screen.getByTestId("bulk-terminal-checkbox-t2") as HTMLInputElement;
+    expect(wtCheckbox.checked).toBe(true);
+    expect(t1Checkbox.checked).toBe(true);
+    expect(t2Checkbox.checked).toBe(true);
+    fireEvent.click(screen.getByText("feature/a").closest("button")!);
+    expect(wtCheckbox.checked).toBe(false);
+    expect(t1Checkbox.checked).toBe(false);
+    expect(t2Checkbox.checked).toBe(false);
   });
 
-  it("select all toggles all enabled rows", () => {
+  it("toggling a single terminal shows the worktree checkbox as indeterminate", () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    fireEvent.click(screen.getByTestId("bulk-terminal-checkbox-t1"));
+    const wtCheckbox = screen.getByTestId("bulk-worktree-checkbox-wt-1") as HTMLInputElement;
+    const t1Checkbox = screen.getByTestId("bulk-terminal-checkbox-t1") as HTMLInputElement;
+    const t2Checkbox = screen.getByTestId("bulk-terminal-checkbox-t2") as HTMLInputElement;
+    expect(t1Checkbox.checked).toBe(true);
+    expect(t2Checkbox.checked).toBe(false);
+    expect(wtCheckbox.checked).toBe(false);
+    expect(wtCheckbox.indeterminate).toBe(true);
+    expect(wtCheckbox.getAttribute("aria-checked")).toBe("mixed");
+  });
+
+  it("worktree checkbox becomes fully checked (non-indeterminate) when all children selected", () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    fireEvent.click(screen.getByTestId("bulk-terminal-checkbox-t1"));
+    fireEvent.click(screen.getByTestId("bulk-terminal-checkbox-t2"));
+    const wtCheckbox = screen.getByTestId("bulk-worktree-checkbox-wt-1") as HTMLInputElement;
+    expect(wtCheckbox.checked).toBe(true);
+    expect(wtCheckbox.indeterminate).toBe(false);
+  });
+
+  it("expand button toggles the row's aria-expanded state", () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    const row = screen.getByTestId("bulk-worktree-row-wt-1");
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(screen.getByTestId("bulk-worktree-expand-wt-1"));
+    expect(row.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(screen.getByTestId("bulk-worktree-expand-wt-1"));
+    expect(row.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("disabled worktrees do not show an expand affordance", () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    const row = screen.getByTestId("bulk-worktree-row-wt-main");
+    expect(row.getAttribute("aria-expanded")).toBeNull();
+    const expandBtn = screen.getByTestId("bulk-worktree-expand-wt-main") as HTMLButtonElement;
+    expect(expandBtn.disabled).toBe(true);
+  });
+
+  it("select all toggles all enabled rows (worktree + terminal checkboxes)", () => {
     render(<BulkCommandPalette />);
     openPalette();
     fireEvent.click(screen.getByText("Select All"));
     const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
     const enabled = checkboxes.filter((c) => !c.disabled);
+    expect(enabled.length).toBeGreaterThan(0);
     expect(enabled.every((c) => c.checked)).toBe(true);
     fireEvent.click(screen.getByText("Deselect All"));
     expect(enabled.every((c) => !c.checked)).toBe(true);
@@ -386,6 +452,16 @@ describe("BulkCommandPalette", () => {
     expect(mockSendKey).toHaveBeenCalledWith("t2", "escape");
   });
 
+  it("sends keystroke to only individually selected terminal", () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    // Select only t1, leaving t2 (same worktree) untouched
+    fireEvent.click(screen.getByTestId("bulk-terminal-checkbox-t1"));
+    fireEvent.click(screen.getByText("Send"));
+    expect(mockSendKey).toHaveBeenCalledTimes(1);
+    expect(mockSendKey).toHaveBeenCalledWith("t1", "escape");
+  });
+
   it("sends double-escape with 1s delay after confirmation", () => {
     render(<BulkCommandPalette />);
     openPalette();
@@ -395,7 +471,7 @@ describe("BulkCommandPalette", () => {
     fireEvent.click(sendBtn);
     // Should show confirmation instead of sending
     expect(mockSendKey).toHaveBeenCalledTimes(0);
-    expect(screen.getByText(/Send Double Escape to 1 worktree\?/)).toBeTruthy();
+    expect(screen.getByText(/Send Double Escape to 1 agent\?/)).toBeTruthy();
     // Click Confirm to actually send
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
     expect(mockSendKey).toHaveBeenCalledTimes(1);
@@ -431,6 +507,22 @@ describe("BulkCommandPalette", () => {
     expect(mockSubmit).toHaveBeenCalledTimes(2);
     expect(mockSubmit).toHaveBeenCalledWith("t1", "npm test");
     expect(mockSubmit).toHaveBeenCalledWith("t2", "npm test");
+  });
+
+  it("text-mode send targets only individually selected terminals", async () => {
+    render(<BulkCommandPalette />);
+    openPalette();
+    fireEvent.click(screen.getByText("Text Command"));
+    // Select only t2, not t1 in the same worktree
+    fireEvent.click(screen.getByTestId("bulk-terminal-checkbox-t2"));
+    const input = screen.getByPlaceholderText(/Type a command/);
+    fireEvent.change(input, { target: { value: "echo hi" } });
+    fireEvent.click(screen.getByText("Preview"));
+    await act(async () => {
+      fireEvent.click(screen.getByText("Confirm"));
+    });
+    expect(mockSubmit).toHaveBeenCalledTimes(1);
+    expect(mockSubmit).toHaveBeenCalledWith("t2", "echo hi");
   });
 
   it("resolves template variables per worktree in preview", () => {
@@ -482,68 +574,61 @@ describe("BulkCommandPalette", () => {
   });
 
   describe("state presets", () => {
-    it("renders preset buttons with counts", () => {
+    it("renders preset buttons with terminal-level counts", () => {
       render(<BulkCommandPalette />);
       openPalette();
+      // Active: t1 (working). Waiting: t3. Idle: t2 (idle) + t6 (undefined→null) = 2.
       expect(screen.getByText("Active (1)")).toBeTruthy();
       expect(screen.getByText("Waiting (1)")).toBeTruthy();
-      expect(screen.getByText("Idle (1)")).toBeTruthy();
+      expect(screen.getByText("Idle (2)")).toBeTruthy();
       expect(screen.getByText("Completed (0)")).toBeTruthy();
     });
 
-    it("Active preset selects worktrees with working state", () => {
+    it("Active preset selects only matching terminals, not siblings in same worktree", () => {
       render(<BulkCommandPalette />);
       openPalette();
       fireEvent.click(screen.getByText("Active (1)"));
-      // wt-1 has dominant state "working" (mock returns first valid state)
-      const wt1Checkbox = screen
-        .getByText("feature/a")
-        .closest("button")!
-        .querySelector('input[type="checkbox"]') as HTMLInputElement;
-      expect(wt1Checkbox.checked).toBe(true);
+      const t1 = screen.getByTestId("bulk-terminal-checkbox-t1") as HTMLInputElement;
+      const t2 = screen.getByTestId("bulk-terminal-checkbox-t2") as HTMLInputElement;
+      const wt1 = screen.getByTestId("bulk-worktree-checkbox-wt-1") as HTMLInputElement;
+      // t1 is "working" → selected; t2 is "idle" in the same worktree → not selected
+      expect(t1.checked).toBe(true);
+      expect(t2.checked).toBe(false);
+      // parent shows indeterminate
+      expect(wt1.checked).toBe(false);
+      expect(wt1.indeterminate).toBe(true);
     });
 
-    it("Waiting preset selects worktrees with waiting state", () => {
+    it("Waiting preset selects terminals with waiting state", () => {
       render(<BulkCommandPalette />);
       openPalette();
       fireEvent.click(screen.getByText("Waiting (1)"));
-      const wt2Checkbox = screen
-        .getByText("feature/b")
-        .closest("button")!
-        .querySelector('input[type="checkbox"]') as HTMLInputElement;
-      expect(wt2Checkbox.checked).toBe(true);
+      const t3 = screen.getByTestId("bulk-terminal-checkbox-t3") as HTMLInputElement;
+      const wt2 = screen.getByTestId("bulk-worktree-checkbox-wt-2") as HTMLInputElement;
+      expect(t3.checked).toBe(true);
+      // wt-2 has only t3 as eligible agent → fully selected
+      expect(wt2.checked).toBe(true);
     });
 
-    it("Idle preset selects worktrees with null dominant state", () => {
+    it("Idle preset selects idle and stateless terminals across worktrees", () => {
       render(<BulkCommandPalette />);
       openPalette();
-      // wt-3 has a single terminal with undefined agentState, so mock returns null
-      fireEvent.click(screen.getByText("Idle (1)"));
-      const wt3Checkbox = screen
-        .getByText("feature/c")
-        .closest("button")!
-        .querySelector('input[type="checkbox"]') as HTMLInputElement;
-      expect(wt3Checkbox.checked).toBe(true);
+      fireEvent.click(screen.getByText("Idle (2)"));
+      const t2 = screen.getByTestId("bulk-terminal-checkbox-t2") as HTMLInputElement;
+      const t6 = screen.getByTestId("bulk-terminal-checkbox-t6") as HTMLInputElement;
+      expect(t2.checked).toBe(true);
+      expect(t6.checked).toBe(true);
     });
 
     it("presets are additive - do not clear existing selection", () => {
       render(<BulkCommandPalette />);
       openPalette();
-      // First select wt-1 manually
       fireEvent.click(screen.getByText("feature/a").closest("button")!);
-      // Then apply Waiting preset
       fireEvent.click(screen.getByText("Waiting (1)"));
-      // Both should be selected
-      const wt1Checkbox = screen
-        .getByText("feature/a")
-        .closest("button")!
-        .querySelector('input[type="checkbox"]') as HTMLInputElement;
-      const wt2Checkbox = screen
-        .getByText("feature/b")
-        .closest("button")!
-        .querySelector('input[type="checkbox"]') as HTMLInputElement;
-      expect(wt1Checkbox.checked).toBe(true);
-      expect(wt2Checkbox.checked).toBe(true);
+      const wt1 = screen.getByTestId("bulk-worktree-checkbox-wt-1") as HTMLInputElement;
+      const wt2 = screen.getByTestId("bulk-worktree-checkbox-wt-2") as HTMLInputElement;
+      expect(wt1.checked).toBe(true);
+      expect(wt2.checked).toBe(true);
     });
   });
 
@@ -646,11 +731,12 @@ describe("BulkCommandPalette", () => {
     it("ctrl+c shows confirmation before sending", () => {
       render(<BulkCommandPalette />);
       openPalette();
-      fireEvent.click(screen.getByText("feature/a").closest("button")!);
+      // Click single terminal (t3 in wt-2) to select exactly 1 agent
+      fireEvent.click(screen.getByTestId("bulk-terminal-checkbox-t3"));
       fireEvent.click(screen.getByText("Ctrl+C"));
       fireEvent.click(screen.getByRole("button", { name: "Send" }));
       expect(mockSendKey).not.toHaveBeenCalled();
-      expect(screen.getByText(/Send Ctrl\+C to 1 worktree\?/)).toBeTruthy();
+      expect(screen.getByText(/Send Ctrl\+C to 1 agent\?/)).toBeTruthy();
     });
 
     it("non-destructive keystrokes send immediately", () => {


### PR DESCRIPTION
## Summary

- Expands bulk command palette selection from worktree-level to individual terminal-level, so users can target specific agent terminals within a worktree rather than hitting all of them
- Worktree-level checkboxes now act as \"select all\" toggles with an indeterminate state when only some terminals are selected
- Preset filters (Active, Waiting, Idle, Completed) now evaluate agent state per-terminal, not per-worktree

Resolves #4772

## Changes

- `BulkCommandPalette.tsx`: Rewrote selection model to track individual terminal IDs. Each worktree row now expands to show agent terminals, each with its own checkbox. Added indeterminate checkbox state for partial worktree selection. Updated `resolveTargetIds()` to use selected terminal IDs directly instead of iterating all eligible terminals per selected worktree. Preset filter logic now checks terminal-level agent state.
- `BulkCommandPalette.test.tsx`: Updated tests to cover terminal-level selection, indeterminate states, partial selection, and per-terminal preset filtering.

## Testing

Full unit test suite passes. Covered: individual terminal selection within a worktree, worktree toggle select-all/deselect-all, indeterminate checkbox state, preset filters applying at terminal level, and `resolveTargetIds()` returning only selected terminal IDs.