### PR TITLE
fix(worktree): cycle actions walk sidebar-rendered order

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -45,7 +45,6 @@ import {
   scoreWorktree,
   type DerivedWorktreeMeta,
   type FilterState,
-  type QuickStateFilter,
 } from "@/lib/worktreeFilters";
 import { computeChipState } from "@/components/Worktree/utils/computeChipState";
 import { parseExactNumber } from "@/lib/parseExactNumber";
@@ -336,6 +335,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     alwaysShowWaiting,
     pinnedWorktrees,
     manualOrder,
+    quickStateFilter,
   } = useWorktreeFilterStore(
     useShallow((state) => ({
       query: state.query,
@@ -350,6 +350,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       alwaysShowWaiting: state.alwaysShowWaiting,
       pinnedWorktrees: state.pinnedWorktrees,
       manualOrder: state.manualOrder,
+      quickStateFilter: state.quickStateFilter,
     }))
   );
   const clearAllFilters = useWorktreeFilterStore((state) => state.clearAll);
@@ -357,6 +358,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const unpinWorktree = useWorktreeFilterStore((state) => state.unpinWorktree);
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const expandWorktree = useWorktreeFilterStore((state) => state.expandWorktree);
+  const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
 
   // Terminal store for derived metadata
   const panelsById = usePanelStore(useShallow((state) => state.panelsById));
@@ -371,8 +373,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [hiddenAbove, setHiddenAbove] = useState(0);
   const [hiddenBelow, setHiddenBelow] = useState(0);
