### PR TITLE
feat(ipc): rate limit github, files:search, and project:get-bulk-stats handlers

### DIFF
--- a/electron/ipc/handlers/__tests__/files.search.test.ts
+++ b/electron/ipc/handlers/__tests__/files.search.test.ts
@@ -11,6 +11,12 @@ const fileSearchServiceMock = vi.hoisted(() => ({
   search: vi.fn<(payload: { cwd: string; query: string; limit?: number }) => Promise<string[]>>(),
 }));
 
+const checkRateLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils.js", () => ({
+  checkRateLimit: checkRateLimitMock,
+}));
+
 vi.mock("../../../services/FileSearchService.js", () => ({
   fileSearchService: fileSearchServiceMock,
 }));
@@ -104,5 +110,39 @@ describe("files:search handler", () => {
     cleanup();
 
     expect(ipcMain.removeHandler).toHaveBeenCalledWith(CHANNELS.FILES_SEARCH);
+  });
+
+  it("calls checkRateLimit with files:search limits on every invocation", async () => {
+    registerFilesHandlers();
+    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+      .calls;
+    const entry = calls.find((c) => c[0] === CHANNELS.FILES_SEARCH);
+    const handler = entry?.[1] as (
+      event: unknown,
+      payload: unknown
+    ) => Promise<{ files: string[] }>;
+
+    await handler({} as unknown, { cwd: "/tmp/project", query: "readme" });
+
+    expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.FILES_SEARCH, 20, 10_000);
+  });
+
+  it("propagates rate-limit errors and skips search service", async () => {
+    checkRateLimitMock.mockImplementationOnce(() => {
+      throw new Error("Rate limit exceeded");
+    });
+    registerFilesHandlers();
+    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+      .calls;
+    const entry = calls.find((c) => c[0] === CHANNELS.FILES_SEARCH);
+    const handler = entry?.[1] as (
+      event: unknown,
+      payload: unknown
+    ) => Promise<{ files: string[] }>;
+
+    await expect(handler({} as unknown, { cwd: "/tmp/project", query: "readme" })).rejects.toThrow(
+      "Rate limit exceeded"
+    );
+    expect(fileSearchServiceMock.search).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const shellMock = vi.hoisted(() => ({
+  openExternal: vi.fn().mockResolvedValue(undefined),
+}));
+
+const checkRateLimitMock = vi.hoisted(() => vi.fn());
+
+const gitHubServiceMock = vi.hoisted(() => ({
+  getRepoUrl: vi.fn().mockResolvedValue("https://github.com/owner/repo"),
+  listIssues: vi.fn().mockResolvedValue({ issues: [], nextCursor: null }),
+  listPullRequests: vi.fn().mockResolvedValue({ prs: [], nextCursor: null }),
+  assignIssue: vi.fn().mockResolvedValue(undefined),
+  validateGitHubToken: vi
+    .fn()
+    .mockResolvedValue({ valid: true, scopes: [], username: "user", avatarUrl: null }),
+  setGitHubToken: vi.fn(),
+  clearGitHubToken: vi.fn(),
+  hasGitHubToken: vi.fn().mockReturnValue(true),
+  getGitHubConfigAsync: vi.fn().mockResolvedValue({ hasToken: true }),
+  getIssueTooltip: vi.fn().mockResolvedValue(null),
+  getPRTooltip: vi.fn().mockResolvedValue(null),
+  getIssueUrl: vi.fn().mockResolvedValue("https://github.com/owner/repo/issues/1"),
+  getIssueByNumber: vi.fn().mockResolvedValue(null),
+  getPRByNumber: vi.fn().mockResolvedValue(null),
+  getRepoStats: vi.fn().mockResolvedValue({ stats: null, error: undefined }),
+  getProjectHealth: vi.fn().mockResolvedValue({ health: null, error: undefined }),
+  parseGitHubRepoUrl: vi.fn().mockReturnValue(null),
+}));
+
+const workspaceClientMock = vi.hoisted(() => ({
+  updateGitHubToken: vi.fn(),
+}));
+
+const gitHubAuthMock = vi.hoisted(() => ({
+  getTokenVersion: vi.fn().mockReturnValue(1),
+  setValidatedUserInfo: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  shell: shellMock,
+  BrowserWindow: {
+    fromWebContents: vi.fn().mockReturnValue(null),
+  },
+}));
+
+vi.mock("../../utils.js", () => ({
+  checkRateLimit: checkRateLimitMock,
+}));
+
+vi.mock("../../../services/GitHubService.js", () => gitHubServiceMock);
+
+vi.mock("../../../services/WorkspaceClient.js", () => ({
+  getWorkspaceClient: () => workspaceClientMock,
+}));
+
+vi.mock("../../../services/github/index.js", () => ({
+  GitHubAuth: gitHubAuthMock,
+}));
+
+vi.mock("../../../services/GitService.js", () => ({
+  GitService: class {
+    async listRemotes() {
+      return [];
+    }
+  },
+}));
+
+vi.mock("../../../utils/git.js", () => ({
+  getCommitCount: vi.fn().mockResolvedValue(0),
+}));
+
+import { CHANNELS } from "../../channels.js";
+import { registerGithubHandlers } from "../github.js";
+
+function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([registered]) => registered === channel
+  );
+  if (!call) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+describe("github handlers — rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitHubServiceMock.getRepoUrl.mockResolvedValue("https://github.com/owner/repo");
+    gitHubServiceMock.listIssues.mockResolvedValue({ issues: [], nextCursor: null });
+    gitHubServiceMock.validateGitHubToken.mockResolvedValue({
+      valid: true,
+      scopes: [],
+      username: "user",
+      avatarUrl: null,
+    });
+    registerGithubHandlers({} as never);
+  });
+
+  describe("read family (github:list-issues)", () => {
+    it("calls checkRateLimit with read limits (10, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_LIST_ISSUES);
+      await handler({} as never, { cwd: "/tmp/project" });
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.GITHUB_LIST_ISSUES, 10, 10_000);
+      expect(gitHubServiceMock.listIssues).toHaveBeenCalled();
+    });
+
+    it("rejects and skips listIssues when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.GITHUB_LIST_ISSUES);
+
+      await expect(handler({} as never, { cwd: "/tmp/project" })).rejects.toThrow(
+        "Rate limit exceeded"
+      );
+      expect(gitHubServiceMock.listIssues).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("open family (github:open-issues)", () => {
+    it("calls checkRateLimit with open limits (20, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_OPEN_ISSUES);
+      await handler({} as never, "/tmp/project", "bug", "open");
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.GITHUB_OPEN_ISSUES, 20, 10_000);
+      expect(shellMock.openExternal).toHaveBeenCalled();
+    });
+
+    it("rejects and skips shell.openExternal when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.GITHUB_OPEN_ISSUES);
+
+      await expect(handler({} as never, "/tmp/project", "bug", "open")).rejects.toThrow(
+        "Rate limit exceeded"
+      );
+      expect(shellMock.openExternal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("token family (github:set-token)", () => {
+    it("calls checkRateLimit with token limits (5, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_SET_TOKEN);
+      await handler({} as never, "ghp_valid_token");
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.GITHUB_SET_TOKEN, 5, 10_000);
+    });
+
+    it("rejects and skips validateGitHubToken when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.GITHUB_SET_TOKEN);
+
+      await expect(handler({} as never, "ghp_valid_token")).rejects.toThrow("Rate limit exceeded");
+      expect(gitHubServiceMock.validateGitHubToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mutation family (github:assign-issue)", () => {
+    it("calls checkRateLimit with mutation limits (5, 10_000)", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_ASSIGN_ISSUE);
+      await handler({} as never, {
+        cwd: "/tmp/project",
+        issueNumber: 42,
+        username: "octocat",
+      });
+
+      expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.GITHUB_ASSIGN_ISSUE, 5, 10_000);
+      expect(gitHubServiceMock.assignIssue).toHaveBeenCalled();
+    });
+
+    it("rejects and skips assignIssue when rate limit throws", async () => {
+      checkRateLimitMock.mockImplementationOnce(() => {
+        throw new Error("Rate limit exceeded");
+      });
+      const handler = getInvokeHandler(CHANNELS.GITHUB_ASSIGN_ISSUE);
+
+      await expect(
+        handler({} as never, {
+          cwd: "/tmp/project",
+          issueNumber: 42,
+          username: "octocat",
+        })
+      ).rejects.toThrow("Rate limit exceeded");
+      expect(gitHubServiceMock.assignIssue).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -195,4 +195,86 @@ describe("github handlers — rate limiting", () => {
       expect(gitHubServiceMock.assignIssue).not.toHaveBeenCalled();
     });
   });
+
+  describe("all github handlers are rate-limit-wired", () => {
+    type HandlerSpec = {
+      channel: string;
+      maxCalls: number;
+      invoke: (handler: (...args: unknown[]) => Promise<unknown>) => Promise<unknown>;
+    };
+
+    const cwd = "/tmp/project";
+    const specs: HandlerSpec[] = [
+      // read family: 10/10s
+      { channel: CHANNELS.GITHUB_GET_REPO_STATS, maxCalls: 10, invoke: (h) => h({}, cwd) },
+      { channel: CHANNELS.GITHUB_GET_PROJECT_HEALTH, maxCalls: 10, invoke: (h) => h({}, cwd) },
+      { channel: CHANNELS.GITHUB_CHECK_CLI, maxCalls: 10, invoke: (h) => h({}) },
+      { channel: CHANNELS.GITHUB_GET_CONFIG, maxCalls: 10, invoke: (h) => h({}) },
+      { channel: CHANNELS.GITHUB_LIST_ISSUES, maxCalls: 10, invoke: (h) => h({}, { cwd }) },
+      { channel: CHANNELS.GITHUB_LIST_PRS, maxCalls: 10, invoke: (h) => h({}, { cwd }) },
+      {
+        channel: CHANNELS.GITHUB_GET_ISSUE_URL,
+        maxCalls: 10,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      { channel: CHANNELS.GITHUB_LIST_REMOTES, maxCalls: 10, invoke: (h) => h({}, cwd) },
+      // tooltip + by-number (raised from 10/10s to accommodate hover-density and MULTI_FETCH_CAP=20)
+      {
+        channel: CHANNELS.GITHUB_GET_ISSUE_TOOLTIP,
+        maxCalls: 20,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      {
+        channel: CHANNELS.GITHUB_GET_PR_TOOLTIP,
+        maxCalls: 20,
+        invoke: (h) => h({}, { cwd, prNumber: 1 }),
+      },
+      {
+        channel: CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER,
+        maxCalls: 25,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      {
+        channel: CHANNELS.GITHUB_GET_PR_BY_NUMBER,
+        maxCalls: 25,
+        invoke: (h) => h({}, { cwd, prNumber: 1 }),
+      },
+      // open family: 20/10s
+      { channel: CHANNELS.GITHUB_OPEN_ISSUES, maxCalls: 20, invoke: (h) => h({}, cwd) },
+      { channel: CHANNELS.GITHUB_OPEN_PRS, maxCalls: 20, invoke: (h) => h({}, cwd) },
+      { channel: CHANNELS.GITHUB_OPEN_COMMITS, maxCalls: 20, invoke: (h) => h({}, cwd) },
+      {
+        channel: CHANNELS.GITHUB_OPEN_ISSUE,
+        maxCalls: 20,
+        invoke: (h) => h({}, { cwd, issueNumber: 1 }),
+      },
+      {
+        channel: CHANNELS.GITHUB_OPEN_PR,
+        maxCalls: 20,
+        invoke: (h) => h({}, "https://github.com/owner/repo/pull/1"),
+      },
+      // token + mutation family: 5/10s
+      { channel: CHANNELS.GITHUB_SET_TOKEN, maxCalls: 5, invoke: (h) => h({}, "ghp_token") },
+      { channel: CHANNELS.GITHUB_CLEAR_TOKEN, maxCalls: 5, invoke: (h) => h({}) },
+      { channel: CHANNELS.GITHUB_VALIDATE_TOKEN, maxCalls: 5, invoke: (h) => h({}, "ghp_token") },
+      {
+        channel: CHANNELS.GITHUB_ASSIGN_ISSUE,
+        maxCalls: 5,
+        invoke: (h) => h({}, { cwd, issueNumber: 1, username: "octocat" }),
+      },
+    ];
+
+    it("registers all 21 github channels", () => {
+      expect(specs).toHaveLength(21);
+    });
+
+    it.each(specs)(
+      "$channel calls checkRateLimit($channel, $maxCalls, 10_000)",
+      async ({ channel, maxCalls, invoke }) => {
+        const handler = getInvokeHandler(channel);
+        await invoke(handler);
+        expect(checkRateLimitMock).toHaveBeenCalledWith(channel, maxCalls, 10_000);
+      }
+    );
+  });
 });

--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -22,6 +22,14 @@ vi.mock("electron", () => ({
   },
 }));
 
+const checkRateLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils.js", () => ({
+  checkRateLimit: checkRateLimitMock,
+  broadcastToRenderer: vi.fn(),
+  sendToRenderer: vi.fn(),
+}));
+
 vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: {
     getCurrentProjectId: vi.fn(),
@@ -405,6 +413,29 @@ describe("handleProjectGetBulkStats", () => {
     expect(result["proj-a"].waitingAgentCount).toBe(0);
     // ptyStats fields are still populated
     expect(result["proj-a"].terminalCount).toBe(2);
+  });
+
+  it("calls checkRateLimit with project:get-bulk-stats limits", async () => {
+    const ptyClient = makePtyClient();
+    registerProjectCrudHandlers(makeDeps(ptyClient));
+    const handler = getBulkStatsHandler();
+
+    await handler(fakeEvent, ["proj-a"]);
+
+    expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.PROJECT_GET_BULK_STATS, 5, 10_000);
+  });
+
+  it("propagates rate-limit errors without fetching terminals or stats", async () => {
+    checkRateLimitMock.mockImplementationOnce(() => {
+      throw new Error("Rate limit exceeded");
+    });
+    const ptyClient = makePtyClient();
+    registerProjectCrudHandlers(makeDeps(ptyClient));
+    const handler = getBulkStatsHandler();
+
+    await expect(handler(fakeEvent, ["proj-a"])).rejects.toThrow("Rate limit exceeded");
+    expect(ptyClient.getAllTerminalsAsync).not.toHaveBeenCalled();
+    expect(ptyClient.getProjectStats).not.toHaveBeenCalled();
   });
 
   it("skips terminals without a projectId", async () => {

--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -422,7 +422,7 @@ describe("handleProjectGetBulkStats", () => {
 
     await handler(fakeEvent, ["proj-a"]);
 
-    expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.PROJECT_GET_BULK_STATS, 5, 10_000);
+    expect(checkRateLimitMock).toHaveBeenCalledWith(CHANNELS.PROJECT_GET_BULK_STATS, 10, 10_000);
   });
 
   it("propagates rate-limit errors without fetching terminals or stats", async () => {

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -2,6 +2,7 @@ import { ipcMain } from "electron";
 import path from "path";
 import fs from "fs/promises";
 import { CHANNELS } from "../channels.js";
+import { checkRateLimit } from "../utils.js";
 import { fileSearchService } from "../../services/FileSearchService.js";
 import { FileSearchPayloadSchema, FileReadPayloadSchema } from "../../schemas/ipc.js";
 
@@ -14,6 +15,8 @@ export function registerFilesHandlers(): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: unknown
   ): Promise<{ files: string[] }> => {
+    checkRateLimit(CHANNELS.FILES_SEARCH, 20, 10_000);
+
     const parsed = FileSearchPayloadSchema.safeParse(payload);
     if (!parsed.success) {
       console.error("[IPC] Invalid files:search payload:", parsed.error.format());

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -2,6 +2,7 @@ import { ipcMain, shell } from "electron";
 import fs from "fs/promises";
 import path from "path";
 import { CHANNELS } from "../channels.js";
+import { checkRateLimit } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   RepositoryStats,
@@ -57,6 +58,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     cwd: string,
     bypassCache = false
   ): Promise<RepositoryStats> => {
+    checkRateLimit(CHANNELS.GITHUB_GET_REPO_STATS, 10, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
     }
@@ -112,6 +114,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     cwd: string,
     bypassCache = false
   ): Promise<ProjectHealthData> => {
+    checkRateLimit(CHANNELS.GITHUB_GET_PROJECT_HEALTH, 10, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
     }
@@ -187,6 +190,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     query?: string,
     state?: string
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_OPEN_ISSUES, 20, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
     }
@@ -211,6 +215,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     query?: string,
     state?: string
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_OPEN_PRS, 20, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
     }
@@ -234,6 +239,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     cwd: string,
     branch?: string
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_OPEN_COMMITS, 20, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
     }
@@ -258,6 +264,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_OPEN_ISSUE, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -281,6 +288,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_ISSUE));
 
   const handleGitHubOpenPR = async (_event: Electron.IpcMainInvokeEvent, prUrl: string) => {
+    checkRateLimit(CHANNELS.GITHUB_OPEN_PR, 20, 10_000);
     if (typeof prUrl !== "string" || !prUrl) {
       throw new Error("Invalid PR URL");
     }
@@ -298,6 +306,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_PR));
 
   const handleGitHubCheckCli = async (): Promise<GitHubCliStatus> => {
+    checkRateLimit(CHANNELS.GITHUB_CHECK_CLI, 10, 10_000);
     const { hasGitHubToken } = await import("../../services/GitHubService.js");
     if (hasGitHubToken()) {
       return { available: true };
@@ -308,6 +317,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_CHECK_CLI));
 
   const handleGitHubGetConfig = async (): Promise<GitHubTokenConfig> => {
+    checkRateLimit(CHANNELS.GITHUB_GET_CONFIG, 10, 10_000);
     const { getGitHubConfigAsync } = await import("../../services/GitHubService.js");
     return getGitHubConfigAsync();
   };
