### PR TITLE
refactor(toolbar): remove dedicated panel-palette toolbar button

### DIFF
--- a/index.html
+++ b/index.html
@@ -769,9 +769,8 @@
             <div class="skel-toolbar-icon"><div class="skel-shape skel-circle"></div></div>
           </div>
           <div class="skel-divider"></div>
-          <!-- Tool icons: terminal, browser, dev-preview, panel-palette -->
+          <!-- Tool icons: terminal, browser, dev-preview -->
           <div class="skel-btn-group">
-            <div class="skel-toolbar-icon"><div class="skel-shape skel-circle"></div></div>
             <div class="skel-toolbar-icon"><div class="skel-shape skel-circle"></div></div>
             <div class="skel-toolbar-icon"><div class="skel-shape skel-circle"></div></div>
             <div class="skel-toolbar-icon"><div class="skel-shape skel-circle"></div></div>

--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -27,7 +27,6 @@ export type ToolbarButtonId =
   | "settings"
   | "problems"
   | "notification-center"
-  | "panel-palette"
   | "portal-toggle";
 
 /** Configuration for which toolbar buttons are visible and their order */
@@ -65,7 +64,6 @@ export const TOOLBAR_BUTTON_PRIORITIES: Record<ToolbarButtonId, ToolbarButtonPri
   terminal: 3,
   browser: 3,
   "dev-server": 3,
