### PR TITLE
feat(worktree): raise bulk-create concurrency to 3 and stress-test it

### DIFF
--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -279,8 +279,26 @@ describe("WorkspaceService adversarial", () => {
       }
     }
 
-    // Guard against accidentally drifting onto the fromRemote=true --track
-    // path, which still writes to .git/config and reintroduces lock contention.
-    expect(mockSimpleGit.raw).toHaveBeenCalledWith(expect.arrayContaining(["--no-track"]));
+    // Each result must bind to a distinct requestId — rules out duplicated /
+    // misrouted success events silently satisfying the count check above.
+    const requestIds = new Set(resultEvents.map((e) => e.requestId));
+    expect(requestIds.size).toBe(10);
+    for (let i = 0; i < 10; i++) {
+      expect(requestIds.has(`req-stress-${i}`)).toBe(true);
+    }
+
+    // Guard against drifting onto the fromRemote=true --track path, which
+    // still writes to .git/config and reintroduces lock contention. Inspect
+    // every `worktree add` argv so a partial drift (9 of 10 on --no-track)
+    // still fails, unlike an `arrayContaining` smoke check.
+    const worktreeAddCalls = mockSimpleGit.raw.mock.calls.filter(
+      (call): call is [string[]] =>
+        Array.isArray(call[0]) && call[0][0] === "worktree" && call[0][1] === "add"
+    );
+    expect(worktreeAddCalls).toHaveLength(10);
+    for (const [argv] of worktreeAddCalls) {
+      expect(argv).toContain("--no-track");
+      expect(argv).not.toContain("--track");
+    }
   });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -246,4 +246,41 @@ describe("WorkspaceService adversarial", () => {
     );
     expect(monitorEntries.length).toBeLessThanOrEqual(1);
   });
+
+  it("emits 10 successful local create-worktree results under concurrent load without config.lock errors", async () => {
+    // Guards the QUEUE_CONCURRENCY=3 bump in BulkCreateWorktreeDialog (#5163):
+    // with --no-track on the local-create path (PR #5165), install_branch_config
+    // is skipped, so .git/config.lock contention that previously capped the
+    // producer queue at 2 no longer applies. Run 10 concurrent createWorktree
+    // calls on the fromRemote=false path and assert no result event reports a
+    // "could not lock config file" failure.
+    const promises = Array.from({ length: 10 }, (_, i) =>
+      service.createWorktree(`req-stress-${i}`, "/repo", {
+        baseBranch: "main",
+        newBranch: `feature/stress-${i}`,
+        path: `/repo/wt-stress-${i}`,
+        fromRemote: false,
+      })
+    );
+
+    await Promise.allSettled(promises);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const resultEvents = sentEvents.filter(
+      (e): e is WorkspaceHostEvent & { type: "create-worktree-result" } =>
+        e.type === "create-worktree-result"
+    );
+
+    expect(resultEvents).toHaveLength(10);
+    for (const event of resultEvents) {
+      expect(event.success).toBe(true);
+      if ("error" in event && event.error) {
+        expect(event.error).not.toMatch(/could not lock config file/i);
+      }
+    }
+
+    // Guard against accidentally drifting onto the fromRemote=true --track
+    // path, which still writes to .git/config and reintroduces lock contention.
+    expect(mockSimpleGit.raw).toHaveBeenCalledWith(expect.arrayContaining(["--no-track"]));
+  });
 });

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -223,12 +223,14 @@ function progressReducer(state: ProgressState, action: ProgressAction): Progress
 }
 
 const MAX_AUTO_RETRIES = 2;
-// Cap in-flight creation requests as defense-in-depth for `.git/` lock
-// contention (see #3807). The backend leaky-bucket rate limiter is the
-// primary throttle — pacing at the producer side would only create a
-// conflicting secondary rate limiter and re-introduce the feast/famine
-// burst pattern (see #5098).
-const QUEUE_CONCURRENCY = 2;
+// Cap in-flight creation requests at a small parallel fan-out. The backend
+// leaky-bucket rate limiter remains the primary throttle — pacing at the
+// producer side would only create a conflicting secondary rate limiter and
+// re-introduce the feast/famine burst pattern (see #5098). Raised from 2 to
+// 3 now that `--no-track` (see #5163, PR #5165) avoids `install_branch_config`
+// and its `.git/config.lock` write, eliminating the contention that
+// previously justified the tighter cap (see #3807).
+const QUEUE_CONCURRENCY = 3;
 const BACKOFF_BASE_MS = 3000;
 const BACKOFF_CAP_MS = 30000;
 const VERIFICATION_SETTLE_MS = 800;

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -277,19 +277,13 @@ describe("BulkCreateWorktreeDialog", () => {
       screen.getByTestId("bulk-create-confirm-button").click();
     });
 
-    // Both concurrency slots fill immediately (concurrency = 2) — the
+    // All three concurrency slots fill immediately (concurrency = 3) — the
     // backend leaky-bucket rate limiter drives the real cadence.
-    expect(mockWorktreeCreate).toHaveBeenCalledTimes(2);
-
-    // Resolve first to free a concurrency slot so the third task starts
-    await act(async () => {
-      resolvers[0]?.("wt-1");
-      await vi.advanceTimersByTimeAsync(0);
-    });
     expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
 
