### PR TITLE
fix(notifications): detach focus listeners on window destroy

### DIFF
--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -29,15 +29,21 @@ class NotificationService {
   private trackedWindows = new Map<number, TrackedWindow>();
   private activeNotifications = new Set<Notification>();
 
-  private detachAllWindowListeners(): void {
-    for (const [, tracked] of this.trackedWindows) {
-      if (!tracked.browserWindow.isDestroyed()) {
-        tracked.browserWindow.off("focus", tracked.focusHandler);
-        tracked.browserWindow.off("blur", tracked.blurHandler);
-      }
+  detachWindowListeners(windowId: number): void {
+    const tracked = this.trackedWindows.get(windowId);
+    if (!tracked) return;
+    if (!tracked.browserWindow.isDestroyed()) {
+      tracked.browserWindow.off("focus", tracked.focusHandler);
+      tracked.browserWindow.off("blur", tracked.blurHandler);
     }
-    this.trackedWindows.clear();
-    this.focusedWindows.clear();
+    this.trackedWindows.delete(windowId);
+    this.focusedWindows.delete(windowId);
+  }
+
+  private detachAllWindowListeners(): void {
+    for (const id of [...this.trackedWindows.keys()]) {
+      this.detachWindowListeners(id);
+    }
   }
 
   private attachWindowListeners(ctx: WindowContext): void {

--- a/electron/services/__tests__/NotificationService.test.ts
+++ b/electron/services/__tests__/NotificationService.test.ts
@@ -155,6 +155,59 @@ describe("NotificationService", () => {
     expect(win2.off).toHaveBeenCalledWith("blur", expect.any(Function));
   });
 
+  it("detachWindowListeners clears focus state when the window was destroyed mid-session", () => {
+    const win = createWindowMock(true);
+    notificationService.initialize(createRegistryMock([win]) as never);
+
+    expect(notificationService.isWindowFocused()).toBe(true);
+
+    // Simulate native destruction before cleanup runs
+    win.isDestroyed.mockReturnValue(true);
+    notificationService.detachWindowListeners(win.id);
+
+    // Guarded: off() must NOT be called on a destroyed window (Electron 41 throws)
+    expect(win.off).not.toHaveBeenCalled();
+    // Stale focus state must be cleared so isWindowFocused() is correct
+    expect(notificationService.isWindowFocused()).toBe(false);
+
+    // Second call is a no-op — must not throw
+    expect(() => notificationService.detachWindowListeners(win.id)).not.toThrow();
+  });
+
+  it("detachWindowListeners removes focus/blur listeners when the window is still alive", () => {
+    const win = createWindowMock(true);
+    notificationService.initialize(createRegistryMock([win]) as never);
+
+    expect(notificationService.isWindowFocused()).toBe(true);
+
+    notificationService.detachWindowListeners(win.id);
+
+    expect(win.off).toHaveBeenCalledWith("focus", expect.any(Function));
+    expect(win.off).toHaveBeenCalledWith("blur", expect.any(Function));
+    expect(notificationService.isWindowFocused()).toBe(false);
+  });
+
+  it("detachWindowListeners only clears the targeted window in a multi-window setup", () => {
+    const win1 = createWindowMock(true);
+    const win2 = createWindowMock(true);
+    notificationService.initialize(createRegistryMock([win1, win2]) as never);
+
+    expect(notificationService.isWindowFocused()).toBe(true);
+
+    notificationService.detachWindowListeners(win1.id);
+
+    // win1's listeners gone
+    expect(win1.off).toHaveBeenCalledWith("focus", expect.any(Function));
+    expect(win1.off).toHaveBeenCalledWith("blur", expect.any(Function));
+    // win2 untouched
+    expect(win2.off).not.toHaveBeenCalled();
+    // win2 still focused, so service still reports focused
+    expect(notificationService.isWindowFocused()).toBe(true);
+
+    notificationService.detachWindowListeners(win2.id);
+    expect(notificationService.isWindowFocused()).toBe(false);
+  });
+
   it("isWindowFocused returns true if any window is focused", () => {
     const win1 = createWindowMock(false);
     const win2 = createWindowMock(false);

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -356,6 +356,7 @@ export async function setupWindowServices(
 
   if (windowRegistry) {
     notificationService.initialize(windowRegistry);
+    ctx.cleanup.push(() => notificationService.detachWindowListeners(win.id));
   }
   console.log("[MAIN] NotificationService initialized");
 


### PR DESCRIPTION
## Summary

- `NotificationService` was holding onto `focus`/`blur` handlers for closed windows, causing stale listeners to accumulate over the lifetime of the app
- Added a public `detachWindowListeners(windowId)` method that safely removes a single window's entries from `trackedWindows` and `focusedWindows`, with an `isDestroyed()` guard because `BrowserWindow.off()` throws on destroyed windows in Electron 41
- Wired it into `windowServices.ts` via `ctx.cleanup`, so `WindowRegistry.unregister()` cleans up automatically on window close

Resolves #5189

## Changes

- `NotificationService.ts`: new `detachWindowListeners(windowId)` public method; refactored `detachAllWindowListeners()` to delegate to it (spread-then-iterate for mutation safety)
- `windowServices.ts`: `ctx.cleanup.push(() => notificationService.detachWindowListeners(win.id))` inside the `if (windowRegistry)` guard
- `NotificationService.test.ts`: 3 new Vitest cases covering the destroyed-window guard, live-at-cleanup path, and multi-window partial detach

## Testing

10/10 tests pass (`npx vitest run electron/services/__tests__/NotificationService.test.ts`). No E2E tests cover `NotificationService` directly. Typecheck and lint clean.