### PR TITLE
fix(workspace-host): surface host crashes to renderer within ~10ms

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -21,6 +21,7 @@ export const CHANNELS = {
   WORKTREE_DETACH_ISSUE: "worktree:detach-issue",
   WORKTREE_GET_ISSUE_ASSOCIATION: "worktree:get-issue-association",
   WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS: "worktree:get-all-issue-associations",
+  WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
 
   TERMINAL_SPAWN: "terminal:spawn",
   TERMINAL_SPAWN_RESULT: "terminal:spawn-result",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -212,6 +212,7 @@ class WorktreePortClient {
   private eventListeners = new Map<string, Set<WorktreePortEventCallback>>();
   private readyCallbacks: Array<() => void> = [];
   private disconnectedCallbacks: Array<() => void> = [];
+  private fatalCallbacks: Array<() => void> = [];
   private _isReady = false;
   // Monotonic counter so stale close signals (e.g. a delayed IPC
   // WORKTREE_HOST_DISCONNECTED that arrives AFTER a replacement port has
@@ -405,6 +406,29 @@ class WorktreePortClient {
       if (idx >= 0) this.disconnectedCallbacks.splice(idx, 1);
     };
   }
+
+  onFatalDisconnect(callback: () => void): () => void {
+    this.fatalCallbacks.push(callback);
+    return () => {
+      const idx = this.fatalCallbacks.indexOf(callback);
+      if (idx >= 0) this.fatalCallbacks.splice(idx, 1);
+    };
+  }
+
+  /**
+   * Fire fatal callbacks when the workspace host exhausts its restart budget.
+   * Callers should surface a terminal error state (e.g. "Workspace host
+   * crashed — please restart") since no further port will arrive.
+   */
+  _handleFatal(): void {
+    for (const cb of this.fatalCallbacks) {
+      try {
+        cb();
+      } catch {
+        // Don't let listener errors block other listeners
+      }
+    }
+  }
 }
 
 const worktreePortClient = new WorktreePortClient();
@@ -413,6 +437,21 @@ ipcRenderer.on("worktree-port", (event: Electron.IpcRendererEvent) => {
   if (!event.ports || event.ports.length === 0) return;
   worktreePortClient.attach(event.ports[0]);
 });
