### PR TITLE
fix(resource-profile): scale memory-pressure thresholds to device RAM

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { app, powerMonitor } from "electron";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -16,8 +17,13 @@ const DOWNGRADE_HOLD_MS = 30_000;
 const UPGRADE_HOLD_MS = 60_000;
 const WARMUP_TICKS = 2;
 
-const MEMORY_THRESHOLD_HIGH_MB = 1200;
-const MEMORY_THRESHOLD_LOW_MB = 600;
+// Memory-pressure thresholds scale with device RAM so machines with very
+// different physical memory behave sensibly. On an 8 GB machine these
+// fractions evaluate to ~1229 MB / ~655 MB, preserving the originally-tuned
+// behavior; on a 64 GB machine they scale up to ~9830 MB / ~5243 MB, which
+// stops false "efficiency" drops when the app has plenty of headroom.
+const HIGH_FRACTION = 0.15;
+const LOW_FRACTION = 0.08;
 const WORKTREE_COUNT_HIGH = 8;
 
 export interface ResourceProfileDeps {
@@ -34,8 +40,14 @@ export class ResourceProfileService {
   private tickCount = 0;
   private disposed = false;
   private cachedWorktreeCount = 0;
+  private readonly memoryThresholdHighMb: number;
+  private readonly memoryThresholdLowMb: number;
 
-  constructor(private deps: ResourceProfileDeps) {}
+  constructor(private deps: ResourceProfileDeps) {
+    const totalRamMb = os.totalmem() / 1024 / 1024;
+    this.memoryThresholdHighMb = totalRamMb * HIGH_FRACTION;
+    this.memoryThresholdLowMb = totalRamMb * LOW_FRACTION;
+  }
 
   setWorktreeCount(count: number): void {
     this.cachedWorktreeCount = count;
@@ -117,9 +129,9 @@ export class ResourceProfileService {
         totalPrivateMb += (proc.memory.privateBytes ?? proc.memory.workingSetSize) / 1024;
       }
 
-      if (totalPrivateMb > MEMORY_THRESHOLD_HIGH_MB) {
+      if (totalPrivateMb > this.memoryThresholdHighMb) {
         pressureScore += 2;
-      } else if (totalPrivateMb > MEMORY_THRESHOLD_LOW_MB) {
+      } else if (totalPrivateMb > this.memoryThresholdLowMb) {
         pressureScore += 1;
       }
     } catch {

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -23,9 +23,12 @@ vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
 }));
 
+import os from "os";
 import { app, powerMonitor } from "electron";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 import { ResourceProfileService, type ResourceProfileDeps } from "../ResourceProfileService.js";
+
+const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as Mock;
 const mockIsOnBatteryPower = powerMonitor.isOnBatteryPower as unknown as Mock;
@@ -109,12 +112,16 @@ describe("ResourceProfileService adversarial", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // Pin total RAM so MB-based test values cross the intended threshold bands
+    // regardless of the CI host's actual memory.
+    vi.spyOn(os, "totalmem").mockReturnValue(EIGHT_GB);
     mockGetAppMetrics.mockReturnValue([]);
     mockIsOnBatteryPower.mockReturnValue(false);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("does not thrash profiles when pressure oscillates around the hysteresis boundary", () => {

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -24,10 +24,13 @@ vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
 }));
 
+import os from "os";
 import { app, powerMonitor } from "electron";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 import { ResourceProfileService, type ResourceProfileDeps } from "../ResourceProfileService.js";
 import { RESOURCE_PROFILE_CONFIGS } from "../../../shared/types/resourceProfile.js";
+
+const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as Mock;
 const mockIsOnBatteryPower = powerMonitor.isOnBatteryPower as unknown as Mock;
@@ -83,12 +86,16 @@ describe("ResourceProfileService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    // Pin total RAM so threshold-crossing tests behave identically across CI hosts.
+    // 8 GB yields ~1229 MB HIGH / ~655 MB LOW, matching the originally-tuned constants.
+    vi.spyOn(os, "totalmem").mockReturnValue(EIGHT_GB);
     mockGetAppMetrics.mockReturnValue([]);
     mockIsOnBatteryPower.mockReturnValue(false);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("starts in balanced profile", () => {
@@ -288,6 +295,46 @@ describe("ResourceProfileService", () => {
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
+  it("scales thresholds up on high-RAM devices so 1.3 GB usage is not pressure", () => {
+    // 64 GB Mac: HIGH threshold = 9830 MB, LOW = 5243 MB.
+    // 1300 MB of privateBytes should contribute zero pressure, letting the
+    // service upgrade to "performance" instead of dropping to "efficiency".
+    vi.spyOn(os, "totalmem").mockReturnValue(64 * 1024 * 1024 * 1024);
+
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    // Warmup (2 ticks = 60s) + first real eval (30s) + 60s upgrade hold (2 ticks)
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("performance");
+
+    service.stop();
+  });
+
+  it("scales thresholds down on low-RAM devices so 500 MB usage is detected", () => {
+    // 4 GB machine: HIGH = 614 MB, LOW = 328 MB.
+    // 500 MB of privateBytes crosses the LOW band (score 1), preventing the
+    // service from upgrading to "performance" — it correctly stays "balanced".
+    vi.spyOn(os, "totalmem").mockReturnValue(4 * 1024 * 1024 * 1024);
+
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 500)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    // Warmup + full upgrade hold — enough time to transition if score were 0.
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
 
     service.stop();
   });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -321,18 +321,20 @@ describe("ResourceProfileService", () => {
 
   it("scales thresholds down on low-RAM devices so 500 MB usage is detected", () => {
     // 4 GB machine: HIGH = 614 MB, LOW = 328 MB.
-    // 500 MB of privateBytes crosses the LOW band (score 1), preventing the
-    // service from upgrading to "performance" — it correctly stays "balanced".
+    // 500 MB of privateBytes must score LOW (+1), not HIGH (+2). To discriminate,
+    // pair with 10 worktrees (+1). LOW + worktrees = 2 → balanced;
+    // HIGH + worktrees = 3 → efficiency. The "balanced" assertion only passes
+    // if the 500 MB reading was scored as LOW.
     vi.spyOn(os, "totalmem").mockReturnValue(4 * 1024 * 1024 * 1024);
 
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    service.setWorktreeCount(10);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 500)]);
     mockIsOnBatteryPower.mockReturnValue(false);
 
-    // Warmup + full upgrade hold — enough time to transition if score were 0.
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("balanced");
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `MEMORY_THRESHOLD_HIGH_MB=1200` / `LOW_MB=600` in `ResourceProfileService` with fractions of `os.totalmem()` (15% high, 8% low), cached at construction. On 8 GB machines the new thresholds (~1229/655 MB) preserve the originally-tuned behaviour. On 64 GB machines they scale to ~9.8/5.2 GB, stopping false efficiency drops when the system has plenty of headroom.
- Pinned `os.totalmem()` to 8 GB in both test files so existing MB-based assertions still cross the right bands. Added two new scaling tests: 64 GB + high-memory → performance, and 4 GB + 500 MB + 10 worktrees → balanced (LOW-vs-HIGH discriminator).

Resolves #5222

## Changes

- `electron/services/ResourceProfileService.ts` — `HIGH_FRACTION = 0.15` and `LOW_FRACTION = 0.08` replace the hardcoded constants. Two readonly instance fields hold the computed byte thresholds.
- `electron/services/__tests__/ResourceProfileService.test.ts` — `os.totalmem` mocked to 8 GB in `beforeEach`; two new scaling tests added.
- `electron/services/__tests__/ResourceProfileService.adversarial.test.ts` — `os.totalmem` mocked to 8 GB in `beforeEach` so oscillation/co-pressure coverage is unchanged.

## Testing

Unit test suite covers the original behaviour at 8 GB, plus scaling at 64 GB (high memory → performance, not efficiency) and the low-RAM 4 GB case (balanced as the LOW/HIGH discriminator). All tests pass.