### PR TITLE
feat(actions): route user-facing agent launches through ActionService

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,7 +209,7 @@ function App() {
   const { findNearest, findByIndex, findDockByIndex, getCurrentLocation } = useGridNavigation();
 
   const { worktrees, worktreeMap } = useWorktrees();
-  const newTerminalPalette = useNewTerminalPalette({ launchAgent, worktreeMap });
+  const newTerminalPalette = useNewTerminalPalette({ worktreeMap });
   const panelPalette = usePanelPalette();
   const projectSwitcherPalette = useProjectSwitcherPalette();
   const actionPalette = useActionPalette();
@@ -364,7 +364,7 @@ function App() {
     usePaletteStore.getState().closePalette("theme");
   }, []);
 
-  const overviewWorktreeActions = useWorktreeActions({ launchAgent });
+  const overviewWorktreeActions = useWorktreeActions();
 
   useAppEventListeners();
 

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -295,7 +295,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const [isRefreshing, startRefreshTransition] = useTransition();
   const currentProject = useProjectStore((state) => state.currentProject);
   useProjectSettings();
-  const { launchAgent, availability, agentSettings } = useAgentLauncher();
+  const { availability, agentSettings } = useAgentLauncher();
   const {
     activeWorktreeId,
     focusedWorktreeId,
@@ -772,7 +772,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   const worktreeActions = useWorktreeActions({
     onOpenRecipeEditor: handleOpenRecipeEditor,
-    launchAgent,
   });
 
   const handleCloseRecipeEditor = useCallback(() => {

--- a/src/hooks/__tests__/useNewTerminalPalette.test.tsx
+++ b/src/hooks/__tests__/useNewTerminalPalette.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment jsdom
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorktreeState } from "@/types";
 
-const { getEffectiveAgentIdsMock, getLaunchOptionsMock, cliAvailabilityState } = vi.hoisted(() => ({
+const {
+  dispatchMock,
+  addPanelMock,
+  getEffectiveAgentIdsMock,
+  getLaunchOptionsMock,
+  cliAvailabilityState,
+} = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+  addPanelMock: vi.fn(),
   getEffectiveAgentIdsMock: vi.fn(),
   getLaunchOptionsMock: vi.fn(),
   cliAvailabilityState: {
@@ -28,14 +37,14 @@ vi.mock("@/components/TerminalPalette/launchOptions", () => ({
 
 vi.mock("@/store", () => ({
   useWorktreeSelectionStore: (selector: (state: { activeWorktreeId: string | null }) => unknown) =>
-    selector({ activeWorktreeId: null }),
-  usePanelStore: (selector: (state: { addPanel: typeof vi.fn }) => unknown) =>
-    selector({ addPanel: vi.fn() }),
+    selector({ activeWorktreeId: "wt-1" }),
+  usePanelStore: (selector: (state: { addPanel: typeof addPanelMock }) => unknown) =>
+    selector({ addPanel: addPanelMock }),
 }));
 
 vi.mock("@/store/projectStore", () => ({
-  useProjectStore: (selector: (state: { currentProject: null }) => unknown) =>
-    selector({ currentProject: null }),
+  useProjectStore: (selector: (state: { currentProject: { path: string } | null }) => unknown) =>
+    selector({ currentProject: { path: "/repo" } }),
 }));
 
 vi.mock("@/store/cliAvailabilityStore", () => {
@@ -46,26 +55,49 @@ vi.mock("@/store/cliAvailabilityStore", () => {
 });
 
 vi.mock("@/services/ActionService", () => ({
-  actionService: { dispatch: vi.fn() },
+  actionService: { dispatch: dispatchMock },
 }));
 
-import { useNewTerminalPalette } from "../useNewTerminalPalette";
+import { useNewTerminalPalette, MORE_AGENTS_TERMINAL_ID } from "../useNewTerminalPalette";
 
-function makeOption(id: string) {
+function makeOption(id: string, overrides: { type?: string; kind?: string } = {}) {
   return {
     id,
-    type: id,
+    type: overrides.type ?? id,
+    kind: overrides.kind,
     label: id,
     description: `${id} description`,
     icon: null,
   };
 }
 
+function makeWorktreeMap(): Map<string, WorktreeState> {
+  const map = new Map<string, WorktreeState>();
+  map.set("wt-1", {
+    id: "wt-1",
+    worktreeId: "wt-1",
+    path: "/repo/wt-1",
+    name: "wt-1",
+    branch: "main",
+    isCurrent: false,
+    isMainWorktree: false,
+    worktreeChanges: null,
+    lastActivityTimestamp: null,
+  });
+  return map;
+}
+
 describe("useNewTerminalPalette", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     cliAvailabilityState.isInitialized = true;
-    cliAvailabilityState.availability = {};
+    cliAvailabilityState.availability = {
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+    };
 
     getEffectiveAgentIdsMock.mockReturnValue(["claude", "gemini", "codex"]);
     getLaunchOptionsMock.mockReturnValue([
@@ -73,15 +105,17 @@ describe("useNewTerminalPalette", () => {
       makeOption("gemini"),
       makeOption("codex"),
       makeOption("terminal"),
-      makeOption("browser"),
+      makeOption("browser", { type: "terminal", kind: "browser" }),
     ]);
+
+    dispatchMock.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   function render() {
     return renderHook(() =>
       useNewTerminalPalette({
-        launchAgent: vi.fn().mockResolvedValue(null),
-        worktreeMap: new Map(),
+        worktreeMap: makeWorktreeMap(),
       })
     );
   }
@@ -128,11 +162,94 @@ describe("useNewTerminalPalette", () => {
   });
 
   it("always includes the more-agents entry at the end", () => {
-    cliAvailabilityState.availability = { claude: "ready", gemini: "ready", codex: "ready" };
-
     const { result } = render();
 
     const ids = result.current.results.map((opt) => opt.id);
     expect(ids[ids.length - 1]).toBe("more-agents");
+  });
+
+  it("dispatches agent.launch through the ActionService when an agent option is selected", async () => {
+    const { result } = render();
+    const option = result.current.results.find((r) => r.id === "claude");
+    expect(option).toBeDefined();
+
+    await act(async () => {
+      await result.current.handleSelect(option!);
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "agent.launch",
+      {
+        agentId: "claude",
+        worktreeId: "wt-1",
+        cwd: "/repo/wt-1",
+        location: "grid",
+      },
+      { source: "user" }
+    );
+    expect(addPanelMock).not.toHaveBeenCalled();
+  });
+
+  it("adds a browser panel without dispatching agent.launch for the browser option", async () => {
+    addPanelMock.mockResolvedValueOnce("term-browser");
+    const { result } = render();
+    const option = result.current.results.find((r) => r.kind === "browser");
+    expect(option).toBeDefined();
+
+    await act(async () => {
+      await result.current.handleSelect(option!);
+    });
+
+    expect(addPanelMock).toHaveBeenCalledWith({
+      kind: "browser",
+      cwd: "/repo/wt-1",
+      worktreeId: "wt-1",
+      location: "grid",
+    });
+    expect(dispatchMock).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("opens the agents settings tab for MORE_AGENTS_TERMINAL_ID and does not dispatch agent.launch", async () => {
+    const { result } = render();
+    const option = result.current.results.find((r) => r.id === MORE_AGENTS_TERMINAL_ID);
+    expect(option).toBeDefined();
+
+    await act(async () => {
+      await result.current.handleSelect(option!);
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "agents" },
+      { source: "user" }
+    );
+    expect(dispatchMock).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("logs an error and still closes when agent.launch dispatch fails", async () => {
+    dispatchMock.mockResolvedValueOnce({
+      ok: false,
+      error: { code: "NOT_FOUND", message: "Action not found" },
+    });
+
+    const { result } = render();
+    const option = result.current.results.find((r) => r.id === "claude");
+
+    await act(async () => {
+      await result.current.handleSelect(option!);
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to launch claude terminal:",
+      expect.objectContaining({ message: "Action not found" })
+    );
   });
 });

--- a/src/hooks/__tests__/useNewTerminalPalette.test.tsx
+++ b/src/hooks/__tests__/useNewTerminalPalette.test.tsx
@@ -8,16 +8,20 @@ const {
   addPanelMock,
   getEffectiveAgentIdsMock,
   getLaunchOptionsMock,
+  closePaletteMock,
   cliAvailabilityState,
+  paletteState,
 } = vi.hoisted(() => ({
   dispatchMock: vi.fn(),
   addPanelMock: vi.fn(),
   getEffectiveAgentIdsMock: vi.fn(),
   getLaunchOptionsMock: vi.fn(),
+  closePaletteMock: vi.fn(),
   cliAvailabilityState: {
     availability: {} as Record<string, string>,
     isInitialized: true,
   },
+  paletteState: { activePaletteId: null as string | null },
 }));
 
 vi.mock("@shared/config/agentRegistry", () => ({
@@ -52,6 +56,25 @@ vi.mock("@/store/cliAvailabilityStore", () => {
     selector(cliAvailabilityState);
   store.getState = () => cliAvailabilityState;
   return { useCliAvailabilityStore: store };
+});
+
+vi.mock("@/store/paletteStore", () => {
+  const store = Object.assign(
+    (selector: (state: { activePaletteId: string | null }) => unknown) => selector(paletteState),
+    {
+      getState: () => ({
+        activePaletteId: paletteState.activePaletteId,
+        openPalette: (id: string) => {
+          paletteState.activePaletteId = id;
+        },
+        closePalette: (id: string) => {
+          closePaletteMock(id);
+          if (paletteState.activePaletteId === id) paletteState.activePaletteId = null;
+        },
+      }),
+    }
+  );
+  return { usePaletteStore: store };
 });
 
 vi.mock("@/services/ActionService", () => ({
@@ -98,6 +121,7 @@ describe("useNewTerminalPalette", () => {
       gemini: "ready",
       codex: "ready",
     };
+    paletteState.activePaletteId = null;
 
     getEffectiveAgentIdsMock.mockReturnValue(["claude", "gemini", "codex"]);
     getLaunchOptionsMock.mockReturnValue([

--- a/src/hooks/__tests__/useWorktreeActions.test.tsx
+++ b/src/hooks/__tests__/useWorktreeActions.test.tsx
@@ -83,6 +83,20 @@ describe("useWorktreeActions", () => {
 
     expect(message).toBe("Copied 0 files to clipboard");
   });
+
+  it("handleLaunchAgent dispatches agent.launch through the ActionService", () => {
+    dispatchMock.mockResolvedValueOnce({ ok: true, result: { terminalId: "term-1" } });
+
+    const { result } = renderHook(() => useWorktreeActions());
+    result.current.handleLaunchAgent("wt-1", "claude");
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "agent.launch",
+      { agentId: "claude", worktreeId: "wt-1", location: "grid" },
+      { source: "user" }
+    );
+  });
 });
 
 describe("formatCopyResultMessage", () => {

--- a/src/hooks/__tests__/useWorktreeActions.test.tsx
+++ b/src/hooks/__tests__/useWorktreeActions.test.tsx
@@ -97,6 +97,19 @@ describe("useWorktreeActions", () => {
       { source: "user" }
     );
   });
+
+  it("handleLaunchAgent dispatches agent.launch for dev-preview panels", () => {
+    dispatchMock.mockResolvedValueOnce({ ok: true, result: { terminalId: "term-dev" } });
+
+    const { result } = renderHook(() => useWorktreeActions());
+    result.current.handleLaunchAgent("wt-1", "dev-preview");
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "agent.launch",
+      { agentId: "dev-preview", worktreeId: "wt-1", location: "grid" },
+      { source: "user" }
+    );
+  });
 });
 
 describe("formatCopyResultMessage", () => {

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -4,7 +4,6 @@ import {
   getMoreAgentsOption,
   type LaunchOption,
 } from "@/components/TerminalPalette/launchOptions";
-import type { LaunchAgentOptions } from "./useAgentLauncher";
 import { useWorktreeSelectionStore, usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
@@ -15,7 +14,6 @@ import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 interface UseNewTerminalPaletteProps {
-  launchAgent: (type: string, options?: LaunchAgentOptions) => Promise<string | null>;
   worktreeMap: Map<string, WorktreeState>;
 }
 
@@ -37,7 +35,6 @@ function filterLaunchOptions(items: LaunchOption[], query: string): LaunchOption
 export const MORE_AGENTS_TERMINAL_ID = "more-agents";
 
 export function useNewTerminalPalette({
-  launchAgent,
   worktreeMap,
 }: UseNewTerminalPaletteProps): UseNewTerminalPaletteReturn {
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
@@ -97,17 +94,25 @@ export function useNewTerminalPalette({
           return;
         }
 
-        await launchAgent(option.type, {
-          worktreeId: targetWorktreeId || undefined,
-          cwd,
-          location: "grid",
-        });
+        const result = await actionService.dispatch(
+          "agent.launch",
+          {
+            agentId: option.type,
+            worktreeId: targetWorktreeId || undefined,
+            cwd,
+            location: "grid",
+          },
+          { source: "user" }
+        );
+        if (!result.ok) {
+          console.error(`Failed to launch ${option.type} terminal:`, result.error);
+        }
         close();
       } catch (error) {
         console.error(`Failed to launch ${option.type} terminal:`, error);
       }
     },
-    [activeWorktreeId, worktreeMap, currentProject, launchAgent, addPanel, close]
+    [activeWorktreeId, worktreeMap, currentProject, addPanel, close]
   );
 
   const confirmSelection = useCallback(() => {

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -100,7 +100,6 @@ export async function copyContextWithFeedback(
 
 export interface UseWorktreeActionsOptions {
   onOpenRecipeEditor?: (worktreeId: string, initialTerminals?: RecipeTerminal[]) => void;
-  launchAgent?: (agentId: string, options: { worktreeId: string; location: "grid" }) => void;
 }
 
 export interface WorktreeActions {
@@ -114,7 +113,6 @@ export interface WorktreeActions {
 
 export function useWorktreeActions({
   onOpenRecipeEditor,
-  launchAgent,
 }: UseWorktreeActionsOptions = {}): WorktreeActions {
   const addError = useErrorStore((state) => state.addError);
 
@@ -222,12 +220,13 @@ export function useWorktreeActions({
     [addError, onOpenRecipeEditor]
   );
 
-  const handleLaunchAgent = useCallback(
-    (worktreeId: string, agentId: string) => {
-      launchAgent?.(agentId, { worktreeId, location: "grid" });
-    },
-    [launchAgent]
-  );
+  const handleLaunchAgent = useCallback((worktreeId: string, agentId: string) => {
+    void actionService.dispatch(
+      "agent.launch",
+      { agentId, worktreeId, location: "grid" },
+      { source: "user" }
+    );
+  }, []);
 
   return useMemo(
     () => ({

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -247,3 +247,62 @@ describe("agentActions adversarial", () => {
     expect([...(set as Set<string>)].sort()).toEqual(["backup", "other", "primary"]);
   });
 });
+
+describe("agent.launch dispatch integration", () => {
+  it("routes through ActionService.dispatch with validated args and returns terminalId", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+
+    for (const [, factory] of registry) {
+      service.register(factory());
+    }
+
+    const result = await service.dispatch<{ terminalId: string }>(
+      "agent.launch",
+      { agentId: "claude", worktreeId: "wt-1", location: "grid" },
+      { source: "user" }
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result).toEqual({ terminalId: "term-1" });
+    }
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith("claude", {
+      location: "grid",
+      cwd: undefined,
+      worktreeId: "wt-1",
+      prompt: undefined,
+      interactive: undefined,
+      modelId: undefined,
+    });
+  });
+
+  it("rejects malformed args with a VALIDATION_ERROR result rather than invoking the callback", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+
+    for (const [, factory] of registry) {
+      service.register(factory());
+    }
+
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "not-a-real-agent" },
+      { source: "user" }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("VALIDATION_ERROR");
+    }
+    expect(callbacks.onLaunchAgent).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -281,7 +281,7 @@ describe("agent.launch dispatch integration", () => {
     });
   });
 
-  it("rejects malformed args with a VALIDATION_ERROR result rather than invoking the callback", async () => {
+  it("rejects malformed args with a VALIDATION_ERROR targeting agentId and never invokes the callback", async () => {
     const { ActionService } = await import("../../../ActionService");
     const service = new ActionService();
 
@@ -302,7 +302,33 @@ describe("agent.launch dispatch integration", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.code).toBe("VALIDATION_ERROR");
+      expect(JSON.stringify(result.error.details)).toContain("agentId");
     }
     expect(callbacks.onLaunchAgent).not.toHaveBeenCalled();
+  });
+
+  it("accepts dev-preview through the schema so worktree-card dev-preview launches don't silently fail", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+
+    for (const [, factory] of registry) {
+      service.register(factory());
+    }
+
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "dev-preview", worktreeId: "wt-1", location: "grid" },
+      { source: "user" }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
+      "dev-preview",
+      expect.objectContaining({ worktreeId: "wt-1", location: "grid" })
+    );
   });
 });

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { BUILT_IN_AGENT_IDS, BUILT_IN_TERMINAL_TYPES } from "@shared/config/agentIds";
 
-export const AgentIdSchema = z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser"]);
+export const AgentIdSchema = z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]);
 
 export const LaunchLocationSchema = z.enum(["grid", "dock"]);
 


### PR DESCRIPTION
## Summary

- Routes the two remaining user-facing `agent.launch` call-sites (`useWorktreeActions` and `useNewTerminalPalette`) through `actionService.dispatch("agent.launch", ...)` so launches show up in the action log and are reachable via the MCP manifest and keybindings.
- Fixes a pre-existing schema gap where `dev-preview` wasn't accepted by `AgentIdSchema`, which would have caused silent failures under the new dispatch path.
- System/programmatic callers (wizard auto-launch, panel palette picks, onboarding) keep calling `useAgentLauncher.launchAgent` directly to avoid flooding the action log with loop iterations, per the issue guidance.

Resolves #5209

## Changes

- `src/hooks/useWorktreeActions.ts` — dispatches `agent.launch` instead of accepting a `launchAgent` prop
- `src/hooks/useNewTerminalPalette.ts` — dispatches `agent.launch` with `result.ok` check; closes after check; removes unused `LaunchAgentOptions` import
- `src/components/Sidebar/SidebarContent.tsx` — stops passing `launchAgent` to `useWorktreeActions`
- `src/App.tsx` — drops `launchAgent` arg from `useNewTerminalPalette` and `useWorktreeActions(overview)` calls
- `src/services/actions/definitions/schemas.ts` — adds `"dev-preview"` to `AgentIdSchema` enum
- Tests: `useWorktreeActions.test.tsx`, `useNewTerminalPalette.test.tsx` (new), `agentActions.adversarial.test.ts`

## Testing

44 targeted tests pass across `useWorktreeActions`, `useNewTerminalPalette`, and `agentActions.adversarial`. 160 action-definition tests pass overall. `npm run check` (typecheck + lint + format) is clean with 401 warnings matching the pre-existing baseline.

Adversarial coverage confirms: round-trip dispatch of valid args, rejection of unknown `agentId` with `VALIDATION_ERROR` pointing at `agentId`, and acceptance of `dev-preview`.