### PR TITLE
fix(agents): gate picker/palette visibility on availability, not pin state

### DIFF
--- a/src/components/HelpPanel/HelpAgentPicker.tsx
+++ b/src/components/HelpPanel/HelpAgentPicker.tsx
@@ -1,50 +1,45 @@
 import { useMemo, useCallback } from "react";
-import { Settings } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { AGENT_REGISTRY } from "@/config/agents";
-import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
-import { actionService } from "@/services/ActionService";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { isAgentMissing } from "../../../shared/utils/agentAvailability";
+import { isAgentInstalled } from "../../../shared/utils/agentAvailability";
 
 interface HelpAgentPickerProps {
   onSelectAgent: (agentId: string) => void;
 }
 
 export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
-  const settings = useAgentSettingsStore((s) => s.settings);
   const availability = useCliAvailabilityStore((s) => s.availability);
+  const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
 
-  const enabledAgents = useMemo(() => {
-    return BUILT_IN_AGENT_IDS.filter((id) => {
-      if (settings?.agents && settings.agents[id]?.pinned !== true) return false;
-      if (isAgentMissing(availability[id])) return false;
-      return true;
-    });
-  }, [settings, availability]);
+  const installedAgents = useMemo(() => {
+    if (!isAvailabilityInitialized) return [];
+    return BUILT_IN_AGENT_IDS.filter((id) => isAgentInstalled(availability[id]));
+  }, [isAvailabilityInitialized, availability]);
 
-  const handleOpenSettings = useCallback(() => {
-    void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
+  const handleOpenSetupWizard = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("daintree:open-agent-setup-wizard"));
   }, []);
 
-  if (enabledAgents.length === 0) {
+  if (installedAgents.length === 0) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center gap-4 p-8 text-center">
-        <p className="text-sm text-daintree-text/50">No agents are currently available.</p>
+        <p className="text-sm text-daintree-text/50">No agents are installed.</p>
         <p className="text-xs text-daintree-text/40">
-          Enable an agent in settings to use as your Daintree assistant.
+          Install an agent using the setup wizard to use as your Daintree assistant.
         </p>
         <Button
           type="button"
           variant="outline"
           size="sm"
-          onClick={handleOpenSettings}
+          onClick={handleOpenSetupWizard}
           className="gap-1.5"
         >
-          <Settings className="w-3.5 h-3.5" />
-          <span>Agent Settings</span>
+          <Sparkles className="w-3.5 h-3.5" />
+          <span>Run setup wizard</span>
         </Button>
       </div>
     );
@@ -59,7 +54,7 @@ export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
       </div>
 
       <div className="flex flex-col gap-2">
