### PR TITLE
fix(bulk-create): surface clone-layout terminal spawn failures

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -799,13 +799,16 @@ export function BulkCreateWorktreeDialog({
                   type: "ITEM_TERMINALS_SPAWNING",
                   issueNumber: itemNumber,
                 });
-                try {
-                  for (const t of cloneTerminals) {
+                const spawnedIds: string[] = [];
+                const failedIndices: number[] = [];
+                for (const [index, t] of cloneTerminals.entries()) {
+                  try {
                     const isDevPreview = t.type === "dev-preview";
                     const isAgent = !isDevPreview && t.type !== "terminal";
 
+                    let panelId: string | null;
                     if (isDevPreview) {
-                      await usePanelStore.getState().addPanel({
+                      panelId = await usePanelStore.getState().addPanel({
                         kind: "dev-preview",
                         title: t.title,
                         cwd: worktreePath,
@@ -813,42 +816,67 @@ export function BulkCreateWorktreeDialog({
                         exitBehavior: t.exitBehavior,
                         devCommand: t.devCommand?.trim() || undefined,
                       });
-                      continue;
-                    }
-
-                    let command: string | undefined;
-                    if (isAgent) {
-                      const agentConfig = getAgentConfig(t.type);
-                      const baseCommand = agentConfig?.command || t.type;
-                      const entry = cloneAgentSettings?.agents?.[t.type] ?? {};
-                      command = generateAgentCommand(baseCommand, entry, t.type, {
-                        clipboardDirectory: cloneClipboardDirectory,
-                      });
                     } else {
-                      command = t.command?.trim() || undefined;
+                      let command: string | undefined;
+                      if (isAgent) {
+                        const agentConfig = getAgentConfig(t.type);
+                        const baseCommand = agentConfig?.command || t.type;
+                        const entry = cloneAgentSettings?.agents?.[t.type] ?? {};
+                        command = generateAgentCommand(baseCommand, entry, t.type, {
+                          clipboardDirectory: cloneClipboardDirectory,
+                        });
+                      } else {
+                        command = t.command?.trim() || undefined;
+                      }
+
+                      panelId = await usePanelStore.getState().addPanel({
+                        kind: isAgent ? "agent" : "terminal",
+                        agentId: isAgent ? t.type : undefined,
+                        title: t.title,
+                        cwd: worktreePath,
+                        worktreeId,
+                        exitBehavior: t.exitBehavior,
+                        command,
+                      });
                     }
 
-                    await usePanelStore.getState().addPanel({
-                      kind: isAgent ? "agent" : "terminal",
-                      agentId: isAgent ? t.type : undefined,
-                      title: t.title,
-                      cwd: worktreePath,
-                      worktreeId,
-                      exitBehavior: t.exitBehavior,
-                      command,
-                    });
+                    if (panelId != null) {
+                      spawnedIds.push(panelId);
+                    } else {
+                      failedIndices.push(index);
+                    }
+                  } catch {
+                    failedIndices.push(index);
                   }
-                  const updatedTracked = tracking.get(itemNumber);
-                  if (updatedTracked) updatedTracked.cloneComplete = true;
-                } catch {
-                  // Clone is best-effort; worktree was created
+                }
+                const updatedTracked = tracking.get(itemNumber);
+                if (updatedTracked) {
+                  updatedTracked.spawnedTerminalIds = [
+                    ...updatedTracked.spawnedTerminalIds,
+                    ...spawnedIds,
+                  ];
+                  updatedTracked.failedTerminalIndices = failedIndices;
+                  updatedTracked.cloneComplete = failedIndices.length === 0;
                 }
                 dispatchProgress({
                   type: "ITEM_TERMINALS_RESULT",
                   issueNumber: itemNumber,
-                  spawnedTerminalIds: [],
-                  failedTerminalIndices: [],
+                  spawnedTerminalIds: spawnedIds,
+                  failedTerminalIndices: failedIndices,
                 });
+
+                if (failedIndices.length > 0) {
+                  const errorMsg = `${failedIndices.length} terminal(s) failed to spawn`;
+                  failedItems.add(itemNumber);
+                  dispatchProgress({
+                    type: "ITEM_FAILED",
+                    issueNumber: itemNumber,
+                    error: errorMsg,
+                    attempts: attempt,
+                    failedStep: "terminals",
+                  });
+                  return;
+                }
               } else if (
                 selectedRecipeId &&
                 selectedRecipeId !== CLONE_LAYOUT_ID &&

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -1114,12 +1114,15 @@ export function BulkCreateWorktreeDialog({
       );
       if (toRetry.length === 0) return;
 
-      // Reset terminal tracking for retried items so verification doesn't use stale data
+      // Reset terminal tracking for retried items so verification doesn't use stale data.
+      // cloneComplete is also cleared so retry re-enters the clone branch — otherwise a
+      // post-success verification failure silently short-circuits to ITEM_SUCCEEDED.
       for (const issueNumber of failedIssueNumbers) {
         const tracked = batchTrackingRef.current.get(issueNumber);
         if (tracked) {
           tracked.spawnedTerminalIds = [];
           tracked.failedTerminalIndices = [];
+          tracked.cloneComplete = false;
         }
       }
 

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1389,6 +1389,93 @@ describe("BulkCreateWorktreeDialog", () => {
     const terminalCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "terminal");
     expect(terminalCall?.[0].command).toBe("ls");
   });
+
+  it("clone layout continues spawning and surfaces failure when addPanel throws mid-loop", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "A", exitBehavior: "close", command: "cmd-a" },
+      { type: "terminal", title: "B", exitBehavior: "close", command: "cmd-b" },
+      { type: "terminal", title: "C", exitBehavior: "close", command: "cmd-c" },
+    ]);
+    mockAddPanel
+      .mockResolvedValueOnce("panel-a")
+      .mockRejectedValueOnce(new Error("spawn failed"))
+      .mockResolvedValueOnce("panel-c");
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    // Loop continued past the throw — all three terminals attempted.
+    expect(mockAddPanel).toHaveBeenCalledTimes(3);
+
+    // Item is surfaced as failed, not silently succeeded.
+    expect(screen.queryByText(/1 of 1 created/)).toBeNull();
+    expect(screen.getByText(/0 of 1 created/)).toBeTruthy();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(screen.getByTestId("bulk-create-retry-button")).toBeTruthy();
+  });
+
+  it("clone layout treats addPanel returning null as a per-terminal failure", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "A", exitBehavior: "close", command: "cmd-a" },
+      { type: "terminal", title: "B", exitBehavior: "close", command: "cmd-b" },
+    ]);
+    mockAddPanel.mockResolvedValueOnce("panel-a").mockResolvedValueOnce(null);
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText(/1 of 1 created/)).toBeNull();
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(screen.getByTestId("bulk-create-retry-button")).toBeTruthy();
+  });
+
+  it("clone layout retry re-enters clone branch after partial failure", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "A", exitBehavior: "close", command: "cmd-a" },
+      { type: "terminal", title: "B", exitBehavior: "close", command: "cmd-b" },
+    ]);
+    // First run: second terminal throws. Retry run: both succeed.
+    mockAddPanel
+      .mockResolvedValueOnce("panel-a1")
+      .mockRejectedValueOnce(new Error("spawn failed"))
+      .mockResolvedValueOnce("panel-a2")
+      .mockResolvedValueOnce("panel-b2");
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(screen.getByText(/1 failed/)).toBeTruthy();
+    expect(mockAddPanel).toHaveBeenCalledTimes(2);
+
+    // Retry: cloneComplete must have stayed false, so the branch re-enters.
+    await act(async () => {
+      screen.getByTestId("bulk-create-retry-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(4);
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    expect(screen.queryByText(/1 failed/)).toBeNull();
+  });
 });
 
 describe("BulkCreateWorktreeDialog — PR mode", () => {

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1476,6 +1476,43 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
     expect(screen.queryByText(/1 failed/)).toBeNull();
   });
