### PR TITLE
fix(workspace): serialize concurrent resource actions to prevent race conditions

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -75,6 +75,8 @@ export class WorkspaceService {
   private listService = new WorktreeListService();
   private prService: PRIntegrationService;
   private _shutdownController = new AbortController();
+  private resourceActionQueues = new Map<string, PQueue>();
+  private resourceActionAbortControllers = new Map<string, AbortController>();
 
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.prService = new PRIntegrationService(pullRequestService, events, {
@@ -239,6 +241,7 @@ export class WorkspaceService {
           this.activeWorktreeId = null;
         }
 
+        this.cleanupResourceActionState(id);
         monitor.stop();
         this.monitors.delete(id);
         clearGitDirCache(monitor.path);
@@ -337,7 +340,13 @@ export class WorkspaceService {
               this.handleExternalWorktreeRemoval(worktreeId);
             },
             onResourceStatusPoll: (worktreeId) => {
-              void this.runResourceAction(`auto-status-${worktreeId}`, worktreeId, "status");
+              return this.runResourceAction(
+                `auto-status-${worktreeId}`,
+                worktreeId,
+                "status",
+                undefined,
+                { origin: "auto-poll" }
+              );
             },
           },
           this.mainBranch,
@@ -484,6 +493,7 @@ export class WorkspaceService {
       this.activeWorktreeId = null;
     }
 
+    this.cleanupResourceActionState(worktreeId);
     monitor.stop();
     this.monitors.delete(worktreeId);
 
@@ -1155,6 +1165,7 @@ export class WorkspaceService {
       // Clean up the monitor immediately after worktree removal succeeds,
       // before attempting branch deletion — so the monitor doesn't linger
       // if branch deletion fails.
+      this.cleanupResourceActionState(worktreeId);
       monitor.stop();
       this.monitors.delete(worktreeId);
 
@@ -1541,11 +1552,43 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     });
   }
 
+  private getResourceActionQueue(worktreeId: string): PQueue {
+    let queue = this.resourceActionQueues.get(worktreeId);
+    if (!queue) {
+      queue = new PQueue({ concurrency: 1 });
+      this.resourceActionQueues.set(worktreeId, queue);
+    }
+    return queue;
+  }
+
+  private getResourceActionAbortController(worktreeId: string): AbortController {
+    let controller = this.resourceActionAbortControllers.get(worktreeId);
+    if (!controller) {
+      controller = new AbortController();
+      this.resourceActionAbortControllers.set(worktreeId, controller);
+    }
+    return controller;
+  }
+
+  private cleanupResourceActionState(worktreeId: string): void {
+    const controller = this.resourceActionAbortControllers.get(worktreeId);
+    if (controller) {
+      controller.abort();
+      this.resourceActionAbortControllers.delete(worktreeId);
+    }
+    const queue = this.resourceActionQueues.get(worktreeId);
+    if (queue) {
+      queue.clear();
+      this.resourceActionQueues.delete(worktreeId);
+    }
+  }
+
   async runResourceAction(
     requestId: string,
     worktreeId: string,
     action: "provision" | "teardown" | "resume" | "pause" | "status",
-    environmentId?: string
+    environmentId?: string,
+    options?: { origin?: "auto-poll" }
   ): Promise<{ success: boolean; error?: string; output?: string }> {
     const monitor = this.monitors.get(worktreeId);
     if (!monitor) {
@@ -1567,6 +1610,46 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       });
       return { success: false, error: "No project root path" };
     }
+
+    const queue = this.getResourceActionQueue(worktreeId);
+
+    // Auto-poll: skip if any resource action is already in-flight or queued
+    if (options?.origin === "auto-poll" && (queue.pending > 0 || queue.size > 0)) {
+      return { success: true };
+    }
+
+    const controller = this.getResourceActionAbortController(worktreeId);
+
+    const queued = await queue
+      .add(
+        () =>
+          this._executeResourceAction(
+            requestId,
+            worktreeId,
+            action,
+            environmentId,
+            controller.signal
+          ),
+        { signal: controller.signal }
+      )
+      .catch(() => undefined);
+
+    return queued ?? { success: false, error: "Aborted" };
+  }
+
+  private async _executeResourceAction(
+    requestId: string,
+    worktreeId: string,
+    action: "provision" | "teardown" | "resume" | "pause" | "status",
+    environmentId: string | undefined,
+    signal: AbortSignal
+  ): Promise<{ success: boolean; error?: string; output?: string }> {
+    const monitor = this.monitors.get(worktreeId);
+    if (!monitor || !this.projectRootPath) {
+      return { success: false, error: "Worktree not found" };
+    }
+
+    if (signal.aborted) return { success: false, error: "Aborted" };
 
     const config = await this.lifecycleService.loadConfig(monitor.path, this.projectRootPath);
 
@@ -1702,12 +1785,19 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         cwd: monitor.path,
         env,
         timeoutMs: statusTimeoutMs,
+        signal,
         onProgress: () => {},
       });
 
