### PR TITLE
fix(agents): default pins based on CLI install state, not opt-out

### DIFF
--- a/electron/services/migrations/013-cleanup-phantom-pins.ts
+++ b/electron/services/migrations/013-cleanup-phantom-pins.ts
@@ -10,6 +10,10 @@ interface StoredAgentSettings {
   [key: string]: unknown;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Phantom predicate: an entry is considered phantom IFF it has exactly one
  * key (`pinned`) and its value is `true`. These entries were synthesized by
@@ -18,9 +22,17 @@ interface StoredAgentSettings {
  *
  * Entries with `pinned: false` (explicit unpin) or any other field alongside
  * `pinned: true` (e.g. `customFlags`, `primaryModelId`, `dangerousEnabled`)
- * represent real user configuration and must be preserved untouched.
+ * represent real user configuration and must be preserved untouched. A narrow
+ * false-positive exists: a v0.7.0 user who unpinned an agent then re-pinned
+ * it produces a bare `{ pinned: true }` via the IPC merge path. Migration
+ * 013 strips that entry, but the renderer normalizer re-synthesizes
+ * `pinned: true` on the next init for installed agents — so the user-visible
+ * outcome matches intent. The narrow loss case (user pinned an uninstalled
+ * agent they planned to install later) is acceptable given the one-shot
+ * upgrade window.
  */
-function isPhantomPinEntry(entry: StoredAgentEntry): boolean {
+function isPhantomPinEntry(entry: unknown): boolean {
+  if (!isPlainObject(entry)) return false;
   const keys = Object.keys(entry);
   return keys.length === 1 && keys[0] === "pinned" && entry.pinned === true;
 }
@@ -29,18 +41,23 @@ export const migration013: Migration = {
   version: 13,
   description: "Clean up phantom pinned entries for uninstalled agents (issue #5158)",
   up: (store) => {
-    const agentSettings = store.get("agentSettings") as StoredAgentSettings | undefined;
-    if (!agentSettings?.agents) return;
+    const agentSettings = store.get("agentSettings") as unknown;
+    if (!isPlainObject(agentSettings)) return;
+    const rawAgents = (agentSettings as StoredAgentSettings).agents;
+    if (!isPlainObject(rawAgents)) return;
 
     const kept: Record<string, StoredAgentEntry> = {};
     let changed = false;
 
-    for (const [id, entry] of Object.entries(agentSettings.agents)) {
+    for (const [id, entry] of Object.entries(rawAgents)) {
       if (isPhantomPinEntry(entry)) {
         changed = true;
         continue;
       }
-      kept[id] = entry;
+      // Non-phantom and non-object entries (e.g. a corrupted `null`) pass
+      // through untouched — cleaning up truly malformed data is out of scope
+      // for this migration.
+      kept[id] = entry as StoredAgentEntry;
     }
 
     if (!changed) return;
@@ -48,6 +65,6 @@ export const migration013: Migration = {
     // electron-store v11 throws on `store.set(key, undefined)` — rebuild the
     // whole `agentSettings` object and write it back in one call (matches
     // migration 012's pattern and avoids the v11 delete foot-gun).
-    store.set("agentSettings", { ...agentSettings, agents: kept });
+    store.set("agentSettings", { ...(agentSettings as StoredAgentSettings), agents: kept });
   },
 };

--- a/electron/services/migrations/013-cleanup-phantom-pins.ts
+++ b/electron/services/migrations/013-cleanup-phantom-pins.ts
@@ -1,0 +1,53 @@
+import type { Migration } from "../StoreMigrations.js";
+
+interface StoredAgentEntry {
+  pinned?: boolean;
+  [key: string]: unknown;
+}
+
+interface StoredAgentSettings {
+  agents?: Record<string, StoredAgentEntry>;
+  [key: string]: unknown;
+}
+
+/**
+ * Phantom predicate: an entry is considered phantom IFF it has exactly one
+ * key (`pinned`) and its value is `true`. These entries were synthesized by
+ * the v0.7.0 normalizer and migration 012 for every registered agent —
+ * including ones the user never installed — so they carry no real intent.
+ *
+ * Entries with `pinned: false` (explicit unpin) or any other field alongside
+ * `pinned: true` (e.g. `customFlags`, `primaryModelId`, `dangerousEnabled`)
+ * represent real user configuration and must be preserved untouched.
+ */
+function isPhantomPinEntry(entry: StoredAgentEntry): boolean {
+  const keys = Object.keys(entry);
+  return keys.length === 1 && keys[0] === "pinned" && entry.pinned === true;
+}
+
+export const migration013: Migration = {
+  version: 13,
+  description: "Clean up phantom pinned entries for uninstalled agents (issue #5158)",
+  up: (store) => {
+    const agentSettings = store.get("agentSettings") as StoredAgentSettings | undefined;
+    if (!agentSettings?.agents) return;
+
+    const kept: Record<string, StoredAgentEntry> = {};
+    let changed = false;
+
+    for (const [id, entry] of Object.entries(agentSettings.agents)) {
+      if (isPhantomPinEntry(entry)) {
+        changed = true;
+        continue;
+      }
+      kept[id] = entry;
+    }
+
+    if (!changed) return;
+
+    // electron-store v11 throws on `store.set(key, undefined)` — rebuild the
+    // whole `agentSettings` object and write it back in one call (matches
+    // migration 012's pattern and avoids the v11 delete foot-gun).
+    store.set("agentSettings", { ...agentSettings, agents: kept });
+  },
+};

--- a/electron/services/migrations/__tests__/013-cleanup-phantom-pins.test.ts
+++ b/electron/services/migrations/__tests__/013-cleanup-phantom-pins.test.ts
@@ -126,6 +126,46 @@ describe("migration013 — cleanup phantom pinned entries", () => {
     expect(store.set).toHaveBeenCalledTimes(1);
   });
 
+  it("does not throw on malformed agentSettings shapes", () => {
+    const shapes: Array<[string, unknown]> = [
+      ["agents is null", { agents: null }],
+      ["agents is a string", { agents: "oops" }],
+      ["agents is an array", { agents: [] }],
+      ["an entry is null", { agents: { claude: null } }],
+      ["an entry is a string", { agents: { claude: "oops" } }],
+      ["agentSettings is a string", "nope"],
+      ["agentSettings is an array", []],
+    ];
+
+    for (const [label, value] of shapes) {
+      const store = makeStoreMock({ agentSettings: value });
+      expect(() => migration013.up(store), `case: ${label}`).not.toThrow();
+    }
+  });
+
+  it("preserves malformed non-phantom entries untouched", () => {
+    // A corrupted entry like `null` is not phantom (predicate requires an
+    // object) and not our problem to repair — it should pass through
+    // alongside any phantom-stripping that happens.
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          opencode: { pinned: true },
+          broken: null,
+          claude: { pinned: true, customFlags: "" },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+
+    const written = (store.set as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      agents: Record<string, unknown>;
+    };
+    expect(Object.keys(written.agents).sort()).toEqual(["broken", "claude"]);
+    expect(written.agents.broken).toBeNull();
+  });
+
   it("removes multiple phantoms in one call", () => {
     const data: Record<string, unknown> = {
       agentSettings: {

--- a/electron/services/migrations/__tests__/013-cleanup-phantom-pins.test.ts
+++ b/electron/services/migrations/__tests__/013-cleanup-phantom-pins.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import { migration013 } from "../013-cleanup-phantom-pins.js";
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+  } as unknown as Parameters<typeof migration013.up>[0];
+}
+
+describe("migration013 — cleanup phantom pinned entries", () => {
+  it("has version 13", () => {
+    expect(migration013.version).toBe(13);
+  });
+
+  it("removes entries that have only `{ pinned: true }`", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          opencode: { pinned: true },
+          cursor: { pinned: true },
+          claude: { pinned: true, customFlags: "--verbose" },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+
+    expect(store.set).toHaveBeenCalledWith("agentSettings", {
+      agents: { claude: { pinned: true, customFlags: "--verbose" } },
+    });
+  });
+
+  it("preserves `{ pinned: true }` when any additional field is present", () => {
+    const cases: Array<[string, Record<string, unknown>]> = [
+      ["customFlags", { pinned: true, customFlags: "" }],
+      ["dangerousEnabled", { pinned: true, dangerousEnabled: false }],
+      ["primaryModelId null", { pinned: true, primaryModelId: null }],
+      ["assistantModelId", { pinned: true, assistantModelId: "claude-opus-4-6" }],
+      ["inlineMode", { pinned: true, inlineMode: false }],
+    ];
+
+    for (const [label, entry] of cases) {
+      const data: Record<string, unknown> = {
+        agentSettings: { agents: { claude: entry } },
+      };
+      const store = makeStoreMock(data);
+      migration013.up(store);
+      // No phantoms found, no write expected.
+      expect(store.set, `case: ${label}`).not.toHaveBeenCalled();
+    }
+  });
+
+  it("preserves explicit `pinned: false` entries", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: { agents: { gemini: { pinned: false } } },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("preserves entries whose sole field is NOT `pinned: true`", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: { agents: { codex: { customFlags: "--debug" } } },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when agentSettings is absent", () => {
+    const store = makeStoreMock({});
+    migration013.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when agentSettings has no agents", () => {
+    const store = makeStoreMock({ agentSettings: {} });
+    migration013.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when agents is empty", () => {
+    const store = makeStoreMock({ agentSettings: { agents: {} } });
+    migration013.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated top-level keys on agentSettings", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        defaultAgent: "claude",
+        agents: {
+          opencode: { pinned: true },
+          claude: { pinned: true, customFlags: "--verbose" },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+
+    expect(store.set).toHaveBeenCalledWith("agentSettings", {
+      defaultAgent: "claude",
+      agents: { claude: { pinned: true, customFlags: "--verbose" } },
+    });
+  });
+
+  it("is idempotent — running twice yields the same result and no second write", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          opencode: { pinned: true },
+          claude: { pinned: true, customFlags: "--verbose" },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+    expect(store.set).toHaveBeenCalledTimes(1);
+
+    // Second run: no phantoms left, so no further writes.
+    migration013.up(store);
+    expect(store.set).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes multiple phantoms in one call", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          opencode: { pinned: true },
+          cursor: { pinned: true },
+          kira: { pinned: true },
+          copilot: { pinned: true },
+          claude: { pinned: true, customFlags: "" },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration013.up(store);
+
+    const written = (store.set as ReturnType<typeof vi.fn>).mock.calls[0][1] as {
+      agents: Record<string, unknown>;
+    };
+    expect(Object.keys(written.agents).sort()).toEqual(["claude"]);
+  });
+});

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -10,6 +10,7 @@ import { migration009 } from "./009-per-project-window-state.js";
 import { migration010 } from "./010-add-working-pulse-setting.js";
 import { migration011 } from "./011-minimal-soundscape-defaults.js";
 import { migration012 } from "./012-default-pin-agents.js";
+import { migration013 } from "./013-cleanup-phantom-pins.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -23,4 +24,5 @@ export const migrations: Migration[] = [
   migration010,
   migration011,
   migration012,
+  migration013,
 ];

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -70,10 +70,12 @@ export const DEFAULT_ROUTING_CONFIG: AgentRoutingConfig = {
 
 export interface AgentSettingsEntry {
   /**
-   * Pin state for the toolbar. Opt-out semantics: `undefined` means pinned
-   * (installed agents default to the toolbar), and only explicit `false`
-   * unpins. Use `isAgentPinned()` from `shared/utils/agentPinned.ts` rather
-   * than reading this field directly so the default stays consistent.
+   * Pin state for the toolbar. Opt-in semantics: `undefined` means unpinned,
+   * and only explicit `true` pins the agent. The renderer normalizer
+   * synthesizes `pinned: true` for registered agents whose CLI is installed,
+   * so uninstalled agents stay off the toolbar until the user pins them
+   * explicitly. Use `isAgentPinned()` from `shared/utils/agentPinned.ts`
+   * rather than reading this field directly so the default stays consistent.
    */
   pinned?: boolean;
   customFlags?: string;

--- a/shared/utils/__tests__/agentPinned.test.ts
+++ b/shared/utils/__tests__/agentPinned.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { isAgentPinned, isAgentPinnedById } from "../agentPinned.js";
+
+describe("isAgentPinned — opt-in semantics", () => {
+  it("returns false for undefined entry", () => {
+    expect(isAgentPinned(undefined)).toBe(false);
+  });
+
+  it("returns false for null entry", () => {
+    expect(isAgentPinned(null)).toBe(false);
+  });
+
+  it("returns false for empty entry", () => {
+    expect(isAgentPinned({})).toBe(false);
+  });
+
+  it("returns false when pinned is undefined", () => {
+    expect(isAgentPinned({ pinned: undefined })).toBe(false);
+  });
+
+  it("returns true only when pinned is explicitly true", () => {
+    expect(isAgentPinned({ pinned: true })).toBe(true);
+  });
+
+  it("returns false when pinned is explicitly false", () => {
+    expect(isAgentPinned({ pinned: false })).toBe(false);
+  });
+
+  it("ignores other fields and reads pinned only", () => {
+    expect(isAgentPinned({ customFlags: "--verbose", dangerousEnabled: true })).toBe(false);
+    expect(isAgentPinned({ pinned: true, customFlags: "--verbose" })).toBe(true);
+  });
+});
+
+describe("isAgentPinnedById", () => {
+  it("returns false when settings is null", () => {
+    expect(isAgentPinnedById(null, "claude")).toBe(false);
+  });
+
+  it("returns false when settings is undefined", () => {
+    expect(isAgentPinnedById(undefined, "claude")).toBe(false);
+  });
+
+  it("returns false when agent entry is missing", () => {
+    expect(isAgentPinnedById({ agents: {} }, "claude")).toBe(false);
+  });
+
+  it("returns true when the agent entry is explicitly pinned", () => {
+    expect(isAgentPinnedById({ agents: { claude: { pinned: true } } }, "claude")).toBe(true);
+  });
+
+  it("returns false when the agent entry is explicitly unpinned", () => {
+    expect(isAgentPinnedById({ agents: { claude: { pinned: false } } }, "claude")).toBe(false);
+  });
+});

--- a/shared/utils/agentPinned.ts
+++ b/shared/utils/agentPinned.ts
@@ -1,13 +1,15 @@
 import type { AgentSettings, AgentSettingsEntry } from "../types/agentSettings.js";
 
 /**
- * Returns true if the agent is pinned to the toolbar. Treats missing entries
- * and missing `pinned` fields as pinned=true (default-pin semantics): installed
- * agents show in the toolbar until the user explicitly unpins them.
+ * Returns true only when the entry explicitly sets `pinned: true`. Missing
+ * entries and missing `pinned` fields resolve to `false` (opt-in semantics).
+ * The renderer normalizer synthesizes `pinned: true` for registered agents
+ * whose CLI is installed — uninstalled or unknown-state agents stay unpinned
+ * until the user pins them explicitly.
  */
 export function isAgentPinned(entry: AgentSettingsEntry | undefined | null): boolean {
-  if (!entry) return true;
-  return entry.pinned !== false;
+  if (!entry) return false;
+  return entry.pinned === true;
 }
 
 export function isAgentPinnedById(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ import {
   usePaletteStore,
   useNotificationSettingsStore,
 } from "./store";
+import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { isAgentReady } from "../shared/utils/agentAvailability";
 import { isAgentPinned } from "../shared/utils/agentPinned";
 import { useShallow } from "zustand/react/shallow";
@@ -185,12 +186,13 @@ function App() {
   );
 
   const { launchAgent, availability, agentSettings, refreshSettings } = useAgentLauncher();
+  const normalizedAgentSettings = useAgentSettingsStore((s) => s.settings);
 
   const hasAnySelectedAgent = useMemo(() => {
-    if (agentSettings === null) return null;
-    const agents = agentSettings.agents ?? {};
+    if (normalizedAgentSettings === null) return null;
+    const agents = normalizedAgentSettings.agents ?? {};
     return BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agents[id]));
-  }, [agentSettings]);
+  }, [normalizedAgentSettings]);
 
   useTerminalConfig();
   useAppThemeConfig();
@@ -337,8 +339,9 @@ function App() {
       }
 
       const defaultAgent = useAgentPreferencesStore.getState().defaultAgent;
-      const selected = agentSettings?.agents
-        ? Object.entries(agentSettings.agents)
+      const normalized = useAgentSettingsStore.getState().settings;
+      const selected = normalized?.agents
+        ? Object.entries(normalized.agents)
             .filter(([, entry]) => isAgentPinned(entry))
             .map(([id]) => id)
         : [];
@@ -350,7 +353,7 @@ function App() {
         }).catch(() => {});
       }
     },
-    [launchAgent, activeWorktreeId, availability, agentSettings, switchProject, currentProject?.id]
+    [launchAgent, activeWorktreeId, availability, switchProject, currentProject?.id]
   );
 
   const closeNotesPalette = useCallback(() => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -256,12 +256,16 @@ describe("AgentTrayButton", () => {
     expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
   });
 
-  it("treats missing pinned entries as pinned (opt-out)", () => {
+  it("treats missing pinned entries as unpinned (opt-in, issue #5158)", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({});
 
     const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
-    expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("true");
+    // Missing entry no longer implies pinned — the renderer normalizer is
+    // responsible for synthesizing `pinned: true` when the CLI is installed,
+    // and the tray reads from the normalized store. A raw entry without
+    // `pinned` should read as unpinned.
+    expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("false");
   });
 
   it("puts missing and installed-but-unauth agents in Also Available with pill badge", () => {
@@ -333,12 +337,14 @@ describe("AgentTrayButton", () => {
     expect(getByText("No agents available")).toBeTruthy();
   });
 
-  it("handles null store settings gracefully", () => {
+  it("handles null store settings gracefully (opt-in default)", () => {
     mockSettings = null;
     const availability = { claude: "ready" } as unknown as CliAvailability;
 
     const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
-    expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("true");
+    // Null settings means the normalizer hasn't run yet — with opt-in
+    // semantics, that reads as unpinned until real data arrives.
+    expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("false");
   });
 
   it("ignores panels from other worktrees for session detection", () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import "./index.css";
 import { applyDefaultAppTheme } from "./theme/applyAppTheme";
 import { ensureTerminalFontLoaded } from "./config/terminalFont";
 import { initStoreOrchestrator } from "./store/rendererStoreOrchestrator";
+import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { registerRendererGlobalErrorHandlers } from "./utils/rendererGlobalErrorHandlers";
 import { renderBootstrapError } from "./utils/renderBootstrapError";
 import {
@@ -35,6 +36,13 @@ async function bootstrap() {
   }
 
   cleanupOrchestrator = initStoreOrchestrator();
+
+  // Kick off the agent-settings store so `App.tsx`, `Toolbar`, and the tray
+  // all read from a normalized snapshot on cold boot. The install-aware
+  // default-pin path in `normalizeAgentSelection` depends on this running —
+  // without it the store stays null and the orchestrator's availability
+  // subscription never gets a chance to reconcile (see issue #5158).
+  void useAgentSettingsStore.getState().initialize();
 
   await ensureTerminalFontLoaded();
 

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -287,4 +287,68 @@ describe("agentSettingsStore adversarial", () => {
     expect(state.isInitialized).toBe(false);
     expect(state.settings?.agents.claude?.customFlags).not.toBe("hello");
   });
+
+  it("stale refresh failures yield silently instead of throwing unhandled rejections", async () => {
+    registryMock.getEffectiveAgentIds.mockReturnValue(["claude"]);
+    setAvailability({ claude: "ready" }, true);
+
+    useAgentSettingsStore.setState({
+      settings: { agents: { claude: { pinned: true } } } as never,
+      isInitialized: true,
+      isLoading: false,
+    });
+
+    let rejectStale: (e: unknown) => void = () => {};
+    clientMock.get
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectStale = reject;
+          })
+      )
+      .mockResolvedValueOnce({ agents: { claude: { pinned: false } } });
+
+    const stale = useAgentSettingsStore.getState().refresh();
+    const fresh = useAgentSettingsStore.getState().refresh();
+    await fresh;
+
+    // Now fail the stale attempt. It must NOT reject — fire-and-forget
+    // callers (orchestrator subscription, toggle handlers) would surface an
+    // unhandled rejection otherwise.
+    rejectStale(new Error("stale failure"));
+    await expect(stale).resolves.toBeUndefined();
+
+    expect(useAgentSettingsStore.getState().settings?.agents.claude?.pinned).toBe(false);
+  });
+
+  it("initialize after a concurrent refresh flips isInitialized even when the result is stale", async () => {
+    registryMock.getEffectiveAgentIds.mockReturnValue(["claude"]);
+    setAvailability({ claude: "ready" }, true);
+
+    let resolveInit: (v: unknown) => void = () => {};
+    clientMock.get
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveInit = resolve;
+          })
+      )
+      .mockResolvedValueOnce({ agents: { claude: { pinned: false } } });
+
+    // Kick off init; it holds initPromise. While in-flight, another caller
+    // triggers a refresh (bumping the epoch and invalidating init).
+    const initPending = useAgentSettingsStore.getState().initialize();
+    useAgentSettingsStore.setState({ isInitialized: false, isLoading: true });
+    const concurrent = useAgentSettingsStore.getState().refresh();
+    await concurrent;
+
+    resolveInit({ agents: { claude: { pinned: true } } });
+    await initPending;
+
+    // Stale init must still flip isInitialized and clear initPromise so
+    // subsequent `initialize()` calls short-circuit (no-op) correctly.
+    const state = useAgentSettingsStore.getState();
+    expect(state.isInitialized).toBe(true);
+    expect(state.isLoading).toBe(false);
+  });
 });

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -24,10 +24,24 @@ import {
   getPinnedAgents,
   normalizeAgentSelection,
 } from "../agentSettingsStore";
