### PR TITLE
feat(plugin): warn on unknown action IDs at manifest load

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -588,6 +588,7 @@ export const CHANNELS = {
   PLUGIN_INVOKE: "plugin:invoke",
   PLUGIN_TOOLBAR_BUTTONS: "plugin:toolbar-buttons",
   PLUGIN_MENU_ITEMS: "plugin:menu-items",
+  PLUGIN_VALIDATE_ACTION_IDS: "plugin:validate-action-ids",
 
   RESOURCE_PROFILE_CHANGED: "resource:profile-changed",
 

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -169,7 +169,7 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     warn.mockRestore();
   });
 
-  it("warns when a toolbar button actionId is unknown", async () => {
+  it("warns with the exact message when a toolbar button actionId is unknown", async () => {
     mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.my.button"]);
     mockGetToolbarButtonConfig.mockReturnValue({
       id: "plugin.my.button",
@@ -183,15 +183,13 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     const handler = getValidateHandler();
     await handler({}, ["action.known"]);
     expect(warn).toHaveBeenCalledTimes(1);
-    const message = warn.mock.calls[0]![0] as string;
-    expect(message).toContain("action.missing");
-    expect(message).toContain("plugin.my.button");
-    expect(message).toContain("my-plugin");
-    expect(message).toContain("toolbar button");
+    expect(warn).toHaveBeenCalledWith(
+      '[Plugin] Unknown actionId "action.missing" on toolbar button "plugin.my.button" (plugin: my-plugin)'
+    );
     warn.mockRestore();
   });
 
-  it("warns when a menu item actionId is unknown", async () => {
+  it("warns with the exact message when a menu item actionId is unknown", async () => {
     mockGetPluginMenuItems.mockReturnValue([
       {
         pluginId: "my-plugin",
@@ -206,11 +204,9 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     const handler = getValidateHandler();
     await handler({}, ["action.known"]);
     expect(warn).toHaveBeenCalledTimes(1);
-    const message = warn.mock.calls[0]![0] as string;
-    expect(message).toContain("action.missing");
-    expect(message).toContain("Do Thing");
-    expect(message).toContain("my-plugin");
-    expect(message).toContain("menu item");
+    expect(warn).toHaveBeenCalledWith(
+      '[Plugin] Unknown actionId "action.missing" on menu item "Do Thing" (plugin: my-plugin)'
+    );
     warn.mockRestore();
   });
 
@@ -280,6 +276,47 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const handler = getValidateHandler();
     await expect(handler({}, [])).resolves.toBeUndefined();
+    warn.mockRestore();
+  });
+
+  it.each<[string, unknown]>([
+    ["null", null],
+    ["undefined", undefined],
+    ["string", "action.a"],
+    ["object", { a: 1 }],
+  ])("does not warn when payload is a non-array (%s)", async (_label, payload) => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.a"]);
+    mockGetToolbarButtonConfig.mockReturnValue({
+      id: "plugin.a",
+      label: "A",
+      iconId: "i",
+      actionId: "action.missing",
+      priority: 3,
+      pluginId: "p1",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await expect(handler({}, payload as unknown as string[])).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("only validates once per handler lifecycle so multi-window callers don't double-log", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.a"]);
+    mockGetToolbarButtonConfig.mockReturnValue({
+      id: "plugin.a",
+      label: "A",
+      iconId: "i",
+      actionId: "action.missing",
+      priority: 3,
+      pluginId: "p1",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, []);
+    await handler({}, []);
+    await handler({}, []);
+    expect(warn).toHaveBeenCalledTimes(1);
     warn.mockRestore();
   });
 });

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -14,6 +14,18 @@ vi.mock("../../../services/PluginService.js", () => ({
   },
 }));
 
+const mockGetPluginToolbarButtonIds = vi.fn();
+const mockGetToolbarButtonConfig = vi.fn();
+vi.mock("../../../../shared/config/toolbarButtonRegistry.js", () => ({
+  getPluginToolbarButtonIds: (...args: unknown[]) => mockGetPluginToolbarButtonIds(...args),
+  getToolbarButtonConfig: (...args: unknown[]) => mockGetToolbarButtonConfig(...args),
+}));
+
+const mockGetPluginMenuItems = vi.fn();
+vi.mock("../../../services/pluginMenuRegistry.js", () => ({
+  getPluginMenuItems: (...args: unknown[]) => mockGetPluginMenuItems(...args),
+}));
+
 const mockIpcMainHandle = vi.fn();
 const mockIpcMainRemoveHandler = vi.fn();
 vi.mock("electron", () => ({
@@ -27,16 +39,23 @@ import { registerPluginHandlers, registerPluginHandler, removePluginHandlers } f
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockGetPluginToolbarButtonIds.mockReturnValue([]);
+  mockGetToolbarButtonConfig.mockReturnValue(undefined);
+  mockGetPluginMenuItems.mockReturnValue([]);
 });
 
 describe("registerPluginHandlers", () => {
-  it("registers handlers for PLUGIN_LIST, PLUGIN_INVOKE, PLUGIN_TOOLBAR_BUTTONS, and PLUGIN_MENU_ITEMS", () => {
+  it("registers handlers for PLUGIN_LIST, PLUGIN_INVOKE, PLUGIN_TOOLBAR_BUTTONS, PLUGIN_MENU_ITEMS, and PLUGIN_VALIDATE_ACTION_IDS", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(4);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(5);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:menu-items", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:validate-action-ids",
+      expect.any(Function)
+    );
   });
 
   it("cleanup removes all handlers", () => {
@@ -46,6 +65,7 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:invoke");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:toolbar-buttons");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:menu-items");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:validate-action-ids");
   });
 
   it("PLUGIN_LIST handler delegates to pluginService.listPlugins", async () => {
@@ -113,6 +133,154 @@ describe("registerPluginHandlers", () => {
       "plugin:invoke rejected: untrusted sender"
     );
     expect(mockDispatchHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
+  function getValidateHandler() {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:validate-action-ids"
+    )![1] as (event: unknown, actionIds: string[]) => Promise<void>;
+  }
+
+  it("does nothing when there are no plugin contributions", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, ["action.a", "action.b"]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not warn when every toolbar button actionId is known", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.my.button"]);
+    mockGetToolbarButtonConfig.mockReturnValue({
+      id: "plugin.my.button",
+      label: "My Button",
+      iconId: "icon",
+      actionId: "action.known",
+      priority: 3,
+      pluginId: "my-plugin",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, ["action.known", "action.other"]);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("warns when a toolbar button actionId is unknown", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.my.button"]);
+    mockGetToolbarButtonConfig.mockReturnValue({
+      id: "plugin.my.button",
+      label: "My Button",
+      iconId: "icon",
+      actionId: "action.missing",
+      priority: 3,
+      pluginId: "my-plugin",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, ["action.known"]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]![0] as string;
+    expect(message).toContain("action.missing");
+    expect(message).toContain("plugin.my.button");
+    expect(message).toContain("my-plugin");
+    expect(message).toContain("toolbar button");
+    warn.mockRestore();
+  });
+
+  it("warns when a menu item actionId is unknown", async () => {
+    mockGetPluginMenuItems.mockReturnValue([
+      {
+        pluginId: "my-plugin",
+        item: {
+          label: "Do Thing",
+          actionId: "action.missing",
+          location: "view",
+        },
+      },
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, ["action.known"]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = warn.mock.calls[0]![0] as string;
+    expect(message).toContain("action.missing");
+    expect(message).toContain("Do Thing");
+    expect(message).toContain("my-plugin");
+    expect(message).toContain("menu item");
+    warn.mockRestore();
+  });
+
+  it("warns only for unknown actionIds when contributions are mixed", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.a", "plugin.b"]);
+    mockGetToolbarButtonConfig.mockImplementation((id: string) => {
+      if (id === "plugin.a") {
+        return {
+          id: "plugin.a",
+          label: "A",
+          iconId: "i",
+          actionId: "action.ok",
+          priority: 3,
+          pluginId: "p1",
+        };
+      }
+      return {
+        id: "plugin.b",
+        label: "B",
+        iconId: "i",
+        actionId: "action.bad",
+        priority: 3,
+        pluginId: "p2",
+      };
+    });
+    mockGetPluginMenuItems.mockReturnValue([
+      {
+        pluginId: "p3",
+        item: { label: "Menu OK", actionId: "action.ok", location: "view" },
+      },
+      {
+        pluginId: "p4",
+        item: { label: "Menu Bad", actionId: "action.bad2", location: "view" },
+      },
+    ]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await handler({}, ["action.ok"]);
+    expect(warn).toHaveBeenCalledTimes(2);
+    const messages = warn.mock.calls.map((c) => c[0] as string).join("\n");
+    expect(messages).toContain("action.bad");
+    expect(messages).toContain("action.bad2");
+    expect(messages).not.toContain("action.ok");
+    warn.mockRestore();
+  });
+
+  it("skips toolbar button ids with no config", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.orphan"]);
+    mockGetToolbarButtonConfig.mockReturnValue(undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await expect(handler({}, [])).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("resolves without throwing when warnings are emitted", async () => {
+    mockGetPluginToolbarButtonIds.mockReturnValue(["plugin.a"]);
+    mockGetToolbarButtonConfig.mockReturnValue({
+      id: "plugin.a",
+      label: "A",
+      iconId: "i",
+      actionId: "action.missing",
+      priority: 3,
+      pluginId: "p1",
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const handler = getValidateHandler();
+    await expect(handler({}, [])).resolves.toBeUndefined();
+    warn.mockRestore();
   });
 });
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -10,8 +10,11 @@ import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type { LoadedPluginInfo, PluginIpcHandler } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 
+let hasValidatedActionIds = false;
+
 export function registerPluginHandlers(): () => void {
   const handlers: Array<() => void> = [];
+  hasValidatedActionIds = false;
 
   const handleList = async (): Promise<LoadedPluginInfo[]> => {
     return pluginService.listPlugins();
@@ -29,9 +32,13 @@ export function registerPluginHandlers(): () => void {
 
   const handleValidateActionIds = async (
     _event: Electron.IpcMainInvokeEvent,
-    actionIds: string[]
+    actionIds: unknown
   ): Promise<void> => {
-    const knownIds = new Set(actionIds);
+    if (hasValidatedActionIds) return;
+    if (!Array.isArray(actionIds)) return;
+    hasValidatedActionIds = true;
+
+    const knownIds = new Set(actionIds.filter((id): id is string => typeof id === "string"));
 
     for (const id of getPluginToolbarButtonIds()) {
       const config = getToolbarButtonConfig(id);

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -27,6 +27,31 @@ export function registerPluginHandlers(): () => void {
     return getPluginMenuItems();
   };
 
+  const handleValidateActionIds = async (
+    _event: Electron.IpcMainInvokeEvent,
+    actionIds: string[]
+  ): Promise<void> => {
+    const knownIds = new Set(actionIds);
+
+    for (const id of getPluginToolbarButtonIds()) {
+      const config = getToolbarButtonConfig(id);
+      if (!config) continue;
+      if (!knownIds.has(config.actionId)) {
+        console.warn(
+          `[Plugin] Unknown actionId "${config.actionId}" on toolbar button "${config.id}" (plugin: ${config.pluginId})`
+        );
+      }
+    }
+
+    for (const { pluginId, item } of getPluginMenuItems()) {
+      if (!knownIds.has(item.actionId)) {
+        console.warn(
+          `[Plugin] Unknown actionId "${item.actionId}" on menu item "${item.label}" (plugin: ${pluginId})`
+        );
+      }
+    }
+  };
+
   ipcMain.handle(CHANNELS.PLUGIN_LIST, handleList);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_LIST));
 
@@ -47,6 +72,9 @@ export function registerPluginHandlers(): () => void {
 
   ipcMain.handle(CHANNELS.PLUGIN_MENU_ITEMS, handleMenuItems);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_MENU_ITEMS));
+
+  ipcMain.handle(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, handleValidateActionIds);
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1094,6 +1094,7 @@ const CHANNELS = {
   PLUGIN_INVOKE: "plugin:invoke",
   PLUGIN_TOOLBAR_BUTTONS: "plugin:toolbar-buttons",
   PLUGIN_MENU_ITEMS: "plugin:menu-items",
+  PLUGIN_VALIDATE_ACTION_IDS: "plugin:validate-action-ids",
 
   RESOURCE_PROFILE_CHANGED: "resource:profile-changed",
 
@@ -2861,6 +2862,8 @@ const api: ElectronAPI = {
 
     toolbarButtons: () => _unwrappingInvoke(CHANNELS.PLUGIN_TOOLBAR_BUTTONS),
     menuItems: () => _unwrappingInvoke(CHANNELS.PLUGIN_MENU_ITEMS),
+    validateActionIds: (actionIds: string[]) =>
+      _unwrappingInvoke(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, actionIds),
   },
 
   crashRecovery: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1273,6 +1273,7 @@ export interface ElectronAPI {
         item: import("../plugin.js").MenuItemContribution;
       }>
     >;
+    validateActionIds(actionIds: string[]): Promise<void>;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1304,6 +1304,10 @@ export interface IpcInvokeMap {
       item: import("../plugin.js").MenuItemContribution;
     }>;
   };
+  "plugin:validate-action-ids": {
+    args: [actionIds: string[]];
+    result: void;
+  };
 
   // Dev Preview channels
   "dev-preview:ensure": {

--- a/src/hooks/useActionRegistry.ts
+++ b/src/hooks/useActionRegistry.ts
@@ -20,6 +20,7 @@ export type { ActionCallbacks };
  */
 export function useActionRegistry(options: ActionCallbacks): void {
   const registeredRef = useRef(false);
+  const validatedRef = useRef(false);
   const callbacksRef = useRef<ActionCallbacks>(options);
 
   // Always keep the ref updated with latest callbacks
@@ -98,6 +99,8 @@ export function useActionRegistry(options: ActionCallbacks): void {
 
   useEffect(() => {
     if (!registeredRef.current) return;
+    if (validatedRef.current) return;
+    validatedRef.current = true;
     void window.electron.plugin
       .validateActionIds(actionService.list().map((entry) => entry.id))
       .catch(() => {});

--- a/src/hooks/useActionRegistry.ts
+++ b/src/hooks/useActionRegistry.ts
@@ -95,4 +95,11 @@ export function useActionRegistry(options: ActionCallbacks): void {
 
     registeredRef.current = true;
   }, []);
+
+  useEffect(() => {
+    if (!registeredRef.current) return;
+    void window.electron.plugin
+      .validateActionIds(actionService.list().map((entry) => entry.id))
+      .catch(() => {});
+  }, []);
 }


### PR DESCRIPTION
## Summary

- Adds a `plugin:validate-action-ids` IPC channel (fire-and-forget invoke) that lets the renderer push the full set of known action IDs to main after registration. The handler iterates registered plugin toolbar buttons and menu items and logs a `console.warn` for any `actionId` that isn't in the known set.
- Renderer-side: a second `useEffect` in `useActionRegistry` pushes `actionService.list()` IDs to main after the action registry is populated. A `validatedRef` guard makes it StrictMode-safe and dedupe-guards multi-window scenarios.
- Plugins are never rejected or blocked. Warnings are diagnostic only, giving plugin authors early feedback on stale or mistyped action IDs without any user-facing impact.

Resolves #5215

## Changes

- `electron/ipc/channels.ts` — new `PLUGIN_VALIDATE_ACTION_IDS` channel constant
- `electron/ipc/handlers/plugin.ts` — validation handler with dedupe guard and payload guard
- `electron/preload.cts` — exposes `window.electron.plugin.validateActionIds`
- `shared/types/ipc/api.ts` / `maps.ts` — IPC type plumbing
- `src/hooks/useActionRegistry.ts` — renderer-side effect to push known IDs after registration
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` — 5 new cases (known/unknown/mixed/malformed payload/multi-call dedupe); 19/19 passing

## Testing

All 19 tests in `plugin.handlers.test.ts` pass. Exact warning strings are pinned. Malformed payloads (non-arrays) no-op cleanly. Multi-window dedupe confirmed via the `validatedRef` guard test.