### PR TITLE
fix(terminal): make standard terminals robust against xterm DOM renderer pausing

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -29,6 +29,7 @@ export interface HibernationManagerDeps {
   clearDirectingState: (id: string) => void;
   onUserInput: (id: string, data: string) => void;
   onEnterPressed: (id: string) => void;
+  onWriteParsedReflow?: (managed: ManagedTerminal) => void;
 }
 
 export class TerminalHibernationManager {
@@ -181,6 +182,7 @@ export class TerminalHibernationManager {
       if (managed && !managed.isUserScrolledBack && !managed.isAltBuffer) {
         this.deps.scrollToBottomSafe(managed);
       }
+      this.deps.onWriteParsedReflow?.(managed);
     });
     managed.listeners.push(() => writeParsedDisposable.dispose());
 
@@ -339,6 +341,24 @@ export class TerminalHibernationManager {
     managed.restoreGeneration += 1;
     managed.isSerializedRestoreInProgress = false;
     managed.deferredOutput = [];
+    // Clear the reflow throttle so post-wake writes trigger an immediate
+    // IO re-evaluation.
+    managed.lastReflowAt = 0;
+
+    // Re-bind the fresh Terminal to its DOM host. Without this, the
+    // terminal exists in memory with a working buffer but no rendered
+    // output — a zombie. Only safe when the host has measurable
+    // dimensions (xterm.js measures character cell size during open()).
+    // If the host is offscreen/zero-sized, leave isOpened=false so
+    // TerminalInstanceService.attach() will open it on next mount.
+    if (hostElement.clientWidth > 0 && hostElement.clientHeight > 0) {
+      try {
+        terminal.open(hostElement);
+        managed.isOpened = true;
+      } catch (err) {
+        logError(`[TIS.unhibernate] terminal.open failed for ${id}`, err);
+      }
+    }
 
     managed.isHibernated = false;
     managed.isDetached = false;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -45,12 +45,20 @@ export { isNonKeyboardInput } from "./inputUtils";
  * isIntersecting=false, causing xterm to set _isPaused=true and halt rendering.
  * Sub-pixel padding jitter keeps the element in the layout tree throughout.
  */
-function forceXtermReflow(element: HTMLElement): void {
+export function forceXtermReflow(element: HTMLElement): void {
   const prev = element.style.paddingTop;
   element.style.paddingTop = "0.01px";
   void element.offsetHeight;
   element.style.paddingTop = prev;
 }
+
+// Throttle per-terminal reflows to bound layout cost under write bursts while
+// still recovering a paused DOM renderer within one write cadence window.
+const REFLOW_THROTTLE_MS = 250;
+
+// Periodic heartbeat interval — low frequency is enough to recover a paused
+// renderer that has no writes, without costing measurable CPU.
+const REFLOW_HEARTBEAT_MS = 3000;
 
 function canAutoInitializeTerminalIngest(): boolean {
   return (
@@ -82,6 +90,18 @@ class TerminalInstanceService {
   private agentStateController: TerminalAgentStateController;
   private restoreController: TerminalRestoreController;
   private hibernationManager: TerminalHibernationManager;
+  private reflowHeartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  private readonly _onVisibilityChange = (): void => {
+    if (typeof document === "undefined" || document.visibilityState !== "visible") return;
+    for (const managed of this.instances.values()) {
+      this.maybeReflowTerminal(managed);
+    }
+  };
+  private readonly _onWindowFocus = (): void => {
+    for (const managed of this.instances.values()) {
+      this.maybeReflowTerminal(managed);
+    }
+  };
 
   constructor() {
     if (canAutoInitializeTerminalIngest()) {
@@ -122,7 +142,29 @@ class TerminalInstanceService {
       clearDirectingState: (id) => this.agentStateController.clearDirectingState(id),
       onUserInput: (id, data) => this.onUserInput(id, data),
       onEnterPressed: (id) => this.onEnterPressed(id),
+      onWriteParsedReflow: (managed) => this.maybeReflowTerminal(managed),
     });
+
+    // Periodic heartbeat: recovers a DOM-renderer terminal whose
+    // IntersectionObserver has paused rendering, even while no new writes are
+    // arriving. Cheap (~1–5ms per visible non-agent terminal).
+    if (typeof setInterval === "function") {
+      this.reflowHeartbeatTimer = setInterval(() => {
+        for (const managed of this.instances.values()) {
+          this.maybeReflowTerminal(managed);
+        }
+      }, REFLOW_HEARTBEAT_MS);
+    }
+
+    // App-level recovery: reflow visible terminals whenever the window
+    // regains focus or the tab becomes visible. These are the moments a
+    // user is most likely to notice a blank terminal.
+    if (typeof document !== "undefined" && typeof document.addEventListener === "function") {
+      document.addEventListener("visibilitychange", this._onVisibilityChange);
+    }
+    if (typeof window !== "undefined" && typeof window.addEventListener === "function") {
+      window.addEventListener("focus", this._onWindowFocus);
+    }
 
     this.wakeManager = new TerminalWakeManager({
       getInstance: (id) => this.instances.get(id),
@@ -243,6 +285,36 @@ class TerminalInstanceService {
 
   notifyUserInput(id: string, data = ""): void {
     this.onUserInput(id, data);
+  }
+
+  /**
+   * Force an IntersectionObserver reflow on a standard terminal if it's
+   * eligible — used by onWriteParsed, the periodic heartbeat, and
+   * visibility/focus recovery paths. All guards live here so every caller
+   * stays consistent.
+   *
+   * Skips: agent terminals (WebGL, immune), hibernated/invisible/attaching
+   * terminals, alt-buffer (TUI) sessions, and terminals without a rendered
+   * element. Throttled per terminal.
+   */
+  private maybeReflowTerminal(managed: ManagedTerminal): void {
+    if (managed.kind === "agent") return;
+    if (managed.isHibernated) return;
+    if (!managed.isVisible) return;
+    if (managed.isAttaching) return;
+    if (managed.isAltBuffer) return;
+    const element = managed.terminal.element;
+    if (!element) return;
+
+    const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+    if (now - (managed.lastReflowAt ?? 0) < REFLOW_THROTTLE_MS) return;
+    managed.lastReflowAt = now;
+
+    try {
+      forceXtermReflow(element);
+    } catch (err) {
+      logWarn("forceXtermReflow failed", { error: err });
+    }
   }
 
   private onUserInput(id: string, data: string): void {
@@ -688,6 +760,7 @@ class TerminalInstanceService {
       if (managed && !managed.isUserScrolledBack && !managed.isAltBuffer) {
         this.scrollToBottomSafe(managed);
       }
+      this.maybeReflowTerminal(managed);
     });
     listeners.push(() => writeParsedDisposable.dispose());
 
@@ -1458,6 +1531,17 @@ class TerminalInstanceService {
       managed.terminal.refresh(0, managed.terminal.rows - 1);
 
       this.resizeController.fit(id);
+
+      // Force IO re-evaluation so a DOM-renderer terminal that got stuck
+      // with _isPaused=true actually resumes drawing. Without this, redraw
+      // only clears the atlas and refreshes rows — a paused renderer still
+      // renders nothing. This makes `terminal.redraw` a reliable user
+      // escape hatch for the IO pause bug.
+      const termEl = managed.terminal.element;
+      if (termEl) {
+        forceXtermReflow(termEl);
+        managed.lastReflowAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+      }
     } catch (error) {
       logError(`resetRenderer failed for ${id}`, error);
     }
@@ -1699,6 +1783,16 @@ class TerminalInstanceService {
 
   dispose(): void {
     this.stopPolling();
+    if (this.reflowHeartbeatTimer !== undefined) {
+      clearInterval(this.reflowHeartbeatTimer);
+      this.reflowHeartbeatTimer = undefined;
+    }
+    if (typeof document !== "undefined" && typeof document.removeEventListener === "function") {
+      document.removeEventListener("visibilitychange", this._onVisibilityChange);
+    }
+    if (typeof window !== "undefined" && typeof window.removeEventListener === "function") {
+      window.removeEventListener("focus", this._onWindowFocus);
+    }
     this.instances.forEach((_, id) => this.destroy(id));
     this.offscreenManager.dispose();
     this.wakeManager.dispose();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -305,6 +305,10 @@ class TerminalInstanceService {
     if (managed.isAltBuffer) return;
     const element = managed.terminal.element;
     if (!element) return;
+    // A transiently-detached element can't be unpaused by a reflow, and
+    // stamping lastReflowAt here would throttle away the next legitimate
+    // reflow once it's reattached.
+    if (!element.isConnected) return;
 
     const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     if (now - (managed.lastReflowAt ?? 0) < REFLOW_THROTTLE_MS) return;
@@ -1355,6 +1359,11 @@ class TerminalInstanceService {
       if (Number.isInteger(cols) && Number.isInteger(rows) && cols > 0 && rows > 0) {
         this.resizeController.sendPtyResize(id, cols, rows);
       }
+      // Clear throttle so any subsequent write triggers an immediate reflow;
+      // settled-strategy agents are WebGL so maybeReflowTerminal itself is a
+      // no-op, but the clear is cheap and keeps the post-wake contract
+      // uniform across paths.
+      managed.lastReflowAt = 0;
       return;
     }
 
@@ -1362,10 +1371,17 @@ class TerminalInstanceService {
     // reflect the current window size rather than pre-hibernation cache.
     // fit() already guards against offscreen/small terminals (returns null).
     const fitResult = this.resizeController.fit(id);
-    if (fitResult) return;
+    if (!fitResult) {
+      // Fallback: fit() returned null (terminal offscreen or container too small).
+      this.resizeController.forceImmediateResize(id);
+    }
 
-    // Fallback: fit() returned null (terminal offscreen or container too small).
-    this.resizeController.forceImmediateResize(id);
+    // Kick the IO unpause path for standard terminals that just woke up —
+    // without this, a renderer that was paused pre-hibernation can stay
+    // blank until the next write or the 3s heartbeat. Throttle is cleared
+    // first so this runs unconditionally.
+    managed.lastReflowAt = 0;
+    this.maybeReflowTerminal(managed);
   }
 
   private getResizeStrategyForTerminal(managed: ManagedTerminal): "default" | "settled" {
@@ -1530,20 +1546,28 @@ class TerminalInstanceService {
       managed.terminal.clearTextureAtlas();
       managed.terminal.refresh(0, managed.terminal.rows - 1);
 
-      this.resizeController.fit(id);
-
-      // Force IO re-evaluation so a DOM-renderer terminal that got stuck
-      // with _isPaused=true actually resumes drawing. Without this, redraw
-      // only clears the atlas and refreshes rows — a paused renderer still
-      // renders nothing. This makes `terminal.redraw` a reliable user
-      // escape hatch for the IO pause bug.
-      const termEl = managed.terminal.element;
-      if (termEl) {
-        forceXtermReflow(termEl);
-        managed.lastReflowAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+      try {
+        this.resizeController.fit(id);
+      } catch (error) {
+        logError(`resetRenderer fit failed for ${id}`, error);
       }
     } catch (error) {
       logError(`resetRenderer failed for ${id}`, error);
+    }
+
+    // Force IO re-evaluation so a DOM-renderer terminal that got stuck
+    // with _isPaused=true actually resumes drawing. Runs independently of
+    // the refresh/fit block so the user-invokable escape hatch works even
+    // when fit() throws. Clear the throttle so any follow-up automatic
+    // reflow (onWriteParsed, heartbeat, focus) fires immediately.
+    const termEl = managed.terminal.element;
+    if (termEl) {
+      try {
+        forceXtermReflow(termEl);
+      } catch (error) {
+        logWarn(`forceXtermReflow failed for ${id}`, { error });
+      }
+      managed.lastReflowAt = 0;
     }
   }
 

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -4,6 +4,33 @@ import { TerminalHibernationManager, HibernationManagerDeps } from "../TerminalH
 import type { ManagedTerminal } from "../types";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
+const { freshTerminalOpenMock, freshTerminalOnWriteParsed } = vi.hoisted(() => ({
+  freshTerminalOpenMock: vi.fn(),
+  freshTerminalOnWriteParsed: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: vi.fn(function MockTerminal(this: Record<string, unknown>) {
+    this.options = { scrollback: 5000 };
+    this.rows = 24;
+    this.cols = 80;
+    this.buffer = {
+      active: { length: 0, type: "normal", baseY: 0, viewportY: 0 },
+      onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+    this.parser = {
+      registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+    this.dispose = vi.fn();
+    this.open = freshTerminalOpenMock;
+    this.onData = vi.fn(() => ({ dispose: vi.fn() }));
+    this.onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    this.onWriteParsed = freshTerminalOnWriteParsed;
+    this.onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    this.getSelection = vi.fn(() => "");
+  }),
+}));
+
 vi.mock("@/clients", () => ({
   terminalClient: {
     write: vi.fn(),
@@ -54,9 +81,14 @@ function makeMockTerminal() {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     },
     dispose: vi.fn(),
+    open: vi.fn(),
     onData: vi.fn(() => ({ dispose: vi.fn() })),
     onScroll: vi.fn(() => ({ dispose: vi.fn() })),
-    onWriteParsed: vi.fn(() => ({ dispose: vi.fn() })),
+    onWriteParsed: vi.fn((cb: () => void) => {
+      // capture so tests can simulate a parsed write
+      (makeMockTerminal as unknown as { _lastWriteParsedCb?: () => void })._lastWriteParsedCb = cb;
+      return { dispose: vi.fn() };
+    }),
     onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
     getSelection: vi.fn(() => ""),
   };
@@ -139,6 +171,9 @@ describe("TerminalHibernationManager", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    freshTerminalOpenMock.mockReset();
+    freshTerminalOnWriteParsed.mockClear();
+    freshTerminalOnWriteParsed.mockImplementation(() => ({ dispose: vi.fn() }));
     managed = makeMockManaged();
     deps = makeMockDeps(managed);
     manager = new TerminalHibernationManager(deps);
@@ -313,6 +348,64 @@ describe("TerminalHibernationManager", () => {
       manager.unhibernate("t1");
 
       expect(managed.listeners.length).toBeGreaterThan(initialCount);
+    });
+
+    it("should open fresh terminal when host has non-zero dimensions", () => {
+      Object.defineProperty(managed.hostElement, "clientWidth", { value: 800, configurable: true });
+      Object.defineProperty(managed.hostElement, "clientHeight", {
+        value: 600,
+        configurable: true,
+      });
+
+      manager.unhibernate("t1");
+
+      expect(freshTerminalOpenMock).toHaveBeenCalledWith(managed.hostElement);
+      expect(managed.isOpened).toBe(true);
+    });
+
+    it("should leave isOpened=false when host is zero-sized and not call open", () => {
+      // jsdom hostElement has 0 clientWidth/clientHeight by default
+      manager.unhibernate("t1");
+
+      expect(freshTerminalOpenMock).not.toHaveBeenCalled();
+      expect(managed.isOpened).toBe(false);
+    });
+
+    it("should invoke onWriteParsedReflow when the fresh terminal emits a parsed write", () => {
+      const onWriteParsedReflow = vi.fn();
+      deps.onWriteParsedReflow = onWriteParsedReflow;
+
+      manager.unhibernate("t1");
+
+      // Grab the last registered onWriteParsed callback and invoke it
+      const callback = freshTerminalOnWriteParsed.mock.calls.at(-1)?.[0] as
+        | (() => void)
+        | undefined;
+      expect(callback).toBeTypeOf("function");
+      callback!();
+
+      expect(onWriteParsedReflow).toHaveBeenCalledWith(managed);
+    });
+
+    it("should reset lastReflowAt so next reflow fires immediately", () => {
+      managed.lastReflowAt = 99999;
+      manager.unhibernate("t1");
+      expect(managed.lastReflowAt).toBe(0);
+    });
+
+    it("should not throw if terminal.open throws (bad host)", () => {
+      Object.defineProperty(managed.hostElement, "clientWidth", { value: 800, configurable: true });
+      Object.defineProperty(managed.hostElement, "clientHeight", {
+        value: 600,
+        configurable: true,
+      });
+      freshTerminalOpenMock.mockImplementationOnce(() => {
+        throw new Error("boom");
+      });
+
+      expect(() => manager.unhibernate("t1")).not.toThrow();
+      // Left as not opened on failure so attach() can retry
+      expect(managed.isOpened).toBe(false);
     });
 
     it("should not leak listeners across hibernate/unhibernate cycles", () => {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -377,10 +377,11 @@ describe("TerminalHibernationManager", () => {
 
       manager.unhibernate("t1");
 
-      // Grab the last registered onWriteParsed callback and invoke it
-      const callback = freshTerminalOnWriteParsed.mock.calls.at(-1)?.[0] as
-        | (() => void)
-        | undefined;
+      // Grab the last registered onWriteParsed callback and invoke it.
+      // The mock is declared without typed args, so coerce the call log to
+      // a shape we can index into.
+      const calls = freshTerminalOnWriteParsed.mock.calls as unknown as Array<[() => void]>;
+      const callback = calls.at(-1)?.[0];
       expect(callback).toBeTypeOf("function");
       callback!();
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({
+      visualBuffers: [],
+      signalBuffer: null,
+    })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+type ReflowTestService = {
+  instances: Map<string, ManagedTerminal>;
+  maybeReflowTerminal: (managed: ManagedTerminal) => void;
+  resetRenderer: (id: string) => void;
+  resizeController: { fit: (id: string) => unknown };
+};
+
+function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
+  const hostElement = document.createElement("div");
+  const termEl = document.createElement("div");
+  hostElement.appendChild(termEl);
+  // Force offsetHeight to be readable (jsdom returns 0, but the read still
+  // forces layout — we observe the side-effect via paddingTop jitter).
+  const paddingTopHistory: string[] = [];
+  const style = termEl.style;
+  const orig = Object.getOwnPropertyDescriptor(style, "paddingTop");
+  Object.defineProperty(style, "paddingTop", {
+    configurable: true,
+    get(): string {
+      return orig?.get?.call(style) ?? "";
+    },
+    set(value: string): void {
+      paddingTopHistory.push(value);
+      orig?.set?.call(style, value);
+    },
+  });
+  (termEl as HTMLDivElement & { __paddingTopHistory: string[] }).__paddingTopHistory =
+    paddingTopHistory;
+
+  return {
+    terminal: { element: termEl } as unknown as ManagedTerminal["terminal"],
+    type: "terminal",
+    kind: "terminal",
+    hostElement,
+    isOpened: true,
+    isVisible: true,
+    isFocused: false,
+    isHibernated: false,
+    isAttaching: false,
+    isUserScrolledBack: false,
+    isAltBuffer: false,
+    lastActiveTime: Date.now(),
+    lastWidth: 0,
+    lastHeight: 0,
+    lastAttachAt: 0,
+    lastDetachAt: 0,
+    lastReflowAt: 0,
+    latestCols: 80,
+    latestRows: 24,
+    latestWasAtBottom: true,
+    listeners: [],
+    exitSubscribers: new Set(),
+    agentStateSubscribers: new Set(),
+    altBufferListeners: new Set(),
+    writeChain: Promise.resolve(),
+    restoreGeneration: 0,
+    isSerializedRestoreInProgress: false,
+    deferredOutput: [],
+    scrollbackRestoreState: "none",
+    attachGeneration: 0,
+    attachRevealToken: 0,
+    keyHandlerInstalled: false,
+    ipcListenerCount: 0,
+    getRefreshTier: () => 0 as unknown as ManagedTerminal["lastAppliedTier"] as never,
+    fitAddon: { fit: vi.fn() } as unknown as ManagedTerminal["fitAddon"],
+    serializeAddon: { serialize: vi.fn() } as unknown as ManagedTerminal["serializeAddon"],
+    imageAddon: null,
+    searchAddon: {} as ManagedTerminal["searchAddon"],
+    fileLinksDisposable: null,
+    webLinksAddon: null,
+    ...overrides,
+  } as ManagedTerminal;
+}
+
+function paddingHistory(managed: ManagedTerminal): string[] {
+  const el = managed.terminal.element as unknown as { __paddingTopHistory: string[] };
+  return el.__paddingTopHistory;
+}
+
+describe("TerminalInstanceService maybeReflowTerminal", () => {
+  let service: ReflowTestService;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: ReflowTestService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+  });
+
+  it("reflows a visible standard terminal and records lastReflowAt", () => {
+    const managed = makeManaged();
+    service.maybeReflowTerminal(managed);
+
+    // paddingTop was set to "0.01px" then restored
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
+  it("throttles per-terminal reflows within 250ms", () => {
+    const managed = makeManaged();
+    service.maybeReflowTerminal(managed);
+    const history1 = paddingHistory(managed).length;
+
+    service.maybeReflowTerminal(managed);
+    const history2 = paddingHistory(managed).length;
+
+    // Second call short-circuited — no additional jitter writes
+    expect(history2).toBe(history1);
+  });
+
+  it("allows reflow again after the throttle window", () => {
+    const managed = makeManaged();
+    service.maybeReflowTerminal(managed);
+    const history1 = paddingHistory(managed).length;
+
+    // Simulate throttle window passing
+    managed.lastReflowAt = (managed.lastReflowAt ?? 0) - 500;
+    service.maybeReflowTerminal(managed);
+    const history2 = paddingHistory(managed).length;
+
+    expect(history2).toBeGreaterThan(history1);
+  });
+
+  it("skips agent terminals (WebGL — immune)", () => {
+    const managed = makeManaged({ kind: "agent" });
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed).length).toBe(0);
+    expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("skips hibernated terminals", () => {
+    const managed = makeManaged({ isHibernated: true });
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("skips invisible terminals", () => {
+    const managed = makeManaged({ isVisible: false });
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("skips alt-buffer (TUI) terminals", () => {
+    const managed = makeManaged({ isAltBuffer: true });
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("skips terminals that are mid-attach", () => {
+    const managed = makeManaged({ isAttaching: true });
+    service.maybeReflowTerminal(managed);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("skips when terminal has no rendered element yet", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { element: HTMLElement | undefined }).element = undefined;
+    service.maybeReflowTerminal(managed);
+    // lastReflowAt not set because we short-circuited on missing element
+    expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("resetRenderer calls forceXtermReflow on the terminal element", () => {
+    const managed = makeManaged();
+    // resetRenderer requires connected host element with clientWidth/Height >= 50
+    document.body.appendChild(managed.hostElement);
+    Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
+    Object.defineProperty(managed.hostElement, "clientHeight", { value: 200, configurable: true });
+    // Augment mock terminal with the methods resetRenderer needs
+    const term = managed.terminal as unknown as {
+      element: HTMLElement;
+      rows: number;
+      clearTextureAtlas: () => void;
+      refresh: (a: number, b: number) => void;
+    };
+    term.rows = 24;
+    term.clearTextureAtlas = vi.fn();
+    term.refresh = vi.fn();
+    service.instances.set("t1", managed);
+    // Stub fit to avoid jsdom's missing checkVisibility.
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
+
+    service.resetRenderer("t1");
+
+    expect(term.clearTextureAtlas).toHaveBeenCalled();
+    expect(term.refresh).toHaveBeenCalledWith(0, 23);
+    expect(paddingHistory(managed)).toContain("0.01px");
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -58,6 +58,10 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
   const hostElement = document.createElement("div");
   const termEl = document.createElement("div");
   hostElement.appendChild(termEl);
+  // maybeReflowTerminal short-circuits if element.isConnected is false, so
+  // attach to the document by default. Individual tests can detach the host
+  // to assert the disconnected-short-circuit path.
+  document.body.appendChild(hostElement);
   // Force offsetHeight to be readable (jsdom returns 0, but the read still
   // forces layout — we observe the side-effect via paddingTop jitter).
   const paddingTopHistory: string[] = [];
@@ -140,6 +144,7 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
 
   afterEach(() => {
     service.instances.clear();
+    document.body.innerHTML = "";
   });
 
   it("reflows a visible standard terminal and records lastReflowAt", () => {
@@ -215,13 +220,23 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(managed.lastReflowAt).toBe(0);
   });
 
-  it("resetRenderer calls forceXtermReflow on the terminal element", () => {
+  it("skips — and does not stamp throttle — when element is detached", () => {
     const managed = makeManaged();
-    // resetRenderer requires connected host element with clientWidth/Height >= 50
-    document.body.appendChild(managed.hostElement);
+    // Disconnect from document
+    managed.hostElement.remove();
+    expect((managed.terminal.element as HTMLElement).isConnected).toBe(false);
+
+    service.maybeReflowTerminal(managed);
+    // Throttle must NOT be stamped — otherwise the next legitimate reflow
+    // after reattachment would be suppressed for 250ms.
+    expect(managed.lastReflowAt).toBe(0);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("resetRenderer calls forceXtermReflow and clears the throttle", () => {
+    const managed = makeManaged({ lastReflowAt: 99999 });
     Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
     Object.defineProperty(managed.hostElement, "clientHeight", { value: 200, configurable: true });
-    // Augment mock terminal with the methods resetRenderer needs
     const term = managed.terminal as unknown as {
       element: HTMLElement;
       rows: number;
@@ -232,7 +247,6 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     term.clearTextureAtlas = vi.fn();
     term.refresh = vi.fn();
     service.instances.set("t1", managed);
-    // Stub fit to avoid jsdom's missing checkVisibility.
     vi.spyOn(service.resizeController, "fit").mockImplementation(() => null);
 
     service.resetRenderer("t1");
@@ -240,5 +254,32 @@ describe("TerminalInstanceService maybeReflowTerminal", () => {
     expect(term.clearTextureAtlas).toHaveBeenCalled();
     expect(term.refresh).toHaveBeenCalledWith(0, 23);
     expect(paddingHistory(managed)).toContain("0.01px");
+    // Throttle is cleared so the next onWriteParsed/heartbeat tick
+    // reflows immediately.
+    expect(managed.lastReflowAt).toBe(0);
+  });
+
+  it("resetRenderer still runs forceXtermReflow when fit() throws", () => {
+    const managed = makeManaged();
+    Object.defineProperty(managed.hostElement, "clientWidth", { value: 200, configurable: true });
+    Object.defineProperty(managed.hostElement, "clientHeight", { value: 200, configurable: true });
+    const term = managed.terminal as unknown as {
+      element: HTMLElement;
+      rows: number;
+      clearTextureAtlas: () => void;
+      refresh: (a: number, b: number) => void;
+    };
+    term.rows = 24;
+    term.clearTextureAtlas = vi.fn();
+    term.refresh = vi.fn();
+    service.instances.set("t1", managed);
+    vi.spyOn(service.resizeController, "fit").mockImplementation(() => {
+      throw new Error("fit boom");
+    });
+
+    expect(() => service.resetRenderer("t1")).not.toThrow();
+    // The escape hatch — forceXtermReflow — must still run even if fit throws.
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBe(0);
   });
 });

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -35,6 +35,9 @@ export interface ManagedTerminal {
   keyHandlerInstalled: boolean;
   lastAttachAt: number;
   lastDetachAt: number;
+  // Last time forceXtermReflow() ran for this terminal — used to throttle the
+  // IntersectionObserver unpause reflow across write/heartbeat/focus triggers.
+  lastReflowAt?: number;
   // Visibility tracking
   isVisible: boolean;
   lastActiveTime: number;


### PR DESCRIPTION
## Summary

- xterm.js 6.0's IntersectionObserver can silently set `_isPaused=true` on the DOM renderer when a parent layout change, CSS transform, or clip-path briefly drops `isIntersecting` below threshold. Standard terminals use the DOM renderer (agent terminals use WebGL and are structurally immune). The fix adds layered automatic recovery so a paused renderer heals itself without requiring the user to drag panels around.
- `TerminalHibernationManager.unhibernate()` was leaving fresh Terminal instances in a zombie state because `terminal.open()` was never called on the new instance. The renderer-policy-driven wake path would restore the buffer but never bind the DOM. Fixed with a dimension guard (defers to `attach()` when `clientWidth/Height` is zero).

Resolves #5085

## Changes

- New `maybeReflowTerminal()` helper with a 250ms per-terminal throttle. Guards skip agent terminals, hibernated terminals, invisible terminals, terminals that are attaching, alt-buffer mode, and detached elements.
- Reflow triggered on: `onWriteParsed` (initial mount + unhibernate paths), a 3s heartbeat covering idle terminals, `window.focus` and `document.visibilitychange` for the "came back and it was blank" case, and post-wake in `unhibernate()`.
- `resetRenderer()` augmented to call `forceXtermReflow` and clear the throttle timestamp, making the existing `terminal.redraw` action a reliable user-invokable escape hatch. Reflow now runs outside the `fit()` try block so it recovers a paused renderer even when `fit` throws.
- `TerminalHibernationManager.unhibernate()` now calls `terminal.open(hostElement)` on the fresh Terminal instance, guarded by `clientWidth/Height > 0`.

## Testing

17 new unit tests across two files:

- `TerminalHibernationManager.test.ts`: 5 new tests covering the open dimension guard (both branches), reflow dependency injection, open-failure tolerance, and `lastReflowAt` reset on unhibernate.
- `TerminalInstanceService.reflow.test.ts` (new, 12 tests): every guard condition, throttle behaviour, detached-element short-circuit, and the `resetRenderer` escape hatch including the fit-throws path.

All 463 terminal service tests pass. Typecheck, lint, and format clean.