### PR TITLE
fix(project,e2e): repair nightly E2E onboarding and online agent flows

### DIFF
--- a/e2e/full/core-persistence-advanced.spec.ts
+++ b/e2e/full/core-persistence-advanced.spec.ts
@@ -223,11 +223,14 @@ test.describe.serial("Persistence: Theme, Notifications & Keybindings across res
     const notifCheckbox2 = w2.locator(SEL.settings.notifCompletedCheckbox);
     await expect(notifCheckbox2).toBeChecked({ timeout: T_SHORT });
 
-    // Verify keybinding override persisted
+    // Verify keybinding override persisted. Scope the heading assertion to
+    // the settings dialog — the WelcomeScreen renders its own h3 with the
+    // same text behind the dialog, which otherwise trips Playwright's
+    // strict-mode uniqueness check.
     await w2.locator(`${SEL.settings.navSidebar} button`, { hasText: "Keyboard" }).click();
-    await expect(w2.locator("h3", { hasText: "Keyboard Shortcuts" })).toBeVisible({
-      timeout: T_SHORT,
-    });
+    await expect(
+      w2.getByRole("dialog").getByRole("heading", { name: "Keyboard Shortcuts" })
+    ).toBeVisible({ timeout: T_SHORT });
 
     const searchInput2 = w2.locator(SEL.settings.shortcutsSearchInput);
     await searchInput2.fill("Open settings");

--- a/e2e/full/core-worktree-session-bulk.spec.ts
+++ b/e2e/full/core-worktree-session-bulk.spec.ts
@@ -33,7 +33,9 @@ test.describe.serial("Core: Worktree Session Bulk", () => {
 
     const sessionsTrigger = window.getByRole("menuitem", { name: "Sessions" });
     await expect(sessionsTrigger).toBeVisible({ timeout: T_SHORT });
-    await sessionsTrigger.hover();
+    // Hover doesn't reliably open Radix submenus on Linux CI. Click the
+    // trigger so the submenu opens on all platforms.
+    await sessionsTrigger.click();
   }
 
   async function clickSessionsItem(name: string | RegExp) {

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -185,6 +185,7 @@ export const SEL = {
   agent: {
     panel: '[aria-label^="Claude agent:"]',
     startButton: '[aria-label="Start Claude Agent"]',
+    trayButton: '[aria-label="Agent tray"]',
   },
   opencodeAgent: {
     panel: '[aria-label^="OpenCode agent:"]',

--- a/e2e/online/claude-online.spec.ts
+++ b/e2e/online/claude-online.spec.ts
@@ -53,7 +53,11 @@ test.describe("Claude Online Flow", () => {
     await test.step("launch Claude agent", async () => {
       const { window } = ctx;
 
-      await window.locator(SEL.agent.startButton).click();
+      // Agents are unpinned by default, so the toolbar shows the Agent Tray
+      // rather than a direct "Start Claude Agent" button. Open the tray and
+      // click the Claude entry under "Launch".
+      await window.locator(SEL.agent.trayButton).click();
+      await window.getByRole("menuitem", { name: "Claude" }).click();
 
       const agentPanel = window.locator(SEL.agent.panel);
       await expect(agentPanel).toBeVisible({ timeout: 30_000 });

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -53,7 +53,11 @@ test.describe("OpenCode Online Flow", () => {
     await test.step("launch OpenCode agent", async () => {
       const { window } = ctx;
 
-      await window.locator(SEL.opencodeAgent.startButton).click();
+      // Agents are unpinned by default, so the toolbar shows the Agent Tray
+      // rather than a direct "Start OpenCode Agent" button. Open the tray and
+      // click the OpenCode entry under "Launch".
+      await window.locator(SEL.agent.trayButton).click();
+      await window.getByRole("menuitem", { name: "OpenCode" }).click();
 
       const agentPanel = window.locator(SEL.opencodeAgent.panel);
       await expect(agentPanel).toBeVisible({ timeout: 30_000 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -220,6 +220,7 @@ function App() {
   const onboardingWizardOpen = useProjectStore((state) => state.onboardingWizardOpen);
   const onboardingProjectId = useProjectStore((state) => state.onboardingProjectId);
   const closeOnboardingWizard = useProjectStore((state) => state.closeOnboardingWizard);
+  const switchProject = useProjectStore((state) => state.switchProject);
 
   const createFolderDialogOpen = useProjectStore((state) => state.createFolderDialogOpen);
   const closeCreateFolderDialog = useProjectStore((state) => state.closeCreateFolderDialog);
@@ -315,30 +316,40 @@ function App() {
     [launchAgent]
   );
 
-  const handleWizardFinish = useCallback(() => {
-    // In e2e mode, skip the automatic primary-agent launch — it leaves an
-    // extra panel in the grid that breaks panel-count assertions in tests
-    // that expect a clean post-onboarding state. The behaviour is locally
-    // observable only when an agent CLI (e.g., Claude) is installed, so
-    // tests pass on CI but fail on dev machines without this guard.
-    if (typeof window !== "undefined" && window.__CANOPY_E2E_MODE__) {
-      return;
-    }
+  const handleWizardFinish = useCallback(
+    (finishedProjectId: string) => {
+      // Switch to the newly-onboarded project. Opening the wizard on the
+      // current view (rather than pre-switching) avoids stranding it in a
+      // throttled background view; we complete the switch here instead.
+      if (finishedProjectId && finishedProjectId !== currentProject?.id) {
+        void switchProject(finishedProjectId);
+      }
 
-    const defaultAgent = useAgentPreferencesStore.getState().defaultAgent;
-    const selected = agentSettings?.agents
-      ? Object.entries(agentSettings.agents)
-          .filter(([, entry]) => entry.pinned === true)
-          .map(([id]) => id)
-      : [];
-    const primaryAgent = defaultAgent ?? selected[0];
+      // In e2e mode, skip the automatic primary-agent launch — it leaves an
+      // extra panel in the grid that breaks panel-count assertions in tests
+      // that expect a clean post-onboarding state. The behaviour is locally
+      // observable only when an agent CLI (e.g., Claude) is installed, so
+      // tests pass on CI but fail on dev machines without this guard.
+      if (typeof window !== "undefined" && window.__CANOPY_E2E_MODE__) {
+        return;
+      }
 
-    if (primaryAgent && isAgentReady(availability[primaryAgent])) {
-      launchAgent(primaryAgent, {
-        worktreeId: activeWorktreeId ?? undefined,
-      }).catch(() => {});
-    }
-  }, [launchAgent, activeWorktreeId, availability, agentSettings]);
+      const defaultAgent = useAgentPreferencesStore.getState().defaultAgent;
+      const selected = agentSettings?.agents
+        ? Object.entries(agentSettings.agents)
+            .filter(([, entry]) => entry.pinned === true)
+            .map(([id]) => id)
+        : [];
+      const primaryAgent = defaultAgent ?? selected[0];
+
+      if (primaryAgent && isAgentReady(availability[primaryAgent])) {
+        launchAgent(primaryAgent, {
+          worktreeId: activeWorktreeId ?? undefined,
+        }).catch(() => {});
+      }
+    },
+    [launchAgent, activeWorktreeId, availability, agentSettings, switchProject, currentProject?.id]
+  );
 
   const closeNotesPalette = useCallback(() => {
     usePaletteStore.getState().closePalette("notes");

--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -22,7 +22,7 @@ interface ProjectOnboardingWizardProps {
   isOpen: boolean;
   projectId: string;
   onClose: () => void;
-  onFinish?: () => void;
+  onFinish?: (projectId: string) => void;
 }
 
 export function ProjectOnboardingWizard({
@@ -90,7 +90,7 @@ export function ProjectOnboardingWizard({
       });
 
       onClose();
-      onFinish?.();
+      onFinish?.(projectId);
     } catch (error) {
       setSaveError(error instanceof Error ? error.message : "Failed to save settings");
     } finally {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -187,10 +187,19 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const isNewProject = !existingProjectIds.has(newProject.id);
 
       await get().loadProjects();
-      await get().switchProject(newProject.id);
 
       if (isNewProject) {
-        set({ onboardingWizardOpen: true, onboardingProjectId: newProject.id });
+        // Open the onboarding wizard on the current view; the switch to the
+        // new project happens when the wizard finishes. Swapping views first
+        // strands the wizard in the deactivated (background-throttled) view,
+        // where React state updates stall and the Finish button stays disabled.
+        set({
+          isLoading: false,
+          onboardingWizardOpen: true,
+          onboardingProjectId: newProject.id,
+        });
+      } else {
+        await get().switchProject(newProject.id);
       }
     } catch (error) {
       logErrorWithContext(error, {


### PR DESCRIPTION
## Summary

Fixes persistent nightly E2E failures on Linux, macOS, and Windows (all root causes had been present for weeks).

| Suite | Before | After |
| --- | --- | --- |
| E2E Online (macOS/Linux/Windows) | 2 fail × 3 | ✅ green |
| E2E Full Core — Linux | 9 fail + 2 flaky | ✅ green ([run](https://github.com/canopyide/canopy/actions/runs/24357516198)) |
| E2E Full Core — macOS | 1 hard + 2 flaky | ✅ green ([run](https://github.com/canopyide/canopy/actions/runs/24361695293)) |
| E2E Full Core — Windows | 16 fail | 9 fail (all 9 unrelated Windows-only issues — see Deferred) |

### 1. Project onboarding wizard after addProject (fixes 9 Linux + 9 Windows tests)

`addProjectByPath` called `switchProject` first and then set the onboarding state. `ProjectViewManager.deactivateCurrentView` calls `setBackgroundThrottling(true)` on the outgoing view, so the wizard opened in a now-throttled WebContentsView. On Linux and Windows CI the throttled view's pending React state update (`isLoading` → `false`) never flushed, so the Finish button stayed disabled and every test that added a second project timed out.

Open the wizard on the current (still-active) view, and defer the project switch until `onFinish` fires. The wizard now passes its `projectId` to `onFinish`, and `App.tsx`'s handler triggers `switchProject` after the wizard closes. Existing-project adds keep their immediate-switch behavior.

### 2. Online agent launch (fixes 2 tests × 3 platforms)

Since #5121 flipped the toolbar to opt-in (agents pinned-only), the direct `Start Claude Agent` / `Start OpenCode Agent` buttons no longer render for fresh E2E user-data-dirs. Route the online tests through the AgentTray (`aria-label="Agent tray"`) and click the agent name inside the "Launch" group.

### 3. Sessions submenu on Linux (fixes 1 flaky test)

`core-worktree-session-bulk` hovered the "Sessions" submenu trigger. Radix submenus don't reliably open on hover under Linux CI. Click the trigger instead.

### 4. Keyboard Shortcuts heading on macOS (fixes 1 flaky test)

`core-persistence-advanced` used an unscoped `locator("h3", hasText)` for the keyboard-settings heading. The WelcomeScreen also renders an `<h3>Keyboard Shortcuts</h3>`, so the locator matched two elements and tripped Playwright's strict-mode check. Scope to the dialog heading, matching the pattern used in session 1 of the same test.

## Test plan

- [x] Typecheck + lint + format (`npm run check`)
- [x] Unit tests — 5237 / 5237 pass
- [x] Local Playwright — `core-project-lifecycle`, `core-advanced`, `core-cross-project-workflows`, `core-error-recovery`, `core-ipc-cleanup`, `core-project-deletion-cleanup`, `core-project-management-advanced`, `core-project-switch-race` — 42 / 42 pass
- [x] Local Playwright — `core-worktree-session-bulk` — green (dock all fixed)
- [x] Local Playwright — Claude online progresses past the tray click (unrelated local PTY issue halts later in the flow)
- [x] CI E2E Online — all three platforms green
- [x] CI E2E Core — Linux green, macOS green

## Deferred

9 Windows-only failures that are unrelated to this PR's root causes (all present in nightlies before this branch — they're file/timing/platform issues specific to Windows):

- core-browser-panel:300 (console capture)
- core-crash-recovery:387 (panel restoration)
- core-global-env-inheritance:151 (terminal inherits env on Windows)
- core-ipc-cleanup:131
- core-keyboard-navigation-advanced:66 (Ctrl+Tab cycling)
- core-project-switch-race:128, :140
- core-pty-resilience:166 (CANOPY_PID extraction)
- core-worktree-resource-lifecycle:310

These should be filed as separate tickets; Windows E2E is nightly-only per CLAUDE.md and has been red for ~2 weeks on these specific cases.