### PR TITLE
fix(telemetry): flush Sentry before app.exit to prevent losing queued events

### DIFF
--- a/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  return {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+    _handlers: handlers,
+  };
+});
+
+const appMock = vi.hoisted(() => ({
+  getPath: vi.fn(() => "/tmp/user-data"),
+  relaunch: vi.fn(),
+  exit: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  app: appMock,
+}));
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn(() => undefined),
+  set: vi.fn(),
+}));
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+const gpuMonitorMock = vi.hoisted(() => ({
+  isGpuDisabledByFlag: vi.fn(() => false),
+  writeGpuDisabledFlag: vi.fn(),
+  clearGpuDisabledFlag: vi.fn(),
+}));
+
+vi.mock("../../../services/GpuCrashMonitorService.js", () => gpuMonitorMock);
+
+const telemetryServiceMock = vi.hoisted(() => ({
+  closeTelemetry: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
+
+import { registerGpuHandlers } from "../app/gpu.js";
+
+describe("GPU_SET_HARDWARE_ACCELERATION handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMainMock._handlers.clear();
+  });
+
+  it("disables GPU, then calls relaunch, closeTelemetry, exit(0) — in order", async () => {
+    const callOrder: string[] = [];
+    gpuMonitorMock.writeGpuDisabledFlag.mockImplementation(() => callOrder.push("writeFlag"));
+    appMock.relaunch.mockImplementation(() => callOrder.push("relaunch"));
+    telemetryServiceMock.closeTelemetry.mockImplementation(async () => {
+      callOrder.push("closeTelemetry");
+    });
+    appMock.exit.mockImplementation(() => callOrder.push("exit"));
+
+    registerGpuHandlers();
+    const handler = ipcMainMock._handlers.get("gpu:set-hardware-acceleration")!;
+    expect(handler).toBeDefined();
+
+    await handler({} as Electron.IpcMainInvokeEvent, false);
+
+    expect(callOrder).toEqual(["writeFlag", "relaunch", "closeTelemetry", "exit"]);
+    expect(appMock.exit).toHaveBeenCalledWith(0);
+    expect(storeMock.set).toHaveBeenCalledWith("gpu", { hardwareAccelerationDisabled: true });
+  });
+
+  it("enables GPU: clears flag, relaunch, closeTelemetry, exit(0) — in order", async () => {
+    const callOrder: string[] = [];
+    gpuMonitorMock.clearGpuDisabledFlag.mockImplementation(() => callOrder.push("clearFlag"));
+    appMock.relaunch.mockImplementation(() => callOrder.push("relaunch"));
+    telemetryServiceMock.closeTelemetry.mockImplementation(async () => {
+      callOrder.push("closeTelemetry");
+    });
+    appMock.exit.mockImplementation(() => callOrder.push("exit"));
+
+    registerGpuHandlers();
+    const handler = ipcMainMock._handlers.get("gpu:set-hardware-acceleration")!;
+
+    await handler({} as Electron.IpcMainInvokeEvent, true);
+
+    expect(callOrder).toEqual(["clearFlag", "relaunch", "closeTelemetry", "exit"]);
+    expect(storeMock.set).toHaveBeenCalledWith("gpu", { hardwareAccelerationDisabled: false });
+  });
+});

--- a/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/gpu.handlers.test.ts
@@ -53,41 +53,56 @@ describe("GPU_SET_HARDWARE_ACCELERATION handler", () => {
     ipcMainMock._handlers.clear();
   });
 
