### PR TITLE
fix(worktree): generate agent command when cloning layout

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -15,7 +15,7 @@ import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { worktreeClient, githubClient } from "@/clients";
+import { worktreeClient, githubClient, agentSettingsClient, systemClient } from "@/clients";
 import { detectPrefixFromIssue, buildBranchName } from "@/components/Worktree/branchPrefixUtils";
 import { generateBranchSlug } from "@/utils/textParsing";
 import { notify } from "@/lib/notify";
@@ -29,8 +29,10 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useRecipePicker, CLONE_LAYOUT_ID } from "@/components/Worktree/hooks/useRecipePicker";
 import { useNewWorktreeProjectSettings } from "@/components/Worktree/hooks/useNewWorktreeProjectSettings";
+import { getAgentConfig } from "@/config/agents";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import type { BranchInfo } from "@shared/types";
+import { generateAgentCommand } from "@shared/types";
 
 type BulkCreateMode = "issue" | "pr";
 
@@ -502,6 +504,30 @@ export function BulkCreateWorktreeDialog({
           ? useRecipeStore.getState().generateRecipeFromActiveTerminals(sourceWorktreeId)
           : null;
 
+      // Pre-fetch agent settings once so each cloned agent panel can regenerate
+      // its spawn command from current config (mirrors recipeStore.ts). Source
+      // RecipeTerminal.command is not reused for agents — it may embed a
+      // path-scoped session ID from the source worktree (see #5179, PR #4781).
+      let cloneAgentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
+      let cloneClipboardDirectory: string | undefined;
+      if (
+        cloneTerminals &&
+        cloneTerminals.some((t) => t.type !== "terminal" && t.type !== "dev-preview")
+      ) {
+        try {
+          const [settings, tmpDir] = await Promise.all([
+            agentSettingsClient.get(),
+            systemClient.getTmpDir().catch(() => ""),
+          ]);
+          if (runIdRef.current !== currentRunId) return;
+          cloneAgentSettings = settings;
+          cloneClipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
+        } catch {
+          if (runIdRef.current !== currentRunId) return;
+          // Non-fatal: agents fall back to generating with empty settings.
+        }
+      }
+
       const queue = new PQueue({
         concurrency: QUEUE_CONCURRENCY,
       });
@@ -775,19 +801,41 @@ export function BulkCreateWorktreeDialog({
                 });
                 try {
                   for (const t of cloneTerminals) {
+                    const isDevPreview = t.type === "dev-preview";
+                    const isAgent = !isDevPreview && t.type !== "terminal";
+
+                    if (isDevPreview) {
+                      await usePanelStore.getState().addPanel({
+                        kind: "dev-preview",
+                        title: t.title,
+                        cwd: worktreePath,
+                        worktreeId,
+                        exitBehavior: t.exitBehavior,
+                        devCommand: t.devCommand?.trim() || undefined,
+                      });
+                      continue;
+                    }
+
+                    let command: string | undefined;
+                    if (isAgent) {
+                      const agentConfig = getAgentConfig(t.type);
+                      const baseCommand = agentConfig?.command || t.type;
+                      const entry = cloneAgentSettings?.agents?.[t.type] ?? {};
+                      command = generateAgentCommand(baseCommand, entry, t.type, {
+                        clipboardDirectory: cloneClipboardDirectory,
+                      });
+                    } else {
+                      command = t.command?.trim() || undefined;
+                    }
+
                     await usePanelStore.getState().addPanel({
-                      kind:
-                        t.type === "dev-preview"
-                          ? "dev-preview"
-                          : t.type === "terminal"
-                            ? "terminal"
-                            : "agent",
-                      agentId:
-                        t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                      kind: isAgent ? "agent" : "terminal",
+                      agentId: isAgent ? t.type : undefined,
                       title: t.title,
                       cwd: worktreePath,
                       worktreeId,
                       exitBehavior: t.exitBehavior,
+                      command,
                     });
                   }
                   const updatedTracked = tracking.get(itemNumber);

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -11,6 +11,10 @@ const mockGetDefaultPath = vi.fn();
 const mockListBranches = vi.fn();
 const mockFetchPRBranch = vi.fn();
 const mockAssignIssue = vi.fn();
+const mockAgentSettingsGet = vi.fn();
+const mockSystemGetTmpDir = vi.fn();
+const mockGetAgentConfig = vi.fn();
+const mockGenerateAgentCommand = vi.fn();
 
 vi.mock("@/clients", () => ({
   worktreeClient: {
@@ -23,15 +27,35 @@ vi.mock("@/clients", () => ({
   githubClient: {
     assignIssue: (...args: unknown[]) => mockAssignIssue(...args),
   },
+  agentSettingsClient: {
+    get: (...args: unknown[]) => mockAgentSettingsGet(...args),
+  },
+  systemClient: {
+    getTmpDir: (...args: unknown[]) => mockSystemGetTmpDir(...args),
+  },
 }));
 
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (...args: unknown[]) => mockGetAgentConfig(...args),
+}));
+
+vi.mock("@shared/types", async (importActual) => {
+  const actual = await importActual<typeof import("@shared/types")>();
+  return {
+    ...actual,
+    generateAgentCommand: (...args: unknown[]) => mockGenerateAgentCommand(...args),
+  };
+});
+
 const mockRunRecipeWithResults = vi.fn();
+const mockGenerateRecipeFromActiveTerminals = vi.fn();
 vi.mock("@/store/recipeStore", () => ({
   useRecipeStore: Object.assign(() => ({ recipes: [] }), {
     getState: () => ({
       runRecipeWithResults: mockRunRecipeWithResults,
       getRecipeById: () => null,
-      generateRecipeFromActiveTerminals: () => [],
+      generateRecipeFromActiveTerminals: (...args: unknown[]) =>
+        mockGenerateRecipeFromActiveTerminals(...args),
     }),
   }),
 }));
@@ -113,12 +137,13 @@ vi.mock("@/store/worktreeStore", () => ({
 }));
 
 let mockTerminals: Array<{ id: string; exitCode?: number }> = [];
+const mockAddPanel = vi.fn();
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: () => ({
       panelsById: Object.fromEntries(mockTerminals.map((t) => [t.id, t])),
       panelIds: mockTerminals.map((t) => t.id),
-      addPanel: vi.fn().mockResolvedValue("clone-terminal-id"),
+      addPanel: (...args: unknown[]) => mockAddPanel(...args),
     }),
   },
 }));