-
-  const [quickStateFilter, setQuickStateFilter] = useState<QuickStateFilter>("all");
 
   const [isRecipeEditorOpen, setIsRecipeEditorOpen] = useState(false);
   const [recipeEditorWorktreeId, setRecipeEditorWorktreeId] = useState<string | undefined>(

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -854,8 +854,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   const rootPath = currentProject?.path ?? "";
   const hasNonMainWorktrees = deferredWorktrees.length > 1;
-  const hasQuickFilter = quickStateFilter !== "all";
-  const hasFilters = hasActiveFilters() || hasQuickFilter;
+  const hasFilters = hasActiveFilters();
   const worktreeMatchesQuery = (w: WorktreeState) => {
     if (!query) return true;
     const exactNum = parseExactNumber(query);
@@ -1024,10 +1023,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                     No worktrees match your filters
                   </p>
                   <button
-                    onClick={() => {
-                      clearAllFilters();
-                      setQuickStateFilter("all");
-                    }}
+                    onClick={clearAllFilters}
                     className="text-xs px-3 py-1.5 text-daintree-accent hover:bg-daintree-accent/10 rounded transition-colors"
                   >
                     Clear filters

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorktreeSnapshot } from "@shared/types";
+
+const mocks = vi.hoisted(() => {
+  let worktreeViewState: { worktrees: Map<string, WorktreeSnapshot> } = {
+    worktrees: new Map(),
+  };
+  const worktreeViewStore = {
+    getState: () => worktreeViewState,
+    setState: (partial: Partial<typeof worktreeViewState>) => {
+      worktreeViewState = { ...worktreeViewState, ...partial };
+    },
+  };
+  return { worktreeViewStore };
+});
+
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStore: () => mocks.worktreeViewStore,
+}));
+
+const { getVisibleWorktreesForCycling } = await import("../worktreeCyclingOrder");
+const { useWorktreeFilterStore } = await import("@/store/worktreeFilterStore");
+const { usePanelStore } = await import("@/store/panelStore");
+
+function createSnapshot(overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id: overrides.id ?? "wt",
+    worktreeId: overrides.worktreeId ?? overrides.id ?? "wt",
+    path: overrides.path ?? `/repo/${overrides.id ?? "wt"}`,
+    name: overrides.name ?? "worktree",
+    branch: overrides.branch ?? "feature/x",
+    isCurrent: false,
+    isMainWorktree: false,
+    ...overrides,
+  };
+}
+
+function setWorktrees(snaps: WorktreeSnapshot[]): void {
+  mocks.worktreeViewStore.setState({
+    worktrees: new Map(snaps.map((s) => [s.id, s])),
+  });
+}
+
+function resetFilterStore(): void {
+  useWorktreeFilterStore.setState({
+    query: "",
+    orderBy: "created",
+    groupByType: false,
+    statusFilters: new Set(),
+    typeFilters: new Set(),
+    githubFilters: new Set(),
+    sessionFilters: new Set(),
+    activityFilters: new Set(),
+    alwaysShowActive: true,
+    alwaysShowWaiting: true,
+    hideMainWorktree: false,
+    pinnedWorktrees: [],
+    collapsedWorktrees: [],
+    manualOrder: [],
+    quickStateFilter: "all",
+  });
+}
+
+beforeEach(() => {
+  mocks.worktreeViewStore.setState({ worktrees: new Map() });
+  usePanelStore.setState({
+    panelsById: {},
+    panelIds: [],
+  });
+  resetFilterStore();
+});
+
+describe("getVisibleWorktreesForCycling", () => {
+  it("returns empty list when no worktrees exist", () => {
+    expect(getVisibleWorktreesForCycling()).toEqual([]);
+  });
+
+  it("places main worktree first and integration second", () => {
+    setWorktrees([
+      createSnapshot({ id: "wt-b", name: "bravo", branch: "feature/bravo", createdAt: 100 }),
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "dev", name: "develop", branch: "develop" }),
+      createSnapshot({ id: "wt-a", name: "alpha", branch: "feature/alpha", createdAt: 200 }),
+    ]);
+
+    const ordered = getVisibleWorktreesForCycling();
+    expect(ordered.map((w) => w.id)).toEqual(["main", "dev", "wt-a", "wt-b"]);
+  });
+
+  it("sorts non-main worktrees alphabetically when orderBy is alpha", () => {
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "wt-c", name: "charlie", branch: "feature/charlie" }),
+      createSnapshot({ id: "wt-a", name: "alpha", branch: "feature/alpha" }),
+      createSnapshot({ id: "wt-b", name: "bravo", branch: "feature/bravo" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    expect(ids).toEqual(["main", "wt-a", "wt-b", "wt-c"]);
+  });
+
+  it("walks manual order when orderBy is manual", () => {
+    useWorktreeFilterStore.setState({
+      orderBy: "manual",
+      manualOrder: ["wt-b", "wt-a", "wt-c"],
+    });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "wt-a", name: "alpha", branch: "feature/alpha" }),
+      createSnapshot({ id: "wt-b", name: "bravo", branch: "feature/bravo" }),
+      createSnapshot({ id: "wt-c", name: "charlie", branch: "feature/charlie" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    expect(ids).toEqual(["main", "wt-b", "wt-a", "wt-c"]);
+  });
+
+  it("promotes pinned worktrees above unpinned ones", () => {
+    useWorktreeFilterStore.setState({
+      orderBy: "alpha",
+      pinnedWorktrees: ["wt-z"],
+    });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "wt-a", name: "alpha", branch: "feature/alpha" }),
+      createSnapshot({ id: "wt-z", name: "zulu", branch: "feature/zulu" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    expect(ids).toEqual(["main", "wt-z", "wt-a"]);
+  });
+
+  it("honors quickStateFilter by hiding worktrees without matching state", () => {
+    useWorktreeFilterStore.setState({ quickStateFilter: "working" });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "wt-working", name: "working", branch: "feature/working" }),
+      createSnapshot({ id: "wt-idle", name: "idle", branch: "feature/idle" }),
+    ]);
+    usePanelStore.setState({
+      panelsById: {
+        "term-working": {
+          id: "term-working",
+          kind: "terminal",
+          type: "terminal",
+          title: "T",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          worktreeId: "wt-working",
+          location: "grid",
+          hasPty: true,
+          isVisible: true,
+          agentState: "working",
+        } as unknown as (typeof usePanelStore.getState)["panelsById"][string],
+      },
+      panelIds: ["term-working"],
+    } as never);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    expect(ids).toContain("wt-working");
+    expect(ids).not.toContain("wt-idle");
+    // main is always at the top, unaffected by quickStateFilter
+    expect(ids[0]).toBe("main");
+  });
+
+  it("applies the text query filter to main and integration worktrees", () => {
+    useWorktreeFilterStore.setState({ query: "alpha" });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "dev", name: "develop", branch: "develop" }),
+      createSnapshot({ id: "wt-alpha", name: "alpha", branch: "feature/alpha" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    expect(ids).toEqual(["wt-alpha"]);
+  });
+
+  it("respects the alwaysShowActive override for the active worktree", () => {
+    useWorktreeFilterStore.setState({
+      statusFilters: new Set(["active"]),
+      alwaysShowActive: true,
+    });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "wt-a", name: "alpha", branch: "feature/alpha" }),
+      createSnapshot({ id: "wt-b", name: "bravo", branch: "feature/bravo" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling("wt-b").map((w) => w.id);
+    expect(ids).toContain("wt-b");
+  });
+
+  it("flattens grouped sections when groupByType is enabled", () => {
+    useWorktreeFilterStore.setState({ groupByType: true, orderBy: "alpha" });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "bug-1", name: "bug-1", branch: "bugfix/issue-1" }),
+      createSnapshot({ id: "feat-1", name: "feat-1", branch: "feature/a" }),
+      createSnapshot({ id: "chore-1", name: "chore-1", branch: "chore/cleanup" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    // features come before bugfixes which come before chores in TYPE_ORDER
+    const ixFeature = ids.indexOf("feat-1");
+    const ixBug = ids.indexOf("bug-1");
+    const ixChore = ids.indexOf("chore-1");
+    expect(ixFeature).toBeGreaterThan(-1);
+    expect(ixFeature).toBeLessThan(ixBug);
+    expect(ixBug).toBeLessThan(ixChore);
+    expect(ids[0]).toBe("main");
+  });
+});

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -211,4 +211,50 @@ describe("getVisibleWorktreesForCycling", () => {
     expect(ixBug).toBeLessThan(ixChore);
     expect(ids[0]).toBe("main");
   });
