### PR TITLE
fix(projectCrud): resolve sender window for open dialog in multi-window

### DIFF
--- a/electron/ipc/handlers/__tests__/project.openDialog.test.ts
+++ b/electron/ipc/handlers/__tests__/project.openDialog.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showErrorBox: vi.fn(),
+  },
+  shell: {
+    openPath: vi.fn(),
+    openExternal: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue(os.tmpdir()),
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: {
+    getCurrentProjectId: vi.fn(),
+    getProjectById: vi.fn(),
+    setCurrentProject: vi.fn(),
+    getProjectState: vi.fn(),
+    saveProjectState: vi.fn(),
+    getAllProjects: vi.fn(() => []),
+    getCurrentProject: vi.fn(() => null),
+    updateProjectStatus: vi.fn(),
+  },
+}));
+
+vi.mock("../../../services/ProjectSwitchService.js", () => ({
+  ProjectSwitchService: class MockProjectSwitchService {
+    onSwitch = vi.fn();
+    switchProject = vi.fn();
+    reopenProject = vi.fn();
+  },
+}));
+
+vi.mock("../../../services/RunCommandDetector.js", () => ({
+  runCommandDetector: { detect: vi.fn().mockResolvedValue([]) },
+}));
+
+const mockGetWindowForWebContents = vi.fn();
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: (...args: unknown[]) => mockGetWindowForWebContents(...args),
+}));
+
+vi.mock("../../../window/portDistribution.js", () => ({
+  distributePortsToView: vi.fn(),
+}));
+
+import { ipcMain, dialog } from "electron";
+import { CHANNELS } from "../../channels.js";
+import { registerProjectCrudHandlers } from "../projectCrud.js";
+import type { HandlerDependencies } from "../../types.js";
+
+function getHandler(channel: string): (...args: unknown[]) => unknown {
+  const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+  for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+    handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+  }
+  const handler = handleMap.get(channel);
+  if (!handler) throw new Error(`No handler registered for ${channel}`);
+  return handler;
+}
+
+describe("handleProjectOpenDialog", () => {
+  let handler: (...args: unknown[]) => unknown;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const deps = {
+      mainWindow: { id: 1 } as unknown,
+      windowRegistry: {
+        getPrimary: () => ({
+          windowId: 1,
+          webContentsId: 10,
+          browserWindow: { id: 1, isDestroyed: () => false },
+        }),
+        getByWindowId: () => undefined,
+        getByWebContentsId: () => undefined,
+        all: () => [],
+        size: 1,
+      },
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+    handler = getHandler(CHANNELS.PROJECT_OPEN_DIALOG);
+  });
+
+  it("parents the dialog to the sender window when getWindowForWebContents returns a window", async () => {
+    const fakeWindow = { id: 2, isDestroyed: () => false };
+    mockGetWindowForWebContents.mockReturnValue(fakeWindow);
+    (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mockResolvedValue({
+      canceled: false,
+      filePaths: ["/projects/my-repo"],
+    });
+
+    const fakeEvent = { sender: { id: 20 } };
+    const result = await handler(fakeEvent);
+
+    expect(mockGetWindowForWebContents).toHaveBeenCalledWith(fakeEvent.sender);
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      fakeWindow,
+      expect.objectContaining({
+        title: "Open Git Repository",
+        properties: ["openDirectory", "createDirectory"],
+      })
+    );
+    expect(result).toBe("/projects/my-repo");
+  });
+
+  it("calls dialog without parent when getWindowForWebContents returns null", async () => {
+    mockGetWindowForWebContents.mockReturnValue(null);
+    (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mockResolvedValue({
+      canceled: false,
+      filePaths: ["/projects/fallback"],
+    });
+
+    const fakeEvent = { sender: { id: 99 } };
+    const result = await handler(fakeEvent);
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Open Git Repository",
+      })
+    );
+    // Should NOT have been called with a window as first arg
+    const callArgs = (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs).toHaveLength(1); // only opts, no window
+    expect(result).toBe("/projects/fallback");
+  });
+
+  it("returns null when dialog is canceled", async () => {
+    mockGetWindowForWebContents.mockReturnValue({ id: 1 });
+    (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mockResolvedValue({
+      canceled: true,
+      filePaths: [],
+    });
+
+    const result = await handler({ sender: { id: 10 } });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when filePaths is empty", async () => {
+    mockGetWindowForWebContents.mockReturnValue({ id: 1 });
+    (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mockResolvedValue({
+      canceled: false,
+      filePaths: [],
+    });
+
+    const result = await handler({ sender: { id: 10 } });
+    expect(result).toBeNull();
+  });
+
+  it("returns the first file path on success", async () => {
+    mockGetWindowForWebContents.mockReturnValue({ id: 1 });
+    (dialog.showOpenDialog as ReturnType<typeof vi.fn>).mockResolvedValue({
+      canceled: false,
+      filePaths: ["/first/path", "/second/path"],
+    });
+
+    const result = await handler({ sender: { id: 10 } });
+    expect(result).toBe("/first/path");
+  });
+});

--- a/electron/ipc/handlers/projectCrud.ts
+++ b/electron/ipc/handlers/projectCrud.ts
@@ -36,7 +36,6 @@ export function getProjectStatsService(): ProjectStatsService | null {
 }
 
 export function registerProjectCrudHandlers(deps: HandlerDependencies): () => void {
-  const mainWindow = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
   const handlers: Array<() => void> = [];
 
   const projectSwitchService = deps.projectSwitchService ?? new ProjectSwitchService(deps);
@@ -294,13 +293,14 @@ export function registerProjectCrudHandlers(deps: HandlerDependencies): () => vo
   ipcMain.handle(CHANNELS.PROJECT_SWITCH, handleProjectSwitch);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SWITCH));
 
-  const handleProjectOpenDialog = async () => {
+  const handleProjectOpenDialog = async (event: Electron.IpcMainInvokeEvent) => {
+    const senderWindow = getWindowForWebContents(event.sender);
     const dialogOpts = {
       properties: ["openDirectory" as const, "createDirectory" as const],
       title: "Open Git Repository",
     };
-    const result = mainWindow
-      ? await dialog.showOpenDialog(mainWindow, dialogOpts)
+    const result = senderWindow
+      ? await dialog.showOpenDialog(senderWindow, dialogOpts)
       : await dialog.showOpenDialog(dialogOpts);
 
     if (result.canceled || result.filePaths.length === 0) {


### PR DESCRIPTION
## Summary

- Opening a project in a new window failed because `handleProjectOpenDialog` was capturing a stale `mainWindow` reference instead of resolving the window from the IPC event sender.
- Fixed by passing the `event` parameter through to the handler and using `getWindowForWebContents(event.sender)` to resolve the correct window dynamically.
- Removed the dead `mainWindow` closure capture that was the root cause.

Resolves #5034

## Changes

- `electron/ipc/handlers/projectCrud.ts`: Added `event` parameter to `handleProjectOpenDialog`, resolve sender window via `getWindowForWebContents(event.sender)` rather than a stale closure.
- `electron/ipc/handlers/__tests__/project.openDialog.test.ts`: 5 new tests covering the correct window resolution, null safety, and that the stale-closure path no longer exists.

## Testing

Unit tests added and passing. The fix is targeted: only the window resolution path changes, everything else in `handleProjectOpenDialog` is untouched.