@@ -237,6 +262,12 @@ beforeEach(() => {
   setupWorktreeCreateMocks();
   mockTerminals = [];
   mockSelectedRecipeId = null;
+  mockAddPanel.mockResolvedValue("clone-terminal-id");
+  mockAgentSettingsGet.mockResolvedValue({ agents: {} });
+  mockSystemGetTmpDir.mockResolvedValue("/tmp");
+  mockGetAgentConfig.mockReturnValue({ command: "claude" });
+  mockGenerateAgentCommand.mockReturnValue("claude --fresh");
+  mockGenerateRecipeFromActiveTerminals.mockReturnValue([]);
 });
 
 afterEach(() => {
@@ -1239,6 +1270,124 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(screen.getByText(/3 of 3 created/)).toBeTruthy();
     expect(onComplete).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clone layout generates command for agent panels and preserves plain terminal commands", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      {
+        type: "claude",
+        title: "Agent",
+        exitBehavior: "stay",
+        command: "claude --resume stale-session",
+      },
+      {
+        type: "terminal",
+        title: "Shell",
+        exitBehavior: "close",
+        command: "npm test",
+      },
+      {
+        type: "dev-preview",
+        title: "Preview",
+        exitBehavior: "close",
+        devCommand: "npm run dev",
+      },
+    ]);
+    mockAgentSettingsGet.mockResolvedValue({ agents: { claude: { flags: [] } } });
+    mockSystemGetTmpDir.mockResolvedValue("/tmp");
+    mockGetAgentConfig.mockReturnValue({ command: "claude" });
+    mockGenerateAgentCommand.mockReturnValue("claude --fresh-generated");
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+
+    // Agent command is regenerated from current settings, not the stale one
+    // captured at recipe-generation time.
+    expect(mockGenerateAgentCommand).toHaveBeenCalledWith(
+      "claude",
+      { flags: [] },
+      "claude",
+      expect.objectContaining({ clipboardDirectory: "/tmp/daintree-clipboard" })
+    );
+
+    const agentCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "agent");
+    expect(agentCall).toBeDefined();
+    expect(agentCall?.[0].command).toBe("claude --fresh-generated");
+    expect(agentCall?.[0].agentId).toBe("claude");
+    expect(agentCall?.[0].command).not.toContain("stale-session");
+
+    // Plain terminal command is passed through verbatim (it's a user-authored
+    // shell command, not a path-scoped agent invocation).
+    const terminalCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "terminal");
+    expect(terminalCall).toBeDefined();
+    expect(terminalCall?.[0].command).toBe("npm test");
+
+    // Dev-preview carries devCommand, not command.
+    const devPreviewCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "dev-preview");
+    expect(devPreviewCall).toBeDefined();
+    expect(devPreviewCall?.[0].devCommand).toBe("npm run dev");
+  });
+
+  it("clone layout degrades gracefully when agent settings IPC fails", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "claude", title: "Agent", exitBehavior: "stay" },
+    ]);
+    mockAgentSettingsGet.mockRejectedValue(new Error("IPC timeout"));
+    mockGetAgentConfig.mockReturnValue({ command: "claude" });
+    mockGenerateAgentCommand.mockReturnValue("claude --default");
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    // Worktree still created — failed IPC is non-fatal.
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+
+    // Agent command was still generated (with an empty settings entry).
+    expect(mockGenerateAgentCommand).toHaveBeenCalledWith(
+      "claude",
+      {},
+      "claude",
+      expect.objectContaining({ clipboardDirectory: undefined })
+    );
+    const agentCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "agent");
+    expect(agentCall?.[0].command).toBe("claude --default");
+  });
+
+  it("clone layout skips agent-settings prefetch when no agent panels present", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "Shell", exitBehavior: "close", command: "ls" },
+    ]);
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    // No agent panels → prefetch is skipped entirely.
+    expect(mockAgentSettingsGet).not.toHaveBeenCalled();
+    expect(mockGenerateAgentCommand).not.toHaveBeenCalled();
+
+    const terminalCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "terminal");
+    expect(terminalCall?.[0].command).toBe("ls");
   });
 });
 


### PR DESCRIPTION
## Summary

- Clone layout was calling `addPanel()` with only `kind`, `title`, `cwd`, and `exitBehavior` — the `command` was never passed, so cloned agent panels started a bare shell instead of launching the agent.
- Pre-fetches `agentSettingsClient.get()` and `systemClient.getTmpDir()` once per batch (guarded by a `hasAgent` check), then calls `generateAgentCommand()` for each agent panel using current settings. Mirrors the pattern in `recipeStore.ts`.
- Plain terminal `command` and dev-preview `devCommand` are now passed through to `addPanel` (they were previously dropped). Agent panels deliberately regenerate from current settings rather than carrying over the source command, which may embed a path-scoped session ID (see #4781).

Resolves #5179

## Changes

- `src/components/GitHub/BulkCreateWorktreeDialog.tsx` — fixed clone-layout loop to pre-fetch agent settings and regenerate agent commands; terminal and dev-preview commands passed through
- `src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx` — 3 new tests: agent command regeneration, IPC failure degradation, and settings prefetch skipped when no agent panels present

## Testing

All 42 tests in `BulkCreateWorktreeDialog.test.tsx` pass. Typecheck, lint ratchet, and format are clean.