### PR TITLE
fix(recipe): preserve agent model and launch flags when cloning layouts

### DIFF
--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -180,6 +180,10 @@ export interface RecipeTerminal {
   devCommand?: string;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely (optional, defaults to "keep") */
   exitBehavior?: PanelExitBehavior;
+  /** Per-panel model override captured at launch (agent types only). Transient — stripped before disk persistence. */
+  agentModelId?: string;
+  /** Process-level launch flags captured at launch (agent types only). Transient — stripped before disk persistence. */
+  agentLaunchFlags?: string[];
 }
 
 /** A saved terminal recipe */

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -824,6 +824,7 @@ export function BulkCreateWorktreeDialog({
                         const entry = cloneAgentSettings?.agents?.[t.type] ?? {};
                         command = generateAgentCommand(baseCommand, entry, t.type, {
                           clipboardDirectory: cloneClipboardDirectory,
+                          modelId: t.agentModelId,
                         });
                       } else {
                         command = t.command?.trim() || undefined;

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -837,6 +837,8 @@ export function BulkCreateWorktreeDialog({
                         worktreeId,
                         exitBehavior: t.exitBehavior,
                         command,
+                        agentModelId: isAgent ? t.agentModelId : undefined,
+                        agentLaunchFlags: isAgent ? t.agentLaunchFlags : undefined,
                       });
                     }
 

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1317,7 +1317,10 @@ describe("BulkCreateWorktreeDialog", () => {
       "claude",
       { flags: [] },
       "claude",
-      expect.objectContaining({ clipboardDirectory: "/tmp/daintree-clipboard" })
+      expect.objectContaining({
+        clipboardDirectory: "/tmp/daintree-clipboard",
+        modelId: "claude-opus-4-7",
+      })
     );
 
     const agentCall = mockAddPanel.mock.calls.find((c) => c[0].kind === "agent");

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1280,6 +1280,8 @@ describe("BulkCreateWorktreeDialog", () => {
         title: "Agent",
         exitBehavior: "stay",
         command: "claude --resume stale-session",
+        agentModelId: "claude-opus-4-7",
+        agentLaunchFlags: ["--resume", "old"],
       },
       {
         type: "terminal",
@@ -1323,6 +1325,9 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(agentCall?.[0].command).toBe("claude --fresh-generated");
     expect(agentCall?.[0].agentId).toBe("claude");
     expect(agentCall?.[0].command).not.toContain("stale-session");
+    // Per-panel agent overrides survive the clone-layout projection.
+    expect(agentCall?.[0].agentModelId).toBe("claude-opus-4-7");
+    expect(agentCall?.[0].agentLaunchFlags).toEqual(["--resume", "old"]);
 
     // Plain terminal command is passed through verbatim (it's a user-authored
     // shell command, not a path-scoped agent invocation).

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -522,18 +522,18 @@ export function NewWorktreeDialog({
                 .getState()
                 .generateRecipeFromActiveTerminals(sourceWorktreeId);
               for (const t of terminals) {
+                const isDevPreview = t.type === "dev-preview";
+                const isAgent = !isDevPreview && t.type !== "terminal";
                 await usePanelStore.getState().addPanel({
-                  kind:
-                    t.type === "dev-preview"
-                      ? "dev-preview"
-                      : t.type === "terminal"
-                        ? "terminal"
-                        : "agent",
-                  agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                  kind: isDevPreview ? "dev-preview" : isAgent ? "agent" : "terminal",
+                  agentId: isAgent ? t.type : undefined,
                   title: t.title,
                   cwd: worktreePath.trim(),
                   worktreeId,
                   exitBehavior: t.exitBehavior,
+                  devCommand: isDevPreview ? t.devCommand : undefined,
+                  agentModelId: isAgent ? t.agentModelId : undefined,
+                  agentLaunchFlags: isAgent ? t.agentLaunchFlags : undefined,
                 });
               }
             } catch (cloneErr) {
@@ -704,18 +704,18 @@ export function NewWorktreeDialog({
               .getState()
               .generateRecipeFromActiveTerminals(sourceWorktreeId);
             for (const t of terminals) {
+              const isDevPreview = t.type === "dev-preview";
+              const isAgent = !isDevPreview && t.type !== "terminal";
               await usePanelStore.getState().addPanel({
-                kind:
-                  t.type === "dev-preview"
-                    ? "dev-preview"
-                    : t.type === "terminal"
-                      ? "terminal"
-                      : "agent",
-                agentId: t.type !== "terminal" && t.type !== "dev-preview" ? t.type : undefined,
+                kind: isDevPreview ? "dev-preview" : isAgent ? "agent" : "terminal",
+                agentId: isAgent ? t.type : undefined,
                 title: t.title,
                 cwd: worktreePath.trim(),
                 worktreeId,
                 exitBehavior: t.exitBehavior,
+                devCommand: isDevPreview ? t.devCommand : undefined,
+                agentModelId: isAgent ? t.agentModelId : undefined,
+                agentLaunchFlags: isAgent ? t.agentLaunchFlags : undefined,
               });
             }
           } catch (cloneErr) {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -224,6 +224,73 @@ describe("recipeStore", () => {
       expect(persistedRecipe?.terminals?.[0]?.agentModelId).toBeUndefined();
       expect(persistedRecipe?.terminals?.[0]?.agentLaunchFlags).toBeUndefined();
     });
+
+    it("strips agentModelId and agentLaunchFlags when persisting a global recipe update", async () => {
+      useRecipeStore.setState({
+        globalRecipes: [
+          {
+            id: "global-agent",
+            name: "Global Agent",
+            terminals: [{ type: "terminal", title: "Shell", env: {} }],
+            createdAt: 1000,
+          },
+        ],
+        projectRecipes: [],
+        inRepoRecipes: [],
+        recipes: [
+          {
+            id: "global-agent",
+            name: "Global Agent",
+            terminals: [{ type: "terminal", title: "Shell", env: {} }],
+            createdAt: 1000,
+          },
+        ],
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore.getState().updateRecipe("global-agent", {
+        terminals: [
+          {
+            type: "claude",
+            title: "Agent",
+            env: {},
+            agentModelId: "claude-opus-4-7",
+            agentLaunchFlags: ["--resume", "xyz"],
+          },
+        ],
+      });
+
+      expect(globalUpdateRecipeMock).toHaveBeenCalledTimes(1);
+      const persistedUpdates = globalUpdateRecipeMock.mock.calls[0]?.[1];
+      expect(persistedUpdates?.terminals?.[0]?.agentModelId).toBeUndefined();
+      expect(persistedUpdates?.terminals?.[0]?.agentLaunchFlags).toBeUndefined();
+    });
+
+    it("drops session-override fields from recipes loaded from disk (defense-in-depth)", async () => {
+      const contaminatedRecipe = {
+        id: "inrepo-contaminated",
+        name: "Contaminated",
+        terminals: [
+          {
+            type: "claude" as const,
+            title: "Agent",
+            env: {},
+            agentModelId: "claude-opus-4-7",
+            agentLaunchFlags: ["--resume", "old"],
+          },
+        ],
+        createdAt: 1000,
+      };
+      globalGetRecipesMock.mockResolvedValueOnce([]);
+      getRecipesMock.mockResolvedValueOnce([]);
+      getInRepoRecipesMock.mockResolvedValueOnce([contaminatedRecipe]);
+
+      await useRecipeStore.getState().loadRecipes("project-1");
+
+      const loaded = useRecipeStore.getState().inRepoRecipes[0];
+      expect(loaded?.terminals[0]?.agentModelId).toBeUndefined();
+      expect(loaded?.terminals[0]?.agentLaunchFlags).toBeUndefined();
+    });
   });
 
   it("sanitizes agent commands on update before persisting", async () => {

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -57,12 +57,19 @@ vi.mock("@/clients", () => ({
   },
 }));
 
+const panelStoreState: {
+  panelIds: string[];
+  panelsById: Record<string, unknown>;
+  addPanel: typeof addTerminalMock;
+} = {
+  panelIds: [],
+  panelsById: {},
+  addPanel: addTerminalMock,
+};
+
 vi.mock("../panelStore", () => ({
   usePanelStore: {
-    getState: vi.fn(() => ({
-      terminals: [],
-      addPanel: addTerminalMock,
-    })),
+    getState: vi.fn(() => panelStoreState),
   },
 }));
 
@@ -72,6 +79,8 @@ describe("recipeStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useRecipeStore.getState().reset();
+    panelStoreState.panelIds = [];
+    panelStoreState.panelsById = {};
   });
 
   it("rejects malformed recipe json", async () => {
@@ -105,6 +114,116 @@ describe("recipeStore", () => {
     expect(recipe?.terminals[2]?.command).toBeUndefined();
     expect(recipe?.terminals[2]?.initialPrompt).toBe("hello");
     expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe("generateRecipeFromActiveTerminals", () => {
+    it("preserves agentModelId and agentLaunchFlags for agent panels (clone-layout flow)", () => {
+      panelStoreState.panelIds = ["panel-agent", "panel-plain", "panel-dev"];
+      panelStoreState.panelsById = {
+        "panel-agent": {
+          id: "panel-agent",
+          kind: "agent",
+          agentId: "claude",
+          title: "Claude",
+          worktreeId: "wt-1",
+          location: "active",
+          agentModelId: "claude-opus-4-7",
+          agentLaunchFlags: ["--resume", "abc123"],
+        },
+        "panel-plain": {
+          id: "panel-plain",
+          kind: "terminal",
+          title: "Shell",
+          worktreeId: "wt-1",
+          location: "active",
+          command: "npm test",
+          // Plain terminals should never carry agent overrides in the projection.
+          agentModelId: "should-be-ignored",
+          agentLaunchFlags: ["should-be-ignored"],
+        },
+        "panel-dev": {
+          id: "panel-dev",
+          kind: "dev-preview",
+          title: "Preview",
+          worktreeId: "wt-1",
+          location: "active",
+          devCommand: "npm run dev",
+        },
+      };
+
+      const terminals = useRecipeStore.getState().generateRecipeFromActiveTerminals("wt-1");
+      expect(terminals).toHaveLength(3);
+
+      const agentEntry = terminals.find((t) => t.type === "claude");
+      expect(agentEntry?.agentModelId).toBe("claude-opus-4-7");
+      expect(agentEntry?.agentLaunchFlags).toEqual(["--resume", "abc123"]);
+
+      const plainEntry = terminals.find((t) => t.type === "terminal");
+      expect(plainEntry?.agentModelId).toBeUndefined();
+      expect(plainEntry?.agentLaunchFlags).toBeUndefined();
+
+      const devEntry = terminals.find((t) => t.type === "dev-preview");
+      expect(devEntry?.devCommand).toBe("npm run dev");
+      expect(devEntry?.agentModelId).toBeUndefined();
+      expect(devEntry?.agentLaunchFlags).toBeUndefined();
+    });
+
+    it("strips agentModelId and agentLaunchFlags when persisting to disk via createRecipe", async () => {
+      useRecipeStore.setState({ currentProjectId: "project-1" });
+      await useRecipeStore.getState().createRecipe(
+        "project-1",
+        "Layout",
+        undefined,
+        [
+          {
+            type: "claude",
+            title: "Agent",
+            env: {},
+            agentModelId: "claude-opus-4-7",
+            agentLaunchFlags: ["--resume", "abc"],
+          },
+        ],
+        false
+      );
+
+      expect(updateInRepoRecipeMock).toHaveBeenCalledTimes(1);
+      const persistedRecipe = updateInRepoRecipeMock.mock.calls[0]?.[1];
+      expect(persistedRecipe?.terminals?.[0]?.agentModelId).toBeUndefined();
+      expect(persistedRecipe?.terminals?.[0]?.agentLaunchFlags).toBeUndefined();
+    });
+
+    it("strips agentModelId and agentLaunchFlags when persisting to disk via updateRecipe", async () => {
+      useRecipeStore.setState({ currentProjectId: "project-1" });
+      await useRecipeStore
+        .getState()
+        .createRecipe(
+          "project-1",
+          "Layout",
+          undefined,
+          [{ type: "terminal", title: "Shell", command: "npm test", env: {} }],
+          false
+        );
+
+      const recipeId = useRecipeStore.getState().recipes[0]?.id;
+      expect(recipeId).toBeTruthy();
+
+      updateInRepoRecipeMock.mockClear();
+      await useRecipeStore.getState().updateRecipe(recipeId!, {
+        terminals: [
+          {
+            type: "claude",
+            title: "Agent",
+            env: {},
+            agentModelId: "claude-opus-4-7",
+            agentLaunchFlags: ["--resume", "xyz"],
+          },
+        ],
+      });
+
+      const persistedRecipe = updateInRepoRecipeMock.mock.calls[0]?.[1];
+      expect(persistedRecipe?.terminals?.[0]?.agentModelId).toBeUndefined();
+      expect(persistedRecipe?.terminals?.[0]?.agentLaunchFlags).toBeUndefined();
+    });
   });
 
   it("sanitizes agent commands on update before persisting", async () => {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -27,6 +27,22 @@ function isAgentRecipeType(type: RecipeTerminalType): boolean {
   return type !== "terminal" && type !== "dev-preview";
 }
 
+// Recipes read from disk may still contain agentModelId/agentLaunchFlags if
+// they were written by an older build before those fields were stripped on
+// persist. Treat them as session-only state and drop them at load time.
+function stripSessionOverridesFromRecipe(recipe: TerminalRecipe): TerminalRecipe {
+  let changed = false;
+  const terminals = recipe.terminals.map((terminal) => {
+    if (terminal.agentModelId === undefined && terminal.agentLaunchFlags === undefined) {
+      return terminal;
+    }
+    changed = true;
+    const { agentModelId: _m, agentLaunchFlags: _f, ...rest } = terminal;
+    return rest;
+  });
+  return changed ? { ...recipe, terminals } : recipe;
+}
+
 function sanitizeRecipeTerminal(terminal: RecipeTerminal): RecipeTerminal {
   const isAgent = isAgentRecipeType(terminal.type);
   const command = terminal.command?.trim() || undefined;
@@ -158,7 +174,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
         : {}),
     });
     try {
-      const [globalRecipes, projectRecipes, inRepoRecipes] = await Promise.all([
+      const [globalRecipesRaw, projectRecipesRaw, inRepoRecipesRaw] = await Promise.all([
         globalRecipesClient.getRecipes(),
         projectClient.getRecipes(projectId),
         projectClient.getInRepoRecipes(projectId).catch(() => [] as TerminalRecipe[]),
@@ -166,6 +182,9 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       if (requestId !== loadRecipesRequestId || get().currentProjectId !== projectId) {
         return;
       }
+      const globalRecipes = globalRecipesRaw.map(stripSessionOverridesFromRecipe);
+      const projectRecipes = projectRecipesRaw.map(stripSessionOverridesFromRecipe);
+      const inRepoRecipes = inRepoRecipesRaw.map(stripSessionOverridesFromRecipe);
       set({
         globalRecipes,
         projectRecipes,

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -43,6 +43,9 @@ function sanitizeRecipeTerminal(terminal: RecipeTerminal): RecipeTerminal {
     initialPrompt: isAgent ? initialPrompt : undefined,
     devCommand: terminal.type === "dev-preview" ? devCommand : undefined,
     args,
+    // Session-scoped overrides must never leak into disk-saved recipes.
+    agentModelId: undefined,
+    agentLaunchFlags: undefined,
   };
 }
 
@@ -53,6 +56,8 @@ function terminalToRecipeTerminal(terminal: TerminalInstance): RecipeTerminal {
       ? "dev-preview"
       : (terminal.agentId ?? terminal.type ?? "terminal");
 
+  const isAgent = isAgentRecipeType(type);
+
   return {
     type,
     title: terminal.title || undefined,
@@ -60,6 +65,8 @@ function terminalToRecipeTerminal(terminal: TerminalInstance): RecipeTerminal {
     devCommand: terminal.kind === "dev-preview" ? terminal.devCommand : undefined,
     env: {},
     exitBehavior: terminal.exitBehavior,
+    agentModelId: isAgent ? terminal.agentModelId : undefined,
+    agentLaunchFlags: isAgent ? terminal.agentLaunchFlags : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- `RecipeTerminal` now carries optional `agentModelId` and `agentLaunchFlags` fields, populated at snapshot time for agent panels and stripped before writing to disk, so the values are available for cloning without leaking session state into saved recipes.
- Both clone paths in `NewWorktreeDialog` and the bulk-create loop in `BulkCreateWorktreeDialog` now forward these fields (and `devCommand` for dev-preview panels) when building the new layout, so the cloned worktree launches with the same model and flags as the source.
- Load-time sanitisation in `loadRecipes` strips both fields from any pre-contaminated disk data as a defence-in-depth measure.

Resolves #5197

## Changes

- `shared/types/project.ts` — added optional `agentModelId` / `agentLaunchFlags` to `RecipeTerminal`
- `src/store/recipeStore.ts` — snapshot projection, disk sanitisation, and load-time defence
- `src/components/Worktree/NewWorktreeDialog.tsx` — forward fields in both clone branches
- `src/components/GitHub/BulkCreateWorktreeDialog.tsx` — thread `agentModelId` into `generateAgentCommand` and `addPanel` metadata in the agent clone loop

## Testing

Unit tests cover the projection (fields captured for agent panels, omitted for others), disk sanitisation (create, update, and global sanitise paths), load-time stripping, and the bulk-clone command/metadata forwarding. All pass. No existing tests broken.