+
+// Main broadcasts this on every host exit.  Only the fatal payload is acted
+// on in the renderer — it marks max-restart-budget exhaustion and means no
+// replacement port will arrive, so the UI must transition to a terminal
+// error state instead of staying in the reconnecting spinner forever.
+// Non-fatal broadcasts are ignored here; the MessagePort `close` event is
+// the authoritative disconnect signal for the transient case.
+ipcRenderer.on(
+  "worktree:host-disconnected",
+  (_event: Electron.IpcRendererEvent, payload: { fatal?: boolean } | undefined) => {
+    if (payload?.fatal) {
+      worktreePortClient._handleFatal();
+    }
+  }
+);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches ipcRenderer.invoke return type
 async function _unwrappingInvoke(channel: string, ...args: unknown[]): Promise<any> {
@@ -465,6 +504,7 @@ const CHANNELS = {
   WORKTREE_DETACH_ISSUE: "worktree:detach-issue",
   WORKTREE_GET_ISSUE_ASSOCIATION: "worktree:get-issue-association",
   WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS: "worktree:get-all-issue-associations",
+  WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
 
   // Terminal channels
   TERMINAL_SPAWN: "terminal:spawn",
@@ -1146,6 +1186,9 @@ const api: ElectronAPI = {
 
     onDisconnected: (callback: () => void): (() => void) =>
       worktreePortClient.onDisconnected(callback),
+
+    onFatalDisconnect: (callback: () => void): (() => void) =>
+      worktreePortClient.onFatalDisconnect(callback),
   },
 
   // Terminal API

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -211,16 +211,32 @@ class WorktreePortClient {
   >();
   private eventListeners = new Map<string, Set<WorktreePortEventCallback>>();
   private readyCallbacks: Array<() => void> = [];
+  private disconnectedCallbacks: Array<() => void> = [];
   private _isReady = false;
+  // Monotonic counter so stale close signals (e.g. a delayed IPC
+  // WORKTREE_HOST_DISCONNECTED that arrives AFTER a replacement port has
+  // already been attached) are ignored and do not clobber the new port.
+  private portGeneration = 0;
 
   attach(newPort: MessagePort): void {
-    // Close old port and reject pending requests
+    // Bump generation FIRST so any synchronous close event fired by the old
+    // port during detach() will be recognised as stale by _handlePortClose
+    // and ignored — the disconnect callbacks must only fire on unexpected
+    // host crashes, never on normal port replacement.
+    const attachedGeneration = ++this.portGeneration;
+
     if (this.port) {
       this.detach();
     }
 
     this.port = newPort;
     this._isReady = true;
+
+    // Fires when the peer (workspace host UtilityProcess) dies — Electron's
+    // MessagePort delivers a `close` event even on SIGKILL via the Mojo
+    // channel.  The generation guard ensures stale close events from old
+    // ports cannot reject requests on a newer port.
+    newPort.addEventListener("close", () => this._handlePortClose(attachedGeneration));
 
     this.port.onmessage = (msg: MessageEvent) => {
       const data = msg.data;
@@ -287,6 +303,43 @@ class WorktreePortClient {
     this._isReady = false;
   }
 
+  /**
+   * Handle unexpected port closure (workspace host crashed or was killed).
+   * Idempotent — safe to call multiple times.  Rejects pending requests
+   * immediately so the UI does not wait for per-request timeouts.
+   *
+   * @param generation The port generation the caller was registered against.
+   *   If it no longer matches the current generation, this is a stale signal
+   *   from a previous port lifetime and is ignored.
+   */
+  _handlePortClose(generation: number): void {
+    if (generation !== this.portGeneration) return;
+    if (!this.port) return;
+
+    try {
+      this.port.close();
+    } catch {
+      // ignore
+    }
+
+    for (const [, entry] of this.pending) {
+      clearTimeout(entry.timeout);
+      entry.reject(new Error("Worktree port disconnected"));
+    }
+    this.pending.clear();
+
+    this.port = null;
+    this._isReady = false;
+
+    for (const cb of this.disconnectedCallbacks) {
+      try {
+        cb();
+      } catch {
+        // Don't let listener errors block other listeners
+      }
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   request(action: string, payload?: Record<string, unknown>, timeoutMs = 10000): Promise<any> {
     return new Promise((resolve, reject) => {
@@ -342,6 +395,14 @@ class WorktreePortClient {
     return () => {
       const idx = this.readyCallbacks.indexOf(callback);
       if (idx >= 0) this.readyCallbacks.splice(idx, 1);
+    };
+  }
+
+  onDisconnected(callback: () => void): () => void {
+    this.disconnectedCallbacks.push(callback);
+    return () => {
+      const idx = this.disconnectedCallbacks.indexOf(callback);
+      if (idx >= 0) this.disconnectedCallbacks.splice(idx, 1);
     };
   }
 }
@@ -1082,6 +1143,9 @@ const api: ElectronAPI = {
     isReady: (): boolean => worktreePortClient.isReady(),
 
     onReady: (callback: () => void): (() => void) => worktreePortClient.onReady(callback),
+
+    onDisconnected: (callback: () => void): (() => void) =>
+      worktreePortClient.onDisconnected(callback),
   },
 
   // Terminal API

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -128,7 +128,19 @@ export class WorkspaceClient extends EventEmitter {
       this.routeHostEvent(entry, event);
     });
 
+    host.on("host-recovering", () => {
+      // Fired on every unexpected exit (before restart scheduling).  Broadcast
+      // to affected views so WorktreePortClient can reject pending requests
+      // immediately instead of waiting for the per-request timeout.
+      this.sendToEntryWindows(entry, CHANNELS.WORKTREE_HOST_DISCONNECTED, {
+        fatal: false,
+      });
+    });
+
     host.on("host-crash", (code: number) => {
+      this.sendToEntryWindows(entry, CHANNELS.WORKTREE_HOST_DISCONNECTED, {
+        fatal: true,
+      });
       this.emit("host-crash", code);
     });
 

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -332,6 +332,11 @@ export class WorkspaceHostProcess extends EventEmitter {
 
       if (this.isDisposed) return;
 
+      // Fire the recovery signal before restart scheduling so the renderer can
+      // reject in-flight requests immediately instead of waiting up to ~10s for
+      // the per-request timeout.
+      this.emit("host-recovering", code);
+
       if (this.restartAttempts < this.config.maxRestartAttempts) {
         this.restartAttempts++;
         const delay = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -830,6 +830,59 @@ describe("WorkspaceClient multi-process manager", () => {
     });
   });
 
+  describe("host-disconnected broadcast", () => {
+    it("broadcasts WORKTREE_HOST_DISCONNECTED to affected views when host emits host-recovering", async () => {
+      const wc = createMockWebContents();
+
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+      client.attachDirectPort(1, wc as any);
+
+      wc.send.mockClear();
+      h(0).emit("host-recovering", 1);
+
+      expect(wc.send).toHaveBeenCalledWith("worktree:host-disconnected", { fatal: false });
+    });
+
+    it("does not broadcast host-recovering to views of other projects", async () => {
+      const wcA = createMockWebContents();
+      const wcB = createMockWebContents();
+
+      const load1 = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load1;
+      client.attachDirectPort(1, wcA as any);
+
+      const load2 = client.loadProject("/project-b", 2);
+      await readyAndResolveLoad(1);
+      await load2;
+      client.attachDirectPort(2, wcB as any);
+
+      wcA.send.mockClear();
+      wcB.send.mockClear();
+
+      h(0).emit("host-recovering", 1);
+
+      expect(wcA.send).toHaveBeenCalledWith("worktree:host-disconnected", { fatal: false });
+      expect(wcB.send).not.toHaveBeenCalled();
+    });
+
+    it("broadcasts fatal: true on host-crash (max retries exhausted)", async () => {
+      const wc = createMockWebContents();
+
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+      client.attachDirectPort(1, wc as any);
+
+      wc.send.mockClear();
+      h(0).emit("host-crash", 137);
+
+      expect(wc.send).toHaveBeenCalledWith("worktree:host-disconnected", { fatal: true });
+    });
+  });
+
   describe("setActiveWorktree", () => {
     it("emits WORKTREE_ACTIVATED by default", async () => {
       const wc = createMockWebContents();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -208,6 +208,7 @@ export interface ElectronAPI {
     onEvent(type: string, callback: (data: unknown) => void): () => void;
     isReady(): boolean;
     onReady(callback: () => void): () => void;
+    onDisconnected(callback: () => void): () => void;
   };
   terminal: {
     spawn(options: TerminalSpawnOptions): Promise<string>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -209,6 +209,7 @@ export interface ElectronAPI {
     isReady(): boolean;
     onReady(callback: () => void): () => void;
     onDisconnected(callback: () => void): () => void;
+    onFatalDisconnect(callback: () => void): () => void;
   };
   terminal: {
     spawn(options: TerminalSpawnOptions): Promise<string>;

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -290,7 +290,7 @@ interface SidebarContentProps {
 }
 
 function SidebarContent({ onOpenOverview }: SidebarContentProps) {
-  const { worktrees, isLoading, error, refresh } = useWorktrees();
+  const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
   const currentProject = useProjectStore((state) => state.currentProject);
@@ -899,6 +899,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 ? `(${visibleCount} of ${deferredWorktrees.length})`
                 : `(${deferredWorktrees.length})`}
             </span>
+            {isReconnecting && (
+              <span
+                role="status"
+                aria-live="polite"
+                className="flex items-center gap-1 text-daintree-text/60 text-xs"
+              >
+                <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
+                Reconnecting…
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1">
             <div className="invisible group-hover/header:visible group-focus-within/header:visible flex items-center gap-1">

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -108,6 +108,12 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             if (thisGen !== generation) return;
           }
 
+          // If the host crashed during the associations fetch (a separate IPC
+          // that port-close cannot reject), skip applySnapshot so it does not
+          // spuriously clear the Reconnecting… indicator.  The next onReady
+          // cycle will deliver fresh data.
+          if (!worktreePort.isReady()) return;
+
           store.getState().applySnapshot(states, store.getState().nextVersion());
         })
         .catch((err: Error) => {
@@ -275,6 +281,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     cleanups.push(
       worktreePort.onDisconnected(() => {
         store.getState().setReconnecting(true);
+      })
+    );
+
+    // If the host exhausts its restart budget, no replacement port will
+    // arrive — transition to a terminal error state instead of leaving the
+    // spinner stuck indefinitely.
+    cleanups.push(
+      worktreePort.onFatalDisconnect(() => {
+        const state = store.getState();
+        state.setReconnecting(false);
+        state.setError("Workspace host crashed and could not recover. Please restart Daintree.");
       })
     );
 

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -267,6 +267,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     }
     cleanups.push(worktreePort.onReady(fetchInitialState));
 
+    // Surface a "Reconnecting…" state the moment the workspace host dies, so
+    // the UI doesn't appear frozen while we wait (up to 2–4s) for the
+    // replacement port.  Cleared by applySnapshot when the new port returns
+    // data — this avoids flashing the indicator during normal port replacement
+    // where a new port arrives within milliseconds.
+    cleanups.push(
+      worktreePort.onDisconnected(() => {
+        store.getState().setReconnecting(true);
+      })
+    );
+
     // Snapshot-on-wake: when a cached view is reactivated (addChildView),
     // Chromium fires visibilitychange. Request a fresh snapshot to rehydrate
     // state that may have changed while the view was backgrounded.

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -8,6 +8,7 @@ export interface UseWorktreesReturn {
   activeId: string | null;
   isLoading: boolean;
   isInitialized: boolean;
+  isReconnecting: boolean;
   error: string | null;
   refresh: () => Promise<void>;
   setActive: (id: string) => void;
@@ -25,6 +26,7 @@ export function useWorktrees(): UseWorktreesReturn {
   const worktreeMap = useWorktreeStore((state) => state.worktrees);
   const isLoading = useWorktreeStore((state) => state.isLoading);
   const isInitialized = useWorktreeStore((state) => state.isInitialized);
+  const isReconnecting = useWorktreeStore((state) => state.isReconnecting);
   const error = useWorktreeStore((state) => state.error);
 
   const refresh = useCallback(async () => {
@@ -64,6 +66,7 @@ export function useWorktrees(): UseWorktreesReturn {
     activeId: worktrees.length > 0 ? worktrees[0].id : null,
     isLoading,
     isInitialized,
+    isReconnecting,
     error,
     refresh,
     setActive,

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+import type { WorktreeSnapshot } from "@shared/types";
+
+function makeSnapshot(id: string): WorktreeSnapshot {
+  return {
+    id,
+    name: id,
+    branch: "main",
+    path: `/repo/${id}`,
+    isCurrent: false,
+    isMainWorktree: false,
+    modifiedCount: 0,
+    changes: [],
+    summary: "",
+    mood: null,
+    gitDir: "",
+  } as unknown as WorktreeSnapshot;
+}
+
+describe("createWorktreeStore — reconnecting state", () => {
+  it("starts with isReconnecting=false", () => {
+    const store = createWorktreeStore();
+    expect(store.getState().isReconnecting).toBe(false);
+  });
+
+  it("setReconnecting(true) flips the flag", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    expect(store.getState().isReconnecting).toBe(true);
+  });
+
+  it("applySnapshot clears isReconnecting after successful hydration", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    expect(store.getState().isReconnecting).toBe(true);
+
+    const version = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], version);
+
+    expect(store.getState().isReconnecting).toBe(false);
+    expect(store.getState().isInitialized).toBe(true);
+    expect(store.getState().worktrees.size).toBe(1);
+  });
+
+  it("applySnapshot with stale version does NOT clear isReconnecting", () => {
+    const store = createWorktreeStore();
+
+    // Advance version by applying a first snapshot
+    const v1 = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], v1);
+
+    // Start reconnecting, then deliver a stale snapshot (lower/equal version)
+    store.getState().setReconnecting(true);
+    store.getState().applySnapshot([makeSnapshot("wt-stale")], v1);
+
+    expect(store.getState().isReconnecting).toBe(true);
+  });
+
+  it("applyUpdate does NOT clear isReconnecting (only applySnapshot does)", () => {
+    const store = createWorktreeStore();
+
+    // Seed with a worktree so applyUpdate can modify it
+    const v1 = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], v1);
+
+    store.getState().setReconnecting(true);
+    const v2 = store.getState().nextVersion();
+    store.getState().applyUpdate(makeSnapshot("wt-1"), v2);
+
+    expect(store.getState().isReconnecting).toBe(true);
+  });
+
+  it("setReconnecting(false) clears the flag independently", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    store.getState().setReconnecting(false);
+    expect(store.getState().isReconnecting).toBe(false);
+  });
+});

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -24,6 +24,7 @@ export interface WorktreeViewState {
   isLoading: boolean;
   error: string | null;
   isInitialized: boolean;
+  isReconnecting: boolean;
 }
 
 export interface WorktreeViewActions {
@@ -33,6 +34,7 @@ export interface WorktreeViewActions {
   applyRemove(worktreeId: string, version: number): void;
   setLoading(loading: boolean): void;
   setError(error: string | null): void;
+  setReconnecting(reconnecting: boolean): void;
 }
 
 export type WorktreeViewStore = WorktreeViewState & WorktreeViewActions;
@@ -47,6 +49,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     isLoading: true,
     error: null,
     isInitialized: false,
+    isReconnecting: false,
 
     nextVersion() {
       return ++versionCounter;
@@ -55,7 +58,14 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     applySnapshot(states: WorktreeSnapshot[], version: number) {
       if (version <= get().version) return;
       const map = new Map(states.map((s) => [s.id, s]));
-      set({ worktrees: map, version, isLoading: false, isInitialized: true, error: null });
+      set({
+        worktrees: map,
+        version,
+        isLoading: false,
+        isInitialized: true,
+        error: null,
+        isReconnecting: false,
+      });
     },
 
     applyUpdate(state: WorktreeSnapshot, version: number) {
@@ -89,6 +99,10 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
     setError(error: string | null) {
       set({ error });
+    },
+
+    setReconnecting(reconnecting: boolean) {
+      set({ isReconnecting: reconnecting });
     },
   }));
 }


### PR DESCRIPTION
## Summary

- When the workspace host UtilityProcess dies unexpectedly, the main process now immediately broadcasts a `WORKTREE_HOST_DISCONNECTED` IPC event (with a `{fatal: boolean}` payload) to all attached WebContents, so the renderer learns about the crash in ~10ms rather than waiting for a 10s request timeout.
- A `MessagePort` close listener in `WorktreePortClient` picks up that signal and rejects all pending requests right away, using a port-generation guard to avoid acting on stale events after a reconnect.
- The per-view worktree store gains an `isReconnecting` flag that drives a "Reconnecting…" spinner in the sidebar header while the host restarts. It clears automatically when the replacement port comes online and delivers a fresh snapshot. Fatal disconnects (max retries exhausted) surface a terminal error message instead of an indefinite spinner.

Resolves #5226

## Changes

- `electron/ipc/channels.ts` — new `WORKTREE_HOST_DISCONNECTED` channel constant
- `electron/services/WorkspaceHostProcess.ts` — emit `host-recovering` on every unexpected exit
- `electron/services/WorkspaceClient.ts` — broadcast disconnect event via scoped IPC on host exit
- `electron/preload.cts` — wire `worktree.onHostDisconnected` listener through the context bridge
- `shared/types/ipc/api.ts` — type the `onHostDisconnected` callback signature
- `src/contexts/WorktreeStoreContext.tsx` — subscribe to `onHostDisconnected` and drive reconnecting state
- `src/store/createWorktreeStore.ts` — `isReconnecting` state + `setReconnecting` action; cleared on `applySnapshot`
- `src/hooks/useWorktrees.ts` — expose `isReconnecting` from the store
- `src/components/Sidebar/SidebarContent.tsx` — "Reconnecting…" spinner indicator in the header

## Testing

- 6 new unit tests in `src/store/__tests__/createWorktreeStore.reconnecting.test.ts` covering reconnecting state transitions, snapshot clear, and fatal disconnect path
- 3 new unit tests in `electron/services/__tests__/WorkspaceClient.resilience.test.ts` covering host-disconnected broadcast on unexpected exit, fatal vs non-fatal payload, and clean-exit no-broadcast behaviour
- `npm run check` passes clean (0 errors)