### PR TITLE
docs: add Kiro CLI to README agent list and install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Canopy is a desktop environment where multiple AI agents work side by side — isolated, observable, and under your control. Instead of juggling terminal windows and manually wiring context between tools, Canopy gives your agents a stable place to run while you focus on reviewing their work.
 
-It works with any CLI agent — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex](https://github.com/openai/codex), [OpenCode](https://github.com/anomalyco/opencode), [Cursor Agent](https://docs.cursor.com/agent) — and stays out of the way.
+It works with any CLI agent — [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Gemini CLI](https://github.com/google-gemini/gemini-cli), [Codex](https://github.com/openai/codex), [OpenCode](https://github.com/anomalyco/opencode), [Cursor Agent](https://docs.cursor.com/agent), [Kiro CLI](https://kiro.dev/docs/cli/chat/) — and stays out of the way.
 
 ---
 
@@ -103,6 +103,7 @@ npm install -g @google/gemini-cli           # Gemini CLI
 npm install -g @openai/codex                # Codex CLI
 npm install -g opencode-ai@latest           # OpenCode
 npm install -g @anthropic-ai/cursor-agent   # Cursor Agent
+curl -fsSL https://cli.kiro.dev/install | bash  # Kiro CLI (macOS/Linux)
 ```
 
 ---


### PR DESCRIPTION
summary                                                                             
                                                                                   
  - Add Kiro CLI to the supported agents list in the intro paragraph                  
  - Add curl install command for Kiro CLI (macOS/Linux) to the "Install Agent CLIs"   
  section                                                                             
                                                                                      
  Context                                                                             
                                                                                      
  Follow-up to #5019 which added Kiro as a built-in agent. This aligns the README with
   the updated agent registry.                          
                                                                                      
  Test plan                                                                           
                                                                                     
  - Verify README renders correctly on GitHub                                         
  - Confirm Kiro link resolves to https://kiro.dev/docs/cli/chat/
  - Confirm install command matches shared/config/agentRegistry.ts                    
                                                                                      
  🤖 Generated with Claude Code            