@@ -318,6 +328,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     token: string
   ): Promise<GitHubTokenValidation> => {
+    checkRateLimit(CHANNELS.GITHUB_SET_TOKEN, 5, 10_000);
     if (typeof token !== "string" || !token.trim()) {
       return { valid: false, scopes: [], error: "Token is required" };
     }
@@ -354,6 +365,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_SET_TOKEN));
 
   const handleGitHubClearToken = async (): Promise<void> => {
+    checkRateLimit(CHANNELS.GITHUB_CLEAR_TOKEN, 5, 10_000);
     const { clearGitHubToken } = await import("../../services/GitHubService.js");
     clearGitHubToken();
 
@@ -371,6 +383,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     token: string
   ): Promise<GitHubTokenValidation> => {
+    checkRateLimit(CHANNELS.GITHUB_VALIDATE_TOKEN, 5, 10_000);
     if (typeof token !== "string" || !token.trim()) {
       return { valid: false, scopes: [], error: "Token is required" };
     }
@@ -392,6 +405,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       sortOrder?: "created" | "updated";
     }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_LIST_ISSUES, 10, 10_000);
     if (!options || typeof options.cwd !== "string" || !options.cwd) {
       throw new Error("Invalid options: cwd is required");
     }
@@ -416,6 +430,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       sortOrder?: "created" | "updated";
     }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_LIST_PRS, 10, 10_000);
     if (!options || typeof options.cwd !== "string" || !options.cwd) {
       throw new Error("Invalid options: cwd is required");
     }