+      if (result.aborted) return { success: false, error: "Aborted" };
+
+      // Re-read monitor after await — it may have been removed during the command
+      const statusMonitor = this.monitors.get(worktreeId);
+      if (!statusMonitor) return { success: false, error: "Worktree removed" };
+
       try {
         const parsed = JSON.parse(result.output);
-        monitor.setResourceStatus({
+        statusMonitor.setResourceStatus({
           lastStatus: parsed.status ?? "unhealthy",
           lastOutput: result.output,
           lastCheckedAt: Date.now(),
@@ -1718,7 +1808,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         // Non-JSON output: if command succeeded (exit 0), treat as "unknown" (neutral) rather
         // than "unhealthy" — the script may not emit JSON but still indicates a live resource.
         // Only mark "unhealthy" when the command itself failed (non-zero exit).
-        monitor.setResourceStatus({
+        statusMonitor.setResourceStatus({
           lastStatus: result.success ? "unknown" : "unhealthy",
           lastOutput: result.output,
           lastCheckedAt: Date.now(),
@@ -1726,37 +1816,37 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       }
 
       // Re-substitute connect command with endpoint from status
-      const statusEndpoint = monitor.resourceStatus?.endpoint;
-      if (statusEndpoint && resourceConfig.connect) {
+      const statusEndpoint = statusMonitor.resourceStatus?.endpoint;
+      if (statusEndpoint && resourceConfig.connect && this.projectRootPath) {
         const varsWithEndpoint = this.lifecycleService.buildVariables(
-          monitor.path,
+          statusMonitor.path,
           this.projectRootPath,
-          monitor.name,
-          monitor.branch,
+          statusMonitor.name,
+          statusMonitor.branch,
           statusEndpoint
         );
-        monitor.setResourceConnectCommand(
+        statusMonitor.setResourceConnectCommand(
           this.lifecycleService.substituteVariables(resourceConfig.connect, varsWithEndpoint)
         );
       }
 
-      if (statusEndpoint && monitor.resourceStatus?.lastStatus === "ready") {
-        const resolvedConnect = monitor.resourceConnectCommand;
+      if (statusEndpoint && statusMonitor.resourceStatus?.lastStatus === "ready") {
+        const resolvedConnect = statusMonitor.resourceConnectCommand;
         if (resolvedConnect) {
-          await this.generateRemoteWrapper(monitor.path, resolvedConnect, statusEndpoint);
+          await this.generateRemoteWrapper(statusMonitor.path, resolvedConnect, statusEndpoint);
         }
       }
 
-      monitor.setLifecycleStatus({
+      statusMonitor.setLifecycleStatus({
         phase: "resource-status",
         state: result.timedOut ? "timed-out" : result.success ? "success" : "failed",
         totalCommands: 1,
         output: result.output,
         error: result.error,
-        startedAt: monitor.lifecycleStatus?.startedAt ?? Date.now(),
+        startedAt: statusMonitor.lifecycleStatus?.startedAt ?? Date.now(),
         completedAt: Date.now(),
       });
-      this.emitUpdate(monitor);
+      this.emitUpdate(statusMonitor);
 
       this.sendEvent({
         type: "resource-action-result",
@@ -1814,6 +1904,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       cwd: monitor.path,
       env,
       timeoutMs,
+      signal,
       onProgress: (commandIndex, totalCommands, command) => {
         const m = this.monitors.get(worktreeId);
         if (m) {
@@ -1829,6 +1920,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         }
       },
     });
+
+    if (result.aborted) return { success: false, error: "Aborted" };
 
     const finalMonitor = this.monitors.get(worktreeId);
     if (finalMonitor) {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1649,7 +1649,15 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       return { success: false, error: "Worktree not found" };
     }
 
-    if (signal.aborted) return { success: false, error: "Aborted" };
+    if (signal.aborted) {
+      this.sendEvent({
+        type: "resource-action-result",
+        requestId,
+        success: false,
+        error: "Aborted",
+      });
+      return { success: false, error: "Aborted" };
+    }
 
     const config = await this.lifecycleService.loadConfig(monitor.path, this.projectRootPath);
 
@@ -1789,7 +1797,15 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         onProgress: () => {},
       });
 
-      if (result.aborted) return { success: false, error: "Aborted" };
+      if (result.aborted) {
+        this.sendEvent({
+          type: "resource-action-result",
+          requestId,
+          success: false,
+          error: "Aborted",
+        });
+        return { success: false, error: "Aborted" };
+      }
 
       // Re-read monitor after await — it may have been removed during the command
       const statusMonitor = this.monitors.get(worktreeId);
@@ -2028,6 +2044,9 @@ ${connectCommand} "$@"
   dispose(): void {
     this._shutdownController.abort();
     this.prService.cleanup();
+    for (const id of this.monitors.keys()) {
+      this.cleanupResourceActionState(id);
+    }
     for (const monitor of this.monitors.values()) {
       monitor.stop();
     }

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -58,6 +58,7 @@ export interface RunCommandsOptions {
   cwd: string;
   env: Record<string, string>;
   timeoutMs?: number;
+  signal?: AbortSignal;
   onProgress: (commandIndex: number, totalCommands: number, command: string) => void;
 }
 
@@ -66,6 +67,7 @@ export interface RunCommandsResult {
   output: string;
   error?: string;
   timedOut?: boolean;
+  aborted?: boolean;
 }
 
 async function fileExists(p: string): Promise<boolean> {
@@ -187,7 +189,7 @@ export class WorktreeLifecycleService {
    * On Unix, process group kill terminates the whole tree; on Windows, taskkill /T is used.
    */
   async runCommands(commands: string[], options: RunCommandsOptions): Promise<RunCommandsResult> {
-    const { cwd, env, onProgress, timeoutMs = DEFAULT_TIMEOUT_MS } = options;
+    const { cwd, env, onProgress, timeoutMs = DEFAULT_TIMEOUT_MS, signal } = options;
 
     if (!commands.length) {
       return { success: true, output: "" };
@@ -197,6 +199,15 @@ export class WorktreeLifecycleService {
     const deadline = Date.now() + timeoutMs;
 
     for (let i = 0; i < commands.length; i++) {
+      if (signal?.aborted) {
+        return {
+          success: false,
+          output: tailOutput(outputChunks),
+          aborted: true,
+          error: "Aborted",
+        };
+      }
+
       const command = commands[i];
       const remainingMs = deadline - Date.now();
 
@@ -211,7 +222,23 @@ export class WorktreeLifecycleService {
 
       onProgress(i, commands.length, command);
 
-      const result = await this.runSingleCommand(command, cwd, env, remainingMs, outputChunks);
+      const result = await this.runSingleCommand(
+        command,
+        cwd,
+        env,
+        remainingMs,
+        outputChunks,
+        signal
+      );
+
+      if (result.aborted) {
+        return {
+          success: false,
+          output: tailOutput(outputChunks),
+          aborted: true,
+          error: "Aborted",
+        };
+      }
 
       if (!result.success) {
         return {
@@ -231,8 +258,13 @@ export class WorktreeLifecycleService {
     cwd: string,
     env: Record<string, string>,
     timeoutMs: number,
-    outputChunks: string[]
-  ): Promise<{ success: boolean; timedOut?: boolean; error?: string }> {
+    outputChunks: string[],
+    signal?: AbortSignal
+  ): Promise<{ success: boolean; timedOut?: boolean; aborted?: boolean; error?: string }> {
+    if (signal?.aborted) {
+      return Promise.resolve({ success: false, aborted: true, error: "Aborted" });
+    }
+
     const isWin = process.platform === "win32";
 
     return new Promise((resolve) => {
@@ -244,6 +276,7 @@ export class WorktreeLifecycleService {
       });
 
       let timedOut = false;
+      let aborted = false;
 
       const killProcess = () => {
         if (isWin) {
@@ -280,6 +313,15 @@ export class WorktreeLifecycleService {
         }, 5_000);
       };
 
+      const onAbort = () => {
+        aborted = true;
+        killProcess();
+      };
+
+      if (signal) {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
       const timeoutHandle = setTimeout(() => {
         timedOut = true;
         killProcess();
@@ -295,11 +337,18 @@ export class WorktreeLifecycleService {
 
       child.on("error", (err) => {
         clearTimeout(timeoutHandle);
+        signal?.removeEventListener("abort", onAbort);
         resolve({ success: false, error: err.message });
       });
 
       child.on("close", (code) => {
         clearTimeout(timeoutHandle);
+        signal?.removeEventListener("abort", onAbort);
+
+        if (aborted) {
+          resolve({ success: false, aborted: true, error: "Aborted" });
+          return;
+        }
 
         if (timedOut) {
           resolve({

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -43,7 +43,7 @@ export interface WorktreeMonitorCallbacks {
   onError?: (worktreeId: string, error: Error) => void;
   onBranchChanged?: (worktreeId: string, newBranch: string) => void;
   onExternalRemoval?: (worktreeId: string) => void;
-  onResourceStatusPoll?: (worktreeId: string) => void;
+  onResourceStatusPoll?: (worktreeId: string) => Promise<unknown> | void;
 }
 
 export class WorktreeMonitor {
@@ -390,7 +390,7 @@ export class WorktreeMonitor {
     if (this.resourcePollIntervalMs <= 0 || !this._hasResourceConfig || !this._hasStatusCommand)
       return;
 
-    this.resourcePollTimer = setTimeout(() => {
+    this.resourcePollTimer = setTimeout(async () => {
       this.resourcePollTimer = null;
       if (
         this._isRunning &&
@@ -398,7 +398,12 @@ export class WorktreeMonitor {
         this._hasStatusCommand &&
         this.resourcePollIntervalMs > 0
       ) {
-        this.callbacks.onResourceStatusPoll?.(this.id);
+        try {
+          await this.callbacks.onResourceStatusPoll?.(this.id);
+        } catch {
+          // Poll callback failure — swallowed intentionally
+        }
+        if (!this._isRunning) return;
         this.scheduleResourcePoll();
       }
     }, this.resourcePollIntervalMs);

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -1292,3 +1292,230 @@ describe("WorkspaceService.runLifecycleSetup — resource config caching", () =>
     expect(monitor.resourceConnectCommand).toBe("ssh user@host");
   });
 });
+
+describe("WorkspaceService.runResourceAction — concurrency", () => {
+  let service: WorkspaceService;
+  let mockSendEvent: ReturnType<typeof vi.fn>;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockSendEvent = vi.fn();
+
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(
+      mockSendEvent as unknown as (event: WorkspaceHostEvent) => void
+    );
+
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+
+    service["projectRootPath"] = "/test/root";
+    service["git"] = mockSimpleGit as unknown as SimpleGit;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function createAndRegisterMonitor(overrides: Partial<Worktree> = {}): WorktreeMonitor {
+    const wt = createTestWorktree(overrides);
+    const monitor = new WorktreeMonitorClass(
+      wt,
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: false,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(wt.id, monitor);
+    return monitor;
+  }
+
+  async function setupConfig(config: Record<string, unknown>) {
+    const fsModule = await import("fs/promises");
+    const mockAccess = vi.mocked(fsModule.access);
+    const mockReadFile = vi.mocked(fsModule.readFile);
+
+    mockAccess.mockImplementation(async (p: unknown) => {
+      if (n(p as string).endsWith("/test/root/.canopy/config.json")) return undefined;
+      throw new Error("ENOENT");
+    });
+    mockReadFile.mockResolvedValue(JSON.stringify(config) as never);
+  }
+
+  /** Creates a deferred promise pair — caller controls when the spawn child resolves. */
+  function makeDeferredSpawnChild() {
+    let resolveChild!: () => void;
+    const childDone = new Promise<void>((r) => {
+      resolveChild = r;
+    });
+    const invoked = { count: 0 };
+
+    const factory = () => {
+      invoked.count++;
+      const child = {
+        pid: 99,
+        stdout: {
+          on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+            if (event === "data") {
+              childDone.then(() => cb(Buffer.from('{"status":"ready"}')));
+            }
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((event: string, cb: (...args: unknown[]) => void) => {
+          if (event === "close") childDone.then(() => cb(0));
+        }),
+        kill: vi.fn(),
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return child as any;
+    };
+
+    return { factory, resolveChild, invoked };
+  }
+
+  it("serializes two manual actions on the same worktree", async () => {
+    createAndRegisterMonitor();
+    await setupConfig({
+      resource: { provision: ["deploy"], status: "check" },
+    });
+
+    const executionOrder: string[] = [];
+    const deferred1 = makeDeferredSpawnChild();
+    const deferred2 = makeDeferredSpawnChild();
+    let callCount = 0;
+
+    const childProcessModule = await import("child_process");
+    vi.mocked(childProcessModule.spawn).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        executionOrder.push("action1-start");
+        return deferred1.factory();
+      }
+      executionOrder.push("action2-start");
+      return deferred2.factory();
+    });
+
+    // Fire both actions concurrently
+    const p1 = service.runResourceAction("req-c1", "/test/worktree", "provision");
+    const p2 = service.runResourceAction("req-c2", "/test/worktree", "provision");
+
+    // Give first action time to start
+    await new Promise((r) => setTimeout(r, 20));
+    expect(executionOrder).toEqual(["action1-start"]);
+
+    // Complete first action
+    deferred1.resolveChild();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(executionOrder).toContain("action2-start");
+
+    // Complete second action
+    deferred2.resolveChild();
+    await Promise.all([p1, p2]);
+
+    expect(executionOrder).toEqual(["action1-start", "action2-start"]);
+  });
+
+  it("auto-poll skips when a manual action is in-flight", async () => {
+    createAndRegisterMonitor();
+    await setupConfig({
+      resource: { provision: ["deploy"], status: "check" },
+    });
+
+    const deferred = makeDeferredSpawnChild();
+    const childProcessModule = await import("child_process");
+    vi.mocked(childProcessModule.spawn).mockImplementation(deferred.factory);
+
+    // Start a manual provision action (holds the queue)
+    const provisionPromise = service.runResourceAction("req-m1", "/test/worktree", "provision");
+
+    // Give it time to start
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Auto-poll should skip silently (no event emitted)
+    await service.runResourceAction(
+      "auto-status-/test/worktree",
+      "/test/worktree",
+      "status",
+      undefined,
+      { origin: "auto-poll" }
+    );
+
+    // Only one spawn invocation (the manual action), poll was skipped
+    expect(deferred.invoked.count).toBe(1);
+
+    // No status result event emitted for the skipped poll
+    const statusResults = mockSendEvent.mock.calls.filter(
+      (c: unknown[]) => (c[0] as { requestId?: string }).requestId === "auto-status-/test/worktree"
+    );
+    expect(statusResults).toHaveLength(0);
+
+    deferred.resolveChild();
+    await provisionPromise;
+  });
+
+  it("actions on different worktrees run concurrently", async () => {
+    createAndRegisterMonitor({ id: "/test/wt-a", path: "/test/wt-a", name: "wt-a" });
+    createAndRegisterMonitor({ id: "/test/wt-b", path: "/test/wt-b", name: "wt-b" });
+    await setupConfig({
+      resource: { provision: ["deploy"], status: "check" },
+    });
+
+    const deferredA = makeDeferredSpawnChild();
+    const deferredB = makeDeferredSpawnChild();
+    let callCount = 0;
+
+    const childProcessModule = await import("child_process");
+    vi.mocked(childProcessModule.spawn).mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? deferredA.factory() : deferredB.factory();
+    });
+
+    // Fire both concurrently on different worktrees
+    const pA = service.runResourceAction("req-a", "/test/wt-a", "provision");
+    const pB = service.runResourceAction("req-b", "/test/wt-b", "provision");
+
+    // Give time for both to start
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Both should have started (independent queues)
+    expect(callCount).toBe(2);
+
+    deferredA.resolveChild();
+    deferredB.resolveChild();
+    await Promise.all([pA, pB]);
+  });
+
+  it("cleanup aborts in-flight action silently on worktree removal", async () => {
+    createAndRegisterMonitor();
+    await setupConfig({
+      resource: { provision: ["deploy"], status: "check" },
+    });
+
+    const deferred = makeDeferredSpawnChild();
+    const childProcessModule = await import("child_process");
+    vi.mocked(childProcessModule.spawn).mockImplementation(deferred.factory);
+
+    // Start an action that will be held open
+    const actionPromise = service.runResourceAction("req-abort", "/test/worktree", "provision");
+
+    // Give it time to start
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Simulate worktree removal — triggers cleanupResourceActionState
+    service["cleanupResourceActionState"]("/test/worktree");
+
+    deferred.resolveChild();
+    await actionPromise;
+
+    // Queue and controller should be cleaned up
+    expect(service["resourceActionQueues"].has("/test/worktree")).toBe(false);
+    expect(service["resourceActionAbortControllers"].has("/test/worktree")).toBe(false);
+  });
+});

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -787,4 +787,112 @@ describe("WorktreeMonitor", () => {
       expect(snapshot.hasTeardownCommand).toBe(true);
     });
   });
+
+  describe("resource poll timer — await-before-rearm", () => {
+    it("does not re-arm until the poll callback resolves", async () => {
+      let resolveCallback!: () => void;
+      const pollPromise = new Promise<void>((r) => {
+        resolveCallback = r;
+      });
+      let callCount = 0;
+
+      const callbacks = makeCallbacks({
+        onResourceStatusPoll: vi.fn(() => {
+          callCount++;
+          return pollPromise;
+        }),
+      });
+
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      monitor.startWithoutGitStatus();
+      monitor.setHasResourceConfig(true);
+      monitor.setHasStatusCommand(true);
+      monitor.setResourcePollInterval(5000);
+
+      // Fire the first timer
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(1);
+
+      // Advance past another interval — should NOT fire again because callback hasn't resolved
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(1);
+
+      // Resolve the first callback — timer should re-arm
+      resolveCallback();
+      await vi.advanceTimersByTimeAsync(1);
+
+      // Now advance past the re-armed interval
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(2);
+
+      monitor.stop();
+    });
+
+    it("stop() during awaited callback prevents re-arm", async () => {
+      let resolveCallback!: () => void;
+      const pollPromise = new Promise<void>((r) => {
+        resolveCallback = r;
+      });
+      let callCount = 0;
+
+      const callbacks = makeCallbacks({
+        onResourceStatusPoll: vi.fn(() => {
+          callCount++;
+          return pollPromise;
+        }),
+      });
+
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      monitor.startWithoutGitStatus();
+      monitor.setHasResourceConfig(true);
+      monitor.setHasStatusCommand(true);
+      monitor.setResourcePollInterval(5000);
+
+      // Fire the timer
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(1);
+
+      // Stop the monitor while the callback is in-flight
+      monitor.stop();
+
+      // Resolve the callback — should NOT re-arm because _isRunning is false
+      resolveCallback();
+      await vi.advanceTimersByTimeAsync(1);
+
+      // Advance well past the interval — no second call
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(callCount).toBe(1);
+    });
+
+    it("poll re-arms correctly when callback resolves quickly", async () => {
+      let callCount = 0;
+
+      const callbacks = makeCallbacks({
+        onResourceStatusPoll: vi.fn(() => {
+          callCount++;
+          return Promise.resolve();
+        }),
+      });
+
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      monitor.startWithoutGitStatus();
+      monitor.setHasResourceConfig(true);
+      monitor.setHasStatusCommand(true);
+      monitor.setResourcePollInterval(5000);
+
+      // Fire first poll
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(1);
+
+      // Fire second poll (re-armed after first resolved)
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(2);
+
+      // Fire third poll
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(callCount).toBe(3);
+
+      monitor.stop();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a per-worktree async queue in `WorkspaceService` that serializes Provision, Check Status, Deprovision, and Restart actions, preventing overlapping executions from racing on `lifecycleStatus` and `resourceStatus`.
- The auto-poll timer now checks whether an action is already in-flight and skips the poll rather than firing into a concurrent run, eliminating the overlap with slow status commands.
- On dispose, pending queue entries are aborted cleanly to avoid resource leaks or dangling operations after a worktree is removed.

Resolves #5127

## Changes

- `WorkspaceService.ts`: added `ResourceQueue` per worktree with enqueue/abort logic; poll timer respects in-flight state
- `WorktreeLifecycleService.ts`: queue teardown on worktree dispose
- `WorktreeMonitor.ts`: minor wiring to surface abort signals
- New unit tests covering queue serialization, abort-on-dispose, and poll skipping (`WorkspaceService.resource.test.ts`, `WorktreeMonitor.test.ts`)

## Testing

Unit tests added and passing. The two new test files cover the serialization invariant (second action queues behind first), abort-on-dispose (pending actions resolve without running), and poll-skip behaviour (in-flight action suppresses timer poll).