### PR TITLE
feat(theme): accent colour override for themes

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -451,6 +451,7 @@ export const CHANNELS = {
   APP_THEME_SET_PREFERRED_DARK_SCHEME: "app-theme:set-preferred-dark-scheme",
   APP_THEME_SET_PREFERRED_LIGHT_SCHEME: "app-theme:set-preferred-light-scheme",
   APP_THEME_SET_RECENT_SCHEME_IDS: "app-theme:set-recent-scheme-ids",
+  APP_THEME_SET_ACCENT_COLOR_OVERRIDE: "app-theme:set-accent-color-override",
   APP_THEME_SYSTEM_APPEARANCE_CHANGED: "app-theme:system-appearance-changed",
 
   TELEMETRY_GET: "telemetry:get",

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -48,6 +48,21 @@ vi.mock("../../../../shared/theme/index.js", () => ({
     tokens: { "surface-canvas": "#1a1a2e" },
   })),
   normalizeAppColorScheme: vi.fn((s: unknown) => s),
+  normalizeAccentHex: vi.fn((value: unknown): string | null => {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const clean = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+    if (!/^[0-9a-f]{3}$|^[0-9a-f]{6}$/i.test(clean)) return null;
+    const expanded =
+      clean.length === 3
+        ? clean
+            .split("")
+            .map((char) => `${char}${char}`)
+            .join("")
+        : clean;
+    return `#${expanded.toLowerCase()}`;
+  }),
 }));
 
 vi.mock("../../utils.js", () => ({
@@ -232,6 +247,88 @@ describe("appTheme handlers", () => {
           followSystem: true,
           preferredDarkSchemeId: "custom-dark",
           recentSchemeIds: ["bondi"],
+        })
+      );
+    });
+  });
+
+  describe("setAccentColorOverride", () => {
+    it("persists a normalized hex color", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
+      await handler({}, "#AABBCC");
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ accentColorOverride: "#aabbcc" })
+      );
+    });
+
+    it("accepts a hex without leading #", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
+      await handler({}, "ff8040");
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ accentColorOverride: "#ff8040" })
+      );
+    });
+
+    it("persists null to clear the override", async () => {
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        accentColorOverride: "#ff0000",
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
+      await handler({}, null);
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({ accentColorOverride: null })
+      );
+    });
+
+    it("ignores malformed strings without mutating the store", async () => {
+      storeState.data.appTheme = { colorSchemeId: "daintree" };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
+      await handler({}, "not-a-color");
+      await handler({}, "rgb(0,0,0)");
+      await handler({}, 42);
+
+      const relevantCalls = storeMock.set.mock.calls.filter(
+        (c: unknown[]) =>
+          (c[1] as { accentColorOverride?: unknown }).accentColorOverride !== undefined
+      );
+      expect(relevantCalls).toHaveLength(0);
+    });
+
+    it("preserves other appTheme fields when persisting the override", async () => {
+      storeState.data.appTheme = {
+        colorSchemeId: "daintree",
+        followSystem: true,
+        recentSchemeIds: ["bondi"],
+      };
+      registerAppThemeHandlers();
+
+      const handler = getHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE);
+      await handler({}, "#112233");
+
+      expect(storeMock.set).toHaveBeenCalledWith(
+        "appTheme",
+        expect.objectContaining({
+          colorSchemeId: "daintree",
+          followSystem: true,
+          recentSchemeIds: ["bondi"],
+          accentColorOverride: "#112233",
         })
       );
     });

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -4,7 +4,11 @@ import { promises as fs } from "node:fs";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { parseAppThemeFile } from "../../utils/appThemeImporter.js";
-import { resolveAppTheme, normalizeAppColorScheme } from "../../../shared/theme/index.js";
+import {
+  resolveAppTheme,
+  normalizeAppColorScheme,
+  normalizeAccentHex,
+} from "../../../shared/theme/index.js";
 import { typedSend } from "../utils.js";
 import type {
   AppThemeConfig,
@@ -222,6 +226,27 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
   };
   ipcMain.handle(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS, handleSetRecentSchemeIds);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS));
