### PR TITLE
fix(theme): strict colour validation on custom theme import

### DIFF
--- a/electron/utils/__tests__/appThemeImporter.test.ts
+++ b/electron/utils/__tests__/appThemeImporter.test.ts
@@ -218,4 +218,151 @@ describe("appThemeImporter", () => {
     if (result.ok) return;
     expect(result.errors[0]).toContain("No recognized app theme tokens or palette");
   });
+
+  it("accepts the full spectrum of valid CSS color forms", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "All Color Forms",
+        type: "dark",
+        tokens: {
+          "surface-canvas": "#101010",
+          "surface-sidebar": "#abcdefff",
+          "accent-primary": "oklch(0.7 0.13 250)",
+          "accent-hover": "oklch(0.7 0.13 250 / 0.8)",
+          "accent-soft": "color-mix(in oklab, #3E9066 60%, #ffffff)",
+          "accent-muted": "rgba(62, 144, 102, 0.3)",
+          "text-primary": "rgb(255 255 255)",
+          "text-secondary": "hsl(120, 50%, 50%)",
+          "text-link": "hsla(200 50% 50% / 0.9)",
+          "text-inverse": "currentcolor",
+          "text-placeholder": "transparent",
+          "border-default": "rebeccapurple",
+          "focus-ring": "var(--theme-accent-primary)",
+          "accent-rgb": "62, 144, 102",
+          "shadow-ambient": "0 1px 3px rgba(0, 0, 0, 0.3)",
+          "material-opacity": "0.9",
+          "material-blur": "12px",
+        },
+      }),
+      "all-forms.json"
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.scheme.tokens["accent-primary"]).toBe("oklch(0.7 0.13 250)");
+    expect(result.scheme.tokens["accent-rgb"]).toBe("62, 144, 102");
+  });
+
+  it("rejects themes with invalid color values and lists the offending tokens", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Invalid Colors",
+        type: "dark",
+        tokens: {
+          "surface-canvas": "not-a-color",
+          "accent-primary": "#12345",
+          "text-primary": "#fff",
+        },
+      }),
+      "invalid-colors.json"
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join(" ")).toContain("surface-canvas");
+    expect(result.errors.join(" ")).toContain("accent-primary");
+    expect(result.errors.join(" ")).not.toContain("text-primary");
+  });
+
+  it("rejects remote heroImage URLs at import time", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Remote Hero",
+        type: "dark",
+        heroImage: "https://evil.example.com/hero.png",
+        tokens: {
+          "surface-canvas": "#101010",
+        },
+      }),
+      "remote-hero.json"
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((err) => err.includes("heroImage"))).toBe(true);
+  });
+
+  it("rejects each remote heroImage protocol variant", () => {
+    const variants = [
+      "http://example.com/hero.png",
+      "//cdn.example.com/hero.png",
+      "file:///Users/me/hero.png",
+      "C:\\Users\\me\\hero.png",
+      "\\\\server\\share\\hero.png",
+    ];
+    for (const heroImage of variants) {
+      const result = parseAppThemeContent(
+        JSON.stringify({
+          name: "Hero Variant",
+          type: "dark",
+          heroImage,
+          tokens: { "surface-canvas": "#101010" },
+        }),
+        "hero.json"
+      );
+      expect(result.ok, `expected rejection for ${heroImage}`).toBe(false);
+    }
+  });
+
+  it("accepts data: URLs for heroImage", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Data Hero",
+        type: "dark",
+        heroImage: "data:image/png;base64,iVBORw0KGgo=",
+        tokens: { "surface-canvas": "#101010" },
+      }),
+      "data-hero.json"
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.scheme.heroImage).toBe("data:image/png;base64,iVBORw0KGgo=");
+  });
+
+  it("rejects an accent-rgb token in the wrong format", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Bad RGB Triplet",
+        type: "dark",
+        tokens: {
+          "surface-canvas": "#101010",
+          "accent-rgb": "255 128 64",
+        },
+      }),
+      "bad-triplet.json"
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join(" ")).toContain("accent-rgb");
+  });
+
+  it("preserves extensions without validating their values", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Extensions Theme",
+        type: "dark",
+        tokens: { "surface-canvas": "#101010" },
+        extensions: {
+          "toolbar-project-bg": "linear-gradient(180deg, #1a2027, #0f1115)",
+        },
+      }),
+      "extensions.json"
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.scheme.extensions?.["toolbar-project-bg"]).toContain("linear-gradient");
+  });
 });

--- a/electron/utils/__tests__/appThemeImporter.test.ts
+++ b/electron/utils/__tests__/appThemeImporter.test.ts
@@ -348,6 +348,91 @@ describe("appThemeImporter", () => {
     expect(result.errors.join(" ")).toContain("accent-rgb");
   });
 
