### PR TITLE
feat(dev-preview): gate --turbopack on Next.js 15+ with settings toggle

### DIFF
--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import https from "node:https";
 import path from "node:path";
+import { resolveNextMajorVersion } from "../utils/resolveNextVersion.js";
 import type { PtyClient } from "./PtyClient.js";
 import { UrlDetector } from "./UrlDetector.js";
 import type {
@@ -88,7 +89,15 @@ const NEXT_DEV_DIRECT_RE = /\bnext\s+dev\b/;
 const TURBOPACK_FLAG_RE = /--turbo(?:pack)?\b/;
 const PKG_SCRIPT_RE = /^(?:npm\s+run|pnpm(?:\s+run)?|yarn(?:\s+run)?|bun(?:\s+run)?)\s+(\S+)$/;
 
-export async function normalizeNextjsDevCommand(command: string, cwd: string): Promise<string> {
+export async function normalizeNextjsDevCommand(
+  command: string,
+  cwd: string,
+  turbopackEnabled = true
+): Promise<string> {
+  if (!turbopackEnabled) return command;
+  const nextMajor = await resolveNextMajorVersion(cwd);
+  if (nextMajor === null || nextMajor < 15) return command;
+
   if (TURBOPACK_FLAG_RE.test(command)) return command;
 
   if (NEXT_DEV_DIRECT_RE.test(command)) {

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -20,6 +20,7 @@ import { markPerformance } from "../utils/performance.js";
 interface DevPreviewSession extends DevPreviewSessionState {
   cwd: string;
   devCommand: string;
+  turbopackEnabled: boolean;
   env?: Record<string, string>;
   buffer: string;
   lastErrorKey: string | null;
@@ -89,14 +90,21 @@ const NEXT_DEV_DIRECT_RE = /\bnext\s+dev\b/;
 const TURBOPACK_FLAG_RE = /--turbo(?:pack)?\b/;
 const PKG_SCRIPT_RE = /^(?:npm\s+run|pnpm(?:\s+run)?|yarn(?:\s+run)?|bun(?:\s+run)?)\s+(\S+)$/;
 
+function stripTurbopackFlag(command: string): string {
+  return command
+    .replace(/\s+--\s+--turbo(?:pack)?\b/, "") // " -- --turbopack" (pkg manager form)
+    .replace(/\s+--turbo(?:pack)?\b/, "") // " --turbopack" (direct form)
+    .trim();
+}
+
 export async function normalizeNextjsDevCommand(
   command: string,
   cwd: string,
   turbopackEnabled = true
 ): Promise<string> {
-  if (!turbopackEnabled) return command;
+  if (!turbopackEnabled) return stripTurbopackFlag(command);
   const nextMajor = await resolveNextMajorVersion(cwd);
-  if (nextMajor === null || nextMajor < 15) return command;
+  if (nextMajor === null || nextMajor < 15) return stripTurbopackFlag(command);
 
   if (TURBOPACK_FLAG_RE.test(command)) return command;
 
@@ -188,6 +196,7 @@ export class DevPreviewSessionService {
       session.cwd = request.cwd;
       session.worktreeId = request.worktreeId;
       session.devCommand = request.devCommand;
+      session.turbopackEnabled = request.turbopackEnabled ?? true;
       if (envChanged) {
         session.env = cloneEnv(request.env);
       }
@@ -435,6 +444,7 @@ export class DevPreviewSessionService {
       updatedAt: Date.now(),
       cwd: "",
       devCommand: "",
+      turbopackEnabled: true,
       env: undefined,
       buffer: "",
       lastErrorKey: null,
@@ -625,7 +635,7 @@ export class DevPreviewSessionService {
       }, 100);
     };
 
-    void normalizeNextjsDevCommand(trimmedCommand, session.cwd)
+    void normalizeNextjsDevCommand(trimmedCommand, session.cwd, session.turbopackEnabled)
       .then((normalizedCommand) => {
         submitCommand(normalizedCommand);
       })

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -8,10 +8,17 @@ vi.mock("node:fs/promises", () => ({
   readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])),
 }));
 
+const mockResolveNextMajorVersion = vi.fn<() => Promise<number | null>>();
+
+vi.mock("../../utils/resolveNextVersion.js", () => ({
+  resolveNextMajorVersion: (...args: unknown[]) => mockResolveNextMajorVersion(...(args as [])),
+}));
+
 import { beforeEach } from "vitest";
 
 beforeEach(() => {
   mockReadFile.mockReset();
+  mockResolveNextMajorVersion.mockResolvedValue(15);
 });
 
 function mockPkg(scripts: Record<string, string>): void {
@@ -130,6 +137,29 @@ describe("normalizeNextjsDevCommand", () => {
       expect(await normalizeNextjsDevCommand("python manage.py runserver", CWD)).toBe(
         "python manage.py runserver"
       );
+    });
+  });
+
+  describe("version gating", () => {
+    it("skips injection when Next.js major is 14", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      mockPkg({ dev: "next dev" });
+      expect(await normalizeNextjsDevCommand("npm run dev", CWD)).toBe("npm run dev");
+    });
+
+    it("skips injection when version is null", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(null);
+      expect(await normalizeNextjsDevCommand("next dev", CWD)).toBe("next dev");
+    });
+
+    it("injects when Next.js major is 15", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      expect(await normalizeNextjsDevCommand("next dev", CWD)).toBe("next dev --turbopack");
+    });
+
+    it("skips injection when turbopackEnabled is false", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      expect(await normalizeNextjsDevCommand("next dev", CWD, false)).toBe("next dev");
     });
   });
 });

