### PR TITLE
fix(worktree): adaptive debounce cuts file-save lag from ~2s to ~250ms

### DIFF
--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -180,13 +180,16 @@ describe("GitFileWatcher", () => {
       return w;
     }) as unknown as typeof watch);
 
+    // Fixed debounce (min === max) — keeps this test's timing assertion stable
+    // while the adaptive ramp is covered by its own dedicated tests.
     const gitWatcher = new GitFileWatcher({
       worktreePath: "/repo",
       branch: "main",
       debounceMs: 300,
       onChange,
       watchWorktree: true,
-      worktreeDebounceMs: 500,
+      worktreeMinDebounceMs: 500,
+      worktreeMaxDebounceMs: 500,
       worktreeMaxWaitMs: 2000,
     });
 
@@ -224,7 +227,8 @@ describe("GitFileWatcher", () => {
       debounceMs: 300,
       onChange,
       watchWorktree: true,
-      worktreeDebounceMs: 500,
+      worktreeMinDebounceMs: 500,
+      worktreeMaxDebounceMs: 500,
       worktreeMaxWaitMs: 2000,
     });
 
@@ -269,7 +273,8 @@ describe("GitFileWatcher", () => {
       debounceMs: 300,
       onChange,
       watchWorktree: true,
-      worktreeDebounceMs: 500,
+      worktreeMinDebounceMs: 500,
+      worktreeMaxDebounceMs: 500,
       worktreeMaxWaitMs: 2000,
     });
 
@@ -296,7 +301,8 @@ describe("GitFileWatcher", () => {
       debounceMs: 300,
       onChange,
       watchWorktree: true,
-      worktreeDebounceMs: 500,
+      worktreeMinDebounceMs: 500,
+      worktreeMaxDebounceMs: 500,
       worktreeMaxWaitMs: 2000,
     });
 
