### PR TITLE
fix(telemetry): consolidate consent to single privacy.* source of truth

### DIFF
--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -96,8 +96,7 @@ export function registerOnboardingHandlers(): () => void {
     if (state.migratedFromLocalStorage) return state;
 
     const p = (payload ?? {}) as Partial<MigratePayload>;
-    const telemetryState = store.get("telemetry");
-    const telemetrySeen = telemetryState?.hasSeenPrompt ?? false;
+    const telemetrySeen = store.get("privacy")?.hasSeenPrompt ?? false;
     const agentSelectionDismissed = p.agentSelectionDismissed === true;
     const agentSetupComplete = p.agentSetupComplete === true;
     const firstRunToastSeen = p.firstRunToastSeen === true;

--- a/electron/ipc/handlers/privacy.ts
+++ b/electron/ipc/handlers/privacy.ts
@@ -34,6 +34,7 @@ export function registerPrivacyHandlers(): () => void {
       return;
     const privacy = store.get("privacy") ?? {
       telemetryLevel: "off" as const,
+      hasSeenPrompt: false,
       logRetentionDays: 30 as const,
     };
     store.set("privacy", { ...privacy, logRetentionDays: days as 7 | 30 | 90 | 0 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -58,7 +58,6 @@ import { store } from "./store.js";
 import { pruneOldLogs, initializeLogger, registerLoggerTransport } from "./utils/logger.js";
 import { broadcastToRenderer } from "./ipc/utils.js";
 import { registerCommands } from "./services/commands/index.js";
-import { initializeTelemetry } from "./services/TelemetryService.js";
 import { initializeCrashRecoveryService } from "./services/CrashRecoveryService.js";
 import { initializeGpuCrashMonitor } from "./services/GpuCrashMonitorService.js";
 import { initializeTrashedPidCleanup } from "./services/TrashedPidTracker.js";
@@ -137,8 +136,6 @@ if (!gotTheLock) {
   registerLoggerTransport(broadcastToRenderer, () => BrowserWindow.getAllWindows().length > 0);
 
   registerCommands();
-
-  void initializeTelemetry();
 
   crashReporter.start({ uploadToServer: false });
   initializeCrashLoopGuard();

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -68,8 +68,7 @@ const preConsentBuffer: BufferedEvent[] = [];
 const BUFFER_MAX = 100;
 
 export async function initializeTelemetry(): Promise<void> {
-  const { enabled } = store.get("telemetry") ?? { enabled: false, hasSeenPrompt: false };
-  if (!enabled) return;
+  if (getTelemetryLevel() === "off") return;
 
   const dsn = process.env.SENTRY_DSN;
   if (!dsn) return;
@@ -101,36 +100,27 @@ export async function initializeTelemetry(): Promise<void> {
   }
 }
 
-export function isTelemetryEnabled(): boolean {
-  return store.get("telemetry")?.enabled ?? false;
-}
-
 export type TelemetryLevel = "off" | "errors" | "full";
 
-export function getTelemetryLevel(): TelemetryLevel {
-  const privacy = store.get("privacy");
-  if (privacy?.telemetryLevel) return privacy.telemetryLevel;
+const DEFAULT_PRIVACY = {
+  telemetryLevel: "off" as const,
+  hasSeenPrompt: false,
+  logRetentionDays: 30 as const,
+};
 
-  // Migrate from legacy boolean
-  const enabled = store.get("telemetry")?.enabled ?? false;
-  const level: TelemetryLevel = enabled ? "errors" : "off";
-  store.set("privacy", { ...privacy, telemetryLevel: level });
-  return level;
+export function getTelemetryLevel(): TelemetryLevel {
+  return store.get("privacy")?.telemetryLevel ?? "off";
+}
+
+export function isTelemetryEnabled(): boolean {
+  return getTelemetryLevel() !== "off";
 }
 
 export async function setTelemetryLevel(level: TelemetryLevel): Promise<void> {
-  const privacy = store.get("privacy") ?? {
-    telemetryLevel: "off" as const,
-    logRetentionDays: 30 as const,
-  };
+  const privacy = store.get("privacy") ?? DEFAULT_PRIVACY;
   store.set("privacy", { ...privacy, telemetryLevel: level });
 
-  // Keep legacy telemetry.enabled in sync
-  const enabled = level !== "off";
-  const telemetry = store.get("telemetry") ?? { enabled: false, hasSeenPrompt: false };
-  store.set("telemetry", { ...telemetry, enabled });
-
-  if (enabled) {
+  if (level !== "off") {
     await initializeTelemetry();
     flushPreConsentBuffer();
   } else {
@@ -139,22 +129,7 @@ export async function setTelemetryLevel(level: TelemetryLevel): Promise<void> {
 }
 
 export async function setTelemetryEnabled(enabled: boolean): Promise<void> {
-  const current = store.get("telemetry") ?? { enabled: false, hasSeenPrompt: false };
-  store.set("telemetry", { ...current, enabled });
-
-  // Keep privacy.telemetryLevel in sync
-  const privacy = store.get("privacy") ?? {
-    telemetryLevel: "off" as const,
-    logRetentionDays: 30 as const,
-  };
-  store.set("privacy", { ...privacy, telemetryLevel: enabled ? "errors" : "off" });
-
-  if (enabled) {
-    await initializeTelemetry();
-    flushPreConsentBuffer();
-  } else {
-    preConsentBuffer.length = 0;
-  }
+  await setTelemetryLevel(enabled ? "errors" : "off");
 }
 
 function flushPreConsentBuffer(): void {
@@ -171,8 +146,7 @@ function flushPreConsentBuffer(): void {
 }
 
 export function trackEvent(event: string, properties: Record<string, unknown> = {}): void {
-  const telemetry = store.get("telemetry");
-  const hasSeenPrompt = telemetry?.hasSeenPrompt ?? false;
+  const hasSeenPrompt = hasTelemetryPromptBeenShown();
   const level = getTelemetryLevel();
 
   // Only send analytics events at "full" level; "errors" only permits crash reports via Sentry
@@ -197,12 +171,12 @@ export function trackEvent(event: string, properties: Record<string, unknown> = 
 }
 
 export function hasTelemetryPromptBeenShown(): boolean {
-  return store.get("telemetry")?.hasSeenPrompt ?? false;
+  return store.get("privacy")?.hasSeenPrompt ?? false;
 }
 
 export function markTelemetryPromptShown(): void {
-  const current = store.get("telemetry") ?? { enabled: false, hasSeenPrompt: false };
-  store.set("telemetry", { ...current, hasSeenPrompt: true });
+  const privacy = store.get("privacy") ?? DEFAULT_PRIVACY;
+  store.set("privacy", { ...privacy, hasSeenPrompt: true });
 }
 
 export function _getPreConsentBufferLength(): number {

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -120,9 +120,14 @@ export async function setTelemetryLevel(level: TelemetryLevel): Promise<void> {
   const privacy = store.get("privacy") ?? DEFAULT_PRIVACY;
   store.set("privacy", { ...privacy, telemetryLevel: level });
 
-  if (level !== "off") {
+  if (level === "full") {
     await initializeTelemetry();
     flushPreConsentBuffer();
+  } else if (level === "errors") {
+    // Errors-only consent covers crash reports, not analytics — drop any
+    // buffered onboarding analytics rather than replaying them to Sentry.
+    preConsentBuffer.length = 0;
+    await initializeTelemetry();
   } else {
     preConsentBuffer.length = 0;
   }

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -6,7 +6,7 @@ const captureEventMock = vi.hoisted(() => vi.fn(() => "mock-event-id"));
 
 const storeMock = vi.hoisted(() => {
   const data: Record<string, unknown> = {
-    telemetry: { enabled: false, hasSeenPrompt: false },
+    privacy: { telemetryLevel: "off", hasSeenPrompt: false, logRetentionDays: 30 },
   };
   return {
     get: vi.fn((key: string) => data[key]),
@@ -33,11 +33,27 @@ import {
   initializeTelemetry,
   isTelemetryEnabled,
   setTelemetryEnabled,
+  setTelemetryLevel,
+  getTelemetryLevel,
   hasTelemetryPromptBeenShown,
   markTelemetryPromptShown,
   trackEvent,
   _getPreConsentBufferLength,
 } from "../TelemetryService.js";
+
+function setPrivacy(patch: {
+  telemetryLevel?: "off" | "errors" | "full";
+  hasSeenPrompt?: boolean;
+}) {
+  storeMock._data.privacy = {
+    telemetryLevel: "off",
+    hasSeenPrompt: false,
+    logRetentionDays: 30,
+    ...(storeMock._data.privacy as Record<string, unknown>),
+    ...patch,
+  };
+  storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+}
 
 describe("sanitizePath", () => {
   it("redacts macOS home dir username", () => {
@@ -72,102 +88,150 @@ describe("sanitizePath", () => {
   });
 });
 
-describe("isTelemetryEnabled", () => {
+describe("getTelemetryLevel", () => {
   beforeEach(() => {
-    storeMock.get.mockImplementation((key: string) => {
-      if (key === "telemetry") return { enabled: false, hasSeenPrompt: false };
-      return undefined;
-    });
     vi.clearAllMocks();
-    storeMock.get.mockImplementation((key: string) => {
-      if (key === "telemetry") return { enabled: false, hasSeenPrompt: false };
-      return undefined;
-    });
+    setPrivacy({ telemetryLevel: "off" });
   });
 
-  it("returns false when disabled", () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+  it("returns the stored privacy.telemetryLevel", () => {
+    setPrivacy({ telemetryLevel: "errors" });
+    expect(getTelemetryLevel()).toBe("errors");
+  });
+
+  it("returns 'off' when privacy is missing", () => {
+    storeMock.get.mockReturnValue(undefined);
+    expect(getTelemetryLevel()).toBe("off");
+  });
+
+  it("does NOT write to the store on read (no lazy migration)", () => {
+    storeMock.get.mockReturnValue(undefined);
+    getTelemetryLevel();
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+});
+
+describe("isTelemetryEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when level is 'off'", () => {
+    setPrivacy({ telemetryLevel: "off" });
     expect(isTelemetryEnabled()).toBe(false);
   });
 
-  it("returns true when enabled", () => {
-    storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
+  it("returns true when level is 'errors'", () => {
+    setPrivacy({ telemetryLevel: "errors" });
     expect(isTelemetryEnabled()).toBe(true);
   });
 
-  it("returns false when telemetry key is undefined", () => {
+  it("returns true when level is 'full'", () => {
+    setPrivacy({ telemetryLevel: "full" });
+    expect(isTelemetryEnabled()).toBe(true);
+  });
+
+  it("returns false when privacy is undefined", () => {
     storeMock.get.mockReturnValue(undefined);
     expect(isTelemetryEnabled()).toBe(false);
   });
 });
 
-describe("setTelemetryEnabled", () => {
+describe("setTelemetryLevel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
   });
 
-  it("stores enabled=true", async () => {
+  it("writes telemetryLevel to privacy without touching any legacy telemetry key", async () => {
+    await setTelemetryLevel("errors");
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "errors" })
+    );
+    for (const call of storeMock.set.mock.calls) {
+      expect(call[0]).not.toBe("telemetry");
+    }
+  });
+
+  it("preserves hasSeenPrompt when writing telemetryLevel", async () => {
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: true });
+    await setTelemetryLevel("full");
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "full", hasSeenPrompt: true })
+    );
+  });
+});
+
+describe("setTelemetryEnabled (compat shim)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPrivacy({ telemetryLevel: "off" });
+  });
+
+  it("maps true to 'errors'", async () => {
     await setTelemetryEnabled(true);
-    expect(storeMock.set).toHaveBeenCalledWith("telemetry", {
-      enabled: true,
-      hasSeenPrompt: false,
-    });
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "errors" })
+    );
   });
 
-  it("stores enabled=false", async () => {
-    storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
+  it("maps false to 'off'", async () => {
+    setPrivacy({ telemetryLevel: "errors" });
     await setTelemetryEnabled(false);
-    expect(storeMock.set).toHaveBeenCalledWith("telemetry", {
-      enabled: false,
-      hasSeenPrompt: true,
-    });
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "off" })
+    );
   });
 });
 
 describe("hasTelemetryPromptBeenShown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads privacy.hasSeenPrompt", () => {
+    setPrivacy({ hasSeenPrompt: true });
+    expect(hasTelemetryPromptBeenShown()).toBe(true);
+  });
+
   it("returns false when not shown", () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ hasSeenPrompt: false });
     expect(hasTelemetryPromptBeenShown()).toBe(false);
   });
 
-  it("returns true when shown", () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: true });
-    expect(hasTelemetryPromptBeenShown()).toBe(true);
+  it("returns false when privacy is missing", () => {
+    storeMock.get.mockReturnValue(undefined);
+    expect(hasTelemetryPromptBeenShown()).toBe(false);
   });
 });
 
 describe("markTelemetryPromptShown", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
   });
 
-  it("sets hasSeenPrompt to true", () => {
+  it("writes hasSeenPrompt=true on the privacy object (not telemetry)", () => {
     markTelemetryPromptShown();
-    expect(storeMock.set).toHaveBeenCalledWith("telemetry", {
-      enabled: false,
-      hasSeenPrompt: true,
-    });
-  });
-});
-
-describe("sanitizeEvent (via beforeSend logic)", () => {
-  it("sanitizes stack frame filenames", () => {
-    const filename = "/Users/johndoe/projects/daintree/electron/main.ts";
-    expect(sanitizePath(filename)).toBe("/Users/USER/projects/daintree/electron/main.ts");
-  });
-
-  it("sanitizes error message text containing paths", () => {
-    const msg = "ENOENT: no such file or directory, open '/Users/alice/code/app/config.json'";
-    expect(sanitizePath(msg)).toBe(
-      "ENOENT: no such file or directory, open '/Users/USER/code/app/config.json'"
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ hasSeenPrompt: true })
     );
+    for (const call of storeMock.set.mock.calls) {
+      expect(call[0]).not.toBe("telemetry");
+    }
   });
 
-  it("sanitizes Windows-style forward-slash paths", () => {
-    expect(sanitizePath("C:/Users/bob/AppData/Roaming/daintree/log.txt")).toBe(
-      "C:/Users/USER/AppData/Roaming/daintree/log.txt"
+  it("preserves telemetryLevel and other privacy fields", () => {
+    setPrivacy({ telemetryLevel: "full", hasSeenPrompt: false });
+    markTelemetryPromptShown();
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "full", hasSeenPrompt: true })
     );
   });
 });
@@ -178,14 +242,14 @@ describe("initializeTelemetry", () => {
     sentryInitMock.mockReset();
   });
 
-  it("does not call Sentry.init when telemetry is disabled", async () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+  it("does not call Sentry.init when telemetry level is 'off'", async () => {
+    setPrivacy({ telemetryLevel: "off" });
     await initializeTelemetry();
     expect(sentryInitMock).not.toHaveBeenCalled();
   });
 
   it("does not call Sentry.init when DSN is empty", async () => {
-    storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
+    setPrivacy({ telemetryLevel: "errors" });
     const original = process.env.SENTRY_DSN;
     process.env.SENTRY_DSN = "";
     await initializeTelemetry();
@@ -194,9 +258,9 @@ describe("initializeTelemetry", () => {
   });
 
   it("does not drop error events via sampleRate when initialized", async () => {
+    setPrivacy({ telemetryLevel: "errors" });
     const original = process.env.SENTRY_DSN;
     process.env.SENTRY_DSN = "https://test@sentry.io/123";
-    storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
     await initializeTelemetry();
     expect(sentryInitMock).toHaveBeenCalledTimes(1);
     const options = sentryInitMock.mock.calls[0][0] as Record<string, unknown>;
@@ -206,40 +270,45 @@ describe("initializeTelemetry", () => {
     expect(options).not.toHaveProperty("sampleRate");
     process.env.SENTRY_DSN = original;
   });
+
+  it("gates on privacy.telemetryLevel, not any legacy telemetry.enabled field", async () => {
+    // Simulate a privacy-opted-in user where a legacy `telemetry` key is absent.
+    setPrivacy({ telemetryLevel: "errors" });
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    await initializeTelemetry();
+    expect(sentryInitMock).toHaveBeenCalled();
+    process.env.SENTRY_DSN = original;
+  });
 });
 
 describe("trackEvent", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     captureEventMock.mockClear();
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
-    // Clear the buffer by disabling telemetry
-    // (preConsentBuffer.length = 0 happens inside setTelemetryEnabled(false))
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+    await setTelemetryEnabled(false); // clears buffer
   });
 
-  it("buffers events before consent is decided", async () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+  it("buffers events before consent is decided", () => {
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
     trackEvent("onboarding_step_viewed", { step: "telemetry" });
     expect(_getPreConsentBufferLength()).toBeGreaterThan(0);
     expect(captureEventMock).not.toHaveBeenCalled();
   });
 
   it("drops events when consent was explicitly denied", async () => {
-    // Clear buffer first
-    await setTelemetryEnabled(false);
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: true });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: true });
     const before = _getPreConsentBufferLength();
     trackEvent("onboarding_step_viewed", { step: "telemetry" });
     expect(_getPreConsentBufferLength()).toBe(before);
     expect(captureEventMock).not.toHaveBeenCalled();
   });
 
-  it("sends directly when telemetry is enabled and Sentry is initialized", async () => {
+  it("sends directly when telemetry is at 'full' and Sentry is initialized", async () => {
     const original = process.env.SENTRY_DSN;
     process.env.SENTRY_DSN = "https://test@sentry.io/123";
-    storeMock._data.telemetry = { enabled: true, hasSeenPrompt: true };
-    storeMock._data.privacy = { telemetryLevel: "full", logRetentionDays: 30 };
-    storeMock.get.mockImplementation((key: string) => storeMock._data[key]);
+    setPrivacy({ telemetryLevel: "full", hasSeenPrompt: true });
     await initializeTelemetry();
     captureEventMock.mockClear();
 
@@ -256,21 +325,20 @@ describe("trackEvent", () => {
 
   it("does not write buffer contents to the store", () => {
     storeMock.set.mockClear();
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
     trackEvent("onboarding_step_viewed", { step: "telemetry" });
     trackEvent("onboarding_step_viewed", { step: "agentSelection" });
-    // store.set should NOT have been called with any buffer data
     for (const call of storeMock.set.mock.calls) {
       expect(call[0]).not.toContain("buffer");
     }
   });
 });
 
-describe("setTelemetryEnabled with buffer", () => {
+describe("setTelemetryLevel with buffer", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     captureEventMock.mockClear();
-    // Clean buffer
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
     await setTelemetryEnabled(false);
   });
 
@@ -278,14 +346,13 @@ describe("setTelemetryEnabled with buffer", () => {
     const original = process.env.SENTRY_DSN;
     process.env.SENTRY_DSN = "https://test@sentry.io/123";
 
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
     trackEvent("onboarding_step_viewed", { step: "telemetry" });
     trackEvent("onboarding_step_viewed", { step: "agentSelection" });
 
-    // Now enable — this should flush
-    storeMock.get.mockReturnValue({ enabled: true, hasSeenPrompt: true });
+    setPrivacy({ telemetryLevel: "full", hasSeenPrompt: true });
     captureEventMock.mockClear();
-    await setTelemetryEnabled(true);
+    await setTelemetryLevel("full");
 
     expect(captureEventMock).toHaveBeenCalledTimes(2);
     expect(_getPreConsentBufferLength()).toBe(0);
@@ -294,20 +361,19 @@ describe("setTelemetryEnabled with buffer", () => {
   });
 
   it("discards buffer when consent denied", async () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
     trackEvent("onboarding_step_viewed", { step: "telemetry" });
     expect(_getPreConsentBufferLength()).toBeGreaterThan(0);
 
-    await setTelemetryEnabled(false);
+    await setTelemetryLevel("off");
     expect(_getPreConsentBufferLength()).toBe(0);
     expect(captureEventMock).not.toHaveBeenCalled();
   });
 
   it("respects buffer cap", async () => {
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
-    // Clear buffer
-    await setTelemetryEnabled(false);
-    storeMock.get.mockReturnValue({ enabled: false, hasSeenPrompt: false });
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+    await setTelemetryLevel("off");
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
 
     for (let i = 0; i < 110; i++) {
       trackEvent("onboarding_step_viewed", { step: "telemetry", i });

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -370,6 +370,26 @@ describe("setTelemetryLevel with buffer", () => {
     expect(captureEventMock).not.toHaveBeenCalled();
   });
 
+  it("drops (does NOT flush) the buffer at 'errors' level", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+    trackEvent("onboarding_step_viewed", { step: "telemetry" });
+    trackEvent("onboarding_step_viewed", { step: "agentSelection" });
+    expect(_getPreConsentBufferLength()).toBe(2);
+
+    setPrivacy({ telemetryLevel: "errors", hasSeenPrompt: true });
+    captureEventMock.mockClear();
+    await setTelemetryLevel("errors");
+
+    // "errors" permits crash reports only — analytics events must NOT be replayed.
+    expect(captureEventMock).not.toHaveBeenCalled();
+    expect(_getPreConsentBufferLength()).toBe(0);
+
+    process.env.SENTRY_DSN = original;
+  });
+
   it("respects buffer cap", async () => {
     setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
     await setTelemetryLevel("off");

--- a/electron/services/migrations/014-consolidate-telemetry-consent.ts
+++ b/electron/services/migrations/014-consolidate-telemetry-consent.ts
@@ -1,0 +1,59 @@
+import type { Migration } from "../StoreMigrations.js";
+
+type TelemetryLevel = "off" | "errors" | "full";
+
+interface PrivacySnapshot {
+  telemetryLevel?: TelemetryLevel;
+  hasSeenPrompt?: boolean;
+  logRetentionDays?: 7 | 30 | 90 | 0;
+  [key: string]: unknown;
+}
+
+interface LegacyTelemetry {
+  enabled?: unknown;
+  hasSeenPrompt?: unknown;
+  [key: string]: unknown;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isValidLevel(value: unknown): value is TelemetryLevel {
+  return value === "off" || value === "errors" || value === "full";
+}
+
+export const migration014: Migration = {
+  version: 14,
+  description:
+    "Consolidate telemetry consent into privacy.{telemetryLevel,hasSeenPrompt} and drop legacy telemetry key (issue #5257)",
+  up: (store) => {
+    const legacyRaw = (store as unknown as { get: (k: string) => unknown }).get("telemetry");
+    const privacyRaw = store.get("privacy") as unknown;
+
+    const legacy: LegacyTelemetry = isPlainObject(legacyRaw) ? (legacyRaw as LegacyTelemetry) : {};
+    const privacy: PrivacySnapshot = isPlainObject(privacyRaw)
+      ? (privacyRaw as PrivacySnapshot)
+      : {};
+
+    const nextPrivacy: PrivacySnapshot = { ...privacy };
+
+    if (!isValidLevel(nextPrivacy.telemetryLevel)) {
+      nextPrivacy.telemetryLevel = legacy.enabled === true ? "errors" : "off";
+    }
+
+    if (typeof nextPrivacy.hasSeenPrompt !== "boolean") {
+      nextPrivacy.hasSeenPrompt = legacy.hasSeenPrompt === true;
+    }
+
+    store.set("privacy", nextPrivacy as never);
+
+    // Remove the legacy top-level key. electron-store v11 throws on
+    // `store.set(key, undefined)`, so use `delete` directly. The TypeScript
+    // schema no longer includes `telemetry`, so the cast is required.
+    const legacyDelete = (store as unknown as { delete?: (key: string) => void }).delete;
+    if (typeof legacyDelete === "function" && legacyRaw !== undefined) {
+      legacyDelete.call(store, "telemetry");
+    }
+  },
+};

--- a/electron/services/migrations/__tests__/014-consolidate-telemetry-consent.test.ts
+++ b/electron/services/migrations/__tests__/014-consolidate-telemetry-consent.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { migration014 } from "../014-consolidate-telemetry-consent.js";
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    delete: vi.fn((key: string) => {
+      delete data[key];
+    }),
+    _data: data,
+  } as unknown as Parameters<typeof migration014.up>[0] & {
+    _data: Record<string, unknown>;
+  };
+}
+
+describe("migration014 — consolidate telemetry consent", () => {
+  it("has version 14", () => {
+    expect(migration014.version).toBe(14);
+  });
+
+  it("migrates legacy enabled=true to privacy.telemetryLevel='errors'", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: true, hasSeenPrompt: true },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "errors", hasSeenPrompt: true })
+    );
+    expect((store as unknown as { delete: ReturnType<typeof vi.fn> }).delete).toHaveBeenCalledWith(
+      "telemetry"
+    );
+    expect((store as unknown as { _data: Record<string, unknown> })._data.telemetry).toBeUndefined();
+  });
+
+  it("migrates legacy enabled=false to privacy.telemetryLevel='off'", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: false, hasSeenPrompt: false },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "off", hasSeenPrompt: false })
+    );
+  });
+
+  it("preserves an existing privacy.telemetryLevel when legacy disagrees", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: true, hasSeenPrompt: false },
+      privacy: { telemetryLevel: "full", logRetentionDays: 30 },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "full", logRetentionDays: 30 })
+    );
+  });
+
+  it("preserves an existing privacy.hasSeenPrompt when both are set", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: true, hasSeenPrompt: false },
+      privacy: { telemetryLevel: "errors", hasSeenPrompt: true, logRetentionDays: 30 },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ hasSeenPrompt: true })
+    );
+  });
+
+  it("defaults to off/false when neither legacy nor privacy has values", () => {
+    const store = makeStoreMock({});
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "off", hasSeenPrompt: false })
+    );
+  });
+
+  it("is idempotent — a second run with no telemetry key produces no delete call", () => {
+    const data: Record<string, unknown> = {
+      telemetry: { enabled: true, hasSeenPrompt: true },
+    };
+    const store = makeStoreMock(data);
+
+    migration014.up(store);
+    const firstDelete = (store as unknown as { delete: ReturnType<typeof vi.fn> }).delete.mock.calls
+      .length;
+    expect(firstDelete).toBe(1);
+    expect(data.telemetry).toBeUndefined();
+
+    migration014.up(store);
+    const secondDelete = (store as unknown as { delete: ReturnType<typeof vi.fn> }).delete.mock
+      .calls.length;
+    expect(secondDelete).toBe(1); // no additional delete call
+  });
+
+  it("does not throw on malformed telemetry shapes", () => {
+    const shapes: Array<[string, unknown]> = [
+      ["telemetry null", null],
+      ["telemetry array", []],
+      ["telemetry string", "nope"],
+      ["telemetry enabled non-bool", { enabled: "yes", hasSeenPrompt: "yes" }],
+    ];
+    for (const [label, value] of shapes) {
+      const store = makeStoreMock({ telemetry: value });
+      expect(() => migration014.up(store), `case: ${label}`).not.toThrow();
+    }
+  });
+
+  it("treats non-true legacy enabled as 'off'", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: "yes", hasSeenPrompt: false },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "off" })
+    );
+  });
+
+  it("preserves unrelated privacy fields (logRetentionDays)", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: true, hasSeenPrompt: true },
+      privacy: { logRetentionDays: 7 },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({
+        telemetryLevel: "errors",
+        hasSeenPrompt: true,
+        logRetentionDays: 7,
+      })
+    );
+  });
+});