--- a/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
+++ b/electron/services/__tests__/normalizeNextjsDevCommand.test.ts
@@ -162,4 +162,45 @@ describe("normalizeNextjsDevCommand", () => {
       expect(await normalizeNextjsDevCommand("next dev", CWD, false)).toBe("next dev");
     });
   });
+
+  describe("adversarial: renderer pre-injection for old Next.js versions (Bug 3)", () => {
+    // The renderer (findDevServerCandidate) has no version awareness and injects
+    // --turbopack for any Next.js project when turbopackEnabled=true. If that
+    // pre-injected command reaches normalizeNextjsDevCommand on a v14 project,
+    // the main process must strip the flag — not silently pass it through.
+
+    it("strips pre-injected --turbopack from 'next dev --turbopack' when version is 14", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(await normalizeNextjsDevCommand("next dev --turbopack", CWD)).toBe("next dev");
+    });
+
+    it("strips pre-injected -- --turbopack from pkg manager command when version is 14", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(await normalizeNextjsDevCommand("npm run dev -- --turbopack", CWD)).toBe(
+        "npm run dev"
+      );
+    });
+
+    it("strips pre-injected --turbopack from bun command when version is 14", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(14);
+      expect(await normalizeNextjsDevCommand("bun run dev --turbopack", CWD)).toBe("bun run dev");
+    });
+
+    it("strips --turbopack when version is null (unknown = safe default)", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(null);
+      expect(await normalizeNextjsDevCommand("next dev --turbopack", CWD)).toBe("next dev");
+    });
+
+    it("strips --turbopack when turbopackEnabled is false, regardless of version", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      expect(await normalizeNextjsDevCommand("next dev --turbopack", CWD, false)).toBe("next dev");
+    });
+
+    it("strips -- --turbopack when turbopackEnabled is false", async () => {
+      mockResolveNextMajorVersion.mockResolvedValue(15);
+      expect(await normalizeNextjsDevCommand("npm run dev -- --turbopack", CWD, false)).toBe(
+        "npm run dev"
+      );
+    });
+  });
 });