-        {enabledAgents.map((id) => {
+        {installedAgents.map((id) => {
           const config = AGENT_REGISTRY[id];
           if (!config) return null;
           const Icon = config.icon;

--- a/src/components/HelpPanel/HelpAgentPicker.tsx
+++ b/src/components/HelpPanel/HelpAgentPicker.tsx
@@ -13,16 +13,28 @@ interface HelpAgentPickerProps {
 
 export function HelpAgentPicker({ onSelectAgent }: HelpAgentPickerProps) {
   const availability = useCliAvailabilityStore((s) => s.availability);
-  const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
+  // Gate on `hasRealData` (not `isInitialized`): `isInitialized` flips true even on probe
+  // failure, but `hasRealData` waits for a real result — from localStorage cache or a
+  // successful IPC — so users with previously-installed agents don't see the
+  // "No agents are installed" empty state flash on cold open.
+  const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
 
   const installedAgents = useMemo(() => {
-    if (!isAvailabilityInitialized) return [];
+    if (!hasRealData) return [];
     return BUILT_IN_AGENT_IDS.filter((id) => isAgentInstalled(availability[id]));
-  }, [isAvailabilityInitialized, availability]);
+  }, [hasRealData, availability]);
 
   const handleOpenSetupWizard = useCallback(() => {
     window.dispatchEvent(new CustomEvent("daintree:open-agent-setup-wizard"));
   }, []);
+
+  if (!hasRealData) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center gap-2 p-8 text-center">
+        <p className="text-sm text-daintree-text/50">Checking for installed agents…</p>
+      </div>
+    );
+  }
 
   if (installedAgents.length === 0) {
     return (

--- a/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cliAvailabilityState } = vi.hoisted(() => ({
+  cliAvailabilityState: {
+    availability: {} as Record<string, string>,
+    isInitialized: true,
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...rest }: React.PropsWithChildren<{ onClick?: () => void }>) => (
+    <button type="button" onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"],
+}));
+
+vi.mock("@/config/agents", () => ({
+  AGENT_REGISTRY: {
+    claude: { name: "Claude", iconId: "claude", color: "#000", icon: () => null, tooltip: "c" },
+    gemini: { name: "Gemini", iconId: "gemini", color: "#000", icon: () => null, tooltip: "g" },
+    codex: { name: "Codex", iconId: "codex", color: "#000", icon: () => null, tooltip: "cx" },
+  },
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => {
+  const store = (selector: (state: typeof cliAvailabilityState) => unknown) =>
+    selector(cliAvailabilityState);
+  store.getState = () => cliAvailabilityState;
+  return { useCliAvailabilityStore: store };
+});
+
+import { HelpAgentPicker } from "../HelpAgentPicker";
+
+describe("HelpAgentPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cliAvailabilityState.isInitialized = true;
+    cliAvailabilityState.availability = {};
+  });
+
+  it("renders installed agent regardless of pin state (issue #5117)", () => {
+    cliAvailabilityState.availability = {
+      claude: "ready",
+      gemini: "installed",
+      codex: "missing",
+    };
+
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+
+    expect(screen.getByText("Claude")).toBeTruthy();
+    expect(screen.getByText("Gemini")).toBeTruthy();
+    expect(screen.queryByText("Codex")).toBeNull();
+  });
+
+  it("renders empty state when no agents are installed — with no 'Enable' copy", () => {
+    cliAvailabilityState.availability = {
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+    };
+
+    const { container } = render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+
+    expect(screen.getByText("No agents are installed.")).toBeTruthy();
+    expect(screen.getByText("Run setup wizard")).toBeTruthy();
+    expect(container.textContent).not.toMatch(/Enable an agent/i);
+  });
+
+  it("setup wizard CTA dispatches daintree:open-agent-setup-wizard", () => {
+    cliAvailabilityState.availability = {
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+    };
+
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("Run setup wizard"));
+
+    const call = dispatchSpy.mock.calls.find(
+      ([event]) => event instanceof CustomEvent && event.type === "daintree:open-agent-setup-wizard"
+    );
+    expect(call).toBeTruthy();
+
+    dispatchSpy.mockRestore();
+  });
+
+  it("shows empty state while availability is uninitialized", () => {
+    cliAvailabilityState.isInitialized = false;
+    cliAvailabilityState.availability = {};
+
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+
+    expect(screen.getByText("No agents are installed.")).toBeTruthy();
+    expect(screen.queryByText("Claude")).toBeNull();
+  });
+
+  it("calls onSelectAgent when an installed agent is clicked", () => {
+    cliAvailabilityState.availability = { claude: "ready", gemini: "missing", codex: "missing" };
+
+    const onSelectAgent = vi.fn();
+    render(<HelpAgentPicker onSelectAgent={onSelectAgent} />);
+
+    fireEvent.click(screen.getByText("Claude"));
+    expect(onSelectAgent).toHaveBeenCalledWith("claude");
+  });
+});

--- a/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpAgentPicker.test.tsx
@@ -6,6 +6,7 @@ const { cliAvailabilityState } = vi.hoisted(() => ({
   cliAvailabilityState: {
     availability: {} as Record<string, string>,
     isInitialized: true,
+    hasRealData: true,
   },
 }));
 
@@ -44,6 +45,7 @@ describe("HelpAgentPicker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cliAvailabilityState.isInitialized = true;
+    cliAvailabilityState.hasRealData = true;
     cliAvailabilityState.availability = {};
   });
 
@@ -61,7 +63,8 @@ describe("HelpAgentPicker", () => {
     expect(screen.queryByText("Codex")).toBeNull();
   });
 
-  it("renders empty state when no agents are installed — with no 'Enable' copy", () => {
+  it("renders empty state when real data says no agents are installed — with no 'Enable' copy", () => {
+    cliAvailabilityState.hasRealData = true;
     cliAvailabilityState.availability = {
       claude: "missing",
       gemini: "missing",
@@ -76,6 +79,7 @@ describe("HelpAgentPicker", () => {
   });
 
   it("setup wizard CTA dispatches daintree:open-agent-setup-wizard", () => {
+    cliAvailabilityState.hasRealData = true;
     cliAvailabilityState.availability = {
       claude: "missing",
       gemini: "missing",
@@ -95,14 +99,31 @@ describe("HelpAgentPicker", () => {
     dispatchSpy.mockRestore();
   });
 
-  it("shows empty state while availability is uninitialized", () => {
-    cliAvailabilityState.isInitialized = false;
+  it("renders loading sentinel (not empty state) while real data is pending", () => {
+    // hasRealData=false means neither cache nor probe has landed — don't show
+    // "No agents installed" prematurely (avoids flash on cold open with cache).
+    cliAvailabilityState.hasRealData = false;
     cliAvailabilityState.availability = {};
 
     render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
 
-    expect(screen.getByText("No agents are installed.")).toBeTruthy();
+    expect(screen.getByText("Checking for installed agents…")).toBeTruthy();
+    expect(screen.queryByText("No agents are installed.")).toBeNull();
     expect(screen.queryByText("Claude")).toBeNull();
+  });
+
+  it("renders installed agents once cached data lands even before first live probe", () => {
+    // hasRealData=true flips when localStorage cache hydrates the store, even without
+    // a successful IPC call yet. Users with previously-installed agents should see
+    // them immediately on cold open.
+    cliAvailabilityState.hasRealData = true;
+    cliAvailabilityState.availability = { claude: "ready", gemini: "missing", codex: "missing" };
+
+    render(<HelpAgentPicker onSelectAgent={vi.fn()} />);
+
+    expect(screen.getByText("Claude")).toBeTruthy();
+    expect(screen.queryByText("Gemini")).toBeNull();
+    expect(screen.queryByText("Checking for installed agents…")).toBeNull();
   });
 
   it("calls onSelectAgent when an installed agent is clicked", () => {

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -19,7 +19,7 @@ import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
 import { getAgentIds, getAgentConfig } from "@/config/agents";
-import { DEFAULT_AGENT_SETTINGS, getAgentSettingsEntry } from "@shared/types";
+import { DEFAULT_AGENT_SETTINGS } from "@shared/types";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import type {
   HibernationConfig,
@@ -28,7 +28,6 @@ import type {
   AgentSettings,
 } from "@shared/types";
 import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
-import { isAgentPinned } from "../../../shared/utils/agentPinned";
 import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
@@ -451,10 +450,8 @@ export function GeneralTab({
             ) : (
               (() => {
                 const allAgentIds = getAgentIds();
-                const installedAgentIds = allAgentIds.filter(
-                  (id) =>
-                    isAgentInstalled(cliAvailability[id]) &&
-                    isAgentPinned(getAgentSettingsEntry(agentSettings, id))
+                const installedAgentIds = allAgentIds.filter((id) =>
+                  isAgentInstalled(cliAvailability[id])
                 );
                 const hiddenCount = allAgentIds.length - installedAgentIds.length;
 

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -115,7 +115,7 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     setupElectron();
   });
 
-  it("renders only installed, pinned agents (hides uninstalled)", async () => {
+  it("renders all installed agents (hides uninstalled)", async () => {
     setupDispatchMock(
       {
         claude: "ready",
@@ -141,7 +141,7 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     expect(screen.getAllByText("Ready")).toHaveLength(2);
   });
 
-  it("hides unpinned agents", async () => {
+  it("shows installed agents regardless of pin state (issue #5117)", async () => {
     setupDispatchMock(
       { claude: "ready", gemini: "ready", codex: "ready", opencode: "missing", cursor: "missing" },
       {
@@ -155,7 +155,8 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
       expect(screen.getByText("Claude")).toBeTruthy();
     });
 
-    expect(screen.queryByText("Gemini")).toBeNull();
+    // Gemini is installed but unpinned — it MUST appear in System Status.
+    expect(screen.getByText("Gemini")).toBeTruthy();
     expect(screen.getByText("Codex")).toBeTruthy();
   });
 
@@ -198,7 +199,7 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     });
   });
 
-  it("hides summary when all agents installed and pinned", async () => {
+  it("hides summary when all agents are installed", async () => {
     setupDispatchMock(
       { claude: "ready", gemini: "ready", codex: "ready", opencode: "ready", cursor: "ready" },
       {

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -160,6 +160,59 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     expect(screen.getByText("Codex")).toBeTruthy();
   });
 
+  it("shows ALL installed agents when none are pinned (issue #5117, adversarial)", async () => {
+    setupDispatchMock(
+      { claude: "ready", gemini: "ready", codex: "ready", opencode: "missing", cursor: "missing" },
+      {
+        agents: {
+          claude: { pinned: false },
+          gemini: { pinned: false },
+          codex: { pinned: false },
+        },
+      } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Claude")).toBeTruthy();
+    });
+
+    expect(screen.getByText("Gemini")).toBeTruthy();
+    expect(screen.getByText("Codex")).toBeTruthy();
+    expect(screen.queryByText("Opencode")).toBeNull();
+    expect(screen.queryByText("Cursor")).toBeNull();
+  });
+
+  it("hides pinned-but-missing agents (pin alone doesn't make an agent appear)", async () => {
+    setupDispatchMock(
+      {
+        claude: "missing",
+        gemini: "missing",
+        codex: "ready",
+        opencode: "missing",
+        cursor: "missing",
+      },
+      {
+        agents: {
+          claude: { pinned: true },
+          gemini: { pinned: true },
+          codex: { pinned: true },
+        },
+      } as unknown as AgentSettings
+    );
+
+    await renderGeneralTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("Codex")).toBeTruthy();
+    });
+
+    // Pinned but missing → must NOT appear.
+    expect(screen.queryByText("Claude")).toBeNull();
+    expect(screen.queryByText("Gemini")).toBeNull();
+  });
+
   it("shows summary for hidden agents with correct count and pluralization", async () => {
     setupDispatchMock(
       {

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -13,8 +13,7 @@ import {
   type TerminalInstance,
 } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
-import { isAgentReady } from "../../../shared/utils/agentAvailability";
-import { isAgentPinned } from "../../../shared/utils/agentPinned";
+import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
 import { GridPanel } from "./GridPanel";
 import { GridTabGroup } from "./GridTabGroup";
 import { GridNotificationBar } from "./GridNotificationBar";
@@ -58,7 +57,6 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { RecipeRunner } from "./RecipeRunner/RecipeRunner";
-import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
@@ -390,17 +388,14 @@ export function ContentGrid({
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
-  const gridAgentSettings = useAgentSettingsStore((state) => state.settings);
-
-  // undefined = no filter (settings not loaded or pre-migration); Set = loaded, filter to non-hidden
+  // undefined = no filter (availability not yet known); Set = filter to installed agents only.
+  // Pin state intentionally does NOT gate this menu — unpinning from the toolbar must not
+  // remove an installed agent from the grid launch menu. Launch-enablement (ready vs.
+  // installed-but-not-ready) is still gated per-row via `canLaunch` below.
   const gridSelectedAgentIds = useMemo((): Set<string> | undefined => {
-    if (!gridAgentSettings?.agents) return undefined;
-    return new Set(
-      Object.entries(gridAgentSettings.agents)
-        .filter(([, entry]) => isAgentPinned(entry))
-        .map(([id]) => id)
-    );
-  }, [gridAgentSettings]);
+    if (!agentAvailability) return undefined;
+    return new Set(getEffectiveAgentIds().filter((id) => isAgentInstalled(agentAvailability[id])));
+  }, [agentAvailability]);
   const isProjectSwitching = false;
   const { projectIconSvg } = useProjectBranding(currentProject?.id);
   const { worktreeMap } = useWorktrees();

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -13,7 +13,8 @@ import {
   type TerminalInstance,
 } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
-import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
+import { computeGridCanLaunch, computeGridSelectedAgentIds } from "./contentGridAgentFilter";
 import { GridPanel } from "./GridPanel";
 import { GridTabGroup } from "./GridTabGroup";
 import { GridNotificationBar } from "./GridNotificationBar";
@@ -388,14 +389,23 @@ export function ContentGrid({
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
   const showProjectPulse = usePreferencesStore((state) => state.showProjectPulse);
   const currentProject = useProjectStore((state) => state.currentProject);
-  // undefined = no filter (availability not yet known); Set = filter to installed agents only.
-  // Pin state intentionally does NOT gate this menu — unpinning from the toolbar must not
-  // remove an installed agent from the grid launch menu. Launch-enablement (ready vs.
-  // installed-but-not-ready) is still gated per-row via `canLaunch` below.
-  const gridSelectedAgentIds = useMemo((): Set<string> | undefined => {
-    if (!agentAvailability) return undefined;
-    return new Set(getEffectiveAgentIds().filter((id) => isAgentInstalled(agentAvailability[id])));
-  }, [agentAvailability]);
+  const isAvailabilityInitialized = useCliAvailabilityStore((s) => s.isInitialized);
+
+  // undefined = no filter (availability not yet probed); Set = filter to installed agents.
+  // Gate on the store's `isInitialized` flag: the `agentAvailability` prop is always a
+  // defined object (pre-populated by `defaultAvailability()` with every agent as "missing"),
+  // so a `!agentAvailability` guard would never fire and the menu would start empty on cold
+  // boot until the first probe returns. Pin state intentionally does NOT gate this menu —
+  // unpinning from the toolbar must not remove an installed agent from the launch menu.
+  const gridSelectedAgentIds = useMemo(
+    () =>
+      computeGridSelectedAgentIds(
+        isAvailabilityInitialized,
+        agentAvailability,
+        getEffectiveAgentIds()
+      ),
+    [isAvailabilityInitialized, agentAvailability]
+  );
   const isProjectSwitching = false;
   const { projectIconSvg } = useProjectBranding(currentProject?.id);
   const { worktreeMap } = useWorktrees();
@@ -646,11 +656,10 @@ export function ContentGrid({
       .filter((id) => !gridSelectedAgentIds || gridSelectedAgentIds.has(id))
       .map((id) => {
         const agentConfig = getEffectiveAgentConfig(id);
-        const canLaunch =
-          id === "terminal" ? true : !agentAvailability || isAgentReady(agentAvailability[id]);
+        const canLaunch = computeGridCanLaunch(id, isAvailabilityInitialized, agentAvailability);
         return { id, name: agentConfig?.name ?? id, canLaunch };
       });
-  }, [agentAvailability, gridSelectedAgentIds]);
+  }, [agentAvailability, gridSelectedAgentIds, isAvailabilityInitialized]);
 
   const handleGridLaunch = useCallback(
     (agentId: string) => {

--- a/src/components/Terminal/__tests__/contentGridAgentFilter.test.ts
+++ b/src/components/Terminal/__tests__/contentGridAgentFilter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { CliAvailability } from "@shared/types";
+import { computeGridCanLaunch, computeGridSelectedAgentIds } from "../contentGridAgentFilter";
+
+const AGENT_IDS = ["claude", "gemini", "codex", "terminal"] as const;
+
+function availability(overrides: Partial<Record<string, string>>): CliAvailability {
+  return {
+    claude: "missing",
+    gemini: "missing",
+    codex: "missing",
+    terminal: "missing",
+    ...overrides,
+  } as unknown as CliAvailability;
+}
+
+describe("computeGridSelectedAgentIds (issue #5117 loading-guard regression)", () => {
+  it("returns undefined (show all) while availability is not yet probed", () => {
+    // `agentAvailability` prop is always a truthy object in production because the store
+    // pre-populates it with `defaultAvailability()`. The real loading signal is the
+    // store's `isInitialized` flag. If the guard gated on only `agentAvailability`, the
+    // grid's context menu would start empty on cold boot — this test locks that out.
+    const pre = computeGridSelectedAgentIds(false, availability({}), AGENT_IDS);
+    expect(pre).toBeUndefined();
+  });
+
+  it("returns undefined when agentAvailability is legitimately undefined", () => {
+    expect(computeGridSelectedAgentIds(true, undefined, AGENT_IDS)).toBeUndefined();
+  });
+
+  it("filters to installed agents once availability is initialized", () => {
+    const result = computeGridSelectedAgentIds(
+      true,
+      availability({ claude: "ready", gemini: "installed", codex: "missing" }),
+      AGENT_IDS
+    );
+    expect(result).toBeDefined();
+    expect(result!.has("claude")).toBe(true); // ready → installed
+    expect(result!.has("gemini")).toBe(true); // installed
+    expect(result!.has("codex")).toBe(false); // missing
+    expect(result!.has("terminal")).toBe(false); // terminal is not an agent; still missing
+  });
+
+  it("does not use pin state — unpinned installed agents are included (issue #5117)", () => {
+    // The helper takes only availability + agent IDs. Pin state is irrelevant by
+    // construction; this test locks the contract against future regressions.
+    const result = computeGridSelectedAgentIds(
+      true,
+      availability({ claude: "ready", gemini: "ready" }),
+      ["claude", "gemini"]
+    );
+    expect(result).toEqual(new Set(["claude", "gemini"]));
+  });
+});
+
+describe("computeGridCanLaunch", () => {
+  it("always returns true for the 'terminal' id regardless of state", () => {
+    expect(computeGridCanLaunch("terminal", false, undefined)).toBe(true);
+    expect(computeGridCanLaunch("terminal", true, availability({}))).toBe(true);
+  });
+
+  it("returns true for any agent before the first probe lands (show-all contract)", () => {
+    expect(computeGridCanLaunch("claude", false, availability({}))).toBe(true);
+    expect(computeGridCanLaunch("claude", true, undefined)).toBe(true);
+  });
+
+  it("returns true only when agent is `ready` once availability is known", () => {
+    const ready = availability({ claude: "ready", gemini: "installed", codex: "missing" });
+    expect(computeGridCanLaunch("claude", true, ready)).toBe(true);
+    // installed-but-not-ready: menu entry visible but launch disabled.
+    expect(computeGridCanLaunch("gemini", true, ready)).toBe(false);
+    expect(computeGridCanLaunch("codex", true, ready)).toBe(false);
+  });
+});

--- a/src/components/Terminal/contentGridAgentFilter.ts
+++ b/src/components/Terminal/contentGridAgentFilter.ts
@@ -1,0 +1,37 @@
+import type { CliAvailability } from "@shared/types";
+import { isAgentInstalled, isAgentReady } from "../../../shared/utils/agentAvailability";
+
+/**
+ * Compute the set of agent IDs visible in the grid's right-click launch menu.
+ *
+ * Returns `undefined` while availability is not yet probed — the menu treats
+ * `undefined` as "show all" and must not filter to an empty Set during the
+ * initial detection race. Once `isAvailabilityInitialized` flips true, the
+ * set contains every agent the local machine has installed (state `"ready"`
+ * or `"installed"`), regardless of pin state (issue #5117).
+ */
+export function computeGridSelectedAgentIds(
+  isAvailabilityInitialized: boolean,
+  agentAvailability: CliAvailability | undefined,
+  agentIds: readonly string[]
+): Set<string> | undefined {
+  if (!isAvailabilityInitialized || !agentAvailability) return undefined;
+  return new Set(agentIds.filter((id) => isAgentInstalled(agentAvailability[id])));
+}
+
+/**
+ * Whether a specific grid agent row should be launchable (enables the menu item).
+ * `"terminal"` is always launchable (plain shell). Other agents are launchable
+ * only when the probe says the CLI is `"ready"`. Before the first probe lands,
+ * treat everything as launchable — matches the show-all contract used by
+ * `computeGridSelectedAgentIds`.
+ */
+export function computeGridCanLaunch(
+  id: string,
+  isAvailabilityInitialized: boolean,
+  agentAvailability: CliAvailability | undefined
+): boolean {
+  if (id === "terminal") return true;
+  if (!isAvailabilityInitialized || !agentAvailability) return true;
+  return isAgentReady(agentAvailability[id]);
+}

--- a/src/hooks/__tests__/useNewTerminalPalette.test.tsx
+++ b/src/hooks/__tests__/useNewTerminalPalette.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getEffectiveAgentIdsMock, getLaunchOptionsMock, cliAvailabilityState } = vi.hoisted(() => ({
+  getEffectiveAgentIdsMock: vi.fn(),
+  getLaunchOptionsMock: vi.fn(),
+  cliAvailabilityState: {
+    availability: {} as Record<string, string>,
+    isInitialized: true,
+  },
+}));
+
+vi.mock("@shared/config/agentRegistry", () => ({
+  getEffectiveAgentIds: getEffectiveAgentIdsMock,
+}));
+
+vi.mock("@/components/TerminalPalette/launchOptions", () => ({
+  getLaunchOptions: getLaunchOptionsMock,
+  getMoreAgentsOption: () => ({
+    id: "more-agents",
+    type: "terminal",
+    label: "More agents...",
+    description: "Configure which agents appear in this menu",
+    icon: null,
+  }),
+}));
+
+vi.mock("@/store", () => ({
+  useWorktreeSelectionStore: (selector: (state: { activeWorktreeId: string | null }) => unknown) =>
+    selector({ activeWorktreeId: null }),
+  usePanelStore: (selector: (state: { addPanel: typeof vi.fn }) => unknown) =>
+    selector({ addPanel: vi.fn() }),
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (state: { currentProject: null }) => unknown) =>
+    selector({ currentProject: null }),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => {
+  const store = (selector: (state: typeof cliAvailabilityState) => unknown) =>
+    selector(cliAvailabilityState);
+  store.getState = () => cliAvailabilityState;
+  return { useCliAvailabilityStore: store };
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import { useNewTerminalPalette } from "../useNewTerminalPalette";
+
+function makeOption(id: string) {
+  return {
+    id,
+    type: id,
+    label: id,
+    description: `${id} description`,
+    icon: null,
+  };
+}
+
+describe("useNewTerminalPalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cliAvailabilityState.isInitialized = true;
+    cliAvailabilityState.availability = {};
+
+    getEffectiveAgentIdsMock.mockReturnValue(["claude", "gemini", "codex"]);
+    getLaunchOptionsMock.mockReturnValue([
+      makeOption("claude"),
+      makeOption("gemini"),
+      makeOption("codex"),
+      makeOption("terminal"),
+      makeOption("browser"),
+    ]);
+  });
+
+  function render() {
+    return renderHook(() =>
+      useNewTerminalPalette({
+        launchAgent: vi.fn().mockResolvedValue(null),
+        worktreeMap: new Map(),
+      })
+    );
+  }
+
+  it("shows installed agent regardless of pin state (issue #5117)", () => {
+    cliAvailabilityState.availability = {
+      claude: "ready",
+      gemini: "installed",
+      codex: "missing",
+    };
+
+    const { result } = render();
+
+    const ids = result.current.results.map((opt) => opt.id);
+    expect(ids).toContain("claude");
+    expect(ids).toContain("gemini");
+    expect(ids).not.toContain("codex");
+  });
+
+  it("includes non-agent options (terminal, browser) regardless of availability", () => {
+    cliAvailabilityState.availability = {
+      claude: "missing",
+      gemini: "missing",
+      codex: "missing",
+    };
+
+    const { result } = render();
+
+    const ids = result.current.results.map((opt) => opt.id);
+    expect(ids).toContain("terminal");
+    expect(ids).toContain("browser");
+  });
+
+  it("shows all agents before availability is initialized", () => {
+    cliAvailabilityState.isInitialized = false;
+    cliAvailabilityState.availability = {};
+
+    const { result } = render();
+
+    const ids = result.current.results.map((opt) => opt.id);
+    expect(ids).toContain("claude");
+    expect(ids).toContain("gemini");
+    expect(ids).toContain("codex");
+  });
+
+  it("always includes the more-agents entry at the end", () => {
+    cliAvailabilityState.availability = { claude: "ready", gemini: "ready", codex: "ready" };
+
+    const { result } = render();
+
+    const ids = result.current.results.map((opt) => opt.id);
+    expect(ids[ids.length - 1]).toBe("more-agents");
+  });
+});

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -49,14 +49,6 @@ vi.mock("@/store/userAgentRegistryStore", () => ({
   ) => selector({ registry: {} }),
 }));
 
-vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (
-    selector: (state: {
-      settings: { agents: Record<string, { pinned?: boolean }> } | null;
-    }) => unknown
-  ) => selector({ settings: { agents: { claude: { pinned: true }, gemini: { pinned: true } } } }),
-}));
-
 vi.mock("@/store/cliAvailabilityStore", () => {
   const store = (selector: (state: typeof cliAvailabilityState) => unknown) =>
     selector(cliAvailabilityState);
@@ -312,7 +304,7 @@ describe("usePanelPalette", () => {
       expect(claude?.installed).toBe(true);
     });
 
-    it("sets installed=false for unavailable agents", () => {
+    it("omits missing agents from the palette once availability is initialized", () => {
       getEffectiveAgentIdsMock.mockReturnValue(["gemini"]);
       getEffectiveAgentConfigMock.mockReturnValue({
         name: "Gemini",
@@ -325,7 +317,7 @@ describe("usePanelPalette", () => {
       const { result } = renderHook(() => usePanelPalette());
 
       const gemini = result.current.results.find((item) => item.id === "agent:gemini");
-      expect(gemini?.installed).toBe(false);
+      expect(gemini).toBeUndefined();
     });
 
     it("sets installed=undefined before availability is initialized", () => {
@@ -352,24 +344,22 @@ describe("usePanelPalette", () => {
       expect(moreAgents?.installed).toBeUndefined();
     });
 
-    it("handleSelect dispatches setup wizard and returns null for uninstalled agent", () => {
+    it("still defensively routes handleSelect to setup wizard when installed=false is passed", () => {
+      // Missing agents are now filtered out of the palette entirely (issue #5117), but the
+      // handleSelect branch guarding against `installed === false` is kept as a defensive
+      // fallback — e.g. for stale options held in closures or future code paths.
       const dispatchSpy = vi.spyOn(window, "dispatchEvent");
-      getEffectiveAgentIdsMock.mockReturnValue(["gemini"]);
-      getEffectiveAgentConfigMock.mockReturnValue({
+      const { result } = renderHook(() => usePanelPalette());
+      const syntheticOption = {
+        id: "agent:gemini",
         name: "Gemini",
         iconId: "gemini",
         color: "#4285f4",
-        tooltip: "Gemini agent",
-      });
-      cliAvailabilityState.availability = { gemini: "missing" };
+        category: "agent" as const,
+        installed: false,
+      };
 
-      const { result } = renderHook(() => usePanelPalette());
-
-      const gemini = result.current.results.find((item) => item.id === "agent:gemini");
-      expect(gemini).toBeDefined();
-      expect(gemini!.installed).toBe(false);
-
-      const selected = result.current.handleSelect(gemini!);
+      const selected = result.current.handleSelect(syntheticOption);
       expect(selected).toBeNull();
       expect(dispatchSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -402,6 +392,60 @@ describe("usePanelPalette", () => {
 
       const selected = result.current.handleSelect(claude!);
       expect(selected).toBe(claude);
+    });
+  });
+
+  describe("pin-independent visibility (issue #5117)", () => {
+    it("shows installed agents regardless of pin state", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude", "gemini"]);
+      getEffectiveAgentConfigMock.mockImplementation((id: string) => ({
+        name: id.charAt(0).toUpperCase() + id.slice(1),
+        iconId: id,
+        color: "#000",
+        tooltip: `${id} agent`,
+      }));
+      cliAvailabilityState.availability = { claude: "ready", gemini: "installed" };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const ids = result.current.results.map((item) => item.id);
+      expect(ids).toContain("agent:claude");
+      expect(ids).toContain("agent:gemini");
+    });
+
+    it("hides missing agents once availability is initialized", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude", "gemini"]);
+      getEffectiveAgentConfigMock.mockImplementation((id: string) => ({
+        name: id,
+        iconId: id,
+        color: "#000",
+        tooltip: id,
+      }));
+      cliAvailabilityState.availability = { claude: "ready", gemini: "missing" };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const ids = result.current.results.map((item) => item.id);
+      expect(ids).toContain("agent:claude");
+      expect(ids).not.toContain("agent:gemini");
+    });
+
+    it("shows all agents before availability initializes (no premature filter)", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["claude", "gemini"]);
+      getEffectiveAgentConfigMock.mockImplementation((id: string) => ({
+        name: id,
+        iconId: id,
+        color: "#000",
+        tooltip: id,
+      }));
+      cliAvailabilityState.isInitialized = false;
+      cliAvailabilityState.availability = {};
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const ids = result.current.results.map((item) => item.id);
+      expect(ids).toContain("agent:claude");
+      expect(ids).toContain("agent:gemini");
     });
   });
 });

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -7,11 +7,12 @@ import {
 import type { LaunchAgentOptions } from "./useAgentLauncher";
 import { useWorktreeSelectionStore, usePanelStore } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
-import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { WorktreeState } from "@/types";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { actionService } from "@/services/ActionService";
 import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
+import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 interface UseNewTerminalPaletteProps {
   launchAgent: (type: string, options?: LaunchAgentOptions) => Promise<string | null>;
@@ -42,17 +43,18 @@ export function useNewTerminalPalette({
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
   const currentProject = useProjectStore((state) => state.currentProject);
   const addPanel = usePanelStore((state) => state.addPanel);
-  const agentSettings = useAgentSettingsStore((state) => state.settings);
+  const availability = useCliAvailabilityStore((state) => state.availability);
+  const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
 
   const options = useMemo(() => {
     const allOptions = getLaunchOptions();
     const registryAgentIds = new Set(getEffectiveAgentIds());
 
-    // When settings haven't loaded yet, show all agents (no filter).
-    // When loaded, hide agents that are not pinned.
+    // Before availability is known, show all agents (avoids startup flicker).
+    // Once known, hide agents that are not installed.
     const isAgentHidden = (id: string): boolean => {
-      if (!agentSettings?.agents) return false;
-      return agentSettings.agents[id]?.pinned !== true;
+      if (!isAvailabilityInitialized) return false;
+      return !isAgentInstalled(availability[id]);
     };
 
     const filtered = allOptions.filter(
@@ -62,7 +64,7 @@ export function useNewTerminalPalette({
     filtered.push(getMoreAgentsOption());
 
     return filtered;
-  }, [agentSettings]);
+  }, [availability, isAvailabilityInitialized]);
 
   const { results, selectedIndex, close, ...paletteRest } = useSearchablePalette<LaunchOption>({
     items: options,

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -4,7 +4,6 @@ import { getPanelKindIds, getPanelKindConfig } from "@shared/config/panelKindReg
 import { getPanelKindDefinition } from "@/registry";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
-import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { keybindingService } from "@/services/KeybindingService";
@@ -63,7 +62,6 @@ export const MORE_AGENTS_PANEL_ID = "more-agents";
 
 export function usePanelPalette(): UsePanelPaletteReturn {
   const userRegistry = useUserAgentRegistryStore((state) => state.registry);
-  const agentSettings = useAgentSettingsStore((state) => state.settings);
   const availability = useCliAvailabilityStore((state) => state.availability);
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
   const [keybindingVersion, setKeybindingVersion] = useState(0);
@@ -104,8 +102,8 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       });
 
     const isAgentHidden = (agentId: string): boolean => {
-      if (!agentSettings?.agents) return false;
-      return agentSettings.agents[agentId]?.pinned !== true;
+      if (!isAvailabilityInitialized) return false;
+      return !isAgentInstalled(availability[agentId]);
     };
 
     const agentKinds = getEffectiveAgentIds()
@@ -172,14 +170,7 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       ...toolDedup.values(),
       ...resumeOptions,
     ];
-  }, [
-    userRegistry,
-    keybindingVersion,
-    agentSettings,
-    resumeSessions,
-    availability,
-    isAvailabilityInitialized,
-  ]);
+  }, [userRegistry, keybindingVersion, resumeSessions, availability, isAvailabilityInitialized]);
 
   const { results, selectedIndex, close, isOpen, matchesById, ...paletteRest } =
     useSearchablePalette<PanelKindOption>({


### PR DESCRIPTION
## Summary

- Picker and palette call sites that previously filtered agents by pin state now filter by availability (i.e. "is ready to launch?"). Unpinning Gemini from the toolbar no longer removes it from the panel palette, new-terminal palette, or help agent picker.
- The worktree card inline agent tray correctly continues to read pin state, since it mirrors the main toolbar.
- Extracted `contentGridAgentFilter` as a standalone utility so the content grid's agent filter logic is tested and reusable.

Resolves #5117

## Changes

- `HelpAgentPicker` — now shows all available agents, not just pinned ones
- `GeneralTab` system status section — availability-based filtering, updated copy ("Pin to Toolbar" replaces "Enable")
- `ContentGrid` — agent launch menu uses availability predicate; extraction of `contentGridAgentFilter.ts` for unit coverage
- `usePanelPalette` and `useNewTerminalPalette` — both hooks now filter on availability instead of pin state
- New test files for `HelpAgentPicker`, `contentGridAgentFilter`, and `useNewTerminalPalette`; expanded `usePanelPalette` tests

## Testing

Unit tests cover all five changed call sites. The key invariant under test: an available-but-unpinned agent appears in every picker; a pinned-but-unavailable agent does not. The worktree card tray is explicitly asserted to preserve pin-state behaviour. All tests pass via `npm test`.