### PR TITLE
perf(bulk-worktree): batch pre-queries before queue start

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -523,7 +523,9 @@ export function BulkCreateWorktreeDialog({
       if (toCreate.some((p) => p.mode === "pr")) {
         try {
           sharedBranches = await worktreeClient.listBranches(rootPath);
+          if (runIdRef.current !== currentRunId) return;
         } catch (err) {
+          if (runIdRef.current !== currentRunId) return;
           const errorMsg = normalizeError(err);
           for (const planned of toCreate) {
             if (planned.mode !== "pr") continue;
@@ -568,6 +570,7 @@ export function BulkCreateWorktreeDialog({
 
         try {
           let branch = await worktreeClient.getAvailableBranch(rootPath, planned.branchName);
+          if (runIdRef.current !== currentRunId) return;
           if (assignedBranches.has(branch)) {
             let n = 2;
             while (assignedBranches.has(`${branch}-${n}`)) n++;
@@ -575,8 +578,10 @@ export function BulkCreateWorktreeDialog({
           }
           assignedBranches.add(branch);
           const path = await worktreeClient.getDefaultPath(rootPath, branch);
+          if (runIdRef.current !== currentRunId) return;
           precomputed.set(planned.item.number, { branch, path });
         } catch (err) {
+          if (runIdRef.current !== currentRunId) return;
           prequeryFailed.add(planned.item.number);
           failedItems.add(planned.item.number);
           dispatchProgress({

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -30,6 +30,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "@/components/Worktree/hooks/useRecipePicker";
 import { useNewWorktreeProjectSettings } from "@/components/Worktree/hooks/useNewWorktreeProjectSettings";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
+import type { BranchInfo } from "@shared/types";
 
 type BulkCreateMode = "issue" | "pr";
 
@@ -508,7 +509,90 @@ export function BulkCreateWorktreeDialog({
       const failedItems = new Set<number>();
       let lastSuccessfulWorktreeId: string | null = null;
 
+      // Batch pre-queries: hoist read-only IPC calls out of the per-item queue
+      // so N items don't produce N×IPC round-trips before any worktree creates.
+      // Sequential traversal is required — the backend findAvailableBranchName /
+      // findAvailablePath are pure snapshot reads with no reservation, so
+      // parallel Promise.all would race to the same resolved names for items
+      // sharing a base branch. The `assignedBranches` set below adds a
+      // client-side collision guard for the rare same-slug case.
+      let sharedBranches: BranchInfo[] | null = null;
+      const precomputed = new Map<number, { branch: string; path: string }>();
+      const prequeryFailed = new Set<number>();
+
+      if (toCreate.some((p) => p.mode === "pr")) {
+        try {
+          sharedBranches = await worktreeClient.listBranches(rootPath);
+        } catch (err) {
+          const errorMsg = normalizeError(err);
+          for (const planned of toCreate) {
+            if (planned.mode !== "pr") continue;
+            failedItems.add(planned.item.number);
+            dispatchProgress({
+              type: "ITEM_FAILED",
+              issueNumber: planned.item.number,
+              error: errorMsg,
+              attempts: 1,
+              failedStep: "worktree",
+            });
+          }
+          if (toCreate.every((p) => p.mode === "pr")) {
+            dispatchProgress({ type: "DONE" });
+            queueRef.current = null;
+            notify({
+              type: "error",
+              title: "Bulk Create Partial Failure",
+              message: `0 created, ${failedItems.size} failed`,
+            });
+            return;
+          }
+        }
+      }
+
+      const assignedBranches = new Set<string>();
       for (const planned of toCreate) {
+        if (runIdRef.current !== currentRunId) return;
+        if (planned.mode !== "issue") continue;
+
+        // Skip pre-query if the worktree already exists locally — the per-item
+        // path below will detect it via the worktree store and short-circuit.
+        const existingWorktrees = getCurrentViewStore().getState().worktrees;
+        let alreadyExists = false;
+        for (const wt of existingWorktrees.values()) {
+          if (wt.branch && wt.branch === planned.branchName) {
+            alreadyExists = true;
+            break;
+          }
+        }
+        if (alreadyExists) continue;
+
+        try {
+          let branch = await worktreeClient.getAvailableBranch(rootPath, planned.branchName);
+          if (assignedBranches.has(branch)) {
+            let n = 2;
+            while (assignedBranches.has(`${branch}-${n}`)) n++;
+            branch = `${branch}-${n}`;
+          }
+          assignedBranches.add(branch);
+          const path = await worktreeClient.getDefaultPath(rootPath, branch);
+          precomputed.set(planned.item.number, { branch, path });
+        } catch (err) {
+          prequeryFailed.add(planned.item.number);
+          failedItems.add(planned.item.number);
+          dispatchProgress({
+            type: "ITEM_FAILED",
+            issueNumber: planned.item.number,
+            error: normalizeError(err),
+            attempts: 1,
+            failedStep: "worktree",
+          });
+        }
+      }
+
+      if (runIdRef.current !== currentRunId) return;
+
+      for (const planned of toCreate) {
+        if (prequeryFailed.has(planned.item.number)) continue;
         void queue.add(async () => {
           if (runIdRef.current !== currentRunId) return;
 
@@ -545,8 +629,10 @@ export function BulkCreateWorktreeDialog({
                 });
 
                 if (planned.mode === "pr" && planned.headRefName) {
-                  // PR mode: resolve branch from headRefName
-                  const branches = await worktreeClient.listBranches(rootPath);
+                  // PR mode: resolve branch from headRefName. The initial
+                  // listBranches snapshot is hoisted into `sharedBranches`
+                  // above; only refetch after a fetchPRBranch mutation.
+                  const branches = sharedBranches ?? (await worktreeClient.listBranches(rootPath));
                   const remoteBranchName = `origin/${planned.headRefName}`;
                   const remoteBranch = branches.find((b) => b.name === remoteBranchName);
                   const localBranch = branches.find(
@@ -605,18 +691,23 @@ export function BulkCreateWorktreeDialog({
                   worktreePath = path;
                   resolvedBranch = planned.headRefName;
                 } else {
-                  // Issue mode: create new branch from base
+                  // Issue mode: create new branch from base. Branch name and
+                  // path were resolved once in the pre-query phase; fall back
+                  // to a live lookup only for items that had no pre-query
+                  // result (e.g., retry after a worktree-store-detected
+                  // short-circuit branch was later removed).
                   const mainWorktree = Array.from(
                     getCurrentViewStore().getState().worktrees.values()
                   ).find((w) => w.isMainWorktree);
                   const baseBranch = mainWorktree?.branch;
                   if (!baseBranch) throw new Error("No main worktree found for base branch");
 
-                  const availableBranch = await worktreeClient.getAvailableBranch(
-                    rootPath,
-                    planned.branchName
-                  );
-                  const path = await worktreeClient.getDefaultPath(rootPath, availableBranch);
+                  const pre = precomputed.get(itemNumber);
+                  const availableBranch =
+                    pre?.branch ??
+                    (await worktreeClient.getAvailableBranch(rootPath, planned.branchName));
+                  const path =
+                    pre?.path ?? (await worktreeClient.getDefaultPath(rootPath, availableBranch));
 
                   const createdId = await worktreeClient.create(
                     {

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1154,6 +1154,46 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(pathCalls).toContain("feature/shared-branch-2");
   });
 
+  it("does not dispatch stale ITEM_FAILED when cancelled during pre-query", async () => {
+    // Defer getAvailableBranch so we can cancel while the pre-query is
+    // pending. After cancel, the deferred rejection must not pollute the
+    // reducer with a stale ITEM_FAILED row.
+    let rejectPrequery: ((err: Error) => void) | null = null;
+    mockGetAvailableBranch.mockImplementation(
+      () =>
+        new Promise<string>((_resolve, reject) => {
+          rejectPrequery = reject;
+        })
+    );
+
+    const onClose = vi.fn();
+    render(<BulkCreateWorktreeDialog {...defaultProps} onClose={onClose} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    // Cancel while pre-query is still pending.
+    await act(async () => {
+      const buttons = screen.getAllByRole("button");
+      const cancelBtn = buttons.find((b) => b.textContent === "Cancel");
+      cancelBtn?.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Reject the pending pre-query after the cancel has bumped runIdRef.
+    await act(async () => {
+      rejectPrequery?.(new Error("IPC failure after cancel"));
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(onClose).toHaveBeenCalled();
+    // No stale dispatches — the done button never appears, no error rows
+    // bleed into the closed dialog, and no worktree.create was triggered.
+    expect(screen.queryByTestId("bulk-create-done-button")).toBeNull();
+    expect(mockWorktreeCreate).not.toHaveBeenCalled();
+  });
+
   it("dispatches ITEM_FAILED and skips item when pre-query rejects", async () => {
     let availableBranchCalls = 0;
     mockGetAvailableBranch.mockImplementation((_root: string, branch: string) => {
@@ -1334,6 +1374,30 @@ describe("BulkCreateWorktreeDialog — PR mode", () => {
     // Single shared snapshot hoisted before the queue, not one per item.
     expect(mockListBranches).toHaveBeenCalledTimes(1);
     expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails all PRs when shared listBranches snapshot rejects", async () => {
+    const { notify: mockNotify } = await import("@/lib/notify");
+    mockListBranches.mockRejectedValueOnce(new Error("git ls-remote failed"));
+
+    render(<BulkCreateWorktreeDialog {...prProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/0 of 3 created/)).toBeTruthy();
+    expect(screen.getByText(/3 failed/)).toBeTruthy();
+    expect(screen.getAllByText(/git ls-remote failed/).length).toBeGreaterThanOrEqual(1);
+    expect(mockWorktreeCreate).not.toHaveBeenCalled();
+    expect(mockFetchPRBranch).not.toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        message: "0 created, 3 failed",
+      })
+    );
   });
 
   it("fails when branch cannot be fetched from remote", async () => {

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1078,6 +1078,106 @@ describe("BulkCreateWorktreeDialog", () => {
     worktreeDataHolder.map = cleanMap;
   });
 
+  it("runs pre-queries once per batch before any worktree creates", async () => {
+    const createResolvers: Array<(value: string) => void> = [];
+    mockWorktreeCreate.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          createResolvers.push(resolve);
+        })
+    );
+
+    render(<BulkCreateWorktreeDialog {...defaultProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    // With 3 issues, pre-query runs getAvailableBranch + getDefaultPath once each
+    // per item BEFORE any worktree.create call. After the button click and
+    // microtask flush, all pre-queries have completed and both concurrency
+    // slots have filled — but no further pre-query IPC should fire.
+    expect(mockGetAvailableBranch).toHaveBeenCalledTimes(3);
+    expect(mockGetDefaultPath).toHaveBeenCalledTimes(3);
+
+    // The queue has started worktree.create for the first 2 items (concurrency=2)
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(2);
+
+    // Resolve all creates and advance
+    await act(async () => {
+      createResolvers[0]?.("wt-1");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      createResolvers[1]?.("wt-2");
+      createResolvers[2]?.("wt-3");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await advanceTimersGradually(1000);
+
+    // Pre-query call counts must not have grown — confirming the per-item
+    // queue bodies read from the precomputed map, not fresh IPC calls.
+    expect(mockGetAvailableBranch).toHaveBeenCalledTimes(3);
+    expect(mockGetDefaultPath).toHaveBeenCalledTimes(3);
+    expect(screen.getByText(/3 of 3 created/)).toBeTruthy();
+  });
+
+  it("suffixes colliding branch names during pre-query", async () => {
+    // findAvailableBranchName is a pure snapshot read — if two items
+    // independently resolve to the same branch name (e.g., backend returned
+    // identical result before any creates happened), the client-side
+    // `assignedBranches` set must add `-2`, `-3`, ... to prevent a real
+    // collision at create time. Force the scenario by returning a constant
+    // branch name from the mock for both items.
+    mockGetAvailableBranch.mockResolvedValue("feature/shared-branch");
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/worktrees/${branch}`)
+    );
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1), makeIssue(2)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/2 of 2 created/)).toBeTruthy();
+
+    const createCalls = mockWorktreeCreate.mock.calls;
+    expect(createCalls.length).toBe(2);
+    const createdBranches = createCalls.map((c) => c[0].newBranch).sort();
+    // First item keeps the base name; second gets a client-side `-2` suffix.
+    expect(createdBranches).toEqual(["feature/shared-branch", "feature/shared-branch-2"]);
+    // getDefaultPath was called with the post-suffix branch name for item 2.
+    const pathCalls = mockGetDefaultPath.mock.calls.map((c) => c[1]);
+    expect(pathCalls).toContain("feature/shared-branch-2");
+  });
+
+  it("dispatches ITEM_FAILED and skips item when pre-query rejects", async () => {
+    let availableBranchCalls = 0;
+    mockGetAvailableBranch.mockImplementation((_root: string, branch: string) => {
+      availableBranchCalls++;
+      if (availableBranchCalls === 2) {
+        return Promise.reject(new Error("Branch name is invalid"));
+      }
+      return Promise.resolve(branch);
+    });
+
+    render(<BulkCreateWorktreeDialog {...defaultProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText("Branch name is invalid")).toBeTruthy();
+    expect(screen.getByText(/2 of 3 created/)).toBeTruthy();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    // The failed item never reached worktree.create.
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(2);
+  });
+
   it("does not flash empty state when Done is clicked", async () => {
     const onComplete = vi.fn();
     const onClose = vi.fn();
@@ -1213,6 +1313,27 @@ describe("BulkCreateWorktreeDialog — PR mode", () => {
     const createCalls = mockWorktreeCreate.mock.calls;
     expect(createCalls[0][0].useExistingBranch).toBe(true);
     expect(createCalls[0][0].fromRemote).toBe(false);
+  });
+
+  it("calls listBranches once per batch, not once per PR", async () => {
+    mockListBranches.mockResolvedValue([
+      { name: "main", current: true, remote: false },
+      { name: "origin/feature/pr-10", current: false, remote: true },
+      { name: "origin/feature/pr-20", current: false, remote: true },
+      { name: "origin/feature/pr-30", current: false, remote: true },
+    ]);
+
+    render(<BulkCreateWorktreeDialog {...prProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/3 of 3 created/)).toBeTruthy();
+    // Single shared snapshot hoisted before the queue, not one per item.
+    expect(mockListBranches).toHaveBeenCalledTimes(1);
+    expect(mockWorktreeCreate).toHaveBeenCalledTimes(3);
   });
 
   it("fails when branch cannot be fetched from remote", async () => {


### PR DESCRIPTION
## Summary

- Hoists ~N×3 IPC round-trips out of the per-item p-queue in `BulkCreateWorktreeDialog.runBatch` into a single pre-query phase that fires before the queue starts consuming items.
- Issue mode runs sequential `for...of await` calls to `getAvailableBranch` + `getDefaultPath` per item, storing results in a `precomputed: Map`. A client-side `assignedBranches: Set<string>` guard handles same-slug collisions since `findAvailableBranchName` is a pure snapshot read.
- PR mode hoists a single `listBranches` call into `sharedBranches: BranchInfo[]`. The post-`fetchPRBranch` `listBranches` stays per-item because it runs after git state mutation.
- Pre-query failures dispatch `ITEM_FAILED` per item with `attempts: 1`. A `runIdRef` guard after every pre-query `await` prevents a cancel mid-pre-query from polluting a subsequent run's reducer or queue.

Resolves #5162.

## Changes

- `src/components/GitHub/BulkCreateWorktreeDialog.tsx` — pre-query phase implementation for both issue and PR modes, `prequeryFailed` skip set, `runIdRef` stale-dispatch guards
- `src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx` — 6 new tests: pre-query-once, collision-suffix-2, per-item-prequery-failure, PR-listBranches-once, cancel-during-prequery-guard, all-PR-snapshot-failure

## Testing

39/39 tests pass in `BulkCreateWorktreeDialog.test.tsx`, covering pre-query call counts, collision guard, per-item and all-batch failure paths, and the cancel-during-prequery stale-dispatch guard.

For manual verification: bulk-create 30 issues in a real project and check the IPC log. Pre-queries should fire in a single burst before the first `worktree:create`, rather than N×3 interleaved calls.