### PR TITLE
feat(environment): scale GPU tile memory cap by system RAM tier

### DIFF
--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -44,6 +44,10 @@ const fsUtilsMock = vi.hoisted(() => ({
   waitForPathExists: vi.fn(),
 }));
 
+const osMock = vi.hoisted(() => ({
+  totalmem: vi.fn<() => number>(),
+}));
+
 vi.mock("fs", () => ({
   default: {
     existsSync: fsMock.existsSync,
@@ -80,8 +84,9 @@ vi.mock("node:vm", () => ({
 }));
 
 vi.mock("os", () => ({
-  default: { homedir: () => "C:\\Users\\testuser" },
+  default: { homedir: () => "C:\\Users\\testuser", totalmem: osMock.totalmem },
   homedir: () => "C:\\Users\\testuser",
+  totalmem: osMock.totalmem,
 }));
 
 const originalPlatform = process.platform;
@@ -396,6 +401,8 @@ describe("Windows Git PATH discovery", () => {
 });
 
 describe("GPU memory flags", () => {
+  const GIB = 1024 ** 3;
+
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
@@ -408,8 +415,29 @@ describe("GPU memory flags", () => {
     process.argv = originalArgv;
   });
 
-  it("sets force-gpu-mem-available-mb to 1024", async () => {
+  it("sets force-gpu-mem-available-mb to 768 on a 4 GiB machine", async () => {
     fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(4 * GIB);
+
+    await import("../environment.js");
+
+    const { app } = await import("electron");
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "768");
+  });
+
+  it("sets force-gpu-mem-available-mb to 768 at the 8 GiB boundary", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(8 * GIB);
+
+    await import("../environment.js");
+
+    const { app } = await import("electron");
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "768");
+  });
+
+  it("sets force-gpu-mem-available-mb to 1024 just above the 8 GiB boundary", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(8 * GIB + 1);
 
     await import("../environment.js");
 
@@ -417,8 +445,39 @@ describe("GPU memory flags", () => {
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "1024");
   });
 
+  it("sets force-gpu-mem-available-mb to 1024 at the 16 GiB boundary", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(16 * GIB);
+
+    await import("../environment.js");
+
+    const { app } = await import("electron");
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "1024");
+  });
+
+  it("sets force-gpu-mem-available-mb to 2048 just above the 16 GiB boundary", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(16 * GIB + 1);
+
+    await import("../environment.js");
+
+    const { app } = await import("electron");
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "2048");
+  });
+
+  it("sets force-gpu-mem-available-mb to 2048 on a 32 GiB machine", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(32 * GIB);
+
+    await import("../environment.js");
+
+    const { app } = await import("electron");
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith("force-gpu-mem-available-mb", "2048");
+  });
+
   it("does not set gpu-rasterization-msaa-sample-count", async () => {
     fsMock.existsSync.mockReturnValue(false);
+    osMock.totalmem.mockReturnValue(16 * GIB);
 
     await import("../environment.js");
 

--- a/electron/setup/__tests__/refreshPath.test.ts
+++ b/electron/setup/__tests__/refreshPath.test.ts
@@ -22,8 +22,9 @@ vi.mock("fix-path", () => ({ default: vi.fn() }));
 vi.mock("node:v8", () => ({ default: { setFlagsFromString: vi.fn() } }));
 vi.mock("node:vm", () => ({ default: { runInNewContext: vi.fn() } }));
 vi.mock("os", () => ({
-  default: { homedir: () => "/home/testuser" },
+  default: { homedir: () => "/home/testuser", totalmem: () => 16 * 1024 ** 3 },
   homedir: () => "/home/testuser",
+  totalmem: () => 16 * 1024 ** 3,
 }));
 
 const shellEnvMock = vi.fn<() => Promise<Record<string, string>>>();

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -305,8 +305,17 @@ if (process.platform === "linux") {
 
 app.commandLine.appendSwitch("enable-features", enabledFeatures.join(","));
 
-// Raise GPU tile memory budget to keep Retina/multi-panel rendering from exhausting Chromium's default cap
-app.commandLine.appendSwitch("force-gpu-mem-available-mb", "1024");
+// Raise GPU tile memory budget to keep Retina/multi-panel rendering from exhausting Chromium's default cap.
+// Scales with system RAM: ≤8 GiB → 768 MB, >8 and ≤16 GiB → 1024 MB, >16 GiB → 2048 MB.
+// Must run before app.whenReady(), so only synchronous APIs are available.
+function getGpuTileMemoryCapMb(): string {
+  const totalMem = os.totalmem();
+  if (totalMem <= 8 * 1024 ** 3) return "768";
+  if (totalMem <= 16 * 1024 ** 3) return "1024";
+  return "2048";
+}
+
+app.commandLine.appendSwitch("force-gpu-mem-available-mb", getGpuTileMemoryCapMb());
 
 if (process.platform === "win32") {
   const extraPaths = getWindowsExtraPaths();


### PR DESCRIPTION
## Summary

- Replaced the flat `force-gpu-mem-available-mb` value with a RAM-tiered lookup. New helper `getGpuTileMemoryCapMb()` in `electron/setup/environment.ts` returns `"768"` for ≤8 GiB, `"1024"` for >8 and ≤16 GiB, and `"2048"` for >16 GiB.
- Binary GiB thresholds (`1024 ** 3`) throughout. The middle tier matches the previous flat default, so 8–16 GiB machines see no behavioural change.
- Must run pre-`app.whenReady()`, so only synchronous Node APIs are used. `os` was already imported.

Resolves #5181.

## Changes

- `electron/setup/environment.ts`: extracted `getGpuTileMemoryCapMb()` and wired it into the Chromium switch
- `electron/setup/__tests__/environment.test.ts`: extended the hoisted `os` mock with a `totalmem` spy and added 6 boundary tests covering 4 GiB, 8 GiB exactly, 8 GiB+1B, 16 GiB exactly, 16 GiB+1B, and 32 GiB. The +1B over-boundary cases guard against `<` vs `<=` regressions.

## Testing

48/48 `environment.test.ts` tests pass. Typecheck, lint (401/401 warnings, no new ones), and format check all clean.