### PR TITLE
fix(eviction): skip views with active agents during LRU eviction

### DIFF
--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -1,6 +1,6 @@
 import { readdir, stat } from "fs/promises";
 import path from "path";
-import type { AgentState } from "../../shared/types/agent.js";
+import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
 import type { HibernationProjectHibernatedPayload } from "../../shared/types/ipc/hibernation.js";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
@@ -29,13 +29,6 @@ const GIT_SENTINEL_NAMES = new Set([
   "rebase-merge",
   "rebase-apply",
 ]);
-const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set([
-  "working",
-  "running",
-  "waiting",
-  "directing",
-]);
-
 /**
  * HibernationService - Auto-hibernates inactive projects to free resources.
  *

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -21,9 +21,11 @@ import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
 import { isLocalhostUrl } from "../../shared/utils/urlUtils.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
+import { getPtyManager } from "../services/PtyManager.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { logInfo } from "../utils/logger.js";
 import { injectSkeletonCss } from "./skeletonCss.js";
+import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
 
 const GC_DELAY_MS = 100;
 const LOAD_TIMEOUT_MS = 10_000;
@@ -623,6 +625,14 @@ export class ProjectViewManager {
     this.views.delete(projectId);
   }
 
+  private hasActiveAgent(projectId: string): boolean {
+    const terminals = getPtyManager().getAll();
+    return terminals.some(
+      (t) =>
+        t.projectId === projectId && t.agentState != null && ACTIVE_AGENT_STATES.has(t.agentState)
+    );
+  }
+
   private evictStaleViews(reason: EvictionReason): void {
     if (this.views.size <= this.maxCachedViews) return;
     if (this.activeProjectId === null) return;
@@ -631,10 +641,27 @@ export class ProjectViewManager {
       .filter(([id]) => id !== this.activeProjectId)
       .sort(([, a], [, b]) => a.lastUsed - b.lastUsed);
 
-    while (this.views.size > this.maxCachedViews && evictable.length > 0) {
-      const [projectId, entry] = evictable.shift()!;
+    // Partition: evict views without active agents first, only fall back to
+    // active-agent views when safe candidates are exhausted. This keeps memory
+    // bounded (each WebContentsView is ~400-500MB) without silently killing
+    // agent renderers mid-task.
+    const safeToEvict: Array<[string, ViewEntry, boolean]> = [];
+    const activeAgentFallback: Array<[string, ViewEntry, boolean]> = [];
+    for (const [projectId, entry] of evictable) {
+      const active = this.hasActiveAgent(projectId);
+      if (active) {
+        activeAgentFallback.push([projectId, entry, true]);
+      } else {
+        safeToEvict.push([projectId, entry, false]);
+      }
+    }
+
+    const candidates = [...safeToEvict, ...activeAgentFallback];
+
+    while (this.views.size > this.maxCachedViews && candidates.length > 0) {
+      const [projectId, entry, activeAgent] = candidates.shift()!;
       const ageMs = Date.now() - entry.lastUsed;
-      logInfo("projectview.eviction", { projectId, reason, ageMs });
+      logInfo("projectview.eviction", { projectId, reason, ageMs, activeAgent });
       this.evictionTimestamps.set(projectId, Date.now());
       this.cleanupEntry(projectId);
     }

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -257,6 +257,43 @@ describe("ProjectViewManager — eviction safety", () => {
       expect.objectContaining({ projectId: "proj-a", activeAgent: true })
     );
   });
+
+  it("evicts LRU-ordered active-agent views when all candidates are protected", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    // All three cached projects have active agents.
+    mockGetAll.mockReturnValue([
+      { projectId: "proj-a", agentState: "working" },
+      { projectId: "proj-b", agentState: "directing" },
+      { projectId: "proj-c", agentState: "waiting" },
+    ]);
+
+    // Tightening the limit to 1 must evict the two LRU views (proj-a, then proj-b)
+    // in order, and each forced eviction is emitted as a telemetry event.
+    managerWithLimit.setCachedViewLimit(1);
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).toEqual(["proj-c"]);
+
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({ projectId: "proj-a", activeAgent: true })
+    );
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({ projectId: "proj-b", activeAgent: true })
+    );
+  });
 });
 
 describe("ProjectViewManager — telemetry", () => {
@@ -265,6 +302,8 @@ describe("ProjectViewManager — telemetry", () => {
   beforeEach(() => {
     nextWebContentsId = 100;
     vi.clearAllMocks();
+    mockGetAll.mockReset();
+    mockGetAll.mockReturnValue([]);
     win = createMockWindow();
   });
 

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -87,6 +87,11 @@ vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
 }));
 
+const mockGetAll = vi.fn<() => Array<{ projectId?: string; agentState?: string }>>(() => []);
+vi.mock("../../services/PtyManager.js", () => ({
+  getPtyManager: vi.fn(() => ({ getAll: mockGetAll })),
+}));
+
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
 
@@ -112,6 +117,8 @@ describe("ProjectViewManager — eviction safety", () => {
   beforeEach(() => {
     nextWebContentsId = 100;
     vi.clearAllMocks();
+    mockGetAll.mockReset();
+    mockGetAll.mockReturnValue([]);
     win = createMockWindow();
     manager = new ProjectViewManager(win as never, {
       dirname: "/test",
@@ -186,6 +193,70 @@ describe("ProjectViewManager — eviction safety", () => {
     const viewIds = views.map((v) => v.projectId || "");
     expect(viewIds).toContain("proj-b");
   });
+
+  it("skips LRU candidate when its project has an active agent", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // proj-a (oldest) has an active agent. Eviction must skip it and evict proj-b instead
+    // once we go over the limit with proj-c.
+    mockGetAll.mockReturnValue([
+      { projectId: "proj-a", agentState: "working" },
+      { projectId: "proj-b", agentState: "idle" },
+    ]);
+
+    const wcBEntry = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b");
+    const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents> | undefined;
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).toContain("proj-a");
+    expect(remaining).toContain("proj-c");
+    expect(remaining).not.toContain("proj-b");
+    expect(wcA.close).not.toHaveBeenCalled();
+    expect(wcB?.close).toHaveBeenCalled();
+  });
+
+  it("falls back to evicting an active-agent view when all candidates are protected", async () => {
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+
+    // Both background candidates have active agents — fallback must evict the LRU
+    // (proj-a) and emit a telemetry event rather than let the pool grow unbounded.
+    mockGetAll.mockReturnValue([
+      { projectId: "proj-a", agentState: "directing" },
+      { projectId: "proj-b", agentState: "running" },
+    ]);
+
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
+    expect(remaining).not.toContain("proj-a");
+    expect(remaining).toContain("proj-b");
+    expect(remaining).toContain("proj-c");
+    expect(wcA.close).toHaveBeenCalled();
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({ projectId: "proj-a", activeAgent: true })
+    );
+  });
 });
 
 describe("ProjectViewManager — telemetry", () => {
@@ -214,6 +285,7 @@ describe("ProjectViewManager — telemetry", () => {
       projectId: "proj-a",
       reason: "lru",
       ageMs: expect.any(Number),
+      activeAgent: false,
     });
 
     const evictionCall = vi

--- a/shared/types/agent.ts
+++ b/shared/types/agent.ts
@@ -8,6 +8,14 @@ export type AgentState =
   | "completed"
   | "exited";
 
+/** Agent states that indicate in-flight work — used to protect against eviction/hibernation */
+export const ACTIVE_AGENT_STATES: ReadonlySet<AgentState> = new Set([
+  "working",
+  "running",
+  "waiting",
+  "directing",
+]);
+
 /** Classification of why an agent is in the "waiting" state */
 export type WaitingReason = "prompt" | "question";
 


### PR DESCRIPTION
## Summary

- `ProjectViewManager.evictStaleViews()` was purely LRU-ordered with no agent awareness, so a background project running an active agent could have its `WebContentsView` destroyed mid-task.
- Extracts `ACTIVE_AGENT_STATES` from `HibernationService` to `shared/types/agent.ts` so both services share one definition instead of duplicating it.
- Eviction now partitions candidates: safe (non-agent) views are evicted first; active-agent views are only touched when no safe candidates remain and memory pressure still requires reclaiming a view, with a `console.warn` emitted when that happens.

Resolves #5234

## Changes

- `shared/types/agent.ts` — exports `ACTIVE_AGENT_STATES` set
- `electron/services/HibernationService.ts` — imports from shared, drops its own copy
- `electron/window/ProjectViewManager.ts` — adds `hasActiveAgent()` helper, rewrites eviction with the partition strategy
- `electron/window/__tests__/ProjectViewManager.eviction.test.ts` — adds `PtyManager` mock and 3 new cases covering the bypass, the fallback, and the warn

## Testing

Eviction suite: 6/6 pass. Full `electron/window/__tests__/` suite: 114/114 pass. `HibernationService` suite: 58/58 pass. `npm run check` clean.