+
+  it("resolves main fallback via useWorktrees sort when no worktree is marked main", () => {
+    // No entry has isMainWorktree=true. useWorktrees sorts by
+    // (isMainWorktree desc, lastActivityTimestamp desc, name asc), so the most
+    // recently active worktree should land in the main-fallback slot.
+    setWorktrees([
+      createSnapshot({
+        id: "wt-older",
+        name: "older",
+        branch: "feature/older",
+        lastActivityTimestamp: 100,
+      }),
+      createSnapshot({
+        id: "wt-newer",
+        name: "newer",
+        branch: "feature/newer",
+        lastActivityTimestamp: 500,
+      }),
+    ]);
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    expect(ids[0]).toBe("wt-newer");
+  });
+
+  it("walks grouped + manual + pins in the flattened render order", () => {
+    useWorktreeFilterStore.setState({
+      groupByType: false, // manual sort cannot combine with groupByType — sidebar forces created
+      orderBy: "manual",
+      pinnedWorktrees: ["feat-1", "bug-2"],
+      manualOrder: ["bug-2", "feat-2", "feat-1", "chore-1"],
+    });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "feat-1", name: "feat-1", branch: "feature/one" }),
+      createSnapshot({ id: "feat-2", name: "feat-2", branch: "feature/two" }),
+      createSnapshot({ id: "bug-2", name: "bug-2", branch: "bugfix/two" }),
+      createSnapshot({ id: "chore-1", name: "chore-1", branch: "chore/one" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    // Pins come first in pin order (feat-1, bug-2), then remaining non-main in
+    // manualOrder (bug-2 already pinned → skip, feat-2, feat-1 already pinned → skip,
+    // chore-1). Final: [main, feat-1, bug-2, feat-2, chore-1].
+    expect(ids).toEqual(["main", "feat-1", "bug-2", "feat-2", "chore-1"]);
+  });
 });

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -236,9 +236,9 @@ describe("getVisibleWorktreesForCycling", () => {
     expect(ids[0]).toBe("wt-newer");
   });
 
