### PR TITLE
fix(security): gate __daintreeDispatchAction behind E2E mode flag

### DIFF
--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -281,10 +281,11 @@ export class ActionService {
 export const actionService = new ActionService();
 
 // Expose dispatch function for E2E tests (WebGL renderer has no DOM-level action API).
-// Registered unconditionally but gated at call time — the function is harmless
-// in production and avoids import-time env var timing issues.
-if (typeof window !== "undefined") {
-  (window as unknown as Record<string, unknown>).__daintreeDispatchAction = (
+// Gated on the preload-injected __DAINTREE_E2E_MODE__ flag so the global is never
+// attached in production sessions — the flag is only exposed when the Electron
+// process was launched with DAINTREE_E2E_MODE=1 (set exclusively by e2e/helpers/launch.ts).
+if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true) {
+  window.__daintreeDispatchAction = (
     actionId: string,
     args?: unknown,
     options?: { source?: string; confirmed?: boolean }

--- a/src/services/__tests__/ActionService.e2eGate.test.ts
+++ b/src/services/__tests__/ActionService.e2eGate.test.ts
@@ -84,4 +84,27 @@ describe("ActionService window.__daintreeDispatchAction gate", () => {
 
     expect(typeof fakeWindow.__daintreeDispatchAction).toBe("function");
   });
+
+  it("forwards actionId, args, and options to actionService.dispatch", async () => {
+    const fakeWindow: Record<string, unknown> = { __DAINTREE_E2E_MODE__: true };
+    restore = setWindow(fakeWindow);
+
+    vi.resetModules();
+    const mod = await import("../ActionService");
+    const spy = vi.spyOn(mod.actionService, "dispatch").mockResolvedValue(undefined);
+
+    const hook = fakeWindow.__daintreeDispatchAction as (
+      actionId: string,
+      args?: unknown,
+      options?: { source?: string; confirmed?: boolean }
+    ) => unknown;
+    hook("actions.list", { foo: 1 }, { source: "agent", confirmed: true });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(
+      "actions.list",
+      { foo: 1 },
+      { source: "agent", confirmed: true }
+    );
+  });
 });

--- a/src/services/__tests__/ActionService.e2eGate.test.ts
+++ b/src/services/__tests__/ActionService.e2eGate.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("../../store/shortcutHintStore", () => ({
+  shortcutHintStore: {
+    getState: () => ({
+      hydrated: true,
+      counts: {},
+      show: vi.fn(),
+      incrementCount: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../KeybindingService", () => ({
+  keybindingService: {
+    getEffectiveCombo: () => null,
+    getDisplayCombo: () => "",
+  },
+}));
+
+type WindowSlot = { window?: unknown };
+
+function setWindow(value: unknown): () => void {
+  const original = (globalThis as WindowSlot).window;
+  Object.defineProperty(globalThis, "window", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+  return () => {
+    Object.defineProperty(globalThis, "window", {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
+  };
+}
+
+describe("ActionService window.__daintreeDispatchAction gate", () => {
+  let restore: (() => void) | null = null;
+
+  afterEach(() => {
+    restore?.();
+    restore = null;
+    vi.resetModules();
+  });
+
+  it("does not attach __daintreeDispatchAction when __DAINTREE_E2E_MODE__ is absent", async () => {
+    const fakeWindow: Record<string, unknown> = {};
+    restore = setWindow(fakeWindow);
+
+    vi.resetModules();
+    await import("../ActionService");
+
+    expect(fakeWindow.__daintreeDispatchAction).toBeUndefined();
+  });
+
+  it("does not attach __daintreeDispatchAction when __DAINTREE_E2E_MODE__ is false", async () => {
+    const fakeWindow: Record<string, unknown> = { __DAINTREE_E2E_MODE__: false };
+    restore = setWindow(fakeWindow);
+
+    vi.resetModules();
+    await import("../ActionService");
+
+    expect(fakeWindow.__daintreeDispatchAction).toBeUndefined();
+  });
+
+  it("rejects truthy-but-not-true values (e.g. string 'true')", async () => {
+    const fakeWindow: Record<string, unknown> = { __DAINTREE_E2E_MODE__: "true" };
+    restore = setWindow(fakeWindow);
+
+    vi.resetModules();
+    await import("../ActionService");
+
+    expect(fakeWindow.__daintreeDispatchAction).toBeUndefined();
+  });
+
+  it("attaches __daintreeDispatchAction when __DAINTREE_E2E_MODE__ is true", async () => {
+    const fakeWindow: Record<string, unknown> = { __DAINTREE_E2E_MODE__: true };
+    restore = setWindow(fakeWindow);
+
+    vi.resetModules();
+    await import("../ActionService");
+
+    expect(typeof fakeWindow.__daintreeDispatchAction).toBe("function");
+  });
+});

--- a/src/services/__tests__/ActionService.e2eGate.test.ts
+++ b/src/services/__tests__/ActionService.e2eGate.test.ts
@@ -91,7 +91,9 @@ describe("ActionService window.__daintreeDispatchAction gate", () => {
 
     vi.resetModules();
     const mod = await import("../ActionService");
-    const spy = vi.spyOn(mod.actionService, "dispatch").mockResolvedValue(undefined);
+    const spy = vi
+      .spyOn(mod.actionService, "dispatch")
+      .mockResolvedValue({ ok: true, result: undefined });
 
     const hook = fakeWindow.__daintreeDispatchAction as (
       actionId: string,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -26,6 +26,11 @@ declare global {
     };
     __DAINTREE_E2E_MODE__?: boolean;
     __DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS__?: boolean;
+    __daintreeDispatchAction?: (
+      actionId: string,
+      args?: unknown,
+      options?: { source?: string; confirmed?: boolean }
+    ) => unknown;
   }
 }
 


### PR DESCRIPTION
## Summary

- `window.__daintreeDispatchAction` is now only attached when `window.__DAINTREE_E2E_MODE__ === true` (strict equality). In production sessions the flag is `undefined`, so the global is never exposed and untrusted renderer content can't call it with `source: "user"` to bypass the agent-confirmation gate.
- Added `Window.__daintreeDispatchAction?` to `electron.d.ts` alongside the other E2E globals so the type is accurate.
- New focused vitest suite (5 cases) covers absent flag, `false`, string `"true"` (locking the strict-equality contract), `true` (attaches), and a forwarding assertion that `actionId`/`args`/`options` pass through to `actionService.dispatch` unchanged.

Resolves #5248.

## Changes

- `src/services/ActionService.ts` — wrap the module-level assignment in `if (typeof window !== "undefined" && window.__DAINTREE_E2E_MODE__ === true)`
- `src/types/electron.d.ts` — typed `__daintreeDispatchAction?` added to `Window`
- `src/services/__tests__/ActionService.e2eGate.test.ts` — new suite, 5 cases

## Testing

39/39 vitest tests pass (5 new, 34 existing, no regressions). `npm run check` is clean with lint at baseline (401 warnings, no new). E2E core-action-safety spec passes against a production build with `DAINTREE_E2E_MODE=1`.

The runtime gate was chosen over `!import.meta.env.PROD` because E2E runs a production Vite build. A build-time gate would DCE the hook out of the exact bundle E2E tests use, breaking all 6 specs that depend on it. The preload bridge pattern is the established approach for E2E-only renderer globals in this codebase (PR 5080 precedent).