### PR TITLE
feat(theme): live preview on hover in theme pickers

### DIFF
--- a/e2e/full/core-settings-tabs.spec.ts
+++ b/e2e/full/core-settings-tabs.spec.ts
@@ -60,7 +60,10 @@ test.describe.serial("Core: Settings Tabs Coverage", () => {
     }
 
     await targetOption.click();
-    // Theme modal closes on selection — verify trigger now shows the selected theme name
+    // Theme modal stays open on selection so users can keep browsing. Close it
+    // explicitly before asserting the trigger reflects the committed theme.
+    await expect(themeDialog).toBeVisible({ timeout: T_SHORT });
+    await window.keyboard.press("Escape");
     await expect(themeDialog).not.toBeVisible({ timeout: T_SHORT });
     if (targetName) {
       await expect(themeTrigger).toContainText(targetName, { timeout: T_SHORT });

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -100,6 +100,7 @@ export function AppThemePicker() {
   const selectedSchemeId = useAppThemeStore((s) => s.selectedSchemeId);
   const customSchemes = useAppThemeStore((s) => s.customSchemes);
   const commitSchemeSelection = useAppThemeStore((s) => s.commitSchemeSelection);
+  const injectTheme = useAppThemeStore((s) => s.injectTheme);
   const addCustomScheme = useAppThemeStore((s) => s.addCustomScheme);
   const recentSchemeIds = useAppThemeStore((s) => s.recentSchemeIds);
   const followSystem = useAppThemeStore((s) => s.followSystem);
@@ -111,6 +112,7 @@ export function AppThemePicker() {
   const [importWarnings, setImportWarnings] = useState<AppThemeValidationWarning[]>([]);
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
+  const [previewAnnouncement, setPreviewAnnouncement] = useState("");
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const videoGenRef = useRef(0);
@@ -162,7 +164,7 @@ export function AppThemePicker() {
       const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
       commitSchemeSelection(id);
       runThemeReveal(origin ?? null, () => injectSchemeToDOM(scheme));
-      setOpen(false);
+      // Modal stays open during live preview so the user can keep browsing.
 
       try {
         await appThemeClient.setColorScheme(id);
@@ -193,6 +195,43 @@ export function AppThemePicker() {
     },
     [commitSchemeSelection, selectedSchemeId, followSystem, setFollowSystem]
   );
+
+  const handleOpen = useCallback(() => {
+    setPreviewAnnouncement("");
+    setOpen(true);
+  }, []);
+
+  const handleModalClose = useCallback(() => {
+    // On close, ensure the DOM reflects the currently committed selection.
+    // If the user only hovered (no click), the store's selectedSchemeId is
+    // unchanged and this reverts the ephemeral preview. If the user clicked
+    // to commit, the store already holds the new selection so this is a
+    // no-op visually but keeps store and DOM in lockstep regardless.
+    const committed = allSchemes.find((s) => s.id === selectedSchemeId);
+    if (committed) {
+      injectTheme(committed);
+    }
+    setPreviewAnnouncement("");
+    setOpen(false);
+  }, [allSchemes, injectTheme, selectedSchemeId]);
+
+  const handlePreviewItem = useCallback(
+    (id: string) => {
+      const scheme = allSchemes.find((s) => s.id === id);
+      if (!scheme) return;
+      injectTheme(scheme);
+      setPreviewAnnouncement(`Previewing: ${scheme.name}`);
+    },
+    [allSchemes, injectTheme]
+  );
+
+  const handlePreviewEnd = useCallback(() => {
+    const committed = allSchemes.find((s) => s.id === selectedSchemeId);
+    if (committed) {
+      injectTheme(committed);
+    }
+    setPreviewAnnouncement("");
+  }, [allSchemes, selectedSchemeId, injectTheme]);
 
   const handleShuffle = useCallback(
     (e: MouseEvent) => {
@@ -351,7 +390,7 @@ export function AppThemePicker() {
         data-testid="theme-picker-trigger"
         aria-haspopup="dialog"
         aria-expanded={open}
-        onClick={() => setOpen(true)}
+        onClick={handleOpen}
         className={cn(
           "w-full flex items-center gap-3 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
           "border-canopy-border bg-canopy-bg hover:border-canopy-text/30"
@@ -395,7 +434,7 @@ export function AppThemePicker() {
 
       <AppDialog
         isOpen={open}
-        onClose={() => setOpen(false)}
+        onClose={handleModalClose}
         size="xl"
         data-testid="theme-picker-dialog"
       >
@@ -414,6 +453,9 @@ export function AppThemePicker() {
             ]}
             selectedId={selectedSchemeId}
             onSelect={handleSelect}
+            onPreviewItem={handlePreviewItem}
+            onPreviewEnd={handlePreviewEnd}
+            previewAnnouncement={previewAnnouncement}
             columns={3}
             renderPreview={(scheme) => <HeroImage scheme={scheme} size={130} />}
             renderMeta={(scheme) => {

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useRef, useState, type MouseEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+} from "react";
 import { AlertTriangle, Monitor, Palette, Shuffle } from "lucide-react";
 import { ThemeSelector } from "./ThemeSelector";
 import { cn } from "@/lib/utils";
@@ -232,6 +239,22 @@ export function AppThemePicker() {
     }
     setPreviewAnnouncement("");
   }, [allSchemes, selectedSchemeId, injectTheme]);
+
+  // If the picker unmounts mid-preview (e.g. the parent settings view
+  // switches tabs without closing the theme modal first), make sure the DOM
+  // is snapped back to whatever the store currently says is committed so we
+  // do not leak a preview into the app chrome.
+  useEffect(() => {
+    return () => {
+      const committedId = useAppThemeStore.getState().selectedSchemeId;
+      const { customSchemes: storeCustomSchemes } = useAppThemeStore.getState();
+      const pool = [...BUILT_IN_APP_SCHEMES, ...storeCustomSchemes];
+      const committed = pool.find((s) => s.id === committedId);
+      if (committed) {
+        useAppThemeStore.getState().injectTheme(committed);
+      }
+    };
+  }, []);
 
   const handleShuffle = useCallback(
     (e: MouseEvent) => {

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   BUILT_IN_SCHEMES,
   DEFAULT_SCHEME_ID,
@@ -72,9 +72,11 @@ export function ColorSchemePicker() {
   const selectedSchemeId = useTerminalColorSchemeStore((s) => s.selectedSchemeId);
   const customSchemes = useTerminalColorSchemeStore((s) => s.customSchemes);
   const setSelectedSchemeId = useTerminalColorSchemeStore((s) => s.setSelectedSchemeId);
+  const setPreviewSchemeId = useTerminalColorSchemeStore((s) => s.setPreviewSchemeId);
   const addCustomScheme = useTerminalColorSchemeStore((s) => s.addCustomScheme);
   const recentSchemeIds = useTerminalColorSchemeStore((s) => s.recentSchemeIds);
   const appThemeId = useAppThemeStore((s) => s.selectedSchemeId);
+  const [previewAnnouncement, setPreviewAnnouncement] = useState("");
 
   const allSchemes = useMemo(() => [...BUILT_IN_SCHEMES, ...customSchemes], [customSchemes]);
   const recentSchemes = useMemo(
@@ -90,9 +92,37 @@ export function ColorSchemePicker() {
     [allSchemes, recentIdSet]
   );
 
+  const handlePreviewItem = useCallback(
+    (id: string) => {
+      setPreviewSchemeId(id);
+      const scheme = allSchemes.find((s) => s.id === id);
+      if (scheme) {
+        setPreviewAnnouncement(`Previewing: ${scheme.name}`);
+      }
+    },
+    [setPreviewSchemeId, allSchemes]
+  );
+
+  const handlePreviewEnd = useCallback(() => {
+    setPreviewSchemeId(null);
+    setPreviewAnnouncement("");
+  }, [setPreviewSchemeId]);
+
+  // Clear any preview override when the picker unmounts so the committed theme
+  // is restored unconditionally.
+  useEffect(() => {
+    return () => {
+      setPreviewSchemeId(null);
+    };
+  }, [setPreviewSchemeId]);
+
   const handleSelect = useCallback(
     async (id: string) => {
       setSelectedSchemeId(id);
+      // Clearing any active preview override ensures the committed selection
+      // wins immediately instead of being masked by the hover preview state.
+      setPreviewSchemeId(null);
+      setPreviewAnnouncement("");
       try {
         await terminalConfigClient.setColorScheme(id);
         await terminalConfigClient.setRecentSchemeIds(
@@ -102,7 +132,7 @@ export function ColorSchemePicker() {
         console.error("Failed to persist color scheme:", error);
       }
     },
-    [setSelectedSchemeId]
+    [setSelectedSchemeId, setPreviewSchemeId]
   );
 
   const handleImport = useCallback(async () => {
@@ -133,6 +163,9 @@ export function ColorSchemePicker() {
           ]}
           selectedId={selectedSchemeId}
           onSelect={handleSelect}
+          onPreviewItem={handlePreviewItem}
+          onPreviewEnd={handlePreviewEnd}
+          previewAnnouncement={previewAnnouncement}
           renderPreview={(scheme) => (
             <SchemePreview scheme={resolveSchemeForPreview(scheme, appThemeId)} />
           )}
@@ -154,6 +187,9 @@ export function ColorSchemePicker() {
           items={allSchemes}
           selectedId={selectedSchemeId}
           onSelect={handleSelect}
+          onPreviewItem={handlePreviewItem}
+          onPreviewEnd={handlePreviewEnd}
+          previewAnnouncement={previewAnnouncement}
           renderPreview={(scheme) => (
             <SchemePreview scheme={resolveSchemeForPreview(scheme, appThemeId)} />
           )}

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { Search } from "lucide-react";
 
@@ -16,6 +16,12 @@ interface ThemeSelectorCommon<T extends { id: string }> {
   columns?: 2 | 3;
   className?: string;
   id?: string;
+  /** Called when pointer enters or focus lands on a card. Receives the card id. */
+  onPreviewItem?: (id: string) => void;
+  /** Called after pointer leaves or focus blurs a card, on the next animation frame. */
+  onPreviewEnd?: () => void;
+  /** Text announced via a polite aria-live region as the previewed item changes. */
+  previewAnnouncement?: string;
 }
 
 export type ThemeSelectorProps<T extends { id: string }> =
@@ -33,10 +39,44 @@ export function ThemeSelector<T extends { id: string }>({
   columns = 2,
   className,
   id,
+  onPreviewItem,
+  onPreviewEnd,
+  previewAnnouncement,
 }: ThemeSelectorProps<T>) {
   const [query, setQuery] = useState("");
   const getNameRef = useRef(getName);
   getNameRef.current = getName;
+
+  // Single rAF handle shared across all cards so rapid pointer moves between
+  // cards cancel any pending revert before the next preview fires.
+  const revertRafRef = useRef<number | null>(null);
+  const onPreviewEndRef = useRef(onPreviewEnd);
+  onPreviewEndRef.current = onPreviewEnd;
+
+  const cancelPendingRevert = () => {
+    if (revertRafRef.current !== null) {
+      cancelAnimationFrame(revertRafRef.current);
+      revertRafRef.current = null;
+    }
+  };
+
+  const scheduleRevert = () => {
+    cancelPendingRevert();
+    revertRafRef.current = requestAnimationFrame(() => {
+      revertRafRef.current = null;
+      onPreviewEndRef.current?.();
+    });
+  };
+
+  useEffect(
+    () => () => {
+      if (revertRafRef.current !== null) {
+        cancelAnimationFrame(revertRafRef.current);
+        revertRafRef.current = null;
+      }
+    },
+    []
+  );
 
   const filteredGroups = useMemo(() => {
     if (!groups) return null;
@@ -63,14 +103,30 @@ export function ThemeSelector<T extends { id: string }>({
 
   const colsClass = columns === 3 ? "grid-cols-3" : "grid-cols-2";
 
+  const handlePreviewEnter = (itemId: string) => {
+    if (!onPreviewItem) return;
+    cancelPendingRevert();
+    onPreviewItem(itemId);
+  };
+
+  const handlePreviewLeave = () => {
+    if (!onPreviewItem && !onPreviewEnd) return;
+    scheduleRevert();
+  };
+
   const renderCard = (item: T) => (
     <button
       key={item.id}
       role="option"
       aria-selected={item.id === selectedId}
       onClick={(e) => onSelect(item.id, { x: e.clientX, y: e.clientY })}
+      onPointerEnter={() => handlePreviewEnter(item.id)}
+      onPointerLeave={handlePreviewLeave}
+      onFocus={() => handlePreviewEnter(item.id)}
+      onBlur={handlePreviewLeave}
       className={cn(
         "flex flex-col gap-1.5 p-2 rounded-[var(--radius-md)] border transition-colors text-left",
+        "[&>*]:pointer-events-none",
         item.id === selectedId
           ? "border-canopy-accent bg-canopy-accent/10"
           : "border-canopy-border bg-canopy-bg hover:border-canopy-text/30"
@@ -125,6 +181,10 @@ export function ThemeSelector<T extends { id: string }>({
           {filteredItems?.map(renderCard)}
         </div>
       )}
+
+      <div aria-live="polite" aria-atomic="true" className="sr-only">
+        {previewAnnouncement ?? ""}
+      </div>
     </div>
   );
 }

--- a/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
@@ -1,0 +1,285 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: {
+    setColorScheme: vi.fn().mockResolvedValue(undefined),
+    setFollowSystem: vi.fn().mockResolvedValue(undefined),
+    setCustomSchemes: vi.fn().mockResolvedValue(undefined),
+    setRecentSchemeIds: vi.fn().mockResolvedValue(undefined),
+    importTheme: vi.fn().mockResolvedValue({ ok: false, errors: ["Import cancelled"] }),
+    exportTheme: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const storeState: Record<string, unknown> = {};
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: Object.assign(
+    (selector: (s: Record<string, unknown>) => unknown) => selector(storeState),
+    {
+      getState: () => storeState,
+    }
+  ),
+  injectSchemeToDOM: vi.fn(),
+}));
+
+vi.mock("@/lib/appThemeViewTransition", () => ({
+  prefersReducedMotion: () => true,
+  runThemeReveal: (_origin: unknown, commit: () => void) => {
+    commit();
+  },
+}));
+
+vi.mock("@/config/appColorSchemes", () => {
+  const mkTheme = (id: string, name: string, accent: string) => ({
+    id,
+    name,
+    type: "dark" as const,
+    tokens: {
+      "--canopy-accent": accent,
+      "--canopy-success": "#0f0",
+      "--canopy-warning": "#ff0",
+      "--canopy-danger": "#f00",
+      "--canopy-text": "#fff",
+      "--canopy-border": "#333",
+      "--canopy-panel": "#111",
+      "--canopy-sidebar": "#222",
+      "--canopy-bg": "#000",
+    },
+  });
+  return {
+    BUILT_IN_APP_SCHEMES: [
+      mkTheme("theme-a", "Theme A", "#f00"),
+      mkTheme("theme-b", "Theme B", "#00f"),
+      mkTheme("theme-c", "Theme C", "#0ff"),
+    ],
+  };
+});
+
+vi.mock("@shared/theme", () => ({
+  APP_THEME_PREVIEW_KEYS: {
+    accent: "--canopy-accent",
+    success: "--canopy-success",
+    warning: "--canopy-warning",
+    danger: "--canopy-danger",
+    text: "--canopy-text",
+    border: "--canopy-border",
+    panel: "--canopy-panel",
+    sidebar: "--canopy-sidebar",
+    background: "--canopy-bg",
+  },
+  getAppThemeWarnings: () => [],
+  resolveAppTheme: (id: string, customSchemes: { id: string }[]) => {
+    const map: Record<string, { id: string; name: string; type: string; tokens: object }> = {
+      "theme-a": { id: "theme-a", name: "Theme A", type: "dark", tokens: {} },
+      "theme-b": { id: "theme-b", name: "Theme B", type: "dark", tokens: {} },
+      "theme-c": { id: "theme-c", name: "Theme C", type: "dark", tokens: {} },
+    };
+    return map[id] ?? customSchemes.find((s) => s.id === id);
+  },
+}));
+
+// AppDialog renders children inline with an onClose handler exposed via the
+// close button, keeping the test focused on picker logic.
+vi.mock("@/components/ui/AppDialog", () => {
+  const AppDialog = ({
+    isOpen,
+    onClose,
+    children,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    children: React.ReactNode;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="theme-picker-dialog">
+        <button type="button" data-testid="dialog-close" onClick={onClose}>
+          close
+        </button>
+        {children}
+      </div>
+    );
+  };
+  AppDialog.Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  AppDialog.Title = ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>;
+  AppDialog.CloseButton = () => null;
+  AppDialog.BodyScroll = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return { AppDialog };
+});
+
+vi.mock("@/hooks/useEscapeStack", () => ({
+  useEscapeStack: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: vi.fn(() => ({ isVisible: true, shouldRender: true })),
+}));
+
+vi.mock("@/hooks", () => ({
+  useOverlayState: vi.fn(),
+  useEscapeStack: vi.fn(),
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: vi.fn(() => ({ isOpen: false, width: 0 })),
+}));
+
+import { AppThemePicker } from "../AppThemePicker";
+
+let pendingRaf: Array<{ handle: number; cb: FrameRequestCallback }> = [];
+let nextHandle = 0;
+const flushRaf = () => {
+  act(() => {
+    const pending = pendingRaf;
+    pendingRaf = [];
+    for (const entry of pending) entry.cb(0);
+  });
+};
+
+describe("AppThemePicker hover preview", () => {
+  beforeEach(() => {
+    pendingRaf = [];
+    nextHandle = 0;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      nextHandle += 1;
+      pendingRaf.push({ handle: nextHandle, cb });
+      return nextHandle;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+      pendingRaf = pendingRaf.filter((entry) => entry.handle !== handle);
+    });
+
+    Object.assign(storeState, {
+      selectedSchemeId: "theme-a",
+      customSchemes: [],
+      recentSchemeIds: [],
+      followSystem: false,
+      preferredDarkSchemeId: "theme-a",
+      preferredLightSchemeId: "theme-a",
+      setSelectedSchemeId: vi.fn(),
+      commitSchemeSelection: vi.fn(),
+      setSelectedSchemeIdSilent: vi.fn(),
+      injectTheme: vi.fn(),
+      setFollowSystem: vi.fn(),
+      setPreferredDarkSchemeId: vi.fn(),
+      setPreferredLightSchemeId: vi.fn(),
+      setRecentSchemeIds: vi.fn(),
+      addCustomScheme: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  const openDialog = () => {
+    fireEvent.click(screen.getByTestId("theme-picker-trigger"));
+  };
+
+  it("calls injectTheme with the hovered scheme on pointer enter", () => {
+    render(<AppThemePicker />);
+    openDialog();
+
+    const injectTheme = storeState.injectTheme as ReturnType<typeof vi.fn>;
+    injectTheme.mockClear();
+
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+    fireEvent.pointerEnter(cardB);
+
+    expect(injectTheme).toHaveBeenCalledTimes(1);
+    expect((injectTheme.mock.calls[0][0] as { id: string }).id).toBe("theme-b");
+  });
+
+  it("reverts to the committed theme on pointer leave via rAF", () => {
+    render(<AppThemePicker />);
+    openDialog();
+
+    const injectTheme = storeState.injectTheme as ReturnType<typeof vi.fn>;
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+    fireEvent.pointerEnter(cardB);
+    injectTheme.mockClear();
+
+    fireEvent.pointerLeave(cardB);
+    expect(injectTheme).not.toHaveBeenCalled();
+
+    flushRaf();
+
+    expect(injectTheme).toHaveBeenCalledTimes(1);
+    // Reverts to the committed selection (theme-a).
+    expect((injectTheme.mock.calls[0][0] as { id: string }).id).toBe("theme-a");
+  });
+
+  it("click commits via commitSchemeSelection without closing the modal", () => {
+    render(<AppThemePicker />);
+    openDialog();
+
+    expect(screen.queryByTestId("theme-picker-dialog")).not.toBeNull();
+
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+    fireEvent.click(cardB);
+
+    const commitSchemeSelection = storeState.commitSchemeSelection as ReturnType<typeof vi.fn>;
+    expect(commitSchemeSelection).toHaveBeenCalledWith("theme-b");
+    // Modal should still be mounted.
+    expect(screen.queryByTestId("theme-picker-dialog")).not.toBeNull();
+  });
+
+  it("closing the dialog reverts to the origin theme captured on open", () => {
+    render(<AppThemePicker />);
+    openDialog();
+
+    const injectTheme = storeState.injectTheme as ReturnType<typeof vi.fn>;
+    // Simulate hover previewing a different card prior to close so we can see
+    // the origin revert fire with the right scheme id.
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+    fireEvent.pointerEnter(cardB);
+    injectTheme.mockClear();
+
+    fireEvent.click(screen.getByTestId("dialog-close"));
+
+    // The close handler calls injectTheme(originScheme).
+    expect(injectTheme).toHaveBeenCalled();
+    const lastCall = injectTheme.mock.calls[injectTheme.mock.calls.length - 1][0] as {
+      id: string;
+    };
+    expect(lastCall.id).toBe("theme-a");
+    // Dialog is no longer mounted.
+    expect(screen.queryByTestId("theme-picker-dialog")).toBeNull();
+  });
+
+  it("after a committed selection, close syncs DOM to the committed theme (not the origin)", () => {
+    const { rerender } = render(<AppThemePicker />);
+    openDialog();
+
+    const injectTheme = storeState.injectTheme as ReturnType<typeof vi.fn>;
+
+    // Simulate a click-commit updating the store's selectedSchemeId.
+    storeState.selectedSchemeId = "theme-c";
+    rerender(<AppThemePicker />);
+    injectTheme.mockClear();
+
+    fireEvent.click(screen.getByTestId("dialog-close"));
+
+    expect(injectTheme).toHaveBeenCalledTimes(1);
+    expect((injectTheme.mock.calls[0][0] as { id: string }).id).toBe("theme-c");
+  });
+
+  it("updates the aria-live region with the previewed theme name", () => {
+    const { container } = render(<AppThemePicker />);
+    openDialog();
+
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+    fireEvent.pointerEnter(cardB);
+
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent).toBe("Previewing: Theme B");
+
+    fireEvent.pointerLeave(cardB);
+    flushRaf();
+    expect(live?.textContent).toBe("");
+  });
+});

--- a/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
@@ -268,6 +268,69 @@ describe("AppThemePicker hover preview", () => {
     expect((injectTheme.mock.calls[0][0] as { id: string }).id).toBe("theme-c");
   });
 
+  it("handles the pending-revert + click-commit + close race without re-injecting the origin", () => {
+    const { rerender } = render(<AppThemePicker />);
+    openDialog();
+
+    const injectTheme = storeState.injectTheme as ReturnType<typeof vi.fn>;
+    const commitSchemeSelection = storeState.commitSchemeSelection as ReturnType<typeof vi.fn>;
+
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+
+    // Hover B, then leave B — a revert rAF is now queued but not yet flushed.
+    fireEvent.pointerEnter(cardB);
+    fireEvent.pointerLeave(cardB);
+    expect(pendingRaf.length).toBe(1);
+
+    // User clicks B to commit before the rAF fires.
+    fireEvent.click(cardB);
+    expect(commitSchemeSelection).toHaveBeenCalledWith("theme-b");
+
+    // Simulate the store state update that the real commitSchemeSelection would
+    // perform so the subsequent close handler reads the committed value.
+    storeState.selectedSchemeId = "theme-b";
+    rerender(<AppThemePicker />);
+
+    injectTheme.mockClear();
+
+    // Flush the pending revert rAF that was queued on pointerLeave before the
+    // click. It should revert to the currently committed scheme, not the
+    // pre-commit origin.
+    flushRaf();
+
+    const revertCallIds = injectTheme.mock.calls.map(
+      (call: unknown[]) => (call[0] as { id: string }).id
+    );
+    // Origin theme-a should NOT be re-injected.
+    expect(revertCallIds).not.toContain("theme-a");
+
+    injectTheme.mockClear();
+    fireEvent.click(screen.getByTestId("dialog-close"));
+
+    // Closing should sync DOM to the committed theme-b, never the origin.
+    expect(injectTheme).toHaveBeenCalledTimes(1);
+    expect((injectTheme.mock.calls[0][0] as { id: string }).id).toBe("theme-b");
+  });
+
+  it("unmount cleanup restores DOM to the committed theme", () => {
+    const { unmount } = render(<AppThemePicker />);
+    openDialog();
+
+    const injectTheme = storeState.injectTheme as ReturnType<typeof vi.fn>;
+    const cardB = screen.getAllByRole("option").find((o) => o.textContent?.includes("Theme B"))!;
+    fireEvent.pointerEnter(cardB);
+
+    injectTheme.mockClear();
+    unmount();
+
+    // Unmount should have triggered a committed-theme re-inject so the preview
+    // does not leak into the chrome after a tab switch.
+    expect(injectTheme).toHaveBeenCalled();
+    const lastId = (injectTheme.mock.calls[injectTheme.mock.calls.length - 1][0] as { id: string })
+      .id;
+    expect(lastId).toBe("theme-a");
+  });
+
   it("updates the aria-live region with the previewed theme name", () => {
     const { container } = render(<AppThemePicker />);
     openDialog();

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -104,6 +104,7 @@ describe("AppThemePicker shuffle button", () => {
       setSelectedSchemeId: vi.fn(),
       commitSchemeSelection: vi.fn(),
       setSelectedSchemeIdSilent: vi.fn(),
+      injectTheme: vi.fn(),
       setFollowSystem: vi.fn(),
       setPreferredDarkSchemeId: vi.fn(),
       setPreferredLightSchemeId: vi.fn(),

--- a/src/components/Settings/__tests__/ColorSchemePicker.preview.test.tsx
+++ b/src/components/Settings/__tests__/ColorSchemePicker.preview.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+import { DEFAULT_SCHEME_ID } from "@/config/terminalColorSchemes";
+import { useTerminalColorSchemeStore } from "@/store/terminalColorSchemeStore";
+import { useAppThemeStore } from "@/store/appThemeStore";
+
+vi.mock("@/clients/terminalConfigClient", () => ({
+  terminalConfigClient: {
+    setColorScheme: vi.fn().mockResolvedValue(undefined),
+    setRecentSchemeIds: vi.fn().mockResolvedValue(undefined),
+    setCustomSchemes: vi.fn().mockResolvedValue(undefined),
+    importColorScheme: vi.fn().mockResolvedValue({ ok: false }),
+  },
+}));
+
+import { ColorSchemePicker } from "../ColorSchemePicker";
+
+let pendingRaf: Array<{ handle: number; cb: FrameRequestCallback }> = [];
+let nextHandle = 0;
+const flushRaf = () => {
+  act(() => {
+    const pending = pendingRaf;
+    pendingRaf = [];
+    for (const entry of pending) entry.cb(0);
+  });
+};
+
+describe("ColorSchemePicker hover preview", () => {
+  beforeEach(() => {
+    pendingRaf = [];
+    nextHandle = 0;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      nextHandle += 1;
+      pendingRaf.push({ handle: nextHandle, cb });
+      return nextHandle;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+      pendingRaf = pendingRaf.filter((entry) => entry.handle !== handle);
+    });
+
+    useTerminalColorSchemeStore.setState({
+      selectedSchemeId: DEFAULT_SCHEME_ID,
+      customSchemes: [],
+      recentSchemeIds: [],
+      previewSchemeId: null,
+    });
+    useAppThemeStore.setState({ selectedSchemeId: "daintree" });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    useTerminalColorSchemeStore.setState({ previewSchemeId: null });
+  });
+
+  it("sets previewSchemeId in the store on pointer enter", () => {
+    render(<ColorSchemePicker />);
+
+    const draculaCard = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.toLowerCase().includes("dracula"))!;
+    fireEvent.pointerEnter(draculaCard);
+
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBe("dracula");
+  });
+
+  it("clears previewSchemeId on pointer leave after rAF flush", () => {
+    render(<ColorSchemePicker />);
+
+    const card = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.toLowerCase().includes("dracula"))!;
+    fireEvent.pointerEnter(card);
+    fireEvent.pointerLeave(card);
+
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBe("dracula");
+    flushRaf();
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("clears previewSchemeId when the picker unmounts mid-preview", () => {
+    const { unmount } = render(<ColorSchemePicker />);
+    const card = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.toLowerCase().includes("dracula"))!;
+    fireEvent.pointerEnter(card);
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBe("dracula");
+
+    unmount();
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("keyboard focus mirrors pointer preview behavior", () => {
+    render(<ColorSchemePicker />);
+    const card = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.toLowerCase().includes("dracula"))!;
+
+    fireEvent.focus(card);
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBe("dracula");
+
+    fireEvent.blur(card);
+    flushRaf();
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("commit via click clears the preview override", () => {
+    render(<ColorSchemePicker />);
+    const card = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.toLowerCase().includes("dracula"))!;
+
+    fireEvent.pointerEnter(card);
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBe("dracula");
+
+    fireEvent.click(card);
+    expect(useTerminalColorSchemeStore.getState().selectedSchemeId).toBe("dracula");
+    expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("announces the currently previewed scheme via aria-live", () => {
+    const { container } = render(<ColorSchemePicker />);
+    const card = screen
+      .getAllByRole("option")
+      .find((o) => o.textContent?.toLowerCase().includes("dracula"))!;
+
+    fireEvent.pointerEnter(card);
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent).toMatch(/Previewing:/);
+
+    fireEvent.pointerLeave(card);
+    flushRaf();
+    expect(live?.textContent).toBe("");
+  });
+});

--- a/src/components/Settings/__tests__/ThemeSelector.test.tsx
+++ b/src/components/Settings/__tests__/ThemeSelector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
 import { ThemeSelector } from "../ThemeSelector";
 
 interface TestItem {
@@ -132,5 +132,153 @@ describe("ThemeSelector", () => {
   it("renders search input with correct aria-label", () => {
     render(<ThemeSelector {...defaultProps} />);
     expect(screen.getByLabelText("Filter themes")).toBeTruthy();
+  });
+});
+
+describe("ThemeSelector preview interactions", () => {
+  let pendingRaf: Array<{ handle: number; cb: FrameRequestCallback }> = [];
+  let nextHandle = 0;
+
+  const rafSpy = vi.fn((cb: FrameRequestCallback) => {
+    nextHandle += 1;
+    pendingRaf.push({ handle: nextHandle, cb });
+    return nextHandle;
+  });
+  const cafSpy = vi.fn((handle: number) => {
+    pendingRaf = pendingRaf.filter((entry) => entry.handle !== handle);
+  });
+
+  const flushRaf = () => {
+    act(() => {
+      const pending = pendingRaf;
+      pendingRaf = [];
+      for (const entry of pending) entry.cb(0);
+    });
+  };
+
+  beforeEach(() => {
+    pendingRaf = [];
+    nextHandle = 0;
+    rafSpy.mockClear();
+    cafSpy.mockClear();
+    vi.stubGlobal("requestAnimationFrame", rafSpy);
+    vi.stubGlobal("cancelAnimationFrame", cafSpy);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("calls onPreviewItem on pointer enter with the item id", () => {
+    const onPreviewItem = vi.fn();
+    render(<ThemeSelector {...defaultProps} onPreviewItem={onPreviewItem} />);
+
+    const card = screen.getAllByRole("option").find((o) => o.textContent?.includes("Beta Theme"))!;
+    fireEvent.pointerEnter(card);
+
+    expect(onPreviewItem).toHaveBeenCalledWith("beta");
+  });
+
+  it("schedules onPreviewEnd via rAF on pointer leave", () => {
+    const onPreviewItem = vi.fn();
+    const onPreviewEnd = vi.fn();
+    render(
+      <ThemeSelector {...defaultProps} onPreviewItem={onPreviewItem} onPreviewEnd={onPreviewEnd} />
+    );
+
+    const card = screen.getAllByRole("option").find((o) => o.textContent?.includes("Beta Theme"))!;
+    fireEvent.pointerEnter(card);
+    fireEvent.pointerLeave(card);
+
+    expect(onPreviewEnd).not.toHaveBeenCalled();
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+
+    flushRaf();
+
+    expect(onPreviewEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels pending revert when another card receives pointer enter", () => {
+    const onPreviewItem = vi.fn();
+    const onPreviewEnd = vi.fn();
+    render(
+      <ThemeSelector {...defaultProps} onPreviewItem={onPreviewItem} onPreviewEnd={onPreviewEnd} />
+    );
+
+    const options = screen.getAllByRole("option");
+    const cardBeta = options.find((o) => o.textContent?.includes("Beta Theme"))!;
+    const cardGamma = options.find((o) => o.textContent?.includes("Gamma Theme"))!;
+
+    fireEvent.pointerEnter(cardBeta);
+    fireEvent.pointerLeave(cardBeta);
+    fireEvent.pointerEnter(cardGamma);
+
+    flushRaf();
+
+    expect(onPreviewEnd).not.toHaveBeenCalled();
+    expect(onPreviewItem).toHaveBeenNthCalledWith(1, "beta");
+    expect(onPreviewItem).toHaveBeenNthCalledWith(2, "gamma");
+    expect(cafSpy).toHaveBeenCalled();
+  });
+
+  it("mirrors pointer events on focus/blur for keyboard parity", () => {
+    const onPreviewItem = vi.fn();
+    const onPreviewEnd = vi.fn();
+    render(
+      <ThemeSelector {...defaultProps} onPreviewItem={onPreviewItem} onPreviewEnd={onPreviewEnd} />
+    );
+
+    const card = screen.getAllByRole("option").find((o) => o.textContent?.includes("Gamma Theme"))!;
+    fireEvent.focus(card);
+    expect(onPreviewItem).toHaveBeenCalledWith("gamma");
+
+    fireEvent.blur(card);
+    flushRaf();
+    expect(onPreviewEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders previewAnnouncement inside a polite aria-live region", () => {
+    const { container } = render(
+      <ThemeSelector {...defaultProps} previewAnnouncement="Previewing: Beta Theme" />
+    );
+
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).not.toBeNull();
+    expect(live?.getAttribute("aria-atomic")).toBe("true");
+    expect(live?.textContent).toBe("Previewing: Beta Theme");
+  });
+
+  it("mounts the aria-live region even without a preview announcement", () => {
+    const { container } = render(<ThemeSelector {...defaultProps} />);
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live).not.toBeNull();
+    expect(live?.textContent).toBe("");
+  });
+
+  it("cancels pending rAF on unmount", () => {
+    const onPreviewItem = vi.fn();
+    const onPreviewEnd = vi.fn();
+    const { unmount } = render(
+      <ThemeSelector {...defaultProps} onPreviewItem={onPreviewItem} onPreviewEnd={onPreviewEnd} />
+    );
+
+    const card = screen.getAllByRole("option").find((o) => o.textContent?.includes("Beta Theme"))!;
+    fireEvent.pointerEnter(card);
+    fireEvent.pointerLeave(card);
+
+    expect(pendingRaf.length).toBe(1);
+
+    unmount();
+
+    expect(cafSpy).toHaveBeenCalled();
+  });
+
+  it("is a no-op when no preview callbacks are provided", () => {
+    render(<ThemeSelector {...defaultProps} />);
+    const card = screen.getAllByRole("option").find((o) => o.textContent?.includes("Beta Theme"))!;
+    fireEvent.pointerEnter(card);
+    fireEvent.pointerLeave(card);
+    expect(rafSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useTerminalConfig.ts
+++ b/src/hooks/useTerminalConfig.ts
@@ -16,6 +16,7 @@ export function useTerminalConfig() {
   const setFontFamily = useTerminalFontStore((state) => state.setFontFamily);
 
   const selectedSchemeId = useTerminalColorSchemeStore((state) => state.selectedSchemeId);
+  const previewSchemeId = useTerminalColorSchemeStore((state) => state.previewSchemeId);
   const customSchemes = useTerminalColorSchemeStore((state) => state.customSchemes);
   const addCustomScheme = useTerminalColorSchemeStore((state) => state.addCustomScheme);
   const setRecentSchemeIds = useTerminalColorSchemeStore((state) => state.setRecentSchemeIds);
@@ -109,6 +110,7 @@ export function useTerminalConfig() {
     // screenReaderEnabled in deps ensures terminals update when screen reader mode changes
   }, [
     selectedSchemeId,
+    previewSchemeId,
     customSchemes,
     fontSize,
     fontFamily,

--- a/src/store/__tests__/terminalColorSchemeStore.test.ts
+++ b/src/store/__tests__/terminalColorSchemeStore.test.ts
@@ -8,7 +8,11 @@ import {
   type TerminalColorScheme,
 } from "@/config/terminalColorSchemes";
 import { useAppThemeStore } from "../appThemeStore";
-import { selectWrapperBackground, useTerminalColorSchemeStore } from "../terminalColorSchemeStore";
+import {
+  selectEffectiveTheme,
+  selectWrapperBackground,
+  useTerminalColorSchemeStore,
+} from "../terminalColorSchemeStore";
 
 const CUSTOM_SCHEME: TerminalColorScheme = {
   id: "custom-test",
@@ -47,6 +51,7 @@ describe("terminalColorSchemeStore", () => {
       selectedSchemeId: DEFAULT_SCHEME_ID,
       customSchemes: [],
       recentSchemeIds: [],
+      previewSchemeId: null,
     });
     useAppThemeStore.setState({
       selectedSchemeId: "daintree",
@@ -147,6 +152,87 @@ describe("terminalColorSchemeStore", () => {
     expect(theme).toEqual({
       ...CUSTOM_SCHEME.colors,
       ...getTerminalScrollbarDefaults(CUSTOM_SCHEME.type),
+    });
+  });
+
+  describe("previewSchemeId override", () => {
+    it("previewSchemeId overrides selectedSchemeId in getEffectiveTheme", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      store.setPreviewSchemeId("solarized-dark");
+
+      const solarized = getSchemeById("solarized-dark");
+      const theme = useTerminalColorSchemeStore.getState().getEffectiveTheme();
+
+      expect(theme).toEqual({
+        ...solarized!.colors,
+        ...getTerminalScrollbarDefaults(solarized!.type),
+      });
+    });
+
+    it("clearing previewSchemeId restores the committed theme", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      store.setPreviewSchemeId("solarized-dark");
+      store.setPreviewSchemeId(null);
+
+      const dracula = getSchemeById("dracula");
+      const theme = useTerminalColorSchemeStore.getState().getEffectiveTheme();
+
+      expect(theme).toEqual({
+        ...dracula!.colors,
+        ...getTerminalScrollbarDefaults(dracula!.type),
+      });
+    });
+
+    it("does not mutate selectedSchemeId or recentSchemeIds during preview", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      store.setPreviewSchemeId("solarized-dark");
+
+      const state = useTerminalColorSchemeStore.getState();
+      expect(state.selectedSchemeId).toBe("dracula");
+      expect(state.recentSchemeIds).not.toContain("solarized-dark");
+    });
+
+    it("selectEffectiveTheme cache invalidates when only previewSchemeId changes", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      const first = selectEffectiveTheme(useTerminalColorSchemeStore.getState());
+
+      store.setPreviewSchemeId("solarized-dark");
+      const second = selectEffectiveTheme(useTerminalColorSchemeStore.getState());
+
+      const solarized = getSchemeById("solarized-dark");
+      expect(first).not.toEqual(second);
+      expect(second).toEqual({
+        ...solarized!.colors,
+        ...getTerminalScrollbarDefaults(solarized!.type),
+      });
+    });
+
+    it("previewing the default app-linked scheme derives from the app theme", () => {
+      useAppThemeStore.setState({ selectedSchemeId: "bondi" });
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      store.setPreviewSchemeId(DEFAULT_SCHEME_ID);
+
+      const mapped = getMappedTerminalScheme("bondi");
+      expect(mapped).toBeDefined();
+
+      const theme = useTerminalColorSchemeStore.getState().getEffectiveTheme();
+      expect(theme).toEqual({
+        ...mapped!.colors,
+        ...getTerminalScrollbarDefaults(mapped!.type),
+      });
+    });
+
+    it("removeCustomScheme clears a dangling previewSchemeId pointing at it", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.addCustomScheme(CUSTOM_SCHEME);
+      store.setPreviewSchemeId("custom-test");
+      store.removeCustomScheme("custom-test");
+      expect(useTerminalColorSchemeStore.getState().previewSchemeId).toBeNull();
     });
   });
 
@@ -288,6 +374,33 @@ describe("terminalColorSchemeStore", () => {
 
       expect(selectWrapperBackground(useTerminalColorSchemeStore.getState())).toBe(
         "var(--theme-surface-canvas)"
+      );
+    });
+
+    it("honors previewSchemeId when selecting the wrapper background", () => {
+      const dracula = getSchemeById("dracula");
+      expect(dracula).toBeDefined();
+      useTerminalColorSchemeStore.getState().setPreviewSchemeId("dracula");
+
+      expect(selectWrapperBackground(useTerminalColorSchemeStore.getState())).toBe(
+        dracula!.colors.background
+      );
+    });
+
+    it("falls back to the committed selection when previewSchemeId is cleared", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("dracula");
+      store.setPreviewSchemeId("solarized-dark");
+
+      const solarized = getSchemeById("solarized-dark");
+      expect(selectWrapperBackground(useTerminalColorSchemeStore.getState())).toBe(
+        solarized!.colors.background
+      );
+
+      useTerminalColorSchemeStore.getState().setPreviewSchemeId(null);
+      const dracula = getSchemeById("dracula");
+      expect(selectWrapperBackground(useTerminalColorSchemeStore.getState())).toBe(
+        dracula!.colors.background
       );
     });
 

--- a/src/store/__tests__/terminalColorSchemeStore.test.ts
+++ b/src/store/__tests__/terminalColorSchemeStore.test.ts
@@ -227,6 +227,50 @@ describe("terminalColorSchemeStore", () => {
       });
     });
 
+    it("invalidates the cache correctly across a null → dracula → null → default → null walk", () => {
+      const store = useTerminalColorSchemeStore.getState();
+      store.setSelectedSchemeId("solarized-dark");
+
+      const solarized = getSchemeById("solarized-dark")!;
+      const dracula = getSchemeById("dracula")!;
+      const mapped = getMappedTerminalScheme("daintree")!;
+
+      const expectSolarized = () =>
+        expect(selectEffectiveTheme(useTerminalColorSchemeStore.getState())).toEqual({
+          ...solarized.colors,
+          ...getTerminalScrollbarDefaults(solarized.type),
+        });
+      const expectDracula = () =>
+        expect(selectEffectiveTheme(useTerminalColorSchemeStore.getState())).toEqual({
+          ...dracula.colors,
+          ...getTerminalScrollbarDefaults(dracula.type),
+        });
+      const expectMapped = () =>
+        expect(selectEffectiveTheme(useTerminalColorSchemeStore.getState())).toEqual({
+          ...mapped.colors,
+          ...getTerminalScrollbarDefaults(mapped.type),
+        });
+
+      // Start: previewSchemeId null → committed is solarized-dark.
+      expectSolarized();
+
+      // Hop 1: preview dracula.
+      store.setPreviewSchemeId("dracula");
+      expectDracula();
+
+      // Hop 2: clear preview → back to solarized.
+      store.setPreviewSchemeId(null);
+      expectSolarized();
+
+      // Hop 3: preview the default app-linked scheme → reflects app theme mapping.
+      store.setPreviewSchemeId(DEFAULT_SCHEME_ID);
+      expectMapped();
+
+      // Hop 4: clear again → back to solarized.
+      store.setPreviewSchemeId(null);
+      expectSolarized();
+    });
+
     it("removeCustomScheme clears a dangling previewSchemeId pointing at it", () => {
       const store = useTerminalColorSchemeStore.getState();
       store.addCustomScheme(CUSTOM_SCHEME);

--- a/src/store/terminalColorSchemeStore.ts
+++ b/src/store/terminalColorSchemeStore.ts
@@ -16,16 +16,29 @@ interface TerminalColorSchemeState {
   selectedSchemeId: string;
   customSchemes: TerminalColorScheme[];
   recentSchemeIds: string[];
+  /**
+   * Ephemeral override used by the picker for live hover/focus preview.
+   * When non-null, `selectEffectiveTheme` / `selectWrapperBackground` /
+   * `getEffectiveTheme` treat this id as the currently selected scheme
+   * without mutating `selectedSchemeId`. Never persisted.
+   */
+  previewSchemeId: string | null;
   setSelectedSchemeId: (id: string) => void;
+  setPreviewSchemeId: (id: string | null) => void;
   addCustomScheme: (scheme: TerminalColorScheme) => void;
   removeCustomScheme: (id: string) => void;
   setRecentSchemeIds: (ids: string[]) => void;
   getEffectiveTheme: () => ITheme;
 }
 
+function resolveActiveSchemeId(state: TerminalColorSchemeState): string {
+  return state.previewSchemeId ?? state.selectedSchemeId;
+}
+
 export function selectWrapperBackground(state: TerminalColorSchemeState): string {
+  const activeId = resolveActiveSchemeId(state);
   const allSchemes = [...BUILT_IN_SCHEMES, ...state.customSchemes];
-  const scheme = allSchemes.find((s) => s.id === state.selectedSchemeId);
+  const scheme = allSchemes.find((s) => s.id === activeId);
 
   if (!scheme) {
     return "var(--theme-surface-canvas)";
@@ -69,6 +82,7 @@ function computeEffectiveTheme(
 
 let _cachedTheme: ITheme | null = null;
 let _cachedSchemeId: string | null = null;
+let _cachedPreviewSchemeId: string | null = null;
 let _cachedCustomSchemes: TerminalColorScheme[] | null = null;
 let _cachedAppThemeId: string | null = null;
 
@@ -77,15 +91,17 @@ export function selectEffectiveTheme(state: TerminalColorSchemeState): ITheme {
   if (
     _cachedTheme !== null &&
     _cachedSchemeId === state.selectedSchemeId &&
+    _cachedPreviewSchemeId === state.previewSchemeId &&
     _cachedCustomSchemes === state.customSchemes &&
     _cachedAppThemeId === appThemeId
   ) {
     return _cachedTheme;
   }
   _cachedSchemeId = state.selectedSchemeId;
+  _cachedPreviewSchemeId = state.previewSchemeId;
   _cachedCustomSchemes = state.customSchemes;
   _cachedAppThemeId = appThemeId;
-  _cachedTheme = computeEffectiveTheme(state.selectedSchemeId, state.customSchemes);
+  _cachedTheme = computeEffectiveTheme(resolveActiveSchemeId(state), state.customSchemes);
   return _cachedTheme;
 }
 
@@ -93,6 +109,7 @@ export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((s
   selectedSchemeId: DEFAULT_SCHEME_ID,
   customSchemes: [],
   recentSchemeIds: [],
+  previewSchemeId: null,
 
   setSelectedSchemeId: (id) =>
     set((state) => ({
@@ -103,6 +120,8 @@ export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((s
       ),
     })),
 
+  setPreviewSchemeId: (id) => set({ previewSchemeId: id }),
+
   addCustomScheme: (scheme) =>
     set((state) => ({
       customSchemes: [...state.customSchemes.filter((s) => s.id !== scheme.id), scheme],
@@ -112,6 +131,7 @@ export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((s
     set((state) => ({
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: state.selectedSchemeId === id ? DEFAULT_SCHEME_ID : state.selectedSchemeId,
+      previewSchemeId: state.previewSchemeId === id ? null : state.previewSchemeId,
       recentSchemeIds: state.recentSchemeIds.filter((x) => x !== id),
     })),
 
@@ -119,7 +139,7 @@ export const useTerminalColorSchemeStore = create<TerminalColorSchemeState>()((s
     set({ recentSchemeIds: Array.from(new Set(ids)).slice(0, RECENT_SCHEMES_LIMIT) }),
 
   getEffectiveTheme: (): ITheme => {
-    const { selectedSchemeId, customSchemes } = get();
-    return computeEffectiveTheme(selectedSchemeId, customSchemes);
+    const state = get();
+    return computeEffectiveTheme(resolveActiveSchemeId(state), state.customSchemes);
   },
 }));


### PR DESCRIPTION
## Summary

- Hover over a theme card now temporarily applies it to the full app UI via `injectTheme()`, reverting on mouse-leave with rAF debouncing. Click commits and keeps the modal open.
- Terminal colour scheme picker gets the same treatment via a new `previewSchemeId` override in `terminalColorSchemeStore`, so xterm repaints live.
- Escape/close reverts to the theme that was active when the modal opened, not whatever was last previewed.

Resolves #5068

## Changes

- `ThemeSelector`: new `onPreviewItem`/`onPreviewEnd`/`previewAnnouncement` props with pointer and keyboard focus parity, rAF-debounced revert, and a permanently mounted `aria-live` region
- `AppThemePicker`: wires hover previews via `injectTheme`; click no longer closes modal; close handler syncs DOM back to the committed store state; unmount cleanup for tab-switch safety
- `terminalColorSchemeStore`: `previewSchemeId` override consulted by selectors and `getEffectiveTheme`; `useTerminalConfig` subscribes so xterm repaints without a full remount
- `ColorSchemePicker`: wires store preview override on hover, focus, commit, and unmount
- `e2e/full/core-settings-tabs.spec.ts`: updated to assert the theme dialog stays open after selection

## Testing

266 affected unit tests pass. Added 20 new test cases across `ThemeSelector.test`, `AppThemePicker.preview.test` (new), `ColorSchemePicker.preview.test` (new), and `terminalColorSchemeStore.test`. Lint, typecheck, and format all clean.