+
+  const handleSetAccentColorOverride = async (
+    _event: Electron.IpcMainInvokeEvent,
+    color: unknown
+  ) => {
+    let normalized: string | null = null;
+    if (color !== null && color !== undefined) {
+      normalized = normalizeAccentHex(color);
+      if (normalized === null) {
+        console.warn("Invalid accent color override:", color);
+        return;
+      }
+    }
+    const current = getAppThemeConfig();
+    store.set("appTheme", {
+      ...current,
+      accentColorOverride: normalized,
+    } satisfies AppThemeConfig);
+  };
+  ipcMain.handle(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE, handleSetAccentColorOverride);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE));
 
   // nativeTheme listener for auto-switching
   let appearanceTimer: ReturnType<typeof setTimeout> | null = null;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2556,6 +2556,9 @@ const api: ElectronAPI = {
     setRecentSchemeIds: (ids: string[]) =>
       _unwrappingInvoke(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS, ids),
 
+    setAccentColorOverride: (color: string | null) =>
+      _unwrappingInvoke(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE, color),
+
     onSystemAppearanceChanged: (
       callback: (payload: { isDark: boolean; schemeId: string }) => void
     ) => _typedOn(CHANNELS.APP_THEME_SYSTEM_APPEARANCE_CHANGED, callback),

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -861,6 +861,7 @@ const CHANNELS = {
   APP_THEME_SET_PREFERRED_DARK_SCHEME: "app-theme:set-preferred-dark-scheme",
   APP_THEME_SET_PREFERRED_LIGHT_SCHEME: "app-theme:set-preferred-light-scheme",
   APP_THEME_SET_RECENT_SCHEME_IDS: "app-theme:set-recent-scheme-ids",
+  APP_THEME_SET_ACCENT_COLOR_OVERRIDE: "app-theme:set-accent-color-override",
   APP_THEME_SYSTEM_APPEARANCE_CHANGED: "app-theme:system-appearance-changed",
 
   // Telemetry channels

--- a/shared/theme/__tests__/accentOverride.test.ts
+++ b/shared/theme/__tests__/accentOverride.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAccentOverrideToScheme,
+  BUILT_IN_APP_SCHEMES,
+  computeAccentOverrideTokens,
+  normalizeAccentHex,
+} from "../themes.js";
+import type { AppColorScheme } from "../types.js";
+
+const darkScheme = BUILT_IN_APP_SCHEMES.find((s) => s.type === "dark")!;
+const lightScheme = BUILT_IN_APP_SCHEMES.find((s) => s.type === "light")!;
+
+describe("normalizeAccentHex", () => {
+  it("canonicalizes 6-digit hex to lowercase with leading #", () => {
+    expect(normalizeAccentHex("#AABBCC")).toBe("#aabbcc");
+    expect(normalizeAccentHex("aabbcc")).toBe("#aabbcc");
+    expect(normalizeAccentHex("  #AaBbCc  ")).toBe("#aabbcc");
+  });
+
+  it("expands 3-digit shorthand to full hex", () => {
+    expect(normalizeAccentHex("#abc")).toBe("#aabbcc");
+    expect(normalizeAccentHex("f0a")).toBe("#ff00aa");
+  });
+
+  it("rejects invalid input", () => {
+    expect(normalizeAccentHex("")).toBeNull();
+    expect(normalizeAccentHex("rgb(0,0,0)")).toBeNull();
+    expect(normalizeAccentHex("#gggggg")).toBeNull();
+    expect(normalizeAccentHex("#12345")).toBeNull();
+    expect(normalizeAccentHex("#1234567")).toBeNull();
+    expect(normalizeAccentHex(null)).toBeNull();
+    expect(normalizeAccentHex(undefined)).toBeNull();
+    expect(normalizeAccentHex(123)).toBeNull();
+  });
+});
+
+describe("computeAccentOverrideTokens", () => {
+  it("returns the hex as accent-primary and computes rgb triplet", () => {
+    const tokens = computeAccentOverrideTokens("#ff8040", darkScheme);
+    expect(tokens["accent-primary"]).toBe("#ff8040");
+    expect(tokens["accent-rgb"]).toBe("255, 128, 64");
+  });
+
+  it("normalizes the input hex before derivation", () => {
+    const tokens = computeAccentOverrideTokens("AABBCC", darkScheme);
+    expect(tokens["accent-primary"]).toBe("#aabbcc");
+    expect(tokens["accent-rgb"]).toBe("170, 187, 204");
+  });
+
+  it("brightens accent-hover for dark schemes and darkens for light schemes", () => {
+    const dark = computeAccentOverrideTokens("#3366ff", darkScheme);
+    const light = computeAccentOverrideTokens("#3366ff", lightScheme);
+    expect(dark["accent-hover"]).toBe("color-mix(in oklab, #3366ff 90%, #ffffff)");
+    expect(light["accent-hover"]).toBe("color-mix(in oklab, #3366ff 90%, #000000)");
+  });
+
+  it("uses higher alpha for soft/muted on dark than on light", () => {
+    const dark = computeAccentOverrideTokens("#3366ff", darkScheme);
+    const light = computeAccentOverrideTokens("#3366ff", lightScheme);
+    expect(dark["accent-soft"]).toBe("rgba(51, 102, 255, 0.18)");
+    expect(dark["accent-muted"]).toBe("rgba(51, 102, 255, 0.3)");
+    expect(light["accent-soft"]).toBe("rgba(51, 102, 255, 0.12)");
+    expect(light["accent-muted"]).toBe("rgba(51, 102, 255, 0.2)");
+  });
+
+  it("picks a high-contrast accent-foreground for a very light accent", () => {
+    // A near-white accent must choose a dark foreground for readability.
+    const tokens = computeAccentOverrideTokens("#fafafa", darkScheme);
+    // Candidate order: text-inverse, text-primary, #ffffff, #000000.
+    // On a dark theme, text-inverse is dark, so contrast is very high.
+    // Either way, the winner must NOT be #ffffff.
+    expect(tokens["accent-foreground"]).not.toBe("#ffffff");
+  });
+
+  it("picks a high-contrast accent-foreground for a very dark accent", () => {
+    const tokens = computeAccentOverrideTokens("#050505", lightScheme);
+    expect(tokens["accent-foreground"]).not.toBe("#000000");
+  });
+
+  it("throws on invalid hex input", () => {
+    expect(() => computeAccentOverrideTokens("not-a-color", darkScheme)).toThrow();
+  });
+});
+
+describe("applyAccentOverrideToScheme", () => {
+  it("returns the original scheme reference when override is null/undefined/invalid", () => {
+    expect(applyAccentOverrideToScheme(darkScheme, null)).toBe(darkScheme);
+    expect(applyAccentOverrideToScheme(darkScheme, undefined)).toBe(darkScheme);
+    expect(applyAccentOverrideToScheme(darkScheme, "")).toBe(darkScheme);
+    expect(applyAccentOverrideToScheme(darkScheme, "not-hex")).toBe(darkScheme);
+  });
+
+  it("patches all six accent tokens without mutating the input scheme", () => {
+    const originalAccent = darkScheme.tokens["accent-primary"];
+    const patched = applyAccentOverrideToScheme(darkScheme, "#ff0000");
+    expect(patched).not.toBe(darkScheme);
+    expect(darkScheme.tokens["accent-primary"]).toBe(originalAccent);
+    expect(patched.tokens["accent-primary"]).toBe("#ff0000");
+    expect(patched.tokens["accent-hover"]).toContain("#ff0000");
+    expect(patched.tokens["accent-soft"]).toContain("255, 0, 0");
+    expect(patched.tokens["accent-muted"]).toContain("255, 0, 0");
+    expect(patched.tokens["accent-rgb"]).toBe("255, 0, 0");
+    // All non-accent tokens untouched.
+    expect(patched.tokens["surface-canvas"]).toBe(darkScheme.tokens["surface-canvas"]);
+    expect(patched.tokens["text-primary"]).toBe(darkScheme.tokens["text-primary"]);
+  });
+
+  it("preserves scheme metadata (id, name, type, builtin)", () => {
+    const patched = applyAccentOverrideToScheme(darkScheme, "#00ff00");
+    expect(patched.id).toBe(darkScheme.id);
+    expect(patched.name).toBe(darkScheme.name);
+    expect(patched.type).toBe(darkScheme.type);
+    expect(patched.builtin).toBe(darkScheme.builtin);
+  });
+
+  it("also merges override into a synthetic scheme with custom tokens", () => {
+    const synthetic: AppColorScheme = {
+      ...lightScheme,
+      id: "synthetic",
+      name: "Synthetic",
+      builtin: false,
+    };
+    const patched = applyAccentOverrideToScheme(synthetic, "#123456");
+    expect(patched.tokens["accent-primary"]).toBe("#123456");
+    expect(patched.id).toBe("synthetic");
+  });
+});

--- a/shared/theme/themes.ts
+++ b/shared/theme/themes.ts
@@ -382,6 +382,93 @@ export function hexToRgbTriplet(hex: string): string {
   return `${red}, ${green}, ${blue}`;
 }
 
+/**
+ * Normalize a user-supplied accent color to canonical lowercase `#rrggbb`.
+ * Accepts values with or without a leading `#`, case-insensitive, 3-digit or
+ * 6-digit hex. Returns `null` for any other input. Used as the single source of
+ * truth for accent override validation on both sides of the IPC boundary.
+ */
+export function normalizeAccentHex(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const clean = trimmed.startsWith("#") ? trimmed.slice(1) : trimmed;
+  if (!/^[0-9a-f]{3}$|^[0-9a-f]{6}$/i.test(clean)) return null;
+  const expanded =
+    clean.length === 3
+      ? clean
+          .split("")
+          .map((char) => `${char}${char}`)
+          .join("")
+      : clean;
+  return `#${expanded.toLowerCase()}`;
+}
+
+/**
+ * Derive the six accent tokens from a single user-picked hex color. Mirrors
+ * the formulas in `createCanopyTokens` so the override is indistinguishable
+ * from a theme's native accent.
+ *
+ * - `accent-primary`: the hex itself
+ * - `accent-hover`: `color-mix(in oklab, hex 90%, #fff/#000)` (brightened for dark, darkened for light)
+ * - `accent-soft`: `rgba(triplet, 0.18 dark / 0.12 light)`
+ * - `accent-muted`: `rgba(triplet, 0.30 dark / 0.20 light)`
+ * - `accent-rgb`: `R, G, B` triplet for use inside `rgba(var(--theme-accent-rgb), a)`
+ * - `accent-foreground`: best WCAG contrast from the scheme's own text-inverse / text-primary + white/black
+ */
+export function computeAccentOverrideTokens(
+  accentHex: string,
+  baseScheme: Pick<AppColorScheme, "type" | "tokens">
+): Pick<
+  AppColorSchemeTokens,
+  | "accent-primary"
+  | "accent-hover"
+  | "accent-foreground"
+  | "accent-soft"
+  | "accent-muted"
+  | "accent-rgb"
+> {
+  const normalized = normalizeAccentHex(accentHex);
+  if (!normalized) {
+    throw new Error(`computeAccentOverrideTokens: invalid accent hex "${accentHex}"`);
+  }
+  const dark = baseScheme.type === "dark";
+  return {
+    "accent-primary": normalized,
+    "accent-hover": `color-mix(in oklab, ${normalized} 90%, ${dark ? "#ffffff" : "#000000"})`,
+    "accent-soft": withAlpha(normalized, dark ? 0.18 : 0.12),
+    "accent-muted": withAlpha(normalized, dark ? 0.3 : 0.2),
+    "accent-rgb": hexToRgbTriplet(normalized),
+    "accent-foreground": pickReadableForeground(normalized, [
+      baseScheme.tokens["text-inverse"],
+      baseScheme.tokens["text-primary"],
+      "#ffffff",
+      "#000000",
+    ]),
+  };
+}
+
+/**
+ * Return a new scheme with accent tokens patched from the override hex, or the
+ * same scheme reference when no (valid) override is active. Safe to pass an
+ * invalid hex — the input is silently returned unchanged, matching the
+ * no-override branch so callers can call unconditionally.
+ */
+export function applyAccentOverrideToScheme(
+  scheme: AppColorScheme,
+  accentHex: string | null | undefined
+): AppColorScheme {
+  const normalized = normalizeAccentHex(accentHex);
+  if (!normalized) return scheme;
+  return {
+    ...scheme,
+    tokens: {
+      ...scheme.tokens,
+      ...computeAccentOverrideTokens(normalized, scheme),
+    },
+  };
+}
+
 export function getAppThemeById(
   id: string,
   customSchemes: AppColorScheme[] = []

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -214,6 +214,11 @@ export interface AppThemeConfig {
   preferredLightSchemeId?: string;
   /** IDs of the most recently selected themes (LRU, newest first, capped at 5) */
   recentSchemeIds?: string[];
+  /**
+   * User-chosen accent color (canonical #rrggbb) that overrides the active
+   * theme's accent token family. Cleared when set to null/undefined.
+   */
+  accentColorOverride?: string | null;
 }
 
 export interface AppThemeValidationWarning {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1085,6 +1085,7 @@ export interface ElectronAPI {
     setPreferredDarkScheme(schemeId: string): Promise<void>;
     setPreferredLightScheme(schemeId: string): Promise<void>;
     setRecentSchemeIds(ids: string[]): Promise<void>;
+    setAccentColorOverride(color: string | null): Promise<void>;
     onSystemAppearanceChanged(
       callback: (payload: { isDark: boolean; schemeId: string }) => void
     ): () => void;

--- a/src/clients/appThemeClient.ts
+++ b/src/clients/appThemeClient.ts
@@ -40,4 +40,8 @@ export const appThemeClient = {
   setRecentSchemeIds: (ids: string[]): Promise<void> => {
     return window.electron.appTheme.setRecentSchemeIds(ids);
   },
+
+  setAccentColorOverride: (color: string | null): Promise<void> => {
+    return window.electron.appTheme.setAccentColorOverride(color);
+  },
 } as const;

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type ChangeEvent,
+  type FormEvent,
   type MouseEvent,
 } from "react";
 import { AlertTriangle, Monitor, Palette, Shuffle } from "lucide-react";
@@ -177,9 +178,9 @@ export function AppThemePicker() {
   }, [accentColorOverride, selectedScheme]);
 
   const handleAccentInput = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
+    (e: FormEvent<HTMLInputElement>) => {
       // Live preview during drag — Zustand only, no IPC write spam.
-      setAccentColorOverride(e.target.value);
+      setAccentColorOverride(e.currentTarget.value);
     },
     [setAccentColorOverride]
   );

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type MouseEvent,
+} from "react";
 import { AlertTriangle, Monitor, Palette, Shuffle } from "lucide-react";
 import { ThemeSelector } from "./ThemeSelector";
 import { cn } from "@/lib/utils";
