### PR TITLE
perf(zustand): wrap object-returning selectors with useShallow (batch 2)

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -24,6 +24,7 @@ import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvail
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useShallow } from "zustand/react/shallow";
 import {
   getDominantAgentState,
   agentStateDotColor,
@@ -54,8 +55,8 @@ export function AgentButton({
   const { worktrees } = useWorktrees();
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
 
-  const panelsById = usePanelStore((s) => s.panelsById);
-  const panelIds = usePanelStore((s) => s.panelIds);
+  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
+  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
   const activeSession = useMemo(() => {

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -27,6 +27,7 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useShallow } from "zustand/react/shallow";
 import { useKeybindingDisplay } from "@/hooks";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { CliAvailability, AgentState } from "@shared/types";
@@ -94,8 +95,8 @@ export function AgentTrayButton({
   const refreshAvailability = useCliAvailabilityStore((s) => s.refresh);
   const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
 
-  const panelsById = usePanelStore((s) => s.panelsById);
-  const panelIds = usePanelStore((s) => s.panelIds);
+  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
+  const panelIds = usePanelStore(useShallow((s) => s.panelIds));
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
   // Before the first real availability result lands we can't distinguish

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useCallback, useState, useMemo } from "react";
 import type React from "react";
+import { useShallow } from "zustand/react/shallow";
 import { usePortalStore } from "@/store";
 import { cn } from "@/lib/utils";
 import { PortalToolbar } from "./PortalToolbar";
@@ -23,7 +24,17 @@ import {
 import { getElementBoundsAsDip } from "@/lib/portalBounds";
 
 export function PortalDock() {
-  const { width, activeTabId, tabs, links, setWidth, setOpen, defaultNewTabUrl } = usePortalStore();
+  const { width, activeTabId, tabs, links, setWidth, setOpen, defaultNewTabUrl } = usePortalStore(
+    useShallow((s) => ({
+      width: s.width,
+      activeTabId: s.activeTabId,
+      tabs: s.tabs,
+      links: s.links,
+      setWidth: s.setWidth,
+      setOpen: s.setOpen,
+      defaultNewTabUrl: s.defaultNewTabUrl,
+    }))
+  );
   const contentRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
   const [isResizing, setIsResizing] = useState(false);

--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { useNotificationStore, type Notification } from "@/store/notificationStore";
 
@@ -54,8 +55,8 @@ export interface GridNotificationBarProps {
 }
 
 export function GridNotificationBar({ className }: GridNotificationBarProps) {
-  const notification = useNotificationStore((state) =>
-    state.notifications.find((item) => item.placement === "grid-bar")
+  const notification = useNotificationStore(
+    useShallow((state) => state.notifications.find((item) => item.placement === "grid-bar"))
   );
   const removeNotification = useNotificationStore((state) => state.removeNotification);
 


### PR DESCRIPTION
## Summary

- Wrapped `panelsById` and `panelIds` reads in `AgentButton.tsx` and `AgentTrayButton.tsx` with `useShallow`, using separate-per-property calls to match the pattern already in `SidebarContent`, `ContentDock`, and `DndProvider`
- Narrowed the `notifications.find()` selector in `GridNotificationBar.tsx` with `useShallow` to avoid re-renders when unrelated notifications change
- Replaced the whole-store `usePortalStore()` subscription in `PortalDock.tsx` with a `useShallow`-wrapped 7-field selector, eliminating spurious re-renders from any store write

No behaviour changes. Pure defensive cleanup to prevent unnecessary re-renders from object-identity churn.

Resolves #5193

## Changes

- `src/components/Layout/AgentButton.tsx` — two separate `useShallow` selectors for `panelsById` and `panelIds`
- `src/components/Layout/AgentTrayButton.tsx` — same pattern as above
- `src/components/Terminal/GridNotificationBar.tsx` — `useShallow` on the `notifications.find()` selector
- `src/components/Portal/PortalDock.tsx` — narrowed from whole-store subscription to explicit 7-field `useShallow` selector

## Testing

Lint and typecheck pass clean. No logic changes, so no functional test coverage required beyond the existing suite.