### PR TITLE
fix(telemetry): stop dropping 90% of Sentry crash reports

### DIFF
--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -82,7 +82,8 @@ export async function initializeTelemetry(): Promise<void> {
       dsn,
       release: app.getVersion(),
       environment: app.isPackaged ? "production" : "development",
-      sampleRate: 0.1,
+      // Do not set `sampleRate` — it defaults to 1.0 (100% error capture). If
+      // performance tracing is ever added, use `tracesSampleRate` instead.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       beforeSend: sanitizeEvent as any,
       initialScope: {

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -199,12 +199,11 @@ describe("initializeTelemetry", () => {
     storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
     await initializeTelemetry();
     expect(sentryInitMock).toHaveBeenCalledTimes(1);
-    const options = sentryInitMock.mock.calls[0][0] as { sampleRate?: number };
-    // sampleRate must be either absent (SDK default 1.0) or exactly 1 — any
-    // value < 1 silently drops that fraction of crash reports. See #5255.
-    if (options.sampleRate !== undefined) {
-      expect(options.sampleRate).toBe(1);
-    }
+    const options = sentryInitMock.mock.calls[0][0] as Record<string, unknown>;
+    // sampleRate must not be set at all — the SDK default is 1.0 (100%
+    // capture) and any value < 1 silently drops that fraction of crash
+    // reports. Fail closed so reintroduction at any value is caught. See #5255.
+    expect(options).not.toHaveProperty("sampleRate");
     process.env.SENTRY_DSN = original;
   });
 });

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -192,6 +192,21 @@ describe("initializeTelemetry", () => {
     expect(sentryInitMock).not.toHaveBeenCalled();
     process.env.SENTRY_DSN = original;
   });
+
+  it("does not drop error events via sampleRate when initialized", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
+    await initializeTelemetry();
+    expect(sentryInitMock).toHaveBeenCalledTimes(1);
+    const options = sentryInitMock.mock.calls[0][0] as { sampleRate?: number };
+    // sampleRate must be either absent (SDK default 1.0) or exactly 1 — any
+    // value < 1 silently drops that fraction of crash reports. See #5255.
+    if (options.sampleRate !== undefined) {
+      expect(options.sampleRate).toBe(1);
+    }
+    process.env.SENTRY_DSN = original;
+  });
 });
 
 describe("trackEvent", () => {


### PR DESCRIPTION
## Summary

- `sampleRate: 0.1` in `sentry.init()` was silently discarding nine out of ten error events. The field gates error and message captures (not performance traces), so the effect was a 90% blind spot in crash reporting.
- Removed the field entirely so it defaults to `1.0` (100% capture). If we ever add performance tracing, `tracesSampleRate` is the correct knob for that.
- Added a fail-closed regression test that asserts `sampleRate` is never set in the options passed to `sentry.init()`.

Resolves #5255

## Changes

- `electron/services/TelemetryService.ts` — removed `sampleRate: 0.1` from `sentry.init()`
- `electron/services/__tests__/TelemetryService.test.ts` — added assertion that `options.sampleRate` is never present

## Testing

27 unit tests passing. The new regression test explicitly fails if `sampleRate` is re-introduced, so this can't quietly regress.