@@ -6,7 +14,7 @@ import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
 import { injectSchemeToDOM, useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
 import { prefersReducedMotion, runThemeReveal } from "@/lib/appThemeViewTransition";
-import { resolveAppTheme } from "@shared/theme";
+import { applyAccentOverrideToScheme, resolveAppTheme } from "@shared/theme";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { APP_THEME_PREVIEW_KEYS, getAppThemeWarnings } from "@shared/theme";
@@ -109,6 +117,8 @@ export function AppThemePicker() {
   const setPreferredDarkSchemeId = useAppThemeStore((s) => s.setPreferredDarkSchemeId);
   const preferredLightSchemeId = useAppThemeStore((s) => s.preferredLightSchemeId);
   const setPreferredLightSchemeId = useAppThemeStore((s) => s.setPreferredLightSchemeId);
+  const accentColorOverride = useAppThemeStore((s) => s.accentColorOverride);
+  const setAccentColorOverride = useAppThemeStore((s) => s.setAccentColorOverride);
   const [importWarnings, setImportWarnings] = useState<AppThemeValidationWarning[]>([]);
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const [open, setOpen] = useState(false);
@@ -145,9 +155,52 @@ export function AppThemePicker() {
   );
 
   const warningsByScheme = useMemo(
-    () => new Map(allSchemes.map((scheme) => [scheme.id, getAppThemeWarnings(scheme)])),
-    [allSchemes]
+    () =>
+      new Map(
+        allSchemes.map((scheme) => [
+          scheme.id,
+          getAppThemeWarnings(applyAccentOverrideToScheme(scheme, accentColorOverride)),
+        ])
+      ),
+    [allSchemes, accentColorOverride]
   );
+
+  const effectiveAccent = useMemo(
+    () => accentColorOverride ?? selectedScheme.tokens["accent-primary"],
+    [accentColorOverride, selectedScheme]
+  );
+  // Native <input type="color"> only accepts #rrggbb. Fall back to black if the
+  // theme's accent-primary is a non-hex expression (e.g. oklch()).
+  const pickerValue = useMemo(() => {
+    const candidate = accentColorOverride ?? selectedScheme.tokens["accent-primary"];
+    return /^#[0-9a-f]{6}$/i.test(candidate) ? candidate.toLowerCase() : "#000000";
+  }, [accentColorOverride, selectedScheme]);
+
+  const handleAccentInput = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      // Live preview during drag — Zustand only, no IPC write spam.
+      setAccentColorOverride(e.target.value);
+    },
+    [setAccentColorOverride]
+  );
+
+  const handleAccentCommit = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      // Persist on release/close.
+      setAccentColorOverride(e.target.value);
+      appThemeClient.setAccentColorOverride(e.target.value).catch((error) => {
+        console.error("Failed to persist accent color override:", error);
+      });
+    },
+    [setAccentColorOverride]
+  );
+
+  const handleAccentReset = useCallback(() => {
+    setAccentColorOverride(null);
+    appThemeClient.setAccentColorOverride(null).catch((error) => {
+      console.error("Failed to clear accent color override:", error);
+    });
+  }, [setAccentColorOverride]);
 
   const handleSelect = useCallback(
     async (id: string, origin?: { x: number; y: number }) => {
@@ -335,12 +388,15 @@ export function AppThemePicker() {
   const handleExport = useCallback(async () => {
     if (!selectedScheme) return;
     try {
-      await appThemeClient.exportTheme(selectedScheme);
+      // Bake the accent override into the exported scheme tokens so
+      // downstream users of the exported JSON see the user's chosen accent.
+      const effectiveScheme = applyAccentOverrideToScheme(selectedScheme, accentColorOverride);
+      await appThemeClient.exportTheme(effectiveScheme);
     } catch (error) {
       console.error("Failed to export app theme:", error);
       setImportMessage("Failed to export app theme.");
     }
-  }, [selectedScheme]);
+  }, [selectedScheme, accentColorOverride]);
 
   const selectedWarnings = warningsByScheme.get(selectedScheme.id) ?? [];
 
@@ -447,6 +503,51 @@ export function AppThemePicker() {
           </div>
         </div>
       </button>
+
+      <section
+        aria-label="Accent color"
+        className="flex items-center gap-3 p-2 rounded-[var(--radius-md)] border border-canopy-border bg-canopy-bg"
+      >
+        <label
+          htmlFor="accent-color-override-input"
+          className="relative shrink-0 cursor-pointer"
+          style={{ width: 32, height: 32 }}
+        >
+          <div
+            className="w-full h-full rounded-md border border-canopy-border"
+            style={{ backgroundColor: effectiveAccent }}
+            aria-hidden="true"
+          />
+          <input
+            id="accent-color-override-input"
+            data-testid="accent-color-override-input"
+            type="color"
+            value={pickerValue}
+            onInput={handleAccentInput}
+            onChange={handleAccentCommit}
+            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+            aria-label="Accent color"
+          />
+        </label>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-canopy-text">Accent color</div>
+          <div className="text-xs text-canopy-text/60">
+            {accentColorOverride
+              ? `Overriding theme accent (${effectiveAccent})`
+              : "Click the swatch to override the theme accent"}
+          </div>
+        </div>
+        {accentColorOverride && (
+          <button
+            type="button"
+            onClick={handleAccentReset}
+            data-testid="accent-color-override-reset"
+            className="text-xs text-canopy-accent hover:text-canopy-accent/80 transition-colors shrink-0"
+          >
+            Reset to theme default
+          </button>
+        )}
+      </section>
 
       <AppDialog
         isOpen={open}

--- a/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
@@ -71,6 +71,7 @@ vi.mock("@shared/theme", () => ({
     background: "--canopy-bg",
   },
   getAppThemeWarnings: () => [],
+  applyAccentOverrideToScheme: (scheme: unknown) => scheme,
   resolveAppTheme: (id: string, customSchemes: { id: string }[]) => {
     const map: Record<string, { id: string; name: string; type: string; tokens: object }> = {
       "theme-a": { id: "theme-a", name: "Theme A", type: "dark", tokens: {} },
@@ -168,6 +169,8 @@ describe("AppThemePicker hover preview", () => {
       setPreferredLightSchemeId: vi.fn(),
       setRecentSchemeIds: vi.fn(),
       addCustomScheme: vi.fn(),
+      accentColorOverride: null,
+      setAccentColorOverride: vi.fn(),
     });
   });
 

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@shared/theme", () => ({
     background: "--canopy-bg",
   },
   getAppThemeWarnings: () => [],
+  applyAccentOverrideToScheme: (scheme: unknown) => scheme,
   resolveAppTheme: (id: string, customSchemes: { id: string }[]) => {
     const map: Record<string, { id: string; name: string; type: string; tokens: object }> = {
       "theme-a": { id: "theme-a", name: "Theme A", type: "dark", tokens: {} },
@@ -110,6 +111,8 @@ describe("AppThemePicker shuffle button", () => {
       setPreferredLightSchemeId: vi.fn(),
       setRecentSchemeIds: vi.fn(),
       addCustomScheme: vi.fn(),
+      accentColorOverride: null,
+      setAccentColorOverride: vi.fn(),
     });
   });
 

--- a/src/hooks/useAppThemeConfig.ts
+++ b/src/hooks/useAppThemeConfig.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
-import { normalizeAppColorScheme } from "@shared/theme";
+import { normalizeAccentHex, normalizeAppColorScheme } from "@shared/theme";
 import type { AppColorScheme } from "@shared/types/appTheme";
 import type { ColorVisionMode } from "@shared/types";
 
@@ -35,6 +35,15 @@ export function useAppThemeConfig() {
           } catch {
             // ignore malformed custom schemes
           }
+        }
+
+        // Seed accent override before scheme injection so the first injection
+        // already reflects the persisted override. Use the raw Zustand setter
+        // (not setAccentColorOverride) to avoid a redundant DOM inject — the
+        // subsequent setSelectedSchemeIdSilent call below performs it once.
+        const normalizedAccent = normalizeAccentHex(config.accentColorOverride);
+        if (normalizedAccent || config.accentColorOverride === null) {
+          useAppThemeStore.setState({ accentColorOverride: normalizedAccent });
         }
 
         if (typeof config.colorSchemeId === "string" && config.colorSchemeId.trim()) {

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest";
-import { DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
+import { BUILT_IN_APP_SCHEMES, DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
 import { useAppThemeStore } from "../appThemeStore";
 
 describe("appThemeStore.recentSchemeIds LRU", () => {
@@ -13,6 +13,7 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
       preferredDarkSchemeId: "daintree",
       preferredLightSchemeId: "bondi",
       recentSchemeIds: [],
+      accentColorOverride: null,
     });
   });
 
@@ -90,6 +91,57 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
   it("setRecentSchemeIds deduplicates incoming entries", () => {
     useAppThemeStore.getState().setRecentSchemeIds(["a", "b", "a", "c", "b", "d"]);
     expect(useAppThemeStore.getState().recentSchemeIds).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("setAccentColorOverride patches the CSS variables on :root", () => {
+    // Start from a known dark built-in so base accent is a predictable hex.
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("daintree");
+    const baseAccent = document.documentElement.style.getPropertyValue("--theme-accent-primary");
+    expect(baseAccent).toBeTruthy();
+
+    useAppThemeStore.getState().setAccentColorOverride("#ff00aa");
+    expect(useAppThemeStore.getState().accentColorOverride).toBe("#ff00aa");
+    const overridden = document.documentElement.style.getPropertyValue("--theme-accent-primary");
+    expect(overridden).toBe("#ff00aa");
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-rgb")).toBe(
+      "255, 0, 170"
+    );
+    // Non-accent tokens should be unchanged from the base theme.
+    const daintree = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
+    expect(document.documentElement.style.getPropertyValue("--theme-surface-canvas")).toBe(
+      daintree.tokens["surface-canvas"]
+    );
+  });
+
+  it("setAccentColorOverride(null) clears the override and restores theme accent", () => {
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("daintree");
+    const daintree = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
+
+    useAppThemeStore.getState().setAccentColorOverride("#112233");
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      "#112233"
+    );
+
+    useAppThemeStore.getState().setAccentColorOverride(null);
+    expect(useAppThemeStore.getState().accentColorOverride).toBeNull();
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      daintree.tokens["accent-primary"]
+    );
+  });
+
+  it("override survives a subsequent setSelectedSchemeId (theme switch)", () => {
+    useAppThemeStore.getState().setAccentColorOverride("#abcdef");
+    // Switch to a different theme — the override must still be applied.
+    useAppThemeStore.getState().setSelectedSchemeId("bondi");
+    expect(useAppThemeStore.getState().accentColorOverride).toBe("#abcdef");
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      "#abcdef"
+    );
+    // And setSelectedSchemeIdSilent (follow-system, hydration) path too.
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("daintree");
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      "#abcdef"
+    );
   });
 
   it("removeCustomScheme strips the removed id from recentSchemeIds", () => {

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { BUILT_IN_APP_SCHEMES, DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
-import { resolveAppTheme, type AppColorScheme } from "@shared/theme";
+import { applyAccentOverrideToScheme, resolveAppTheme, type AppColorScheme } from "@shared/theme";
 import type { ColorVisionMode } from "@shared/types";
 import { applyAppThemeToRoot, applyColorVisionMode } from "@/theme/applyAppTheme";
 
@@ -14,6 +14,7 @@ interface AppThemeState {
   preferredDarkSchemeId: string;
   preferredLightSchemeId: string;
   recentSchemeIds: string[];
+  accentColorOverride: string | null;
   setSelectedSchemeId: (id: string) => void;
   /**
    * Updates Zustand state for a deliberate scheme selection (selectedSchemeId
@@ -36,12 +37,18 @@ interface AppThemeState {
   setPreferredDarkSchemeId: (id: string) => void;
   setPreferredLightSchemeId: (id: string) => void;
   setRecentSchemeIds: (ids: string[]) => void;
+  setAccentColorOverride: (color: string | null) => void;
 }
 
 function injectSchemeToDOM(scheme: AppColorScheme): void {
-  applyAppThemeToRoot(document.documentElement, scheme);
+  // Read accent override + CVD from the store on every injection so the
+  // modal-close revert, follow-system switch, unmount cleanup, and hover
+  // preview paths all pick up the current user overrides without each
+  // callsite having to reapply them.
+  const { colorVisionMode, accentColorOverride } = useAppThemeStore.getState();
+  const effective = applyAccentOverrideToScheme(scheme, accentColorOverride);
+  applyAppThemeToRoot(document.documentElement, effective);
   // Reapply CVD overrides after theme injection so they aren't overwritten
-  const { colorVisionMode } = useAppThemeStore.getState();
   if (colorVisionMode !== "default") {
     applyColorVisionMode(document.documentElement, colorVisionMode);
   }
@@ -55,6 +62,7 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   preferredDarkSchemeId: "daintree",
   preferredLightSchemeId: "bondi",
   recentSchemeIds: [],
+  accentColorOverride: null,
 
   setSelectedSchemeId: (id) => {
     const { customSchemes } = useAppThemeStore.getState();
@@ -121,6 +129,15 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   setPreferredLightSchemeId: (id) => set({ preferredLightSchemeId: id }),
   setRecentSchemeIds: (ids) =>
     set({ recentSchemeIds: Array.from(new Set(ids)).slice(0, RECENT_SCHEMES_LIMIT) }),
+
+  setAccentColorOverride: (color) => {
+    set({ accentColorOverride: color });
+    // Re-inject the currently active scheme so the override (or its removal)
+    // takes effect immediately via the single injectSchemeToDOM pipeline.
+    const { selectedSchemeId, customSchemes } = useAppThemeStore.getState();
+    const scheme = resolveAppTheme(selectedSchemeId, customSchemes);
+    injectSchemeToDOM(scheme);
+  },
 }));
 
 export { injectSchemeToDOM };


### PR DESCRIPTION
## Summary

- Adds a colour picker to Appearance settings that lets users override the active theme's accent colour family without touching anything else
- Derived variants (hover, soft, muted) are computed algorithmically from the chosen base colour using oklab colour mixing, matching the existing theme system patterns
- The override persists across theme switches, is clearable via a \"Reset to theme default\" option, and is included in theme exports

Resolves #5074

## Changes

- `shared/theme/themes.ts` — `computeAccentOverride()` derives the full accent token family from a single hex colour; `applyAccentOverride()` injects CSS variables; `removeAccentOverride()` cleans up
- `shared/theme/types.ts` — adds `accentOverride` field to `AppThemeConfig`
- `electron/ipc/channels.ts` + `electron/ipc/handlers/appTheme.ts` — new `SET_ACCENT_OVERRIDE` IPC channel
- `electron/preload.cts` + `src/clients/appThemeClient.ts` — exposes `setAccentOverride` to the renderer
- `src/store/appThemeStore.ts` + `src/hooks/useAppThemeConfig.ts` — wires override state and re-applies on theme switch
- `src/components/Settings/AppThemePicker.tsx` — colour picker UI with reset option; contrast warning runs against the overridden accent

## Testing

- Unit tests cover `computeAccentOverride`, persistence across theme switches, and reset behaviour (`shared/theme/__tests__/accentOverride.test.ts`)
- IPC handler tests in `electron/ipc/handlers/__tests__/appTheme.handlers.test.ts`
- Store tests updated in `src/store/__tests__/appThemeStore.test.ts`
- Existing AppThemePicker tests pass unchanged