### PR TITLE
fix(hydration): preserve custom session names across project switches

### DIFF
--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -206,6 +206,24 @@ describe("buildArgsForBackendTerminal", () => {
     expect(result.agentId).toBe("claude");
     expect(result.kind).toBe("agent");
   });
+
+  it("prefers saved title over backend title to preserve user renames", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", title: "Shell" },
+      { id: "t1", location: "grid", title: "My Custom Name" },
+      "/p"
+    );
+    expect(result.title).toBe("My Custom Name");
+  });
+
+  it("falls back to backend title when saved title is missing", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", title: "Shell" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.title).toBe("Shell");
+  });
 });
 
 describe("buildArgsForReconnectedFallback", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -241,7 +241,7 @@ describe("buildArgsForReconnectedFallback", () => {
     const result = buildArgsForReconnectedFallback(reconnected, saved, "/fallback");
     expect(result.existingId).toBe("t1");
     expect(result.cwd).toBe("/reconnected");
-    expect(result.title).toBe("Shell");
+    expect(result.title).toBe("Old Title");
     expect(result.worktreeId).toBe("wt1");
     expect(result.location).toBe("dock");
   });
@@ -255,6 +255,15 @@ describe("buildArgsForReconnectedFallback", () => {
     expect(result.cwd).toBe("/saved");
     expect(result.title).toBe("Saved");
     expect(result.worktreeId).toBe("wt1");
+  });
+
+  it("falls back to reconnected title when saved title is missing", () => {
+    const result = buildArgsForReconnectedFallback(
+      { id: "t1", cwd: "/p", kind: "terminal", title: "Shell" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.title).toBe("Shell");
   });
 });
 

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -157,7 +157,7 @@ export function buildArgsForBackendTerminal(
     kind: backendTerminal.kind ?? (agentId ? "agent" : "terminal"),
     type: backendTerminal.type,
     agentId,
-    title: backendTerminal.title,
+    title: saved.title ?? backendTerminal.title,
     cwd,
     worktreeId: backendTerminal.worktreeId,
     location,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -207,7 +207,7 @@ export function buildArgsForReconnectedFallback(
     kind: reconnectedKind ?? (agentId ? "agent" : "terminal"),
     type: reconnectedTerminal.type ?? saved.type,
     agentId,
-    title: reconnectedTerminal.title ?? saved.title,
+    title: saved.title ?? reconnectedTerminal.title,
     cwd,
     worktreeId: reconnectedTerminal.worktreeId ?? saved.worktreeId,
     location,


### PR DESCRIPTION
## Summary

- Custom panel titles set by the user were being overwritten on project switch because the hydration builders unconditionally applied backend-provided titles over saved state.
- Fixed by checking for `saved.title` first in both the standard hydration path and the reconnect fallback path, so user-renamed sessions keep their name when switching projects and back.
- Regression tests added covering both hydration paths to prevent this regressing.

Resolves #5103

## Changes

- `src/utils/stateHydration/statePatcher.ts`: prefer `saved.title` over backend title in `buildHydratedPanel` and `buildReconnectedPanel`
- `src/utils/stateHydration/__tests__/statePatcher.test.ts`: new test cases asserting custom titles survive hydration and reconnect

## Testing

Unit tests pass. Both fix commits carry targeted regression tests that reproduce the original bug (custom title discarded) and confirm the fix.