+  it("rejects palette-format themes when a palette color is invalid", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Bad Palette",
+        palette: {
+          type: "dark",
+          surfaces: {
+            grid: "not-a-color",
+            sidebar: "#151a20",
+            canvas: "#1a2027",
+            panel: "#202730",
+            elevated: "#28313c",
+          },
+          text: {
+            primary: "#edf2f7",
+            secondary: "#cbd5e0",
+            muted: "#94a3b8",
+            inverse: "#0f1115",
+          },
+          border: "#334155",
+          accent: "#38bdf8",
+          status: {
+            success: "#22c55e",
+            warning: "#f59e0b",
+            danger: "#ef4444",
+            info: "#60a5fa",
+          },
+          activity: {
+            active: "#22d3ee",
+            idle: "#64748b",
+            working: "#38bdf8",
+            waiting: "#fbbf24",
+          },
+          syntax: {
+            comment: "#64748b",
+            punctuation: "#cbd5e1",
+            number: "#fbbf24",
+            string: "#86efac",
+            operator: "#7dd3fc",
+            keyword: "#c084fc",
+            function: "#93c5fd",
+            link: "#38bdf8",
+            quote: "#94a3b8",
+            chip: "#22d3ee",
+          },
+        },
+      }),
+      "bad-palette.json"
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join(" ")).toContain("palette.surfaces.grid");
+  });
+
+  it("rejects a javascript: heroImage URL", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "JS Hero",
+        type: "dark",
+        heroImage: "javascript:alert(1)",
+        tokens: { "surface-canvas": "#101010" },
+      }),
+      "js-hero.json"
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((err) => err.includes("heroImage"))).toBe(true);
+  });
+
+  it("rejects a non-image data: URL for heroImage", () => {
+    const result = parseAppThemeContent(
+      JSON.stringify({
+        name: "Data HTML Hero",
+        type: "dark",
+        heroImage: "data:text/html,<script>alert(1)</script>",
+        tokens: { "surface-canvas": "#101010" },
+      }),
+      "data-html-hero.json"
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((err) => err.includes("heroImage"))).toBe(true);
+  });
+
   it("preserves extensions without validating their values", () => {
     const result = parseAppThemeContent(
       JSON.stringify({

--- a/electron/utils/appThemeImporter.ts
+++ b/electron/utils/appThemeImporter.ts
@@ -7,6 +7,7 @@ import {
   getBuiltInAppSchemeForType,
   inferAppThemeTypeFromTokens,
   normalizeAppColorScheme,
+  validateImportedThemeData,
   type AppThemeImportResult,
   type ThemePalette,
 } from "../../shared/theme/index.js";
@@ -112,6 +113,15 @@ export function parseAppThemeContent(content: string, filename: string): AppThem
     };
   }
 
+  const rawRecord = rawTheme as Record<string, unknown>;
+  const validation = validateImportedThemeData({
+    tokens: rawTokens,
+    heroImage: rawRecord.heroImage,
+  });
+  if (!validation.valid) {
+    return { ok: false, errors: validation.errors };
+  }
+
   const paletteType =
     rawTheme.palette &&
     typeof rawTheme.palette === "object" &&
@@ -122,7 +132,6 @@ export function parseAppThemeContent(content: string, filename: string): AppThem
   const resolvedType =
     rawTheme.type ?? paletteType ?? inferAppThemeTypeFromTokens(rawTokens) ?? "dark";
   const name = rawTheme.name?.trim() || getFileDisplayName(filename);
-  const rawRecord = rawTheme as Record<string, unknown>;
   const scheme = normalizeAppColorScheme(
     {
       id: rawTheme.id?.trim() || generateThemeId(name),

--- a/electron/utils/appThemeImporter.ts
+++ b/electron/utils/appThemeImporter.ts
@@ -116,6 +116,7 @@ export function parseAppThemeContent(content: string, filename: string): AppThem
   const rawRecord = rawTheme as Record<string, unknown>;
   const validation = validateImportedThemeData({
     tokens: rawTokens,
+    palette: rawTheme.palette,
     heroImage: rawRecord.heroImage,
   });
   if (!validation.valid) {

--- a/shared/theme/__tests__/colorValidator.test.ts
+++ b/shared/theme/__tests__/colorValidator.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import {
+  isValidAccentRgbTriplet,
+  isValidCssColor,
+  isValidThemeHeroImage,
+  validateImportedThemeData,
+} from "../colorValidator.js";
+
+describe("isValidCssColor", () => {
+  it("accepts hex colors in 3/4/6/8 digit forms", () => {
+    expect(isValidCssColor("#fff")).toBe(true);
+    expect(isValidCssColor("#FFFF")).toBe(true);
+    expect(isValidCssColor("#123456")).toBe(true);
+    expect(isValidCssColor("#12345678")).toBe(true);
+    expect(isValidCssColor("#ABCDEF")).toBe(true);
+  });
+
+  it("rejects malformed hex", () => {
+    expect(isValidCssColor("#")).toBe(false);
+    expect(isValidCssColor("#12")).toBe(false);
+    expect(isValidCssColor("#12345")).toBe(false);
+    expect(isValidCssColor("#1234567")).toBe(false);
+    expect(isValidCssColor("#123456789")).toBe(false);
+    expect(isValidCssColor("#gggggg")).toBe(false);
+  });
+
+  it("accepts rgb()/rgba() in legacy and modern forms", () => {
+    expect(isValidCssColor("rgb(255, 0, 0)")).toBe(true);
+    expect(isValidCssColor("rgba(255, 128, 64, 0.5)")).toBe(true);
+    expect(isValidCssColor("rgb(255 128 64)")).toBe(true);
+    expect(isValidCssColor("rgb(255 128 64 / 0.5)")).toBe(true);
+    expect(isValidCssColor("rgba(100%, 50%, 25%, 0.75)")).toBe(true);
+  });
+
+  it("rejects malformed rgb()", () => {
+    expect(isValidCssColor("rgb(255, 0)")).toBe(false);
+    expect(isValidCssColor("rgb()")).toBe(false);
+    expect(isValidCssColor("rgb(255 128, 64)")).toBe(false);
+    expect(isValidCssColor("rgb(oops)")).toBe(false);
+  });
+
+  it("accepts hsl()/hsla() in legacy and modern forms", () => {
+    expect(isValidCssColor("hsl(120, 50%, 50%)")).toBe(true);
+    expect(isValidCssColor("hsla(120deg, 50%, 50%, 0.5)")).toBe(true);
+    expect(isValidCssColor("hsl(120 50% 50%)")).toBe(true);
+    expect(isValidCssColor("hsl(120deg 50% 50% / 0.5)")).toBe(true);
+  });
+
+  it("accepts oklch() and oklab() including slash-alpha syntax", () => {
+    expect(isValidCssColor("oklch(0.7 0.13 250)")).toBe(true);
+    expect(isValidCssColor("oklch(0.7 0.13 250 / 0.8)")).toBe(true);
+    expect(isValidCssColor("oklch(0.7, 0.13, 250)")).toBe(true);
+    expect(isValidCssColor("oklab(0.65 0.05 -0.05)")).toBe(true);
+    expect(isValidCssColor("oklab(0.65 0.05 -0.05 / 0.5)")).toBe(true);
+  });
+
+  it("rejects malformed oklch()", () => {
+    expect(isValidCssColor("oklch(0.7 0.13)")).toBe(false);
+    expect(isValidCssColor("oklch()")).toBe(false);
+  });
+
+  it("accepts color-mix() with valid prefix and balanced parens", () => {
+    expect(isValidCssColor("color-mix(in oklab, #ff0000 50%, #00ff00)")).toBe(true);
+    expect(isValidCssColor("color-mix(in srgb, red, blue)")).toBe(true);
+    expect(isValidCssColor("color-mix(in oklch longer hue, red, blue)")).toBe(true);
+    expect(isValidCssColor("color-mix(in oklab, rgb(255, 0, 0) 50%, #00ff00)")).toBe(true);
+  });
+
+  it("rejects malformed color-mix()", () => {
+    expect(isValidCssColor("color-mix(red, blue)")).toBe(false);
+    expect(isValidCssColor("color-mix(in oklab, red, blue")).toBe(false);
+    expect(isValidCssColor("color-mix()")).toBe(false);
+  });
+
+  it("accepts var() with double-dash custom property", () => {
+    expect(isValidCssColor("var(--accent-primary)")).toBe(true);
+    expect(isValidCssColor("var(--theme-accent, #ff0000)")).toBe(true);
+    expect(isValidCssColor("var( --custom )")).toBe(true);
+  });
+
+  it("rejects var() without double-dash or argument", () => {
+    expect(isValidCssColor("var()")).toBe(false);
+    expect(isValidCssColor("var(accent)")).toBe(false);
+    expect(isValidCssColor("var(-accent)")).toBe(false);
+  });
+
+  it("accepts CSS named colors, transparent, and currentcolor", () => {
+    expect(isValidCssColor("red")).toBe(true);
+    expect(isValidCssColor("rebeccapurple")).toBe(true);
+    expect(isValidCssColor("TRANSPARENT")).toBe(true);
+    expect(isValidCssColor("currentcolor")).toBe(true);
+    expect(isValidCssColor("CurrentColor")).toBe(true);
+  });
+
+  it("rejects unknown named colors and garbage strings", () => {
+    expect(isValidCssColor("not-a-color")).toBe(false);
+    expect(isValidCssColor("bogus")).toBe(false);
+    expect(isValidCssColor("")).toBe(false);
+    expect(isValidCssColor("   ")).toBe(false);
+  });
+});
+
+describe("isValidAccentRgbTriplet", () => {
+  it("accepts comma-space triplet with values 0-255", () => {
+    expect(isValidAccentRgbTriplet("62, 144, 102")).toBe(true);
+    expect(isValidAccentRgbTriplet("0, 0, 0")).toBe(true);
+    expect(isValidAccentRgbTriplet("255, 255, 255")).toBe(true);
+    expect(isValidAccentRgbTriplet("62,144,102")).toBe(true);
+  });
+
+  it("rejects out-of-range components", () => {
+    expect(isValidAccentRgbTriplet("256, 0, 0")).toBe(false);
+    expect(isValidAccentRgbTriplet("-1, 0, 0")).toBe(false);
+    expect(isValidAccentRgbTriplet("999, 0, 0")).toBe(false);
+  });
+
+  it("rejects wrong separators and shapes", () => {
+    expect(isValidAccentRgbTriplet("62 144 102")).toBe(false);
+    expect(isValidAccentRgbTriplet("62, 144")).toBe(false);
+    expect(isValidAccentRgbTriplet("rgb(62, 144, 102)")).toBe(false);
+    expect(isValidAccentRgbTriplet("")).toBe(false);
+  });
+});
+
+describe("isValidThemeHeroImage", () => {
+  it("accepts relative and root-relative paths", () => {
+    expect(isValidThemeHeroImage("/themes/foo.webp")).toBe(true);
+    expect(isValidThemeHeroImage("./foo.webp")).toBe(true);
+    expect(isValidThemeHeroImage("foo.webp")).toBe(true);
+    expect(isValidThemeHeroImage("images/hero/foo.png")).toBe(true);
+  });
+
+  it("accepts data: URLs", () => {
+    expect(isValidThemeHeroImage("data:image/png;base64,iVBORw0KGgo=")).toBe(true);
+    expect(isValidThemeHeroImage("DATA:image/jpeg;base64,xyz")).toBe(true);
+  });
+
+  it("rejects remote protocols", () => {
+    expect(isValidThemeHeroImage("http://example.com/img.png")).toBe(false);
+    expect(isValidThemeHeroImage("https://example.com/img.png")).toBe(false);
+    expect(isValidThemeHeroImage("//cdn.example.com/img.png")).toBe(false);
+    expect(isValidThemeHeroImage("file:///Users/me/img.png")).toBe(false);
+  });
+
+  it("rejects Windows absolute paths and UNC paths", () => {
+    expect(isValidThemeHeroImage("C:\\Users\\me\\img.png")).toBe(false);
+    expect(isValidThemeHeroImage("C:/Users/me/img.png")).toBe(false);
+    expect(isValidThemeHeroImage("\\\\server\\share\\img.png")).toBe(false);
+  });
+
+  it("rejects empty strings", () => {
+    expect(isValidThemeHeroImage("")).toBe(false);
+    expect(isValidThemeHeroImage("   ")).toBe(false);
+  });
+});
+
+describe("validateImportedThemeData", () => {
+  it("returns valid for a clean color token set", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "surface-canvas": "#101010",
+        "accent-primary": "oklch(0.7 0.13 250)",
+        "text-primary": "rgba(255, 255, 255, 0.9)",
+        "accent-rgb": "62, 144, 102",
+        "shadow-ambient": "0 1px 3px rgba(0, 0, 0, 0.3)",
+        "material-opacity": "0.9",
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("aggregates multiple invalid token failures into a single error message", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "surface-canvas": "not-a-color",
+        "accent-primary": "also-invalid",
+        "text-primary": "#fff",
+      },
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("surface-canvas");
+    expect(result.errors[0]).toContain("accent-primary");
+    expect(result.errors[0]).not.toContain("text-primary");
+  });
+
+  it("rejects an invalid accent-rgb triplet with its own token in the list", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "accent-rgb": "255 128 64",
+      },
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors[0]).toContain("accent-rgb");
+  });
+
+  it("rejects a remote heroImage URL alongside color errors", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "surface-canvas": "not-a-color",
+      },
+      heroImage: "https://evil.example.com/img.png",
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.some((e) => e.includes("surface-canvas"))).toBe(true);
+    expect(result.errors.some((e) => e.includes("heroImage"))).toBe(true);
+  });
+
+  it("ignores unknown token keys (importer handles those separately as warnings)", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "surface-canvas": "#101010",
+        "not-a-real-token": "garbage value",
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects non-string token values", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "surface-canvas": 12345 as unknown as string,
+      },
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects empty string values on non-color tokens", () => {
+    const result = validateImportedThemeData({
+      tokens: {
+        "material-blur": "",
+      },
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/shared/theme/__tests__/colorValidator.test.ts
+++ b/shared/theme/__tests__/colorValidator.test.ts
@@ -66,22 +66,31 @@ describe("isValidCssColor", () => {
     expect(isValidCssColor("color-mix(in oklab, rgb(255, 0, 0) 50%, #00ff00)")).toBe(true);
   });
 
+  it("rejects color-mix() with invalid inner colors", () => {
+    expect(isValidCssColor("color-mix(in oklab, not-a-color, blue)")).toBe(false);
+    expect(isValidCssColor("color-mix(in oklab, #ff0000, bogus)")).toBe(false);
+    expect(isValidCssColor("color-mix(in oklab, nope)")).toBe(false);
+  });
+
   it("rejects malformed color-mix()", () => {
     expect(isValidCssColor("color-mix(red, blue)")).toBe(false);
     expect(isValidCssColor("color-mix(in oklab, red, blue")).toBe(false);
     expect(isValidCssColor("color-mix()")).toBe(false);
   });
 
-  it("accepts var() with double-dash custom property", () => {
+  it("accepts var() with double-dash custom property and color fallback", () => {
     expect(isValidCssColor("var(--accent-primary)")).toBe(true);
     expect(isValidCssColor("var(--theme-accent, #ff0000)")).toBe(true);
     expect(isValidCssColor("var( --custom )")).toBe(true);
   });
 
-  it("rejects var() without double-dash or argument", () => {
+  it("rejects var() without double-dash, empty name, or invalid fallback", () => {
     expect(isValidCssColor("var()")).toBe(false);
     expect(isValidCssColor("var(accent)")).toBe(false);
     expect(isValidCssColor("var(-accent)")).toBe(false);
+    expect(isValidCssColor("var(--)")).toBe(false);
+    expect(isValidCssColor("var(--theme-accent, )")).toBe(false);
+    expect(isValidCssColor("var(--x, not-a-color)")).toBe(false);
   });
 
   it("accepts CSS named colors, transparent, and currentcolor", () => {
@@ -130,16 +139,26 @@ describe("isValidThemeHeroImage", () => {
     expect(isValidThemeHeroImage("images/hero/foo.png")).toBe(true);
   });
 
-  it("accepts data: URLs", () => {
+  it("accepts data:image/ URLs", () => {
     expect(isValidThemeHeroImage("data:image/png;base64,iVBORw0KGgo=")).toBe(true);
     expect(isValidThemeHeroImage("DATA:image/jpeg;base64,xyz")).toBe(true);
+    expect(isValidThemeHeroImage("data:image/svg+xml;base64,abc")).toBe(true);
   });
 
-  it("rejects remote protocols", () => {
+  it("rejects non-image data: URLs", () => {
+    expect(isValidThemeHeroImage("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isValidThemeHeroImage("data:text/plain,hello")).toBe(false);
+    expect(isValidThemeHeroImage("data:application/javascript,alert(1)")).toBe(false);
+  });
+
+  it("rejects remote protocols and script-capable schemes", () => {
     expect(isValidThemeHeroImage("http://example.com/img.png")).toBe(false);
     expect(isValidThemeHeroImage("https://example.com/img.png")).toBe(false);
     expect(isValidThemeHeroImage("//cdn.example.com/img.png")).toBe(false);
     expect(isValidThemeHeroImage("file:///Users/me/img.png")).toBe(false);
+    expect(isValidThemeHeroImage("javascript:alert(1)")).toBe(false);
+    expect(isValidThemeHeroImage("vbscript:msgbox(1)")).toBe(false);
+    expect(isValidThemeHeroImage("ftp://example.com/x.png")).toBe(false);
   });
 
   it("rejects Windows absolute paths and UNC paths", () => {
@@ -236,5 +255,73 @@ describe("validateImportedThemeData", () => {
       },
     });
     expect(result.valid).toBe(false);
+  });
+
+  it("handles null or missing tokens without throwing", () => {
+    expect(
+      validateImportedThemeData({ tokens: null as unknown as Record<string, unknown> }).valid
+    ).toBe(true);
+    expect(validateImportedThemeData({}).valid).toBe(true);
+  });
+
+  it("rejects non-object tokens", () => {
+    const result = validateImportedThemeData({
+      tokens: "not-an-object" as unknown as Record<string, unknown>,
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors[0]).toContain("Invalid tokens");
+  });
+
+  it("rejects palette-format themes with invalid color values", () => {
+    const result = validateImportedThemeData({
+      palette: {
+        type: "dark",
+        surfaces: {
+          grid: "not-a-color",
+          sidebar: "#151a20",
+          canvas: "#1a2027",
+          panel: "#202730",
+          elevated: "#28313c",
+        },
+        text: {
+          primary: "#edf2f7",
+          secondary: "#cbd5e0",
+          muted: "#94a3b8",
+          inverse: "#0f1115",
+        },
+        border: "#334155",
+        accent: "also-bogus",
+        status: {
+          success: "#22c55e",
+          warning: "#f59e0b",
+          danger: "#ef4444",
+          info: "#60a5fa",
+        },
+        activity: {
+          active: "#22d3ee",
+          idle: "#64748b",
+          working: "#38bdf8",
+          waiting: "#fbbf24",
+        },
+        syntax: {
+          comment: "#64748b",
+          punctuation: "#cbd5e1",
+          number: "#fbbf24",
+          string: "#86efac",
+          operator: "#7dd3fc",
+          keyword: "#c084fc",
+          function: "#93c5fd",
+          link: "#38bdf8",
+          quote: "#94a3b8",
+          chip: "#22d3ee",
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    const joined = result.errors.join(" ");
+    expect(joined).toContain("palette.surfaces.grid");
+    expect(joined).toContain("palette.accent");
   });
 });

--- a/shared/theme/colorValidator.ts
+++ b/shared/theme/colorValidator.ts
@@ -1,0 +1,354 @@
+import { APP_THEME_TOKEN_KEYS, type AppThemeTokenKey } from "./types.js";
+
+const APP_THEME_TOKEN_KEY_SET: ReadonlySet<string> = new Set<string>(APP_THEME_TOKEN_KEYS);
+
+/**
+ * Token keys whose values are NOT CSS colors. These are either numeric/dimension
+ * values (opacity, blur, length, scale), multi-value shadow strings, or special
+ * formats (the `accent-rgb` triplet, the `chrome-noise-texture` gradient/keyword).
+ *
+ * Tokens not in this set are validated as CSS colors by `isValidCssColor`.
+ * `accent-rgb` uses its own dedicated validator (`isValidAccentRgbTriplet`).
+ */
+export const NON_COLOR_TOKEN_KEYS: ReadonlySet<AppThemeTokenKey> = new Set<AppThemeTokenKey>([
+  "material-blur",
+  "material-saturation",
+  "material-opacity",
+  "radius-scale",
+  "scrollbar-width",
+  "panel-state-edge-width",
+  "panel-state-edge-inset-block",
+  "panel-state-edge-radius",
+  "focus-ring-offset",
+  "chrome-noise-texture",
+  "shadow-ambient",
+  "shadow-floating",
+  "shadow-dialog",
+  "accent-rgb",
+  "state-chip-bg-opacity",
+  "state-chip-border-opacity",
+  "label-pill-bg-opacity",
+  "label-pill-border-opacity",
+]);
+
+/** CSS Color Level 4 named colors (147) plus `transparent` and `currentcolor`. */
+const CSS_NAMED_COLORS: ReadonlySet<string> = new Set<string>([
+  "aliceblue",
+  "antiquewhite",
+  "aqua",
+  "aquamarine",
+  "azure",
+  "beige",
+  "bisque",
+  "black",
+  "blanchedalmond",
+  "blue",
+  "blueviolet",
+  "brown",
+  "burlywood",
+  "cadetblue",
+  "chartreuse",
+  "chocolate",
+  "coral",
+  "cornflowerblue",
+  "cornsilk",
+  "crimson",
+  "cyan",
+  "darkblue",
+  "darkcyan",
+  "darkgoldenrod",
+  "darkgray",
+  "darkgreen",
+  "darkgrey",
+  "darkkhaki",
+  "darkmagenta",
+  "darkolivegreen",
+  "darkorange",
+  "darkorchid",
+  "darkred",
+  "darksalmon",
+  "darkseagreen",
+  "darkslateblue",
+  "darkslategray",
+  "darkslategrey",
+  "darkturquoise",
+  "darkviolet",
+  "deeppink",
+  "deepskyblue",
+  "dimgray",
+  "dimgrey",
+  "dodgerblue",
+  "firebrick",
+  "floralwhite",
+  "forestgreen",
+  "fuchsia",
+  "gainsboro",
+  "ghostwhite",
+  "gold",
+  "goldenrod",
+  "gray",
+  "green",
+  "greenyellow",
+  "grey",
+  "honeydew",
+  "hotpink",
+  "indianred",
+  "indigo",
+  "ivory",
+  "khaki",
+  "lavender",
+  "lavenderblush",
+  "lawngreen",
+  "lemonchiffon",
+  "lightblue",
+  "lightcoral",
+  "lightcyan",
+  "lightgoldenrodyellow",
+  "lightgray",
+  "lightgreen",
+  "lightgrey",
+  "lightpink",
+  "lightsalmon",
+  "lightseagreen",
+  "lightskyblue",
+  "lightslategray",
+  "lightslategrey",
+  "lightsteelblue",
+  "lightyellow",
+  "lime",
+  "limegreen",
+  "linen",
+  "magenta",
+  "maroon",
+  "mediumaquamarine",
+  "mediumblue",
+  "mediumorchid",
+  "mediumpurple",
+  "mediumseagreen",
+  "mediumslateblue",
+  "mediumspringgreen",
+  "mediumturquoise",
+  "mediumvioletred",
+  "midnightblue",
+  "mintcream",
+  "mistyrose",
+  "moccasin",
+  "navajowhite",
+  "navy",
+  "oldlace",
+  "olive",
+  "olivedrab",
+  "orange",
+  "orangered",
+  "orchid",
+  "palegoldenrod",
+  "palegreen",
+  "paleturquoise",
+  "palevioletred",
+  "papayawhip",
+  "peachpuff",
+  "peru",
+  "pink",
+  "plum",
+  "powderblue",
+  "purple",
+  "rebeccapurple",
+  "red",
+  "rosybrown",
+  "royalblue",
+  "saddlebrown",
+  "salmon",
+  "sandybrown",
+  "seagreen",
+  "seashell",
+  "sienna",
+  "silver",
+  "skyblue",
+  "slateblue",
+  "slategray",
+  "slategrey",
+  "snow",
+  "springgreen",
+  "steelblue",
+  "tan",
+  "teal",
+  "thistle",
+  "tomato",
+  "turquoise",
+  "violet",
+  "wheat",
+  "white",
+  "whitesmoke",
+  "yellow",
+  "yellowgreen",
+  "transparent",
+  "currentcolor",
+]);
+
+const HEX_RE = /^#(?:[0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+// Matches an rgb()/rgba() call in either legacy (comma) or modern (space +
+// optional slash alpha) form. Inner numbers can be integers, decimals, or
+// percentages. Mixing comma and space separators is rejected.
+const RGB_RE =
+  /^rgba?\(\s*(?:-?\d*\.?\d+%?\s*,\s*-?\d*\.?\d+%?\s*,\s*-?\d*\.?\d+%?(?:\s*,\s*-?\d*\.?\d+%?)?|-?\d*\.?\d+%?\s+-?\d*\.?\d+%?\s+-?\d*\.?\d+%?(?:\s*\/\s*-?\d*\.?\d+%?)?)\s*\)$/i;
+
+// Matches an hsl()/hsla() call. Hue may carry a unit (deg/rad/turn/grad).
+const HSL_RE =
+  /^hsla?\(\s*(?:-?\d*\.?\d+(?:deg|rad|turn|grad)?\s*,\s*-?\d*\.?\d+%\s*,\s*-?\d*\.?\d+%(?:\s*,\s*-?\d*\.?\d+%?)?|-?\d*\.?\d+(?:deg|rad|turn|grad)?\s+-?\d*\.?\d+%\s+-?\d*\.?\d+%(?:\s*\/\s*-?\d*\.?\d+%?)?)\s*\)$/i;
+
+// Matches oklch()/oklab() — modern slash-alpha or legacy comma form.
+const OKLCH_OKLAB_RE =
+  /^okl(?:ch|ab)\(\s*(?:-?\d*\.?\d+%?\s+-?\d*\.?\d+%?\s+-?\d*\.?\d+(?:deg|rad|turn|grad)?%?(?:\s*\/\s*-?\d*\.?\d+%?)?|-?\d*\.?\d+%?\s*,\s*-?\d*\.?\d+%?\s*,\s*-?\d*\.?\d+(?:deg|rad|turn|grad)?%?(?:\s*,\s*-?\d*\.?\d+%?)?)\s*\)$/i;
+
+const COLOR_MIX_PREFIX_RE =
+  /^color-mix\(\s*in\s+[a-z-]+(?:\s+(?:longer|shorter|increasing|decreasing)\s+hue)?\s*,/i;
+const VAR_PREFIX_RE = /^var\(\s*--/;
+
+const NAMED_COLOR_RE = /^[a-z]+$/i;
+
+function hasBalancedParens(value: string): boolean {
+  let depth = 0;
+  for (const ch of value) {
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth < 0) return false;
+    }
+  }
+  return depth === 0;
+}
+
+/**
+ * Returns true if `value` is structurally a valid CSS color string. Accepts
+ * hex (3/4/6/8 digits), `rgb()`/`rgba()`, `hsl()`/`hsla()`, `oklch()`/`oklab()`,
+ * `color-mix(in <space>, ...)`, `var(--...)`, and the CSS named colors
+ * (including `transparent` and `currentcolor`).
+ *
+ * This is structural validation, not full CSS parsing — e.g. `color-mix()` is
+ * checked for a valid prefix and balanced parens but nested color values are
+ * not recursively validated. That tradeoff avoids false negatives on legal CSS
+ * while still blocking obvious garbage like `"not-a-color"`.
+ */
+export function isValidCssColor(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  if (HEX_RE.test(trimmed)) return true;
+
+  if (trimmed.startsWith("#")) return false;
+
+  if (/^rgba?\(/i.test(trimmed)) return RGB_RE.test(trimmed);
+  if (/^hsla?\(/i.test(trimmed)) return HSL_RE.test(trimmed);
+  if (/^okl(?:ch|ab)\(/i.test(trimmed)) return OKLCH_OKLAB_RE.test(trimmed);
+
+  if (/^color-mix\(/i.test(trimmed)) {
+    if (!trimmed.endsWith(")")) return false;
+    if (!hasBalancedParens(trimmed)) return false;
+    return COLOR_MIX_PREFIX_RE.test(trimmed);
+  }
+
+  if (/^var\(/i.test(trimmed)) {
+    if (!trimmed.endsWith(")")) return false;
+    if (!hasBalancedParens(trimmed)) return false;
+    return VAR_PREFIX_RE.test(trimmed);
+  }
+
+  // Bare identifier → named color table lookup.
+  if (NAMED_COLOR_RE.test(trimmed)) {
+    return CSS_NAMED_COLORS.has(trimmed.toLowerCase());
+  }
+
+  return false;
+}
+
+/**
+ * Validates the `accent-rgb` token, which carries a comma-space RGB triplet
+ * like `"62, 144, 102"` (the format produced by `hexToRgbTriplet`). Each
+ * component must be an integer in 0–255.
+ */
+export function isValidAccentRgbTriplet(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const match = /^\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*$/.exec(value);
+  if (!match) return false;
+  for (let i = 1; i <= 3; i++) {
+    const component = Number(match[i]);
+    if (!Number.isFinite(component) || component < 0 || component > 255) return false;
+  }
+  return true;
+}
+
+/**
+ * Validates `heroImage` values on theme import. Accepts relative paths (with
+ * or without a leading `/`) and `data:` URLs. Rejects remote protocols
+ * (`http:`, `https:`, `file:`), protocol-relative `//`, Windows absolute
+ * (`C:\...`), and UNC (`\\server\share`).
+ */
+export function isValidThemeHeroImage(value: string): boolean {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (trimmed.toLowerCase().startsWith("data:")) return true;
+  return !/^(?:https?|file):|^\/\/|^[a-zA-Z]:[\\/]|^\\\\/i.test(trimmed);
+}
+
+export interface ImportedThemeDataForValidation {
+  tokens: Record<string, unknown>;
+  heroImage?: unknown;
+}
+
+export type ValidateImportedThemeDataResult = { valid: true } | { valid: false; errors: string[] };
+
+/**
+ * Validates user-supplied theme data at the import boundary. Iterates the
+ * `tokens` map and checks each recognized key against the appropriate
+ * validator (color / `accent-rgb` triplet / non-color pass-through), then
+ * validates `heroImage` if present. Unknown token keys are ignored here — the
+ * importer emits a separate "Ignored unknown tokens" warning for those.
+ *
+ * Returns all failures together so users see every problem in one pass.
+ */
+export function validateImportedThemeData(
+  data: ImportedThemeDataForValidation
+): ValidateImportedThemeDataResult {
+  const errors: string[] = [];
+  const invalidColorTokens: string[] = [];
+
+  for (const [key, value] of Object.entries(data.tokens)) {
+    if (!APP_THEME_TOKEN_KEY_SET.has(key)) continue;
+    if (typeof value !== "string") {
+      invalidColorTokens.push(key);
+      continue;
+    }
+
+    const tokenKey = key as AppThemeTokenKey;
+    if (tokenKey === "accent-rgb") {
+      if (!isValidAccentRgbTriplet(value)) invalidColorTokens.push(key);
+      continue;
+    }
+    if (NON_COLOR_TOKEN_KEYS.has(tokenKey)) {
+      if (!value.trim()) invalidColorTokens.push(key);
+      continue;
+    }
+    if (!isValidCssColor(value)) invalidColorTokens.push(key);
+  }
+
+  if (invalidColorTokens.length > 0) {
+    invalidColorTokens.sort();
+    errors.push(
+      `Invalid color values for token(s): ${invalidColorTokens.join(", ")}. ` +
+        `Values must be valid CSS colors (hex, rgb/rgba, hsl/hsla, oklch/oklab, color-mix, var, or named color).`
+    );
+  }
+
+  if (data.heroImage !== undefined && data.heroImage !== null) {
+    if (typeof data.heroImage !== "string" || !isValidThemeHeroImage(data.heroImage)) {
+      errors.push(
+        `Invalid heroImage value. heroImage must be a relative path or a data: URL — remote URLs and absolute OS paths are not allowed.`
+      );
+    }
+  }
+
+  return errors.length === 0 ? { valid: true } : { valid: false, errors };
+}

--- a/shared/theme/colorValidator.ts
+++ b/shared/theme/colorValidator.ts
@@ -201,10 +201,10 @@ const HSL_RE =
 const OKLCH_OKLAB_RE =
   /^okl(?:ch|ab)\(\s*(?:-?\d*\.?\d+%?\s+-?\d*\.?\d+%?\s+-?\d*\.?\d+(?:deg|rad|turn|grad)?%?(?:\s*\/\s*-?\d*\.?\d+%?)?|-?\d*\.?\d+%?\s*,\s*-?\d*\.?\d+%?\s*,\s*-?\d*\.?\d+(?:deg|rad|turn|grad)?%?(?:\s*,\s*-?\d*\.?\d+%?)?)\s*\)$/i;
 
-const COLOR_MIX_PREFIX_RE =
-  /^color-mix\(\s*in\s+[a-z-]+(?:\s+(?:longer|shorter|increasing|decreasing)\s+hue)?\s*,/i;
-const VAR_PREFIX_RE = /^var\(\s*--/;
-
+const COLOR_MIX_INTERPOLATION_RE =
+  /^in\s+[a-z-]+(?:\s+(?:longer|shorter|increasing|decreasing)\s+hue)?$/i;
+const VAR_NAME_RE = /^--[a-zA-Z_][\w-]*$/;
+const COLOR_COMPONENT_PERCENT_RE = /\s+-?\d*\.?\d+%$/;
 const NAMED_COLOR_RE = /^[a-z]+$/i;
 
 function hasBalancedParens(value: string): boolean {
@@ -219,16 +219,65 @@ function hasBalancedParens(value: string): boolean {
   return depth === 0;
 }
 
+/** Split `inner` on top-level commas (ignoring commas inside nested parens). */
+function splitTopLevelArgs(inner: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    else if (ch === "," && depth === 0) {
+      parts.push(inner.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(inner.slice(start));
+  return parts;
+}
+
+function isValidColorMix(value: string): boolean {
+  if (!value.endsWith(")")) return false;
+  if (!hasBalancedParens(value)) return false;
+  const inner = value.slice("color-mix(".length, -1).trim();
+  const parts = splitTopLevelArgs(inner).map((part) => part.trim());
+  if (parts.length !== 3) return false;
+  if (!COLOR_MIX_INTERPOLATION_RE.test(parts[0])) return false;
+  for (const part of parts.slice(1)) {
+    if (!part) return false;
+    const withoutPercent = part.replace(COLOR_COMPONENT_PERCENT_RE, "").trim();
+    if (!withoutPercent) return false;
+    if (!isValidCssColor(withoutPercent)) return false;
+  }
+  return true;
+}
+
+function isValidVarExpression(value: string): boolean {
+  if (!value.endsWith(")")) return false;
+  if (!hasBalancedParens(value)) return false;
+  const inner = value.slice("var(".length, -1).trim();
+  const parts = splitTopLevelArgs(inner).map((part) => part.trim());
+  if (parts.length === 0 || parts.length > 2) return false;
+  if (!VAR_NAME_RE.test(parts[0])) return false;
+  if (parts.length === 2) {
+    const fallback = parts[1];
+    if (!fallback) return false;
+    if (!isValidCssColor(fallback)) return false;
+  }
+  return true;
+}
+
 /**
  * Returns true if `value` is structurally a valid CSS color string. Accepts
  * hex (3/4/6/8 digits), `rgb()`/`rgba()`, `hsl()`/`hsla()`, `oklch()`/`oklab()`,
- * `color-mix(in <space>, ...)`, `var(--...)`, and the CSS named colors
- * (including `transparent` and `currentcolor`).
+ * `color-mix(in <space>, ...)`, `var(--...)` (with optional color fallback),
+ * and the CSS named colors (including `transparent` and `currentcolor`).
  *
- * This is structural validation, not full CSS parsing — e.g. `color-mix()` is
- * checked for a valid prefix and balanced parens but nested color values are
- * not recursively validated. That tradeoff avoids false negatives on legal CSS
- * while still blocking obvious garbage like `"not-a-color"`.
+ * Structural validation, not full CSS parsing: `color-mix()` and `var()`
+ * arguments are recursively validated one level deep; deeper nesting is not
+ * expected in theme files. The goal is to block obvious garbage like
+ * `"not-a-color"` at the import boundary without rejecting legal CSS.
  */
 export function isValidCssColor(value: string): boolean {
   if (typeof value !== "string") return false;
@@ -243,17 +292,8 @@ export function isValidCssColor(value: string): boolean {
   if (/^hsla?\(/i.test(trimmed)) return HSL_RE.test(trimmed);
   if (/^okl(?:ch|ab)\(/i.test(trimmed)) return OKLCH_OKLAB_RE.test(trimmed);
 
-  if (/^color-mix\(/i.test(trimmed)) {
-    if (!trimmed.endsWith(")")) return false;
-    if (!hasBalancedParens(trimmed)) return false;
-    return COLOR_MIX_PREFIX_RE.test(trimmed);
-  }
-
-  if (/^var\(/i.test(trimmed)) {
-    if (!trimmed.endsWith(")")) return false;
-    if (!hasBalancedParens(trimmed)) return false;
-    return VAR_PREFIX_RE.test(trimmed);
-  }
+  if (/^color-mix\(/i.test(trimmed)) return isValidColorMix(trimmed);
+  if (/^var\(/i.test(trimmed)) return isValidVarExpression(trimmed);
 
   // Bare identifier → named color table lookup.
   if (NAMED_COLOR_RE.test(trimmed)) {
@@ -279,22 +319,125 @@ export function isValidAccentRgbTriplet(value: string): boolean {
   return true;
 }
 
+const DATA_IMAGE_URL_RE = /^data:image\/[a-z0-9.+-]+[;,]/i;
+const URL_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
 /**
- * Validates `heroImage` values on theme import. Accepts relative paths (with
- * or without a leading `/`) and `data:` URLs. Rejects remote protocols
- * (`http:`, `https:`, `file:`), protocol-relative `//`, Windows absolute
- * (`C:\...`), and UNC (`\\server\share`).
+ * Validates `heroImage` values on theme import. Allowlist semantics: only a
+ * `data:image/...` URL or a path (relative, root-relative, or dot-relative)
+ * is accepted. Everything with a URL scheme is rejected, including `http:`,
+ * `https:`, `file:`, `javascript:`, `ftp:`, and non-image `data:` payloads.
+ * Protocol-relative URLs (`//cdn…`), Windows absolute (`C:\...`), and UNC
+ * (`\\server\share`) are rejected.
  */
 export function isValidThemeHeroImage(value: string): boolean {
   if (typeof value !== "string") return false;
   const trimmed = value.trim();
   if (!trimmed) return false;
-  if (trimmed.toLowerCase().startsWith("data:")) return true;
-  return !/^(?:https?|file):|^\/\/|^[a-zA-Z]:[\\/]|^\\\\/i.test(trimmed);
+  if (DATA_IMAGE_URL_RE.test(trimmed)) return true;
+  if (URL_SCHEME_RE.test(trimmed)) return false;
+  if (trimmed.startsWith("//")) return false;
+  if (trimmed.startsWith("\\\\")) return false;
+  return true;
+}
+
+/**
+ * Leaf color keys inside `ThemePalette`. When a theme is imported in palette
+ * format, each of these paths must carry a valid CSS color string.
+ * `accentSecondary`, `overlayTint`, `terminal`, and `strategy` are optional
+ * top-level keys; we only validate them when present.
+ */
+const PALETTE_COLOR_FIELDS = {
+  surfaces: ["grid", "sidebar", "canvas", "panel", "elevated"] as const,
+  text: ["primary", "secondary", "muted", "inverse"] as const,
+  status: ["success", "warning", "danger", "info"] as const,
+  activity: ["active", "idle", "working", "waiting"] as const,
+  terminal: [
+    "background",
+    "foreground",
+    "muted",
+    "cursor",
+    "selection",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "brightRed",
+    "brightGreen",
+    "brightYellow",
+    "brightBlue",
+    "brightMagenta",
+    "brightCyan",
+    "brightWhite",
+  ] as const,
+  syntax: [
+    "comment",
+    "punctuation",
+    "number",
+    "string",
+    "operator",
+    "keyword",
+    "function",
+    "link",
+    "quote",
+    "chip",
+  ] as const,
+} as const;
+
+const PALETTE_TOP_LEVEL_COLORS = ["border", "accent", "accentSecondary", "overlayTint"] as const;
+
+function collectPaletteColorErrors(palette: unknown): string[] {
+  const errors: string[] = [];
+  if (!palette || typeof palette !== "object" || Array.isArray(palette)) {
+    return ["Invalid palette: expected an object."];
+  }
+  const record = palette as Record<string, unknown>;
+  const invalid: string[] = [];
+
+  for (const key of PALETTE_TOP_LEVEL_COLORS) {
+    const value = record[key];
+    if (value === undefined) continue;
+    if (typeof value !== "string" || !isValidCssColor(value)) {
+      invalid.push(`palette.${key}`);
+    }
+  }
+
+  for (const [groupKey, leafKeys] of Object.entries(PALETTE_COLOR_FIELDS) as [
+    keyof typeof PALETTE_COLOR_FIELDS,
+    readonly string[],
+  ][]) {
+    const group = record[groupKey];
+    if (group === undefined) continue;
+    if (!group || typeof group !== "object" || Array.isArray(group)) {
+      invalid.push(`palette.${groupKey}`);
+      continue;
+    }
+    const groupRecord = group as Record<string, unknown>;
+    for (const leafKey of leafKeys) {
+      const value = groupRecord[leafKey];
+      if (value === undefined) continue;
+      if (typeof value !== "string" || !isValidCssColor(value)) {
+        invalid.push(`palette.${groupKey}.${leafKey}`);
+      }
+    }
+  }
+
+  if (invalid.length > 0) {
+    invalid.sort();
+    errors.push(
+      `Invalid color values for palette field(s): ${invalid.join(", ")}. ` +
+        `Values must be valid CSS colors (hex, rgb/rgba, hsl/hsla, oklch/oklab, color-mix, var, or named color).`
+    );
+  }
+
+  return errors;
 }
 
 export interface ImportedThemeDataForValidation {
-  tokens: Record<string, unknown>;
+  tokens?: Record<string, unknown> | null;
+  palette?: unknown;
   heroImage?: unknown;
 }
 
@@ -303,9 +446,10 @@ export type ValidateImportedThemeDataResult = { valid: true } | { valid: false; 
 /**
  * Validates user-supplied theme data at the import boundary. Iterates the
  * `tokens` map and checks each recognized key against the appropriate
- * validator (color / `accent-rgb` triplet / non-color pass-through), then
- * validates `heroImage` if present. Unknown token keys are ignored here — the
- * importer emits a separate "Ignored unknown tokens" warning for those.
+ * validator (color / `accent-rgb` triplet / non-color pass-through), walks
+ * the nested `palette` color leaves when provided, then validates `heroImage`
+ * if present. Unknown token keys are ignored here — the importer emits a
+ * separate "Ignored unknown tokens" warning for those.
  *
  * Returns all failures together so users see every problem in one pass.
  */
@@ -315,23 +459,29 @@ export function validateImportedThemeData(
   const errors: string[] = [];
   const invalidColorTokens: string[] = [];
 
-  for (const [key, value] of Object.entries(data.tokens)) {
-    if (!APP_THEME_TOKEN_KEY_SET.has(key)) continue;
-    if (typeof value !== "string") {
-      invalidColorTokens.push(key);
-      continue;
-    }
+  if (data.tokens !== undefined && data.tokens !== null) {
+    if (typeof data.tokens !== "object" || Array.isArray(data.tokens)) {
+      errors.push("Invalid tokens: expected an object of token name → value pairs.");
+    } else {
+      for (const [key, value] of Object.entries(data.tokens)) {
+        if (!APP_THEME_TOKEN_KEY_SET.has(key)) continue;
+        if (typeof value !== "string") {
+          invalidColorTokens.push(key);
+          continue;
+        }
 
-    const tokenKey = key as AppThemeTokenKey;
-    if (tokenKey === "accent-rgb") {
-      if (!isValidAccentRgbTriplet(value)) invalidColorTokens.push(key);
-      continue;
+        const tokenKey = key as AppThemeTokenKey;
+        if (tokenKey === "accent-rgb") {
+          if (!isValidAccentRgbTriplet(value)) invalidColorTokens.push(key);
+          continue;
+        }
+        if (NON_COLOR_TOKEN_KEYS.has(tokenKey)) {
+          if (!value.trim()) invalidColorTokens.push(key);
+          continue;
+        }
+        if (!isValidCssColor(value)) invalidColorTokens.push(key);
+      }
     }
-    if (NON_COLOR_TOKEN_KEYS.has(tokenKey)) {
-      if (!value.trim()) invalidColorTokens.push(key);
-      continue;
-    }
-    if (!isValidCssColor(value)) invalidColorTokens.push(key);
   }
 
   if (invalidColorTokens.length > 0) {
@@ -342,10 +492,14 @@ export function validateImportedThemeData(
     );
   }
 
+  if (data.palette !== undefined && data.palette !== null) {
+    errors.push(...collectPaletteColorErrors(data.palette));
+  }
+
   if (data.heroImage !== undefined && data.heroImage !== null) {
     if (typeof data.heroImage !== "string" || !isValidThemeHeroImage(data.heroImage)) {
       errors.push(
-        `Invalid heroImage value. heroImage must be a relative path or a data: URL — remote URLs and absolute OS paths are not allowed.`
+        `Invalid heroImage value. heroImage must be a relative path or a data:image/ URL — remote URLs, non-image data URLs, and absolute OS paths are not allowed.`
       );
     }
   }

--- a/shared/theme/index.ts
+++ b/shared/theme/index.ts
@@ -1,3 +1,4 @@
+export * from "./colorValidator.js";
 export * from "./contrast.js";
 export * from "./entityColors.js";
 export * from "./palette.js";


### PR DESCRIPTION
## Summary

- Adds a shared `colorValidator` module in `shared/theme/colorValidator.ts` that validates CSS colour strings against all allowed forms: hex, `rgb`/`rgba`, `hsl`/`hsla`, `oklch`/`oklab`, `color-mix(...)`, `var(...)`, and named colours
- Validates all colour tokens and `heroImage` during custom theme import in `appThemeImporter.ts`, failing early with a clear message listing any offending keys rather than letting invalid values through silently
- Restricts `heroImage` to relative paths and `data:` URLs only, rejecting remote URLs that the CSP would silently block at render time

Resolves #5243

## Changes

- `shared/theme/colorValidator.ts` — new validator with 508-line comprehensive test suite companion (`shared/theme/__tests__/colorValidator.test.ts`)
- `electron/utils/appThemeImporter.ts` — plugs the validator into the import path; rejects themes with invalid colour tokens or disallowed `heroImage` values
- `electron/utils/__tests__/appThemeImporter.test.ts` — 232-line test suite covering valid imports, invalid colour tokens, disallowed hero image URLs, and error message formatting

## Testing

Full unit test suite passes (`npm test`). Tests cover hex shorthand/longhand, all CSS colour function syntaxes, named colours, `var()` references, `color-mix()`, valid relative paths and `data:` URLs for hero images, and rejection cases for remote URLs and malformed colour strings.