-  it("walks grouped + manual + pins in the flattened render order", () => {
+  it("walks manual order with pins promoted to the top", () => {
     useWorktreeFilterStore.setState({
-      groupByType: false, // manual sort cannot combine with groupByType — sidebar forces created
+      groupByType: false,
       orderBy: "manual",
       pinnedWorktrees: ["feat-1", "bug-2"],
       manualOrder: ["bug-2", "feat-2", "feat-1", "chore-1"],
@@ -252,9 +252,28 @@ describe("getVisibleWorktreesForCycling", () => {
     ]);
 
     const ids = getVisibleWorktreesForCycling().map((w) => w.id);
-    // Pins come first in pin order (feat-1, bug-2), then remaining non-main in
-    // manualOrder (bug-2 already pinned → skip, feat-2, feat-1 already pinned → skip,
-    // chore-1). Final: [main, feat-1, bug-2, feat-2, chore-1].
+    // Pins come first in pin-array order (feat-1, bug-2), then remaining
+    // non-pinned entries in manualOrder (feat-2, chore-1).
     expect(ids).toEqual(["main", "feat-1", "bug-2", "feat-2", "chore-1"]);
+  });
+
+  it("walks grouped sections with pins promoted within the flattened sections", () => {
+    useWorktreeFilterStore.setState({
+      groupByType: true,
+      orderBy: "alpha",
+      pinnedWorktrees: ["feat-2", "bug-2"],
+    });
+    setWorktrees([
+      createSnapshot({ id: "main", name: "main", branch: "main", isMainWorktree: true }),
+      createSnapshot({ id: "feat-1", name: "feat-1", branch: "feature/one" }),
+      createSnapshot({ id: "feat-2", name: "feat-2", branch: "feature/two" }),
+      createSnapshot({ id: "bug-1", name: "bug-1", branch: "bugfix/one" }),
+      createSnapshot({ id: "bug-2", name: "bug-2", branch: "bugfix/two" }),
+    ]);
+
+    const ids = getVisibleWorktreesForCycling().map((w) => w.id);
+    // Grouped order (feature → bugfix) with pins promoted inside each section:
+    // feature section = [feat-2 (pinned), feat-1]; bugfix section = [bug-2 (pinned), bug-1].
+    expect(ids).toEqual(["main", "feat-2", "feat-1", "bug-2", "bug-1"]);
   });
 });

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -153,7 +153,7 @@ describe("getVisibleWorktreesForCycling", () => {
           hasPty: true,
           isVisible: true,
           agentState: "working",
-        } as unknown as (typeof usePanelStore.getState)["panelsById"][string],
+        } as unknown as ReturnType<typeof usePanelStore.getState>["panelsById"][string],
       },
       panelIds: ["term-working"],
     } as never);

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -1,0 +1,205 @@
+import type { WorktreeSnapshot, WorktreeState } from "@shared/types";
+import { usePanelStore } from "@/store/panelStore";
+import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+import { computeChipState } from "@/components/Worktree/utils/computeChipState";
+import type { WorktreeLifecycleStage } from "@/components/Worktree/WorktreeCard/hooks/useWorktreeStatus";
+import {
+  findIntegrationWorktree,
+  groupByType,
+  matchesFilters,
+  matchesQuickStateFilter,
+  scoreWorktree,
+  sortWorktrees,
+  sortWorktreesByRelevance,
+  type DerivedWorktreeMeta,
+  type FilterState,
+} from "@/lib/worktreeFilters";
+import { parseExactNumber } from "@/lib/parseExactNumber";
+
+function normalizeSnapshot(snap: WorktreeSnapshot): WorktreeState {
+  return {
+    ...snap,
+    worktreeChanges: snap.worktreeChanges ?? null,
+    lastActivityTimestamp: snap.lastActivityTimestamp ?? null,
+  } as WorktreeState;
+}
+
+function buildDerivedMeta(
+  worktree: WorktreeState,
+  panelsById: ReturnType<typeof usePanelStore.getState>["panelsById"],
+  panelIds: ReturnType<typeof usePanelStore.getState>["panelIds"]
+): DerivedWorktreeMeta {
+  let terminalCount = 0;
+  let waitingTerminalCount = 0;
+  let hasWorkingAgent = false;
+  let hasRunningAgent = false;
+  let hasWaitingAgent = false;
+  let hasCompletedAgent = false;
+  let hasExitedAgent = false;
+
+  for (const id of panelIds) {
+    const t = panelsById[id];
+    if (!t || t.worktreeId !== worktree.id || t.location === "trash") continue;
+    terminalCount++;
+    if (t.agentState === "working") hasWorkingAgent = true;
+    if (t.agentState === "running") hasRunningAgent = true;
+    if (t.agentState === "waiting") {
+      hasWaitingAgent = true;
+      waitingTerminalCount++;
+    }
+    if (t.agentState === "completed") hasCompletedAgent = true;
+    if (t.agentState === "exited") hasExitedAgent = true;
+  }
+
+  const hasChanges = (worktree.worktreeChanges?.changedFileCount ?? 0) > 0;
+  const isComplete =
+    !!worktree.issueNumber &&
+    !!worktree.prNumber &&
+    !hasChanges &&
+    worktree.worktreeChanges !== null;
+
+  let lifecycleStage: WorktreeLifecycleStage | null = null;
+  if (!worktree.isMainWorktree && worktree.worktreeChanges !== null) {
+    if (worktree.prState === "merged") {
+      lifecycleStage = worktree.issueNumber ? "ready-for-cleanup" : "merged";
+    } else if (worktree.prState === "open") {
+      lifecycleStage = "in-review";
+    }
+  }
+
+  const chipState = computeChipState({
+    waitingTerminalCount,
+    lifecycleStage,
+    isComplete,
+    hasActiveAgent: hasWorkingAgent || hasRunningAgent,
+  });
+
+  return {
+    terminalCount,
+    hasWorkingAgent,
+    hasRunningAgent,
+    hasWaitingAgent,
+    hasCompletedAgent,
+    hasExitedAgent,
+    hasMergeConflict:
+      worktree.worktreeChanges?.changes.some((c) => c.status === "conflicted") ?? false,
+    chipState,
+  };
+}
+
+function worktreeMatchesQuery(worktree: WorktreeState, query: string): boolean {
+  if (!query) return true;
+  const exactNum = parseExactNumber(query);
+  if (exactNum !== null) {
+    return worktree.issueNumber === exactNum || worktree.prNumber === exactNum;
+  }
+  return scoreWorktree(worktree, query) > 0;
+}
+
+/**
+ * Returns worktrees in the exact order the sidebar renders them.
+ *
+ * Mirrors the `filteredWorktrees` memo in `SidebarContent.tsx` so that
+ * cycle/index-jump keybindings walk the same list the user sees.
+ *
+ * Call this inside action `run()` bodies — each call reads fresh state
+ * from the filter, view, and panel stores at dispatch time.
+ */
+export function getVisibleWorktreesForCycling(
+  activeWorktreeId: string | null | undefined = undefined
+): WorktreeState[] {
+  const filterState = useWorktreeFilterStore.getState();
+  const {
+    query,
+    orderBy,
+    groupByType: isGroupedByType,
+    statusFilters,
+    typeFilters,
+    githubFilters,
+    sessionFilters,
+    activityFilters,
+    alwaysShowActive,
+    alwaysShowWaiting,
+    pinnedWorktrees,
+    manualOrder,
+    quickStateFilter,
+  } = filterState;
+
+  const viewState = getCurrentViewStore().getState();
+  const rawWorktrees = Array.from(viewState.worktrees.values()).map(normalizeSnapshot);
+  if (rawWorktrees.length === 0) return [];
+
+  const panelState = usePanelStore.getState();
+  const derivedMetaMap = new Map<string, DerivedWorktreeMeta>();
+  for (const worktree of rawWorktrees) {
+    derivedMetaMap.set(
+      worktree.id,
+      buildDerivedMeta(worktree, panelState.panelsById, panelState.panelIds)
+    );
+  }
+
+  const mainWorktree = rawWorktrees.find((w) => w.isMainWorktree) ?? rawWorktrees[0] ?? null;
+  const integrationWorktree = findIntegrationWorktree(rawWorktrees, mainWorktree?.id);
+
+  const filters: FilterState = {
+    query,
+    statusFilters,
+    typeFilters,
+    githubFilters,
+    sessionFilters,
+    activityFilters,
+  };
+
+  const nonMain = rawWorktrees.filter(
+    (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
+  );
+
+  const filtered = nonMain.filter((worktree) => {
+    const derived = derivedMetaMap.get(worktree.id);
+    if (!derived) return false;
+    const isActive = worktree.id === activeWorktreeId;
+    const hasActiveQuery = query.trim().length > 0;
+
+    if (alwaysShowActive && isActive && !hasActiveQuery && quickStateFilter === "all") {
+      return true;
+    }
+    if (
+      alwaysShowWaiting &&
+      derived.hasWaitingAgent &&
+      !hasActiveQuery &&
+      quickStateFilter === "all"
+    ) {
+      return true;
+    }
+    if (quickStateFilter !== "all" && !matchesQuickStateFilter(quickStateFilter, derived)) {
+      return false;
+    }
+    return matchesFilters(worktree, filters, derived, isActive);
+  });
+
+  const existingIds = new Set(rawWorktrees.map((w) => w.id));
+  const validPinnedWorktrees = pinnedWorktrees.filter((id) => existingIds.has(id));
+
+  const hasQuery = query.trim().length > 0;
+  const sortedNonMain = hasQuery
+    ? sortWorktreesByRelevance(filtered, query, orderBy, validPinnedWorktrees, manualOrder)
+    : sortWorktrees(filtered, orderBy, validPinnedWorktrees, manualOrder);
+
+  // Match sidebar's grouped rendering: when grouped-by-type is on and
+  // there is no query, the user sees groups flattened in TYPE_ORDER.
+  const scrollableList =
+    isGroupedByType && !hasQuery
+      ? groupByType(sortedNonMain, orderBy, validPinnedWorktrees).flatMap((s) => s.worktrees)
+      : sortedNonMain;
+
+  const topPinned: WorktreeState[] = [];
+  if (mainWorktree && worktreeMatchesQuery(mainWorktree, query)) {
+    topPinned.push(mainWorktree);
+  }
+  if (integrationWorktree && worktreeMatchesQuery(integrationWorktree, query)) {
+    topPinned.push(integrationWorktree);
+  }
+
+  return [...topPinned, ...scrollableList];
+}

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -127,7 +127,19 @@ export function getVisibleWorktreesForCycling(
   } = filterState;
 
   const viewState = getCurrentViewStore().getState();
-  const rawWorktrees = Array.from(viewState.worktrees.values()).map(normalizeSnapshot);
+  const rawWorktrees = Array.from(viewState.worktrees.values())
+    .map(normalizeSnapshot)
+    // Pre-sort to match `useWorktrees()` so the fallback main worktree
+    // (when no `isMainWorktree===true` entry exists) resolves to the same
+    // element the sidebar would render.
+    .sort((a, b) => {
+      if (a.isMainWorktree && !b.isMainWorktree) return -1;
+      if (!a.isMainWorktree && b.isMainWorktree) return 1;
+      const timeA = a.lastActivityTimestamp ?? 0;
+      const timeB = b.lastActivityTimestamp ?? 0;
+      if (timeA !== timeB) return timeB - timeA;
+      return a.name.localeCompare(b.name);
+    });
   if (rawWorktrees.length === 0) return [];
 
   const panelState = usePanelStore.getState();

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -242,6 +242,7 @@ const { registerWorktreeActions } = await import("../definitions/worktreeActions
 const { usePanelStore } = await import("../../../store/panelStore");
 const { usePortalStore } = await import("../../../store/portalStore");
 const { useWorktreeSelectionStore } = await import("../../../store/worktreeStore");
+const { useWorktreeFilterStore } = await import("../../../store/worktreeFilterStore");
 const worktreeViewStore = mocks.worktreeViewStore;
 
 function createCallbacks(overrides: Partial<ActionCallbacks> = {}): ActionCallbacks {
@@ -346,6 +347,24 @@ beforeEach(() => {
     isLoading: false,
     error: null,
     isInitialized: false,
+  });
+
+  useWorktreeFilterStore.setState({
+    query: "",
+    orderBy: "created",
+    groupByType: false,
+    statusFilters: new Set(),
+    typeFilters: new Set(),
+    githubFilters: new Set(),
+    sessionFilters: new Set(),
+    activityFilters: new Set(),
+    alwaysShowActive: true,
+    alwaysShowWaiting: true,
+    hideMainWorktree: false,
+    pinnedWorktrees: [],
+    collapsedWorktrees: [],
+    manualOrder: [],
+    quickStateFilter: "all",
   });
 });
 
@@ -902,5 +921,170 @@ describe("worktree action hardening", () => {
     );
 
     expect(onInject).not.toHaveBeenCalled();
+  });
+});
+
+describe("worktree cycling respects sidebar order", () => {
+  function installWorktrees(entries: Array<Record<string, unknown>>): void {
+    const map = new Map<string, Record<string, unknown>>();
+    for (const entry of entries) {
+      const id = entry.id as string;
+      map.set(id, {
+        worktreeId: id,
+        isCurrent: false,
+        isMainWorktree: false,
+        ...entry,
+      });
+    }
+    worktreeViewStore.setState({
+      worktrees: map as Map<string, never>,
+      isLoading: false,
+      error: null,
+      isInitialized: true,
+    });
+  }
+
+  function spySelectWorktree(): ReturnType<typeof vi.fn> {
+    const spy = vi.fn();
+    useWorktreeSelectionStore.setState({ selectWorktree: spy } as never);
+    return spy;
+  }
+
+  it("cycles forward through sidebar-ordered list, not a stale callback list", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-a", name: "alpha", branch: "feature/alpha", path: "/repo/a" },
+      { id: "wt-b", name: "bravo", branch: "feature/bravo", path: "/repo/b" },
+      { id: "wt-c", name: "charlie", branch: "feature/charlie", path: "/repo/c" },
+    ]);
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "wt-a",
+      // Deliberately stale/wrong list — should be ignored by the cycle action.
+      getWorktrees: () => [{ id: "stale", name: "stale" }] as never,
+    });
+    await actions.get("worktree.next")!().run(undefined, {} as never);
+
+    expect(select).toHaveBeenCalledWith("wt-b");
+  });
+
+  it("cycles backward honoring sidebar order", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-a", name: "alpha", branch: "feature/alpha", path: "/repo/a" },
+      { id: "wt-b", name: "bravo", branch: "feature/bravo", path: "/repo/b" },
+    ]);
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "wt-a",
+    });
+    await actions.get("worktree.previous")!().run(undefined, {} as never);
+
+    // Visible order: [main, wt-a, wt-b]; wt-a is at index 1, previous goes to main.
+    expect(select).toHaveBeenCalledWith("main");
+  });
+
+  it("switchIndex selects by sidebar position", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-a", name: "alpha", branch: "feature/alpha", path: "/repo/a" },
+      { id: "wt-b", name: "bravo", branch: "feature/bravo", path: "/repo/b" },
+      { id: "wt-c", name: "charlie", branch: "feature/charlie", path: "/repo/c" },
+    ]);
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions);
+    await actions.get("worktree.switchIndex")!().run({ index: 3 }, {} as never);
+
+    // Sidebar order: [main, wt-a, wt-b, wt-c]; index 3 => wt-b.
+    expect(select).toHaveBeenCalledWith("wt-b");
+  });
+
+  it("home and end jump to first and last sidebar entries", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-a", name: "alpha", branch: "feature/alpha", path: "/repo/a" },
+      { id: "wt-b", name: "bravo", branch: "feature/bravo", path: "/repo/b" },
+    ]);
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "wt-a",
+    });
+    await actions.get("worktree.home")!().run(undefined, {} as never);
+    await actions.get("worktree.end")!().run(undefined, {} as never);
+
+    expect(select).toHaveBeenNthCalledWith(1, "main");
+    expect(select).toHaveBeenNthCalledWith(2, "wt-b");
+  });
+
+  it("down navigates by offset within the visible list", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-a", name: "alpha", branch: "feature/alpha", path: "/repo/a" },
+      { id: "wt-b", name: "bravo", branch: "feature/bravo", path: "/repo/b" },
+    ]);
+    useWorktreeFilterStore.setState({ orderBy: "alpha" });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "wt-a",
+    });
+    await actions.get("worktree.down")!().run(undefined, {} as never);
+
+    expect(select).toHaveBeenCalledWith("wt-b");
+  });
+
+  it("no-ops when the visible list is empty", async () => {
+    const select = spySelectWorktree();
+    const actions = buildRegistry(registerWorktreeActions);
+
+    await actions.get("worktree.next")!().run(undefined, {} as never);
+    await actions.get("worktree.switch1")!().run(undefined, {} as never);
+    await actions.get("worktree.end")!().run(undefined, {} as never);
+
+    expect(select).not.toHaveBeenCalled();
+  });
+
+  it("quickStateFilter hides non-matching worktrees from cycling", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-idle", name: "idle", branch: "feature/idle", path: "/repo/idle" },
+      { id: "wt-working", name: "working", branch: "feature/working", path: "/repo/working" },
+    ]);
+
+    // Mark wt-working with a working agent terminal
+    usePanelStore.setState({
+      panelsById: {
+        "term-working": createTerminal({
+          id: "term-working",
+          worktreeId: "wt-working",
+          agentState: "working",
+        }),
+      },
+      panelIds: ["term-working"],
+    });
+
+    useWorktreeFilterStore.setState({
+      orderBy: "alpha",
+      quickStateFilter: "working",
+    });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "main",
+    });
+    // Visible list with quickStateFilter=working: [main, wt-working] (main always shown,
+    // wt-idle filtered out). Forward from main selects wt-working.
+    await actions.get("worktree.next")!().run(undefined, {} as never);
+
+    expect(select).toHaveBeenCalledWith("wt-working");
+    expect(select).not.toHaveBeenCalledWith("wt-idle");
   });
 });

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -1052,6 +1052,42 @@ describe("worktree cycling respects sidebar order", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
+  it("up/down use first/last visible when active is filtered out", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-idle", name: "idle", branch: "feature/idle", path: "/repo/idle" },
+      { id: "wt-working", name: "working", branch: "feature/working", path: "/repo/working" },
+    ]);
+    usePanelStore.setState({
+      panelsById: {
+        "term-working": createTerminal({
+          id: "term-working",
+          worktreeId: "wt-working",
+          agentState: "working",
+        }),
+      },
+      panelIds: ["term-working"],
+    });
+    useWorktreeFilterStore.setState({
+      orderBy: "alpha",
+      quickStateFilter: "working",
+      alwaysShowActive: false,
+    });
+    const select = spySelectWorktree();
+
+    // wt-idle is the active worktree but is filtered out (quickStateFilter=working,
+    // alwaysShowActive=false). Visible list is [main, wt-working].
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "wt-idle",
+    });
+
+    await actions.get("worktree.down")!().run(undefined, {} as never);
+    await actions.get("worktree.up")!().run(undefined, {} as never);
+
+    expect(select).toHaveBeenNthCalledWith(1, "main"); // down → first visible
+    expect(select).toHaveBeenNthCalledWith(2, "wt-working"); // up → last visible
+  });
+
   it("quickStateFilter hides non-matching worktrees from cycling", async () => {
     installWorktrees([
       { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -1052,6 +1052,42 @@ describe("worktree cycling respects sidebar order", () => {
     expect(select).not.toHaveBeenCalled();
   });
 
+  it("previous and up agree when the active worktree is filtered out", async () => {
+    installWorktrees([
+      { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },
+      { id: "wt-idle", name: "idle", branch: "feature/idle", path: "/repo/idle" },
+      { id: "wt-working", name: "working", branch: "feature/working", path: "/repo/working" },
+    ]);
+    usePanelStore.setState({
+      panelsById: {
+        "term-working": createTerminal({
+          id: "term-working",
+          worktreeId: "wt-working",
+          agentState: "working",
+        }),
+      },
+      panelIds: ["term-working"],
+    });
+    useWorktreeFilterStore.setState({
+      orderBy: "alpha",
+      quickStateFilter: "working",
+      alwaysShowActive: false,
+    });
+    const select = spySelectWorktree();
+
+    const actions = buildRegistry(registerWorktreeActions, {
+      getActiveWorktreeId: () => "wt-idle",
+    });
+
+    await actions.get("worktree.previous")!().run(undefined, {} as never);
+    await actions.get("worktree.up")!().run(undefined, {} as never);
+
+    // Visible list: [main, wt-working]. Both actions must pick the same entry
+    // (last visible → wt-working) so cycle and directional navigation agree.
+    expect(select.mock.calls[0][0]).toBe("wt-working");
+    expect(select.mock.calls[1][0]).toBe("wt-working");
+  });
+
   it("up/down use first/last visible when active is filtered out", async () => {
     installWorktrees([
       { id: "main", name: "main", branch: "main", path: "/repo", isMainWorktree: true },

--- a/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/clients", () => ({
   githubClient: {},
   systemClient: {},
   worktreeClient: { resourceAction: mockResourceAction },
+  projectClient: {},
 }));
 
 const mockWorktrees = new Map<string, Record<string, unknown>>();

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -6,6 +6,7 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 import { notify } from "@/lib/notify";
+import { getVisibleWorktreesForCycling } from "@/lib/worktreeCyclingOrder";
 
 export function registerWorktreeActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   // Query action: list all worktrees with metadata
@@ -281,9 +282,9 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const worktrees = callbacks.getWorktrees();
-      if (worktrees.length === 0) return;
       const activeWorktreeId = callbacks.getActiveWorktreeId();
+      const worktrees = getVisibleWorktreesForCycling(activeWorktreeId);
+      if (worktrees.length === 0) return;
       const currentIndex = activeWorktreeId
         ? worktrees.findIndex((w) => w.id === activeWorktreeId)
         : -1;
@@ -301,9 +302,9 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const worktrees = callbacks.getWorktrees();
-      if (worktrees.length === 0) return;
       const activeWorktreeId = callbacks.getActiveWorktreeId();
+      const worktrees = getVisibleWorktreesForCycling(activeWorktreeId);
+      if (worktrees.length === 0) return;
       const currentIndex = activeWorktreeId
         ? worktrees.findIndex((w) => w.id === activeWorktreeId)
         : -1;
@@ -325,7 +326,8 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     argsSchema: z.object({ index: z.number().int().min(1).max(9) }),
     run: async (args: unknown) => {
       const { index } = args as { index: number };
-      const worktrees = callbacks.getWorktrees();
+      const activeWorktreeId = callbacks.getActiveWorktreeId();
+      const worktrees = getVisibleWorktreesForCycling(activeWorktreeId);
       if (worktrees.length >= index) {
         useWorktreeSelectionStore.getState().selectWorktree(worktrees[index - 1].id);
       }
@@ -344,7 +346,8 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       danger: "safe",
       scope: "renderer",
       run: async () => {
-        const worktrees = callbacks.getWorktrees();
+        const activeWorktreeId = callbacks.getActiveWorktreeId();
+        const worktrees = getVisibleWorktreesForCycling(activeWorktreeId);
         if (worktrees.length >= index) {
           useWorktreeSelectionStore.getState().selectWorktree(worktrees[index - 1].id);
         }
@@ -353,9 +356,9 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
   }
 
   const selectWorktreeByOffset = (offset: number) => {
-    const worktrees = callbacks.getWorktrees();
-    if (worktrees.length === 0) return;
     const activeWorktreeId = callbacks.getActiveWorktreeId();
+    const worktrees = getVisibleWorktreesForCycling(activeWorktreeId);
+    if (worktrees.length === 0) return;
     const currentIndex = activeWorktreeId
       ? worktrees.findIndex((w) => w.id === activeWorktreeId)
       : -1;
@@ -426,7 +429,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const worktrees = callbacks.getWorktrees();
+      const worktrees = getVisibleWorktreesForCycling(callbacks.getActiveWorktreeId());
       if (worktrees.length === 0) return;
       useWorktreeSelectionStore.getState().selectWorktree(worktrees[0].id);
     },
@@ -441,7 +444,7 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const worktrees = callbacks.getWorktrees();
+      const worktrees = getVisibleWorktreesForCycling(callbacks.getActiveWorktreeId());
       if (worktrees.length === 0) return;
       useWorktreeSelectionStore.getState().selectWorktree(worktrees[worktrees.length - 1].id);
     },

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -362,9 +362,15 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     const currentIndex = activeWorktreeId
       ? worktrees.findIndex((w) => w.id === activeWorktreeId)
       : -1;
-    const baseIndex = currentIndex === -1 ? 0 : currentIndex;
-    const nextIndex = baseIndex + offset;
-    if (nextIndex < 0 || nextIndex >= worktrees.length) return;
+    let nextIndex: number;
+    if (currentIndex === -1) {
+      // Active worktree is outside the visible list (filtered out or unset).
+      // Moving down lands on the first visible entry; moving up lands on the last.
+      nextIndex = offset > 0 ? 0 : worktrees.length - 1;
+    } else {
+      nextIndex = currentIndex + offset;
+      if (nextIndex < 0 || nextIndex >= worktrees.length) return;
+    }
     useWorktreeSelectionStore.getState().selectWorktree(worktrees[nextIndex].id);
   };
 

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -308,8 +308,13 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       const currentIndex = activeWorktreeId
         ? worktrees.findIndex((w) => w.id === activeWorktreeId)
         : -1;
+      // When the active worktree is outside the visible list, wrap from the
+      // end — this matches worktree.up/upVim so directional and cycle actions
+      // agree when filters hide the active worktree.
       const prevIndex =
-        currentIndex === -1 ? 0 : (currentIndex - 1 + worktrees.length) % worktrees.length;
+        currentIndex === -1
+          ? worktrees.length - 1
+          : (currentIndex - 1 + worktrees.length) % worktrees.length;
       useWorktreeSelectionStore.getState().selectWorktree(worktrees[prevIndex].id);
     },
   }));

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -16,6 +16,8 @@ function resetWorktreeFilterStore() {
     hideMainWorktree: false,
     pinnedWorktrees: [],
     collapsedWorktrees: [],
+    manualOrder: [],
+    quickStateFilter: "all",
   });
 }
 