-  "panel-palette": 4,
   settings: 5,
   "notification-center": 5,
   notes: 5,

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -15,7 +15,6 @@ import {
   Globe,
   Monitor,
   Bell,
-  LayoutGrid,
   Ellipsis,
   GitBranch,
   StickyNote,
@@ -83,7 +82,6 @@ export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenu
   terminal: { label: "Terminal", icon: SquareTerminal },
   browser: { label: "Browser", icon: Globe },
   "dev-server": { label: "Dev Preview", icon: Monitor },
-  "panel-palette": { label: "Panel Palette", icon: LayoutGrid },
   "github-stats": { label: "GitHub Stats", icon: GitPullRequest },
   "notification-center": { label: "Notifications", icon: Bell },
   notes: { label: "Notes", icon: StickyNote },
@@ -431,17 +429,6 @@ export function Toolbar({
         ),
         isAvailable: !!currentProject,
       },
-      "panel-palette": {
-        render: () => (
-          <ToolbarLauncherButton
-            key="panel-palette"
-            type="panel-palette"
-            onLaunchAgent={onLaunchAgent}
-            data-toolbar-item=""
-          />
-        ),
-        isAvailable: true,
-      },
       "voice-recording": {
         render: () => <VoiceRecordingToolbarButton key="voice-recording" data-toolbar-item="" />,
         isAvailable: hasActiveVoiceRecording,
@@ -752,9 +739,6 @@ export function Toolbar({
       browser: () => onLaunchAgent("browser"),
       "dev-server": () => {
         void actionService.dispatch("devServer.start", undefined, { source: "user" });
-      },
-      "panel-palette": () => {
-        void actionService.dispatch("panel.palette", undefined, { source: "user" });
       },
       "notification-center": () => {
         useUIStore.getState().toggleNotificationCenter();

--- a/src/components/Layout/ToolbarLauncherButton.tsx
+++ b/src/components/Layout/ToolbarLauncherButton.tsx
@@ -1,13 +1,11 @@
 import { memo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { SquareTerminal, Globe, LayoutGrid } from "lucide-react";
+import { SquareTerminal, Globe } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { createTooltipWithShortcut } from "@/lib/platform";
 import { useKeybindingDisplay } from "@/hooks";
-import { usePaletteStore } from "@/store";
-import { actionService } from "@/services/ActionService";
 
-type LauncherType = "terminal" | "browser" | "panel-palette";
+type LauncherType = "terminal" | "browser";
 
 const LAUNCHER_CONFIG: Record<
   LauncherType,
@@ -30,12 +28,6 @@ const LAUNCHER_CONFIG: Record<
     tooltipLabel: "Open Browser",
     keybindingAction: "agent.browser",
   },
-  "panel-palette": {
-    icon: LayoutGrid,
-    label: "Panel Palette",
-    tooltipLabel: "Panel Palette",
-    keybindingAction: "panel.palette",
-  },
 };
 
 const toolbarIconButtonClass = "toolbar-icon-button text-canopy-text transition-colors";
@@ -53,20 +45,9 @@ export const ToolbarLauncherButton = memo(function ToolbarLauncherButton({
 }: ToolbarLauncherButtonProps) {
   const config = LAUNCHER_CONFIG[type];
   const shortcut = useKeybindingDisplay(config.keybindingAction);
-  const panelPaletteOpen = usePaletteStore((state) =>
-    type === "panel-palette" ? state.activePaletteId === "panel" : false
-  );
 
   const handleClick = useCallback(() => {
-    if (type === "panel-palette") {
-      if (usePaletteStore.getState().activePaletteId === "panel") {
-        usePaletteStore.getState().closePalette("panel");
-      } else {
-        void actionService.dispatch("panel.palette", undefined, { source: "user" });
-      }
-    } else {
-      onLaunchAgent(type);
-    }
+    onLaunchAgent(type);
   }, [type, onLaunchAgent]);
 
   const Icon = config.icon;
@@ -81,14 +62,7 @@ export const ToolbarLauncherButton = memo(function ToolbarLauncherButton({
             data-toolbar-item={dataToolbarItem}
             onClick={handleClick}
             className={toolbarIconButtonClass}
-            aria-label={
-              type === "panel-palette"
-                ? panelPaletteOpen
-                  ? "Close panel palette"
-                  : "Open panel palette"
-                : config.label
-            }
-            aria-pressed={type === "panel-palette" ? panelPaletteOpen : undefined}
+            aria-label={config.label}
           >
             <Icon />
           </Button>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -80,11 +80,6 @@ const BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ButtonMetadata>> = {
     icon: <Monitor className="h-4 w-4" />,
     description: "Open dev preview panel",
   },
-  "panel-palette": {
-    label: "Panel Palette",
-    icon: <LayoutGrid className="h-4 w-4" />,
-    description: "Open the panel launcher palette",
-  },
   "voice-recording": {
     label: "Voice Recording",
     icon: <Mic className="h-4 w-4" />,

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -172,7 +172,7 @@ describe("toolbarPreferencesStore", () => {
     it("restores multiple hidden buttons across both sides", async () => {
       setStoredState({
         layout: {
-          leftButtons: ["terminal", "browser", "panel-palette"],
+          leftButtons: ["terminal", "browser", "dev-server"],
           rightButtons: ["notes", "settings", "copy-tree"],
           hiddenButtons: ["terminal", "notes", "copy-tree"],
         },
@@ -230,7 +230,7 @@ describe("toolbarPreferencesStore", () => {
     it("re-inserts dev-server for persisted state missing it via mergeButtonList", async () => {
       setStoredState({
         layout: {
-          leftButtons: ["terminal", "browser", "panel-palette"],
+          leftButtons: ["terminal", "browser", "notes"],
           rightButtons: ["notes", "settings"],
           hiddenButtons: [],
         },
@@ -306,7 +306,49 @@ describe("toolbarPreferencesStore", () => {
       expect(store.getState().layout.leftButtons).toContain("agent-tray");
     });
 
-    it("migrates v0 state through both migrations", async () => {
+    it("v3→v4 drops 'panel-palette' from all button arrays", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["agent-tray", "claude", "terminal", "browser", "panel-palette"],
+              rightButtons: ["settings", "panel-palette"],
+              hiddenButtons: ["panel-palette"],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 3,
+        })
+      );
+
+      const store = await loadStore();
+      const { layout } = store.getState();
+      expect(layout.leftButtons).not.toContain("panel-palette");
+      expect(layout.rightButtons).not.toContain("panel-palette");
+      expect(layout.hiddenButtons).not.toContain("panel-palette");
+      // Order of remaining items preserved
+      expect(layout.leftButtons).toContain("agent-tray");
+      expect(layout.leftButtons).toContain("terminal");
+      expect(layout.leftButtons).toContain("browser");
+    });
+
+    it("v3→v4 handles missing layout without throwing", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 3,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.leftButtons).toBeDefined();
+    });
+
+    it("migrates v0 state through all migrations", async () => {
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -14,7 +14,6 @@ const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
   "terminal",
   "browser",
   "dev-server",
-  "panel-palette",
 ];
 
 const DEFAULT_RIGHT_BUTTONS: ToolbarButtonId[] = [
@@ -153,7 +152,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "canopy-toolbar-preferences",
-      version: 3,
+      version: 4,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -193,6 +192,17 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             layout.leftButtons = renameAgentSetup(layout.leftButtons);
             layout.rightButtons = renameAgentSetup(layout.rightButtons);
             layout.hiddenButtons = renameAgentSetup(layout.hiddenButtons);
+          }
+        }
+        if (version < 4) {
+          const layout = state.layout as
+            | { leftButtons?: string[]; rightButtons?: string[]; hiddenButtons?: string[] }
+            | undefined;
+          if (layout) {
+            const drop = (buttons?: string[]) => buttons?.filter((id) => id !== "panel-palette");
+            layout.leftButtons = drop(layout.leftButtons);
+            layout.rightButtons = drop(layout.rightButtons);
+            layout.hiddenButtons = drop(layout.hiddenButtons);
           }
         }
         return state as unknown as ToolbarPreferencesState;


### PR DESCRIPTION
## Summary

- Removes `\"panel-palette\"` from `ToolbarButtonId` and `TOOLBAR_BUTTON_PRIORITIES` since each panel kind already has its own dedicated button and the agent tray covers the agent side
- Adds a v3→v4 migration in `toolbarPreferencesStore` that silently drops `panel-palette` from any persisted `leftButtons`, `rightButtons`, or `hiddenButtons` arrays so existing users don't see a dead slot on upgrade
- Collapses `ToolbarLauncherButton` from a 3-mode component to 2-mode (`terminal | browser`), cleaning up the now-unreachable branch

The `panel.palette` action, its keybinding, and the `PanelPalette` component are all untouched. This is purely a toolbar slot cleanup.

Resolves #5116

## Changes

- `shared/types/toolbar.ts` — removed `panel-palette` from union and priorities map
- `src/store/toolbarPreferencesStore.ts` — bumped version to 4, added migration, removed from `DEFAULT_LEFT_BUTTONS`
- `src/components/Layout/Toolbar.tsx` — removed render entry, icon-map entry, and keybinding dispatch block
- `src/components/Layout/ToolbarLauncherButton.tsx` — collapsed `LauncherType` to `\"terminal\" | \"browser\"`
- `src/components/Settings/ToolbarSettingsTab.tsx` — removed settings UI metadata entry
- `index.html` — updated skeleton loader (one fewer icon in the toolbar skeleton group)
- `src/store/__tests__/toolbarPreferencesStore.test.ts` — migration test asserting the panel-palette ID is dropped from persisted state

## Testing

`npm run check` passes clean. Migration test covers the v3→v4 upgrade path for all three button arrays (`leftButtons`, `rightButtons`, `hiddenButtons`). Typecheck, lint, and format all clean.