### PR TITLE
fix(gpu): raise tile memory cap and clean up GPU switches

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -109,10 +109,8 @@ app.commandLine.appendSwitch(
 // Allow autoplay without user gesture (voice input, media panels).
 // Per-view throttling is managed by ProjectViewManager.setBackgroundThrottling().
 app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
-// Disable unused Chromium features: BackForwardCache wastes memory (no browser navigation),
-// CalculateNativeWinOcclusion causes unnecessary power usage on macOS
+// BackForwardCache wastes memory in an Electron app (no browser navigation history).
 const disabledFeatures = ["BackForwardCache"];
-if (process.platform === "darwin") disabledFeatures.push("CalculateNativeWinOcclusion");
 app.commandLine.appendSwitch("disable-features", disabledFeatures.join(","));
 
 const __filename = fileURLToPath(import.meta.url);

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -416,6 +416,18 @@ describe("GPU memory flags", () => {
     const { app } = await import("electron");
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "1024");
   });
+
+  it("does not set gpu-rasterization-msaa-sample-count", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+
+    await import("../environment.js");
+
+    const { app } = await import("electron");
+    const msaaCalls = vi
+      .mocked(app.commandLine.appendSwitch)
+      .mock.calls.filter(([key]) => key === "gpu-rasterization-msaa-sample-count");
+    expect(msaaCalls).toEqual([]);
+  });
 });
 
 describe("Chromium feature flags", () => {

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -408,25 +408,13 @@ describe("GPU memory flags", () => {
     process.argv = originalArgv;
   });
 
-  it("sets force-gpu-mem-available-mb to 512", async () => {
+  it("sets force-gpu-mem-available-mb to 1024", async () => {
     fsMock.existsSync.mockReturnValue(false);
 
     await import("../environment.js");
 
     const { app } = await import("electron");
-    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "512");
-  });
-
-  it("disables GPU rasterization MSAA", async () => {
-    fsMock.existsSync.mockReturnValue(false);
-
-    await import("../environment.js");
-
-    const { app } = await import("electron");
-    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
-      "gpu-rasterization-msaa-sample-count",
-      "0"
-    );
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "1024");
   });
 });
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -305,9 +305,8 @@ if (process.platform === "linux") {
 
 app.commandLine.appendSwitch("enable-features", enabledFeatures.join(","));
 
-// Cap GPU tile memory budget and disable MSAA to reduce VRAM usage
-app.commandLine.appendSwitch("force-gpu-mem-available-mb", "512");
-app.commandLine.appendSwitch("gpu-rasterization-msaa-sample-count", "0");
+// Raise GPU tile memory budget to keep Retina/multi-panel rendering from exhausting Chromium's default cap
+app.commandLine.appendSwitch("force-gpu-mem-available-mb", "1024");
 
 if (process.platform === "win32") {
   const extraPaths = getWindowsExtraPaths();


### PR DESCRIPTION
## Summary

- Raises `force-gpu-mem-available-mb` from 512 to 1024 in `electron/setup/environment.ts`. The 512 MB cap is per-renderer, not a shared pool, so on Retina with multiple scrollable panels it's too tight. This was causing real tile allocation failures (`cc/tiles/tile_manager.cc:997`) and occasional checkerboarding, not just log noise.
- Removes `gpu-rasterization-msaa-sample-count=0`. This was causing visible sawtooth edges on SVG paths and `border-radius`. Hardware with broken MSAA self-disables via Chromium's `msaa_is_slow` blocklist, so the override is unnecessary and the visual regression isn't worth the trivial VRAM saving.
- Removes the darwin branch in `electron/main.ts` that was pushing `CalculateNativeWinOcclusion` into `disabledFeatures`. That flag is guarded by `#if BUILDFLAG(IS_WIN)` in Chromium source and expired in M130, so it was a confirmed no-op on macOS.

Resolves #5180

## Changes

- `electron/setup/environment.ts`: memory cap 512 → 1024, MSAA switch removed
- `electron/main.ts`: darwin occlusion branch removed
- `electron/setup/__tests__/environment.test.ts`: expectation updated to `"1024"`, positive MSAA assertion replaced with a negative one that verifies the switch is never appended

## Testing

43/43 unit tests pass. Typecheck, lint (401-warning baseline preserved), and format all clean.