--- a/electron/utils/__tests__/resolveNextVersion.test.ts
+++ b/electron/utils/__tests__/resolveNextVersion.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const mockReadFile = vi.fn<(path: string, encoding: string) => Promise<string>>();
+
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])) },
+  readFile: (...args: unknown[]) => mockReadFile(...(args as [string, string])),
+}));
+
+// Import after mocking
+const { resolveNextMajorVersion } = await import("../resolveNextVersion.js");
+
+const CWD = "/project";
+const MODULES_PKG = `${CWD}/node_modules/next/package.json`;
+const ROOT_PKG = `${CWD}/package.json`;
+
+function mockInstalledVersion(version: string) {
+  mockReadFile.mockImplementation(async (p) => {
+    if (p === MODULES_PKG) return JSON.stringify({ version });
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  });
+}
+
+function mockNoNodeModules(deps: Record<string, string>, dev = false) {
+  mockReadFile.mockImplementation(async (p) => {
+    if (p === MODULES_PKG) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    if (p === ROOT_PKG) {
+      return JSON.stringify(dev ? { devDependencies: deps } : { dependencies: deps });
+    }
+    throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  });
+}
+
+function mockNothing() {
+  mockReadFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+}
+
+beforeEach(() => {
+  mockReadFile.mockReset();
+});
+
+describe("resolveNextMajorVersion — node_modules primary path", () => {
+  it("returns 15 for installed version '15.0.0'", async () => {
+    mockInstalledVersion("15.0.0");
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("returns 14 for installed version '14.2.30'", async () => {
+    mockInstalledVersion("14.2.30");
+    expect(await resolveNextMajorVersion(CWD)).toBe(14);
+  });
+
+  it("returns 13 for installed version '13.5.7'", async () => {
+    mockInstalledVersion("13.5.7");
+    expect(await resolveNextMajorVersion(CWD)).toBe(13);
+  });
+
+  it("returns null when version field is missing", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      if (p === MODULES_PKG) return JSON.stringify({ name: "next" });
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    expect(await resolveNextMajorVersion(CWD)).toBeNull();
+  });
+
+  it("returns null when version field is not a string", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      if (p === MODULES_PKG) return JSON.stringify({ version: 15 });
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    expect(await resolveNextMajorVersion(CWD)).toBeNull();
+  });
+});
+
+describe("resolveNextMajorVersion — package.json fallback, common range formats", () => {
+  // These are the adversarial cases — probe all semver prefix styles
+  // that npm/pnpm/yarn actually emit in the wild.
+
+  it("caret range ^15.0.0 → 15 [TURBO-01 core path]", async () => {
+    mockNoNodeModules({ next: "^15.0.0" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("caret range ^14.0.0 → 14", async () => {
+    mockNoNodeModules({ next: "^14.0.0" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(14);
+  });
+
+  it("bare version 15.0.0 → 15", async () => {
+    mockNoNodeModules({ next: "15.0.0" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("major only '15' → 15", async () => {
+    mockNoNodeModules({ next: "15" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("x-range 15.x → 15", async () => {
+    mockNoNodeModules({ next: "15.x" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("x-range 14.x.x → 14", async () => {
+    mockNoNodeModules({ next: "14.x.x" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(14);
+  });
+
+  it("tilde range ~15.0.0 → 15", async () => {
+    mockNoNodeModules({ next: "~15.0.0" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("gte range >=15.0.0 → 15", async () => {
+    mockNoNodeModules({ next: ">=15.0.0" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("gte+lt range '>=15.0.0 <16' → 15", async () => {
+    mockNoNodeModules({ next: ">=15.0.0 <16" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("dist-tag 'latest' → null (cannot determine version)", async () => {
+    mockNoNodeModules({ next: "latest" });
+    expect(await resolveNextMajorVersion(CWD)).toBeNull();
+  });
+
+  it("dist-tag 'canary' → null", async () => {
+    mockNoNodeModules({ next: "canary" });
+    expect(await resolveNextMajorVersion(CWD)).toBeNull();
+  });
+
+  it("reads from devDependencies when next is not in dependencies", async () => {
+    mockNoNodeModules({ next: "^15.0.0" }, true);
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("returns null when next is absent from both dep fields", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      if (p === MODULES_PKG) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      if (p === ROOT_PKG) return JSON.stringify({ dependencies: { react: "^18.0.0" } });
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    expect(await resolveNextMajorVersion(CWD)).toBeNull();
+  });
+});
+
+describe("resolveNextMajorVersion — fallback chain", () => {
+  it("prefers node_modules over package.json when both exist", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      if (p === MODULES_PKG) return JSON.stringify({ version: "15.3.0" });
+      if (p === ROOT_PKG) return JSON.stringify({ dependencies: { next: "^14.0.0" } });
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    // Installed version wins
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("falls back to package.json when node_modules is absent", async () => {
+    mockNoNodeModules({ next: "^15.0.0" });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+
+  it("returns null when both sources are absent", async () => {
+    mockNothing();
+    expect(await resolveNextMajorVersion(CWD)).toBeNull();
+  });
+
+  it("falls back to package.json when node_modules/next/package.json is malformed JSON", async () => {
+    mockReadFile.mockImplementation(async (p) => {
+      if (p === MODULES_PKG) return "not json {{{";
+      if (p === ROOT_PKG) return JSON.stringify({ dependencies: { next: "^15.0.0" } });
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    expect(await resolveNextMajorVersion(CWD)).toBe(15);
+  });
+});
+
+describe("resolveNextMajorVersion — TURBO-01 gate boundary", () => {
+  it("v15 → 15 (injection allowed)", async () => {
+    mockInstalledVersion("15.0.0");
+    const major = await resolveNextMajorVersion(CWD);
+    expect(major).not.toBeNull();
+    expect(major! >= 15).toBe(true);
+  });
+
+  it("v14 → 14 (injection must be blocked)", async () => {
+    mockInstalledVersion("14.2.30");
+    const major = await resolveNextMajorVersion(CWD);
+    expect(major).not.toBeNull();
+    expect(major! < 15).toBe(true);
+  });
+
+  it("^15.0.0 in package.json → injection allowed (end-to-end gate check)", async () => {
+    mockNoNodeModules({ next: "^15.0.0" });
+    const major = await resolveNextMajorVersion(CWD);
+    expect(major).not.toBeNull();
+    expect(major! >= 15).toBe(true);
+  });
+
+  it("^14.0.0 in package.json → injection must be blocked", async () => {
+    mockNoNodeModules({ next: "^14.0.0" });
+    const major = await resolveNextMajorVersion(CWD);
+    expect(major).not.toBeNull();
+    expect(major! < 15).toBe(true);
+  });
+});

--- a/electron/utils/resolveNextVersion.ts
+++ b/electron/utils/resolveNextVersion.ts
@@ -19,7 +19,7 @@ export async function resolveNextMajorVersion(cwd: string): Promise<number | nul
     const pkg = JSON.parse(raw);
     const versionSpec: unknown = pkg?.dependencies?.next ?? pkg?.devDependencies?.next;
     if (typeof versionSpec === "string") {
-      const stripped = versionSpec.replace(/^[^~>=<]*/, "").replace(/^[~>=<^]+/, "");
+      const stripped = versionSpec.replace(/^[\^~>=<v\s]+/, "");
       const major = parseInt(stripped.split(".")[0], 10);
       if (major >= 1) return major;
     }

--- a/electron/utils/resolveNextVersion.ts
+++ b/electron/utils/resolveNextVersion.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export async function resolveNextMajorVersion(cwd: string): Promise<number | null> {
+  try {
+    const raw = await fs.readFile(path.join(cwd, "node_modules/next/package.json"), "utf-8");
+    const pkg = JSON.parse(raw);
+    const version = pkg?.version;
+    if (typeof version === "string") {
+      const major = parseInt(version.split(".")[0], 10);
+      if (major >= 1) return major;
+    }
+  } catch {
+    // fall through to package.json deps check
+  }
+
+  try {
+    const raw = await fs.readFile(path.join(cwd, "package.json"), "utf-8");
+    const pkg = JSON.parse(raw);
+    const versionSpec: unknown = pkg?.dependencies?.next ?? pkg?.devDependencies?.next;
+    if (typeof versionSpec === "string") {
+      const stripped = versionSpec.replace(/^[^~>=<]*/, "").replace(/^[~>=<^]+/, "");
+      const major = parseInt(stripped.split(".")[0], 10);
+      if (major >= 1) return major;
+    }
+  } catch {
+    // fall through to null
+  }
+
+  console.debug("[resolveNextVersion] Could not resolve Next.js version for", cwd);
+  return null;
+}

--- a/shared/types/ipc/devPreview.ts
+++ b/shared/types/ipc/devPreview.ts
@@ -9,6 +9,7 @@ export interface DevPreviewEnsureRequest {
   devCommand: string;
   worktreeId?: string;
   env?: Record<string, string>;
+  turbopackEnabled?: boolean;
 }
 
 export interface DevPreviewSessionRequest {

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -303,6 +303,8 @@ export interface ProjectSettings {
   cloudSyncWarningDismissed?: boolean;
   /** Timeout in seconds before a slow-loading dev preview is automatically reloaded (default: 30, max: 120) */
   devServerLoadTimeout?: number;
+  /** Whether to auto-inject --turbopack for Next.js 15+ projects (default: true) */
+  turbopackEnabled?: boolean;
   /** CopyTree context generation configuration */
   copyTreeSettings?: CopyTreeSettings;
   /** Command overrides for project-specific customization */

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -425,7 +425,7 @@ export function DevPreviewPane({
     setIsAutoDetecting(true);
     try {
       const freshRunners = await projectClient.detectRunners(currentProjectId);
-      const candidate = findDevServerCandidate(freshRunners);
+      const candidate = findDevServerCandidate(freshRunners, projectSettings?.turbopackEnabled ?? true);
 
       if (!candidate) {
         return;
@@ -836,12 +836,12 @@ export function DevPreviewPane({
                   </h3>
                   <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
                     No dev server command is configured for this project.
-                    {allDetectedRunners && findDevServerCandidate(allDetectedRunners)
+                    {allDetectedRunners && findDevServerCandidate(allDetectedRunners, projectSettings?.turbopackEnabled ?? true)
                       ? " We found a script in your package.json that looks like a dev server."
                       : " Configure one to preview your application."}
                   </p>
                   <div className="flex flex-col items-center gap-2">
-                    {allDetectedRunners && findDevServerCandidate(allDetectedRunners) && (
+                    {allDetectedRunners && findDevServerCandidate(allDetectedRunners, projectSettings?.turbopackEnabled ?? true) && (
                       <Button
                         onClick={handleAutoDetect}
                         disabled={isAutoDetecting || isSettingsLoading}
@@ -853,7 +853,7 @@ export function DevPreviewPane({
                         <span className="text-xs">
                           {isAutoDetecting
                             ? "Detecting..."
-                            : `Use \`${findDevServerCandidate(allDetectedRunners)?.command}\``}
+                            : `Use \`${findDevServerCandidate(allDetectedRunners, projectSettings?.turbopackEnabled ?? true)?.command}\``}
                         </span>
                       </Button>
                     )}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -206,6 +206,7 @@ export function DevPreviewPane({
     cwd,
     worktreeId,
     env: projectEnv,
+    turbopackEnabled: projectSettings?.turbopackEnabled ?? true,
   });
 
   const webviewPartition = useMemo(() => {
@@ -425,7 +426,10 @@ export function DevPreviewPane({
     setIsAutoDetecting(true);
     try {
       const freshRunners = await projectClient.detectRunners(currentProjectId);
-      const candidate = findDevServerCandidate(freshRunners, projectSettings?.turbopackEnabled ?? true);
+      const candidate = findDevServerCandidate(
+        freshRunners,
+        projectSettings?.turbopackEnabled ?? true
+      );
 
       if (!candidate) {
         return;
@@ -449,7 +453,7 @@ export function DevPreviewPane({
         setIsAutoDetecting(false);
       }
     }
-  }, [currentProjectId, isAutoDetecting, saveSettings]);
+  }, [currentProjectId, isAutoDetecting, saveSettings, projectSettings?.turbopackEnabled]);
 
   const handleOpenSettings = useCallback(() => {
     void actionService.dispatch("project.settings.open", undefined, { source: "user" });
@@ -836,7 +840,11 @@ export function DevPreviewPane({
                   </h3>
                   <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
                     No dev server command is configured for this project.
-                    {allDetectedRunners && findDevServerCandidate(allDetectedRunners, projectSettings?.turbopackEnabled ?? true)
+                    {allDetectedRunners &&
+                    findDevServerCandidate(
+                      allDetectedRunners,
+                      projectSettings?.turbopackEnabled ?? true
+                    )
                       ? " We found a script in your package.json that looks like a dev server."
                       : " Configure one to preview your application."}
                   </p>

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -50,6 +50,8 @@ interface GeneralTabProps {
   onDevServerCommandChange: (value: string) => void;
   devServerLoadTimeout: number | undefined;
   onDevServerLoadTimeoutChange: (value: number | undefined) => void;
+  turbopackEnabled: boolean;
+  onTurbopackEnabledChange: (value: boolean) => void;
   projectIconSvg: string | undefined;
   onProjectIconSvgChange: (value: string | undefined) => void;
   enableInRepoSettings: (projectId: string) => Promise<Project>;
@@ -70,6 +72,8 @@ export function GeneralTab({
   onDevServerCommandChange,
   devServerLoadTimeout,
   onDevServerLoadTimeoutChange,
+  turbopackEnabled,
+  onTurbopackEnabledChange,
   projectIconSvg,
   onProjectIconSvgChange,
   enableInRepoSettings,
@@ -426,6 +430,23 @@ export function GeneralTab({
             placeholder="30"
             aria-label="Dev server load timeout in seconds"
           />
+        </div>
+
+        <div className="mt-3 flex items-center gap-2">
+          <input
+            id="turbopack-enabled"
+            type="checkbox"
+            checked={turbopackEnabled}
+            onChange={(e) => onTurbopackEnabledChange(e.target.checked)}
+            className="h-4 w-4 rounded border-canopy-border accent-canopy-accent cursor-pointer"
+            aria-label="Auto-inject --turbopack for Next.js 15+ projects"
+          />
+          <label
+            htmlFor="turbopack-enabled"
+            className="text-xs text-canopy-text/60 cursor-pointer select-none"
+          >
+            Auto-inject <code className="font-mono">--turbopack</code> for Next.js 15+ projects
+          </label>
         </div>
       </div>
 

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1331,6 +1331,8 @@ export function SettingsDialog({
                               onDevServerCommandChange={projectForm.setDevServerCommand}
                               devServerLoadTimeout={projectForm.devServerLoadTimeout}
                               onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
+                              turbopackEnabled={projectForm.turbopackEnabled}
+                              onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
                               projectIconSvg={projectForm.projectIconSvg}
                               onProjectIconSvgChange={projectForm.setProjectIconSvg}
                               enableInRepoSettings={projectForm.enableInRepoSettings}

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -11,6 +11,7 @@ export interface UseDevServerOptions {
   cwd: string;
   worktreeId?: string;
   env?: Record<string, string>;
+  turbopackEnabled?: boolean;
 }
 
 export interface UseDevServerState {
@@ -73,6 +74,7 @@ export function useDevServer({
   cwd,
   worktreeId,
   env,
+  turbopackEnabled,
 }: UseDevServerOptions): UseDevServerReturn {
   const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
   const [status, setStatus] = useState<DevPreviewStatus>("stopped");
@@ -105,6 +107,7 @@ export function useDevServer({
     worktreeId?: string;
     devCommand: string;
     env?: Record<string, string>;
+    turbopackEnabled?: boolean;
   }>({
     panelId,
     projectId: currentProjectId,
@@ -112,6 +115,7 @@ export function useDevServer({
     worktreeId,
     devCommand,
     env,
+    turbopackEnabled,
   });
 
   const envSignature = useMemo(() => serializeEnv(env), [env]);
@@ -123,6 +127,7 @@ export function useDevServer({
     worktreeId,
     devCommand,
     env,
+    turbopackEnabled,
   };
 
   const isRequestCurrent = useCallback(
@@ -201,6 +206,7 @@ export function useDevServer({
           devCommand: latest.devCommand,
           worktreeId: latest.worktreeId,
           env: latest.env,
+          turbopackEnabled: latest.turbopackEnabled,
         });
 
         if (isRequestCurrent(requestVersion, requestProjectId, requestPanelId)) {

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -48,6 +48,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
   );
   const [devServerCommand, setDevServerCommand] = useState<string>("");
   const [devServerLoadTimeout, setDevServerLoadTimeout] = useState<number | undefined>(undefined);
+  const [turbopackEnabled, setTurbopackEnabled] = useState<boolean>(true);
   const [commandOverrides, setCommandOverrides] = useState<CommandOverride[]>([]);
   const [copyTreeSettings, setCopyTreeSettings] = useState<CopyTreeSettings>({});
   const [branchPrefixMode, setBranchPrefixMode] = useState<"none" | "username" | "custom">("none");
@@ -160,6 +161,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       setDefaultWorktreeRecipeId(undefined);
       setDevServerCommand("");
       setDevServerLoadTimeout(undefined);
+      setTurbopackEnabled(true);
       setCommandOverrides([]);
       setCopyTreeSettings({});
       setProjectAutoSaveError(null);
@@ -195,6 +197,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     const initialDefaultWorktreeRecipeId = projectSettings.defaultWorktreeRecipeId;
     const initialDevServerCommand = projectSettings.devServerCommand || "";
     const initialDevServerLoadTimeout = projectSettings.devServerLoadTimeout;
+    const initialTurbopackEnabled = projectSettings.turbopackEnabled ?? true;
     const initialCommandOverrides = projectSettings.commandOverrides || [];
     const initialCopyTreeSettings = projectSettings.copyTreeSettings || {};
     const initialBranchPrefixMode = projectSettings.branchPrefixMode ?? "none";
@@ -233,6 +236,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setDefaultWorktreeRecipeId(initialDefaultWorktreeRecipeId);
     setDevServerCommand(initialDevServerCommand);
     setDevServerLoadTimeout(initialDevServerLoadTimeout);
+    setTurbopackEnabled(initialTurbopackEnabled);
     setCommandOverrides(initialCommandOverrides);
     setCopyTreeSettings(initialCopyTreeSettings);
     setBranchPrefixMode(initialBranchPrefixMode);
@@ -359,6 +363,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
         defaultWorktreeRecipeId,
         devServerCommand: devServerCommand.trim() || undefined,
         devServerLoadTimeout,
+        turbopackEnabled: turbopackEnabled === true ? undefined : false,
         commandOverrides: commandOverrides.length > 0 ? commandOverrides : undefined,
         copyTreeSettings: hasCopyTreeSettings ? sanitizedCopyTreeSettings : undefined,
         branchPrefixMode: effectivePrefixMode !== "none" ? effectivePrefixMode : undefined,
@@ -441,6 +446,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setDevServerCommand,
     devServerLoadTimeout,
     setDevServerLoadTimeout,
+    turbopackEnabled,
+    setTurbopackEnabled,
     commandOverrides,
     setCommandOverrides,
     copyTreeSettings,

--- a/src/utils/__tests__/devServerDetection.test.ts
+++ b/src/utils/__tests__/devServerDetection.test.ts
@@ -75,4 +75,21 @@ describe("findDevServerCandidate", () => {
       expect(candidate?.command).toBe("npm run dev");
     });
   });
+
+  describe("turbopackEnabled toggle gating", () => {
+    it("injects by default (turbopackEnabled defaults to true)", () => {
+      const runners = [runner("dev", "npm run dev", "next dev")];
+      expect(findDevServerCandidate(runners)?.command).toBe("npm run dev -- --turbopack");
+    });
+
+    it("does NOT inject when turbopackEnabled is false", () => {
+      const runners = [runner("dev", "npm run dev", "next dev")];
+      expect(findDevServerCandidate(runners, false)?.command).toBe("npm run dev");
+    });
+
+    it("does NOT inject when turbopackEnabled is false for bun runner", () => {
+      const runners = [runner("dev", "bun run dev", "next dev")];
+      expect(findDevServerCandidate(runners, false)?.command).toBe("bun run dev");
+    });
+  });
 });

--- a/src/utils/devServerDetection.ts
+++ b/src/utils/devServerDetection.ts
@@ -5,7 +5,8 @@ const DEV_SCRIPT_PRIORITY = ["dev", "start", "serve"];
 const NEXT_DEV_RE = /\bnext\s+dev\b/;
 const TURBOPACK_FLAG_RE = /--turbo(?:pack)?\b/;
 
-function applyNextjsTurbopack(runner: RunCommand): RunCommand {
+function applyNextjsTurbopack(runner: RunCommand, turbopackEnabled = true): RunCommand {
+  if (!turbopackEnabled) return runner;
   const desc = runner.description ?? "";
   if (!NEXT_DEV_RE.test(desc) || TURBOPACK_FLAG_RE.test(desc)) {
     return runner;
@@ -15,7 +16,8 @@ function applyNextjsTurbopack(runner: RunCommand): RunCommand {
 }
 
 export function findDevServerCandidate(
-  allDetectedRunners: RunCommand[] | undefined
+  allDetectedRunners: RunCommand[] | undefined,
+  turbopackEnabled = true
 ): RunCommand | undefined {
   if (!allDetectedRunners) {
     return undefined;
@@ -25,5 +27,5 @@ export function findDevServerCandidate(
     allDetectedRunners.find((runner) => runner.name === name)
   ).find((runner) => runner !== undefined);
 
-  return candidate ? applyNextjsTurbopack(candidate) : undefined;
+  return candidate ? applyNextjsTurbopack(candidate, turbopackEnabled) : undefined;
 }


### PR DESCRIPTION
## Summary

- Auto-injection of `--turbopack` was unconditional, breaking projects on Next.js <15; now gated behind a semver major ≥ 15 check that reads the installed version from `node_modules` (falling back to `package.json` deps)
- Adds a per-project **Auto-inject --turbopack** toggle in Dev Server settings so users can override in either direction
- Fixes three bugs discovered by adversarial testing: broken caret-range parsing, the toggle never reaching the service call site, and renderer pre-injection leaking through the version gate for old projects

Resolves #5154

## Changes

- `electron/utils/resolveNextVersion.ts` *(new)*: `resolveNextMajorVersion(cwd)` with 3-level fallback — `node_modules/next/package.json` → `package.json` deps → `null` (skip injection)
- `electron/services/DevPreviewSessionService.ts`: `normalizeNextjsDevCommand` gated on version ≥ 15 and `turbopackEnabled`; adds `stripTurbopackFlag()` so the main process actively removes pre-injected flags when the gate says no; threads `turbopackEnabled` through `DevPreviewSession` and the call site
- `shared/types/ipc/devPreview.ts`: adds `turbopackEnabled?: boolean` to `DevPreviewEnsureRequest`
- `src/utils/devServerDetection.ts`: `findDevServerCandidate` / `applyNextjsTurbopack` accept `turbopackEnabled` toggle (renderer-only; version check stays in main)
- `src/components/DevPreview/DevPreviewPane.tsx`: passes `turbopackEnabled` from `projectSettings` into `useDevServer`; fixes missing `useCallback` dep
- `src/hooks/useDevServer.ts`: adds `turbopackEnabled` to `UseDevServerOptions`, `latestContextRef`, and the `ensure()` call
- `shared/types/project.ts`: adds `turbopackEnabled?: boolean` to `ProjectSettings`
- `src/hooks/useProjectSettingsForm.ts`: wires save/load lifecycle for `turbopackEnabled`
- `src/components/Project/GeneralTab.tsx`: checkbox in Dev Server section — "Auto-inject --turbopack for Next.js 15+ projects"
- `src/components/Settings/SettingsDialog.tsx`: passes new props to `ProjectGeneralTab`
- `electron/utils/__tests__/resolveNextVersion.test.ts` *(new)*: 26 tests covering all semver prefix formats (`^`, `~`, `>=`, bare, x-range), fallback chain, malformed JSON, and TURBO-01 boundary conditions
- `electron/services/__tests__/normalizeNextjsDevCommand.test.ts`: mocks `resolveNextMajorVersion`; adds version-gating describe block and 6 adversarial cases for renderer pre-injection stripping
- `src/utils/__tests__/devServerDetection.test.ts`: adds `turbopackEnabled` toggle gating describe block

## Testing

- `npx vitest run` — 69 tests pass across all three affected test files
- `npm run check` — TypeScript clean, lint at baseline (401 warnings), format clean
- Adversarial test strategy: wrote tests expected to fail first, confirmed 17 failures across 3 bugs, then fixed; all 17 now pass
- E2E: dev preview E2E tests (`e2e/core/`) do not cover turbopack injection directly; the unit tests cover the acceptance criteria from the issue