-  it("disables GPU, then calls relaunch, closeTelemetry, exit(0) — in order", async () => {
-    const callOrder: string[] = [];
-    gpuMonitorMock.writeGpuDisabledFlag.mockImplementation(() => callOrder.push("writeFlag"));
-    appMock.relaunch.mockImplementation(() => callOrder.push("relaunch"));
-    telemetryServiceMock.closeTelemetry.mockImplementation(async () => {
-      callOrder.push("closeTelemetry");
+  it("disables GPU then awaits closeTelemetry before exit(0)", async () => {
+    let resolveClose!: () => void;
+    const deferred = new Promise<void>((r) => {
+      resolveClose = r;
     });
-    appMock.exit.mockImplementation(() => callOrder.push("exit"));
+    telemetryServiceMock.closeTelemetry.mockReturnValue(deferred);
 
     registerGpuHandlers();
     const handler = ipcMainMock._handlers.get("gpu:set-hardware-acceleration")!;
     expect(handler).toBeDefined();
 
-    await handler({} as Electron.IpcMainInvokeEvent, false);
+    const handlerPromise = handler({} as Electron.IpcMainInvokeEvent, false);
 
-    expect(callOrder).toEqual(["writeFlag", "relaunch", "closeTelemetry", "exit"]);
-    expect(appMock.exit).toHaveBeenCalledWith(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(gpuMonitorMock.writeGpuDisabledFlag).toHaveBeenCalled();
     expect(storeMock.set).toHaveBeenCalledWith("gpu", { hardwareAccelerationDisabled: true });
+    expect(appMock.relaunch).toHaveBeenCalled();
+    expect(telemetryServiceMock.closeTelemetry).toHaveBeenCalled();
+    expect(appMock.exit).not.toHaveBeenCalled();
+
+    resolveClose();
+    await handlerPromise;
+
+    expect(appMock.exit).toHaveBeenCalledWith(0);
   });
 
-  it("enables GPU: clears flag, relaunch, closeTelemetry, exit(0) — in order", async () => {
-    const callOrder: string[] = [];
-    gpuMonitorMock.clearGpuDisabledFlag.mockImplementation(() => callOrder.push("clearFlag"));
-    appMock.relaunch.mockImplementation(() => callOrder.push("relaunch"));
-    telemetryServiceMock.closeTelemetry.mockImplementation(async () => {
-      callOrder.push("closeTelemetry");
+  it("enables GPU then awaits closeTelemetry before exit(0)", async () => {
+    let resolveClose!: () => void;
+    const deferred = new Promise<void>((r) => {
+      resolveClose = r;
     });
-    appMock.exit.mockImplementation(() => callOrder.push("exit"));
+    telemetryServiceMock.closeTelemetry.mockReturnValue(deferred);
 
     registerGpuHandlers();
     const handler = ipcMainMock._handlers.get("gpu:set-hardware-acceleration")!;
 
-    await handler({} as Electron.IpcMainInvokeEvent, true);
+    const handlerPromise = handler({} as Electron.IpcMainInvokeEvent, true);
 
-    expect(callOrder).toEqual(["clearFlag", "relaunch", "closeTelemetry", "exit"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(gpuMonitorMock.clearGpuDisabledFlag).toHaveBeenCalled();
     expect(storeMock.set).toHaveBeenCalledWith("gpu", { hardwareAccelerationDisabled: false });
+    expect(appMock.relaunch).toHaveBeenCalled();
+    expect(telemetryServiceMock.closeTelemetry).toHaveBeenCalled();
+    expect(appMock.exit).not.toHaveBeenCalled();
+
+    resolveClose();
+    await handlerPromise;
+
+    expect(appMock.exit).toHaveBeenCalledWith(0);
   });
 });

--- a/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  return {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+    _handlers: handlers,
+  };
+});
+
+const appMock = vi.hoisted(() => ({
+  getPath: vi.fn(() => "/tmp/user-data"),
+  relaunch: vi.fn(),
+  exit: vi.fn(),
+}));
+
+const shellMock = vi.hoisted(() => ({ showItemInFolder: vi.fn() }));
+const sessionMock = vi.hoisted(() => ({
+  defaultSession: {
+    clearCache: vi.fn(() => Promise.resolve()),
+    clearCodeCaches: vi.fn(() => Promise.resolve()),
+  },
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  app: appMock,
+  shell: shellMock,
+  session: sessionMock,
+}));
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn(() => undefined),
+  set: vi.fn(),
+}));
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+const telemetryServiceMock = vi.hoisted(() => ({
+  closeTelemetry: vi.fn(() => Promise.resolve()),
+  getTelemetryLevel: vi.fn(() => "off"),
+  setTelemetryLevel: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
+
+import { registerPrivacyHandlers } from "../privacy.js";
+
+describe("PRIVACY_RESET_ALL_DATA handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMainMock._handlers.clear();
+  });
+
+  it("calls relaunch, then closeTelemetry, then exit(0) — in that order", async () => {
+    const callOrder: string[] = [];
+    appMock.relaunch.mockImplementation(() => callOrder.push("relaunch"));
+    telemetryServiceMock.closeTelemetry.mockImplementation(async () => {
+      callOrder.push("closeTelemetry");
+    });
+    appMock.exit.mockImplementation(() => callOrder.push("exit"));
+
+    registerPrivacyHandlers();
+    const handler = ipcMainMock._handlers.get("privacy:reset-all-data")!;
+    expect(handler).toBeDefined();
+
+    await handler();
+
+    expect(callOrder).toEqual(["relaunch", "closeTelemetry", "exit"]);
+    expect(appMock.exit).toHaveBeenCalledWith(0);
+  });
+
+  it("calls relaunch with --reset-data arg", async () => {
+    registerPrivacyHandlers();
+    const handler = ipcMainMock._handlers.get("privacy:reset-all-data")!;
+
+    await handler();
+
+    expect(appMock.relaunch).toHaveBeenCalledWith({
+      args: expect.arrayContaining(["--reset-data"]),
+    });
+  });
+});

--- a/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
@@ -57,21 +57,30 @@ describe("PRIVACY_RESET_ALL_DATA handler", () => {
     ipcMainMock._handlers.clear();
   });
 
-  it("calls relaunch, then closeTelemetry, then exit(0) — in that order", async () => {
-    const callOrder: string[] = [];
-    appMock.relaunch.mockImplementation(() => callOrder.push("relaunch"));
-    telemetryServiceMock.closeTelemetry.mockImplementation(async () => {
-      callOrder.push("closeTelemetry");
+  it("calls relaunch then awaits closeTelemetry before exit(0)", async () => {
+    let resolveClose!: () => void;
+    const deferred = new Promise<void>((r) => {
+      resolveClose = r;
     });
-    appMock.exit.mockImplementation(() => callOrder.push("exit"));
+    telemetryServiceMock.closeTelemetry.mockReturnValue(deferred);
 
     registerPrivacyHandlers();
     const handler = ipcMainMock._handlers.get("privacy:reset-all-data")!;
     expect(handler).toBeDefined();
 
-    await handler();
+    const handlerPromise = handler();
 
-    expect(callOrder).toEqual(["relaunch", "closeTelemetry", "exit"]);
+    // Let synchronous prefix run (relaunch + the closeTelemetry call itself).
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(appMock.relaunch).toHaveBeenCalled();
+    expect(telemetryServiceMock.closeTelemetry).toHaveBeenCalled();
+    // exit MUST NOT fire before closeTelemetry resolves.
+    expect(appMock.exit).not.toHaveBeenCalled();
+
+    resolveClose();
+    await handlerPromise;
+
     expect(appMock.exit).toHaveBeenCalledWith(0);
   });
 

--- a/electron/ipc/handlers/app/gpu.ts
+++ b/electron/ipc/handlers/app/gpu.ts
@@ -6,6 +6,7 @@ import {
   writeGpuDisabledFlag,
   clearGpuDisabledFlag,
 } from "../../../services/GpuCrashMonitorService.js";
+import { closeTelemetry } from "../../../services/TelemetryService.js";
 
 export function registerGpuHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -19,7 +20,10 @@ export function registerGpuHandlers(): () => void {
   ipcMain.handle(CHANNELS.GPU_GET_STATUS, handleGetStatus);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GPU_GET_STATUS));
 
-  const handleSetHardwareAcceleration = (_event: Electron.IpcMainInvokeEvent, enabled: boolean) => {
+  const handleSetHardwareAcceleration = async (
+    _event: Electron.IpcMainInvokeEvent,
+    enabled: boolean
+  ) => {
     const userDataPath = app.getPath("userData");
     if (enabled) {
       clearGpuDisabledFlag(userDataPath);
@@ -29,6 +33,7 @@ export function registerGpuHandlers(): () => void {
       store.set("gpu", { hardwareAccelerationDisabled: true });
     }
     app.relaunch();
+    await closeTelemetry();
     app.exit(0);
   };
   ipcMain.handle(CHANNELS.GPU_SET_HARDWARE_ACCELERATION, handleSetHardwareAcceleration);

--- a/electron/ipc/handlers/privacy.ts
+++ b/electron/ipc/handlers/privacy.ts
@@ -2,6 +2,7 @@ import { ipcMain, app, shell, session } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import {
+  closeTelemetry,
   getTelemetryLevel,
   setTelemetryLevel,
   type TelemetryLevel,
@@ -52,8 +53,9 @@ export function registerPrivacyHandlers(): () => void {
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_CLEAR_CACHE));
 
-  ipcMain.handle(CHANNELS.PRIVACY_RESET_ALL_DATA, () => {
+  ipcMain.handle(CHANNELS.PRIVACY_RESET_ALL_DATA, async () => {
     app.relaunch({ args: process.argv.slice(1).concat(["--reset-data"]) });
+    await closeTelemetry();
     app.exit(0);
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_RESET_ALL_DATA));

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -104,6 +104,12 @@ const closeSharedDbMock = vi.hoisted(() => ({
 
 vi.mock("../../services/persistence/db.js", () => closeSharedDbMock);
 
+const closeTelemetryMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock("../../services/TelemetryService.js", () => ({
+  closeTelemetry: closeTelemetryMock,
+}));
+
 const isSmokeTestMock = vi.hoisted(() => ({ value: false }));
 
 vi.mock("../../setup/environment.js", () => ({
@@ -340,6 +346,57 @@ describe("registerShutdownHandler", () => {
         expect.any(Error)
       );
       warnSpy.mockRestore();
+    });
+  });
+
+  describe("Sentry telemetry flush before exit", () => {
+    afterEach(() => {
+      appMock.exit.mockReset();
+      mcpServerMock.stop.mockReset();
+      mcpServerMock.stop.mockReturnValue(Promise.resolve());
+      closeTelemetryMock.mockReset();
+      closeTelemetryMock.mockResolvedValue(undefined);
+    });
+
+    it("calls closeTelemetry before app.exit(0) on clean shutdown", async () => {
+      const callOrder: string[] = [];
+      closeTelemetryMock.mockImplementation(async () => {
+        callOrder.push("closeTelemetry");
+      });
+      appMock.exit.mockImplementation(() => {
+        callOrder.push("exit");
+      });
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(callOrder).toEqual(["closeTelemetry", "exit"]);
+    });
+
+    it("calls closeTelemetry before app.exit(1) on cleanup error", async () => {
+      mcpServerMock.stop.mockReturnValue(Promise.reject(new Error("MCP stop failed")));
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const callOrder: string[] = [];
+      closeTelemetryMock.mockImplementation(async () => {
+        callOrder.push("closeTelemetry");
+      });
+      appMock.exit.mockImplementation(() => {
+        callOrder.push("exit");
+      });
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(1);
+      });
+
+      expect(callOrder).toEqual(["closeTelemetry", "exit"]);
+      consoleSpy.mockRestore();
     });
   });
 

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -358,44 +358,54 @@ describe("registerShutdownHandler", () => {
       closeTelemetryMock.mockResolvedValue(undefined);
     });
 
-    it("calls closeTelemetry before app.exit(0) on clean shutdown", async () => {
-      const callOrder: string[] = [];
-      closeTelemetryMock.mockImplementation(async () => {
-        callOrder.push("closeTelemetry");
+    it("waits for closeTelemetry to resolve before app.exit(0) on clean shutdown", async () => {
+      let resolveClose!: () => void;
+      const closeDeferred = new Promise<void>((r) => {
+        resolveClose = r;
       });
-      appMock.exit.mockImplementation(() => {
-        callOrder.push("exit");
+      closeTelemetryMock.mockReturnValue(closeDeferred);
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      // Give the cleanup chain a chance to reach closeTelemetry.
+      await vi.waitFor(() => {
+        expect(closeTelemetryMock).toHaveBeenCalled();
       });
+      // The await must hold — exit MUST NOT fire until closeTelemetry resolves.
+      expect(appMock.exit).not.toHaveBeenCalled();
+
+      resolveClose();
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+    });
+
+    it("waits for closeTelemetry to resolve before app.exit(1) on cleanup error", async () => {
+      mcpServerMock.stop.mockReturnValue(Promise.reject(new Error("MCP stop failed")));
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      let resolveClose!: () => void;
+      const closeDeferred = new Promise<void>((r) => {
+        resolveClose = r;
+      });
+      closeTelemetryMock.mockReturnValue(closeDeferred);
 
       const { beforeQuitCb } = await setup({});
       await beforeQuitCb(makeEvent());
 
       await vi.waitFor(() => {
-        expect(appMock.exit).toHaveBeenCalledWith(0);
+        expect(closeTelemetryMock).toHaveBeenCalled();
       });
+      expect(appMock.exit).not.toHaveBeenCalled();
 
-      expect(callOrder).toEqual(["closeTelemetry", "exit"]);
-    });
-
-    it("calls closeTelemetry before app.exit(1) on cleanup error", async () => {
-      mcpServerMock.stop.mockReturnValue(Promise.reject(new Error("MCP stop failed")));
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const callOrder: string[] = [];
-      closeTelemetryMock.mockImplementation(async () => {
-        callOrder.push("closeTelemetry");
-      });
-      appMock.exit.mockImplementation(() => {
-        callOrder.push("exit");
-      });
-
-      const { beforeQuitCb } = await setup({});
-      await beforeQuitCb(makeEvent());
+      resolveClose();
 
       await vi.waitFor(() => {
         expect(appMock.exit).toHaveBeenCalledWith(1);
       });
 
-      expect(callOrder).toEqual(["closeTelemetry", "exit"]);
       consoleSpy.mockRestore();
     });
   });
@@ -421,6 +431,7 @@ describe("registerShutdownHandler", () => {
 
       expect(appMock.exit).toHaveBeenCalledWith(1);
       expect(appMock.exit).toHaveBeenCalledTimes(1);
+      expect(closeTelemetryMock).toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith(
         "[MAIN] Error during cleanup:",
         expect.objectContaining({

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -18,6 +18,7 @@ import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
 import { closeSharedDb } from "../services/persistence/db.js";
+import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
 import { isSignalShutdown } from "./signalShutdownState.js";
 
@@ -207,18 +208,20 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
     });
 
     Promise.race([cleanupPromise, timeoutPromise])
-      .then(() => {
+      .then(async () => {
         if (exitCalled) return;
         exitCalled = true;
         clearTimeout(hardTimer);
         console.log("[MAIN] Graceful shutdown complete");
+        await closeTelemetry();
         app.exit(0);
       })
-      .catch((error) => {
+      .catch(async (error) => {
         if (exitCalled) return;
         exitCalled = true;
         clearTimeout(hardTimer);
         console.error("[MAIN] Error during cleanup:", error);
+        await closeTelemetry();
         app.exit(1);
       });
   });

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import { store } from "../store.js";
+import { closeTelemetry } from "./TelemetryService.js";
 
 const GPU_DISABLED_FLAG = "gpu-disabled.flag";
 const GPU_CRASH_THRESHOLD = 3;
@@ -32,7 +33,7 @@ class GpuCrashMonitorService {
 
     const alreadyDisabled = isGpuDisabledByFlag(app.getPath("userData"));
 
-    app.on("child-process-gone", (_event, details) => {
+    app.on("child-process-gone", async (_event, details) => {
       if (details.type !== "GPU") {
         if (details.reason !== "clean-exit" && details.reason !== "killed") {
           console.warn(
@@ -61,6 +62,7 @@ class GpuCrashMonitorService {
           console.error("[GPU] Failed to write disable flag:", err);
         }
         app.relaunch();
+        await closeTelemetry();
         app.exit(0);
       }
     });

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -57,6 +57,9 @@ function sanitizeEvent(event: SentryEvent): SentryEvent | null {
 
 let initialized = false;
 let captureEventFn: ((event: SentryEvent) => string) | null = null;
+let sentryModule: typeof import("@sentry/electron/main") | null = null;
+
+const SENTRY_CLOSE_TIMEOUT_MS = 2000;
 
 interface BufferedEvent {
   event: string;
@@ -94,6 +97,7 @@ export async function initializeTelemetry(): Promise<void> {
       },
     });
     captureEventFn = sentry.captureEvent;
+    sentryModule = sentry;
     initialized = true;
   } catch (err) {
     console.warn("[Telemetry] Failed to initialize Sentry:", err);
@@ -186,4 +190,20 @@ export function markTelemetryPromptShown(): void {
 
 export function _getPreConsentBufferLength(): number {
   return preConsentBuffer.length;
+}
+
+// Drain buffered Sentry events before process exit. Safe to call when telemetry
+// was never initialized (no-op) and idempotent. Never throws — telemetry failure
+// must never block app exit.
+export async function closeTelemetry(): Promise<void> {
+  if (!initialized || !sentryModule) return;
+  const mod = sentryModule;
+  initialized = false;
+  captureEventFn = null;
+  sentryModule = null;
+  try {
+    await mod.close(SENTRY_CLOSE_TIMEOUT_MS);
+  } catch {
+    // never block exit on telemetry failure
+  }
 }

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -58,8 +58,14 @@ function sanitizeEvent(event: SentryEvent): SentryEvent | null {
 let initialized = false;
 let captureEventFn: ((event: SentryEvent) => string) | null = null;
 let sentryModule: typeof import("@sentry/electron/main") | null = null;
+let initPromise: Promise<void> | null = null;
+let closingPromise: Promise<void> | null = null;
 
 const SENTRY_CLOSE_TIMEOUT_MS = 2000;
+// Cap the wait for in-flight init during shutdown. If init is still pending past
+// this, proceed with close — the alternative is blocking exit on a potentially
+// hung import.
+const SENTRY_INIT_WAIT_CAP_MS = 500;
 
 interface BufferedEvent {
   event: string;
@@ -71,36 +77,45 @@ const preConsentBuffer: BufferedEvent[] = [];
 const BUFFER_MAX = 100;
 
 export async function initializeTelemetry(): Promise<void> {
-  if (getTelemetryLevel() === "off") return;
-
-  const dsn = process.env.SENTRY_DSN;
-  if (!dsn) return;
-
   if (initialized) return;
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    if (getTelemetryLevel() === "off") return;
+
+    const dsn = process.env.SENTRY_DSN;
+    if (!dsn) return;
+
+    try {
+      const sentry = await import("@sentry/electron/main");
+      sentry.init({
+        dsn,
+        release: app.getVersion(),
+        environment: app.isPackaged ? "production" : "development",
+        // Do not set `sampleRate` — it defaults to 1.0 (100% error capture). If
+        // performance tracing is ever added, use `tracesSampleRate` instead.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        beforeSend: sanitizeEvent as any,
+        initialScope: {
+          tags: {
+            platform: process.platform,
+            arch: process.arch,
+            node: process.versions.node,
+          },
+        },
+      });
+      captureEventFn = sentry.captureEvent;
+      sentryModule = sentry;
+      initialized = true;
+    } catch (err) {
+      console.warn("[Telemetry] Failed to initialize Sentry:", err);
+    }
+  })();
 
   try {
-    const sentry = await import("@sentry/electron/main");
-    sentry.init({
-      dsn,
-      release: app.getVersion(),
-      environment: app.isPackaged ? "production" : "development",
-      // Do not set `sampleRate` — it defaults to 1.0 (100% error capture). If
-      // performance tracing is ever added, use `tracesSampleRate` instead.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      beforeSend: sanitizeEvent as any,
-      initialScope: {
-        tags: {
-          platform: process.platform,
-          arch: process.arch,
-          node: process.versions.node,
-        },
-      },
-    });
-    captureEventFn = sentry.captureEvent;
-    sentryModule = sentry;
-    initialized = true;
-  } catch (err) {
-    console.warn("[Telemetry] Failed to initialize Sentry:", err);
+    await initPromise;
+  } finally {
+    initPromise = null;
   }
 }
 
@@ -194,16 +209,37 @@ export function _getPreConsentBufferLength(): number {
 
 // Drain buffered Sentry events before process exit. Safe to call when telemetry
 // was never initialized (no-op) and idempotent. Never throws — telemetry failure
-// must never block app exit.
+// must never block app exit. Concurrent callers share a single in-flight drain.
 export async function closeTelemetry(): Promise<void> {
-  if (!initialized || !sentryModule) return;
-  const mod = sentryModule;
-  initialized = false;
-  captureEventFn = null;
-  sentryModule = null;
-  try {
-    await mod.close(SENTRY_CLOSE_TIMEOUT_MS);
-  } catch {
-    // never block exit on telemetry failure
-  }
+  if (closingPromise) return closingPromise;
+
+  closingPromise = (async () => {
+    // If init is still in flight, wait briefly so we don't miss late-arriving
+    // events. Cap the wait so a hung import can't block exit.
+    if (initPromise) {
+      await Promise.race([
+        initPromise.catch(() => {}),
+        new Promise<void>((resolve) => setTimeout(resolve, SENTRY_INIT_WAIT_CAP_MS)),
+      ]);
+    }
+
+    if (!initialized || !sentryModule) return;
+    const mod = sentryModule;
+    try {
+      const drained = await mod.close(SENTRY_CLOSE_TIMEOUT_MS);
+      if (drained === false) {
+        console.warn(
+          `[Telemetry] Sentry.close timed out after ${SENTRY_CLOSE_TIMEOUT_MS}ms; some events may be lost`
+        );
+      }
+    } catch {
+      // never block exit on telemetry failure
+    } finally {
+      initialized = false;
+      captureEventFn = null;
+      sentryModule = null;
+    }
+  })();
+
+  return closingPromise;
 }

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -29,6 +29,12 @@ vi.mock("electron", () => ({
   app: appMock,
 }));
 
+const telemetryServiceMock = vi.hoisted(() => ({
+  closeTelemetry: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../TelemetryService.js", () => telemetryServiceMock);
+
 import {
   isGpuDisabledByFlag,
   writeGpuDisabledFlag,
@@ -119,8 +125,12 @@ describe("GpuCrashMonitorService", () => {
       emitGpuCrash();
       emitGpuCrash();
       emitGpuCrash();
+      // Let the async crash handler flush — relaunch is sync, but exit is awaited
+      // after closeTelemetry.
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
       expect(appMock.relaunch).toHaveBeenCalledTimes(1);
-      expect(appMock.exit).toHaveBeenCalledWith(0);
       expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
     });
 
@@ -176,8 +186,10 @@ describe("GpuCrashMonitorService", () => {
       emitGpuCrash("oom");
       emitGpuCrash("launch-failed");
       emitGpuCrash("abnormal-exit");
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
       expect(appMock.relaunch).toHaveBeenCalledTimes(1);
-      expect(appMock.exit).toHaveBeenCalledWith(0);
     });
 
     it("persists store state on relaunch", async () => {
@@ -197,8 +209,35 @@ describe("GpuCrashMonitorService", () => {
       emitGpuCrash();
       emitGpuCrash();
       emitGpuCrash();
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledTimes(1);
+      });
       expect(appMock.relaunch).toHaveBeenCalledTimes(1);
-      expect(appMock.exit).toHaveBeenCalledTimes(1);
+    });
+
+    it("waits for closeTelemetry to resolve before app.exit(0) on relaunch", async () => {
+      let resolveClose!: () => void;
+      const deferred = new Promise<void>((r) => {
+        resolveClose = r;
+      });
+      telemetryServiceMock.closeTelemetry.mockReturnValueOnce(deferred);
+
+      await loadAndInit();
+      emitGpuCrash();
+      emitGpuCrash();
+      emitGpuCrash();
+
+      await vi.waitFor(() => {
+        expect(telemetryServiceMock.closeTelemetry).toHaveBeenCalled();
+      });
+      expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).not.toHaveBeenCalled();
+
+      resolveClose();
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
     });
 
     it("does not register duplicate listeners on double initialize", async () => {

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -3,6 +3,7 @@ import os from "os";
 
 const sentryInitMock = vi.hoisted(() => vi.fn());
 const captureEventMock = vi.hoisted(() => vi.fn(() => "mock-event-id"));
+const sentryCloseMock = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
 
 const storeMock = vi.hoisted(() => {
   const data: Record<string, unknown> = {
@@ -26,6 +27,7 @@ vi.mock("electron", () => ({
 vi.mock("@sentry/electron/main", () => ({
   init: sentryInitMock,
   captureEvent: captureEventMock,
+  close: sentryCloseMock,
 }));
 
 import {
@@ -399,5 +401,94 @@ describe("setTelemetryLevel with buffer", () => {
       trackEvent("onboarding_step_viewed", { step: "telemetry", i });
     }
     expect(_getPreConsentBufferLength()).toBe(100);
+  });
+});
+
+describe("closeTelemetry", () => {
+  // Use isolated module instances so each test starts with a clean `initialized` flag.
+  async function loadFreshModule() {
+    vi.resetModules();
+    return await import("../TelemetryService.js");
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sentryCloseMock.mockReset();
+    sentryCloseMock.mockResolvedValue(true);
+  });
+
+  it("is a no-op when telemetry was never initialized", async () => {
+    const mod = await loadFreshModule();
+    await mod.closeTelemetry();
+    expect(sentryCloseMock).not.toHaveBeenCalled();
+  });
+
+  it("calls Sentry.close(2000) after init", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    storeMock._data.telemetry = { enabled: true, hasSeenPrompt: true };
+    storeMock._data.privacy = { telemetryLevel: "errors", logRetentionDays: 30 };
+    storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+
+    const mod = await loadFreshModule();
+    await mod.initializeTelemetry();
+    await mod.closeTelemetry();
+
+    expect(sentryCloseMock).toHaveBeenCalledTimes(1);
+    expect(sentryCloseMock).toHaveBeenCalledWith(2000);
+
+    process.env.SENTRY_DSN = original;
+  });
+
+  it("swallows rejection from Sentry.close", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    storeMock._data.telemetry = { enabled: true, hasSeenPrompt: true };
+    storeMock._data.privacy = { telemetryLevel: "errors", logRetentionDays: 30 };
+    storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+
+    const mod = await loadFreshModule();
+    await mod.initializeTelemetry();
+    sentryCloseMock.mockRejectedValueOnce(new Error("transport exploded"));
+
+    await expect(mod.closeTelemetry()).resolves.toBeUndefined();
+
+    process.env.SENTRY_DSN = original;
+  });
+
+  it("is idempotent — second call is a no-op", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    storeMock._data.telemetry = { enabled: true, hasSeenPrompt: true };
+    storeMock._data.privacy = { telemetryLevel: "errors", logRetentionDays: 30 };
+    storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+
+    const mod = await loadFreshModule();
+    await mod.initializeTelemetry();
+    await mod.closeTelemetry();
+    expect(sentryCloseMock).toHaveBeenCalledTimes(1);
+
+    await mod.closeTelemetry();
+    expect(sentryCloseMock).toHaveBeenCalledTimes(1);
+
+    process.env.SENTRY_DSN = original;
+  });
+
+  it("stops capturing new events after close", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    storeMock._data.telemetry = { enabled: true, hasSeenPrompt: true };
+    storeMock._data.privacy = { telemetryLevel: "full", logRetentionDays: 30 };
+    storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+
+    const mod = await loadFreshModule();
+    await mod.initializeTelemetry();
+    captureEventMock.mockClear();
+
+    await mod.closeTelemetry();
+    mod.trackEvent("post_close_event", {});
+    expect(captureEventMock).not.toHaveBeenCalled();
+
+    process.env.SENTRY_DSN = original;
   });
 });


### PR DESCRIPTION
## Summary

- Sentry's in-flight envelope queue was never drained before `app.exit()`, so errors captured in the final seconds of a session (and any retries from transient transport failures earlier) were silently discarded along with the process.
- Added a `closeTelemetry()` helper in `TelemetryService` that calls `Sentry.close(2000)` and is idempotent across concurrent callers (shared `closingPromise`). It also waits up to 500ms for Sentry init if called during startup, and logs a warning when Sentry reports a flush timeout.
- Wired `closeTelemetry()` into every graceful `app.exit()` path: the before-quit shutdown handler (success, error, and hard-timeout branches), `PRIVACY_RESET_ALL_DATA`, `GPU_SET_HARDWARE_ACCELERATION`, and the `GpuCrashMonitorService` 3-crash relaunch.

Excluded by design: AutoUpdater relaunch (already triggers before-quit), `APP_FORCE_QUIT` (explicitly non-graceful), the signal safety-belt, startup-failure exits, and `globalErrorHandlers` crash paths. None of those are situations where blocking to flush makes sense.

Resolves #5254.

## Changes

- `electron/services/TelemetryService.ts` — new `closeTelemetry()` export; idempotent, init-race-safe, never throws
- `electron/lifecycle/shutdown.ts` — await `closeTelemetry()` in all three exit branches
- `electron/ipc/handlers/app/gpu.ts` — await `closeTelemetry()` before hardware acceleration restart
- `electron/ipc/handlers/privacy.ts` — await `closeTelemetry()` before privacy reset exit
- `electron/services/GpuCrashMonitorService.ts` — await `closeTelemetry()` before crash-triggered relaunch
- Tests added for `closeTelemetry` init-race and concurrent-caller behaviour; shutdown ordering tests converted to deferred-promise pattern to properly prove the await boundary; regression tests added for GPU relaunch and privacy/GPU handler exit paths.

## Testing

Unit tests cover the new helper directly (init race, concurrent callers) and the call sites via regression tests. The existing shutdown ordering tests were reworked to use deferred promises so they actually verify that `closeTelemetry` is awaited before `app.exit` is called, rather than just checking call order after the fact.