### PR TITLE
fix(tests): resolve Windows CI failures from path separator and shell quoting

### DIFF
--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -630,7 +630,7 @@ describe("Canopy -> Daintree userData migration gating", () => {
     // Legacy Canopy userData exists; new Daintree userData does not.
     fsMock.existsSync.mockImplementation((p: string) => {
       if (p.endsWith(".rebrand-migrated")) return false;
-      if (p.endsWith("/Canopy")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
       return false;
     });
 
@@ -645,7 +645,7 @@ describe("Canopy -> Daintree userData migration gating", () => {
     (process.env as Record<string, string | undefined>).BUILD_VARIANT = "canopy";
     fsMock.existsSync.mockImplementation((p: string) => {
       if (p.endsWith(".rebrand-migrated")) return false;
-      if (p.endsWith("/Canopy")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
       return false;
     });
 

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -636,9 +636,11 @@ describe("Canopy -> Daintree userData migration gating", () => {
 
     await import("../environment.js");
 
-    expect(fsMock.cpSync).toHaveBeenCalledWith("/tmp/user-data/Canopy", "/tmp/user-data/Daintree", {
-      recursive: true,
-    });
+    expect(fsMock.cpSync).toHaveBeenCalledWith(
+      path.join("/tmp/user-data", "Canopy"),
+      "/tmp/user-data/Daintree",
+      { recursive: true }
+    );
   });
 
   it("skips the migration when BUILD_VARIANT=canopy (legacy build)", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -709,68 +709,79 @@ describe("WorkspaceService.runResourceAction", () => {
       );
     });
 
-    it("substitutes {{worktree_name}} in connect command", async () => {
-      const monitor = createAndRegisterMonitor({ name: "feat-deploy" });
-      await setupConfig({
-        resource: {
-          provision: ["echo ok"],
-          connect: "ssh {{worktree_name}}@host.example.com",
-        },
+    describe("variable substitution", () => {
+      let originalPlatform: string;
+      beforeEach(() => {
+        originalPlatform = process.platform;
+        Object.defineProperty(process, "platform", { value: "linux", writable: true });
       });
-      await setupSpawn(0);
-
-      await service.runResourceAction("req-sub1", "/test/worktree", "provision");
-
-      expect(monitor.resourceConnectCommand).toBe("ssh 'feat-deploy'@host.example.com");
-    });
-
-    it("substitutes {{branch}} in connect command", async () => {
-      const monitor = createAndRegisterMonitor({ branch: "feature/remote" });
-      await setupConfig({
-        resource: {
-          provision: ["echo ok"],
-          connect: "ssh root@{{branch}}.dev.example.com",
-        },
+      afterEach(() => {
+        Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
       });
-      await setupSpawn(0);
 
-      await service.runResourceAction("req-sub2", "/test/worktree", "provision");
+      it("substitutes {{worktree_name}} in connect command", async () => {
+        const monitor = createAndRegisterMonitor({ name: "feat-deploy" });
+        await setupConfig({
+          resource: {
+            provision: ["echo ok"],
+            connect: "ssh {{worktree_name}}@host.example.com",
+          },
+        });
+        await setupSpawn(0);
 
-      expect(monitor.resourceConnectCommand).toBe("ssh root@'feature/remote'.dev.example.com");
-    });
+        await service.runResourceAction("req-sub1", "/test/worktree", "provision");
 
-    it("leaves unresolved {{endpoint}} placeholder intact", async () => {
-      const monitor = createAndRegisterMonitor();
-      await setupConfig({
-        resource: {
-          provision: ["echo ok"],
-          connect: "ssh root@{{endpoint}} -i ~/.ssh/key",
-        },
+        expect(monitor.resourceConnectCommand).toBe("ssh 'feat-deploy'@host.example.com");
       });
-      await setupSpawn(0);
 
-      await service.runResourceAction("req-sub3", "/test/worktree", "provision");
+      it("substitutes {{branch}} in connect command", async () => {
+        const monitor = createAndRegisterMonitor({ branch: "feature/remote" });
+        await setupConfig({
+          resource: {
+            provision: ["echo ok"],
+            connect: "ssh root@{{branch}}.dev.example.com",
+          },
+        });
+        await setupSpawn(0);
 
-      expect(monitor.resourceConnectCommand).toBe("ssh root@{{endpoint}} -i ~/.ssh/key");
-    });
+        await service.runResourceAction("req-sub2", "/test/worktree", "provision");
 
-    it("substitutes variables in provision commands before execution", async () => {
-      createAndRegisterMonitor({ name: "my-wt", branch: "feat/x" });
-      await setupConfig({
-        resource: {
-          provision: ["deploy --name={{worktree_name}} --branch={{branch}}"],
-        },
+        expect(monitor.resourceConnectCommand).toBe("ssh root@'feature/remote'.dev.example.com");
       });
-      await setupSpawn(0);
 
-      const runCommandsSpy = vi.spyOn(service["lifecycleService"], "runCommands");
+      it("leaves unresolved {{endpoint}} placeholder intact", async () => {
+        const monitor = createAndRegisterMonitor();
+        await setupConfig({
+          resource: {
+            provision: ["echo ok"],
+            connect: "ssh root@{{endpoint}} -i ~/.ssh/key",
+          },
+        });
+        await setupSpawn(0);
 
-      await service.runResourceAction("req-sub4", "/test/worktree", "provision");
+        await service.runResourceAction("req-sub3", "/test/worktree", "provision");
 
-      expect(runCommandsSpy).toHaveBeenCalledWith(
-        ["deploy --name='my-wt' --branch='feat/x'"],
-        expect.any(Object)
-      );
+        expect(monitor.resourceConnectCommand).toBe("ssh root@{{endpoint}} -i ~/.ssh/key");
+      });
+
+      it("substitutes variables in provision commands before execution", async () => {
+        createAndRegisterMonitor({ name: "my-wt", branch: "feat/x" });
+        await setupConfig({
+          resource: {
+            provision: ["deploy --name={{worktree_name}} --branch={{branch}}"],
+          },
+        });
+        await setupSpawn(0);
+
+        const runCommandsSpy = vi.spyOn(service["lifecycleService"], "runCommands");
+
+        await service.runResourceAction("req-sub4", "/test/worktree", "provision");
+
+        expect(runCommandsSpy).toHaveBeenCalledWith(
+          ["deploy --name='my-wt' --branch='feat/x'"],
+          expect.any(Object)
+        );
+      });
     });
   });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -713,10 +713,18 @@ describe("WorkspaceService.runResourceAction", () => {
       let originalPlatform: string;
       beforeEach(() => {
         originalPlatform = process.platform;
-        Object.defineProperty(process, "platform", { value: "linux", writable: true });
+        Object.defineProperty(process, "platform", {
+          value: "linux",
+          writable: true,
+          configurable: true,
+        });
       });
       afterEach(() => {
-        Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+        Object.defineProperty(process, "platform", {
+          value: originalPlatform,
+          writable: true,
+          configurable: true,
+        });
       });
 
       it("substitutes {{worktree_name}} in connect command", async () => {


### PR DESCRIPTION
## Summary

- **`WorkspaceService.resource.test.ts`**: Wrap the four variable-substitution tests in a nested `describe` block that pins `process.platform` to `'linux'`. These tests verify substitution logic, not OS-specific quoting — on Windows, `shellEscapeValue` produces double quotes which broke the single-quote assertions at lines 724, 739, and 770.
- **`environment.test.ts`**: Extend the `existsSync` mock to match both `/Canopy` and `\Canopy` path endings. On Windows, `path.join` uses backslash separators so the forward-slash-only check returned `false`, the migration gate was never entered, and `cpSync` was never called (line 639).

Closes #4671 (Windows wave — April 12–16 nightly runs).

## Test plan

- [x] `npx vitest run electron/workspace-host/__tests__/WorkspaceService.resource.test.ts` — 51 tests pass locally
- [x] `npx vitest run electron/setup/__tests__/environment.test.ts` — 34 tests pass locally
- [ ] Confirm April 17 nightly goes green on Windows for these two files