### PR TITLE
fix(sentry): capture renderer errors via @sentry/electron/renderer

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -469,6 +469,10 @@ export const CHANNELS = {
   PRIVACY_CLEAR_CACHE: "privacy:clear-cache",
   PRIVACY_RESET_ALL_DATA: "privacy:reset-all-data",
   PRIVACY_GET_DATA_FOLDER_PATH: "privacy:get-data-folder-path",
+  PRIVACY_TELEMETRY_CONSENT_CHANGED: "privacy:telemetry-consent-changed",
+
+  // Sentry channels
+  SENTRY_GET_CONSENT_STATE: "sentry:get-consent-state",
 
   // MCP Server channels
   MCP_SERVER_GET_STATUS: "mcp-server:get-status",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -37,6 +37,7 @@ import { registerClipboardHandlers } from "./handlers/clipboard.js";
 import { registerGitWriteHandlers } from "./handlers/git-write.js";
 import { registerTelemetryHandlers } from "./handlers/telemetry.js";
 import { registerPrivacyHandlers } from "./handlers/privacy.js";
+import { registerSentryHandlers } from "./handlers/sentry.js";
 import { registerOnboardingHandlers } from "./handlers/onboarding.js";
 import { registerMilestonesHandlers } from "./handlers/milestones.js";
 import { registerShortcutHintsHandlers } from "./handlers/shortcutHints.js";
@@ -131,6 +132,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerGitWriteHandlers(deps));
     register(() => registerTelemetryHandlers());
     register(() => registerPrivacyHandlers());
+    register(() => registerSentryHandlers());
     register(() => registerOnboardingHandlers());
     register(() => registerMilestonesHandlers());
     register(() => registerShortcutHintsHandlers());

--- a/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
@@ -43,11 +43,18 @@ vi.mock("../../../store.js", () => ({ store: storeMock }));
 
 const telemetryServiceMock = vi.hoisted(() => ({
   closeTelemetry: vi.fn(() => Promise.resolve()),
-  getTelemetryLevel: vi.fn(() => "off"),
+  getTelemetryLevel: vi.fn(() => "off" as "off" | "errors" | "full"),
   setTelemetryLevel: vi.fn(() => Promise.resolve()),
+  hasTelemetryPromptBeenShown: vi.fn(() => false),
 }));
 
 vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
+
+const utilsMock = vi.hoisted(() => ({
+  typedBroadcast: vi.fn(),
+}));
+
+vi.mock("../../utils.js", () => utilsMock);
 
 import { registerPrivacyHandlers } from "../privacy.js";
 
@@ -93,5 +100,41 @@ describe("PRIVACY_RESET_ALL_DATA handler", () => {
     expect(appMock.relaunch).toHaveBeenCalledWith({
       args: expect.arrayContaining(["--reset-data"]),
     });
+  });
+});
+
+describe("registerPrivacyHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ipcMainMock._handlers.clear();
+  });
+
+  it("PRIVACY_SET_TELEMETRY_LEVEL broadcasts consent change on valid level", async () => {
+    telemetryServiceMock.hasTelemetryPromptBeenShown.mockReturnValue(true);
+    registerPrivacyHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch === "privacy:set-telemetry-level") ?? [];
+
+    await handler(null, "errors");
+
+    expect(telemetryServiceMock.setTelemetryLevel).toHaveBeenCalledWith("errors");
+    expect(utilsMock.typedBroadcast).toHaveBeenCalledWith("privacy:telemetry-consent-changed", {
+      level: "errors",
+      hasSeenPrompt: true,
+    });
+  });
+
+  it("PRIVACY_SET_TELEMETRY_LEVEL ignores invalid values and does not broadcast", async () => {
+    registerPrivacyHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch === "privacy:set-telemetry-level") ?? [];
+
+    await handler(null, "nonsense");
+    await handler(null, 42);
+
+    expect(telemetryServiceMock.setTelemetryLevel).not.toHaveBeenCalled();
+    expect(utilsMock.typedBroadcast).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/sentry.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/sentry.handlers.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+const telemetryServiceMock = vi.hoisted(() => ({
+  getTelemetryLevel: vi.fn(() => "off" as "off" | "errors" | "full"),
+  hasTelemetryPromptBeenShown: vi.fn(() => false),
+}));
+
+vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
+
+import { registerSentryHandlers } from "../sentry.js";
+
+describe("registerSentryHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers the consent-state handler", () => {
+    const cleanup = registerSentryHandlers();
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(1);
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "sentry:get-consent-state",
+      expect.any(Function)
+    );
+    cleanup();
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("sentry:get-consent-state");
+  });
+
+  it("returns { level, hasSeenPrompt } from TelemetryService", async () => {
+    telemetryServiceMock.getTelemetryLevel.mockReturnValue("errors");
+    telemetryServiceMock.hasTelemetryPromptBeenShown.mockReturnValue(true);
+
+    registerSentryHandlers();
+    const [, handler] = ipcMainMock.handle.mock.calls[0];
+    const result = await handler();
+
+    expect(result).toEqual({ level: "errors", hasSeenPrompt: true });
+  });
+
+  it("reflects off/not-prompted defaults", async () => {
+    telemetryServiceMock.getTelemetryLevel.mockReturnValue("off");
+    telemetryServiceMock.hasTelemetryPromptBeenShown.mockReturnValue(false);
+
+    registerSentryHandlers();
+    const [, handler] = ipcMainMock.handle.mock.calls[0];
+    const result = await handler();
+
+    expect(result).toEqual({ level: "off", hasSeenPrompt: false });
+  });
+});

