### PR TITLE
Agent tray shows uninstalled agents and only refreshes on restart

### DIFF
--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -1,4 +1,5 @@
 import {
+  useEffect,
   useMemo,
   useRef,
   type ComponentType,
@@ -21,6 +22,7 @@ import { getBrandColorHex } from "@/lib/colorUtils";
 import { getAgentConfig, type AgentIconProps } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useKeybindingDisplay } from "@/hooks";
@@ -85,12 +87,35 @@ export function AgentTrayButton({
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
 
+  const refreshAvailability = useCliAvailabilityStore((s) => s.refresh);
+  const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
+
   const panelsById = usePanelStore((s) => s.panelsById);
   const panelIds = usePanelStore((s) => s.panelIds);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
-  const isAvailabilityLoading = agentAvailability === undefined;
+  // Before the first real availability result lands we can't distinguish
+  // "all agents missing" from "still detecting", so we show a spinner.
+  const isAvailabilityLoading = agentAvailability === undefined || !hasRealData;
   const lastPinActionAt = useRef(0);
+
+  // Re-probe on view visibility changes (Electron LRU reactivation, tab
+  // switches). The window-focus trigger is handled once globally in
+  // useAgentLauncher; both paths share the 30s throttle in the store.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    let disposed = false;
+    const handleVisibility = () => {
+      if (disposed) return;
+      if (document.visibilityState !== "visible") return;
+      void refreshAvailability().catch(() => {});
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      disposed = true;
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [refreshAvailability]);
 
   const agentDominantStates = useMemo(() => {
     const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
@@ -117,9 +142,10 @@ export function AgentTrayButton({
     return result;
   }, [panelsById, panelIds, activeWorktreeId]);
 
-  const { launchable, needsSetup } = useMemo(() => {
+  const { launchable, needsSetup, fallbackSetup } = useMemo(() => {
     const launchable: AgentRow[] = [];
     const needsSetup: AgentRow[] = [];
+    const fallbackSetup: AgentRow[] = [];
 
     for (const id of BUILT_IN_AGENT_IDS) {
       const pinned = isAgentPinned(agentSettings?.agents?.[id]);
@@ -130,12 +156,18 @@ export function AgentTrayButton({
       const state = agentAvailability?.[id];
       if (isAgentReady(state)) {
         launchable.push(row);
-      } else if (isAgentInstalled(state) || state !== undefined) {
+      } else if (isAgentInstalled(state)) {
+        // "installed" means the CLI is on PATH but not fully authenticated
+        // or configured yet. These belong in "Also Available" with a setup
+        // badge. Missing agents do NOT get promoted here.
         needsSetup.push(row);
       }
+      // Always build a fallback row so we can offer discovery when
+      // nothing is installed on this machine.
+      fallbackSetup.push(row);
     }
 
-    return { launchable, needsSetup };
+    return { launchable, needsSetup, fallbackSetup };
   }, [agentAvailability, agentSettings, agentDominantStates]);
 
   const handleLaunch = (row: AgentRow) => {
@@ -152,6 +184,16 @@ export function AgentTrayButton({
 
   const handleCustomizeToolbar = () => {
     void actionService.dispatch("app.settings.openTab", { tab: "toolbar" }, { source: "user" });
+  };
+
+  const handleManageAgents = () => {
+    void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) return;
+    // Fire-and-forget: the store throttle absorbs rapid reopens.
+    void refreshAvailability().catch(() => {});
   };
 
   const togglePin = (row: AgentRow) => {
@@ -174,9 +216,13 @@ export function AgentTrayButton({
   };
 
   const hasAnyContent = launchable.length > 0 || needsSetup.length > 0;
+  // Show every built-in with a Setup badge if nothing is installed — discovery
+  // over an unhelpful "No agents available" dead end. Only kicks in once real
+  // availability data has landed.
+  const showFallback = !isAvailabilityLoading && !hasAnyContent && fallbackSetup.length > 0;
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={handleOpenChange}>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -203,12 +249,9 @@ export function AgentTrayButton({
           if ((e as unknown as PointerEvent).detail > 0) e.preventDefault();
         }}
       >
-        {!hasAnyContent &&
-          (isAvailabilityLoading ? (
-            <div className="px-2.5 py-1.5 text-xs text-daintree-text/60">Checking agents…</div>
-          ) : (
-            <div className="px-2.5 py-1.5 text-xs text-daintree-text/60">No agents available</div>
-          ))}
+        {isAvailabilityLoading && (
+          <div className="px-2.5 py-1.5 text-xs text-daintree-text/60">Checking agents…</div>
+        )}
 
         {launchable.length > 0 && (
           <>
@@ -248,7 +291,33 @@ export function AgentTrayButton({
           </>
         )}
 
-        {hasAnyContent && <DropdownMenuSeparator />}
+        {showFallback && (
+          <>
+            <DropdownMenuLabel>Available Agents</DropdownMenuLabel>
+            {fallbackSetup.map((row) => (
+              <DropdownMenuItem
+                key={`fallback-${row.id}`}
+                onSelect={() => handleSetup(row.id)}
+                className="group h-7"
+                data-testid={`agent-tray-fallback-${row.id}`}
+              >
+                <span className="mr-2 inline-flex h-4 w-4 items-center justify-center grayscale opacity-50">
+                  <row.Icon brandColor={getBrandColorHex(row.id)} />
+                </span>
+                <span className="flex-1 text-daintree-text/70">{row.name}</span>
+                <span className="ml-2 shrink-0 rounded border border-daintree-text/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-daintree-text/50">
+                  Setup
+                </span>
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+
+        {(hasAnyContent || showFallback) && <DropdownMenuSeparator />}
+        <DropdownMenuItem onSelect={handleManageAgents} className="h-7">
+          <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
+          Manage Agents…
+        </DropdownMenuItem>
         <DropdownMenuItem onSelect={handleCustomizeToolbar} className="h-7">
           <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
           Customize Toolbar…

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -6,11 +6,14 @@ import type { AgentSettings, CliAvailability } from "@shared/types";
 const dispatchMock = vi.fn();
 const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
 const setFocusedMock = vi.fn();
+const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
+let openChangeSpy: ((open: boolean) => void) | null = null;
 
 let mockSettings: AgentSettings | null = null;
 let mockPanelsById: Record<string, unknown> = {};
 let mockPanelIds: string[] = [];
 let mockActiveWorktreeId: string | null = null;
+let mockHasRealData = true;
 
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
@@ -24,6 +27,16 @@ type MockAgentStoreState = {
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: (selector: (s: MockAgentStoreState) => unknown) =>
     selector({ settings: mockSettings, setAgentPinned: setAgentPinnedMock }),
+}));
+
+type MockCliAvailabilityStoreState = {
+  refresh: typeof refreshAvailabilityMock;
+  hasRealData: boolean;
+};
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: MockCliAvailabilityStoreState) => unknown) =>
+    selector({ refresh: refreshAvailabilityMock, hasRealData: mockHasRealData }),
 }));
 
 vi.mock("@/store/panelStore", () => ({
@@ -63,7 +76,16 @@ vi.mock("@/lib/colorUtils", () => ({
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    openChangeSpy = onOpenChange ?? null;
+    return <div>{children}</div>;
+  },
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="dropdown-content">{children}</div>
@@ -142,10 +164,13 @@ describe("AgentTrayButton", () => {
     dispatchMock.mockClear();
     setAgentPinnedMock.mockClear();
     setFocusedMock.mockClear();
+    refreshAvailabilityMock.mockClear();
+    openChangeSpy = null;
     mockSettings = null;
     mockPanelsById = {};
     mockPanelIds = [];
     mockActiveWorktreeId = null;
+    mockHasRealData = true;
   });
 
   it("renders the plug trigger with accessible label", () => {
@@ -268,7 +293,7 @@ describe("AgentTrayButton", () => {
     expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("false");
   });
 
-  it("puts missing and installed-but-unauth agents in Also Available with pill badge", () => {
+  it("only puts installed-but-unauth agents in Also Available (missing agents are hidden)", () => {
     const availability = {
       claude: "ready",
       gemini: "missing",
@@ -283,11 +308,17 @@ describe("AgentTrayButton", () => {
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
     expect(labels).toContain("Also Available");
 
-    const setupItems = Array.from(container.querySelectorAll('[role="menuitem"]')).filter((el) =>
-      el.textContent?.includes("Setup")
+    const setupItems = Array.from(container.querySelectorAll('[role="menuitem"]')).filter(
+      (el) =>
+        el.textContent?.includes("Setup") &&
+        !el.textContent.includes("Manage") &&
+        !el.textContent.includes("Customize")
     );
-    // Gemini (missing) + Codex (installed) in Also Available
-    expect(setupItems.length).toBeGreaterThanOrEqual(2);
+    // Only codex (installed) belongs in Also Available. Gemini (missing) must NOT appear.
+    expect(setupItems.length).toBe(1);
+    expect(setupItems[0].textContent).toContain("Codex");
+    const allText = container.textContent ?? "";
+    expect(allText).not.toMatch(/Also Available[\s\S]*Gemini/);
   });
 
   it("dispatches settings for setup items", () => {
@@ -330,11 +361,95 @@ describe("AgentTrayButton", () => {
     expect(getByText("Checking agents…")).toBeTruthy();
   });
 
-  it("shows 'No agents available' for empty availability", () => {
-    const { getByText } = render(
+  it("shows loading placeholder before hasRealData even if availability is supplied", () => {
+    mockHasRealData = false;
+    const { getByText, queryByTestId } = render(
       <AgentTrayButton agentAvailability={{} as unknown as CliAvailability} />
     );
-    expect(getByText("No agents available")).toBeTruthy();
+    expect(getByText("Checking agents…")).toBeTruthy();
+    // Fallback rows must not render during the initial probe.
+    expect(queryByTestId("agent-tray-fallback-claude")).toBeNull();
+  });
+
+  it("shows fallback setup rows when data has loaded but nothing is installed", () => {
+    mockHasRealData = true;
+    const availability = {
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+    } as unknown as CliAvailability;
+
+    const { queryByText, getByTestId, getAllByTestId } = render(
+      <AgentTrayButton agentAvailability={availability} />
+    );
+    // Should NOT show the old dead-end message.
+    expect(queryByText("No agents available")).toBeNull();
+    // Every built-in shows up as a setup row so the user can still discover them.
+    expect(getByTestId("agent-tray-fallback-claude")).toBeTruthy();
+    expect(getByTestId("agent-tray-fallback-gemini")).toBeTruthy();
+    expect(getByTestId("agent-tray-fallback-codex")).toBeTruthy();
+    const labels = getAllByTestId("menu-label").map((el) => el.textContent);
+    expect(labels).toContain("Available Agents");
+  });
+
+  it("triggers a refresh when the dropdown opens", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    expect(openChangeSpy).toBeTruthy();
+    refreshAvailabilityMock.mockClear();
+
+    openChangeSpy!(true);
+    expect(refreshAvailabilityMock).toHaveBeenCalledTimes(1);
+
+    // Closing must not trigger another refresh.
+    openChangeSpy!(false);
+    expect(refreshAvailabilityMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("triggers a refresh on document visibilitychange when visible", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    const { unmount } = render(<AgentTrayButton agentAvailability={availability} />);
+    refreshAvailabilityMock.mockClear();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "hidden",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(refreshAvailabilityMock).not.toHaveBeenCalled();
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(refreshAvailabilityMock).toHaveBeenCalledTimes(1);
+
+    // Unmount must detach the listener so stale components can't refresh.
+    unmount();
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(refreshAvailabilityMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a Manage Agents… footer that opens the agents settings tab", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    const { container } = render(<AgentTrayButton agentAvailability={availability} />);
+    const manage = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
+      el.textContent?.includes("Manage Agents")
+    );
+    expect(manage).toBeTruthy();
+    fireEvent.click(manage!);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "agents" },
+      { source: "user" }
+    );
   });
 
   it("handles null store settings gracefully (opt-in default)", () => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 
@@ -173,6 +173,15 @@ describe("AgentTrayButton", () => {
     mockHasRealData = true;
   });
 
+  afterEach(() => {
+    // jsdom's default `visibilityState` is "visible"; tests that mutate it via
+    // defineProperty can bleed state between files, so reset explicitly.
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      value: "visible",
+    });
+  });
+
   it("renders the plug trigger with accessible label", () => {
     const { getByLabelText, getByTestId } = render(<AgentTrayButton />);
     expect(getByLabelText("Agent tray")).toBeTruthy();
@@ -321,11 +330,20 @@ describe("AgentTrayButton", () => {
     expect(allText).not.toMatch(/Also Available[\s\S]*Gemini/);
   });
 
-  it("dispatches settings for setup items", () => {
-    const availability = { gemini: "missing" } as unknown as CliAvailability;
-    mockSettings = settingsWith({});
+  it("dispatches settings with subtab when an Also-Available setup row is clicked", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "installed",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
 
-    const { container } = render(<AgentTrayButton agentAvailability={availability} />);
+    const { container, getAllByTestId } = render(
+      <AgentTrayButton agentAvailability={availability} />
+    );
+    // Sanity check: this must be the Also-Available branch, not the fallback.
+    const labels = getAllByTestId("menu-label").map((el) => el.textContent);
+    expect(labels).toContain("Also Available");
+
     const setupItem = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
       el.textContent?.includes("Gemini")
     );

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -63,7 +63,9 @@ export function AgentSettings({
   const handleRefreshCliAvailability = useCallback(async () => {
     if (isRefreshingCli) return;
     try {
-      await refreshCliAvailability();
+      // Explicit user gesture — bypass the 30s throttle that exists for
+      // passive triggers (tray-open, window focus, visibility change).
+      await refreshCliAvailability(true);
     } catch (error) {
       console.error("[AgentSettings] Failed to refresh CLI availability:", error);
     }

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -207,6 +207,52 @@ describe("cliAvailabilityStore", () => {
 
       expect(refreshMock).not.toHaveBeenCalled();
     });
+
+    it("throttles a second refresh within 30s of a successful one", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy.mockReturnValue(1_000_000);
+
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockReturnValue(1_000_000 + 10_000);
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockRestore();
+    });
+
+    it("does not throttle after 30s have elapsed", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy.mockReturnValue(2_000_000);
+
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+
+      nowSpy.mockReturnValue(2_000_000 + 31_000);
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(2);
+
+      nowSpy.mockRestore();
+    });
+
+    it("does not throttle after a failed refresh (lastCheckedAt stays null)", async () => {
+      refreshMock.mockRejectedValueOnce(new Error("boom"));
+      await useCliAvailabilityStore
+        .getState()
+        .refresh()
+        .catch(() => {});
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+
+      // Failed refresh should not have set lastCheckedAt, so the throttle
+      // should not fire and this call should go through.
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("cleanupCliAvailabilityStore", () => {

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -277,22 +277,31 @@ describe("cliAvailabilityStore", () => {
         availability: installedAvail,
         lastCheckedAt: Date.now() - 1_000,
       };
-      const getItemSpy = vi.spyOn(Storage.prototype, "getItem");
-      getItemSpy.mockReturnValueOnce(JSON.stringify(fakeCache));
 
-      // Init will hydrate from the cache but then fail the live probe, so
-      // lastCheckedAt should remain null — any future refresh must still run.
-      refreshMock.mockRejectedValueOnce(new Error("transient"));
-      await useCliAvailabilityStore.getState().initialize();
+      // Vitest runs this file under the Node environment, so there's no
+      // browser `Storage` global to spy on. Stub `window.localStorage`
+      // directly — the store loads the cache via `window.localStorage.getItem`.
+      const getItem = vi.fn().mockReturnValueOnce(JSON.stringify(fakeCache));
+      const setItem = vi.fn();
+      vi.stubGlobal("window", { localStorage: { getItem, setItem } });
 
-      expect(useCliAvailabilityStore.getState().lastCheckedAt).toBeNull();
+      try {
+        // Init will hydrate from the cache but then fail the live probe, so
+        // lastCheckedAt should remain null — any future refresh must still run.
+        refreshMock.mockRejectedValueOnce(new Error("transient"));
+        await useCliAvailabilityStore.getState().initialize();
 
-      // The next refresh must not be throttled by the (stale) cache timestamp.
-      refreshMock.mockResolvedValueOnce(installedAvail);
-      await useCliAvailabilityStore.getState().refresh();
-      expect(refreshMock).toHaveBeenCalledTimes(2);
+        expect(useCliAvailabilityStore.getState().lastCheckedAt).toBeNull();
+        // Cached availability should still have hydrated (hasRealData proves it).
+        expect(useCliAvailabilityStore.getState().hasRealData).toBe(true);
 
-      getItemSpy.mockRestore();
+        // The next refresh must not be throttled by the (stale) cache timestamp.
+        refreshMock.mockResolvedValueOnce(installedAvail);
+        await useCliAvailabilityStore.getState().refresh();
+        expect(refreshMock).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
   });
 

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -253,6 +253,47 @@ describe("cliAvailabilityStore", () => {
       await useCliAvailabilityStore.getState().refresh();
       expect(refreshMock).toHaveBeenCalledTimes(2);
     });
+
+    it("force: true bypasses the 30s throttle", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      const nowSpy = vi.spyOn(Date, "now");
+      nowSpy.mockReturnValue(3_000_000);
+
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+
+      // Within the throttle window; without force this would be skipped.
+      nowSpy.mockReturnValue(3_000_000 + 5_000);
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      await useCliAvailabilityStore.getState().refresh(true);
+      expect(refreshMock).toHaveBeenCalledTimes(2);
+
+      nowSpy.mockRestore();
+    });
+
+    it("does not seed the throttle from cached lastCheckedAt on hydrate", async () => {
+      // Arrange: a recent cache (inside the 30s throttle window if it were honoured).
+      const fakeCache = {
+        availability: installedAvail,
+        lastCheckedAt: Date.now() - 1_000,
+      };
+      const getItemSpy = vi.spyOn(Storage.prototype, "getItem");
+      getItemSpy.mockReturnValueOnce(JSON.stringify(fakeCache));
+
+      // Init will hydrate from the cache but then fail the live probe, so
+      // lastCheckedAt should remain null — any future refresh must still run.
+      refreshMock.mockRejectedValueOnce(new Error("transient"));
+      await useCliAvailabilityStore.getState().initialize();
+
+      expect(useCliAvailabilityStore.getState().lastCheckedAt).toBeNull();
+
+      // The next refresh must not be throttled by the (stale) cache timestamp.
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      await useCliAvailabilityStore.getState().refresh();
+      expect(refreshMock).toHaveBeenCalledTimes(2);
+
+      getItemSpy.mockRestore();
+    });
   });
 
   describe("cleanupCliAvailabilityStore", () => {

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -34,6 +34,10 @@ function defaultAvailability(): CliAvailability {
 const CACHE_STORAGE_KEY = "daintree:cliAvailability:v1";
 // Stale cache is still shown but triggers a synchronous refresh on init.
 const CACHE_STALE_AFTER_MS = 24 * 60 * 60 * 1000; // 24h
+// Short-window throttle for mid-session refreshes (tray-open, visibility,
+// focus). Keeps rapid triggers from spamming IPC; longer-term staleness is
+// governed by CACHE_STALE_AFTER_MS during initialize.
+const REFRESH_THROTTLE_MS = 30 * 1000;
 
 const VALID_STATES: ReadonlySet<AgentAvailabilityState> = new Set<AgentAvailabilityState>([
   "ready",
@@ -168,6 +172,14 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get)
   refresh: () => {
     // If init is still in-flight, join it rather than firing a duplicate IPC call.
     if (initPromise) return initPromise;
+
+    // Skip if the last successful probe landed within the throttle window.
+    // Failed refreshes do not set lastCheckedAt, so they stay retryable.
+    const { lastCheckedAt } = get();
+    if (lastCheckedAt !== null && Date.now() - lastCheckedAt < REFRESH_THROTTLE_MS) {
+      return Promise.resolve();
+    }
+
     if (refreshPromise) return refreshPromise;
 
     if (!isElectronAvailable()) return Promise.resolve();

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -22,7 +22,13 @@ interface CliAvailabilityState {
 
 interface CliAvailabilityActions {
   initialize: () => Promise<void>;
-  refresh: () => Promise<void>;
+  /**
+   * Probe CLI availability again. Pass `force: true` for explicit user
+   * gestures (e.g. the Refresh button in AgentSettings) so the 30s throttle
+   * — which exists to absorb passive triggers like tray-open and focus —
+   * does not swallow the request.
+   */
+  refresh: (force?: boolean) => Promise<void>;
 }
 
 type CliAvailabilityStore = CliAvailabilityState & CliAvailabilityActions;
@@ -121,11 +127,16 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get)
     // Hydrate from localStorage before kicking off the IPC call. This kills
     // the first-paint toolbar flicker: cached pins render immediately and
     // only reconcile when the fresh result lands.
+    //
+    // Deliberately omit `lastCheckedAt` so the 30s refresh throttle only
+    // kicks in after a successful *live* probe this session. Persisting
+    // the cached timestamp would mute the first mid-session refresh after
+    // a relaunch (and, with clock skew, could suppress refreshes
+    // indefinitely).
     const cached = loadCache();
     if (cached) {
       set({
         availability: cached.availability,
-        lastCheckedAt: cached.lastCheckedAt,
         hasRealData: true,
       });
     }
@@ -169,15 +180,18 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get)
     return initPromise;
   },
 
-  refresh: () => {
+  refresh: (force = false) => {
     // If init is still in-flight, join it rather than firing a duplicate IPC call.
     if (initPromise) return initPromise;
 
     // Skip if the last successful probe landed within the throttle window.
     // Failed refreshes do not set lastCheckedAt, so they stay retryable.
-    const { lastCheckedAt } = get();
-    if (lastCheckedAt !== null && Date.now() - lastCheckedAt < REFRESH_THROTTLE_MS) {
-      return Promise.resolve();
+    // Explicit user gestures pass `force: true` to bypass the window.
+    if (!force) {
+      const { lastCheckedAt } = get();
+      if (lastCheckedAt !== null && Date.now() - lastCheckedAt < REFRESH_THROTTLE_MS) {
+        return Promise.resolve();
+      }
     }
 
     if (refreshPromise) return refreshPromise;


### PR DESCRIPTION
## Summary

- `AgentTrayButton` now filters strictly on `isAgentInstalled(state)` — agents with state `"missing"` no longer leak into the "Also Available" section via the loose `state !== undefined` fallback.
- `cliAvailabilityStore.refresh()` gains a 30s throttle for passive triggers, with a `force` flag so the Settings "Refresh" button still fires immediately; the tray open path and a per-view `visibilitychange` listener hook into the passive path.
- Empty tray state replaced with a fallback list of all built-in agents with Setup badges (shown only once `hasRealData` is true, so the initial "Checking agents…" spinner still appears). "Manage Agents…" footer item added to the tray.

Fixes #5157

## Changes

- `src/store/cliAvailabilityStore.ts` — throttle logic, `force` param, `initialize()` no longer seeds `lastCheckedAt` from cache (avoids muting mid-session refreshes after a relaunch)
- `src/components/Layout/AgentTrayButton.tsx` — filter fix, tray-open refresh via `onOpenChange`, `visibilitychange` listener, empty-state fallback, "Manage Agents…" footer
- `src/components/Settings/AgentSettings.tsx` — passes `force: true` to the Refresh button call

## Testing

39/39 unit tests passing across both modified test files (18 store + 19 tray + 2 new edge cases covering throttle force-bypass and cache hydration safety). `AgentSettings` subtab tests unaffected (10/10). Typecheck, lint, and format all clean.