### PR TITLE
fix(agent-tray): suppress tooltip reopen after dropdown closes

### DIFF
--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -2,6 +2,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type ComponentType,
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
@@ -99,6 +100,15 @@ export function AgentTrayButton({
   const isAvailabilityLoading = agentAvailability === undefined || !hasRealData;
   const lastPinActionAt = useRef(0);
 
+  // Radix Tooltip reopens whenever the trigger receives focus, including
+  // programmatic focus restoration from DropdownMenu's onCloseAutoFocus. Gate
+  // the Tooltip via controlled state and suppress open=true for one tick
+  // after the dropdown closes so the refocused button doesn't flash the
+  // tooltip back into view. See issue #5153.
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+  const isRestoringFocusRef = useRef(false);
+  const restoreFocusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Re-probe on view visibility changes (Electron LRU reactivation, tab
   // switches). The window-focus trigger is handled once globally in
   // useAgentLauncher; both paths share the 30s throttle in the store.
@@ -116,6 +126,31 @@ export function AgentTrayButton({
       document.removeEventListener("visibilitychange", handleVisibility);
     };
   }, [refreshAvailability]);
+
+  useEffect(() => {
+    return () => {
+      if (restoreFocusTimerRef.current != null) {
+        clearTimeout(restoreFocusTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleTooltipOpenChange = (open: boolean) => {
+    if (open && isRestoringFocusRef.current) return;
+    setTooltipOpen(open);
+  };
+
+  const suppressTooltipDuringFocusRestore = () => {
+    setTooltipOpen(false);
+    isRestoringFocusRef.current = true;
+    if (restoreFocusTimerRef.current != null) {
+      clearTimeout(restoreFocusTimerRef.current);
+    }
+    restoreFocusTimerRef.current = setTimeout(() => {
+      isRestoringFocusRef.current = false;
+      restoreFocusTimerRef.current = null;
+    }, 0);
+  };
 
   const agentDominantStates = useMemo(() => {
     const statesPerAgent = new Map<string, (AgentState | undefined)[]>();
@@ -191,6 +226,7 @@ export function AgentTrayButton({
   };
 
   const handleOpenChange = (open: boolean) => {
+    setTooltipOpen(false);
     if (!open) return;
     // Fire-and-forget: the store throttle absorbs rapid reopens.
     void refreshAvailability().catch(() => {});
@@ -224,7 +260,7 @@ export function AgentTrayButton({
   return (
     <DropdownMenu onOpenChange={handleOpenChange}>
       <TooltipProvider>
-        <Tooltip>
+        <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
           <TooltipTrigger asChild>
             <DropdownMenuTrigger asChild>
               <Button
@@ -245,8 +281,8 @@ export function AgentTrayButton({
         align="start"
         sideOffset={4}
         className="min-w-[16rem]"
-        onCloseAutoFocus={(e) => {
-          if ((e as unknown as PointerEvent).detail > 0) e.preventDefault();
+        onCloseAutoFocus={() => {
+          suppressTooltipDuringFocusRestore();
         }}
       >
         {isAvailabilityLoading && (

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 
 const dispatchMock = vi.fn();
@@ -8,6 +8,9 @@ const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
 const setFocusedMock = vi.fn();
 const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
 let openChangeSpy: ((open: boolean) => void) | null = null;
+let tooltipOpenChangeSpy: ((open: boolean) => void) | null = null;
+let capturedTooltipOpen: boolean | undefined = undefined;
+let closeAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
 
 let mockSettings: AgentSettings | null = null;
 let mockPanelsById: Record<string, unknown> = {};
@@ -87,9 +90,16 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     return <div>{children}</div>;
   },
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="dropdown-content">{children}</div>
-  ),
+  DropdownMenuContent: ({
+    children,
+    onCloseAutoFocus,
+  }: {
+    children: React.ReactNode;
+    onCloseAutoFocus?: (e: { preventDefault: () => void }) => void;
+  }) => {
+    closeAutoFocusSpy = onCloseAutoFocus ?? null;
+    return <div data-testid="dropdown-content">{children}</div>;
+  },
   DropdownMenuItem: ({
     children,
     onSelect,
@@ -123,7 +133,19 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    tooltipOpenChangeSpy = onOpenChange ?? null;
+    capturedTooltipOpen = open;
+    return <>{children}</>;
+  },
   TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -166,6 +188,9 @@ describe("AgentTrayButton", () => {
     setFocusedMock.mockClear();
     refreshAvailabilityMock.mockClear();
     openChangeSpy = null;
+    tooltipOpenChangeSpy = null;
+    capturedTooltipOpen = undefined;
+    closeAutoFocusSpy = null;
     mockSettings = null;
     mockPanelsById = {};
     mockPanelIds = [];
@@ -478,6 +503,61 @@ describe("AgentTrayButton", () => {
     // Null settings means the normalizer hasn't run yet — with opt-in
     // semantics, that reads as unpinned until real data arrives.
     expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("false");
+  });
+
+  it("suppresses tooltip reopen during focus restoration after dropdown closes (issue #5153)", () => {
+    vi.useFakeTimers();
+    try {
+      const availability = { claude: "ready" } as unknown as CliAvailability;
+      mockSettings = settingsWith({ claude: { pinned: true } });
+
+      render(<AgentTrayButton agentAvailability={availability} />);
+      expect(tooltipOpenChangeSpy).toBeTruthy();
+      expect(closeAutoFocusSpy).toBeTruthy();
+
+      // Hover opens the tooltip.
+      act(() => {
+        tooltipOpenChangeSpy!(true);
+      });
+      expect(capturedTooltipOpen).toBe(true);
+
+      // Dropdown opens — handleOpenChange forces the tooltip closed.
+      act(() => {
+        openChangeSpy!(true);
+      });
+      expect(capturedTooltipOpen).toBe(false);
+
+      // Dropdown closes; Radix tries to restore focus which would normally
+      // re-fire Tooltip.onOpenChange(true). The suppression ref must gate it.
+      act(() => {
+        closeAutoFocusSpy!({ preventDefault: vi.fn() });
+        tooltipOpenChangeSpy!(true);
+      });
+      expect(capturedTooltipOpen).toBe(false);
+
+      // After the microtask clears, tooltip opens normally again on hover.
+      act(() => {
+        vi.runAllTimers();
+      });
+      act(() => {
+        tooltipOpenChangeSpy!(true);
+      });
+      expect(capturedTooltipOpen).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not call preventDefault in onCloseAutoFocus (preserves a11y focus return)", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    expect(closeAutoFocusSpy).toBeTruthy();
+
+    const preventDefault = vi.fn();
+    closeAutoFocusSpy!({ preventDefault });
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 
   it("ignores panels from other worktrees for session detection", () => {


### PR DESCRIPTION
## Summary

- The Agent Tray button's tooltip was reappearing after the dropdown closed (on Escape, clicking away, or clicking "Customize Toolbar…") because Radix's `onCloseAutoFocus` restores focus to the trigger, and the `Tooltip`'s focus listener interpreted that as a new hover/focus event.
- The previous `event.detail > 0` guard was unreliable: Radix doesn't contract that value and keyboard/programmatic closes have `detail === 0`, so the tooltip still re-fired.
- Fix makes the `Tooltip` controlled via `tooltipOpen` state, adds an `isRestoringFocusRef` flag raised in `onCloseAutoFocus` and cleared on the next tick, and gates `handleTooltipOpenChange` so any `open=true` during that window is suppressed. `handleOpenChange` also force-closes the tooltip when the dropdown opens to prevent overlap.

Resolves #5153

## Changes

- `src/components/Layout/AgentTrayButton.tsx` — controlled `Tooltip`, `isRestoringFocusRef` guard, force-close tooltip on dropdown open
- `src/components/Layout/__tests__/AgentTrayButton.test.tsx` — two new regression tests: suppresses tooltip reopen during focus restoration, and confirms `preventDefault` is not called in `onCloseAutoFocus` (WCAG 2.4.3 compliance)

## Testing

21/21 unit tests pass. Typecheck clean. Lint ratchet at 401 baseline warnings (no new warnings introduced). `preventDefault` is not called in `onCloseAutoFocus`, so focus still returns to the trigger and keyboard navigation is unaffected.