### PR TITLE
fix(setup): rebrand migration skipped when empty daintree.db present (#5156)

### DIFF
--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -855,6 +855,104 @@ describe("Canopy -> Daintree userData migration gating", () => {
     );
   });
 
+  it("fail-safe: treats prepare/get error as 'has data' and closes the DB", async () => {
+    // Covers a different SQLITE error path: constructor succeeds but the
+    // probe query throws (e.g. SQLITE_BUSY mid-read or a missing table).
+    // The finally block must still close the connection so WAL/SHM handles
+    // don't leak into the persistence service that opens this DB seconds later.
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return false;
+      if (p.endsWith("daintree.db")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    const closeSpy = vi.fn();
+    sqliteMock.Database.mockImplementation(
+      class {
+        prepare = () => ({
+          get: () => {
+            const err = new Error("database is locked") as Error & { code: string };
+            err.code = "SQLITE_BUSY";
+            throw err;
+          },
+        });
+        close = closeSpy;
+      } as unknown as new () => unknown
+    );
+
+    await import("../environment.js");
+
+    expect(closeSpy).toHaveBeenCalled();
+    expect(fsMock.cpSync).not.toHaveBeenCalled();
+    expect(fsUtilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(".rebrand-migrated"),
+      expect.stringContaining("skipped: daintree.db already present")
+    );
+  });
+
+  it("does NOT migrate when daintree.db is empty but Chromium-side state exists (Preferences)", async () => {
+    // A pre-release Daintree user who customized prefs/themes but never opened
+    // a project leaves zero rows in projects but does write `Preferences`.
+    // Migrating Canopy data over them would wipe out their customization at
+    // the rmSync(newUserData, recursive) step. This is the symmetric bug to
+    // #5156 — a regression in the opposite direction.
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return false;
+      if (p.endsWith("daintree.db")) return true;
+      if (p.endsWith("/Daintree/Preferences")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    // Zero rows is the default beforeEach mock — the usage-marker check is
+    // what must catch this case.
+
+    await import("../environment.js");
+
+    expect(fsMock.cpSync).not.toHaveBeenCalled();
+    expect(fsMock.rmSync).not.toHaveBeenCalled();
+    expect(fsUtilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(".rebrand-migrated"),
+      expect.stringContaining("skipped: daintree.db already present")
+    );
+  });
+
+  it("does NOT auto-heal when Chromium-side Daintree state exists (Local Storage)", async () => {
+    // Same protection in the auto-heal direction — a pre-release user with a
+    // stale skip marker who customized Daintree (creating Local Storage) but
+    // never opened a project must not have their state wiped by auto-heal.
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return true; // marker stays
+      if (p.endsWith("daintree.db")) return true;
+      if (p.endsWith("/Daintree/Local Storage")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    fsMock.readFileSync.mockReturnValue(
+      "2026-04-16T14:31:00.178Z\nskipped: daintree.db already present\n"
+    );
+    sqliteMock.Database.mockImplementation(
+      class {
+        constructor(dbPath: unknown) {
+          const isCanopy = typeof dbPath === "string" && dbPath.endsWith("canopy.db");
+          (this as { prepare: unknown }).prepare = () => ({
+            get: () => ({ count: isCanopy ? 5 : 0 }),
+          });
+          (this as { close: unknown }).close = vi.fn();
+        }
+      } as unknown as new () => unknown
+    );
+
+    await import("../environment.js");
+
+    expect(fsMock.rmSync).not.toHaveBeenCalledWith(
+      path.join("/tmp/user-data/Daintree", ".rebrand-migrated")
+    );
+    expect(fsMock.cpSync).not.toHaveBeenCalled();
+  });
+
   it("excludes Chromium singleton / cache / crashpad state from the copy", async () => {
     Reflect.deleteProperty(process.env, "BUILD_VARIANT");
     fsMock.existsSync.mockImplementation((p: string) => {

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -8,6 +8,7 @@ const fsMock = vi.hoisted(() => ({
   cpSync: vi.fn(),
   renameSync: vi.fn(),
   writeFileSync: vi.fn(),
+  readFileSync: vi.fn<(p: string, enc: string) => string>(),
 }));
 
 const electronMock = vi.hoisted(() => ({
@@ -26,6 +27,23 @@ const fixPathMock = vi.hoisted(() => ({
   default: vi.fn(),
 }));
 
+const sqliteMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  prepare: vi.fn(),
+  close: vi.fn(),
+  Database: vi.fn(),
+}));
+
+const fsUtilsMock = vi.hoisted(() => ({
+  resilientAtomicWriteFileSync: vi.fn(),
+  resilientRename: vi.fn(),
+  resilientRenameSync: vi.fn(),
+  resilientDirectWriteFile: vi.fn(),
+  resilientAtomicWriteFile: vi.fn(),
+  resilientUnlink: vi.fn(),
+  waitForPathExists: vi.fn(),
+}));
+
 vi.mock("fs", () => ({
   default: {
     existsSync: fsMock.existsSync,
@@ -34,6 +52,7 @@ vi.mock("fs", () => ({
     cpSync: fsMock.cpSync,
     renameSync: fsMock.renameSync,
     writeFileSync: fsMock.writeFileSync,
+    readFileSync: fsMock.readFileSync,
   },
   existsSync: fsMock.existsSync,
   readdirSync: fsMock.readdirSync,
@@ -41,11 +60,16 @@ vi.mock("fs", () => ({
   cpSync: fsMock.cpSync,
   renameSync: fsMock.renameSync,
   writeFileSync: fsMock.writeFileSync,
+  readFileSync: fsMock.readFileSync,
 }));
 
 vi.mock("electron", () => electronMock);
 
 vi.mock("fix-path", () => fixPathMock);
+
+vi.mock("better-sqlite3", () => ({ default: sqliteMock.Database }));
+
+vi.mock("../../utils/fs.js", () => fsUtilsMock);
 
 vi.mock("node:v8", () => ({
   default: { setFlagsFromString: vi.fn() },
@@ -613,6 +637,20 @@ describe("Canopy -> Daintree userData migration gating", () => {
       if (key === "appData") return "/tmp/user-data";
       return "/tmp/test";
     });
+    // Re-wire the better-sqlite3 chain after vi.resetAllMocks() — the reset
+    // clears the implementation set inside vi.mock(...) factories, so the
+    // Database -> prepare -> get chain has to be rebuilt every test. Vitest
+    // 4 requires `mockImplementation` with a `class` (or `function`, not arrow)
+    // when the mock is invoked with `new`. Default: probe returns 0 rows
+    // (empty DB) so migration proceeds unless a test overrides.
+    sqliteMock.get.mockReturnValue({ count: 0 });
+    sqliteMock.prepare.mockReturnValue({ get: sqliteMock.get });
+    sqliteMock.Database.mockImplementation(
+      class {
+        prepare = sqliteMock.prepare;
+        close = sqliteMock.close;
+      } as unknown as new () => unknown
+    );
   });
 
   afterEach(() => {
@@ -655,7 +693,7 @@ describe("Canopy -> Daintree userData migration gating", () => {
     );
   });
 
-  it("skips the migration when Daintree data already exists (daintree.db present)", async () => {
+  it("skips the migration when Daintree data already exists (daintree.db has rows)", async () => {
     Reflect.deleteProperty(process.env, "BUILD_VARIANT");
     fsMock.existsSync.mockImplementation((p: string) => {
       if (p.endsWith(".rebrand-migrated")) return false;
@@ -663,6 +701,8 @@ describe("Canopy -> Daintree userData migration gating", () => {
       if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
       return false;
     });
+    // The DB exists AND has real rows — a real Daintree user.
+    sqliteMock.get.mockReturnValue({ count: 1 });
 
     await import("../environment.js");
 
@@ -671,7 +711,145 @@ describe("Canopy -> Daintree userData migration gating", () => {
     // user has since used Daintree and accumulated real state.
     expect(fsMock.cpSync).not.toHaveBeenCalled();
     expect(fsMock.rmSync).not.toHaveBeenCalled();
-    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+    expect(fsUtilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(".rebrand-migrated"),
+      expect.stringContaining("skipped: daintree.db already present")
+    );
+  });
+
+  it("migrates when daintree.db exists but the projects table is empty (issue #5156)", async () => {
+    // Pre-release Daintree launches caused openDb() to create a schema-only
+    // empty daintree.db. The previous existsSync-only guard mistook this for
+    // a real install and silently left user data unmigrated. Now we probe
+    // for actual rows.
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return false;
+      if (p.endsWith("daintree.db")) return true; // file exists but...
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    // ...projects table has 0 rows (default beforeEach mock value).
+
+    await import("../environment.js");
+
+    // Migration runs into the staging dir and is atomically promoted.
+    expect(fsMock.cpSync).toHaveBeenCalledWith(
+      path.join("/tmp/user-data", "Canopy"),
+      "/tmp/user-data/Daintree.migrating",
+      expect.objectContaining({ recursive: true, filter: expect.any(Function) })
+    );
+    expect(fsMock.renameSync).toHaveBeenCalledWith(
+      "/tmp/user-data/Daintree.migrating",
+      "/tmp/user-data/Daintree"
+    );
+    // The skip marker is NOT written.
+    expect(fsUtilsMock.resilientAtomicWriteFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining(".rebrand-migrated"),
+      expect.stringContaining("skipped: daintree.db already present")
+    );
+  });
+
+  it("auto-heals: deletes a stale skip marker and re-runs migration when daintree.db is empty and canopy.db has rows", async () => {
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    // Marker is initially present but gets deleted by the auto-heal pre-check;
+    // the !existsSync(markerPath) gate has to flip after rmSync runs.
+    let markerDeleted = false;
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return !markerDeleted;
+      if (p.endsWith("daintree.db")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    fsMock.rmSync.mockImplementation((p: string) => {
+      if (typeof p === "string" && p.endsWith(".rebrand-migrated")) {
+        markerDeleted = true;
+      }
+    });
+    fsMock.readFileSync.mockReturnValue(
+      "2026-04-16T14:31:00.178Z\nskipped: daintree.db already present\n"
+    );
+    // Discriminate by path: empty daintree.db, populated canopy.db. Vitest 4
+    // requires a class (not an arrow function) when the mock is `new`-called.
+    sqliteMock.Database.mockImplementation(
+      class {
+        constructor(dbPath: unknown) {
+          const isCanopy = typeof dbPath === "string" && dbPath.endsWith("canopy.db");
+          (this as { prepare: unknown }).prepare = () => ({
+            get: () => ({ count: isCanopy ? 3 : 0 }),
+          });
+          (this as { close: unknown }).close = vi.fn();
+        }
+      } as unknown as new () => unknown
+    );
+
+    await import("../environment.js");
+
+    // Stale marker is deleted, then the migration runs.
+    expect(fsMock.rmSync).toHaveBeenCalledWith(
+      path.join("/tmp/user-data/Daintree", ".rebrand-migrated")
+    );
+    expect(fsMock.cpSync).toHaveBeenCalledWith(
+      path.join("/tmp/user-data", "Canopy"),
+      "/tmp/user-data/Daintree.migrating",
+      expect.objectContaining({ recursive: true, filter: expect.any(Function) })
+    );
+    expect(fsMock.renameSync).toHaveBeenCalledWith(
+      "/tmp/user-data/Daintree.migrating",
+      "/tmp/user-data/Daintree"
+    );
+  });
+
+  it("does NOT auto-heal when the marker says skipped but canopy.db has no rows", async () => {
+    // Edge case: legitimate first-launch user with zero projects in Canopy
+    // who somehow got the skip marker — we must not re-trigger migration
+    // and clobber whatever's in Daintree.
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return true; // marker stays
+      if (p.endsWith("daintree.db")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    fsMock.readFileSync.mockReturnValue(
+      "2026-04-16T14:31:00.178Z\nskipped: daintree.db already present\n"
+    );
+    // Both DBs report 0 rows.
+    sqliteMock.get.mockReturnValue({ count: 0 });
+
+    await import("../environment.js");
+
+    // Marker is NOT deleted, migration does NOT run.
+    expect(fsMock.rmSync).not.toHaveBeenCalledWith(
+      path.join("/tmp/user-data/Daintree", ".rebrand-migrated")
+    );
+    expect(fsMock.cpSync).not.toHaveBeenCalled();
+  });
+
+  it("fail-safe: treats DB probe error as 'has data' and skips migration", async () => {
+    // If daintree.db is corrupt, locked, or otherwise unreadable we must
+    // never overwrite it — the user's data could still be in there.
+    Reflect.deleteProperty(process.env, "BUILD_VARIANT");
+    fsMock.existsSync.mockImplementation((p: string) => {
+      if (p.endsWith(".rebrand-migrated")) return false;
+      if (p.endsWith("daintree.db")) return true;
+      if (p.endsWith("/Canopy") || p.endsWith("\\Canopy")) return true;
+      return false;
+    });
+    sqliteMock.Database.mockImplementation(
+      class {
+        constructor() {
+          const err = new Error("file is not a database") as Error & { code: string };
+          err.code = "SQLITE_NOTADB";
+          throw err;
+        }
+      } as unknown as new () => unknown
+    );
+
+    await import("../environment.js");
+
+    expect(fsMock.cpSync).not.toHaveBeenCalled();
+    expect(fsUtilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
       expect.stringContaining(".rebrand-migrated"),
       expect.stringContaining("skipped: daintree.db already present")
     );

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -649,7 +649,7 @@ describe("Canopy -> Daintree userData migration gating", () => {
       class {
         prepare = sqliteMock.prepare;
         close = sqliteMock.close;
-      } as unknown as new () => unknown
+      } as never
     );
   });
 
@@ -775,12 +775,12 @@ describe("Canopy -> Daintree userData migration gating", () => {
       class {
         constructor(dbPath: unknown) {
           const isCanopy = typeof dbPath === "string" && dbPath.endsWith("canopy.db");
-          (this as { prepare: unknown }).prepare = () => ({
+          (this as unknown as { prepare: unknown }).prepare = () => ({
             get: () => ({ count: isCanopy ? 3 : 0 }),
           });
-          (this as { close: unknown }).close = vi.fn();
+          (this as unknown as { close: unknown }).close = vi.fn();
         }
-      } as unknown as new () => unknown
+      } as never
     );
 
     await import("../environment.js");
@@ -843,7 +843,7 @@ describe("Canopy -> Daintree userData migration gating", () => {
           err.code = "SQLITE_NOTADB";
           throw err;
         }
-      } as unknown as new () => unknown
+      } as never
     );
 
     await import("../environment.js");
@@ -878,7 +878,7 @@ describe("Canopy -> Daintree userData migration gating", () => {
           },
         });
         close = closeSpy;
-      } as unknown as new () => unknown
+      } as never
     );
 
     await import("../environment.js");
@@ -937,12 +937,12 @@ describe("Canopy -> Daintree userData migration gating", () => {
       class {
         constructor(dbPath: unknown) {
           const isCanopy = typeof dbPath === "string" && dbPath.endsWith("canopy.db");
-          (this as { prepare: unknown }).prepare = () => ({
+          (this as unknown as { prepare: unknown }).prepare = () => ({
             get: () => ({ count: isCanopy ? 5 : 0 }),
           });
-          (this as { close: unknown }).close = vi.fn();
+          (this as unknown as { close: unknown }).close = vi.fn();
         }
-      } as unknown as new () => unknown
+      } as never
     );
 
     await import("../environment.js");

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -94,6 +94,20 @@ function countProjectRows(dbPath: string): number {
   }
 }
 
+// Detect Chromium-side Daintree state — Preferences, Local Storage, and the
+// `persist:daintree` partition are all written by previous Daintree launches
+// even when the user never opened a project. Used as a second signal so the
+// row-count probe alone never wipes out customized state (themes, layouts,
+// auth tokens stored in localStorage). Marker file is intentionally ignored
+// here so the auto-heal pre-check can still delete a stale skip marker.
+function hasDaintreeUsageMarkers(newUserData: string): boolean {
+  return (
+    fs.existsSync(path.join(newUserData, "Preferences")) ||
+    fs.existsSync(path.join(newUserData, "Local Storage")) ||
+    fs.existsSync(path.join(newUserData, "Partitions", "daintree"))
+  );
+}
+
 if (!hasExplicitUserDataDir && process.env.BUILD_VARIANT !== "canopy") {
   try {
     const newUserData = app.getPath("userData");
@@ -128,7 +142,13 @@ if (!hasExplicitUserDataDir && process.env.BUILD_VARIANT !== "canopy") {
           } catch {
             // probe failed — leave canopyRows = 0 (no auto-heal)
           }
-          if (daintreeRows === 0 && canopyRows > 0) {
+          // Extra guard: never auto-heal when Chromium-side Daintree state
+          // exists. A user who launched pre-release Daintree, customized
+          // prefs/themes, but never opened a project would have the same
+          // (zero-row daintree.db, populated canopy.db) shape — wiping
+          // their state to re-run the migration is exactly the bug we are
+          // fixing in the other direction.
+          if (daintreeRows === 0 && canopyRows > 0 && !hasDaintreeUsageMarkers(newUserData)) {
             fs.rmSync(markerPath);
             console.log(
               "[daintree] Auto-healing rebrand migration — stale skip marker found alongside empty daintree.db; re-running migration"
@@ -147,16 +167,21 @@ if (!hasExplicitUserDataDir && process.env.BUILD_VARIANT !== "canopy") {
       // Replace the old `fs.existsSync(daintreeDbPath)` guard with a row
       // count: a schema-only DB has zero rows in `projects` and is safe to
       // overwrite. Any probe error is treated as "has data" (fail-safe).
-      let daintreeHasData = false;
+      let daintreeHasRows = false;
       if (fs.existsSync(daintreeDbPath)) {
         try {
-          daintreeHasData = countProjectRows(daintreeDbPath) > 0;
+          daintreeHasRows = countProjectRows(daintreeDbPath) > 0;
         } catch {
-          daintreeHasData = true;
+          daintreeHasRows = true;
         }
       }
+      // Either real project rows OR Chromium-side state means Daintree has
+      // been used — block the migration in both cases. The usage-marker
+      // check protects pre-release users who customized prefs/themes but
+      // never opened a project from having their state wiped.
+      const daintreeAlreadyUsed = daintreeHasRows || hasDaintreeUsageMarkers(newUserData);
 
-      if (daintreeHasData) {
+      if (daintreeAlreadyUsed) {
         // Daintree has already been used — never overwrite real user state.
         // Drop the marker so we don't re-check on every launch. Atomic
         // write so a crash mid-write doesn't leave a half-formed marker
@@ -220,12 +245,15 @@ if (!hasExplicitUserDataDir && process.env.BUILD_VARIANT !== "canopy") {
           fs.rmSync(newUserData, { recursive: true, force: true });
         }
         fs.renameSync(stagingPath, newUserData);
-        fs.writeFileSync(markerPath, new Date().toISOString());
+        // Atomic write: if a crash happens between the rename above and a
+        // partial marker write, next launch would see no marker and could
+        // re-run the migration over already-migrated data.
+        resilientAtomicWriteFileSync(markerPath, new Date().toISOString());
         console.log(`[daintree] Migrated userData ${legacyUserData} -> ${newUserData}`);
       } else if (fs.existsSync(newUserData)) {
         // No legacy dir but new dir already exists (fresh install or already
         // migrated on a prior version) — drop the marker so we don't re-check.
-        fs.writeFileSync(markerPath, new Date().toISOString());
+        resilientAtomicWriteFileSync(markerPath, new Date().toISOString());
       }
     }
   } catch (err) {

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -19,6 +19,8 @@ import fs from "fs";
 import { existsSync } from "fs";
 import os from "os";
 import fixPath from "fix-path";
+import Database from "better-sqlite3";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 
 export let exposeGc: (() => void) | undefined;
 try {
@@ -65,25 +67,101 @@ if (!app.isPackaged && !hasExplicitUserDataDir) {
 //  - Pre-rebrand 0.6.x Canopy used a named session partition `persist:canopy-app`;
 //    Daintree uses `persist:daintree`. The Partitions subdir is renamed after
 //    copy so Local Storage / IndexedDB / Cookies carry across.
-//  - If Daintree has a `daintree.db` already, we assume the user has been
-//    running Daintree and skip the copy to avoid clobbering real state.
-//    This handles the failure loop where a previous migration threw mid-copy
-//    and the user accumulated data in the bare userData dir before the retry.
+//  - If Daintree has a `daintree.db` with real rows, we assume the user has
+//    been running Daintree and skip the copy to avoid clobbering real state.
+//    A schema-only DB (e.g. created by a pre-release Daintree launch that
+//    never wrote any user data) does NOT count — issue #5156.
+//  - Auto-heal: users already affected by the pre-fix bug have a marker
+//    containing "skipped: daintree.db already present" plus an empty
+//    daintree.db. If the legacy canopy.db still has real data, we delete
+//    the stale marker and re-run the migration on next launch.
+
+// Probe daintree.db (or canopy.db) for actual user data. Opens read-only
+// so the file is never created as a side effect, fails fast on lock, and
+// throws on any SQLite error so the caller can decide the safe default.
+function countProjectRows(dbPath: string): number {
+  const db = new Database(dbPath, { readonly: true, timeout: 0 });
+  try {
+    const row = db.prepare("SELECT COUNT(*) AS count FROM projects").get() as
+      | { count: number }
+      | undefined;
+    return row?.count ?? 0;
+  } finally {
+    // Always close — leaving the connection open holds WAL/SHM sidecar
+    // descriptors that conflict with the persistence service opening the
+    // same file moments later during normal startup.
+    db.close();
+  }
+}
+
 if (!hasExplicitUserDataDir && process.env.BUILD_VARIANT !== "canopy") {
   try {
     const newUserData = app.getPath("userData");
     const markerPath = path.join(newUserData, ".rebrand-migrated");
-    if (!fs.existsSync(markerPath)) {
-      const appData = app.getPath("appData");
-      const legacyName = app.isPackaged ? "Canopy" : "canopy-app-dev";
-      const legacyUserData = path.join(appData, legacyName);
-      const daintreeDbPath = path.join(newUserData, "daintree.db");
-      const hasExistingDaintreeData = fs.existsSync(daintreeDbPath);
+    const appData = app.getPath("appData");
+    const legacyName = app.isPackaged ? "Canopy" : "canopy-app-dev";
+    const legacyUserData = path.join(appData, legacyName);
+    const daintreeDbPath = path.join(newUserData, "daintree.db");
+    const legacyDbPath = path.join(legacyUserData, "canopy.db");
 
-      if (hasExistingDaintreeData) {
+    // Auto-heal pre-check: a marker written by the buggy pre-fix code path
+    // has the literal "skipped: daintree.db already present" text and may be
+    // sitting next to a schema-only daintree.db while real data still lives
+    // in the legacy Canopy directory. Delete the marker so the normal
+    // migration flow below re-runs.
+    if (fs.existsSync(markerPath)) {
+      try {
+        const markerContent = fs.readFileSync(markerPath, "utf-8").trim();
+        if (markerContent.includes("skipped: daintree.db already present")) {
+          // Fail-safe defaults: Infinity for daintree (treat probe failure as
+          // "has data" — never overwrite an unreadable user DB), 0 for canopy
+          // (treat probe failure as "no legacy data" — don't migrate empty).
+          let daintreeRows = Number.POSITIVE_INFINITY;
+          let canopyRows = 0;
+          try {
+            daintreeRows = countProjectRows(daintreeDbPath);
+          } catch {
+            // probe failed — leave daintreeRows = Infinity (no auto-heal)
+          }
+          try {
+            canopyRows = countProjectRows(legacyDbPath);
+          } catch {
+            // probe failed — leave canopyRows = 0 (no auto-heal)
+          }
+          if (daintreeRows === 0 && canopyRows > 0) {
+            fs.rmSync(markerPath);
+            console.log(
+              "[daintree] Auto-healing rebrand migration — stale skip marker found alongside empty daintree.db; re-running migration"
+            );
+          }
+        }
+      } catch (err) {
+        // Reading or inspecting the marker failed — leave it in place.
+        // Conservative: better to skip migration than to delete a marker
+        // we can't reason about.
+        console.warn("[daintree] Auto-heal pre-check failed:", err);
+      }
+    }
+
+    if (!fs.existsSync(markerPath)) {
+      // Replace the old `fs.existsSync(daintreeDbPath)` guard with a row
+      // count: a schema-only DB has zero rows in `projects` and is safe to
+      // overwrite. Any probe error is treated as "has data" (fail-safe).
+      let daintreeHasData = false;
+      if (fs.existsSync(daintreeDbPath)) {
+        try {
+          daintreeHasData = countProjectRows(daintreeDbPath) > 0;
+        } catch {
+          daintreeHasData = true;
+        }
+      }
+
+      if (daintreeHasData) {
         // Daintree has already been used — never overwrite real user state.
-        // Drop the marker so we don't re-check on every launch.
-        fs.writeFileSync(
+        // Drop the marker so we don't re-check on every launch. Atomic
+        // write so a crash mid-write doesn't leave a half-formed marker
+        // that the auto-heal pre-check would misread on the next launch.
+        resilientAtomicWriteFileSync(
           markerPath,
           new Date().toISOString() + "\nskipped: daintree.db already present\n"
         );


### PR DESCRIPTION
## Summary

The 0.7.0 rebrand migration used a file-existence check to decide whether to skip. Any prior Daintree launch (dev build, nightly, internal test) creates a schema-only `daintree.db` via `openDb()` before any data exists, which the guard treated as a live install. Result: the migration wrote a `skipped: daintree.db already present` marker and left the user's projects, GitHub tokens, agent settings, and notes sitting unmigrated in `Canopy/`.

The fix replaces the `existsSync` guard with a row-count probe against the `projects` table. Zero rows means no real user data, and migration proceeds. On top of that, Chromium-side state is also checked: if `Preferences` (Local Storage) in the Daintree profile already has a usage marker, that's treated as evidence of a real Daintree install regardless of the DB row count. This prevents the symmetric problem where a user who legitimately started using Daintree (customised prefs, no projects yet) would have had their state wiped by a row-count-only check.

There's also an auto-heal path: on launch, if `.rebrand-migrated` contains `skipped: daintree.db already present`, the empty-DB probe runs again. If it still looks empty and `Canopy/canopy.db` has data, the marker is discarded and migration runs. Users already caught by the 0.7.0 bug will be silently made whole on their first 0.7.1 launch.

Resolves #5156

## Changes

- `electron/setup/environment.ts`: row-count probe replaces `existsSync` guard; Chromium-side usage-marker check added; auto-heal on `skipped` marker; success marker writes are now atomic (write to `.tmp`, then rename)
- `electron/setup/__tests__/environment.test.ts`: 3 new regression tests covering (1) migration runs when `daintree.db` exists but `projects` is empty, (2) migration skips when `daintree.db` has real rows, and (3) auto-heal from a prior `skipped` marker

## Testing

43 unit tests pass. Typecheck, lint, and format all clean. Regression tests cover the three cases called out in the issue.