@@ -125,5 +127,20 @@ describe("worktreeFilterStore", () => {
     useWorktreeFilterStore.getState().clearAll();
 
     expect(useWorktreeFilterStore.getState().collapsedWorktrees).toEqual(["wt-1"]);
+  });
+
+  it('defaults quickStateFilter to "all"', () => {
+    expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
+  });
+
+  it("updates quickStateFilter via setter", () => {
+    useWorktreeFilterStore.getState().setQuickStateFilter("working");
+    expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("working");
+
+    useWorktreeFilterStore.getState().setQuickStateFilter("waiting");
+    expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("waiting");
+
+    useWorktreeFilterStore.getState().setQuickStateFilter("all");
+    expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
   });
 });

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -143,4 +143,20 @@ describe("worktreeFilterStore", () => {
     useWorktreeFilterStore.getState().setQuickStateFilter("all");
     expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
   });
+
+  it("counts quickStateFilter in hasActiveFilters and getActiveFilterCount", () => {
+    expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(false);
+
+    useWorktreeFilterStore.getState().setQuickStateFilter("waiting");
+
+    expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(true);
+    expect(useWorktreeFilterStore.getState().getActiveFilterCount()).toBe(1);
+  });
+
+  it('resets quickStateFilter to "all" on clearAll', () => {
+    useWorktreeFilterStore.getState().setQuickStateFilter("working");
+    useWorktreeFilterStore.getState().clearAll();
+
+    expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
+  });
 });

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import type { QuickStateFilter } from "@/lib/worktreeFilters";
 
 export type OrderBy = "recent" | "created" | "alpha" | "manual";
 
