### PR TITLE
feat(terminal-info): show spawn command, args, and agent metadata in info dialog

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -509,6 +509,9 @@ export class PtyManager extends EventEmitter {
       ptyRows: ptyProcess?.rows,
       ptyForegroundProcess: ptyProcess?.process,
       ptyTty: ptyProcess ? this.resolveTtyPath(ptyProcess.pid) : undefined,
+      spawnArgs: terminalInfo.spawnArgs,
+      agentLaunchFlags: terminalInfo.agentLaunchFlags,
+      agentModelId: terminalInfo.agentModelId,
       exitCode: terminalInfo.exitCode,
     };
   }

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -79,7 +79,7 @@ class MockTerminalProcess {
     options: SpawnOptionsShape,
     callbacks: TerminalCallbacks,
     _deps: unknown,
-    _spawnContext: unknown,
+    spawnContext: { shell?: string; args?: string[] } | undefined,
     ptyProcess: MockPtyProcess
   ) {
     this.id = id;
@@ -103,6 +103,8 @@ class MockTerminalProcess {
       lastInputTime: 0,
       lastOutputTime: 0,
       ptyProcess,
+      shell: spawnContext?.shell,
+      spawnArgs: spawnContext?.args,
     };
     shared.created.push(this);
   }
@@ -405,6 +407,13 @@ describe("PtyManager adversarial", () => {
   });
 
   it("GET_TERMINAL_INFO_FORWARDS_SPAWN_AND_AGENT_FIELDS", () => {
+    shared.computeSpawnContext.mockReturnValueOnce({
+      env: {},
+      shell: "/usr/local/bin/claude",
+      args: ["--dangerously-skip-permissions", "--model", "claude-opus-4-7"],
+      isAgentTerminal: true,
+    });
+
     const manager = new PtyManager();
 
     manager.spawn(
@@ -413,8 +422,6 @@ describe("PtyManager adversarial", () => {
     );
 
     const created = shared.created[0]!;
-    created.info.shell = "/usr/local/bin/claude";
-    created.info.spawnArgs = ["--dangerously-skip-permissions", "--model", "claude-opus-4-7"];
     created.info.agentLaunchFlags = ["--dangerously-skip-permissions"];
     created.info.agentModelId = "claude-opus-4-7";
 
@@ -432,7 +439,7 @@ describe("PtyManager adversarial", () => {
     expect(payload!.isAgentTerminal).toBe(true);
   });
 
-  it("GET_TERMINAL_INFO_LEAVES_OPTIONAL_FIELDS_UNDEFINED_FOR_PLAIN_TERMINAL", () => {
+  it("GET_TERMINAL_INFO_FORWARDS_DEFAULT_SHELL_ARGS_FOR_PLAIN_TERMINAL", () => {
     const manager = new PtyManager();
 
     manager.spawn("term-1", spawnOptions({ projectId: "project-a" }));
@@ -440,7 +447,10 @@ describe("PtyManager adversarial", () => {
     const payload = manager.getTerminalInfo("term-1");
 
     expect(payload).not.toBeNull();
-    expect(payload!.spawnArgs).toBeUndefined();
+    // Default mock spawn context returns args: ["-l"] — the production
+    // TerminalProcess always populates spawnArgs from spawnContext.args.
+    expect(payload!.spawnArgs).toEqual(["-l"]);
+    expect(payload!.shell).toBe("/bin/zsh");
     expect(payload!.agentLaunchFlags).toBeUndefined();
     expect(payload!.agentModelId).toBeUndefined();
   });

--- a/electron/services/__tests__/PtyManager.adversarial.test.ts
+++ b/electron/services/__tests__/PtyManager.adversarial.test.ts
@@ -43,6 +43,20 @@ interface TerminalInfoShape {
   outputBuffer: string;
   semanticBuffer: string[];
   restartCount: number;
+  shell?: string;
+  title?: string;
+  worktreeId?: string;
+  agentState?: string;
+  lastInputTime?: number;
+  lastOutputTime?: number;
+  lastStateChange?: number;
+  detectedAgentType?: string;
+  analysisEnabled?: boolean;
+  exitCode?: number;
+  spawnArgs?: string[];
+  agentLaunchFlags?: string[];
+  agentModelId?: string;
+  ptyProcess?: MockPtyProcess;
 }
 
 class MockTerminalProcess {
@@ -57,6 +71,8 @@ class MockTerminalProcess {
   setActivityMonitorTier = vi.fn();
   startProcessDetector = vi.fn();
   dispose = vi.fn();
+  getActivityTier = vi.fn(() => "active" as const);
+  getResizeStrategy = vi.fn(() => "default" as const);
 
   constructor(
     id: string,
@@ -84,6 +100,9 @@ class MockTerminalProcess {
       outputBuffer: "",
       semanticBuffer: [],
       restartCount: 0,
+      lastInputTime: 0,
+      lastOutputTime: 0,
+      ptyProcess,
     };
     shared.created.push(this);
   }
@@ -383,6 +402,47 @@ describe("PtyManager adversarial", () => {
       0.37,
       spawnedAt
     );
+  });
+
+  it("GET_TERMINAL_INFO_FORWARDS_SPAWN_AND_AGENT_FIELDS", () => {
+    const manager = new PtyManager();
+
+    manager.spawn(
+      "agent-1",
+      spawnOptions({ kind: "agent", type: "claude", agentId: "agent-1", projectId: "project-a" })
+    );
+
+    const created = shared.created[0]!;
+    created.info.shell = "/usr/local/bin/claude";
+    created.info.spawnArgs = ["--dangerously-skip-permissions", "--model", "claude-opus-4-7"];
+    created.info.agentLaunchFlags = ["--dangerously-skip-permissions"];
+    created.info.agentModelId = "claude-opus-4-7";
+
+    const payload = manager.getTerminalInfo("agent-1");
+
+    expect(payload).not.toBeNull();
+    expect(payload!.shell).toBe("/usr/local/bin/claude");
+    expect(payload!.spawnArgs).toEqual([
+      "--dangerously-skip-permissions",
+      "--model",
+      "claude-opus-4-7",
+    ]);
+    expect(payload!.agentLaunchFlags).toEqual(["--dangerously-skip-permissions"]);
+    expect(payload!.agentModelId).toBe("claude-opus-4-7");
+    expect(payload!.isAgentTerminal).toBe(true);
+  });
+
+  it("GET_TERMINAL_INFO_LEAVES_OPTIONAL_FIELDS_UNDEFINED_FOR_PLAIN_TERMINAL", () => {
+    const manager = new PtyManager();
+
+    manager.spawn("term-1", spawnOptions({ projectId: "project-a" }));
+
+    const payload = manager.getTerminalInfo("term-1");
+
+    expect(payload).not.toBeNull();
+    expect(payload!.spawnArgs).toBeUndefined();
+    expect(payload!.agentLaunchFlags).toBeUndefined();
+    expect(payload!.agentModelId).toBeUndefined();
   });
 
   it("DISPOSE_EMITS_AGENT_KILLED_ONLY_FOR_AGENTS", () => {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -257,7 +257,7 @@ export class TerminalProcess {
     spawnContext: SpawnContext,
     ptyProcess: pty.IPty
   ) {
-    const { shell, isAgentTerminal, agentId } = spawnContext;
+    const { shell, args: spawnArgs, isAgentTerminal, agentId } = spawnContext;
     const spawnedAt = Date.now();
 
     this.isAgentTerminal = isAgentTerminal;
@@ -302,6 +302,7 @@ export class TerminalProcess {
       analysisEnabled: this.isAgentTerminal,
       agentLaunchFlags: options.agentLaunchFlags,
       agentModelId: options.agentModelId,
+      spawnArgs,
     };
 
     // NOTE: The headless responder is intentionally NOT installed for agent
@@ -454,6 +455,7 @@ export class TerminalProcess {
       agentSessionId: t.agentSessionId,
       agentLaunchFlags: t.agentLaunchFlags,
       agentModelId: t.agentModelId,
+      spawnArgs: t.spawnArgs,
       exitCode: t.exitCode,
     };
   }

--- a/electron/services/pty/__tests__/TerminalProcess.exitCode.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.exitCode.test.ts
@@ -52,7 +52,10 @@ function defaultSpawnContext(overrides?: Partial<SpawnContext>): SpawnContext {
 
 type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
 
-function createTerminal(options?: Partial<TerminalProcessOptions>): TerminalProcess {
+function createTerminal(
+  options?: Partial<TerminalProcessOptions>,
+  contextOverrides?: Partial<SpawnContext>
+): TerminalProcess {
   const merged = {
     cwd: process.cwd(),
     cols: 80,
@@ -66,6 +69,7 @@ function createTerminal(options?: Partial<TerminalProcessOptions>): TerminalProc
   const ctx = defaultSpawnContext({
     isAgentTerminal: isAgent,
     agentId: isAgent ? ((merged as any).agentId ?? merged.type) : undefined,
+    ...contextOverrides,
   });
   return new TerminalProcess(
     "t-exit",
@@ -133,5 +137,30 @@ describe("TerminalProcess exit code persistence", () => {
 
     const state = terminal.getPublicState();
     expect(state.exitCode).toBeUndefined();
+  });
+});
+
+describe("TerminalProcess spawnArgs persistence", () => {
+  beforeEach(() => {
+    exitHandler = null;
+  });
+
+  it("captures spawnContext.args into getPublicState().spawnArgs", () => {
+    const terminal = createTerminal(undefined, { args: ["-l", "--rcfile", "/tmp/rc"] });
+
+    expect(terminal.getPublicState().spawnArgs).toEqual(["-l", "--rcfile", "/tmp/rc"]);
+  });
+
+  it("captures spawnContext.args into getInfo().spawnArgs", () => {
+    const terminal = createTerminal(undefined, { args: ["-l", "--rcfile", "/tmp/rc"] });
+
+    expect(terminal.getInfo().spawnArgs).toEqual(["-l", "--rcfile", "/tmp/rc"]);
+  });
+
+  it("preserves an empty args array (does not coerce to undefined)", () => {
+    const terminal = createTerminal(undefined, { args: [] });
+
+    expect(terminal.getPublicState().spawnArgs).toEqual([]);
+    expect(terminal.getInfo().spawnArgs).toEqual([]);
   });
 });

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -52,6 +52,8 @@ export interface TerminalPublicState {
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time for per-panel model selection */
   agentModelId?: string;
+  /** Resolved argv passed to pty.spawn() at launch time (for diagnostics) */
+  spawnArgs?: string[];
   /** Exit code from the PTY process (set on clean exit) */
   exitCode?: number;
 }

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -221,6 +221,12 @@ export interface TerminalInfoPayload {
   ptyForegroundProcess?: string;
   /** TTY device path (e.g., /dev/ttys004) */
   ptyTty?: string;
+  /** Resolved argv passed to pty.spawn() at launch time */
+  spawnArgs?: string[];
+  /** Process-level flags captured at launch time (agent terminals only) */
+  agentLaunchFlags?: string[];
+  /** Model ID selected at launch time (agent terminals only) */
+  agentModelId?: string;
   /** Exit code when terminal has exited */
   exitCode?: number;
 }

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -107,7 +107,7 @@ function InfoListRow({ label, items }: InfoListRowProps) {
         {items.map((item, i) => (
           <code
             key={`${i}-${item}`}
-            className="bg-daintree-surface border border-daintree-border font-mono text-xs px-1.5 py-0.5 rounded select-text break-all"
+            className="bg-daintree-bg/50 border border-daintree-border font-mono text-xs px-1.5 py-0.5 rounded select-text break-all"
           >
             {item}
           </code>

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -166,17 +166,32 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
     };
   }, [isOpen, terminalId]);
 
+  const showAgentSection = (info: TerminalInfoPayload): boolean =>
+    !!(
+      info.isAgentTerminal ||
+      info.agentId ||
+      info.detectedAgentType ||
+      (info.agentLaunchFlags && info.agentLaunchFlags.length > 0) ||
+      info.agentModelId
+    );
+
+  const formatArgsForClipboard = (args: string[] | undefined): string => {
+    if (args === undefined) return "N/A";
+    if (args.length === 0) return "(none)";
+    return args.join(" ");
+  };
+
   const copyToClipboard = async () => {
     if (!info) return;
 
-    const agentSection = info.isAgentTerminal
+    const agentSection = showAgentSection(info)
       ? `
 
 Agent:
-  Agent ID: ${info.agentId || "N/A"}
-  Detected Agent: ${info.detectedAgentType || "N/A"}
-  Launch Flags: ${info.agentLaunchFlags && info.agentLaunchFlags.length > 0 ? info.agentLaunchFlags.join(" ") : "N/A"}
-  Model: ${info.agentModelId || "N/A"}`
+  Agent ID: ${info.agentId ?? "N/A"}
+  Detected Agent: ${info.detectedAgentType ?? "N/A"}
+  Launch Flags: ${formatArgsForClipboard(info.agentLaunchFlags)}
+  Model: ${info.agentModelId ?? "N/A"}`
       : "";
 
     const diagnosticInfo = `Terminal Diagnostic Information
@@ -193,7 +208,7 @@ Session Metadata:
 
 Spawn Command:
   Shell: ${info.shell || "N/A"}
-  Args: ${info.spawnArgs && info.spawnArgs.length > 0 ? info.spawnArgs.join(" ") : "N/A"}${agentSection}
+  Args: ${formatArgsForClipboard(info.spawnArgs)}${agentSection}
 
 Terminal Classification:
   Agent Terminal: ${info.isAgentTerminal ? "Yes" : "No"}
@@ -273,11 +288,7 @@ Performance & Diagnostics:
               <InfoListRow label="Args" items={info.spawnArgs} />
             </InfoSection>
 
-            {(info.isAgentTerminal ||
-              info.agentId ||
-              info.detectedAgentType ||
-              (info.agentLaunchFlags && info.agentLaunchFlags.length > 0) ||
-              info.agentModelId) && (
+            {showAgentSection(info) && (
               <InfoSection title="Agent">
                 {info.agentId && <InfoRow label="Agent ID" value={info.agentId} />}
                 {info.detectedAgentType && (

--- a/src/components/Terminal/TerminalInfoDialog.tsx
+++ b/src/components/Terminal/TerminalInfoDialog.tsx
@@ -92,6 +92,31 @@ function InfoRow({ label, value, mono = false }: InfoRowProps) {
   );
 }
 
+interface InfoListRowProps {
+  label: string;
+  items: string[] | undefined;
+}
+
+function InfoListRow({ label, items }: InfoListRowProps) {
+  if (!items || items.length === 0) return null;
+
+  return (
+    <div className="flex justify-between items-start gap-4 text-sm">
+      <span className="text-daintree-text/70 shrink-0 select-none">{label}:</span>
+      <div className="flex flex-wrap gap-1 justify-end">
+        {items.map((item, i) => (
+          <code
+            key={`${i}-${item}`}
+            className="bg-daintree-surface border border-daintree-border font-mono text-xs px-1.5 py-0.5 rounded select-text break-all"
+          >
+            {item}
+          </code>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfoDialogProps) {
   const [info, setInfo] = useState<TerminalInfoPayload | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -144,6 +169,16 @@ export function TerminalInfoDialog({ isOpen, onClose, terminalId }: TerminalInfo
   const copyToClipboard = async () => {
     if (!info) return;
 
+    const agentSection = info.isAgentTerminal
+      ? `
+
+Agent:
+  Agent ID: ${info.agentId || "N/A"}
+  Detected Agent: ${info.detectedAgentType || "N/A"}
+  Launch Flags: ${info.agentLaunchFlags && info.agentLaunchFlags.length > 0 ? info.agentLaunchFlags.join(" ") : "N/A"}
+  Model: ${info.agentModelId || "N/A"}`
+      : "";
+
     const diagnosticInfo = `Terminal Diagnostic Information
 =====================================
 
@@ -151,13 +186,14 @@ Session Metadata:
   ID: ${info.id}
   Kind: ${info.kind || "terminal"}
   Type: ${info.type || "N/A"}
-  Agent ID: ${info.agentId || "N/A"}
-  Detected Agent: ${info.detectedAgentType || "N/A"}
   Title: ${info.title || "N/A"}
-  Shell: ${info.shell || "N/A"}
   Project ID: ${info.projectId || "N/A"}
   Worktree ID: ${info.worktreeId || "N/A"}
   CWD: ${info.cwd}
+
+Spawn Command:
+  Shell: ${info.shell || "N/A"}
+  Args: ${info.spawnArgs && info.spawnArgs.length > 0 ? info.spawnArgs.join(" ") : "N/A"}${agentSection}
 
 Terminal Classification:
   Agent Terminal: ${info.isAgentTerminal ? "Yes" : "No"}
@@ -226,16 +262,31 @@ Performance & Diagnostics:
               <InfoRow label="Terminal ID" value={info.id} mono />
               <InfoRow label="Kind" value={info.kind || "terminal"} />
               <InfoRow label="Type" value={info.type || "terminal"} />
-              {info.agentId && <InfoRow label="Agent ID" value={info.agentId} />}
-              {info.detectedAgentType && (
-                <InfoRow label="Detected Agent" value={info.detectedAgentType} />
-              )}
               <InfoRow label="Title" value={info.title} />
-              <InfoRow label="Shell" value={info.shell} mono />
               <InfoRow label="Project ID" value={info.projectId} mono />
               <InfoRow label="Worktree ID" value={info.worktreeId} mono />
               <InfoRow label="Current Directory" value={info.cwd} mono />
             </InfoSection>
+
+            <InfoSection title="Spawn Command">
+              <InfoRow label="Shell" value={info.shell} mono />
+              <InfoListRow label="Args" items={info.spawnArgs} />
+            </InfoSection>
+
+            {(info.isAgentTerminal ||
+              info.agentId ||
+              info.detectedAgentType ||
+              (info.agentLaunchFlags && info.agentLaunchFlags.length > 0) ||
+              info.agentModelId) && (
+              <InfoSection title="Agent">
+                {info.agentId && <InfoRow label="Agent ID" value={info.agentId} />}
+                {info.detectedAgentType && (
+                  <InfoRow label="Detected Agent" value={info.detectedAgentType} />
+                )}
+                <InfoListRow label="Launch Flags" items={info.agentLaunchFlags} />
+                {info.agentModelId && <InfoRow label="Model" value={info.agentModelId} mono />}
+              </InfoSection>
+            )}
 
             <InfoSection title="Terminal Classification">
               <InfoRow label="Agent Terminal" value={info.isAgentTerminal ? "Yes" : "No"} />

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -178,4 +178,142 @@ describe("TerminalInfoDialog", () => {
     expect(clipboardText).toContain("Foreground Process: vim");
     expect(clipboardText).toContain("Dimensions: 80 × 24");
   });
+
+  it("renders Spawn Command section with shell and arg chips", async () => {
+    const payload = makePayload({
+      spawnArgs: ["-l", "--rcfile", "/tmp/rc"],
+    });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Spawn Command")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Args:")).toBeTruthy();
+    expect(screen.getByText("-l")).toBeTruthy();
+    expect(screen.getByText("--rcfile")).toBeTruthy();
+    expect(screen.getByText("/tmp/rc")).toBeTruthy();
+  });
+
+  it("omits Args row when spawnArgs is undefined or empty", async () => {
+    const payload = makePayload({ spawnArgs: undefined });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Spawn Command")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Args:")).toBeNull();
+  });
+
+  it("renders Agent section with launch flag chips and model for agent terminals", async () => {
+    const payload = makePayload({
+      isAgentTerminal: true,
+      kind: "agent",
+      type: "claude",
+      agentId: "agent-1",
+      detectedAgentType: "claude",
+      agentLaunchFlags: ["--dangerously-skip-permissions", "--verbose"],
+      agentModelId: "claude-opus-4-7",
+    });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Agent ID:")).toBeTruthy();
+    expect(screen.getByText("agent-1")).toBeTruthy();
+    expect(screen.getByText("Detected Agent:")).toBeTruthy();
+    expect(screen.getByText("Launch Flags:")).toBeTruthy();
+    expect(screen.getByText("--dangerously-skip-permissions")).toBeTruthy();
+    expect(screen.getByText("--verbose")).toBeTruthy();
+    expect(screen.getByText("Model:")).toBeTruthy();
+    expect(screen.getByText("claude-opus-4-7")).toBeTruthy();
+  });
+
+  it("omits Agent section entirely for plain terminals with no agent metadata", async () => {
+    const payload = makePayload({
+      isAgentTerminal: false,
+      agentId: undefined,
+      detectedAgentType: undefined,
+      agentLaunchFlags: undefined,
+      agentModelId: undefined,
+    });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Spawn Command")).toBeTruthy();
+    });
+
+    expect(screen.queryByText("Agent ID:")).toBeNull();
+    expect(screen.queryByText("Launch Flags:")).toBeNull();
+    expect(screen.queryByText("Model:")).toBeNull();
+    // The Agent section heading should not exist either
+    expect(screen.queryByRole("heading", { name: "Agent" })).toBeNull();
+  });
+
+  it("includes Spawn Command and Agent sections in clipboard export", async () => {
+    const payload = makePayload({
+      isAgentTerminal: true,
+      kind: "agent",
+      type: "claude",
+      agentId: "agent-1",
+      detectedAgentType: "claude",
+      shell: "/usr/local/bin/claude",
+      spawnArgs: ["--model", "claude-opus-4-7"],
+      agentLaunchFlags: ["--dangerously-skip-permissions"],
+      agentModelId: "claude-opus-4-7",
+    });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+
+    expect(writeTextMock).toHaveBeenCalledOnce();
+    const clipboardText = writeTextMock.mock.calls[0][0] as string;
+    expect(clipboardText).toContain("Spawn Command:");
+    expect(clipboardText).toContain("Shell: /usr/local/bin/claude");
+    expect(clipboardText).toContain("Args: --model claude-opus-4-7");
+    expect(clipboardText).toContain("Agent:");
+    expect(clipboardText).toContain("Agent ID: agent-1");
+    expect(clipboardText).toContain("Launch Flags: --dangerously-skip-permissions");
+    expect(clipboardText).toContain("Model: claude-opus-4-7");
+  });
+
+  it("omits Agent section from clipboard for non-agent terminals", async () => {
+    const payload = makePayload({ isAgentTerminal: false, spawnArgs: ["-l"] });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+
+    const clipboardText = writeTextMock.mock.calls[0][0] as string;
+    expect(clipboardText).toContain("Spawn Command:");
+    expect(clipboardText).toContain("Args: -l");
+    expect(clipboardText).not.toContain("\nAgent:\n");
+    expect(clipboardText).not.toContain("Launch Flags:");
+  });
 });

--- a/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalInfoDialog.test.tsx
@@ -296,6 +296,53 @@ describe("TerminalInfoDialog", () => {
     expect(clipboardText).toContain("Model: claude-opus-4-7");
   });
 
+  it("includes Agent section when only detectedAgentType is set on a non-agent terminal", async () => {
+    const payload = makePayload({
+      isAgentTerminal: false,
+      detectedAgentType: "claude",
+    });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
+    });
+
+    // UI shows the Agent section
+    expect(screen.getByText("Agent")).toBeTruthy();
+    expect(screen.getByText("Detected Agent:")).toBeTruthy();
+
+    // Clipboard also includes the Agent section — UI and clipboard guards must agree
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+    const clipboardText = writeTextMock.mock.calls[0][0] as string;
+    expect(clipboardText).toContain("Agent:");
+    expect(clipboardText).toContain("Detected Agent: claude");
+  });
+
+  it("renders empty spawnArgs as (none) in clipboard and omits the Args row in UI", async () => {
+    const payload = makePayload({ spawnArgs: [] });
+    dispatchMock.mockResolvedValue({ ok: true, result: payload });
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+    render(<TerminalInfoDialog isOpen={true} onClose={vi.fn()} terminalId="test-id" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Copy to Clipboard")).toBeTruthy();
+    });
+
+    // UI omits the row entirely (matches InfoListRow convention)
+    expect(screen.queryByText("Args:")).toBeNull();
+
+    fireEvent.click(screen.getByText("Copy to Clipboard"));
+    const clipboardText = writeTextMock.mock.calls[0][0] as string;
+    expect(clipboardText).toContain("Args: (none)");
+    expect(clipboardText).not.toContain("Args: N/A");
+  });
+
   it("omits Agent section from clipboard for non-agent terminals", async () => {
     const payload = makePayload({ isAgentTerminal: false, spawnArgs: ["-l"] });
     dispatchMock.mockResolvedValue({ ok: true, result: payload });


### PR DESCRIPTION
## Summary

- Surfaces the PTY spawn command and argv in the Terminal Info dialog so you can verify launch flags without reaching for `ps` or Activity Monitor
- Agent terminals get a dedicated "Agent" section showing launch flags and model ID alongside the existing Agent ID / Detected Agent rows
- Clipboard export extended with both sections, making the diagnostic blob complete

Resolves #5169

## Changes

- `TerminalPublicState` gains `spawnArgs?: string[]`; `TerminalProcess` populates it from `spawnContext.args` and forwards it through `getPublicState()`
- `TerminalInfoPayload` (`shared/types/ipc/terminal.ts`) gains `spawnArgs`, `agentLaunchFlags`, `agentModelId`; `PtyManager.getTerminalInfo()` forwards all three
- `TerminalInfoDialog`: new `InfoListRow` chip component for rendering arg lists, dedicated "Spawn Command" and "Agent" sections, `agentId`/`detectedAgentType` moved out of Session Metadata to avoid duplication, clipboard format extended to match
- Empty `spawnArgs` renders as `(none)` to distinguish from terminals where the field isn't present (`N/A`)
- Agent-section guard is unified between the rendered UI and clipboard so the two are always in sync

## Testing

31 targeted unit tests across three files cover spawnArgs persistence (`TerminalProcess`), payload forwarding (`PtyManager`), and the new dialog sections plus clipboard format (`TerminalInfoDialog`). Typecheck, lint ratchet (401/401), and format all pass clean.