### PR TITLE
fix(workspace): repair stale worktree state after system sleep

### DIFF
--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -46,6 +46,14 @@ interface ProcessEntry {
   host: WorkspaceHostProcess;
   refCount: number;
   initPromise: Promise<void>;
+  /**
+   * Tracks the most recent readiness promise for this entry. Starts as
+   * `initPromise` and is replaced by the `reloadProjectAfterRestart` promise
+   * whenever the host restarts, so `waitForReady()` blocks until the restarted
+   * host has finished loading the project. `initPromise` is retained unchanged
+   * for the poisoned-entry detection in `loadProject`.
+   */
+  currentReadyPromise: Promise<void>;
   cleanupTimeout: NodeJS.Timeout | null;
   windowIds: Set<number>;
   projectPath: string;
@@ -75,7 +83,7 @@ export class WorkspaceClient extends EventEmitter {
   }
 
   async waitForReady(): Promise<void> {
-    const promises = [...this.entries.values()].map((e) => e.initPromise);
+    const promises = [...this.entries.values()].map((e) => e.currentReadyPromise);
     if (promises.length === 0) return;
     await Promise.all(promises);
   }
@@ -145,8 +153,15 @@ export class WorkspaceClient extends EventEmitter {
     });
 
     host.on("restarted", () => {
-      this.reloadProjectAfterRestart(entry).catch((err) => {
+      const restartPromise = this.reloadProjectAfterRestart(entry);
+      // Gate `waitForReady()` on the restart reload so callers (e.g. the
+      // power-monitor resume handler) don't send follow-up requests to a host
+      // that hasn't finished `load-project` yet.
+      entry.currentReadyPromise = restartPromise.catch((err) => {
         console.error(`[WorkspaceClient] Failed to reload project after host restart:`, err);
+        // Swallow the rejection so subsequent `waitForReady()` calls don't
+        // hang forever on a failed reload — downstream IPC calls already
+        // tolerate a partially-broken host.
       });
     });
   }
@@ -410,6 +425,7 @@ export class WorkspaceClient extends EventEmitter {
       host,
       refCount: 1,
       initPromise,
+      currentReadyPromise: initPromise,
       cleanupTimeout: null,
       windowIds: new Set([windowId]),
       projectPath: normalizedPath,
@@ -472,6 +488,7 @@ export class WorkspaceClient extends EventEmitter {
       host,
       refCount: 0,
       initPromise,
+      currentReadyPromise: initPromise,
       cleanupTimeout: null,
       windowIds: new Set(),
       projectPath: normalizedPath,

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -154,15 +154,14 @@ export class WorkspaceClient extends EventEmitter {
 
     host.on("restarted", () => {
       const restartPromise = this.reloadProjectAfterRestart(entry);
-      // Gate `waitForReady()` on the restart reload so callers (e.g. the
-      // power-monitor resume handler) don't send follow-up requests to a host
-      // that hasn't finished `load-project` yet.
-      entry.currentReadyPromise = restartPromise.catch((err) => {
+      restartPromise.catch((err) => {
         console.error(`[WorkspaceClient] Failed to reload project after host restart:`, err);
-        // Swallow the rejection so subsequent `waitForReady()` calls don't
-        // hang forever on a failed reload — downstream IPC calls already
-        // tolerate a partially-broken host.
       });
+      // Gate `waitForReady()` on the restart reload so callers don't race
+      // ahead of `load-project` on a restarted host. Let rejection propagate
+      // so a false-positive "ready" can't unblock callers on a broken host —
+      // the next `restarted` event will overwrite this with a fresh promise.
+      entry.currentReadyPromise = restartPromise;
     });
   }
 
@@ -376,12 +375,16 @@ export class WorkspaceClient extends EventEmitter {
 
     const existingEntry = this.entries.get(normalizedPath);
     if (existingEntry) {
-      // Check if this entry has a failed initPromise (poisoned by prior crash)
-      const isInitFailed = await existingEntry.initPromise.then(
+      // Check if this entry has a failed readiness promise (poisoned by a
+      // prior init crash or a failed post-restart reload). Using
+      // `currentReadyPromise` catches both the original load and the most
+      // recent restart — reusing a host whose restart-reload failed produces
+      // stale state that looks like the wake-staleness bug.
+      const isReadyFailed = await existingEntry.currentReadyPromise.then(
         () => false,
         () => true
       );
-      if (isInitFailed) {
+      if (isReadyFailed) {
         existingEntry.host.dispose();
         this.entries.delete(normalizedPath);
       } else {

--- a/electron/services/__tests__/WorkspaceClient.readiness.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.readiness.test.ts
@@ -198,7 +198,7 @@ describe("WorkspaceClient.waitForReady after host restart", () => {
     expect(resolved).toBe(true);
   });
 
-  it("does not hang forever if the post-restart load-project fails", async () => {
+  it("rejects when the post-restart load-project fails so callers can bail", async () => {
     await loadAndReady("/project-a", 1);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -213,11 +213,81 @@ describe("WorkspaceClient.waitForReady after host restart", () => {
       .filter((r: any) => r.type === "load-project");
     h(0).rejectRequest(loadProjectReqs[1].requestId, new Error("reload failed"));
 
-    await expect(client.waitForReady()).resolves.toBeUndefined();
+    await expect(client.waitForReady()).rejects.toThrow("reload failed");
     expect(consoleError).toHaveBeenCalledWith(
       expect.stringContaining("Failed to reload project after host restart"),
       expect.any(Error)
     );
+    consoleError.mockRestore();
+  });
+
+  it("resolves cleanly when a failed restart-reload is followed by a successful one", async () => {
+    await loadAndReady("/project-a", 1);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Restart 1: fails mid-reload.
+    h(0).resetReady();
+    h(0).emit("restarted");
+    await tick();
+    h(0).simulateReady();
+    await tick();
+    const reqsAfterRestart1 = h(0)
+      .getAllRequests()
+      .filter((r: any) => r.type === "load-project");
+    h(0).rejectRequest(reqsAfterRestart1[1].requestId, new Error("reload 1 failed"));
+    await tick();
+
+    // Restart 2: succeeds. `currentReadyPromise` is replaced by the fresh
+    // restart promise, so waitForReady should now resolve.
+    h(0).resetReady();
+    h(0).emit("restarted");
+    await tick();
+
+    const waitPromise = client.waitForReady();
+    h(0).simulateReady();
+    await tick();
+
+    const reqsAfterRestart2 = h(0)
+      .getAllRequests()
+      .filter((r: any) => r.type === "load-project");
+    expect(reqsAfterRestart2.length).toBe(3);
+    h(0).resolveRequest(reqsAfterRestart2[2].requestId);
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    consoleError.mockRestore();
+  });
+
+  it("loadProject on a poisoned restarted entry disposes the old host and creates a new one", async () => {
+    await loadAndReady("/project-a", 1);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Restart fails — entry's currentReadyPromise rejects.
+    h(0).resetReady();
+    h(0).emit("restarted");
+    await tick();
+    h(0).simulateReady();
+    await tick();
+    const reqs = h(0)
+      .getAllRequests()
+      .filter((r: any) => r.type === "load-project");
+    h(0).rejectRequest(reqs[1].requestId, new Error("reload failed"));
+    await tick();
+
+    // Second window tries to attach to the same project. The poisoned entry
+    // must NOT be reused — loadProject should dispose it and spin up a new
+    // host.
+    const load = client.loadProject("/project-a", 2);
+    await tick();
+    expect(h(0).dispose).toHaveBeenCalledTimes(1);
+    expect(mockHosts.length).toBe(2);
+
+    h(1).simulateReady();
+    await tick();
+    const newReq = h(1).getLastRequest()!;
+    expect(newReq.type).toBe("load-project");
+    h(1).resolveRequest(newReq.requestId);
+
+    await expect(load).resolves.toBeUndefined();
     consoleError.mockRestore();
   });
 });

--- a/electron/services/__tests__/WorkspaceClient.readiness.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.readiness.test.ts
@@ -1,0 +1,223 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+
+  const mockHosts: any[] = [];
+
+  class MockWorkspaceHostProcess extends EventEmitter {
+    projectPath: string;
+    private _isReady = false;
+    private _isDisposed = false;
+    private readyResolve: (() => void) | null = null;
+    private readyPromise: Promise<void>;
+    private responseHandlers = new Map<string, (result: any) => void>();
+    private responseRejects = new Map<string, (error: Error) => void>();
+
+    constructor(projectPath: string) {
+      super();
+      this.projectPath = projectPath;
+      this.readyPromise = new Promise((resolve) => {
+        this.readyResolve = resolve;
+      });
+      mockHosts.push(this);
+    }
+
+    waitForReady(): Promise<void> {
+      return this.readyPromise;
+    }
+
+    isReady(): boolean {
+      return this._isReady && !this._isDisposed;
+    }
+
+    generateRequestId(): string {
+      return `req-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    }
+
+    send = vi.fn(() => true);
+
+    sendWithResponse = vi.fn(<T>(request: { requestId: string; type: string }): Promise<T> => {
+      return new Promise<T>((resolve, reject) => {
+        this.responseHandlers.set(request.requestId, resolve);
+        this.responseRejects.set(request.requestId, reject);
+      });
+    });
+
+    pauseHealthCheck = vi.fn();
+    resumeHealthCheck = vi.fn();
+    dispose = vi.fn(() => {
+      this._isDisposed = true;
+    });
+
+    simulateReady(): void {
+      this._isReady = true;
+      if (this.readyResolve) {
+        this.readyResolve();
+        this.readyResolve = null;
+      }
+    }
+
+    /** Reset the ready promise to simulate a restart that hasn't completed yet. */
+    resetReady(): void {
+      this._isReady = false;
+      this.readyPromise = new Promise((resolve) => {
+        this.readyResolve = resolve;
+      });
+    }
+
+    resolveRequest(requestId: string, result: any = {}): void {
+      const handler = this.responseHandlers.get(requestId);
+      if (handler) {
+        this.responseHandlers.delete(requestId);
+        handler(result);
+      }
+    }
+
+    rejectRequest(requestId: string, error: Error): void {
+      const handler = this.responseRejects.get(requestId);
+      if (handler) {
+        this.responseRejects.delete(requestId);
+        this.responseHandlers.delete(requestId);
+        handler(error);
+      }
+    }
+
+    getLastRequest(): { requestId: string; type: string; [key: string]: any } | undefined {
+      const calls = this.sendWithResponse.mock.calls;
+      if (calls.length === 0) return undefined;
+      return calls[calls.length - 1][0] as any;
+    }
+
+    getAllRequests(): Array<{ requestId: string; type: string; [key: string]: any }> {
+      return this.sendWithResponse.mock.calls.map(([req]: any) => req);
+    }
+
+    attachRendererPort = vi.fn(() => true);
+  }
+
+  return { mockHosts, MockWorkspaceHostProcess };
+});
+
+vi.mock("../WorkspaceHostProcess.js", () => ({
+  WorkspaceHostProcess: MockWorkspaceHostProcess,
+}));
+
+vi.mock("electron", () => {
+  class MockMessageChannelMain {
+    port1 = { close: vi.fn() };
+    port2 = { close: vi.fn() };
+  }
+  return {
+    BrowserWindow: {
+      getAllWindows: vi.fn(() => []),
+    },
+    MessageChannelMain: MockMessageChannelMain,
+  };
+});
+
+vi.mock("../events.js", () => ({
+  events: { emit: vi.fn() },
+}));
+
+import { WorkspaceClient } from "../WorkspaceClient.js";
+
+type MockHost = InstanceType<typeof MockWorkspaceHostProcess>;
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("WorkspaceClient.waitForReady after host restart", () => {
+  let client: WorkspaceClient;
+
+  beforeEach(() => {
+    mockHosts.length = 0;
+    client = new WorkspaceClient({
+      maxRestartAttempts: 3,
+      showCrashDialog: false,
+      healthCheckIntervalMs: 1000,
+    });
+  });
+
+  afterEach(() => {
+    client.dispose();
+  });
+
+  function h(index: number): MockHost {
+    return mockHosts[index];
+  }
+
+  async function loadAndReady(projectPath: string, windowId: number): Promise<void> {
+    const load = client.loadProject(projectPath, windowId);
+    h(mockHosts.length - 1).simulateReady();
+    await tick();
+    const req = h(mockHosts.length - 1).getLastRequest()!;
+    h(mockHosts.length - 1).resolveRequest(req.requestId);
+    await load;
+  }
+
+  it("resolves immediately when no entries exist", async () => {
+    await expect(client.waitForReady()).resolves.toBeUndefined();
+  });
+
+  it("resolves immediately once initial loadProject has completed", async () => {
+    await loadAndReady("/project-a", 1);
+    await expect(client.waitForReady()).resolves.toBeUndefined();
+  });
+
+  it("blocks until the post-restart load-project completes", async () => {
+    await loadAndReady("/project-a", 1);
+
+    // Simulate crash + restart: reset the host's ready promise so the reload
+    // has to actually wait, then emit the restart event.
+    h(0).resetReady();
+    h(0).emit("restarted");
+    await tick();
+
+    let resolved = false;
+    const waitPromise = client.waitForReady().then(() => {
+      resolved = true;
+    });
+    await tick();
+    expect(resolved).toBe(false);
+
+    // Host becomes ready, but `reloadProjectAfterRestart` still has to await
+    // its load-project response — `waitForReady` must block on that too.
+    h(0).simulateReady();
+    await tick();
+    expect(resolved).toBe(false);
+
+    // Find the post-restart load-project request and resolve it.
+    const loadProjectReqs = h(0)
+      .getAllRequests()
+      .filter((r: any) => r.type === "load-project");
+    expect(loadProjectReqs.length).toBe(2);
+    h(0).resolveRequest(loadProjectReqs[1].requestId);
+
+    await waitPromise;
+    expect(resolved).toBe(true);
+  });
+
+  it("does not hang forever if the post-restart load-project fails", async () => {
+    await loadAndReady("/project-a", 1);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    h(0).resetReady();
+    h(0).emit("restarted");
+    await tick();
+    h(0).simulateReady();
+    await tick();
+
+    const loadProjectReqs = h(0)
+      .getAllRequests()
+      .filter((r: any) => r.type === "load-project");
+    h(0).rejectRequest(loadProjectReqs[1].requestId, new Error("reload failed"));
+
+    await expect(client.waitForReady()).resolves.toBeUndefined();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to reload project after host restart"),
+      expect.any(Error)
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/electron/window/__tests__/powerMonitor.test.ts
+++ b/electron/window/__tests__/powerMonitor.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { PtyClient } from "../../services/PtyClient.js";
+import type { WorkspaceClient } from "../../services/WorkspaceClient.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PowerHandler = (...args: any[]) => void;
+
+const powerHandlers = new Map<string, PowerHandler>();
+let mockGetAllWindows: ReturnType<typeof vi.fn>;
+let mockGetAppWebContents: ReturnType<typeof vi.fn>;
+
+function createMockWindow(options: { destroyed?: boolean } = {}) {
+  const wc = {
+    send: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+  };
+  return {
+    wc,
+    win: {
+      isDestroyed: vi.fn(() => options.destroyed ?? false),
+      webContents: wc,
+    },
+  };
+}
+
+function createMockPtyClient(): PtyClient {
+  return {
+    pauseHealthCheck: vi.fn(),
+    pauseAll: vi.fn(),
+    resumeHealthCheck: vi.fn(),
+    resumeAll: vi.fn(),
+  } as unknown as PtyClient;
+}
+
+function createMockWorkspaceClient(overrides: Partial<WorkspaceClient> = {}): WorkspaceClient {
+  return {
+    pauseHealthCheck: vi.fn(),
+    resumeHealthCheck: vi.fn(),
+    setPollingEnabled: vi.fn(),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as WorkspaceClient;
+}
+
+let setupPowerMonitor: typeof import("../powerMonitor.js").setupPowerMonitor;
+let clearResumeTimeout: typeof import("../powerMonitor.js").clearResumeTimeout;
+
+describe("setupPowerMonitor", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    powerHandlers.clear();
+    vi.resetModules();
+
+    mockGetAllWindows = vi.fn(() => []);
+
+    vi.doMock("electron", () => ({
+      app: { on: vi.fn() },
+      BrowserWindow: {
+        getFocusedWindow: vi.fn(() => null),
+        getAllWindows: mockGetAllWindows,
+      },
+      powerMonitor: {
+        on: vi.fn((event: string, handler: PowerHandler) => {
+          powerHandlers.set(event, handler);
+        }),
+      },
+    }));
+
+    vi.doMock("../../ipc/channels.js", () => ({
+      CHANNELS: { SYSTEM_WAKE: "system:wake" },
+    }));
+
+    mockGetAppWebContents = vi.fn((win: { webContents: unknown }) => win.webContents);
+    vi.doMock("../webContentsRegistry.js", () => ({
+      getAppWebContents: mockGetAppWebContents,
+    }));
+
+    const mod = await import("../powerMonitor.js");
+    setupPowerMonitor = mod.setupPowerMonitor;
+    clearResumeTimeout = mod.clearResumeTimeout;
+  });
+
+  afterEach(() => {
+    clearResumeTimeout();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("pauses pty and workspace services on suspend", () => {
+    const ptyClient = createMockPtyClient();
+    const workspaceClient = createMockWorkspaceClient();
+
+    setupPowerMonitor({
+      getPtyClient: () => ptyClient,
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    const suspendHandler = powerHandlers.get("suspend")!;
+    expect(suspendHandler).toBeDefined();
+    suspendHandler();
+
+    expect(ptyClient.pauseHealthCheck).toHaveBeenCalledTimes(1);
+    expect(ptyClient.pauseAll).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.pauseHealthCheck).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("does not trigger refresh before the 2s resume debounce elapses", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(1999);
+
+    expect(workspaceClient.waitForReady).not.toHaveBeenCalled();
+    expect(workspaceClient.setPollingEnabled).not.toHaveBeenCalled();
+    expect(workspaceClient.refresh).not.toHaveBeenCalled();
+  });
+
+  it("runs the full refresh sequence after the 2s debounce and broadcasts SYSTEM_WAKE", async () => {
+    const ptyClient = createMockPtyClient();
+    const callLog: string[] = [];
+    const workspaceClient = createMockWorkspaceClient({
+      waitForReady: vi.fn(() => {
+        callLog.push("waitForReady");
+        return Promise.resolve();
+      }),
+      setPollingEnabled: vi.fn((enabled: boolean) => {
+        callLog.push(`setPollingEnabled(${enabled})`);
+      }),
+      resumeHealthCheck: vi.fn(() => {
+        callLog.push("resumeHealthCheck");
+      }),
+      refresh: vi.fn(() => {
+        callLog.push("refresh");
+        return Promise.resolve();
+      }),
+    } as unknown as Partial<WorkspaceClient>);
+
+    const { win, wc } = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+
+    setupPowerMonitor({
+      getPtyClient: () => ptyClient,
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    // Simulate a sleep/wake cycle to exercise the sleepDuration branch
+    powerHandlers.get("suspend")!();
+    // Reset the call log so we only capture the resume-side sequence below.
+    callLog.length = 0;
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(callLog).toEqual([
+      "waitForReady",
+      "setPollingEnabled(true)",
+      "resumeHealthCheck",
+      "refresh",
+    ]);
+    expect(ptyClient.resumeAll).toHaveBeenCalledTimes(1);
+    expect(ptyClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
+    expect(wc.send).toHaveBeenCalledWith(
+      "system:wake",
+      expect.objectContaining({
+        sleepDuration: expect.any(Number),
+        timestamp: expect.any(Number),
+      })
+    );
+  });
+
+  it("coalesces multiple rapid resume events into a single refresh", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    const resume = powerHandlers.get("resume")!;
+    resume();
+    await vi.advanceTimersByTimeAsync(500);
+    resume();
+    await vi.advanceTimersByTimeAsync(500);
+    resume();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(workspaceClient.refresh).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("cancels a pending resume refresh when a suspend arrives before the debounce fires", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(1000);
+    powerHandlers.get("suspend")!();
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(workspaceClient.refresh).not.toHaveBeenCalled();
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(false);
+    expect(workspaceClient.setPollingEnabled).not.toHaveBeenCalledWith(true);
+  });
+
+  it("still resumes pty and broadcasts SYSTEM_WAKE when workspaceClient is null", async () => {
+    const ptyClient = createMockPtyClient();
+    const { win, wc } = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+
+    setupPowerMonitor({
+      getPtyClient: () => ptyClient,
+      getWorkspaceClient: () => null,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(ptyClient.resumeAll).toHaveBeenCalledTimes(1);
+    expect(ptyClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
+    expect(wc.send).toHaveBeenCalledWith("system:wake", expect.any(Object));
+  });
+
+  it("catches and logs errors from workspaceClient.refresh", async () => {
+    const refreshError = new Error("refresh failed");
+    const workspaceClient = createMockWorkspaceClient({
+      refresh: vi.fn().mockRejectedValue(refreshError),
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(consoleError).toHaveBeenCalledWith("[MAIN] Error during resume:", refreshError);
+  });
+
+  it("skips destroyed windows when broadcasting SYSTEM_WAKE", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    const live = createMockWindow();
+    const dead = createMockWindow({ destroyed: true });
+    mockGetAllWindows.mockReturnValue([live.win, dead.win]);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(live.wc.send).toHaveBeenCalledWith("system:wake", expect.any(Object));
+    expect(dead.wc.send).not.toHaveBeenCalled();
+  });
+
+  it("skips SYSTEM_WAKE for a window whose webContents is destroyed", async () => {
+    const workspaceClient = createMockWorkspaceClient();
+    const { win, wc } = createMockWindow();
+    wc.isDestroyed.mockReturnValue(true);
+    mockGetAllWindows.mockReturnValue([win]);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+});

--- a/electron/window/__tests__/powerMonitor.test.ts
+++ b/electron/window/__tests__/powerMonitor.test.ts
@@ -263,6 +263,40 @@ describe("setupPowerMonitor", () => {
     expect(dead.wc.send).not.toHaveBeenCalled();
   });
 
+  it("blocks refresh and broadcast until waitForReady resolves", async () => {
+    let resolveReady: (() => void) | null = null;
+    const readyPromise = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const workspaceClient = createMockWorkspaceClient({
+      waitForReady: vi.fn(() => readyPromise),
+    });
+    const { win, wc } = createMockWindow();
+    mockGetAllWindows.mockReturnValue([win]);
+
+    setupPowerMonitor({
+      getPtyClient: () => createMockPtyClient(),
+      getWorkspaceClient: () => workspaceClient,
+    });
+
+    powerHandlers.get("resume")!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(workspaceClient.waitForReady).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.setPollingEnabled).not.toHaveBeenCalled();
+    expect(workspaceClient.resumeHealthCheck).not.toHaveBeenCalled();
+    expect(workspaceClient.refresh).not.toHaveBeenCalled();
+    expect(wc.send).not.toHaveBeenCalled();
+
+    resolveReady!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(workspaceClient.setPollingEnabled).toHaveBeenCalledWith(true);
+    expect(workspaceClient.resumeHealthCheck).toHaveBeenCalledTimes(1);
+    expect(workspaceClient.refresh).toHaveBeenCalledTimes(1);
+    expect(wc.send).toHaveBeenCalledWith("system:wake", expect.any(Object));
+  });
+
   it("skips SYSTEM_WAKE for a window whose webContents is destroyed", async () => {
     const workspaceClient = createMockWorkspaceClient();
     const { win, wc } = createMockWindow();

--- a/electron/window/powerMonitor.ts
+++ b/electron/window/powerMonitor.ts
@@ -41,6 +41,10 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
     clearResumeTimeout();
     resumeTimeout = setTimeout(async () => {
       resumeTimeout = null;
+      // Capture and clear suspendTime up front so a mid-handler exception
+      // can't leak it into the next wake cycle's sleepDuration calculation.
+      const sleepDuration = suspendTime ? Date.now() - suspendTime : 0;
+      suspendTime = null;
       try {
         const ptyClient = deps.getPtyClient();
         const workspaceClient = deps.getWorkspaceClient();
@@ -54,7 +58,6 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
           workspaceClient.resumeHealthCheck();
           await workspaceClient.refresh();
         }
-        const sleepDuration = suspendTime ? Date.now() - suspendTime : 0;
         BrowserWindow.getAllWindows().forEach((win) => {
           if (win && !win.isDestroyed()) {
             const wc = getAppWebContents(win);
@@ -70,7 +73,6 @@ export function setupPowerMonitor(deps: PowerMonitorDeps): void {
             }
           }
         });
-        suspendTime = null;
       } catch (error) {
         console.error("[MAIN] Error during resume:", error);
       }


### PR DESCRIPTION
## Summary

- `WorkspaceClient` now tracks a `currentReadyPromise` per entry that follows the host's most recent readiness state (initial load OR post-restart reload). Previously, `waitForReady()` would resolve against the original init promise even after a UtilityProcess restart, letting `refresh()` race ahead of the reloaded host and produce stale state.
- `loadProject` reuse check now inspects `currentReadyPromise` instead of `initPromise`, so entries poisoned by a failed restart-reload are properly disposed rather than reused as healthy.
- The `resume` handler in `powerMonitor.ts` captures and clears `suspendTime` up front so a mid-handler exception can't leak the timestamp into the next wake cycle's `sleepDuration` calculation.

Resolves #5232

## Changes

- `electron/services/WorkspaceClient.ts`: `currentReadyPromise` field tracks readiness through restarts; `loadProject` reuse guard updated accordingly
- `electron/window/powerMonitor.ts`: `suspendTime` cleared atomically at the top of the resume handler
- `electron/window/__tests__/powerMonitor.test.ts` (new): 9 tests covering suspend/resume debounce, full refresh sequence, coalescing, cancellation, null workspaceClient, refresh errors, destroyed windows, and the `waitForReady` gate
- `electron/services/__tests__/WorkspaceClient.readiness.test.ts` (new): 4 tests covering the readiness contract, flapping-host recovery, and poisoned-entry disposal

## Testing

74/74 tests pass across the touched files. Typecheck clean, lint at baseline, no formatting changes required.