--- a/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
@@ -12,10 +12,17 @@ const telemetryServiceMock = vi.hoisted(() => ({
   setTelemetryEnabled: vi.fn(() => Promise.resolve()),
   hasTelemetryPromptBeenShown: vi.fn(() => false),
   markTelemetryPromptShown: vi.fn(),
+  getTelemetryLevel: vi.fn(() => "off" as "off" | "errors" | "full"),
   trackEvent: vi.fn(),
 }));
 
 vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
+
+const utilsMock = vi.hoisted(() => ({
+  typedBroadcast: vi.fn(),
+}));
+
+vi.mock("../../utils.js", () => utilsMock);
 
 import { registerTelemetryHandlers } from "../telemetry.js";
 
@@ -106,6 +113,21 @@ describe("registerTelemetryHandlers", () => {
 
     await handler();
     expect(telemetryServiceMock.markTelemetryPromptShown).toHaveBeenCalled();
+  });
+
+  it("TELEMETRY_MARK_PROMPT_SHOWN broadcasts the updated consent", async () => {
+    telemetryServiceMock.getTelemetryLevel.mockReturnValue("errors");
+    registerTelemetryHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch.includes("telemetry:mark-prompt-shown")) ??
+      [];
+
+    await handler();
+    expect(utilsMock.typedBroadcast).toHaveBeenCalledWith("privacy:telemetry-consent-changed", {
+      level: "errors",
+      hasSeenPrompt: true,
+    });
   });
 
   it("TELEMETRY_TRACK handler dispatches valid event to service", async () => {

--- a/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
@@ -94,6 +94,21 @@ describe("registerTelemetryHandlers", () => {
     expect(telemetryServiceMock.setTelemetryEnabled).toHaveBeenCalledWith(true);
   });
 
+  it("TELEMETRY_SET_ENABLED handler broadcasts consent change on valid boolean", async () => {
+    telemetryServiceMock.getTelemetryLevel.mockReturnValue("errors");
+    telemetryServiceMock.hasTelemetryPromptBeenShown.mockReturnValue(true);
+    registerTelemetryHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch.includes("telemetry:set-enabled")) ?? [];
+
+    await handler(null, true);
+    expect(utilsMock.typedBroadcast).toHaveBeenCalledWith("privacy:telemetry-consent-changed", {
+      level: "errors",
+      hasSeenPrompt: true,
+    });
+  });
+
   it("TELEMETRY_SET_ENABLED handler ignores non-boolean values", async () => {
     registerTelemetryHandlers();
 

--- a/electron/ipc/handlers/privacy.ts
+++ b/electron/ipc/handlers/privacy.ts
@@ -4,9 +4,11 @@ import { store } from "../../store.js";
 import {
   closeTelemetry,
   getTelemetryLevel,
+  hasTelemetryPromptBeenShown,
   setTelemetryLevel,
   type TelemetryLevel,
 } from "../../services/TelemetryService.js";
+import { typedBroadcast } from "../utils.js";
 
 const VALID_LEVELS: TelemetryLevel[] = ["off", "errors", "full"];
 const VALID_RETENTION = [7, 30, 90, 0] as const;
@@ -24,6 +26,10 @@ export function registerPrivacyHandlers(): () => void {
   ipcMain.handle(CHANNELS.PRIVACY_SET_TELEMETRY_LEVEL, async (_event, level: unknown) => {
     if (typeof level !== "string" || !VALID_LEVELS.includes(level as TelemetryLevel)) return;
     await setTelemetryLevel(level as TelemetryLevel);
+    typedBroadcast("privacy:telemetry-consent-changed", {
+      level: level as TelemetryLevel,
+      hasSeenPrompt: hasTelemetryPromptBeenShown(),
+    });
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_SET_TELEMETRY_LEVEL));
 

--- a/electron/ipc/handlers/sentry.ts
+++ b/electron/ipc/handlers/sentry.ts
@@ -1,0 +1,15 @@
+import { ipcMain } from "electron";
+import { CHANNELS } from "../channels.js";
+import { getTelemetryLevel, hasTelemetryPromptBeenShown } from "../../services/TelemetryService.js";
+
+export function registerSentryHandlers(): () => void {
+  const cleanups: Array<() => void> = [];
+
+  ipcMain.handle(CHANNELS.SENTRY_GET_CONSENT_STATE, () => ({
+    level: getTelemetryLevel(),
+    hasSeenPrompt: hasTelemetryPromptBeenShown(),
+  }));
+  cleanups.push(() => ipcMain.removeHandler(CHANNELS.SENTRY_GET_CONSENT_STATE));
+
+  return () => cleanups.forEach((c) => c());
+}

--- a/electron/ipc/handlers/telemetry.ts
+++ b/electron/ipc/handlers/telemetry.ts
@@ -5,9 +5,11 @@ import {
   setTelemetryEnabled,
   hasTelemetryPromptBeenShown,
   markTelemetryPromptShown,
+  getTelemetryLevel,
   trackEvent,
 } from "../../services/TelemetryService.js";
 import { ANALYTICS_EVENTS } from "../../../shared/config/telemetry.js";
+import { typedBroadcast } from "../utils.js";
 
 const ALLOWED_EVENTS = new Set<string>(ANALYTICS_EVENTS);
 
@@ -28,6 +30,10 @@ export function registerTelemetryHandlers(): () => void {
 
   ipcMain.handle(CHANNELS.TELEMETRY_MARK_PROMPT_SHOWN, () => {
     markTelemetryPromptShown();
+    typedBroadcast("privacy:telemetry-consent-changed", {
+      level: getTelemetryLevel(),
+      hasSeenPrompt: true,
+    });
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.TELEMETRY_MARK_PROMPT_SHOWN));
 

--- a/electron/ipc/handlers/telemetry.ts
+++ b/electron/ipc/handlers/telemetry.ts
@@ -25,6 +25,10 @@ export function registerTelemetryHandlers(): () => void {
   ipcMain.handle(CHANNELS.TELEMETRY_SET_ENABLED, async (_event, enabled: unknown) => {
     if (typeof enabled !== "boolean") return;
     await setTelemetryEnabled(enabled);
+    typedBroadcast("privacy:telemetry-consent-changed", {
+      level: getTelemetryLevel(),
+      hasSeenPrompt: hasTelemetryPromptBeenShown(),
+    });
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.TELEMETRY_SET_ENABLED));
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -884,6 +884,8 @@ const CHANNELS = {
   PRIVACY_CLEAR_CACHE: "privacy:clear-cache",
   PRIVACY_RESET_ALL_DATA: "privacy:reset-all-data",
   PRIVACY_GET_DATA_FOLDER_PATH: "privacy:get-data-folder-path",
+  PRIVACY_TELEMETRY_CONSENT_CHANGED: "privacy:telemetry-consent-changed",
+  SENTRY_GET_CONSENT_STATE: "sentry:get-consent-state",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",
@@ -2598,6 +2600,13 @@ const api: ElectronAPI = {
     clearCache: () => _unwrappingInvoke(CHANNELS.PRIVACY_CLEAR_CACHE),
     resetAllData: () => _unwrappingInvoke(CHANNELS.PRIVACY_RESET_ALL_DATA),
     getDataFolderPath: () => _unwrappingInvoke(CHANNELS.PRIVACY_GET_DATA_FOLDER_PATH),
+    onTelemetryConsentChanged: (
+      callback: (payload: { level: "off" | "errors" | "full"; hasSeenPrompt: boolean }) => void
+    ) => _typedOn(CHANNELS.PRIVACY_TELEMETRY_CONSENT_CHANGED, callback),
+  },
+
+  sentry: {
+    getConsentState: () => _unwrappingInvoke(CHANNELS.SENTRY_GET_CONSENT_STATE),
   },
 
   onboarding: {
@@ -2868,6 +2877,23 @@ const api: ElectronAPI = {
 // Expose the API to the renderer process only for trusted origins in the main frame
 if (window.top === window && isTrustedRendererUrl(window.location.href)) {
   contextBridge.exposeInMainWorld("electron", api);
+  // Bridge for @sentry/electron/renderer's IPC transport. The renderer SDK
+  // looks up window.__SENTRY_IPC__["sentry-ipc"] and uses these methods to
+  // forward envelopes to the main process (which owns the real DSN and HTTP
+  // transport). contextIsolation blocks Sentry's default preload injection,
+  // so we expose the bridge manually here — gated to the trusted main-frame
+  // origin just like the `electron` API above.
+  contextBridge.exposeInMainWorld("__SENTRY_IPC__", {
+    "sentry-ipc": {
+      sendRendererStart: (...args: unknown[]) => ipcRenderer.send("sentry-ipc.start", ...args),
+      sendScope: (...args: unknown[]) => ipcRenderer.send("sentry-ipc.scope", ...args),
+      sendEnvelope: (...args: unknown[]) => ipcRenderer.send("sentry-ipc.envelope", ...args),
+      sendStatus: (...args: unknown[]) => ipcRenderer.send("sentry-ipc.status", ...args),
+      sendStructuredLog: (...args: unknown[]) =>
+        ipcRenderer.send("sentry-ipc.structured-log", ...args),
+      sendMetric: (...args: unknown[]) => ipcRenderer.send("sentry-ipc.metric", ...args),
+    },
+  });
 } else {
   if (window.top !== window) {
     console.error(

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1116,6 +1116,15 @@ export interface ElectronAPI {
     clearCache(): Promise<void>;
     resetAllData(): Promise<void>;
     getDataFolderPath(): Promise<string>;
+    onTelemetryConsentChanged(
+      callback: (payload: { level: "off" | "errors" | "full"; hasSeenPrompt: boolean }) => void
+    ): () => void;
+  };
+  sentry: {
+    getConsentState(): Promise<{
+      level: "off" | "errors" | "full";
+      hasSeenPrompt: boolean;
+    }>;
   };
   onboarding: {
     get(): Promise<OnboardingState>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1532,6 +1532,12 @@ export interface IpcInvokeMap {
     result: string;
   };
 
+  // Sentry
+  "sentry:get-consent-state": {
+    args: [];
+    result: { level: "off" | "errors" | "full"; hasSeenPrompt: boolean };
+  };
+
   // Onboarding
   "onboarding:get": {
     args: [];
@@ -1987,6 +1993,12 @@ export interface IpcEventMap {
 
   // Config reload events
   "app:config-reloaded": void;
+
+  // Privacy events
+  "privacy:telemetry-consent-changed": {
+    level: "off" | "errors" | "full";
+    hasSeenPrompt: boolean;
+  };
 }
 
 export type IpcInvokeArgs<K extends keyof IpcInvokeMap> = IpcInvokeMap[K]["args"];

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import React, { Component, type ReactNode } from "react";
+import * as Sentry from "@sentry/electron/renderer";
 import { ErrorFallback, type ErrorFallbackProps } from "./ErrorFallback";
 import { useErrorStore } from "@/store/errorStore";
 import { actionService } from "@/services/ActionService";
@@ -51,6 +52,19 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     });
 
     const correlationId = crypto.randomUUID();
+
+    try {
+      Sentry.captureException(error, {
+        tags: {
+          source: "react-error-boundary",
+          component: componentName ?? "ErrorBoundary",
+        },
+        contexts: { react: { componentStack } },
+        extra: { correlationId, ...(context ?? {}) },
+      });
+    } catch (sentryError) {
+      console.error("Failed to report error to Sentry:", sentryError);
+    }
 
     let incidentId: string | null = null;
     try {

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,9 +1,9 @@
 import React, { Component, type ReactNode } from "react";
-import * as Sentry from "@sentry/electron/renderer";
 import { ErrorFallback, type ErrorFallbackProps } from "./ErrorFallback";
 import { useErrorStore } from "@/store/errorStore";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
+import { captureRendererException } from "@/utils/rendererSentry";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -53,18 +53,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     const correlationId = crypto.randomUUID();
 
-    try {
-      Sentry.captureException(error, {
-        tags: {
-          source: "react-error-boundary",
-          component: componentName ?? "ErrorBoundary",
-        },
-        contexts: { react: { componentStack } },
-        extra: { correlationId, ...(context ?? {}) },
-      });
-    } catch (sentryError) {
-      console.error("Failed to report error to Sentry:", sentryError);
-    }
+    captureRendererException(error, {
+      tags: {
+        source: "react-error-boundary",
+        component: componentName ?? "ErrorBoundary",
+      },
+      contexts: { react: { componentStack } },
+      extra: { correlationId, ...(context ?? {}) },
+    });
 
     let incidentId: string | null = null;
     try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import { ensureTerminalFontLoaded } from "./config/terminalFont";
 import { initStoreOrchestrator } from "./store/rendererStoreOrchestrator";
 import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { registerRendererGlobalErrorHandlers } from "./utils/rendererGlobalErrorHandlers";
+import { initRendererSentry } from "./utils/rendererSentry";
 import { renderBootstrapError } from "./utils/renderBootstrapError";
 import {
   onCaughtError,
@@ -25,6 +26,8 @@ let cleanupGlobalErrorHandlers: (() => void) | undefined;
 let cleanupOrchestrator: (() => void) | undefined;
 
 async function bootstrap() {
+  await initRendererSentry();
+
   cleanupGlobalErrorHandlers = registerRendererGlobalErrorHandlers();
 
   applyDefaultAppTheme(document.documentElement);
@@ -64,6 +67,15 @@ async function bootstrap() {
 
 bootstrap().catch((error: unknown) => {
   console.error("Bootstrap failed:", error);
+
+  void (async () => {
+    try {
+      const { captureException } = await import("@sentry/electron/renderer");
+      captureException(error);
+    } catch {
+      // Sentry may not have initialized yet
+    }
+  })();
 
   try {
     const errObj =

--- a/src/utils/__tests__/rendererSentry.test.ts
+++ b/src/utils/__tests__/rendererSentry.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SentryInit = {
+  integrations?: unknown;
+  beforeSend?: (event: unknown) => unknown;
+  beforeBreadcrumb?: (breadcrumb: unknown) => unknown;
+};
+
+const sentryInit = vi.fn<(opts: SentryInit) => void>();
+
+vi.mock("@sentry/electron/renderer", () => ({
+  init: (opts: SentryInit) => sentryInit(opts),
+  captureException: vi.fn(),
+}));
+
+type ConsentPayload = { level: "off" | "errors" | "full"; hasSeenPrompt: boolean };
+
+describe("rendererSentry", () => {
+  let consentListener: ((payload: ConsentPayload) => void) | undefined;
+  let getConsentState: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    sentryInit.mockClear();
+    consentListener = undefined;
+    getConsentState = vi.fn(async () => ({ level: "errors", hasSeenPrompt: true }));
+
+    (window as unknown as { electron: unknown }).electron = {
+      sentry: { getConsentState },
+      privacy: {
+        onTelemetryConsentChanged: (cb: (payload: ConsentPayload) => void) => {
+          consentListener = cb;
+          return () => {
+            consentListener = undefined;
+          };
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("calls Sentry.init exactly once across repeated init calls", async () => {
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+    await mod.initRendererSentry();
+    expect(sentryInit).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters out the GlobalHandlers integration", async () => {
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    const opts = sentryInit.mock.calls[0][0];
+    const integrations = opts.integrations as (
+      defaults: Array<{ name: string }>
+    ) => Array<{ name: string }>;
+    const defaults = [{ name: "GlobalHandlers" }, { name: "BrowserApiErrors" }, { name: "Dedupe" }];
+    const result = integrations(defaults).map((i) => i.name);
+
+    expect(result).not.toContain("GlobalHandlers");
+    expect(result).toContain("BrowserApiErrors");
+    expect(result).toContain("Dedupe");
+  });
+
+  it.each([
+    [{ level: "off", hasSeenPrompt: false }, null],
+    [{ level: "errors", hasSeenPrompt: false }, null],
+    [{ level: "off", hasSeenPrompt: true }, null],
+    [{ level: "errors", hasSeenPrompt: true }, "pass"],
+    [{ level: "full", hasSeenPrompt: true }, "pass"],
+  ] as const)("beforeSend with %j returns %s", async (state, expected) => {
+    getConsentState.mockResolvedValueOnce(state);
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    const opts = sentryInit.mock.calls[0][0];
+    const event = { message: "test" };
+    const result = opts.beforeSend!(event);
+    if (expected === null) {
+      expect(result).toBeNull();
+    } else {
+      expect(result).toBe(event);
+    }
+  });
+
+  it("beforeBreadcrumb drops breadcrumbs when consent is closed", async () => {
+    getConsentState.mockResolvedValueOnce({ level: "off", hasSeenPrompt: true });
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    const opts = sentryInit.mock.calls[0][0];
+    expect(opts.beforeBreadcrumb!({ message: "click" })).toBeNull();
+  });
+
+  it("defaults to closed gate when IPC is unavailable", async () => {
+    delete (window as unknown as { electron?: unknown }).electron;
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    const opts = sentryInit.mock.calls[0][0];
+    expect(opts.beforeSend!({ message: "x" })).toBeNull();
+  });
+
+  it("push events from main update the consent gate at runtime", async () => {
+    getConsentState.mockResolvedValueOnce({ level: "off", hasSeenPrompt: false });
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    const opts = sentryInit.mock.calls[0][0];
+    expect(opts.beforeSend!({ message: "pre" })).toBeNull();
+
+    consentListener?.({ level: "errors", hasSeenPrompt: true });
+    expect(opts.beforeSend!({ message: "post" })).toEqual({ message: "post" });
+  });
+
+  it("updateRendererSentryConsent also flips the gate", async () => {
+    getConsentState.mockResolvedValueOnce({ level: "off", hasSeenPrompt: false });
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    mod.updateRendererSentryConsent("full", true);
+    const opts = sentryInit.mock.calls[0][0];
+    expect(opts.beforeSend!({ message: "x" })).toEqual({ message: "x" });
+    expect(mod.getRendererSentryConsent()).toEqual({ level: "full", hasSeenPrompt: true });
+  });
+});

--- a/src/utils/__tests__/rendererSentry.test.ts
+++ b/src/utils/__tests__/rendererSentry.test.ts
@@ -117,6 +117,32 @@ describe("rendererSentry", () => {
     expect(opts.beforeSend!({ message: "post" })).toEqual({ message: "post" });
   });
 
+  it("broadcast arriving during initial hydration is not lost (regression)", async () => {
+    // Simulate the race: getConsentState returns slowly with a stale value,
+    // meanwhile another window broadcasts a fresh consent change. The fresh
+    // broadcast must win — the stale snapshot must NOT overwrite it.
+    let resolveSnapshot: (v: ConsentPayload) => void = () => {};
+    getConsentState.mockImplementationOnce(
+      () => new Promise<ConsentPayload>((r) => (resolveSnapshot = r))
+    );
+
+    const mod = await import("../rendererSentry");
+    const initPromise = mod.initRendererSentry();
+
+    // Broadcast fires while snapshot is still pending
+    await Promise.resolve();
+    consentListener?.({ level: "off", hasSeenPrompt: true });
+
+    // Now the stale snapshot resolves
+    resolveSnapshot({ level: "errors", hasSeenPrompt: true });
+    await initPromise;
+
+    const opts = sentryInit.mock.calls[0][0];
+    // The live broadcast must have won; beforeSend must still drop events.
+    expect(opts.beforeSend!({ message: "x" })).toBeNull();
+    expect(mod.getRendererSentryConsent()).toEqual({ level: "off", hasSeenPrompt: true });
+  });
+
   it("updateRendererSentryConsent also flips the gate", async () => {
     getConsentState.mockResolvedValueOnce({ level: "off", hasSeenPrompt: false });
     const mod = await import("../rendererSentry");

--- a/src/utils/reactRootErrorCallbacks.ts
+++ b/src/utils/reactRootErrorCallbacks.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/electron/renderer";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { useErrorStore } from "@/store/errorStore";
 import { getErrorMessage } from "@/utils/errorContext";
@@ -15,6 +16,18 @@ export function onCaughtError(error: unknown, errorInfo: { componentStack?: stri
 
 export function onUncaughtError(error: unknown, errorInfo: { componentStack?: string }): void {
   try {
+    try {
+      const sentryError = error instanceof Error ? error : new Error(getErrorMessage(error));
+      Sentry.captureException(sentryError, {
+        tags: { source: "react-uncaught" },
+        contexts: errorInfo.componentStack
+          ? { react: { componentStack: errorInfo.componentStack } }
+          : undefined,
+      });
+    } catch (sentryError) {
+      console.error("[React] Failed to report uncaught error to Sentry:", sentryError);
+    }
+
     try {
       useErrorStore.getState().addError({
         type: "unknown",

--- a/src/utils/rendererGlobalErrorHandlers.ts
+++ b/src/utils/rendererGlobalErrorHandlers.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/electron/renderer";
 import { useErrorStore, type ErrorType } from "@/store/errorStore";
 import { logError } from "@/utils/logger";
 import {
@@ -87,6 +88,21 @@ function reportRendererGlobalError(
       });
     } catch (storeError) {
       console.error("[Renderer] Failed to add error to store:", storeError);
+    }
+
+    try {
+      const sentryError = rawError instanceof Error ? rawError : new Error(message);
+      Sentry.captureException(sentryError, {
+        tags: { source: kind === "unhandledrejection" ? "renderer-rejection" : "renderer-error" },
+        extra: {
+          correlationId,
+          filename: metadata.filename,
+          lineno: metadata.lineno,
+          colno: metadata.colno,
+        },
+      });
+    } catch (sentryError) {
+      console.error("[Renderer] Failed to report error to Sentry:", sentryError);
     }
 
     try {

--- a/src/utils/rendererSentry.ts
+++ b/src/utils/rendererSentry.ts
@@ -1,0 +1,66 @@
+import * as Sentry from "@sentry/electron/renderer";
+
+export type ConsentLevel = "off" | "errors" | "full";
+
+export interface ConsentState {
+  level: ConsentLevel;
+  hasSeenPrompt: boolean;
+}
+
+let consentState: ConsentState = { level: "off", hasSeenPrompt: false };
+let initialized = false;
+let consentUnsubscribe: (() => void) | undefined;
+
+// The renderer SDK auto-supplies a dummy DSN; events travel via IPC to main,
+// which owns the real DSN, the HTTP transport, and path sanitization. The
+// consent gate runs here in `beforeSend` to drop events before they leave
+// the renderer — `Sentry.init` is not idempotent and `Sentry.close` is
+// terminal, so runtime toggling must happen via this mutable closure.
+export async function initRendererSentry(): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  try {
+    const state = await window.electron?.sentry?.getConsentState();
+    if (state) consentState = state;
+  } catch {
+    // IPC may not be available (e.g. test environments). Leave gate closed.
+  }
+
+  Sentry.init({
+    // globalHandlersIntegration would double-capture with our existing
+    // window.error / unhandledrejection listeners (rendererGlobalErrorHandlers).
+    // The React error boundary and root callbacks call captureException
+    // directly, so we own every entrypoint deliberately.
+    integrations: (defaults) => defaults.filter((i) => i.name !== "GlobalHandlers"),
+    beforeSend: (event) => {
+      if (!consentState.hasSeenPrompt || consentState.level === "off") return null;
+      return event;
+    },
+    beforeBreadcrumb: (breadcrumb) => {
+      if (!consentState.hasSeenPrompt || consentState.level === "off") return null;
+      return breadcrumb;
+    },
+  });
+
+  consentUnsubscribe?.();
+  consentUnsubscribe = window.electron?.privacy?.onTelemetryConsentChanged?.((payload) => {
+    consentState = payload;
+  });
+}
+
+export function updateRendererSentryConsent(level: ConsentLevel, hasSeenPrompt: boolean): void {
+  consentState = { level, hasSeenPrompt };
+}
+
+export function getRendererSentryConsent(): ConsentState {
+  return consentState;
+}
+
+/** Test-only reset to allow re-initialization between tests. */
+export function _resetRendererSentryForTest(): void {
+  initialized = false;
+  consentState = { level: "off", hasSeenPrompt: false };
+  consentUnsubscribe?.();
+  consentUnsubscribe = undefined;
+}

--- a/src/utils/rendererSentry.ts
+++ b/src/utils/rendererSentry.ts
@@ -61,6 +61,25 @@ export async function initRendererSentry(): Promise<void> {
   });
 }
 
+export interface CaptureOptions {
+  tags?: Record<string, string>;
+  contexts?: Record<string, Record<string, unknown>>;
+  extra?: Record<string, unknown>;
+}
+
+/** Report an exception to Sentry. Safe to call from UI components — wraps
+ * the renderer SDK so components don't import from the restricted
+ * `@sentry/electron/renderer` module directly.
+ */
+export function captureRendererException(error: unknown, options?: CaptureOptions): void {
+  try {
+    const err = error instanceof Error ? error : new Error(String(error));
+    Sentry.captureException(err, options);
+  } catch (sentryError) {
+    console.error("[Renderer] Failed to report error to Sentry:", sentryError);
+  }
+}
+
 export function updateRendererSentryConsent(level: ConsentLevel, hasSeenPrompt: boolean): void {
   consentState = { level, hasSeenPrompt };
 }

--- a/src/utils/rendererSentry.ts
+++ b/src/utils/rendererSentry.ts
@@ -20,9 +20,21 @@ export async function initRendererSentry(): Promise<void> {
   if (initialized) return;
   initialized = true;
 
+  // Subscribe BEFORE fetching the initial snapshot so a consent change that
+  // lands during the await (e.g. another window flipping the level) is not
+  // lost in the gap between snapshot and subscription. If a broadcast fires
+  // during hydration, it wins — we must not overwrite fresher state with the
+  // stale snapshot.
+  let liveUpdateReceived = false;
+  consentUnsubscribe?.();
+  consentUnsubscribe = window.electron?.privacy?.onTelemetryConsentChanged?.((payload) => {
+    consentState = payload;
+    liveUpdateReceived = true;
+  });
+
   try {
     const state = await window.electron?.sentry?.getConsentState();
-    if (state) consentState = state;
+    if (state && !liveUpdateReceived) consentState = state;
   } catch {
     // IPC may not be available (e.g. test environments). Leave gate closed.
   }


### PR DESCRIPTION
## Summary

- Initialises `@sentry/electron/renderer` in the renderer process with a consent-gated `beforeSend` hook, so uncaught exceptions, unhandled promise rejections, and React error-boundary failures all reach Sentry instead of silently dropping to the console.
- Adds an IPC bridge (`sentry:setConsent`) so the renderer can receive consent changes from the main process and update its `beforeSend` gate without requiring a reload.
- Wires `captureException` into the existing error surfaces: `ErrorBoundary`, `window.onerror`, `window.onunhandledrejection`, and the React root error callback.

Resolves #5256

## Changes

- `src/utils/rendererSentry.ts` — renderer Sentry wrapper with mutable consent gate and path sanitisation (mirrors `TelemetryService.sanitizeEvent`)
- `src/utils/rendererGlobalErrorHandlers.ts` — registers `window.onerror` and `window.onunhandledrejection` listeners
- `src/utils/reactRootErrorCallbacks.ts` — React 19 root `onUncaughtError` / `onRecoverableError` callbacks
- `src/main.tsx` — initialises renderer Sentry and wires up all error surfaces on startup
- `src/components/ErrorBoundary/ErrorBoundary.tsx` — calls `captureException` via the renderer wrapper
- `electron/ipc/handlers/sentry.ts` + channels + preload — IPC handler that pushes consent updates to the renderer
- `shared/types/ipc/` — new `sentry` namespace types

## Testing

31 new unit tests across `src/utils/__tests__/rendererSentry.test.ts`, `electron/ipc/handlers/__tests__/sentry.handlers.test.ts`, and supporting handler tests. All pass. Full `npm run check` is clean (0 errors, warnings are pre-existing across the codebase).