+
+  it("clone layout retry re-enters clone branch after verification failure", async () => {
+    mockSelectedRecipeId = "__clone_layout__";
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "A", exitBehavior: "close", command: "cmd-a" },
+    ]);
+    // First run spawns successfully but terminal crashes post-batch.
+    mockAddPanel.mockResolvedValueOnce("panel-crash");
+    mockTerminals = [{ id: "panel-crash", exitCode: 1 }];
+
+    const props = { ...defaultProps, selectedIssues: [makeIssue(1)] };
+    render(<BulkCreateWorktreeDialog {...props} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    // Verification caught the crash and marked the item failed.
+    expect(screen.getByText(/terminal\(s\) crashed/)).toBeTruthy();
+    expect(screen.getByTestId("bulk-create-retry-button")).toBeTruthy();
+    expect(mockAddPanel).toHaveBeenCalledTimes(1);
+
+    // Retry: healthy terminal this time. cloneComplete must have been reset so
+    // the clone branch re-runs; otherwise the retry silently marks succeeded
+    // with zero spawn attempts.
+    mockAddPanel.mockResolvedValueOnce("panel-healthy");
+    mockTerminals = [{ id: "panel-healthy", exitCode: undefined }];
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-retry-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockAddPanel).toHaveBeenCalledTimes(2);
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+  });
 });
 
 describe("BulkCreateWorktreeDialog — PR mode", () => {


### PR DESCRIPTION
## Summary

- The bulk clone-layout path was silently swallowing terminal spawn failures, leaving items stuck in a succeeded state when PTY IPC or panel-limit errors occurred.
- Per-iteration try/catch now handles both `null` returns (soft fail: panel limit) and thrown errors (hard fail: PTY IPC), collecting failed indices and dispatching `ITEM_FAILED` instead of letting `ITEM_SUCCEEDED` override a broken state.
- `cloneComplete` is only set on full success, and `handleRetryFailed` now clears it alongside other tracking fields so retries actually re-enter the clone branch instead of short-circuiting to a phantom success.

Resolves #5207

## Changes

- Replaced the outer try/catch in `BulkCreateWorktreeDialog.tsx` with per-iteration error handling so the loop continues past a single `addPanel` failure
- Populates `ITEM_TERMINALS_RESULT` with real `spawnedIds`/`failedIndices` instead of hardcoded empty arrays
- Dispatches `ITEM_FAILED` and returns early when any terminal failed, mirroring the recipe path at lines 914-931
- Clears `cloneComplete` in `handleRetryFailed` so post-verification failures re-run the clone branch
- Adds 4 unit tests: throw mid-loop, null return, retry-after-partial-failure, and verification-failure retry

## Notes

Selective retry (re-spawning only the failed terminals rather than all of them) is pre-existing behaviour shared with the recipe path's user-retry flow. Fixing it only in clone-layout would create divergence, so that's left as a follow-up if the duplicate-panel-on-retry UX becomes a pain.

## Testing

46/46 unit tests passing (42 existing + 4 new). The new tests cover the specific failure modes this PR addresses.