### PR TITLE
fix(settings): refresh sidebar after saving GitHub token

### DIFF
--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -67,7 +67,7 @@ export function GitHubSettingsTab() {
         }
         const config = configResult.result as any;
         updateConfig(config);
-        void actionService.dispatch("worktree.refreshPullRequests", undefined, {
+        void actionService.dispatch("worktree.refresh", undefined, {
           source: "user",
         });
       } else {

--- a/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
+++ b/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { GitHubSettingsTab } from "../GitHubSettingsTab";
+
+vi.mock("@/store", () => ({
+  useGitHubConfigStore: vi.fn(),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn(),
+  },
+}));
+
+import { useGitHubConfigStore } from "@/store";
+import { actionService } from "@/services/ActionService";
+
+const mockedUseGitHubConfigStore = vi.mocked(useGitHubConfigStore);
+const mockedDispatch = vi.mocked(actionService.dispatch);
+
+function setupStore(overrides: Record<string, unknown> = {}) {
+  mockedUseGitHubConfigStore.mockReturnValue({
+    config: { hasToken: false, owner: null, repo: null },
+    isLoading: false,
+    error: null,
+    initialize: vi.fn(),
+    updateConfig: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useGitHubConfigStore>);
+}
+
+describe("GitHubSettingsTab handleSaveToken", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupStore();
+  });
+
+  it("dispatches worktree.refresh after a successful token save so the sidebar re-fetches", async () => {
+    mockedDispatch.mockImplementation(async (actionId: string) => {
+      if (actionId === "github.setToken") {
+        return { ok: true, result: { valid: true } } as never;
+      }
+      if (actionId === "github.getConfig") {
+        return {
+          ok: true,
+          result: { hasToken: true, owner: null, repo: null },
+        } as never;
+      }
+      if (actionId === "worktree.refresh") {
+        return { ok: true, result: undefined } as never;
+      }
+      return { ok: true, result: undefined } as never;
+    });
+
+    render(<GitHubSettingsTab />);
+
+    fireEvent.change(screen.getByLabelText(/github personal access token/i), {
+      target: { value: "ghp_valid_token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save token" }));
+
+    await waitFor(() => {
+      expect(mockedDispatch).toHaveBeenCalledWith(
+        "worktree.refresh",
+        undefined,
+        expect.objectContaining({ source: "user" })
+      );
+    });
+
+    expect(mockedDispatch).not.toHaveBeenCalledWith(
+      "worktree.refreshPullRequests",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("does not dispatch worktree.refresh when token validation fails", async () => {
+    mockedDispatch.mockImplementation(async (actionId: string) => {
+      if (actionId === "github.setToken") {
+        return {
+          ok: true,
+          result: { valid: false, error: "Invalid token" },
+        } as never;
+      }
+      return { ok: true, result: undefined } as never;
+    });
+
+    render(<GitHubSettingsTab />);
+
+    fireEvent.change(screen.getByLabelText(/github personal access token/i), {
+      target: { value: "ghp_invalid" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save token" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid token/i)).toBeTruthy();
+    });
+
+    expect(mockedDispatch).not.toHaveBeenCalledWith(
+      "worktree.refresh",
+      expect.anything(),
+      expect.anything()
+    );
+    expect(mockedDispatch).not.toHaveBeenCalledWith(
+      "worktree.refreshPullRequests",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+});

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -155,6 +155,48 @@ describe("useRepositoryStats", () => {
         expect(result.current.error).toBeNull();
       });
     });
+
+    it("clears isTokenError when daintree:refresh-sidebar triggers a successful refetch", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValueOnce({
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: null,
+        ghError: "GitHub token not configured. Set it in Settings.",
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.isTokenError).toBe(true);
+        expect(result.current.error).toBe("GitHub token not configured. Set it in Settings.");
+      });
+
+      getRepoStatsMock.mockResolvedValueOnce({
+        commitCount: 5,
+        issueCount: 2,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 2000,
+      });
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+        expect(getRepoStatsMock.mock.calls[1]?.[1]).toBe(true);
+        expect(result.current.isTokenError).toBe(false);
+        expect(result.current.error).toBeNull();
+      });
+    });
   });
 
   it("queues a refetch on project switch when an earlier fetch is still in flight", async () => {


### PR DESCRIPTION
## Summary

- `handleSaveToken` was dispatching `worktree.refreshPullRequests` after saving, which doesn't fire `daintree:refresh-sidebar`. Swapped to `worktree.refresh`, which fires that event and still performs the PR refresh internally via `Promise.allSettled`.
- `useRepositoryStats` already listens for `daintree:refresh-sidebar` and re-fetches with `forceRefresh: true`, so `isTokenError` now clears immediately without needing a restart.
- The toolbar buttons (Issues, Pull Requests) no longer route back to settings after a valid token is saved.

Resolves #5166

## Changes

- `src/components/Settings/GitHubSettingsTab.tsx` — one-line swap in `handleSaveToken`: `worktree.refreshPullRequests` → `worktree.refresh`
- `src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx` (new) — two tests covering the positive path (refresh called on success) and negative path (refresh not called on validation failure)
- `src/hooks/__tests__/useRepositoryStats.test.tsx` — one regression test confirming `isTokenError` clears on `daintree:refresh-sidebar` after a token is saved

## Testing

All 712 tests in the Settings and hooks suites pass. Typecheck, lint (baseline 401 warnings, no new), and format all clean.