--- a/electron/services/migrations/__tests__/014-consolidate-telemetry-consent.test.ts
+++ b/electron/services/migrations/__tests__/014-consolidate-telemetry-consent.test.ts
@@ -122,6 +122,18 @@ describe("migration014 — consolidate telemetry consent", () => {
     );
   });
 
+  it("does not regress privacy='full' when legacy telemetry.enabled=false", () => {
+    const store = makeStoreMock({
+      telemetry: { enabled: false, hasSeenPrompt: true },
+      privacy: { telemetryLevel: "full", hasSeenPrompt: true, logRetentionDays: 30 },
+    });
+    migration014.up(store);
+    expect(store.set).toHaveBeenCalledWith(
+      "privacy",
+      expect.objectContaining({ telemetryLevel: "full", hasSeenPrompt: true })
+    );
+  });
+
   it("preserves unrelated privacy fields (logRetentionDays)", () => {
     const store = makeStoreMock({
       telemetry: { enabled: true, hasSeenPrompt: true },

--- a/electron/services/migrations/__tests__/014-consolidate-telemetry-consent.test.ts
+++ b/electron/services/migrations/__tests__/014-consolidate-telemetry-consent.test.ts
@@ -33,7 +33,9 @@ describe("migration014 — consolidate telemetry consent", () => {
     expect((store as unknown as { delete: ReturnType<typeof vi.fn> }).delete).toHaveBeenCalledWith(
       "telemetry"
     );
-    expect((store as unknown as { _data: Record<string, unknown> })._data.telemetry).toBeUndefined();
+    expect(
+      (store as unknown as { _data: Record<string, unknown> })._data.telemetry
+    ).toBeUndefined();
   });
 
   it("migrates legacy enabled=false to privacy.telemetryLevel='off'", () => {

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -11,6 +11,7 @@ import { migration010 } from "./010-add-working-pulse-setting.js";
 import { migration011 } from "./011-minimal-soundscape-defaults.js";
 import { migration012 } from "./012-default-pin-agents.js";
 import { migration013 } from "./013-cleanup-phantom-pins.js";
+import { migration014 } from "./014-consolidate-telemetry-consent.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -25,4 +26,5 @@ export const migrations: Migration[] = [
   migration011,
   migration012,
   migration013,
+  migration014,
 ];

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -147,12 +147,9 @@ export interface StoreSchema {
   >;
   worktreeIssueMap: Record<string, IssueAssociation>;
   appTheme: Partial<AppThemeConfig>;
-  telemetry: {
-    enabled: boolean;
-    hasSeenPrompt: boolean;
-  };
   privacy: {
     telemetryLevel: "off" | "errors" | "full";
+    hasSeenPrompt: boolean;
     logRetentionDays: 7 | 30 | 90 | 0;
   };
   voiceInput: {
@@ -273,12 +270,9 @@ const storeOptions = {
     windowStates: {},
     worktreeIssueMap: {},
     appTheme: {},
-    telemetry: {
-      enabled: false,
-      hasSeenPrompt: false,
-    },
     privacy: {
       telemetryLevel: "off" as const,
+      hasSeenPrompt: false,
       logRetentionDays: 30 as const,
     },
     voiceInput: {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -24,6 +24,7 @@ import { taskQueueService } from "../services/TaskQueueService.js";
 import { store } from "../store.js";
 import { MigrationRunner } from "../services/StoreMigrations.js";
 import { migrations } from "../services/migrations/index.js";
+import { initializeTelemetry } from "../services/TelemetryService.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { secureStorage } from "../services/SecureStorage.js";
 import { notificationService } from "../services/NotificationService.js";
@@ -301,6 +302,10 @@ export async function setupWindowServices(
         .catch(() => app.exit(1));
       return;
     }
+
+    // Initialize Sentry after migrations — reads privacy.telemetryLevel,
+    // which is guaranteed populated by migration014.
+    void initializeTelemetry();
 
     // Initialize GitHubAuth
     GitHubAuth.initializeStorage({


### PR DESCRIPTION
## Summary

- Removes the duplicate `telemetry.enabled` boolean field and makes `privacy.telemetryLevel` the single source of truth for consent state
- Adds migration 014 that reads the legacy field on first boot and promotes it to `privacy.telemetryLevel`, then drops it from the store schema so nothing can write to it again
- Cleans up `TelemetryService` by removing the two-way sync logic and consolidating all reads/writes through the `privacy.*` namespace

Resolves #5257

## Changes

- `electron/services/TelemetryService.ts` — removed `getTelemetryLevel()` migration shim, `setTelemetryEnabled()`, and all dual-write paths; service now reads/writes only `privacy.telemetryLevel`
- `electron/services/migrations/014-consolidate-telemetry-consent.ts` — new migration that handles the one-time promotion of legacy `telemetry.enabled` + `telemetry.hasSeenPrompt` to `privacy.*`
- `electron/store.ts` — removed `telemetry` block from the store schema
- `electron/ipc/handlers/onboarding.ts`, `electron/window/windowServices.ts` — updated callsites to use the consolidated API
- Tests updated throughout to reflect the simplified surface

## Testing

Full unit test suite passes. Migration 014 has its own test file covering all transition cases: fresh install, legacy opt-in, legacy opt-out, already-migrated state, and the `hasSeenPrompt` flag promotion.