+import { useCliAvailabilityStore } from "../cliAvailabilityStore";
+import type { CliAvailability } from "@shared/types";
+
+function setAvailability(
+  overrides: Partial<Record<string, "ready" | "installed" | "missing">>,
+  hasRealData = true
+) {
+  const availability = {
+    claude: overrides.claude ?? "missing",
+    codex: overrides.codex ?? "missing",
+  } as unknown as CliAvailability;
+  useCliAvailabilityStore.setState({ availability, hasRealData });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
   cleanupAgentSettingsStore();
+  setAvailability({}, false);
 });
 
 afterEach(() => {
@@ -35,34 +49,16 @@ afterEach(() => {
 });
 
 describe("agentSettingsStore adversarial", () => {
-  it("normalizeAgentSelection seeds pinned:true on entries missing the flag", () => {
+  it("normalizeAgentSelection preserves explicit pinned flags regardless of availability", () => {
     const before = {
       agents: {
-        claude: {
-          enabled: true,
-          selected: true,
-          toolbarPinned: true,
-          primaryModelId: null,
-          autoCompact: true,
-          defaultMethodIndex: 0,
-          customCommand: null,
-          flags: {},
-        },
-        codex: {
-          enabled: true,
-          selected: false,
-          toolbarPinned: false,
-          primaryModelId: null,
-          autoCompact: true,
-          defaultMethodIndex: 0,
-          customCommand: null,
-          pinned: false,
-          flags: {},
-        },
+        claude: { pinned: true, customFlags: "" },
+        codex: { pinned: false, customFlags: "" },
       },
-    };
+    } as never;
 
-    const after = normalizeAgentSelection(before as never);
+    const availability = { claude: "missing", codex: "ready" } as unknown as CliAvailability;
+    const after = normalizeAgentSelection(before, availability, true);
     expect(after.agents.claude.pinned).toBe(true);
     expect(after.agents.codex.pinned).toBe(false);
   });
@@ -75,7 +71,8 @@ describe("agentSettingsStore adversarial", () => {
       },
     } as never;
 
-    expect(normalizeAgentSelection(settings)).toBe(settings);
+    const availability = { claude: "ready", codex: "missing" } as unknown as CliAvailability;
+    expect(normalizeAgentSelection(settings, availability, true)).toBe(settings);
   });
 
   it("concurrent initialize() calls dedupe into a single client fetch", async () => {
@@ -175,8 +172,9 @@ describe("agentSettingsStore adversarial", () => {
     expect(getPinnedAgents()).toEqual([]);
   });
 
-  it("initialize applies normalizeAgentSelection so missing pinned flags default to true", async () => {
+  it("initialize leaves pinned absent for entries without explicit pin when availability has no real data (issue #5158)", async () => {
     registryMock.getEffectiveAgentIds.mockReturnValue(["claude", "codex"]);
+    setAvailability({ claude: "ready", codex: "missing" }, false);
     clientMock.get.mockResolvedValue({
       agents: {
         claude: { enabled: true, flags: {} },
@@ -187,11 +185,30 @@ describe("agentSettingsStore adversarial", () => {
     await useAgentSettingsStore.getState().initialize();
 
     const state = useAgentSettingsStore.getState();
+    // hasRealData === false: pre-probe state means we do NOT phantom-synthesize
+    // a default. The orchestrator re-runs normalization after availability lands.
+    expect(state.settings?.agents.claude?.pinned).toBeUndefined();
+    expect(state.settings?.agents.codex?.pinned).toBe(false);
+  });
+
+  it("initialize synthesizes pinned from CLI availability when real data is present", async () => {
+    registryMock.getEffectiveAgentIds.mockReturnValue(["claude", "codex"]);
+    setAvailability({ claude: "ready", codex: "missing" }, true);
+    clientMock.get.mockResolvedValue({
+      agents: {
+        claude: { enabled: true, flags: {} },
+        codex: { enabled: true, flags: {} },
+      },
+    });
+
+    await useAgentSettingsStore.getState().initialize();
+
+    const state = useAgentSettingsStore.getState();
     expect(state.settings?.agents.claude?.pinned).toBe(true);
     expect(state.settings?.agents.codex?.pinned).toBe(false);
   });
 
-  it("getPinnedAgents treats missing pinned fields as pinned (opt-out default)", () => {
+  it("getPinnedAgents returns only agents with explicit pinned: true (opt-in)", () => {
     useAgentSettingsStore.setState({
       settings: {
         agents: {
@@ -202,7 +219,72 @@ describe("agentSettingsStore adversarial", () => {
         },
       } as never,
     });
-    // Only explicit `pinned: false` excludes an agent; `{}` defaults to pinned.
-    expect(getPinnedAgents().sort()).toEqual(["a", "c", "d"]);
+    // Missing `pinned` field no longer implies pinned — only explicit `true`.
+    expect(getPinnedAgents().sort()).toEqual(["a", "d"]);
+  });
+
+  it("stale refresh result does not overwrite a newer snapshot", async () => {
+    registryMock.getEffectiveAgentIds.mockReturnValue(["claude", "codex"]);
+    setAvailability({ claude: "ready" }, true);
+
+    // Seed initial state so `refresh` has something to overwrite.
+    useAgentSettingsStore.setState({
+      settings: { agents: { claude: { pinned: true, customFlags: "" } } } as never,
+      isInitialized: true,
+      isLoading: false,
+    });
+
+    let resolveStale: (v: unknown) => void = () => {};
+    const stalePromise = new Promise((resolve) => {
+      resolveStale = resolve;
+    });
+    clientMock.get
+      .mockImplementationOnce(() => stalePromise)
+      .mockResolvedValueOnce({
+        agents: { claude: { pinned: false, customFlags: "fresh" } },
+      });
+
+    const refreshA = useAgentSettingsStore.getState().refresh();
+    const refreshB = useAgentSettingsStore.getState().refresh();
+    await refreshB;
+
+    // Now let the stale (first) refresh resolve — it must not clobber B's result.
+    resolveStale({ agents: { claude: { pinned: true, customFlags: "stale" } } });
+    await refreshA;
+
+    const state = useAgentSettingsStore.getState();
+    expect(state.settings?.agents.claude).toEqual({ pinned: false, customFlags: "fresh" });
+  });
+
+  it("cleanup during an in-flight refresh invalidates the result", async () => {
+    registryMock.getEffectiveAgentIds.mockReturnValue(["claude"]);
+    setAvailability({ claude: "ready" }, true);
+
+    useAgentSettingsStore.setState({
+      settings: null,
+      isInitialized: true,
+      isLoading: false,
+    });
+
+    let resolveGet: (v: unknown) => void = () => {};
+    clientMock.get.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveGet = resolve;
+        })
+    );
+
+    const pending = useAgentSettingsStore.getState().refresh();
+
+    cleanupAgentSettingsStore();
+
+    resolveGet({ agents: { claude: { pinned: true, customFlags: "hello" } } });
+    await pending;
+
+    // cleanupAgentSettingsStore resets `settings` to DEFAULT_AGENT_SETTINGS;
+    // the invalidated refresh result must not have overwritten that.
+    const state = useAgentSettingsStore.getState();
+    expect(state.isInitialized).toBe(false);
+    expect(state.settings?.agents.claude?.customFlags).not.toBe("hello");
   });
 });

--- a/src/store/__tests__/normalizeAgentSelection.test.ts
+++ b/src/store/__tests__/normalizeAgentSelection.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { normalizeAgentSelection } from "../agentSettingsStore";
 import { getEffectiveAgentIds } from "../../../shared/config/agentRegistry";
-import type { AgentSettings } from "@shared/types";
+import type { AgentSettings, CliAvailability } from "@shared/types";
 
 describe("normalizeAgentSelection", () => {
   const makeSettings = (agents: Record<string, { pinned?: boolean }>): AgentSettings => ({
@@ -14,33 +14,74 @@ describe("normalizeAgentSelection", () => {
     ),
   });
 
-  it("preserves explicit pinned: true and pinned: false", () => {
+  function availabilityFor(
+    overrides: Partial<Record<string, "ready" | "installed" | "missing">> = {}
+  ): CliAvailability {
+    return Object.fromEntries(
+      getEffectiveAgentIds().map((id) => [id, overrides[id] ?? "missing"])
+    ) as CliAvailability;
+  }
+
+  it("preserves explicit pinned: true and pinned: false regardless of availability", () => {
     const settings = makeSettings({
       claude: { pinned: false },
       gemini: { pinned: true },
     });
-    const result = normalizeAgentSelection(settings);
+    const availability = availabilityFor({ claude: "ready", gemini: "missing" });
+    const result = normalizeAgentSelection(settings, availability, true);
     expect(result.agents.claude.pinned).toBe(false);
     expect(result.agents.gemini.pinned).toBe(true);
   });
 
-  it("seeds pinned: true for registered agents with no stored pinned value", () => {
-    const settings = makeSettings({
-      claude: {},
-      gemini: {},
-    });
-    const result = normalizeAgentSelection(settings);
+  it("synthesizes pinned: true for installed agents when hasRealData is true", () => {
+    const settings = makeSettings({ claude: {} });
+    const availability = availabilityFor({ claude: "installed" });
+    const result = normalizeAgentSelection(settings, availability, true);
     expect(result.agents.claude.pinned).toBe(true);
-    expect(result.agents.gemini.pinned).toBe(true);
   });
 
-  it("creates pinned: true entries for registered agents missing from stored settings", () => {
-    const settings: AgentSettings = { agents: {} };
-    const result = normalizeAgentSelection(settings);
+  it("synthesizes pinned: true for ready agents when hasRealData is true", () => {
+    const settings = makeSettings({ claude: {} });
+    const availability = availabilityFor({ claude: "ready" });
+    const result = normalizeAgentSelection(settings, availability, true);
+    expect(result.agents.claude.pinned).toBe(true);
+  });
 
-    for (const id of getEffectiveAgentIds()) {
-      expect(result.agents[id]).toEqual({ pinned: true });
+  it("synthesizes pinned: false for missing agents when hasRealData is true (issue #5158)", () => {
+    const settings = makeSettings({ claude: {} });
+    const availability = availabilityFor({ claude: "missing" });
+    const result = normalizeAgentSelection(settings, availability, true);
+    expect(result.agents.claude.pinned).toBe(false);
+  });
+
+  it("creates entries only for installed agents when store is empty and hasRealData is true", () => {
+    const settings: AgentSettings = { agents: {} };
+    const allIds = getEffectiveAgentIds();
+    const [firstInstalled] = allIds;
+    const availability = availabilityFor({ [firstInstalled]: "installed" });
+    const result = normalizeAgentSelection(settings, availability, true);
+
+    for (const id of allIds) {
+      if (id === firstInstalled) {
+        expect(result.agents[id]).toEqual({ pinned: true });
+      } else {
+        expect(result.agents[id]).toEqual({ pinned: false });
+      }
     }
+  });
+
+  it("leaves pinned absent when hasRealData is false (pre-probe race)", () => {
+    const settings: AgentSettings = { agents: {} };
+    const result = normalizeAgentSelection(settings, availabilityFor(), false);
+    // Pre-probe: don't phantom-synthesize anything — the orchestrator will
+    // re-run normalization once availability lands. Empty input stays empty.
+    expect(result.agents).toEqual({});
+  });
+
+  it("leaves existing entries with pinned: undefined untouched when hasRealData is false", () => {
+    const settings = makeSettings({ claude: {} });
+    const result = normalizeAgentSelection(settings, availabilityFor(), false);
+    expect(result.agents.claude.pinned).toBeUndefined();
   });
 
   it("returns same reference when no changes are needed", () => {
@@ -52,7 +93,22 @@ describe("normalizeAgentSelection", () => {
         ])
       ),
     };
-    const result = normalizeAgentSelection(settings);
+    const result = normalizeAgentSelection(settings, availabilityFor(), true);
     expect(result).toBe(settings);
+  });
+
+  it("treats undefined availability as fully missing when hasRealData is true", () => {
+    const settings = makeSettings({ claude: {} });
+    const result = normalizeAgentSelection(settings, undefined, true);
+    expect(result.agents.claude.pinned).toBe(false);
+  });
+
+  it("defaults to the pre-probe branch when called with only settings (back-compat)", () => {
+    const settings: AgentSettings = { agents: {} };
+    // No availability args passed — hasRealData defaults to false, so no
+    // phantom synthesis occurs. Mirrors what happens during boot before
+    // `cliAvailabilityStore.initialize()` has hydrated any real data.
+    const result = normalizeAgentSelection(settings);
+    expect(result.agents).toEqual({});
   });
 });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -21,7 +21,12 @@ vi.mock("@/clients", () => ({
     setTabGroups: vi.fn().mockResolvedValue(undefined),
   },
   agentSettingsClient: {
-    get: vi.fn().mockResolvedValue({}),
+    get: vi.fn().mockResolvedValue({ agents: {} }),
+    set: vi.fn(),
+    reset: vi.fn(),
+  },
+  cliAvailabilityClient: {
+    refresh: vi.fn(),
   },
 }));
 
@@ -73,6 +78,10 @@ const { useConsoleCaptureStore } = await import("../consoleCaptureStore");
 const { useVoiceRecordingStore } = await import("../voiceRecordingStore");
 const { unregisterInputController } = await import("../terminalInputStore");
 const { semanticAnalysisService } = await import("@/services/SemanticAnalysisService");
+const { useCliAvailabilityStore, cleanupCliAvailabilityStore } =
+  await import("../cliAvailabilityStore");
+const { useAgentSettingsStore, cleanupAgentSettingsStore } = await import("../agentSettingsStore");
+const { agentSettingsClient } = await import("@/clients");
 const { initStoreOrchestrator, destroyStoreOrchestrator } =
   await import("../rendererStoreOrchestrator");
 
@@ -797,5 +806,77 @@ describe("rendererStoreOrchestrator", () => {
 
     // Worktree should NOT have been switched since orchestrator is destroyed
     expect(useWorktreeSelectionStore.getState().activeWorktreeId).toBe("wt-1");
+  });
+
+  describe("availability → agent-settings sync (issue #5158)", () => {
+    beforeEach(() => {
+      cleanupCliAvailabilityStore();
+      cleanupAgentSettingsStore();
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockReset();
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({ agents: {} });
+    });
+
+    afterEach(() => {
+      cleanupCliAvailabilityStore();
+      cleanupAgentSettingsStore();
+    });
+
+    it("re-runs agentSettings normalization when hasRealData transitions false → true", async () => {
+      useAgentSettingsStore.setState({
+        settings: { agents: {} },
+        isInitialized: true,
+        isLoading: false,
+        error: null,
+      });
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockClear();
+
+      useCliAvailabilityStore.setState({ hasRealData: true });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(agentSettingsClient.get).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire when hasRealData is already true", () => {
+      useCliAvailabilityStore.setState({ hasRealData: true });
+
+      useAgentSettingsStore.setState({
+        settings: { agents: {} },
+        isInitialized: true,
+        isLoading: false,
+        error: null,
+      });
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockClear();
+
+      // Mutating something unrelated while hasRealData stays true — must NOT
+      // trigger a re-normalize.
+      useCliAvailabilityStore.setState({ isRefreshing: true });
+
+      expect(agentSettingsClient.get).not.toHaveBeenCalled();
+    });
+
+    it("skips refresh when agentSettingsStore is not yet initialized", () => {
+      // Not yet initialized — initial store state.
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockClear();
+
+      useCliAvailabilityStore.setState({ hasRealData: true });
+
+      expect(agentSettingsClient.get).not.toHaveBeenCalled();
+    });
+
+    it("stops firing after the orchestrator is destroyed", () => {
+      useAgentSettingsStore.setState({
+        settings: { agents: {} },
+        isInitialized: true,
+        isLoading: false,
+        error: null,
+      });
+      destroyStoreOrchestrator();
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockClear();
+
+      useCliAvailabilityStore.setState({ hasRealData: true });
+
+      expect(agentSettingsClient.get).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -837,7 +837,7 @@ describe("rendererStoreOrchestrator", () => {
       expect(agentSettingsClient.get).toHaveBeenCalledTimes(1);
     });
 
-    it("does not fire when hasRealData is already true", () => {
+    it("does not fire on unrelated cliAvailabilityStore updates", () => {
       useCliAvailabilityStore.setState({ hasRealData: true });
 
       useAgentSettingsStore.setState({
@@ -848,11 +848,36 @@ describe("rendererStoreOrchestrator", () => {
       });
       (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockClear();
 
-      // Mutating something unrelated while hasRealData stays true — must NOT
-      // trigger a re-normalize.
+      // Mutate a sibling flag without changing `availability` or the
+      // `hasRealData` transition — must NOT trigger a re-normalize.
       useCliAvailabilityStore.setState({ isRefreshing: true });
 
       expect(agentSettingsClient.get).not.toHaveBeenCalled();
+    });
+
+    it("re-runs normalization when availability ref changes after initial boot", async () => {
+      useCliAvailabilityStore.setState({
+        availability: { claude: "missing" } as never,
+        hasRealData: true,
+      });
+
+      useAgentSettingsStore.setState({
+        settings: { agents: {} },
+        isInitialized: true,
+        isLoading: false,
+        error: null,
+      });
+      (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockClear();
+
+      // Simulate the user installing a CLI outside Daintree: focus listener
+      // refreshes cliAvailabilityStore, which swaps the `availability` ref.
+      useCliAvailabilityStore.setState({
+        availability: { claude: "ready" } as never,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(agentSettingsClient.get).toHaveBeenCalledTimes(1);
     });
 
     it("skips refresh when agentSettingsStore is not yet initialized", () => {

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -90,26 +90,40 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
     if (initPromise) return initPromise;
 
     const myEpoch = ++normalizeEpoch;
-    initPromise = (async () => {
+    const promise = (async () => {
       try {
         set({ isLoading: true, error: null });
 
         const raw = (await agentSettingsClient.get()) ?? DEFAULT_AGENT_SETTINGS;
-        if (myEpoch !== normalizeEpoch) return;
+        if (myEpoch !== normalizeEpoch) {
+          // A concurrent refresh/update bumped the epoch — its result is
+          // authoritative. Flip `isInitialized` anyway so the store exits the
+          // loading state (and future `initialize()` calls no-op as intended).
+          set({ isLoading: false, isInitialized: true });
+          return;
+        }
         const { availability, hasRealData } = readAvailabilitySnapshot();
         const settings = normalizeAgentSelection(raw, availability, hasRealData);
         set({ settings, isLoading: false, isInitialized: true });
       } catch (e) {
-        if (myEpoch !== normalizeEpoch) return;
+        if (myEpoch !== normalizeEpoch) {
+          set({ isLoading: false, isInitialized: true });
+          return;
+        }
         set({
           error: e instanceof Error ? e.message : "Failed to load agent settings",
           isLoading: false,
           isInitialized: true,
         });
+      } finally {
+        // Clear the cached promise so a later `initialize()` can retry after
+        // cleanup/reset, even if this run was superseded by a concurrent op.
+        if (initPromise === promise) initPromise = null;
       }
     })();
 
-    return initPromise;
+    initPromise = promise;
+    return promise;
   },
 
   refresh: async () => {
@@ -122,7 +136,10 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       const settings = normalizeAgentSelection(raw, availability, hasRealData);
       set({ settings });
     } catch (e) {
-      if (myEpoch !== normalizeEpoch) throw e;
+      // Stale failures yield silently — whichever newer op bumped the epoch
+      // owns the error surface now, and fire-and-forget callers should not
+      // see spurious unhandled rejections from an invalidated attempt.
+      if (myEpoch !== normalizeEpoch) return;
       set({ error: e instanceof Error ? e.message : "Failed to refresh agent settings" });
       throw e;
     }
@@ -138,7 +155,7 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       const settings = normalizeAgentSelection(raw, availability, hasRealData);
       set({ settings });
     } catch (e) {
-      if (myEpoch !== normalizeEpoch) throw e;
+      if (myEpoch !== normalizeEpoch) return;
       set({ error: e instanceof Error ? e.message : `Failed to update ${agentId} settings` });
       throw e;
     }
@@ -158,7 +175,7 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       const settings = normalizeAgentSelection(raw, availability, hasRealData);
       set({ settings });
     } catch (e) {
-      if (myEpoch !== normalizeEpoch) throw e;
+      if (myEpoch !== normalizeEpoch) return;
       set({ error: e instanceof Error ? e.message : "Failed to reset agent settings" });
       throw e;
     }

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -1,17 +1,28 @@
 import { create } from "zustand";
-import type { AgentSettings, AgentSettingsEntry } from "@shared/types";
+import type { AgentSettings, AgentSettingsEntry, CliAvailability } from "@shared/types";
 import { agentSettingsClient } from "@/clients";
 import { DEFAULT_AGENT_SETTINGS } from "@shared/types";
 import { getEffectiveAgentIds } from "../../shared/config/agentRegistry";
 import { isAgentPinned } from "../../shared/utils/agentPinned";
+import { isAgentInstalled } from "../../shared/utils/agentAvailability";
+import { useCliAvailabilityStore } from "./cliAvailabilityStore";
 
 /**
- * In-memory normalization: seeds `pinned: true` for any registered agent that
- * is either missing from stored settings or has no explicit `pinned` value.
- * Does NOT persist. New/installed agents default to pinned so they surface in
- * the toolbar until the user explicitly unpins them.
+ * In-memory normalization: seeds `pinned` for any registered agent missing an
+ * explicit value, using the current CLI availability snapshot as the source of
+ * truth. Installed/ready agents default to `pinned: true` so they surface in
+ * the toolbar; missing agents default to `pinned: false` so uninstalled CLIs
+ * never phantom-pin (see issue #5158). When availability data has not yet
+ * loaded (`hasRealData === false`), the pinned flag stays absent — the
+ * renderer orchestrator re-runs normalization once real availability arrives.
+ * Explicit `pinned: true` / `pinned: false` values from the persisted store
+ * are always preserved. Does NOT persist.
  */
-export function normalizeAgentSelection(settings: AgentSettings): AgentSettings {
+export function normalizeAgentSelection(
+  settings: AgentSettings,
+  availability?: CliAvailability | null,
+  hasRealData: boolean = false
+): AgentSettings {
   const registeredIds = getEffectiveAgentIds();
   let changed = false;
   const agents = { ...settings.agents };
@@ -20,18 +31,28 @@ export function normalizeAgentSelection(settings: AgentSettings): AgentSettings 
     const entry = agents[id];
 
     if (!entry) {
-      agents[id] = { pinned: true };
-      changed = true;
+      if (hasRealData) {
+        agents[id] = { pinned: isAgentInstalled(availability?.[id]) };
+        changed = true;
+      }
       continue;
     }
 
-    if (entry.pinned === undefined) {
-      agents[id] = { ...entry, pinned: true };
+    if (entry.pinned === undefined && hasRealData) {
+      agents[id] = { ...entry, pinned: isAgentInstalled(availability?.[id]) };
       changed = true;
     }
   }
 
   return changed ? { ...settings, agents } : settings;
+}
+
+function readAvailabilitySnapshot(): {
+  availability: CliAvailability;
+  hasRealData: boolean;
+} {
+  const state = useCliAvailabilityStore.getState();
+  return { availability: state.availability, hasRealData: state.hasRealData };
 }
 
 interface AgentSettingsState {
@@ -52,6 +73,11 @@ interface AgentSettingsActions {
 type AgentSettingsStore = AgentSettingsState & AgentSettingsActions;
 
 let initPromise: Promise<void> | null = null;
+// Monotonic counter that guards stale async writes. `cleanupAgentSettingsStore`
+// and concurrent `refresh`/`updateAgent`/`reset` calls all bump this so a
+// slower in-flight normalization result can't overwrite a newer snapshot
+// (see lesson #1377).
+let normalizeEpoch = 0;
 
 export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => ({
   settings: null,
@@ -63,14 +89,18 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
     if (get().isInitialized) return Promise.resolve();
     if (initPromise) return initPromise;
 
+    const myEpoch = ++normalizeEpoch;
     initPromise = (async () => {
       try {
         set({ isLoading: true, error: null });
 
         const raw = (await agentSettingsClient.get()) ?? DEFAULT_AGENT_SETTINGS;
-        const settings = normalizeAgentSelection(raw);
+        if (myEpoch !== normalizeEpoch) return;
+        const { availability, hasRealData } = readAvailabilitySnapshot();
+        const settings = normalizeAgentSelection(raw, availability, hasRealData);
         set({ settings, isLoading: false, isInitialized: true });
       } catch (e) {
+        if (myEpoch !== normalizeEpoch) return;
         set({
           error: e instanceof Error ? e.message : "Failed to load agent settings",
           isLoading: false,
@@ -83,24 +113,32 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
   },
 
   refresh: async () => {
+    const myEpoch = ++normalizeEpoch;
     set({ error: null });
     try {
       const raw = (await agentSettingsClient.get()) ?? DEFAULT_AGENT_SETTINGS;
-      const settings = normalizeAgentSelection(raw);
+      if (myEpoch !== normalizeEpoch) return;
+      const { availability, hasRealData } = readAvailabilitySnapshot();
+      const settings = normalizeAgentSelection(raw, availability, hasRealData);
       set({ settings });
     } catch (e) {
+      if (myEpoch !== normalizeEpoch) throw e;
       set({ error: e instanceof Error ? e.message : "Failed to refresh agent settings" });
       throw e;
     }
   },
 
   updateAgent: async (agentId: string, updates: Partial<AgentSettingsEntry>) => {
+    const myEpoch = ++normalizeEpoch;
     set({ error: null });
     try {
       const raw = await agentSettingsClient.set(agentId, updates);
-      const settings = normalizeAgentSelection(raw);
+      if (myEpoch !== normalizeEpoch) return;
+      const { availability, hasRealData } = readAvailabilitySnapshot();
+      const settings = normalizeAgentSelection(raw, availability, hasRealData);
       set({ settings });
     } catch (e) {
+      if (myEpoch !== normalizeEpoch) throw e;
       set({ error: e instanceof Error ? e.message : `Failed to update ${agentId} settings` });
       throw e;
     }
@@ -111,12 +149,16 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
   },
 
   reset: async (agentId?: string) => {
+    const myEpoch = ++normalizeEpoch;
     set({ error: null });
     try {
       const raw = await agentSettingsClient.reset(agentId);
-      const settings = normalizeAgentSelection(raw);
+      if (myEpoch !== normalizeEpoch) return;
+      const { availability, hasRealData } = readAvailabilitySnapshot();
+      const settings = normalizeAgentSelection(raw, availability, hasRealData);
       set({ settings });
     } catch (e) {
+      if (myEpoch !== normalizeEpoch) throw e;
       set({ error: e instanceof Error ? e.message : "Failed to reset agent settings" });
       throw e;
     }
@@ -132,6 +174,7 @@ export function getPinnedAgents(): string[] {
 }
 
 export function cleanupAgentSettingsStore() {
+  normalizeEpoch++;
   initPromise = null;
   useAgentSettingsStore.setState({
     settings: DEFAULT_AGENT_SETTINGS,

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -90,6 +90,11 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
     if (initPromise) return initPromise;
 
     const myEpoch = ++normalizeEpoch;
+    // Use a holder so the `finally` block can reach back to the promise
+    // reference that will exist immediately after the IIFE synchronously
+    // returns. Strict TS won't let a `let`/`const` captured in the IIFE be
+    // compared before assignment, but a property assignment is fine.
+    const ref: { current: Promise<void> | null } = { current: null };
     const promise = (async () => {
       try {
         set({ isLoading: true, error: null });
@@ -118,10 +123,11 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       } finally {
         // Clear the cached promise so a later `initialize()` can retry after
         // cleanup/reset, even if this run was superseded by a concurrent op.
-        if (initPromise === promise) initPromise = null;
+        if (initPromise === ref.current) initPromise = null;
       }
     })();
 
+    ref.current = promise;
     initPromise = promise;
     return promise;
   },

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -121,12 +121,18 @@ export function initStoreOrchestrator(): () => void {
   unsubscribers.push(unsubLayoutUndo);
 
   // 5. Availability → agent-settings re-normalization: installed/missing state
-  //    is the input to `normalizeAgentSelection`, so re-run normalization once
-  //    real availability data arrives (see issue #5158). Fires only on the
-  //    `hasRealData: false → true` transition; re-checks after a manual
-  //    refresh do not need to re-run since availability is read live.
+  //    is the input to `normalizeAgentSelection`, so re-run normalization any
+  //    time a fresh availability snapshot lands (see issue #5158). Fires on
+  //    the `hasRealData: false → true` transition AND on subsequent
+  //    `availability` reference changes — the latter covers the focus-refresh
+  //    path in `useAgentLauncher`, where a user who installs a CLI outside
+  //    Daintree needs their tray/toolbar state to reconcile without an app
+  //    restart. `cliAvailabilityStore` only swaps the `availability` object
+  //    on real IPC completion, so ref equality is a reliable trigger.
   const unsubAvailability = useCliAvailabilityStore.subscribe((state, prevState) => {
-    if (!state.hasRealData || prevState.hasRealData) return;
+    const realDataLanded = state.hasRealData && !prevState.hasRealData;
+    const availabilityChanged = state.availability !== prevState.availability;
+    if (!realDataLanded && !availabilityChanged) return;
     const { isInitialized, isLoading } = useAgentSettingsStore.getState();
     if (!isInitialized || isLoading) return;
     void useAgentSettingsStore.getState().refresh();

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -9,6 +9,8 @@ import { semanticAnalysisService } from "@/services/SemanticAnalysisService";
 import { useConsoleCaptureStore } from "./consoleCaptureStore";
 import { useVoiceRecordingStore } from "./voiceRecordingStore";
 import { useLayoutUndoStore } from "./layoutUndoStore";
+import { useCliAvailabilityStore } from "./cliAvailabilityStore";
+import { useAgentSettingsStore } from "./agentSettingsStore";
 import { debounce } from "@/utils/debounce";
 
 const debouncedPersistMruList = debounce(persistMruList, 150);
@@ -117,6 +119,19 @@ export function initStoreOrchestrator(): () => void {
     prevIdSet = currentIdSet;
   });
   unsubscribers.push(unsubLayoutUndo);
+
+  // 5. Availability → agent-settings re-normalization: installed/missing state
+  //    is the input to `normalizeAgentSelection`, so re-run normalization once
+  //    real availability data arrives (see issue #5158). Fires only on the
+  //    `hasRealData: false → true` transition; re-checks after a manual
+  //    refresh do not need to re-run since availability is read live.
+  const unsubAvailability = useCliAvailabilityStore.subscribe((state, prevState) => {
+    if (!state.hasRealData || prevState.hasRealData) return;
+    const { isInitialized, isLoading } = useAgentSettingsStore.getState();
+    if (!isInitialized || isLoading) return;
+    void useAgentSettingsStore.getState().refresh();
+  });
+  unsubscribers.push(unsubAvailability);
 
   cleanupFn = () => {
     for (const unsub of unsubscribers) unsub();


### PR DESCRIPTION
## Summary

- The old logic defaulted every known agent to `pinned: true`, so users would see tray icons for Claude, Gemini, and Codex regardless of whether any were installed. This PR flips it to opt-in: an agent is pinned only when it has been confirmed installed.
- `normalizeAgentSelection()` now takes live `CliAvailability` data and sets `pinned` based on actual install state. A cross-store subscription in `rendererStoreOrchestrator` re-runs normalization whenever CLI availability changes (covers focus-refresh after an external install). A monotonic `normalizeEpoch` guard prevents stale async writes from overwriting a newer snapshot.
- Migration 013 cleans up phantom `{ pinned: true }` entries left behind by migration 012, so existing installs converge to the correct state without user action.

Resolves #5158

## Changes

- `shared/utils/agentPinned.ts` — opt-in semantics; missing entry resolves to `false`
- `src/store/agentSettingsStore.ts` — `normalizeAgentSelection` accepts `CliAvailability` + `hasRealData`; monotonic epoch guard on all write paths
- `src/store/rendererStoreOrchestrator.ts` — cross-store subscription re-normalizes on availability change
- `src/App.tsx` + `src/main.tsx` — reads pinned state from normalized store; bootstrap kicks off `initialize()`
- `electron/services/migrations/013-cleanup-phantom-pins.ts` — strips phantom pin entries

## Testing

New unit tests cover the opt-in pinned utility, migration 013 (including malformed-input edge cases), `normalizeAgentSelection` with various availability states, adversarial store conditions, and the orchestrator subscription behaviour. Two existing `AgentTrayButton` tests updated to reflect opt-in semantics. All tests pass.