### PR TITLE
fix(accessibility): remove role=grid from panel layout container

### DIFF
--- a/e2e/full/core-accessibility.spec.ts
+++ b/e2e/full/core-accessibility.spec.ts
@@ -24,12 +24,6 @@ function buildAxeScanner(page: import("@playwright/test").Page) {
       // canvas content also triggers false positives. Fires across the entire app, so
       // .exclude() on individual selectors is impractical.
       "color-contrast",
-      // aria-required-children: xterm.js terminal grid uses ARIA roles that don't satisfy
-      // required-children constraints. Third-party DOM structure, not fixable.
-      "aria-required-children",
-      // nested-interactive: xterm.js nests interactive elements within its DOM tree.
-      // Third-party DOM structure, not fixable.
-      "nested-interactive",
     ]);
 }
 

--- a/e2e/full/core-accessibility.spec.ts
+++ b/e2e/full/core-accessibility.spec.ts
@@ -24,6 +24,10 @@ function buildAxeScanner(page: import("@playwright/test").Page) {
       // canvas content also triggers false positives. Fires across the entire app, so
       // .exclude() on individual selectors is impractical.
       "color-contrast",
+      // nested-interactive: Worktree cards wrap real <button> descendants in a
+      // role="button" container (WorktreeCard, WorktreeDetailsSection, FileStageRow).
+      // Fixing this requires restructuring the card components, which is out of scope.
+      "nested-interactive",
     ]);
 }
 

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -408,7 +408,7 @@ export async function refreshActiveWindow(app: ElectronApplication, oldPage?: Pa
     // 3. Click inside the document to give the browser keyboard focus to a
     // real node, then poll `document.hasFocus()` and retry a few times if
     // the document isn't claiming focus yet.
-    const grid = newWindow.locator('[role="grid"][aria-label="Panel grid"]').first();
+    const grid = newWindow.locator('[data-grid-container="true"]').first();
     const clickTarget = (await grid.isVisible({ timeout: 2_000 }).catch(() => false))
       ? grid
       : newWindow.locator("body");

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -1030,9 +1030,7 @@ export function ContentGrid({
                     : `grid-template-columns ${GRID_TRANSITION_DURATION_MS}ms ease-out`,
                   overflowY: "auto",
                 }}
-                role="grid"
                 id="panel-grid"
-                aria-label="Panel grid"
                 data-grid-container="true"
               >
                 {isEmpty && !showPlaceholder ? (

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -231,9 +231,7 @@ export function TwoPaneSplitLayout({
             gap: 0,
             backgroundColor: "var(--color-grid-bg)",
           }}
-          role="grid"
           id="panel-grid"
-          aria-label="Panel grid - two pane split"
           data-grid-container="true"
           data-split-mode="true"
         >


### PR DESCRIPTION
## Summary

- Remove `role="grid"` and `aria-label="Panel grid"` from the inner CSS grid div in `ContentGrid` and `TwoPaneSplitLayout`. The outer `role="region"` wrapper is the correct landmark for this surface.
- Update the E2E focus-acquisition selector in `e2e/helpers/launch.ts` from the now-removed ARIA attribute to `[data-grid-container="true"]`, preventing a silent fallback-to-body regression across all tests using `launchApp()`.
- Remove the `aria-required-children` axe suppression — xterm 6.0 uses valid `role="list"` internally, so the rule no longer fires once our own `role="grid"` is gone. The `nested-interactive` suppression is kept (real source: worktree card `role="button"` wrappers) with a corrected comment.

Resolves #5231

## Changes

- `src/components/Terminal/ContentGrid.tsx` — dropped `role="grid"` and `aria-label="Panel grid"` from inner grid div
- `src/components/Terminal/TwoPaneSplitLayout.tsx` — same removal on the split container
- `e2e/helpers/launch.ts` — focus selector updated to `[data-grid-container="true"]`
- `e2e/full/core-accessibility.spec.ts` — `aria-required-children` suppression removed; `nested-interactive` kept with corrected rationale

## Accessibility impact

Screen readers no longer announce the panel area as a table. NVDA/JAWS no longer force Forms Mode and VoiceOver no longer requires Interact Mode before arrow keys reach the xterm textarea inside each panel.

## Testing

- `npm run fix` and `npm run format:check` pass with no changes
- CI: `core-accessibility.spec.ts`, `core-focus-management.spec.ts`, `core-terminal-layout-operations.spec.ts`, and `core-drag-drop.spec.ts` should pass unchanged
- Manual: verify with a screen reader that the panel area is no longer announced as a grid/table