### PR TITLE
fix(plugin): authenticate sender on plugin:invoke IPC handler

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -61,7 +61,7 @@ describe("registerPluginHandlers", () => {
     expect(result).toBe(plugins);
   });
 
-  it("PLUGIN_INVOKE handler delegates to pluginService.dispatchHandler", async () => {
+  it("PLUGIN_INVOKE handler delegates to pluginService.dispatchHandler for trusted senders", async () => {
     mockDispatchHandler.mockResolvedValue({ data: "hello" });
 
     registerPluginHandlers();
@@ -69,7 +69,8 @@ describe("registerPluginHandlers", () => {
       (c: unknown[]) => c[0] === "plugin:invoke"
     )![1] as (...args: unknown[]) => unknown;
 
-    const result = await invokeHandler({}, "my-plugin", "get-data", "arg1", "arg2");
+    const trustedEvent = { senderFrame: { url: "app://daintree/" } };
+    const result = await invokeHandler(trustedEvent, "my-plugin", "get-data", "arg1", "arg2");
     expect(mockDispatchHandler).toHaveBeenCalledWith("my-plugin", "get-data", ["arg1", "arg2"]);
     expect(result).toEqual({ data: "hello" });
   });
@@ -82,9 +83,36 @@ describe("registerPluginHandlers", () => {
       (c: unknown[]) => c[0] === "plugin:invoke"
     )![1] as (...args: unknown[]) => unknown;
 
-    await expect(invokeHandler({}, "x", "y")).rejects.toThrow(
+    const trustedEvent = { senderFrame: { url: "app://daintree/" } };
+    await expect(invokeHandler(trustedEvent, "x", "y")).rejects.toThrow(
       "No plugin handler registered for x:y"
     );
+  });
+
+  it("PLUGIN_INVOKE handler rejects untrusted senders and does not dispatch", async () => {
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const untrustedEvent = { senderFrame: { url: "https://evil.com/attack.html" } };
+    await expect(invokeHandler(untrustedEvent, "my-plugin", "get-data", "arg1")).rejects.toThrow(
+      "plugin:invoke rejected: untrusted sender"
+    );
+    expect(mockDispatchHandler).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INVOKE handler rejects when senderFrame is missing and does not dispatch", async () => {
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const nullFrameEvent = { senderFrame: null };
+    await expect(invokeHandler(nullFrameEvent, "my-plugin", "get-data")).rejects.toThrow(
+      "plugin:invoke rejected: untrusted sender"
+    );
+    expect(mockDispatchHandler).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -6,6 +6,7 @@ import {
   getToolbarButtonConfig,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
+import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type { LoadedPluginInfo, PluginIpcHandler } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 
@@ -31,7 +32,11 @@ export function registerPluginHandlers(): () => void {
 
   ipcMain.handle(
     CHANNELS.PLUGIN_INVOKE,
-    async (_event, pluginId: string, channel: string, ...args: unknown[]) => {
+    async (event, pluginId: string, channel: string, ...args: unknown[]) => {
+      const senderUrl = event.senderFrame?.url;
+      if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
+        throw new Error(`plugin:invoke rejected: untrusted sender (url=${senderUrl ?? "unknown"})`);
+      }
       return await pluginService.dispatchHandler(pluginId, channel, args);
     }
   );


### PR DESCRIPTION
## Summary

- Adds an explicit `isTrustedRendererUrl(event.senderFrame?.url)` guard at the top of the `PLUGIN_INVOKE` handler, throwing immediately on untrusted or missing sender frames before any plugin dispatch occurs.
- This is defence-in-depth on top of the global `enforceIpcSenderValidation()` monkey-patch in `electron/setup/security.ts`. Having the check at the handler level makes the authentication intent visible exactly where it matters, rather than relying solely on the process-wide guard.
- Updated existing tests to pass a real trusted `senderFrame` mock, and added two new rejection tests covering the untrusted-URL and null-senderFrame cases.

Resolves #5216

## Changes

- `electron/ipc/handlers/plugin.ts` — sender authentication guard on `PLUGIN_INVOKE`
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` — updated mocks + two new rejection tests

## Testing

All 9 tests pass. Typecheck, lint, and format are clean.