### PR TITLE
feat(project-views): auto-size cached project views default by system RAM

### DIFF
--- a/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
@@ -334,22 +334,30 @@ describe("terminalConfig handlers", () => {
     expect(storeState.data.terminalConfig).toMatchObject({ cachedProjectViews: 5 });
   });
 
-  it("setCachedProjectViews rejects out-of-range values", async () => {
-    registerTerminalConfigHandlers();
+  it("setCachedProjectViews rejects out-of-range values without mutating store or pvm", async () => {
+    const mockPvm = { setCachedViewLimit: vi.fn() };
+    registerTerminalConfigHandlers({ projectViewManager: mockPvm } as never);
     const handler = getHandler(CHANNELS.TERMINAL_CONFIG_SET_CACHED_PROJECT_VIEWS);
 
     await expect(handler({}, 0)).rejects.toThrow("Invalid cachedProjectViews value");
     await expect(handler({}, 6)).rejects.toThrow("Invalid cachedProjectViews value");
     await expect(handler({}, -1)).rejects.toThrow("Invalid cachedProjectViews value");
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+    expect(mockPvm.setCachedViewLimit).not.toHaveBeenCalled();
   });
 
-  it("setCachedProjectViews rejects non-integer and non-finite values", async () => {
-    registerTerminalConfigHandlers();
+  it("setCachedProjectViews rejects non-integer and non-finite values without side effects", async () => {
+    const mockPvm = { setCachedViewLimit: vi.fn() };
+    registerTerminalConfigHandlers({ projectViewManager: mockPvm } as never);
     const handler = getHandler(CHANNELS.TERMINAL_CONFIG_SET_CACHED_PROJECT_VIEWS);
 
     await expect(handler({}, 1.5)).rejects.toThrow("Invalid cachedProjectViews value");
     await expect(handler({}, Number.NaN)).rejects.toThrow("Invalid cachedProjectViews value");
     await expect(handler({}, Infinity)).rejects.toThrow("Invalid cachedProjectViews value");
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+    expect(mockPvm.setCachedViewLimit).not.toHaveBeenCalled();
   });
 
   it("setCachedProjectViews calls projectViewManager.setCachedViewLimit", async () => {

--- a/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
   ipcMain: {
@@ -25,6 +25,14 @@ const storeMock = vi.hoisted(() => ({
   set: vi.fn((key: string, value: unknown) => {
     storeState.data[key] = value;
   }),
+}));
+
+const osState = vi.hoisted(() => ({ totalmem: 8 * 1024 ** 3 }));
+
+vi.mock("node:os", () => ({
+  default: {
+    totalmem: () => osState.totalmem,
+  },
 }));
 
 vi.mock("../../../store.js", () => ({
@@ -61,6 +69,12 @@ describe("terminalConfig handlers", () => {
         screenReaderMode: "auto",
       },
     };
+    osState.totalmem = 8 * 1024 ** 3;
+    delete process.env.DAINTREE_E2E_MODE;
+  });
+
+  afterEach(() => {
+    delete process.env.DAINTREE_E2E_MODE;
   });
 
   it("registers all handlers and cleanup removes them", () => {
@@ -86,11 +100,131 @@ describe("terminalConfig handlers", () => {
     expect(removedChannels).toEqual(expect.arrayContaining(registeredChannels));
   });
 
-  it("get returns current terminal config", async () => {
+  it("get returns current terminal config with an effective cachedProjectViews", async () => {
     registerTerminalConfigHandlers();
     const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
-    await expect(handler({}, undefined)).resolves.toEqual(storeState.data.terminalConfig);
+    const result = (await handler({}, undefined)) as Record<string, unknown>;
+
+    expect(result).toEqual(
+      expect.objectContaining(storeState.data.terminalConfig as Record<string, unknown>)
+    );
+    expect(result.cachedProjectViews).toBe(1);
+  });
+
+  describe("get derives cachedProjectViews", () => {
+    it("preserves a stored preference regardless of RAM", async () => {
+      (storeState.data.terminalConfig as Record<string, unknown>).cachedProjectViews = 5;
+      osState.totalmem = 128 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(5);
+    });
+
+    it("preserves a stored preference in E2E mode", async () => {
+      process.env.DAINTREE_E2E_MODE = "1";
+      (storeState.data.terminalConfig as Record<string, unknown>).cachedProjectViews = 2;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(2);
+    });
+
+    it("returns 1 for an 8 GiB machine with no preference", async () => {
+      osState.totalmem = 8 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(1);
+    });
+
+    it("returns 1 for a 16 GiB machine with no preference", async () => {
+      osState.totalmem = 16 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(1);
+    });
+
+    it("returns 1 for a 24 GiB machine (below the 32 GiB threshold)", async () => {
+      osState.totalmem = 24 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(1);
+    });
+
+    it("returns 2 at the 32 GiB threshold", async () => {
+      osState.totalmem = 32 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(2);
+    });
+
+    it("returns 2 for a 48 GiB machine", async () => {
+      osState.totalmem = 48 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(2);
+    });
+
+    it("returns 3 at the 64 GiB threshold", async () => {
+      osState.totalmem = 64 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(3);
+    });
+
+    it("returns 3 for a 128 GiB machine", async () => {
+      osState.totalmem = 128 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(3);
+    });
+
+    it("returns 4 in E2E mode when no preference is stored, regardless of RAM", async () => {
+      process.env.DAINTREE_E2E_MODE = "1";
+      osState.totalmem = 8 * 1024 ** 3;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(4);
+    });
+
+    it("treats corrupted stored values as absent and falls back to the RAM default", async () => {
+      osState.totalmem = 64 * 1024 ** 3;
+      (storeState.data.terminalConfig as Record<string, unknown>).cachedProjectViews = "bogus";
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(3);
+    });
+
+    it("treats out-of-range stored values as absent and falls back to the RAM default", async () => {
+      osState.totalmem = 32 * 1024 ** 3;
+      (storeState.data.terminalConfig as Record<string, unknown>).cachedProjectViews = 99;
+      registerTerminalConfigHandlers();
+      const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
+
+      const result = (await handler({}, undefined)) as Record<string, unknown>;
+      expect(result.cachedProjectViews).toBe(2);
+    });
   });
 
   it("setScrollback accepts valid finite integer in range", async () => {

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -1,13 +1,9 @@
 import { ipcMain, dialog, BrowserWindow } from "electron";
-import os from "node:os";
 import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { parseColorSchemeFile } from "../../utils/colorSchemeImporter.js";
-import {
-  computeDefaultCachedViews,
-  isValidCachedProjectViews,
-} from "../../utils/cachedProjectViews.js";
+import { effectiveCachedProjectViews } from "../../utils/cachedProjectViews.js";
 import type { HandlerDependencies } from "../types.js";
 
 function getTerminalConfigObject(): Record<string, unknown> {
@@ -16,12 +12,6 @@ function getTerminalConfigObject(): Record<string, unknown> {
     return config as Record<string, unknown>;
   }
   return {};
-}
-
-function effectiveCachedProjectViews(stored: unknown): number {
-  if (isValidCachedProjectViews(stored)) return stored;
-  if (process.env.DAINTREE_E2E_MODE) return 4;
-  return computeDefaultCachedViews(os.totalmem());
 }
 
 export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () => void {

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -1,8 +1,13 @@
 import { ipcMain, dialog, BrowserWindow } from "electron";
+import os from "node:os";
 import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { parseColorSchemeFile } from "../../utils/colorSchemeImporter.js";
+import {
+  computeDefaultCachedViews,
+  isValidCachedProjectViews,
+} from "../../utils/cachedProjectViews.js";
 import type { HandlerDependencies } from "../types.js";
 
 function getTerminalConfigObject(): Record<string, unknown> {
@@ -13,11 +18,21 @@ function getTerminalConfigObject(): Record<string, unknown> {
   return {};
 }
 
+function effectiveCachedProjectViews(stored: unknown): number {
+  if (isValidCachedProjectViews(stored)) return stored;
+  if (process.env.DAINTREE_E2E_MODE) return 4;
+  return computeDefaultCachedViews(os.totalmem());
+}
+
 export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
   const handleTerminalConfigGet = async () => {
-    return getTerminalConfigObject();
+    const config = getTerminalConfigObject();
+    return {
+      ...config,
+      cachedProjectViews: effectiveCachedProjectViews(config.cachedProjectViews),
+    };
   };
   ipcMain.handle(CHANNELS.TERMINAL_CONFIG_GET, handleTerminalConfigGet);
   handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_GET));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,7 @@ import "./setup/environment.js";
 
 import { app, BrowserWindow, crashReporter, protocol } from "electron";
 import { registerGlobalErrorHandlers } from "./setup/globalErrorHandlers.js";
+import os from "node:os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
@@ -25,6 +26,7 @@ import {
 } from "./window/windowRef.js";
 import { WindowRegistry } from "./window/WindowRegistry.js";
 import { ProjectViewManager } from "./window/ProjectViewManager.js";
+import { computeDefaultCachedViews } from "./utils/cachedProjectViews.js";
 import { setupBrowserWindow } from "./window/createWindow.js";
 import { distributePortsToView } from "./window/portDistribution.js";
 import {
@@ -183,8 +185,9 @@ if (!gotTheLock) {
         // cached view alive is required so the wizard rendered in the
         // originating project view survives a switch into a freshly added
         // project view. Increase the cache only when the e2e harness flag is
-        // set so production behavior is unchanged.
-        (process.env.DAINTREE_E2E_MODE ? 4 : undefined),
+        // set so production behavior is unchanged. Otherwise auto-size the
+        // default from system RAM so higher-memory machines cache more views.
+        (process.env.DAINTREE_E2E_MODE ? 4 : computeDefaultCachedViews(os.totalmem())),
       onViewEvicted: (wcId) => {
         getWorkspaceClientRef()?.removeDirectPort(wcId);
         getWorktreePortBrokerRef()?.closePortsForView(wcId);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,7 +3,6 @@ import "./setup/environment.js";
 
 import { app, BrowserWindow, crashReporter, protocol } from "electron";
 import { registerGlobalErrorHandlers } from "./setup/globalErrorHandlers.js";
-import os from "node:os";
 import path from "path";
 import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
@@ -26,7 +25,7 @@ import {
 } from "./window/windowRef.js";
 import { WindowRegistry } from "./window/WindowRegistry.js";
 import { ProjectViewManager } from "./window/ProjectViewManager.js";
-import { computeDefaultCachedViews } from "./utils/cachedProjectViews.js";
+import { effectiveCachedProjectViews } from "./utils/cachedProjectViews.js";
 import { setupBrowserWindow } from "./window/createWindow.js";
 import { distributePortsToView } from "./window/portDistribution.js";
 import {
@@ -179,15 +178,13 @@ if (!gotTheLock) {
       dirname: __dirname,
       onRecreateWindow: () => createWindow(initialProjectPath, initialProjectId),
       windowRegistry,
-      cachedProjectViews:
-        store.get("terminalConfig")?.cachedProjectViews ??
-        // E2E tests add and switch projects rapidly. Keeping more than one
-        // cached view alive is required so the wizard rendered in the
-        // originating project view survives a switch into a freshly added
-        // project view. Increase the cache only when the e2e harness flag is
-        // set so production behavior is unchanged. Otherwise auto-size the
-        // default from system RAM so higher-memory machines cache more views.
-        (process.env.DAINTREE_E2E_MODE ? 4 : computeDefaultCachedViews(os.totalmem())),
+      // Resolve to the same value the IPC handler returns so the main-process
+      // LRU cap and the renderer's Settings view agree on first boot. Invalid
+      // persisted values fall through to the E2E override or RAM-based default
+      // instead of leaking into ProjectViewManager.
+      cachedProjectViews: effectiveCachedProjectViews(
+        store.get("terminalConfig")?.cachedProjectViews
+      ),
       onViewEvicted: (wcId) => {
         getWorkspaceClientRef()?.removeDirectPort(wcId);
         getWorktreePortBrokerRef()?.closePortsForView(wcId);

--- a/electron/utils/__tests__/cachedProjectViews.test.ts
+++ b/electron/utils/__tests__/cachedProjectViews.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { computeDefaultCachedViews, isValidCachedProjectViews } from "../cachedProjectViews.js";
+import {
+  computeDefaultCachedViews,
+  effectiveCachedProjectViews,
+  isValidCachedProjectViews,
+} from "../cachedProjectViews.js";
 
 const GIB = 1024 ** 3;
 
@@ -55,5 +59,68 @@ describe("isValidCachedProjectViews", () => {
     expect(isValidCachedProjectViews("3")).toBe(false);
     expect(isValidCachedProjectViews(null)).toBe(false);
     expect(isValidCachedProjectViews(undefined)).toBe(false);
+  });
+});
+
+describe("effectiveCachedProjectViews", () => {
+  const mem = (gib: number) => gib * GIB;
+
+  it("preserves a valid stored preference regardless of RAM or E2E mode", () => {
+    expect(effectiveCachedProjectViews(2, { totalMemBytes: mem(128), isE2E: true })).toBe(2);
+    expect(effectiveCachedProjectViews(5, { totalMemBytes: mem(8), isE2E: false })).toBe(5);
+    expect(effectiveCachedProjectViews(1, { totalMemBytes: mem(64), isE2E: true })).toBe(1);
+  });
+
+  it("returns the E2E override when no valid preference is stored", () => {
+    expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: true })).toBe(4);
+    expect(effectiveCachedProjectViews(null, { totalMemBytes: mem(128), isE2E: true })).toBe(4);
+    expect(effectiveCachedProjectViews("bogus", { totalMemBytes: mem(8), isE2E: true })).toBe(4);
+  });
+
+  it("derives from RAM when no preference and not in E2E mode", () => {
+    expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: false })).toBe(1);
+    expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(32), isE2E: false })).toBe(
+      2
+    );
+    expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(64), isE2E: false })).toBe(
+      3
+    );
+  });
+
+  it("treats corrupted stored values as absent and falls back", () => {
+    const ramDefault64 = { totalMemBytes: mem(64), isE2E: false };
+    expect(effectiveCachedProjectViews("bogus", ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews(99, ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews(0, ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews(-1, ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews(2.5, ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews(Number.NaN, ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews({ v: 2 }, ramDefault64)).toBe(3);
+  });
+
+  it("honors the E2E override when stored value is invalid", () => {
+    expect(effectiveCachedProjectViews(99, { totalMemBytes: mem(64), isE2E: true })).toBe(4);
+    expect(effectiveCachedProjectViews("bogus", { totalMemBytes: mem(8), isE2E: true })).toBe(4);
+    expect(effectiveCachedProjectViews(0, { totalMemBytes: mem(128), isE2E: true })).toBe(4);
+  });
+
+  it("reads DAINTREE_E2E_MODE from the environment when isE2E is not provided", () => {
+    const prev = process.env.DAINTREE_E2E_MODE;
+    try {
+      process.env.DAINTREE_E2E_MODE = "1";
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(4);
+      process.env.DAINTREE_E2E_MODE = "0";
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(1);
+      process.env.DAINTREE_E2E_MODE = "false";
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(1);
+      delete process.env.DAINTREE_E2E_MODE;
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(1);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.DAINTREE_E2E_MODE;
+      } else {
+        process.env.DAINTREE_E2E_MODE = prev;
+      }
+    }
   });
 });

--- a/electron/utils/__tests__/cachedProjectViews.test.ts
+++ b/electron/utils/__tests__/cachedProjectViews.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { computeDefaultCachedViews, isValidCachedProjectViews } from "../cachedProjectViews.js";
+
+const GIB = 1024 ** 3;
+
+describe("computeDefaultCachedViews", () => {
+  it("returns 1 for machines with 16 GiB or less", () => {
+    expect(computeDefaultCachedViews(4 * GIB)).toBe(1);
+    expect(computeDefaultCachedViews(8 * GIB)).toBe(1);
+    expect(computeDefaultCachedViews(16 * GIB)).toBe(1);
+  });
+
+  it("returns 1 for machines between 16 and 32 GiB", () => {
+    expect(computeDefaultCachedViews(24 * GIB)).toBe(1);
+    expect(computeDefaultCachedViews(32 * GIB - 1)).toBe(1);
+  });
+
+  it("returns 2 at the 32 GiB threshold and up to just below 64 GiB", () => {
+    expect(computeDefaultCachedViews(32 * GIB)).toBe(2);
+    expect(computeDefaultCachedViews(48 * GIB)).toBe(2);
+    expect(computeDefaultCachedViews(64 * GIB - 1)).toBe(2);
+  });
+
+  it("returns 3 at the 64 GiB threshold and above", () => {
+    expect(computeDefaultCachedViews(64 * GIB)).toBe(3);
+    expect(computeDefaultCachedViews(96 * GIB)).toBe(3);
+    expect(computeDefaultCachedViews(128 * GIB)).toBe(3);
+  });
+
+  it("falls back to 1 for invalid or non-positive inputs", () => {
+    expect(computeDefaultCachedViews(0)).toBe(1);
+    expect(computeDefaultCachedViews(-1)).toBe(1);
+    expect(computeDefaultCachedViews(Number.NaN)).toBe(1);
+    expect(computeDefaultCachedViews(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+});
+
+describe("isValidCachedProjectViews", () => {
+  it("accepts integers within [1, 5]", () => {
+    for (const n of [1, 2, 3, 4, 5]) {
+      expect(isValidCachedProjectViews(n)).toBe(true);
+    }
+  });
+
+  it("rejects out-of-range integers", () => {
+    expect(isValidCachedProjectViews(0)).toBe(false);
+    expect(isValidCachedProjectViews(6)).toBe(false);
+    expect(isValidCachedProjectViews(-1)).toBe(false);
+  });
+
+  it("rejects non-integer numbers and non-numbers", () => {
+    expect(isValidCachedProjectViews(2.5)).toBe(false);
+    expect(isValidCachedProjectViews(Number.NaN)).toBe(false);
+    expect(isValidCachedProjectViews("3")).toBe(false);
+    expect(isValidCachedProjectViews(null)).toBe(false);
+    expect(isValidCachedProjectViews(undefined)).toBe(false);
+  });
+});

--- a/electron/utils/__tests__/cachedProjectViews.test.ts
+++ b/electron/utils/__tests__/cachedProjectViews.test.ts
@@ -104,6 +104,26 @@ describe("effectiveCachedProjectViews", () => {
     expect(effectiveCachedProjectViews(0, { totalMemBytes: mem(128), isE2E: true })).toBe(4);
   });
 
+  it("prefers an explicit opts.isE2E over the environment variable", () => {
+    const prev = process.env.DAINTREE_E2E_MODE;
+    try {
+      process.env.DAINTREE_E2E_MODE = "1";
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: false })).toBe(
+        1
+      );
+      delete process.env.DAINTREE_E2E_MODE;
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: true })).toBe(
+        4
+      );
+    } finally {
+      if (prev === undefined) {
+        delete process.env.DAINTREE_E2E_MODE;
+      } else {
+        process.env.DAINTREE_E2E_MODE = prev;
+      }
+    }
+  });
+
   it("reads DAINTREE_E2E_MODE from the environment when isE2E is not provided", () => {
     const prev = process.env.DAINTREE_E2E_MODE;
     try {

--- a/electron/utils/cachedProjectViews.ts
+++ b/electron/utils/cachedProjectViews.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+
 const GIB = 1024 ** 3;
 
 export function computeDefaultCachedViews(totalMemBytes: number): number {
@@ -9,4 +11,20 @@ export function computeDefaultCachedViews(totalMemBytes: number): number {
 
 export function isValidCachedProjectViews(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 5;
+}
+
+export interface EffectiveCachedProjectViewsOptions {
+  totalMemBytes?: number;
+  isE2E?: boolean;
+}
+
+export function effectiveCachedProjectViews(
+  stored: unknown,
+  opts: EffectiveCachedProjectViewsOptions = {}
+): number {
+  if (isValidCachedProjectViews(stored)) return stored;
+  const isE2E = opts.isE2E ?? process.env.DAINTREE_E2E_MODE === "1";
+  if (isE2E) return 4;
+  const totalMemBytes = opts.totalMemBytes ?? os.totalmem();
+  return computeDefaultCachedViews(totalMemBytes);
 }

--- a/electron/utils/cachedProjectViews.ts
+++ b/electron/utils/cachedProjectViews.ts
@@ -1,0 +1,12 @@
+const GIB = 1024 ** 3;
+
+export function computeDefaultCachedViews(totalMemBytes: number): number {
+  if (!Number.isFinite(totalMemBytes) || totalMemBytes <= 0) return 1;
+  if (totalMemBytes >= 64 * GIB) return 3;
+  if (totalMemBytes >= 32 * GIB) return 2;
+  return 1;
+}
+
+export function isValidCachedProjectViews(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 5;
+}


### PR DESCRIPTION
## Summary

- On first boot (no stored preference), `cachedProjectViews` now defaults based on total RAM: <32 GiB → 1, ≥32 GiB → 2, ≥64 GiB → 3. Users with a saved value are unaffected.
- A shared `effectiveCachedProjectViews` resolver in `electron/utils/cachedProjectViews.ts` is used at both `ProjectViewManager` construction time and in the `TERMINAL_CONFIG_GET` IPC handler, so the LRU cap and the Settings view read from the same source on first boot.
- Invalid or corrupt stored values (non-integer, out-of-range, wrong type) are treated as absent and fall back to the RAM-based default. The E2E override (`DAINTREE_E2E_MODE=1` → 4) is preserved.

Resolves #5237

## Changes

- `electron/utils/cachedProjectViews.ts` (new) — `computeDefaultCachedViews`, `isValidCachedProjectViews`, `effectiveCachedProjectViews`
- `electron/utils/__tests__/cachedProjectViews.test.ts` (new) — 15 unit tests covering RAM thresholds, E2E override precedence, and validation
- `electron/ipc/handlers/terminalConfig.ts` — GET handler enriches response via shared resolver instead of inline logic
- `electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts` — +11 derivation and precedence tests, strengthened setter rejection tests
- `electron/main.ts` — `ProjectViewManager` constructor uses shared resolver

## Testing

71+ tests green locally across the utility, handler, PVM eviction, and adversarial preferences test suites. Typecheck, lint (401 warnings, 0 errors), and format all clean.