@@ -433,6 +448,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number; username: string }
   ): Promise<void> => {
+    checkRateLimit(CHANNELS.GITHUB_ASSIGN_ISSUE, 5, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -464,6 +480,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -491,6 +508,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; prNumber: number }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_GET_PR_TOOLTIP, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -518,6 +536,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number }
   ): Promise<string | null> => {
+    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_URL, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -545,6 +564,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -572,6 +592,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; prNumber: number }
   ) => {
+    checkRateLimit(CHANNELS.GITHUB_GET_PR_BY_NUMBER, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -601,6 +622,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   ): Promise<
     Array<{ name: string; fetchUrl: string; parsedRepo: { owner: string; repo: string } | null }>
   > => {
+    checkRateLimit(CHANNELS.GITHUB_LIST_REMOTES, 10, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
     }

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -480,7 +480,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number }
   ) => {
-    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, 10, 10_000);
+    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -508,7 +508,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; prNumber: number }
   ) => {
-    checkRateLimit(CHANNELS.GITHUB_GET_PR_TOOLTIP, 10, 10_000);
+    checkRateLimit(CHANNELS.GITHUB_GET_PR_TOOLTIP, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -564,7 +564,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; issueNumber: number }
   ) => {
-    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, 10, 10_000);
+    checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, 25, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }
@@ -592,7 +592,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     _event: Electron.IpcMainInvokeEvent,
     payload: { cwd: string; prNumber: number }
   ) => {
-    checkRateLimit(CHANNELS.GITHUB_GET_PR_BY_NUMBER, 10, 10_000);
+    checkRateLimit(CHANNELS.GITHUB_GET_PR_BY_NUMBER, 25, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
     }

--- a/electron/ipc/handlers/projectCrud.ts
+++ b/electron/ipc/handlers/projectCrud.ts
@@ -6,7 +6,7 @@ import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { runCommandDetector } from "../../services/RunCommandDetector.js";
 import { ProjectSwitchService } from "../../services/ProjectSwitchService.js";
-import { broadcastToRenderer, sendToRenderer } from "../utils.js";
+import { broadcastToRenderer, sendToRenderer, checkRateLimit } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type { Project, ProjectSettings } from "../../types/index.js";
 import type {
@@ -607,6 +607,7 @@ export function registerProjectCrudHandlers(deps: HandlerDependencies): () => vo
     _event: Electron.IpcMainInvokeEvent,
     projectIds: string[]
   ): Promise<BulkProjectStats> => {
+    checkRateLimit(CHANNELS.PROJECT_GET_BULK_STATS, 5, 10_000);
     if (!Array.isArray(projectIds)) {
       throw new Error("Invalid projectIds: must be an array");
     }

--- a/electron/ipc/handlers/projectCrud.ts
+++ b/electron/ipc/handlers/projectCrud.ts
@@ -607,7 +607,7 @@ export function registerProjectCrudHandlers(deps: HandlerDependencies): () => vo
     _event: Electron.IpcMainInvokeEvent,
     projectIds: string[]
   ): Promise<BulkProjectStats> => {
-    checkRateLimit(CHANNELS.PROJECT_GET_BULK_STATS, 5, 10_000);
+    checkRateLimit(CHANNELS.PROJECT_GET_BULK_STATS, 10, 10_000);
     if (!Array.isArray(projectIds)) {
       throw new Error("Invalid projectIds: must be an array");
     }


### PR DESCRIPTION
## Summary

- Adds `checkRateLimit` to all 21 `github:*` IPC handlers, `files:search`, and `project:get-bulk-stats` to protect against runaway renderer fan-out
- Limits calibrated to real UI patterns: fetch handlers at 25/10s (supports `MULTI_FETCH_CAP=20`), tooltips at 20/10s, reads at 10/10s, mutations at 5/10s, `files:search` at 20/10s, `project:get-bulk-stats` at 10/10s
- Per-channel isolation throughout; no changes to `channelToCategory` to avoid the PR #4519 regression

Resolves #5227

## Changes

- `electron/ipc/handlers/github.ts` — `checkRateLimit` added to all 21 handlers with limits calibrated per operation class
- `electron/ipc/handlers/files.ts` — `checkRateLimit` placed outside the existing try/catch so rate-limit errors surface to the renderer while backend failures still degrade gracefully to `{ files: [] }`
- `electron/ipc/handlers/projectCrud.ts` — `checkRateLimit` added to `project:get-bulk-stats` for multi-window polling protection
- New `electron/ipc/handlers/__tests__/github.rateLimit.test.ts` — table-driven coverage for all 21 handlers plus family-level rejection tests
- Extended `files.search.test.ts` and `project.bulkStats.test.ts` with rate-limit mocks and assertions

## Testing

49 targeted tests pass. Typecheck, lint ratchet (401=401), and format all clean.