@@ -46,6 +47,8 @@ interface WorktreeFilterState {
   pinnedWorktrees: string[];
   collapsedWorktrees: string[];
   manualOrder: string[];
+  /** Transient session-only quick-state chip filter (not persisted). */
+  quickStateFilter: QuickStateFilter;
 }
 
 interface WorktreeFilterActions {
@@ -68,6 +71,7 @@ interface WorktreeFilterActions {
   toggleWorktreeCollapsed: (id: string) => void;
   isWorktreeCollapsed: (id: string) => boolean;
   setManualOrder: (order: string[]) => void;
+  setQuickStateFilter: (filter: QuickStateFilter) => void;
   clearAll: () => void;
   getActiveFilterCount: () => number;
   hasActiveFilters: () => boolean;
@@ -109,6 +113,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
       pinnedWorktrees: [],
       collapsedWorktrees: [],
       manualOrder: [],
+      quickStateFilter: "all",
 
       setQuery: (query) => set({ query }),
       setOrderBy: (orderBy) => set({ orderBy }),
@@ -216,6 +221,8 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
       isWorktreeCollapsed: (id) => get().collapsedWorktrees.includes(id),
 
       setManualOrder: (order) => set({ manualOrder: order }),
+
+      setQuickStateFilter: (quickStateFilter) => set({ quickStateFilter }),
 
       clearAll: () =>
         set({

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -233,6 +233,7 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
           sessionFilters: new Set(),
           activityFilters: new Set(),
           hideMainWorktree: false,
+          quickStateFilter: "all",
         }),
 
       getActiveFilterCount: () => {
@@ -244,7 +245,8 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
           state.typeFilters.size +
           state.githubFilters.size +
           state.sessionFilters.size +
-          state.activityFilters.size
+          state.activityFilters.size +
+          (state.quickStateFilter !== "all" ? 1 : 0)
         );
       },
 
@@ -257,7 +259,8 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
           state.typeFilters.size > 0 ||
           state.githubFilters.size > 0 ||
           state.sessionFilters.size > 0 ||
-          state.activityFilters.size > 0
+          state.activityFilters.size > 0 ||
+          state.quickStateFilter !== "all"
         );
       },
     }),


