### PR TITLE
fix(theme): restore fontFamily in CodeMirror editor theme

### DIFF
--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -197,7 +197,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   return (
     <div
       className={cn(
-        "overflow-auto font-mono [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
+        "overflow-auto [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
         className
       )}
     >

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -197,7 +197,7 @@ export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function
   return (
     <div
       className={cn(
-        "overflow-auto [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
+        "overflow-auto text-[13px] [&_.cm-editor]:min-h-full [&_.cm-scroller]:!overflow-visible",
         className
       )}
     >

--- a/src/components/Notes/__tests__/editorTheme.test.ts
+++ b/src/components/Notes/__tests__/editorTheme.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { canopyTheme } from "../editorTheme";
+import { DEFAULT_TERMINAL_FONT_FAMILY } from "@/config/terminalFont";
+
+/**
+ * Walk an object tree looking for a property value, handling circular refs.
+ */
+function deepContainsValue(obj: unknown, target: string, seen = new WeakSet()): boolean {
+  if (obj === target) return true;
+  if (typeof obj === "string" && obj.includes(target)) return true;
+  if (obj == null || typeof obj !== "object") return false;
+  if (seen.has(obj as object)) return false;
+  seen.add(obj as object);
+  for (const val of Object.values(obj as Record<string, unknown>)) {
+    if (deepContainsValue(val, target, seen)) return true;
+  }
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      if (deepContainsValue(item, target, seen)) return true;
+    }
+  }
+  return false;
+}
+
+describe("canopyTheme", () => {
+  it("includes fontFamily in the theme extension", () => {
+    expect(deepContainsValue(canopyTheme, DEFAULT_TERMINAL_FONT_FAMILY)).toBe(true);
+  });
+
+  it("is a valid CodeMirror extension array", () => {
+    expect(Array.isArray(canopyTheme)).toBe(true);
+    expect(canopyTheme.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Notes/__tests__/editorTheme.test.ts
+++ b/src/components/Notes/__tests__/editorTheme.test.ts
@@ -29,6 +29,6 @@ describe("canopyTheme", () => {
 
   it("is a valid CodeMirror extension array", () => {
     expect(Array.isArray(canopyTheme)).toBe(true);
-    expect(canopyTheme.length).toBeGreaterThan(0);
+    expect((canopyTheme as readonly unknown[]).length).toBeGreaterThan(0);
   });
 });

--- a/src/components/Notes/editorTheme.ts
+++ b/src/components/Notes/editorTheme.ts
@@ -1,5 +1,6 @@
 import { createTheme } from "@uiw/codemirror-themes";
 import { tags as t } from "@lezer/highlight";
+import { DEFAULT_TERMINAL_FONT_FAMILY } from "@/config/terminalFont";
 
 export const canopyTheme = createTheme({
   theme: "dark",
@@ -12,6 +13,7 @@ export const canopyTheme = createTheme({
     lineHighlight: "var(--theme-border-default)",
     gutterBackground: "var(--theme-surface-canvas)",
     gutterForeground: "var(--theme-activity-idle)",
+    fontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
   },
   styles: [
     { tag: t.heading, color: "var(--theme-accent-primary)", fontWeight: "bold" },


### PR DESCRIPTION
## Summary

Fixes a regression of #4053 — the file preview (`CodeViewer`) was rendering in the browser's default monospace font instead of JetBrains Mono. The original fix (`9f5ec7b`) was undone in `43718d5` when `fontFamily` was removed from the shared `canopyTheme` to support sans-serif in the notes editor.

- Re-add `fontFamily: DEFAULT_TERMINAL_FONT_FAMILY` to `canopyTheme` settings
- Remove the ineffective `font-mono` CSS class from the `CodeViewer` wrapper (CodeMirror ignores inherited font-family)
- Set `text-[13px]` on the `CodeViewer` wrapper for consistent sizing with the notes editor

The notes editor is unaffected — it already overrides the font at the scroller level via `codeBlockExtension.ts`.

Closes #4053

## Test plan

- [ ] Open a file in the file preview — confirm it renders in JetBrains Mono at 13px
- [ ] Open the notes editor — confirm body text is sans-serif at 13px
- [ ] Add a fenced code block in notes — confirm it renders in JetBrains Mono
- [ ] Open the notes palette — confirm same behavior as notes editor