-    // Resolve remaining
+    // Resolve all
     await act(async () => {
+      resolvers[0]?.("wt-1");
       resolvers[1]?.("wt-2");
       resolvers[2]?.("wt-3");
       await vi.advanceTimersByTimeAsync(0);
@@ -316,8 +310,8 @@ describe("BulkCreateWorktreeDialog", () => {
       screen.getByTestId("bulk-create-confirm-button").click();
     });
 
-    // Should show "Creating worktree..." label for the two items that started
-    // immediately under concurrency = 2.
+    // Should show "Creating worktree..." labels for the items that started
+    // immediately under concurrency = 3.
     expect(screen.getAllByText("Creating worktree\u2026").length).toBeGreaterThanOrEqual(1);
 
     // Resolve all
@@ -979,16 +973,22 @@ describe("BulkCreateWorktreeDialog", () => {
     );
 
     const onClose = vi.fn();
-    render(<BulkCreateWorktreeDialog {...defaultProps} onClose={onClose} />);
+    // Use 4 items so that with concurrency=3 at least one item stays queued,
+    // letting us verify the queue-clearing + stale-handler cancel semantics.
+    const props = {
+      ...defaultProps,
+      selectedIssues: [makeIssue(1), makeIssue(2), makeIssue(3), makeIssue(4)],
+    };
+    render(<BulkCreateWorktreeDialog {...props} onClose={onClose} />);
 
     await act(async () => {
       screen.getByTestId("bulk-create-confirm-button").click();
     });
 
-    // Items 1 and 2 both start immediately under concurrency = 2; item 3
-    // is still queued. Cancel before any resolve so the queue is cleared
-    // and item 3 never starts.
-    expect(mockWorktreeCreate).toHaveBeenCalledTimes(2);
+    // Items 1-3 start immediately under concurrency = 3; item 4 is still
+    // queued. Cancel before any resolve so the queue is cleared and item 4
+    // never starts.
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
 
     // Close the dialog before remaining items finish
     await act(async () => {
@@ -1000,15 +1000,16 @@ describe("BulkCreateWorktreeDialog", () => {
 
     expect(onClose).toHaveBeenCalled();
 
-    // Resolving the in-flight items after cancel must not trigger item 3 —
+    // Resolving the in-flight items after cancel must not trigger item 4 —
     // runIdRef has been bumped so the stale handlers exit early.
     await act(async () => {
       resolvers[0]?.("wt-1");
       resolvers[1]?.("wt-2");
+      resolvers[2]?.("wt-3");
       await vi.advanceTimersByTimeAsync(1000);
     });
 
-    expect(mockWorktreeCreate).toHaveBeenCalledTimes(2);
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
     expect(screen.queryByTestId("bulk-create-done-button")).toBeNull();
   });
 
@@ -1027,7 +1028,7 @@ describe("BulkCreateWorktreeDialog", () => {
       screen.getByTestId("bulk-create-confirm-button").click();
     });
 
-    // Advance to let the first two items start (concurrency = 2)
+    // Advance to let all three items start (concurrency = 3)
     await advanceTimersGradually(400);
 
     // Resolve the first item

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1096,20 +1096,17 @@ describe("BulkCreateWorktreeDialog", () => {
 
     // With 3 issues, pre-query runs getAvailableBranch + getDefaultPath once each
     // per item BEFORE any worktree.create call. After the button click and
-    // microtask flush, all pre-queries have completed and both concurrency
+    // microtask flush, all pre-queries have completed and all three concurrency
     // slots have filled — but no further pre-query IPC should fire.
     expect(mockGetAvailableBranch).toHaveBeenCalledTimes(3);
     expect(mockGetDefaultPath).toHaveBeenCalledTimes(3);
 
-    // The queue has started worktree.create for the first 2 items (concurrency=2)
-    expect(mockWorktreeCreate).toHaveBeenCalledTimes(2);
+    // The queue has started worktree.create for all 3 items (concurrency=3)
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
 
     // Resolve all creates and advance
     await act(async () => {
       createResolvers[0]?.("wt-1");
-      await vi.advanceTimersByTimeAsync(0);
-    });
-    await act(async () => {
       createResolvers[1]?.("wt-2");
       createResolvers[2]?.("wt-3");
       await vi.advanceTimersByTimeAsync(0);


### PR DESCRIPTION
## Summary

- Bumps `QUEUE_CONCURRENCY` in `BulkCreateWorktreeDialog.tsx` from 2 to 3 now that `--no-track` (landed in #5165) removes the `install_branch_config` call that was causing `.git/config.lock` contention during concurrent worktree creation.
- Adds an adversarial stress test (`WorkspaceService.adversarial.test.ts`) that fires 10 concurrent local `createWorktree` calls and asserts zero "could not lock config file" errors, distinct `requestId`s for every call, and that every `worktree add` argv includes `--no-track` (and not `--track`).
- Updates existing `BulkCreateWorktreeDialog` tests to reflect the new 3-slot cadence, including extending the cancel-during-execution test to 4 items so a queued item stays in the queue long enough to exercise stale-handler guards.

Resolves #5163

## Changes

- `src/components/GitHub/BulkCreateWorktreeDialog.tsx` — `QUEUE_CONCURRENCY` 2 → 3
- `electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts` — new 10-concurrent-call stress test
- `src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx` — updated cadence expectations and extended cancel test

## Testing

The stress test runs on all three CI platforms (Ubuntu, macOS, Windows) via the existing nightly matrix. Locally, `npm test` passes cleanly across all three changed files. The concurrency bump is safe: with `--no-track` in place there are no config file writes during `git worktree add`, so the previous contention path no longer exists.