@@ -313,6 +319,289 @@ describe("GitFileWatcher", () => {
     dotGitCallback?.("rename", "HEAD");
     await vi.advanceTimersByTimeAsync(300);
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("single worktree event flushes at minimum debounce", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 150,
+      worktreeMaxDebounceMs: 800,
+      worktreeMaxWaitMs: 1500,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    worktreeCallback?.("change", "src/a.ts");
+
+    await vi.advanceTimersByTimeAsync(149);
+    expect(onChange).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("burst ramps debounce delay proportional to event count", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 150,
+      worktreeMaxDebounceMs: 800,
+      worktreeMaxWaitMs: 1500,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    // Emit 5 synchronous events — delay = 150 + (5-1)*10 = 190ms
+    for (let i = 0; i < 5; i++) {
+      worktreeCallback?.("change", `src/file${i}.ts`);
+    }
+
+    await vi.advanceTimersByTimeAsync(189);
+    expect(onChange).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("ramp saturates at worktreeMaxDebounceMs ceiling", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 150,
+      worktreeMaxDebounceMs: 800,
+      // No max-wait — isolate ramp saturation from ceiling flush
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    // 200 synchronous events far exceed the ramp window (65 events saturate at 800ms)
+    for (let i = 0; i < 200; i++) {
+      worktreeCallback?.("change", `src/file${i}.ts`);
+    }
+
+    await vi.advanceTimersByTimeAsync(799);
+    expect(onChange).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("burst count resets after flush so next session starts at min debounce", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 150,
+      worktreeMaxDebounceMs: 800,
+      worktreeMaxWaitMs: 1500,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    // Burst of 10 events → delay = 150 + 9*10 = 240ms
+    for (let i = 0; i < 10; i++) {
+      worktreeCallback?.("change", `src/a${i}.ts`);
+    }
+    await vi.advanceTimersByTimeAsync(240);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Long quiet period to confirm no stale timers and no stale count
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // New single-event session must fire at minDelay (150ms), not stale ramp (240ms)
+    worktreeCallback?.("change", "src/new.ts");
+    await vi.advanceTimersByTimeAsync(149);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves no pending timers after trailing debounce flush", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 150,
+      worktreeMaxDebounceMs: 800,
+      worktreeMaxWaitMs: 1500,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    worktreeCallback?.("change", "src/a.ts");
+    worktreeCallback?.("change", "src/b.ts");
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("leaves no pending timers after max-wait flush", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 500,
+      worktreeMaxDebounceMs: 500,
+      worktreeMaxWaitMs: 1500,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    // Sustained burst that never lets trailing debounce fire — forces max-wait flush
+    worktreeCallback?.("change", "src/file0.ts");
+    for (let i = 1; i <= 9; i++) {
+      await vi.advanceTimersByTimeAsync(150);
+      worktreeCallback?.("change", `src/file${i}.ts`);
+    }
+    // Advance past max-wait (1500ms total from first event)
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("dispose during active burst prevents callback and clears timers", async () => {
+    const onChange = vi.fn();
+    let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      cb?: (eventType: string, filename: string | null) => void
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        worktreeCallback = cb;
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      worktreeMinDebounceMs: 150,
+      worktreeMaxDebounceMs: 800,
+      worktreeMaxWaitMs: 1500,
+    });
+
+    expect(gitWatcher.start()).toBe(true);
+
+    worktreeCallback?.("change", "src/a.ts");
+    worktreeCallback?.("change", "src/b.ts");
+    gitWatcher.dispose();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("onWatcherFailed is called when recursive watcher emits error on Linux ENOSPC", () => {

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -17,8 +17,10 @@ export interface GitFileWatcherOptions {
   onChange: () => void;
   /** Watch the working tree recursively for file edits (macOS FSEvents). */
   watchWorktree?: boolean;
-  /** Debounce for working tree events. Defaults to debounceMs if not set. */
-  worktreeDebounceMs?: number;
+  /** Minimum debounce delay for worktree events — first event in a burst fires at this delay. */
+  worktreeMinDebounceMs?: number;
+  /** Maximum debounce delay for worktree events — sustained bursts ramp up to this. */
+  worktreeMaxDebounceMs?: number;
   /** Max wait ceiling for worktree debounce — forces a flush during sustained bursts. */
   worktreeMaxWaitMs?: number;
   /** Called when the recursive worktree watcher fails at runtime (error or startup). */
@@ -31,11 +33,15 @@ export class GitFileWatcher {
   private debounceTimer: NodeJS.Timeout | null = null;
   private worktreeDebounceTimer: NodeJS.Timeout | null = null;
   private worktreeMaxWaitTimer: NodeJS.Timeout | null = null;
+  private worktreeBurstCount = 0;
   private disposed = false;
   private readonly worktreePath: string;
   private readonly debounceMs: number;
-  private readonly worktreeDebounceMs: number;
+  private readonly worktreeMinDebounceMs: number;
+  private readonly worktreeMaxDebounceMs: number;
   private readonly worktreeMaxWaitMs: number | undefined;
+  /** Per-event ramp applied inside the min..max range. Private tuning constant. */
+  private readonly worktreeDebounceRampMs = 10;
   private readonly onChange: () => void;
   private readonly onWatcherFailed: (() => void) | undefined;
   private readonly watchWorktree: boolean;
@@ -44,7 +50,8 @@ export class GitFileWatcher {
   constructor(options: GitFileWatcherOptions) {
     this.worktreePath = options.worktreePath;
     this.debounceMs = options.debounceMs;
-    this.worktreeDebounceMs = options.worktreeDebounceMs ?? options.debounceMs;
+    this.worktreeMinDebounceMs = options.worktreeMinDebounceMs ?? options.debounceMs;
+    this.worktreeMaxDebounceMs = options.worktreeMaxDebounceMs ?? this.worktreeMinDebounceMs;
     this.worktreeMaxWaitMs = options.worktreeMaxWaitMs;
     this.onChange = options.onChange;
     this.onWatcherFailed = options.onWatcherFailed;
@@ -116,6 +123,7 @@ export class GitFileWatcher {
       clearTimeout(this.worktreeMaxWaitTimer);
       this.worktreeMaxWaitTimer = null;
     }
+    this.worktreeBurstCount = 0;
 
     for (const watcher of this.watchers) {
       try {
@@ -303,39 +311,48 @@ export class GitFileWatcher {
     }, this.debounceMs);
   }
 
-  /** Handle working tree file changes. Separate debounce (can be longer). */
+  /**
+   * Handle working tree file changes with an adaptive debounce. The first event
+   * in a burst fires at `worktreeMinDebounceMs`; each subsequent event adds
+   * `worktreeDebounceRampMs` to the pending delay up to `worktreeMaxDebounceMs`.
+   * A `worktreeMaxWaitMs` ceiling forces a flush during sustained bursts.
+   */
   private handleWorktreeChange(): void {
     if (this.disposed) {
       return;
     }
 
+    this.worktreeBurstCount++;
+    const delay = Math.min(
+      this.worktreeMaxDebounceMs,
+      this.worktreeMinDebounceMs + (this.worktreeBurstCount - 1) * this.worktreeDebounceRampMs
+    );
+
     if (this.worktreeDebounceTimer) {
       clearTimeout(this.worktreeDebounceTimer);
     }
+    this.worktreeDebounceTimer = setTimeout(() => this.flushWorktreeChange(), delay);
 
-    // Start max-wait ceiling on first event in a burst
     if (this.worktreeMaxWaitMs != null && !this.worktreeMaxWaitTimer) {
-      this.worktreeMaxWaitTimer = setTimeout(() => {
-        this.worktreeMaxWaitTimer = null;
-        if (this.worktreeDebounceTimer) {
-          clearTimeout(this.worktreeDebounceTimer);
-          this.worktreeDebounceTimer = null;
-        }
-        if (!this.disposed) {
-          this.onChange();
-        }
-      }, this.worktreeMaxWaitMs);
+      this.worktreeMaxWaitTimer = setTimeout(
+        () => this.flushWorktreeChange(),
+        this.worktreeMaxWaitMs
+      );
     }
+  }
 
-    this.worktreeDebounceTimer = setTimeout(() => {
+  private flushWorktreeChange(): void {
+    if (this.worktreeDebounceTimer) {
+      clearTimeout(this.worktreeDebounceTimer);
       this.worktreeDebounceTimer = null;
-      if (this.worktreeMaxWaitTimer) {
-        clearTimeout(this.worktreeMaxWaitTimer);
-        this.worktreeMaxWaitTimer = null;
-      }
-      if (!this.disposed) {
-        this.onChange();
-      }
-    }, this.worktreeDebounceMs);
+    }
+    if (this.worktreeMaxWaitTimer) {
+      clearTimeout(this.worktreeMaxWaitTimer);
+      this.worktreeMaxWaitTimer = null;
+    }
+    this.worktreeBurstCount = 0;
+    if (!this.disposed) {
+      this.onChange();
+    }
   }
 }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -23,7 +23,9 @@ const GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS = 1000;
 const WATCHER_FALLBACK_POLL_INTERVAL_MS = 30_000;
 const WATCHER_RETRY_INTERVAL_MS = 30_000;
 const WATCHER_MAX_RETRIES = 5;
-const WATCHER_WORKTREE_MAX_WAIT_MS = 2000;
+const WATCHER_WORKTREE_MIN_DEBOUNCE_MS = 150;
+const WATCHER_WORKTREE_MAX_DEBOUNCE_MS = 800;
+const WATCHER_WORKTREE_MAX_WAIT_MS = 1500;
 const PLAN_FILE_CANDIDATES = ["TODO.md", "PLAN.md", "plan.md", "TASKS.md"] as const;
 const RESOURCE_POLL_DEFAULT_ACTIVE_MS = 30_000;
 const RESOURCE_POLL_DEFAULT_BACKGROUND_MS = 120_000;
@@ -662,7 +664,8 @@ export class WorktreeMonitor {
       debounceMs: this.gitWatchDebounceMs,
       onChange: () => this.handleGitFileChange(),
       watchWorktree: true,
-      worktreeDebounceMs: 1000,
+      worktreeMinDebounceMs: WATCHER_WORKTREE_MIN_DEBOUNCE_MS,
+      worktreeMaxDebounceMs: WATCHER_WORKTREE_MAX_DEBOUNCE_MS,
       worktreeMaxWaitMs: WATCHER_WORKTREE_MAX_WAIT_MS,
       onWatcherFailed: () => this.handleWatcherFailed(),
     });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -39,12 +39,14 @@ vi.mock("../../utils/gitUtils.js", () => ({
 
 let mockWatcherStartResult = false;
 let capturedOnWatcherFailed: (() => void) | undefined;
+let capturedWatcherOptions: Record<string, unknown> | undefined;
 
 vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
-      constructor(opts: { onWatcherFailed?: () => void }) {
+      constructor(opts: { onWatcherFailed?: () => void } & Record<string, unknown>) {
         capturedOnWatcherFailed = opts.onWatcherFailed;
+        capturedWatcherOptions = opts;
       }
       start() {
         return mockWatcherStartResult;
@@ -109,6 +111,7 @@ describe("WorktreeMonitor", () => {
     vi.clearAllMocks();
     mockWatcherStartResult = false;
     capturedOnWatcherFailed = undefined;
+    capturedWatcherOptions = undefined;
   });
 
   afterEach(() => {
@@ -346,6 +349,32 @@ describe("WorktreeMonitor", () => {
       await monitor.start();
 
       expect(monitor.hasWatcher).toBe(true);
+      monitor.stop();
+    });
+
+    it("constructs GitFileWatcher with adaptive worktree debounce options", async () => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(capturedWatcherOptions).toBeDefined();
+      expect(capturedWatcherOptions).toMatchObject({
+        watchWorktree: true,
+        worktreeMinDebounceMs: 150,
+        worktreeMaxDebounceMs: 800,
+        worktreeMaxWaitMs: 1500,
+      });
+      expect(capturedWatcherOptions).not.toHaveProperty("worktreeDebounceMs");
+
       monitor.stop();
     });
 


### PR DESCRIPTION
## Summary

- Replaced the hardcoded 1000ms/2000ms debounce in `GitFileWatcher` with an adaptive burst-aware debounce: the first event in a burst flushes at `worktreeMinDebounceMs` (150ms), each subsequent event adds 10ms up to `worktreeMaxDebounceMs` (800ms), with a `worktreeMaxWaitMs` ceiling of 1500ms as the backstop.
- A shared `flushWorktreeChange()` helper keeps both timer paths (trailing debounce and max-wait) symmetric and resets the burst counter on flush. `closeWatchers()` also resets the counter so reopened watchers start fresh.
- `worktreeDebounceMs` in `GitFileWatcherOptions` has been replaced with `worktreeMinDebounceMs` / `worktreeMaxDebounceMs`. The one call site in `WorktreeMonitor.startWatcher()` is updated accordingly.

Resolves #5224

## Changes

- `electron/utils/gitFileWatcher.ts` — adaptive debounce logic with burst counter
- `electron/workspace-host/WorktreeMonitor.ts` — updated to pass `worktreeMinDebounceMs` / `worktreeMaxDebounceMs`
- `electron/utils/__tests__/gitFileWatcher.test.ts` — 4 existing tests updated for new option names; 7 new adaptive debounce tests added (single-event at minDelay, proportional ramp, saturation at maxDelay, burstCount reset, no lingering timers on trailing flush, no lingering timers on max-wait flush, dispose during burst)
- `electron/workspace-host/__tests__/WorktreeMonitor.test.ts` — 1 new assertion that adaptive options plumb through from `startWatcher()`

## Testing

`gitFileWatcher.test.ts` 17/17 pass. `WorktreeMonitor.test.ts` 36/36 pass. Typecheck, lint (401-warning baseline preserved), and format all clean.

End-user impact: worktree badge updates in ~250-300ms after a file save on macOS (was 1.5-2.5s), while `git checkout` and `npm install` bursts still ramp up gracefully and stay well within the max-wait ceiling.