### PR TITLE
feat(telemetry): add structured events for project view eviction, revival, and cold-start

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -7,6 +7,7 @@
 
 import { BrowserWindow, WebContentsView, session } from "electron";
 import path from "path";
+import { performance } from "node:perf_hooks";
 import {
   registerWebContents,
   registerAppView,
@@ -21,6 +22,7 @@ import { isLocalhostUrl } from "../../shared/utils/urlUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { notifyError } from "../ipc/errorHandlers.js";
+import { logInfo } from "../utils/logger.js";
 import { injectSkeletonCss } from "./skeletonCss.js";
 
 const GC_DELAY_MS = 100;
@@ -29,6 +31,8 @@ const CRASH_LOOP_WINDOW_MS = 60_000;
 const CRASH_LOOP_THRESHOLD = 3;
 
 type ViewState = "loading" | "active" | "cached";
+
+type EvictionReason = "lru" | "pressure" | "limit-change";
 
 interface ViewEntry {
   view: WebContentsView;
@@ -64,6 +68,7 @@ export class ProjectViewManager {
   private windowRegistry?: import("./WindowRegistry.js").WindowRegistry;
   private switchChain: Promise<void> = Promise.resolve();
   private resizeHandler: (() => void) | null = null;
+  private evictionTimestamps = new Map<string, number>();
 
   constructor(win: BrowserWindow, opts: ProjectViewManagerOptions) {
     this.win = win;
@@ -154,6 +159,14 @@ export class ProjectViewManager {
     // Try to activate cached view
     const cached = this.views.get(projectId);
     if (cached && !cached.view.webContents.isDestroyed()) {
+      const evictedAt = this.evictionTimestamps.get(projectId);
+      if (evictedAt !== undefined) {
+        logInfo("projectview.revival", {
+          projectId,
+          timeSinceEvictionMs: Date.now() - evictedAt,
+        });
+        this.evictionTimestamps.delete(projectId);
+      }
       this.activateView(cached);
       return { view: cached.view, isNew: false };
     }
@@ -163,6 +176,7 @@ export class ProjectViewManager {
       this.cleanupEntry(projectId);
     }
 
+    const coldStartAt = performance.now();
     const view = this.createView(projectId);
     const entry: ViewEntry = {
       view,
@@ -194,6 +208,10 @@ export class ProjectViewManager {
     try {
       // Load the renderer with projectId context
       await this.loadView(view, projectId);
+      logInfo("projectview.coldstart", {
+        projectId,
+        durationMs: Math.round(performance.now() - coldStartAt),
+      });
     } catch (loadError) {
       // Rollback: clean up the failed new view
       this.cleanupEntry(projectId);
@@ -221,7 +239,7 @@ export class ProjectViewManager {
     }
 
     // Evict LRU views if over limit
-    this.evictStaleViews();
+    this.evictStaleViews("lru");
 
     return { view, isNew: true };
   }
@@ -250,7 +268,7 @@ export class ProjectViewManager {
   setCachedViewLimit(n: number): void {
     const safe = Number.isFinite(n) ? n : 1;
     this.maxCachedViews = Math.max(1, Math.min(5, safe));
-    this.evictStaleViews();
+    this.evictStaleViews("limit-change");
   }
 
   destroyView(projectId: string): void {
@@ -280,6 +298,7 @@ export class ProjectViewManager {
     }
     this.views.clear();
     this.webContentsToProject.clear();
+    this.evictionTimestamps.clear();
     this.activeProjectId = null;
   }
 
@@ -597,7 +616,7 @@ export class ProjectViewManager {
     this.views.delete(projectId);
   }
 
-  private evictStaleViews(): void {
+  private evictStaleViews(reason: EvictionReason): void {
     if (this.views.size <= this.maxCachedViews) return;
     if (this.activeProjectId === null) return;
 
@@ -606,8 +625,10 @@ export class ProjectViewManager {
       .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
 
     while (this.views.size > this.maxCachedViews && evictable.length > 0) {
-      const [projectId] = evictable.shift()!;
-      console.log(`[ProjectViewManager] Evicting cached view for project: ${projectId}`);
+      const [projectId, entry] = evictable.shift()!;
+      const ageMs = Date.now() - entry.lastUsed;
+      logInfo("projectview.eviction", { projectId, reason, ageMs });
+      this.evictionTimestamps.set(projectId, Date.now());
       this.cleanupEntry(projectId);
     }
   }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -159,6 +159,13 @@ export class ProjectViewManager {
     // Try to activate cached view
     const cached = this.views.get(projectId);
     if (cached && !cached.view.webContents.isDestroyed()) {
+      // "revival" measures time since this projectId was last evicted — not time
+      // since the current cached view (a cold-started successor) was last active.
+      // Eviction destroys the original view, so any cache hit for a previously-
+      // evicted projectId necessarily hits a later cold-started entry. The
+      // timestamp persists across the cold-start so cache-pressure signals stay
+      // observable at the project level. Consumed on read to fire only once per
+      // eviction → return cycle.
       const evictedAt = this.evictionTimestamps.get(projectId);
       if (evictedAt !== undefined) {
         logInfo("projectview.revival", {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -83,7 +83,12 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
 }));
 
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+}));
+
 import { ProjectViewManager } from "../ProjectViewManager.js";
+import { logInfo } from "../../utils/logger.js";
 
 function createMockWindow() {
   return {
@@ -106,6 +111,7 @@ describe("ProjectViewManager — eviction safety", () => {
 
   beforeEach(() => {
     nextWebContentsId = 100;
+    vi.clearAllMocks();
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -179,5 +185,186 @@ describe("ProjectViewManager — eviction safety", () => {
     // proj-b should still be cached (getAllViews includes it)
     const viewIds = views.map((v) => v.projectId || "");
     expect(viewIds).toContain("proj-b");
+  });
+});
+
+describe("ProjectViewManager — telemetry", () => {
+  let win: ReturnType<typeof createMockWindow>;
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    vi.clearAllMocks();
+    win = createMockWindow();
+  });
+
+  it("emits projectview.eviction with reason=lru when switch overflows the cache", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith("projectview.eviction", {
+      projectId: "proj-a",
+      reason: "lru",
+      ageMs: expect.any(Number),
+    });
+
+    const evictionCall = vi
+      .mocked(logInfo)
+      .mock.calls.find(
+        ([event, ctx]) =>
+          event === "projectview.eviction" && (ctx as { projectId: string }).projectId === "proj-a"
+      );
+    expect(evictionCall).toBeDefined();
+    const ctx = evictionCall![1] as { ageMs: number };
+    expect(ctx.ageMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("emits projectview.eviction with reason=limit-change when setCachedViewLimit shrinks the cache", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    vi.mocked(logInfo).mockClear();
+
+    manager.setCachedViewLimit(1);
+
+    const limitChangeCalls = vi
+      .mocked(logInfo)
+      .mock.calls.filter(([event]) => event === "projectview.eviction");
+    expect(limitChangeCalls.length).toBeGreaterThan(0);
+    for (const [, ctx] of limitChangeCalls) {
+      expect((ctx as { reason: string }).reason).toBe("limit-change");
+    }
+  });
+
+  it("emits projectview.revival exactly once when a previously-evicted project is activated from cache", async () => {
+    // Trace (cachedProjectViews=2):
+    //   1. register proj-a (active=a)
+    //   2. switchTo b   → views: {a, b}, active=b
+    //   3. switchTo c   → evicts a (LRU), evictionTimestamps={a: t1}, active=c
+    //   4. switchTo a   → cold-start a (a was destroyed), evicts b, active=a
+    //   5. switchTo b   → cold-start b (b was destroyed), evicts c, active=b
+    //   6. switchTo a   → cache hit on a; evictionTimestamps has {a: t1} → revival fires
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+    await manager.switchTo("proj-a", "/path/a");
+    await manager.switchTo("proj-b", "/path/b");
+
+    vi.mocked(logInfo).mockClear();
+
+    await manager.switchTo("proj-a", "/path/a");
+
+    const revivalCalls = vi
+      .mocked(logInfo)
+      .mock.calls.filter(([event]) => event === "projectview.revival");
+    expect(revivalCalls.length).toBe(1);
+    expect(revivalCalls[0][1]).toMatchObject({
+      projectId: "proj-a",
+      timeSinceEvictionMs: expect.any(Number),
+    });
+    expect(
+      (revivalCalls[0][1] as { timeSinceEvictionMs: number }).timeSinceEvictionMs
+    ).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not emit projectview.revival a second time for the same project without a new eviction (timestamp is consumed on read)", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    // Set up a revival for proj-a (same trace as the previous test)
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+    await manager.switchTo("proj-a", "/path/a");
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-a", "/path/a"); // revival fires for proj-a — timestamp consumed
+
+    // Switch away to a fresh cold-started project so the next return to proj-a
+    // exercises the cache-hit path without touching any other stale timestamps.
+    // proj-d is new; cold-starting it evicts proj-b (LRU), leaving {a, d} cached.
+    await manager.switchTo("proj-d", "/path/d");
+
+    vi.mocked(logInfo).mockClear();
+
+    // Return to proj-a — cache hit, but evictionTimestamps has no entry for proj-a.
+    await manager.switchTo("proj-a", "/path/a");
+
+    const revivalCalls = vi
+      .mocked(logInfo)
+      .mock.calls.filter(([event]) => event === "projectview.revival");
+    expect(revivalCalls.length).toBe(0);
+  });
+
+  it("emits projectview.coldstart on successful view creation", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    vi.mocked(logInfo).mockClear();
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    const coldStartCall = vi
+      .mocked(logInfo)
+      .mock.calls.find(([event]) => event === "projectview.coldstart");
+    expect(coldStartCall).toBeDefined();
+    expect(coldStartCall![1]).toMatchObject({
+      projectId: "proj-b",
+      durationMs: expect.any(Number),
+    });
+    expect((coldStartCall![1] as { durationMs: number }).durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("dispose clears evictionTimestamps to prevent revival replay after new manager", async () => {
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c"); // evicts proj-a
+
+    // dispose should not throw and should clear internal state
+    expect(() => manager.dispose()).not.toThrow();
+    expect(manager.getAllViews().length).toBe(0);
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -242,14 +242,22 @@ describe("ProjectViewManager — telemetry", () => {
 
     vi.mocked(logInfo).mockClear();
 
+    // Shrink from 3 to 1 — evicts the 2 LRU non-active projects (proj-a, proj-b)
     manager.setCachedViewLimit(1);
 
     const limitChangeCalls = vi
       .mocked(logInfo)
       .mock.calls.filter(([event]) => event === "projectview.eviction");
-    expect(limitChangeCalls.length).toBeGreaterThan(0);
+    expect(limitChangeCalls.length).toBe(2);
+
+    const evictedIds = limitChangeCalls.map(([, ctx]) => (ctx as { projectId: string }).projectId);
+    expect(evictedIds).toContain("proj-a");
+    expect(evictedIds).toContain("proj-b");
+
     for (const [, ctx] of limitChangeCalls) {
-      expect((ctx as { reason: string }).reason).toBe("limit-change");
+      const c = ctx as { reason: string; ageMs: number };
+      expect(c.reason).toBe("limit-change");
+      expect(c.ageMs).toBeGreaterThanOrEqual(0);
     }
   });
 
@@ -350,7 +358,7 @@ describe("ProjectViewManager — telemetry", () => {
     expect((coldStartCall![1] as { durationMs: number }).durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  it("dispose clears evictionTimestamps to prevent revival replay after new manager", async () => {
+  it("dispose tears down cleanly after an eviction recorded a timestamp", async () => {
     const manager = new ProjectViewManager(win as never, {
       dirname: "/test",
       cachedProjectViews: 2,

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -126,8 +126,13 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
 }));
 
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+}));
+
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { notifyError } from "../../ipc/errorHandlers.js";
+import { logInfo } from "../../utils/logger.js";
 
 function createMockWindow() {
   return {
@@ -164,6 +169,7 @@ describe("ProjectViewManager — switch failure rollback", () => {
     nextWebContentsId = 200;
     wcQueue = [];
     vi.mocked(notifyError).mockClear();
+    vi.mocked(logInfo).mockClear();
 
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, { dirname: "/test", cachedProjectViews: 3 });
@@ -199,6 +205,9 @@ describe("ProjectViewManager — switch failure rollback", () => {
       expect.any(Error),
       expect.objectContaining({ source: "project-switch" })
     );
+    expect(
+      vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
+    ).toHaveLength(0);
   });
 
   it("rolls back when did-fail-load fires", async () => {
@@ -215,6 +224,9 @@ describe("ProjectViewManager — switch failure rollback", () => {
     expect(err.message).toBe("View load failed: ERR_ABORTED (-3)");
     expect(manager.getActiveProjectId()).toBe("proj-a");
     expect(failWc.close).toHaveBeenCalled();
+    expect(
+      vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
+    ).toHaveLength(0);
   });
 
   it("rolls back when render-process-gone fires during load", async () => {
@@ -230,6 +242,9 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const err = await errPromise;
     expect(err.message).toBe("Renderer process gone during load: crashed");
     expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(
+      vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
+    ).toHaveLength(0);
   });
 
   it("rolls back when load times out (10s)", async () => {
@@ -244,6 +259,9 @@ describe("ProjectViewManager — switch failure rollback", () => {
     const err = await errPromise;
     expect(err.message).toBe("View load timed out");
     expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(
+      vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
+    ).toHaveLength(0);
   });
 
   it("sets activeProjectId to null when no previous view exists", async () => {


### PR DESCRIPTION
## Summary

Three structured telemetry events added to `ProjectViewManager` using the existing `logInfo` pipeline, replacing bare `console.log` calls with typed, queryable events.

Resolves #5238

## Changes

- `projectview.eviction` emitted from `evictStaleViews()` with `{ projectId, reason, ageMs }`. The `reason` field is threaded as `"lru" | "pressure" | "limit-change"` through the call sites.
- `projectview.revival` emitted from the `performSwitch()` cache-hit path when a prior eviction timestamp exists. Fields `{ projectId, timeSinceEvictionMs }`. Timestamp is consumed on read so the value is accurate and doesn't linger.
- `projectview.coldstart` emitted after a successful `loadView()` with `{ projectId, durationMs }` using monotonic `performance.now()` timing. The rollback path does not emit, so the event is success-only.

Also includes an `EvictionReason` type alias and cleanup of the `evictionTimestamps` map in `dispose()`.

## Testing

- 6 new tests in `ProjectViewManager.eviction.test.ts` covering all three events, the consumed-timestamp property, and dispose safety.
- Negative assertions in `ProjectViewManager.switchFailure.test.ts` confirming `projectview.coldstart` is not emitted on preload-error, did-fail-load, render-process-gone, or timeout.
- All 118 tests in `electron/window/__tests__/` pass. `npm run check` clean.