### PR TITLE
fix(toolbar): sync agent pin state between tray and Settings toolbar (#5112)

### DIFF
--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -22,6 +22,7 @@ import {
 import { getBrandColorHex } from "@/lib/colorUtils";
 import { getAgentConfig, type AgentIconProps } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
+import { useActionMruStore } from "@/store/actionMruStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { usePanelStore } from "@/store/panelStore";
@@ -87,6 +88,8 @@ export function AgentTrayButton({
 }: AgentTrayButtonProps) {
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
+
+  const actionMruList = useActionMruStore((s) => s.actionMruList);
 
   const refreshAvailability = useCliAvailabilityStore((s) => s.refresh);
   const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
@@ -190,10 +193,13 @@ export function AgentTrayButton({
 
       const state = agentAvailability?.[id];
       if (isAgentReady(state)) {
-        launchable.push(row);
+        // Pinned agents already live in the main toolbar — listing them in
+        // the tray's Launch section wastes dropdown space. Users unpin via
+        // the main toolbar button or Settings > Toolbar.
+        if (!pinned) launchable.push(row);
       } else if (isAgentInstalled(state)) {
         // "installed" means the CLI is on PATH but not fully authenticated
-        // or configured yet. These belong in "Also Available" with a setup
+        // or configured yet. These belong in "Needs Setup" with a setup
         // badge. Missing agents do NOT get promoted here.
         needsSetup.push(row);
       }
@@ -202,8 +208,21 @@ export function AgentTrayButton({
       fallbackSetup.push(row);
     }
 
+    // Sort Launch by palette MRU (lower index = more recent). Untracked
+    // agents keep their natural BUILT_IN_AGENT_IDS order after any tracked
+    // ones. Only palette dispatches populate `actionMruList`; tray launches
+    // don't record MRU, but palette-sourced recency is the signal we have.
+    launchable.sort((a, b) => {
+      const ai = actionMruList.indexOf(`agent.${a.id}`);
+      const bi = actionMruList.indexOf(`agent.${b.id}`);
+      if (ai === -1 && bi === -1) return 0;
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    });
+
     return { launchable, needsSetup, fallbackSetup };
-  }, [agentAvailability, agentSettings, agentDominantStates]);
+  }, [agentAvailability, agentSettings, agentDominantStates, actionMruList]);
 
   const handleLaunch = (row: AgentRow) => {
     void actionService.dispatch("agent.launch", { agentId: row.id }, { source: "user" });
@@ -291,7 +310,7 @@ export function AgentTrayButton({
 
         {launchable.length > 0 && (
           <>
-            <DropdownMenuLabel>Agents</DropdownMenuLabel>
+            <DropdownMenuLabel>Launch</DropdownMenuLabel>
             {launchable.map((row) => (
               <LaunchRow
                 key={`launch-${row.id}`}
@@ -308,7 +327,7 @@ export function AgentTrayButton({
         {needsSetup.length > 0 && (
           <>
             {launchable.length > 0 && <DropdownMenuSeparator />}
-            <DropdownMenuLabel>Also Available</DropdownMenuLabel>
+            <DropdownMenuLabel>Needs Setup</DropdownMenuLabel>
             {needsSetup.map((row) => (
               <DropdownMenuItem
                 key={`setup-${row.id}`}

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -17,6 +17,7 @@ let mockPanelsById: Record<string, unknown> = {};
 let mockPanelIds: string[] = [];
 let mockActiveWorktreeId: string | null = null;
 let mockHasRealData = true;
+let mockActionMruList: string[] = [];
 
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
@@ -30,6 +31,11 @@ type MockAgentStoreState = {
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: (selector: (s: MockAgentStoreState) => unknown) =>
     selector({ settings: mockSettings, setAgentPinned: setAgentPinnedMock }),
+}));
+
+vi.mock("@/store/actionMruStore", () => ({
+  useActionMruStore: (selector: (s: { actionMruList: string[] }) => unknown) =>
+    selector({ actionMruList: mockActionMruList }),
 }));
 
 type MockCliAvailabilityStoreState = {
@@ -196,6 +202,7 @@ describe("AgentTrayButton", () => {
     mockPanelIds = [];
     mockActiveWorktreeId = null;
     mockHasRealData = true;
+    mockActionMruList = [];
   });
 
   afterEach(() => {
@@ -213,12 +220,13 @@ describe("AgentTrayButton", () => {
     expect(getByTestId("plug-icon")).toBeTruthy();
   });
 
-  it("lists every ready agent regardless of pin state", () => {
+  it("lists ready, unpinned agents in the Launch section", () => {
     const availability = {
       claude: "ready",
       gemini: "ready",
       codex: "ready",
     } as unknown as CliAvailability;
+    // Claude pinned -> already on the main toolbar, excluded from tray.
     mockSettings = settingsWith({
       claude: { pinned: true },
       gemini: { pinned: false },
@@ -229,10 +237,62 @@ describe("AgentTrayButton", () => {
     );
 
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
-    expect(labels).toContain("Agents");
+    expect(labels).toContain("Launch");
 
     const rows = agentRows(container);
-    expect(rows).toEqual(["claude", "gemini", "codex"]);
+    // Claude pinned -> omitted; gemini and codex both unpinned -> listed.
+    expect(rows).toEqual(["gemini", "codex"]);
+  });
+
+  it("excludes all pinned agents from the Launch section", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({
+      claude: { pinned: true },
+      gemini: { pinned: true },
+      codex: { pinned: true },
+    });
+
+    const { container, queryAllByTestId } = render(
+      <AgentTrayButton agentAvailability={availability} />
+    );
+
+    expect(agentRows(container)).toEqual([]);
+    // Launch section should not render at all when empty.
+    const labels = queryAllByTestId("menu-label").map((el) => el.textContent);
+    expect(labels).not.toContain("Launch");
+  });
+
+  it("sorts the Launch section by palette MRU", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockActionMruList = ["agent.codex", "agent.claude"];
+
+    const { container } = render(<AgentTrayButton agentAvailability={availability} />);
+
+    // codex most recent, claude next, gemini untracked -> pushed to the end.
+    expect(agentRows(container)).toEqual(["codex", "claude", "gemini"]);
+  });
+
+  it("preserves natural order when the MRU list is empty", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockActionMruList = [];
+
+    const { container } = render(<AgentTrayButton agentAvailability={availability} />);
+
+    expect(agentRows(container)).toEqual(["claude", "gemini", "codex"]);
   });
 
   it("dispatches agent.launch when no active session exists", () => {
@@ -251,7 +311,8 @@ describe("AgentTrayButton", () => {
 
   it("always launches a new session even when agent already has one running", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
-    mockSettings = settingsWith({ claude: { pinned: true } });
+    // Unpinned so claude still appears in the tray's Launch list.
+    mockSettings = settingsWith({ claude: { pinned: false } });
     mockPanelsById = {
       "panel-1": {
         id: "panel-1",
@@ -276,29 +337,32 @@ describe("AgentTrayButton", () => {
     expect(setFocusedMock).not.toHaveBeenCalled();
   });
 
-  it("renders a filled pin indicator for pinned agents", () => {
+  it("renders a hollow pin indicator on unpinned Launch rows", () => {
+    // Pinned agents are excluded from the Launch list entirely, so pin
+    // indicators only render for unpinned rows. They should read as
+    // `data-pinned="false"` and be clickable to promote to pinned.
     const availability = {
-      claude: "ready",
       gemini: "ready",
+      codex: "ready",
     } as unknown as CliAvailability;
     mockSettings = settingsWith({
-      claude: { pinned: true },
       gemini: { pinned: false },
+      codex: { pinned: false },
     });
 
     const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
-    expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("true");
     expect(getByTestId("agent-tray-pin-gemini").getAttribute("data-pinned")).toBe("false");
+    expect(getByTestId("agent-tray-pin-codex").getAttribute("data-pinned")).toBe("false");
   });
 
-  it("clicking pin toggles pinned without launching", () => {
+  it("clicking the pin indicator promotes an unpinned agent without launching", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
-    mockSettings = settingsWith({ claude: { pinned: true } });
+    mockSettings = settingsWith({ claude: { pinned: false } });
 
     const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
     fireEvent.click(getByTestId("agent-tray-pin-claude"));
 
-    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
     expect(dispatchMock).not.toHaveBeenCalledWith(
       "agent.launch",
       expect.anything(),
@@ -327,7 +391,7 @@ describe("AgentTrayButton", () => {
     expect(getByTestId("agent-tray-pin-claude").getAttribute("data-pinned")).toBe("false");
   });
 
-  it("only puts installed-but-unauth agents in Also Available (missing agents are hidden)", () => {
+  it("only puts installed-but-unauth agents in Needs Setup (missing agents are hidden)", () => {
     const availability = {
       claude: "ready",
       gemini: "missing",
@@ -340,7 +404,7 @@ describe("AgentTrayButton", () => {
     );
 
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
-    expect(labels).toContain("Also Available");
+    expect(labels).toContain("Needs Setup");
 
     const setupItems = Array.from(container.querySelectorAll('[role="menuitem"]')).filter(
       (el) =>
@@ -348,14 +412,14 @@ describe("AgentTrayButton", () => {
         !el.textContent.includes("Manage") &&
         !el.textContent.includes("Customize")
     );
-    // Only codex (installed) belongs in Also Available. Gemini (missing) must NOT appear.
+    // Only codex (installed) belongs in Needs Setup. Gemini (missing) must NOT appear.
     expect(setupItems.length).toBe(1);
     expect(setupItems[0].textContent).toContain("Codex");
     const allText = container.textContent ?? "";
-    expect(allText).not.toMatch(/Also Available[\s\S]*Gemini/);
+    expect(allText).not.toMatch(/Needs Setup[\s\S]*Gemini/);
   });
 
-  it("dispatches settings with subtab when an Also-Available setup row is clicked", () => {
+  it("dispatches settings with subtab when a Needs-Setup row is clicked", () => {
     const availability = {
       claude: "ready",
       gemini: "installed",
@@ -365,9 +429,9 @@ describe("AgentTrayButton", () => {
     const { container, getAllByTestId } = render(
       <AgentTrayButton agentAvailability={availability} />
     );
-    // Sanity check: this must be the Also-Available branch, not the fallback.
+    // Sanity check: this must be the Needs-Setup branch, not the fallback.
     const labels = getAllByTestId("menu-label").map((el) => el.textContent);
-    expect(labels).toContain("Also Available");
+    expect(labels).toContain("Needs Setup");
 
     const setupItem = Array.from(container.querySelectorAll('[role="menuitem"]')).find((el) =>
       el.textContent?.includes("Gemini")
@@ -562,7 +626,8 @@ describe("AgentTrayButton", () => {
 
   it("ignores panels from other worktrees for session detection", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
-    mockSettings = settingsWith({ claude: { pinned: true } });
+    // Unpinned so claude still appears in the tray's Launch list.
+    mockSettings = settingsWith({ claude: { pinned: false } });
     mockPanelsById = {
       "panel-1": {
         id: "panel-1",

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -33,8 +33,11 @@ import {
 } from "lucide-react";
 import { CopyTreeIcon } from "@/components/icons";
 import { useToolbarPreferencesStore } from "@/store";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import type { AgentSettings } from "@shared/types";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { isAgentPinnedById } from "../../../shared/utils/agentPinned";
 import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
@@ -43,6 +46,22 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 
 type ButtonMetadata = { label: string; icon: React.ReactNode; description: string };
+
+// Agent-ID writes and reads for visibility go through `agentSettingsStore`
+// (the authoritative IPC-persisted store). `toolbarPreferencesStore.hiddenButtons`
+// is the source of truth only for non-agent buttons. A `version: 5` migration
+// strips stale agent IDs from persisted `hiddenButtons` so they can't shadow
+// the canonical pinned state.
+const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
+
+function isEffectivelyVisible(
+  buttonId: AnyToolbarButtonId,
+  hiddenButtons: string[],
+  agentSettings: AgentSettings | null
+): boolean {
+  if (AGENT_ID_SET.has(buttonId)) return isAgentPinnedById(agentSettings, buttonId);
+  return !hiddenButtons.includes(buttonId);
+}
 
 const BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ButtonMetadata>> = {
   "agent-tray": {
@@ -177,16 +196,17 @@ function SortableButtonItem({
 }
 
 export function ToolbarSettingsTab() {
-  const {
-    layout,
-    launcher,
-    setLeftButtons,
-    setRightButtons,
-    toggleButtonVisibility,
-    setAlwaysShowDevServer,
-    setDefaultSelection,
-    reset,
-  } = useToolbarPreferencesStore();
+  const layout = useToolbarPreferencesStore((s) => s.layout);
+  const launcher = useToolbarPreferencesStore((s) => s.launcher);
+  const setLeftButtons = useToolbarPreferencesStore((s) => s.setLeftButtons);
+  const setRightButtons = useToolbarPreferencesStore((s) => s.setRightButtons);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
+  const setAlwaysShowDevServer = useToolbarPreferencesStore((s) => s.setAlwaysShowDevServer);
+  const setDefaultSelection = useToolbarPreferencesStore((s) => s.setDefaultSelection);
+  const reset = useToolbarPreferencesStore((s) => s.reset);
+
+  const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -252,16 +272,24 @@ export function ToolbarSettingsTab() {
 
   const handleToggleLeft = useCallback(
     (buttonId: AnyToolbarButtonId) => {
+      if (AGENT_ID_SET.has(buttonId)) {
+        void setAgentPinned(buttonId, !isAgentPinnedById(agentSettings, buttonId));
+        return;
+      }
       toggleButtonVisibility(buttonId, "left");
     },
-    [toggleButtonVisibility]
+    [agentSettings, setAgentPinned, toggleButtonVisibility]
   );
 
   const handleToggleRight = useCallback(
     (buttonId: AnyToolbarButtonId) => {
+      if (AGENT_ID_SET.has(buttonId)) {
+        void setAgentPinned(buttonId, !isAgentPinnedById(agentSettings, buttonId));
+        return;
+      }
       toggleButtonVisibility(buttonId, "right");
     },
-    [toggleButtonVisibility]
+    [agentSettings, setAgentPinned, toggleButtonVisibility]
   );
 
   return (
@@ -269,7 +297,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Left Side Buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => !layout.hiddenButtons.includes(id)).length} of ${layout.leftButtons.length} visible.`}
+        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => isEffectivelyVisible(id, layout.hiddenButtons, agentSettings)).length} of ${layout.leftButtons.length} visible.`}
       >
         <DndContext
           sensors={sensors}
@@ -282,7 +310,7 @@ export function ToolbarSettingsTab() {
                 <SortableButtonItem
                   key={buttonId}
                   buttonId={buttonId}
-                  isVisible={!layout.hiddenButtons.includes(buttonId)}
+                  isVisible={isEffectivelyVisible(buttonId, layout.hiddenButtons, agentSettings)}
                   onToggle={handleToggleLeft}
                   allMetadata={allMetadata}
                 />
@@ -295,7 +323,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Right Side Buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => !layout.hiddenButtons.includes(id)).length} of ${layout.rightButtons.length} visible.`}
+        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => isEffectivelyVisible(id, layout.hiddenButtons, agentSettings)).length} of ${layout.rightButtons.length} visible.`}
       >
         <DndContext
           sensors={sensors}
@@ -308,7 +336,7 @@ export function ToolbarSettingsTab() {
                 <SortableButtonItem
                   key={buttonId}
                   buttonId={buttonId}
-                  isVisible={!layout.hiddenButtons.includes(buttonId)}
+                  isVisible={isEffectivelyVisible(buttonId, layout.hiddenButtons, agentSettings)}
                   onToggle={handleToggleRight}
                   allMetadata={allMetadata}
                 />

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { AgentSettings } from "@shared/types";
+
+const setLeftButtonsMock = vi.fn();
+const setRightButtonsMock = vi.fn();
+const toggleButtonVisibilityMock = vi.fn();
+const setAlwaysShowDevServerMock = vi.fn();
+const setDefaultSelectionMock = vi.fn();
+const resetMock = vi.fn();
+const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
+
+interface ToolbarState {
+  layout: {
+    leftButtons: string[];
+    rightButtons: string[];
+    hiddenButtons: string[];
+  };
+  launcher: {
+    alwaysShowDevServer: boolean;
+    defaultSelection?: string;
+  };
+  setLeftButtons: typeof setLeftButtonsMock;
+  setRightButtons: typeof setRightButtonsMock;
+  toggleButtonVisibility: typeof toggleButtonVisibilityMock;
+  setAlwaysShowDevServer: typeof setAlwaysShowDevServerMock;
+  setDefaultSelection: typeof setDefaultSelectionMock;
+  reset: typeof resetMock;
+}
+
+let mockToolbarState: ToolbarState = {
+  layout: { leftButtons: [], rightButtons: [], hiddenButtons: [] },
+  launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
+  setLeftButtons: setLeftButtonsMock,
+  setRightButtons: setRightButtonsMock,
+  toggleButtonVisibility: toggleButtonVisibilityMock,
+  setAlwaysShowDevServer: setAlwaysShowDevServerMock,
+  setDefaultSelection: setDefaultSelectionMock,
+  reset: resetMock,
+};
+
+let mockAgentSettings: AgentSettings | null = null;
+
+vi.mock("@/store", () => ({
+  useToolbarPreferencesStore: (selector: (s: ToolbarState) => unknown) =>
+    selector(mockToolbarState),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (
+    selector: (s: {
+      settings: AgentSettings | null;
+      setAgentPinned: typeof setAgentPinnedMock;
+    }) => unknown
+  ) => selector({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock }),
+}));
+
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"] as const,
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (id: string) => ({
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    icon: () => null,
+  }),
+}));
+
+vi.mock("@/hooks/usePluginToolbarButtons", () => ({
+  usePluginToolbarButtons: () => ({ buttonIds: [], configs: new Map() }),
+}));
+
+// @dnd-kit renders a sortable context plus listeners for each row. For unit
+// tests we only care about the rendered rows and the checkbox toggle paths —
+// stub the context and sortable hook so drag behavior doesn't need a real DOM.
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCenter: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: () => [],
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+  verticalListSortingStrategy: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+vi.mock("@/components/icons", () => ({
+  CopyTreeIcon: () => null,
+  McpServerIcon: () => null,
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => null;
+  return {
+    GripVertical: Icon,
+    SquareTerminal: Icon,
+    Globe: Icon,
+    Monitor: Icon,
+    AlertTriangle: Icon,
+    Settings: Icon,
+    AlertCircle: Icon,
+    Bell: Icon,
+    Mic: Icon,
+    LayoutGrid: Icon,
+    Rocket: Icon,
+    RotateCcw: Icon,
+    StickyNote: Icon,
+    Puzzle: Icon,
+  };
+});
+
+vi.mock("../SettingsSection", () => ({
+  SettingsSection: ({
+    children,
+    description,
+    title,
+  }: {
+    children: React.ReactNode;
+    description?: string;
+    title?: string;
+  }) => (
+    <section data-testid={`section-${title}`} data-description={description}>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock("../SettingsSwitchCard", () => ({
+  SettingsSwitchCard: () => null,
+}));
+
+import { ToolbarSettingsTab } from "../ToolbarSettingsTab";
+
+function agentSettings(overrides: Record<string, { pinned?: boolean }>): AgentSettings {
+  return { agents: overrides } as unknown as AgentSettings;
+}
+
+describe("ToolbarSettingsTab — agent visibility routing", () => {
+  beforeEach(() => {
+    setLeftButtonsMock.mockClear();
+    setRightButtonsMock.mockClear();
+    toggleButtonVisibilityMock.mockClear();
+    setAlwaysShowDevServerMock.mockClear();
+    setDefaultSelectionMock.mockClear();
+    resetMock.mockClear();
+    setAgentPinnedMock.mockClear();
+
+    mockToolbarState = {
+      layout: {
+        // Mix of agent IDs and non-agent IDs so we can test both branches.
+        leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
+        rightButtons: ["notes", "settings"],
+        hiddenButtons: [],
+      },
+      launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
+      setLeftButtons: setLeftButtonsMock,
+      setRightButtons: setRightButtonsMock,
+      toggleButtonVisibility: toggleButtonVisibilityMock,
+      setAlwaysShowDevServer: setAlwaysShowDevServerMock,
+      setDefaultSelection: setDefaultSelectionMock,
+      reset: resetMock,
+    };
+    mockAgentSettings = null;
+  });
+
+  it("shows agent rows as checked when pinned in agentSettingsStore", () => {
+    mockAgentSettings = agentSettings({
+      claude: { pinned: true },
+      gemini: { pinned: false },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+
+    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
+    const geminiCheckbox = getByLabelText("Toggle Gemini Agent visibility") as HTMLInputElement;
+    expect(claudeCheckbox.checked).toBe(true);
+    expect(geminiCheckbox.checked).toBe(false);
+  });
+
+  it("ignores hiddenButtons for agent IDs (agentSettingsStore wins)", () => {
+    // Stale entry from pre-migration persisted state — the UI must still
+    // derive the agent's visibility from `agentSettingsStore`, not from
+    // `hiddenButtons`.
+    mockToolbarState.layout.hiddenButtons = ["claude"];
+    mockAgentSettings = agentSettings({
+      claude: { pinned: true },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
+    expect(claudeCheckbox.checked).toBe(true);
+  });
+
+  it("routes agent checkbox toggle to setAgentPinned (not toggleButtonVisibility)", () => {
+    mockAgentSettings = agentSettings({
+      claude: { pinned: true },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Claude Agent visibility"));
+
+    expect(setAgentPinnedMock).toHaveBeenCalledTimes(1);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("routes agent checkbox toggle upward (unpinned → pinned) via setAgentPinned", () => {
+    mockAgentSettings = agentSettings({
+      gemini: { pinned: false },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Gemini Agent visibility"));
+
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps non-agent checkbox toggle on toggleButtonVisibility", () => {
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Terminal visibility"));
+
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("terminal", "left");
+    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+  });
+
+  it("reflects pinned agents in the section visible-count summary", () => {
+    mockAgentSettings = agentSettings({
+      claude: { pinned: true },
+      gemini: { pinned: false },
+    });
+
+    const { getByTestId } = render(<ToolbarSettingsTab />);
+    // Left side: agent-tray (visible), claude (pinned, visible),
+    // gemini (unpinned, not visible), terminal (not hidden, visible) => 3 / 4.
+    const leftSection = getByTestId("section-Left Side Buttons");
+    expect(leftSection.getAttribute("data-description")).toContain("3 of 4 visible");
+  });
+
+  it("treats null agentSettings as all-unpinned without crashing", () => {
+    mockAgentSettings = null;
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
+    expect(claudeCheckbox.checked).toBe(false);
+  });
+
+  it("handles a right-side agent correctly (routes through setAgentPinned)", () => {
+    // Relocate codex to the right side — an unlikely but possible layout.
+    mockToolbarState.layout = {
+      leftButtons: ["agent-tray", "terminal"],
+      rightButtons: ["codex", "settings"],
+      hiddenButtons: [],
+    };
+    mockAgentSettings = agentSettings({
+      codex: { pinned: true },
+    });
+
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Codex Agent visibility"));
+
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", false);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -1,0 +1,334 @@
+// @vitest-environment jsdom
+//
+// Integration test for issue #5112: proves that the Agent Tray's pin toggle
+// and Settings > Toolbar's checkbox share the same canonical state via
+// `agentSettingsStore`. A shared mutable mock store stands in for the real
+// Zustand store; both UIs read from and write to the same settings object,
+// which is exactly the guarantee the split-brain fix provides.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import type { AgentSettings, CliAvailability } from "@shared/types";
+
+// Shared settings state — mutated by setAgentPinnedMock, read by both UIs.
+let sharedSettings: AgentSettings | null = null;
+
+const setAgentPinnedMock = vi.fn(async (id: string, pinned: boolean) => {
+  sharedSettings = {
+    ...(sharedSettings ?? ({ agents: {} } as AgentSettings)),
+    agents: {
+      ...(sharedSettings?.agents ?? {}),
+      [id]: { ...(sharedSettings?.agents?.[id] ?? {}), pinned },
+    },
+  } as AgentSettings;
+});
+
+const dispatchMock = vi.fn();
+const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
+const toggleButtonVisibilityMock = vi.fn();
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (
+    selector: (s: {
+      settings: AgentSettings | null;
+      setAgentPinned: typeof setAgentPinnedMock;
+    }) => unknown
+  ) => selector({ settings: sharedSettings, setAgentPinned: setAgentPinnedMock }),
+}));
+
+vi.mock("@/store/actionMruStore", () => ({
+  useActionMruStore: (selector: (s: { actionMruList: string[] }) => unknown) =>
+    selector({ actionMruList: [] }),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (
+    selector: (s: { refresh: typeof refreshAvailabilityMock; hasRealData: boolean }) => unknown
+  ) => selector({ refresh: refreshAvailabilityMock, hasRealData: true }),
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ panelsById: {}, panelIds: [], setFocused: vi.fn() }),
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string | null }) => unknown) =>
+    selector({ activeWorktreeId: null }),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
+}));
+
+vi.mock("@/hooks", () => ({ useKeybindingDisplay: () => null }));
+
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"] as const,
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (id: string) => ({
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    icon: () => null,
+  }),
+}));
+
+vi.mock("@/lib/colorUtils", () => ({ getBrandColorHex: (id: string) => `#${id}` }));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    onKeyDown,
+    className,
+    ...props
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+    onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+    className?: string;
+  } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div
+      role="menuitem"
+      className={className}
+      onClick={(e) => onSelect?.(e as unknown as Event)}
+      onKeyDown={onKeyDown}
+      tabIndex={0}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="menu-label">{children}</div>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("lucide-react", () => {
+  const Icon = () => null;
+  return {
+    Plug: Icon,
+    Pin: Icon,
+    Plus: Icon,
+    Settings2: Icon,
+    GripVertical: Icon,
+    SquareTerminal: Icon,
+    Globe: Icon,
+    Monitor: Icon,
+    AlertTriangle: Icon,
+    Settings: Icon,
+    AlertCircle: Icon,
+    Bell: Icon,
+    Mic: Icon,
+    LayoutGrid: Icon,
+    Rocket: Icon,
+    RotateCcw: Icon,
+    StickyNote: Icon,
+    Puzzle: Icon,
+  };
+});
+
+// Settings-tab mocks.
+let sharedToolbarLayout = {
+  leftButtons: ["agent-tray", "claude", "gemini", "codex", "terminal"] as string[],
+  rightButtons: ["settings"] as string[],
+  hiddenButtons: [] as string[],
+};
+const sharedToolbarLauncher = { alwaysShowDevServer: false, defaultSelection: undefined };
+
+vi.mock("@/store", () => ({
+  useToolbarPreferencesStore: (
+    selector: (s: {
+      layout: typeof sharedToolbarLayout;
+      launcher: typeof sharedToolbarLauncher;
+      setLeftButtons: () => void;
+      setRightButtons: () => void;
+      toggleButtonVisibility: typeof toggleButtonVisibilityMock;
+      setAlwaysShowDevServer: () => void;
+      setDefaultSelection: () => void;
+      reset: () => void;
+    }) => unknown
+  ) =>
+    selector({
+      layout: sharedToolbarLayout,
+      launcher: sharedToolbarLauncher,
+      setLeftButtons: vi.fn(),
+      setRightButtons: vi.fn(),
+      toggleButtonVisibility: toggleButtonVisibilityMock,
+      setAlwaysShowDevServer: vi.fn(),
+      setDefaultSelection: vi.fn(),
+      reset: vi.fn(),
+    }),
+}));
+
+vi.mock("@/hooks/usePluginToolbarButtons", () => ({
+  usePluginToolbarButtons: () => ({ buttonIds: [], configs: new Map() }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCenter: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: () => [],
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+  verticalListSortingStrategy: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({ CSS: { Transform: { toString: () => "" } } }));
+
+vi.mock("@/components/icons", () => ({
+  CopyTreeIcon: () => null,
+  McpServerIcon: () => null,
+}));
+
+vi.mock("@/components/Settings/SettingsSection", () => ({
+  SettingsSection: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+}));
+
+vi.mock("@/components/Settings/SettingsSwitchCard", () => ({
+  SettingsSwitchCard: () => null,
+}));
+
+import { AgentTrayButton } from "@/components/Layout/AgentTrayButton";
+import { ToolbarSettingsTab } from "@/components/Settings/ToolbarSettingsTab";
+
+function agentRows(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-testid^="agent-tray-row-"]'))
+    .map((el) => el.getAttribute("data-testid")?.replace("agent-tray-row-", "") ?? "")
+    .filter(Boolean);
+}
+
+describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#5112)", () => {
+  beforeEach(() => {
+    setAgentPinnedMock.mockClear();
+    toggleButtonVisibilityMock.mockClear();
+    dispatchMock.mockClear();
+    refreshAvailabilityMock.mockClear();
+    sharedSettings = {
+      agents: {
+        claude: { pinned: true },
+        gemini: { pinned: false },
+        codex: { pinned: false },
+      },
+    } as AgentSettings;
+    sharedToolbarLayout = {
+      leftButtons: ["agent-tray", "claude", "gemini", "codex", "terminal"],
+      rightButtons: ["settings"],
+      hiddenButtons: [],
+    };
+  });
+
+  it("unpinning in Settings > Toolbar makes the agent reappear in the tray's Launch list", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+    } as unknown as CliAvailability;
+
+    // Initial tray render: claude is pinned so it's excluded from Launch.
+    const tray = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(agentRows(tray.container)).toEqual(["gemini", "codex"]);
+    tray.unmount();
+
+    // User unchecks claude in Settings > Toolbar.
+    const settings = render(<ToolbarSettingsTab />);
+    const claudeCheckbox = settings.getByLabelText(
+      "Toggle Claude Agent visibility"
+    ) as HTMLInputElement;
+    expect(claudeCheckbox.checked).toBe(true);
+    fireEvent.click(claudeCheckbox);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+    settings.unmount();
+
+    // Re-render the tray — claude should now appear in Launch because the
+    // shared settings store reflects the Settings-tab change.
+    const tray2 = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(agentRows(tray2.container)).toEqual(["claude", "gemini", "codex"]);
+  });
+
+  it("pinning in the tray makes the Settings > Toolbar checkbox flip to checked", () => {
+    const availability = {
+      gemini: "ready",
+      codex: "ready",
+    } as unknown as CliAvailability;
+    // Start with gemini unpinned — it's in the tray.
+    sharedSettings = {
+      agents: {
+        claude: { pinned: true },
+        gemini: { pinned: false },
+        codex: { pinned: false },
+      },
+    } as AgentSettings;
+
+    // Initial Settings render: gemini unchecked.
+    const settings = render(<ToolbarSettingsTab />);
+    const geminiCheckboxA = settings.getByLabelText(
+      "Toggle Gemini Agent visibility"
+    ) as HTMLInputElement;
+    expect(geminiCheckboxA.checked).toBe(false);
+    settings.unmount();
+
+    // User clicks the pin indicator in the tray for gemini.
+    const tray = render(<AgentTrayButton agentAvailability={availability} />);
+    fireEvent.click(tray.getByTestId("agent-tray-pin-gemini"));
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
+    tray.unmount();
+
+    // Re-render Settings — gemini is now checked because the shared store
+    // picked up the tray's write.
+    const settings2 = render(<ToolbarSettingsTab />);
+    const geminiCheckboxB = settings2.getByLabelText(
+      "Toggle Gemini Agent visibility"
+    ) as HTMLInputElement;
+    expect(geminiCheckboxB.checked).toBe(true);
+  });
+
+  it("Settings checkbox toggles for agent IDs never touch toolbarPreferencesStore.hiddenButtons", () => {
+    const settings = render(<ToolbarSettingsTab />);
+    fireEvent.click(settings.getByLabelText("Toggle Claude Agent visibility"));
+    fireEvent.click(settings.getByLabelText("Toggle Terminal visibility"));
+
+    // Agent -> setAgentPinned; non-agent -> toggleButtonVisibility.
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("terminal", "left");
+    // Agent toggles never write hiddenButtons.
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalledWith("claude", expect.anything());
+  });
+});

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -348,6 +348,86 @@ describe("toolbarPreferencesStore", () => {
       expect(store.getState().layout.leftButtons).toBeDefined();
     });
 
+    it("v4→v5 strips built-in agent IDs from hiddenButtons", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
+              rightButtons: ["settings"],
+              hiddenButtons: ["claude", "notes", "gemini"],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 4,
+        })
+      );
+
+      const store = await loadStore();
+      const { layout } = store.getState();
+      // Agent IDs stripped; non-agent entries preserved.
+      expect(layout.hiddenButtons).toEqual(["notes"]);
+      // Ordering arrays untouched.
+      expect(layout.leftButtons).toContain("claude");
+      expect(layout.leftButtons).toContain("gemini");
+    });
+
+    it("v4→v5 strips every built-in agent ID including rarer ones", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["agent-tray", "terminal"],
+              rightButtons: ["settings"],
+              hiddenButtons: ["claude", "gemini", "codex", "opencode", "cursor", "notes"],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 4,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.hiddenButtons).toEqual(["notes"]);
+    });
+
+    it("v4→v5 leaves hiddenButtons untouched when no agent IDs are present", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["agent-tray", "terminal"],
+              rightButtons: ["settings"],
+              hiddenButtons: ["notes", "copy-tree"],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 4,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.hiddenButtons).toEqual(["notes", "copy-tree"]);
+    });
+
+    it("v4→v5 handles missing layout without throwing", async () => {
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 4,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.leftButtons).toBeDefined();
+    });
+
     it("migrates v0 state through all migrations", async () => {
       storageMock.setItem(
         STORAGE_KEY,

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1,8 +1,19 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Mirror the production 7 agent IDs so the v5 migration is exercised against
+// the real set, not a subset. Keeping the mock in sync guards against
+// regressions when new built-in agents ship.
 vi.mock("@shared/config/agentIds", () => ({
-  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex", "opencode", "cursor"] as const,
+  BUILT_IN_AGENT_IDS: [
+    "claude",
+    "gemini",
+    "codex",
+    "opencode",
+    "cursor",
+    "kiro",
+    "copilot",
+  ] as const,
 }));
 
 let useToolbarPreferencesStore: typeof import("../toolbarPreferencesStore").useToolbarPreferencesStore;
@@ -381,7 +392,16 @@ describe("toolbarPreferencesStore", () => {
             layout: {
               leftButtons: ["agent-tray", "terminal"],
               rightButtons: ["settings"],
-              hiddenButtons: ["claude", "gemini", "codex", "opencode", "cursor", "notes"],
+              hiddenButtons: [
+                "claude",
+                "gemini",
+                "codex",
+                "opencode",
+                "cursor",
+                "kiro",
+                "copilot",
+                "notes",
+              ],
             },
             launcher: { alwaysShowDevServer: false },
           },
@@ -390,6 +410,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
+      // All 7 built-in agent IDs stripped; non-agent entries preserved.
       expect(store.getState().layout.hiddenButtons).toEqual(["notes"]);
     });
 
@@ -411,6 +432,31 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       expect(store.getState().layout.hiddenButtons).toEqual(["notes", "copy-tree"]);
+    });
+
+    it("v4→v5 is a no-op on already-v5 state (idempotency guard)", async () => {
+      // Rehydrating a store that's already at v5 must not re-apply the
+      // migration — agent IDs legitimately absent from hiddenButtons should
+      // stay absent, and the filter path must not run again.
+      storageMock.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            layout: {
+              leftButtons: ["agent-tray", "claude", "terminal"],
+              rightButtons: ["settings"],
+              hiddenButtons: ["notes"],
+            },
+            launcher: { alwaysShowDevServer: false },
+          },
+          version: 5,
+        })
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.hiddenButtons).toEqual(["notes"]);
+      // Ordering arrays untouched.
+      expect(store.getState().layout.leftButtons).toContain("claude");
     });
 
     it("v4→v5 handles missing layout without throwing", async () => {

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -152,7 +152,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 4,
+      version: 5,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -203,6 +203,16 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             layout.leftButtons = drop(layout.leftButtons);
             layout.rightButtons = drop(layout.rightButtons);
             layout.hiddenButtons = drop(layout.hiddenButtons);
+          }
+        }
+        if (version < 5) {
+          // Agent visibility moved to `agentSettingsStore.settings.agents[id].pinned`.
+          // Stale agent IDs in `hiddenButtons` from older versions would shadow the
+          // canonical pinned state after this migration, so strip them.
+          const layout = state.layout as { hiddenButtons?: string[] } | undefined;
+          if (layout?.hiddenButtons) {
+            const agentIds = new Set<string>(BUILT_IN_AGENT_IDS);
+            layout.hiddenButtons = layout.hiddenButtons.filter((id) => !agentIds.has(id));
           }
         }
         return state as unknown as ToolbarPreferencesState;


### PR DESCRIPTION
## Summary

- The Agent Tray and Settings > Toolbar were using separate stores to track agent pin state, causing split-brain where unpinning in one surface had no effect on the other. Both surfaces now write to `agentSettingsStore` as the single source of truth.
- `ToolbarSettingsTab` now routes agent button visibility toggles through `setAgentPinned` instead of `toggleButtonVisibility`, keeping IPC-backed persistence for agent pin state while leaving the non-agent button path unchanged.
- Pinned agents are filtered out of the Agent Tray's Launch list since they're already visible in the toolbar proper.

Resolves #5112

## Changes

- `toolbarPreferencesStore.ts`: added `isAgentId` guard so agent IDs fall back to `agentSettingsStore.setAgentPinned` for the visibility toggle
- `ToolbarSettingsTab.tsx`: conditional dispatch based on whether the button ID maps to an agent
- `AgentTrayButton.tsx`: filters out already-pinned agents from the Launch section of the dropdown
- New integration test (`agentPinSync.integration.test.tsx`) covering the round-trip sync in both directions
- Extended unit tests for `ToolbarSettingsTab` and `toolbarPreferencesStore`

## Testing

Unit and integration tests added covering the cross-surface sync. All existing tests pass. The integration test specifically exercises the scenario described in the issue: unpin via tray, assert Settings reflects it, and vice versa.