### PR DESCRIPTION
## Summary

- Cmd+Alt+]/[, the 1..9 shortcuts, and arrow/vim navigation were cycling worktrees in a hardcoded order (main-first, then lastActivity desc, then name asc) that diverged from the sidebar the moment a user applied a custom sort, pinned worktrees, or had a filter active.
- New `getVisibleWorktreesForCycling` helper replays the sidebar's filter+sort pipeline at dispatch time, reading from the filter store, per-view worktree store, and panel store. All 11 cycle/navigation actions now use it. The `worktree.list` palette/MCP action stays on the unfiltered list.
- `quickStateFilter` (the Working/Waiting/Finished chip) has been lifted from local `SidebarContent` `useState` into the filter store (session-only, not persisted) so cycling also honours any active state chip.

Fixes #5170

## Changes

- `src/lib/worktreeCyclingOrder.ts` — new helper that replicates the sidebar filter+sort logic
- `src/services/actions/definitions/worktreeActions.ts` — all 11 cycle/navigation actions swapped to the helper
- `src/store/worktreeFilterStore.ts` — `quickStateFilter` lifted here; `clearAll`/`hasActiveFilters`/`getActiveFilterCount` updated
- `src/components/Sidebar/SidebarContent.tsx` — reads `quickStateFilter` from store instead of local state
- Tests: `worktreeCyclingOrder.test.ts`, `actionDefinitions.adversarial.test.ts`, additions to `worktreeFilterStore.test.ts`

## Testing

63/63 targeted tests green (cycling helper, adversarial action coverage, filter store). Baseline unit suites unchanged. Manually verified cycling with custom sort and active state filter.