### PR TITLE
feat(onboarding): first-run welcome card and agent discovery badge

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -515,6 +515,8 @@ export const CHANNELS = {
   ONBOARDING_MARK_TOAST_SEEN: "onboarding:mark-toast-seen",
   ONBOARDING_MARK_NEWSLETTER_SEEN: "onboarding:mark-newsletter-seen",
   ONBOARDING_MARK_WAITING_NUDGE_SEEN: "onboarding:mark-waiting-nudge-seen",
+  ONBOARDING_MARK_AGENTS_SEEN: "onboarding:mark-agents-seen",
+  ONBOARDING_DISMISS_WELCOME_CARD: "onboarding:dismiss-welcome-card",
   ONBOARDING_CHECKLIST_GET: "onboarding:checklist-get",
   ONBOARDING_CHECKLIST_DISMISS: "onboarding:checklist-dismiss",
   ONBOARDING_CHECKLIST_MARK_ITEM: "onboarding:checklist-mark-item",

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+const storeMock = vi.hoisted(() => {
+  const data: Record<string, unknown> = {};
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    _data: data,
+  };
+});
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+import { registerOnboardingHandlers } from "../onboarding.js";
+
+function getHandler(channel: string) {
+  return ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channel)![1] as (
+    _e: unknown,
+    ...args: unknown[]
+  ) => unknown;
+}
+
+function seedOnboarding(partial: Record<string, unknown> = {}) {
+  storeMock._data["onboarding"] = {
+    schemaVersion: 1,
+    completed: false,
+    currentStep: null,
+    agentSetupIds: [],
+    firstRunToastSeen: false,
+    newsletterPromptSeen: false,
+    waitingNudgeSeen: false,
+    migratedFromLocalStorage: false,
+    checklist: {
+      dismissed: false,
+      celebrationShown: false,
+      items: {
+        openedProject: false,
+        launchedAgent: false,
+        createdWorktree: false,
+        subscribedNewsletter: false,
+      },
+    },
+    ...partial,
+  };
+}
+
+describe("registerOnboardingHandlers — discovery IPC", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(storeMock._data)) {
+      delete storeMock._data[key];
+    }
+  });
+
+  it("get normalizes missing seenAgentIds and welcomeCardDismissed to defaults", () => {
+    registerOnboardingHandlers();
+    // Raw store is missing the new fields entirely (pre-existing state).
+    seedOnboarding({});
+    const get = getHandler("onboarding:get");
+    const state = get(null) as {
+      seenAgentIds: string[];
+      welcomeCardDismissed: boolean;
+    };
+    expect(state.seenAgentIds).toEqual([]);
+    expect(state.welcomeCardDismissed).toBe(false);
+  });
+
+  it("get filters out non-string values from seenAgentIds", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ seenAgentIds: ["claude", 42, null, "codex"] });
+    const get = getHandler("onboarding:get");
+    const state = get(null) as { seenAgentIds: string[] };
+    expect(state.seenAgentIds).toEqual(["claude", "codex"]);
+  });
+
+  it("markAgentsSeen adds new ids, dedupes against existing seen set", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ seenAgentIds: ["claude"] });
+    const mark = getHandler("onboarding:mark-agents-seen");
+    const result = mark(null, ["codex", "claude", "gemini"]) as {
+      seenAgentIds: string[];
+    };
+    expect(result.seenAgentIds.sort()).toEqual(["claude", "codex", "gemini"]);
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "onboarding",
+      expect.objectContaining({
+        seenAgentIds: expect.arrayContaining(["claude", "codex", "gemini"]),
+      })
+    );
+  });
+
+  it("markAgentsSeen is idempotent when called with the same ids twice", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ seenAgentIds: [] });
+    const mark = getHandler("onboarding:mark-agents-seen");
+    mark(null, ["claude"]);
+    // Reload simulated state so the handler sees the new persisted value.
+    storeMock._data["onboarding"] = {
+      ...(storeMock._data["onboarding"] as Record<string, unknown>),
+      seenAgentIds: ["claude"],
+    };
+    const result = mark(null, ["claude"]) as { seenAgentIds: string[] };
+    expect(result.seenAgentIds).toEqual(["claude"]);
+  });
+
+  it("markAgentsSeen ignores non-array payloads and non-string ids", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ seenAgentIds: [] });
+    const mark = getHandler("onboarding:mark-agents-seen");
+
+    const resultA = mark(null, "not-an-array") as { seenAgentIds: string[] };
+    expect(resultA.seenAgentIds).toEqual([]);
+
+    const resultB = mark(null, [42, null, "claude"]) as { seenAgentIds: string[] };
+    expect(resultB.seenAgentIds).toEqual(["claude"]);
+  });
+
+  it("dismissWelcomeCard flips the flag and returns the updated state", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ welcomeCardDismissed: false });
+    const dismiss = getHandler("onboarding:dismiss-welcome-card");
+    const result = dismiss(null) as { welcomeCardDismissed: boolean };
+    expect(result.welcomeCardDismissed).toBe(true);
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "onboarding",
+      expect.objectContaining({ welcomeCardDismissed: true })
+    );
+  });
+
+  it("dismissWelcomeCard is idempotent once dismissed", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ welcomeCardDismissed: true });
+    const dismiss = getHandler("onboarding:dismiss-welcome-card");
+    const result = dismiss(null) as { welcomeCardDismissed: boolean };
+    expect(result.welcomeCardDismissed).toBe(true);
+  });
+
+  it("cleanup removes both discovery handlers", () => {
+    const cleanup = registerOnboardingHandlers();
+    cleanup();
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:mark-agents-seen");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:dismiss-welcome-card");
+  });
+});

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -98,18 +98,23 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     );
   });
 
-  it("markAgentsSeen is idempotent when called with the same ids twice", () => {
+  it("markAgentsSeen is idempotent and skips the persist when already seen", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ seenAgentIds: ["claude"] });
+    const mark = getHandler("onboarding:mark-agents-seen");
+    storeMock.set.mockClear();
+    const result = mark(null, ["claude"]) as { seenAgentIds: string[] };
+    expect(result.seenAgentIds).toEqual(["claude"]);
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("markAgentsSeen with empty payload does not write to the store", () => {
     registerOnboardingHandlers();
     seedOnboarding({ seenAgentIds: [] });
     const mark = getHandler("onboarding:mark-agents-seen");
-    mark(null, ["claude"]);
-    // Reload simulated state so the handler sees the new persisted value.
-    storeMock._data["onboarding"] = {
-      ...(storeMock._data["onboarding"] as Record<string, unknown>),
-      seenAgentIds: ["claude"],
-    };
-    const result = mark(null, ["claude"]) as { seenAgentIds: string[] };
-    expect(result.seenAgentIds).toEqual(["claude"]);
+    storeMock.set.mockClear();
+    mark(null, []);
+    expect(storeMock.set).not.toHaveBeenCalled();
   });
 
   it("markAgentsSeen ignores non-array payloads and non-string ids", () => {

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -196,8 +196,17 @@ export function registerOnboardingHandlers(): () => void {
       ? (payload as unknown[]).filter((id): id is string => typeof id === "string")
       : [];
     const state = getOnboardingState();
-    const merged = Array.from(new Set([...state.seenAgentIds, ...incoming]));
-    const updated: OnboardingState = { ...state, seenAgentIds: merged };
+    if (incoming.length === 0) return state;
+    const existing = new Set(state.seenAgentIds);
+    let changed = false;
+    for (const id of incoming) {
+      if (!existing.has(id)) {
+        existing.add(id);
+        changed = true;
+      }
+    }
+    if (!changed) return state;
+    const updated: OnboardingState = { ...state, seenAgentIds: Array.from(existing) };
     store.set("onboarding", updated);
     return updated;
   });

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -35,6 +35,8 @@ function getOnboardingState(): OnboardingState {
       firstRunToastSeen: true,
       newsletterPromptSeen: true,
       waitingNudgeSeen: true,
+      seenAgentIds: [],
+      welcomeCardDismissed: true,
       migratedFromLocalStorage: true,
       checklist: {
         dismissed: true,
@@ -58,6 +60,8 @@ function getOnboardingState(): OnboardingState {
       firstRunToastSeen: false,
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
+      seenAgentIds: [],
+      welcomeCardDismissed: false,
       migratedFromLocalStorage: false,
       checklist: DEFAULT_CHECKLIST,
     };
@@ -67,6 +71,10 @@ function getOnboardingState(): OnboardingState {
   return {
     ...raw,
     agentSetupIds: Array.isArray(raw.agentSetupIds) ? raw.agentSetupIds : [],
+    seenAgentIds: Array.isArray(raw.seenAgentIds)
+      ? (raw.seenAgentIds as string[]).filter((id) => typeof id === "string")
+      : [],
+    welcomeCardDismissed: raw.welcomeCardDismissed === true,
     checklist: {
       ...DEFAULT_CHECKLIST,
       ...checklist,
@@ -182,6 +190,26 @@ export function registerOnboardingHandlers(): () => void {
     });
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN));
+
+  ipcMain.handle(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, (_event, payload: unknown) => {
+    const incoming = Array.isArray(payload)
+      ? (payload as unknown[]).filter((id): id is string => typeof id === "string")
+      : [];
+    const state = getOnboardingState();
+    const merged = Array.from(new Set([...state.seenAgentIds, ...incoming]));
+    const updated: OnboardingState = { ...state, seenAgentIds: merged };
+    store.set("onboarding", updated);
+    return updated;
+  });
+  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN));
+
+  ipcMain.handle(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD, () => {
+    const state = getOnboardingState();
+    const updated: OnboardingState = { ...state, welcomeCardDismissed: true };
+    store.set("onboarding", updated);
+    return updated;
+  });
+  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD));
 
   ipcMain.handle(CHANNELS.ONBOARDING_CHECKLIST_GET, () => getChecklistState());
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_CHECKLIST_GET));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2733,6 +2733,9 @@ const api: ElectronAPI = {
     markToastSeen: () => _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_TOAST_SEEN),
     markNewsletterSeen: () => _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_NEWSLETTER_SEEN),
     markWaitingNudgeSeen: () => _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN),
+    markAgentsSeen: (agentIds: string[]) =>
+      _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, agentIds),
+    dismissWelcomeCard: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD),
     getChecklist: () => _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_GET),
     dismissChecklist: () => _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_DISMISS),
     markChecklistItem: (item: ChecklistItemId) =>

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1036,6 +1036,8 @@ const CHANNELS = {
   ONBOARDING_MARK_TOAST_SEEN: "onboarding:mark-toast-seen",
   ONBOARDING_MARK_NEWSLETTER_SEEN: "onboarding:mark-newsletter-seen",
   ONBOARDING_MARK_WAITING_NUDGE_SEEN: "onboarding:mark-waiting-nudge-seen",
+  ONBOARDING_MARK_AGENTS_SEEN: "onboarding:mark-agents-seen",
+  ONBOARDING_DISMISS_WELCOME_CARD: "onboarding:dismiss-welcome-card",
   ONBOARDING_CHECKLIST_GET: "onboarding:checklist-get",
   ONBOARDING_CHECKLIST_DISMISS: "onboarding:checklist-dismiss",
   ONBOARDING_CHECKLIST_MARK_ITEM: "onboarding:checklist-mark-item",

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -183,6 +183,8 @@ export interface StoreSchema {
     firstRunToastSeen: boolean;
     newsletterPromptSeen: boolean;
     waitingNudgeSeen: boolean;
+    seenAgentIds: string[];
+    welcomeCardDismissed: boolean;
     // TODO(0.9.0): Remove after deleting onboarding:migrate and the renderer
     // localStorage import path for old Canopy onboarding keys.
     migratedFromLocalStorage: boolean;
@@ -308,6 +310,8 @@ const storeOptions = {
       firstRunToastSeen: false,
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
+      seenAgentIds: [],
+      welcomeCardDismissed: false,
       migratedFromLocalStorage: false,
       checklist: {
         dismissed: false,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1143,6 +1143,8 @@ export interface ElectronAPI {
     markToastSeen(): Promise<void>;
     markNewsletterSeen(): Promise<void>;
     markWaitingNudgeSeen(): Promise<void>;
+    markAgentsSeen(agentIds: string[]): Promise<OnboardingState>;
+    dismissWelcomeCard(): Promise<OnboardingState>;
     getChecklist(): Promise<ChecklistState>;
     dismissChecklist(): Promise<void>;
     markChecklistItem(item: ChecklistItemId): Promise<void>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -184,6 +184,8 @@ export interface OnboardingState {
   firstRunToastSeen: boolean;
   newsletterPromptSeen: boolean;
   waitingNudgeSeen: boolean;
+  seenAgentIds: string[];
+  welcomeCardDismissed: boolean;
   // TODO(0.9.0): Remove after deleting onboarding:migrate and the renderer
   // localStorage import path for old Canopy onboarding keys.
   migratedFromLocalStorage: boolean;
@@ -1577,6 +1579,14 @@ export interface IpcInvokeMap {
   "onboarding:mark-waiting-nudge-seen": {
     args: [];
     result: void;
+  };
+  "onboarding:mark-agents-seen": {
+    args: [agentIds: string[]];
+    result: OnboardingState;
+  };
+  "onboarding:dismiss-welcome-card": {
+    args: [];
+    result: OnboardingState;
   };
   "onboarding:checklist-get": {
     args: [];

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -29,6 +29,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useShallow } from "zustand/react/shallow";
 import { useKeybindingDisplay } from "@/hooks";
+import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { CliAvailability, AgentState } from "@shared/types";
 import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
@@ -50,6 +51,7 @@ type AgentRow = {
   Icon: ComponentType<AgentIconProps>;
   pinned: boolean;
   dominantState: AgentState | null;
+  isNew: boolean;
 };
 
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
@@ -63,11 +65,12 @@ const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentSt
 function buildAgentRow(
   id: BuiltInAgentId,
   pinned: boolean,
-  dominantState: AgentState | null
+  dominantState: AgentState | null,
+  isNew: boolean
 ): AgentRow | null {
   const config = getAgentConfig(id);
   if (!config) return null;
-  return { id, name: config.name, Icon: config.icon, pinned, dominantState };
+  return { id, name: config.name, Icon: config.icon, pinned, dominantState, isNew };
 }
 
 function RunningDot({ state }: { state: AgentState | null }) {
@@ -94,6 +97,13 @@ export function AgentTrayButton({
 
   const refreshAvailability = useCliAvailabilityStore((s) => s.refresh);
   const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
+
+  const {
+    loaded: onboardingLoaded,
+    seenAgentIds,
+    welcomeCardDismissed,
+    markAgentsSeen,
+  } = useAgentDiscoveryOnboarding();
 
   const panelsById = usePanelStore(useShallow((s) => s.panelsById));
   const panelIds = usePanelStore(useShallow((s) => s.panelIds));
@@ -181,6 +191,25 @@ export function AgentTrayButton({
     return result;
   }, [panelsById, panelIds, activeWorktreeId]);
 
+  const readyAgentIds = useMemo(() => {
+    return BUILT_IN_AGENT_IDS.filter((id) => isAgentReady(agentAvailability?.[id]));
+  }, [agentAvailability]);
+
+  // While the first-run welcome card is still waiting to be acknowledged we
+  // suppress the tray discovery badge for the initial cohort so both
+  // affordances don't fire for the same agents. Day-N discovery activates
+  // once the card is dismissed.
+  const newAgentIds = useMemo<ReadonlySet<string>>(() => {
+    if (!onboardingLoaded || !welcomeCardDismissed) return new Set<string>();
+    const set = new Set<string>();
+    for (const id of readyAgentIds) {
+      if (!seenAgentIds.includes(id)) set.add(id);
+    }
+    return set;
+  }, [onboardingLoaded, welcomeCardDismissed, readyAgentIds, seenAgentIds]);
+
+  const showDiscoveryBadge = newAgentIds.size > 0;
+
   const { launchable, needsSetup, fallbackSetup } = useMemo(() => {
     const launchable: AgentRow[] = [];
     const needsSetup: AgentRow[] = [];
@@ -189,7 +218,7 @@ export function AgentTrayButton({
     for (const id of BUILT_IN_AGENT_IDS) {
       const pinned = isAgentPinned(agentSettings?.agents?.[id]);
       const dominant = agentDominantStates.get(id) ?? null;
-      const row = buildAgentRow(id, pinned, dominant);
+      const row = buildAgentRow(id, pinned, dominant, newAgentIds.has(id));
       if (!row) continue;
 
       const state = agentAvailability?.[id];
@@ -223,7 +252,7 @@ export function AgentTrayButton({
     });
 
     return { launchable, needsSetup, fallbackSetup };
-  }, [agentAvailability, agentSettings, agentDominantStates, actionMruList]);
+  }, [agentAvailability, agentSettings, agentDominantStates, actionMruList, newAgentIds]);
 
   const handleLaunch = (row: AgentRow) => {
     void actionService.dispatch("agent.launch", { agentId: row.id }, { source: "user" });
@@ -250,6 +279,9 @@ export function AgentTrayButton({
     if (!open) return;
     // Fire-and-forget: the store throttle absorbs rapid reopens.
     void refreshAvailability().catch(() => {});
+    if (readyAgentIds.length > 0) {
+      void markAgentsSeen(readyAgentIds);
+    }
   };
 
   const togglePin = (row: AgentRow) => {
@@ -288,9 +320,18 @@ export function AgentTrayButton({
                 size="icon"
                 data-toolbar-item={dataToolbarItem}
                 className="toolbar-agent-button text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] focus-visible:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))] transition-colors"
-                aria-label="Agent tray"
+                aria-label={showDiscoveryBadge ? "Agent tray — new agents detected" : "Agent tray"}
               >
-                <Plug />
+                <span className="relative inline-flex items-center justify-center">
+                  <Plug />
+                  {showDiscoveryBadge && (
+                    <span
+                      data-testid="agent-tray-discovery-badge"
+                      className="absolute top-0 right-0 size-1.5 rounded-full bg-sky-400 ring-1 ring-daintree-sidebar"
+                      aria-hidden="true"
+                    />
+                  )}
+                </span>
               </Button>
             </DropdownMenuTrigger>
           </TooltipTrigger>
@@ -411,6 +452,15 @@ function LaunchRow({
       </span>
 
       <span className="flex-1">{row.name}</span>
+
+      {row.isNew && (
+        <span
+          data-testid={`agent-tray-new-pill-${row.id}`}
+          className="ml-2 shrink-0 rounded border border-sky-400/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-sky-300"
+        >
+          New
+        </span>
+      )}
 
       {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}
 

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -195,18 +195,32 @@ export function AgentTrayButton({
     return BUILT_IN_AGENT_IDS.filter((id) => isAgentReady(agentAvailability?.[id]));
   }, [agentAvailability]);
 
-  // While the first-run welcome card is still waiting to be acknowledged we
-  // suppress the tray discovery badge for the initial cohort so both
-  // affordances don't fire for the same agents. Day-N discovery activates
-  // once the card is dismissed.
+  const hasNoPinnedAgents = useMemo(() => {
+    if (!agentSettings?.agents) return true;
+    return !BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agentSettings.agents?.[id]));
+  }, [agentSettings]);
+
+  // While the first-run welcome card is actually being rendered, suppress
+  // the tray discovery badge so the card and badge don't both fire for the
+  // same agents. Critically, this is gated on whether the card would render
+  // right now — not whether the dismiss flag is false — so a user who pins
+  // via the tray/settings (which leaves `welcomeCardDismissed: false`)
+  // still gets Day-N discovery for agents installed later.
+  const welcomeCardRenderable =
+    onboardingLoaded &&
+    hasRealData &&
+    !welcomeCardDismissed &&
+    readyAgentIds.length > 0 &&
+    hasNoPinnedAgents;
+
   const newAgentIds = useMemo<ReadonlySet<string>>(() => {
-    if (!onboardingLoaded || !welcomeCardDismissed) return new Set<string>();
+    if (!onboardingLoaded || welcomeCardRenderable) return new Set<string>();
     const set = new Set<string>();
     for (const id of readyAgentIds) {
       if (!seenAgentIds.includes(id)) set.add(id);
     }
     return set;
-  }, [onboardingLoaded, welcomeCardDismissed, readyAgentIds, seenAgentIds]);
+  }, [onboardingLoaded, welcomeCardRenderable, readyAgentIds, seenAgentIds]);
 
   const showDiscoveryBadge = newAgentIds.size > 0;
 

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -662,7 +662,7 @@ describe("AgentTrayButton", () => {
     expect(queryByTestId("agent-tray-new-pill-gemini")).toBeNull();
   });
 
-  it("suppresses the discovery badge while the welcome card has not been dismissed", () => {
+  it("suppresses the discovery badge while the welcome card is actually renderable", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({});
     mockWelcomeCardDismissed = false;
@@ -671,6 +671,24 @@ describe("AgentTrayButton", () => {
     const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
     expect(queryByTestId("agent-tray-discovery-badge")).toBeNull();
     expect(queryByTestId("agent-tray-new-pill-claude")).toBeNull();
+  });
+
+  it("shows the discovery badge when a pinned agent exists even if welcomeCardDismissed is false", () => {
+    // Regression: users who pin via Settings or elsewhere never flip
+    // `welcomeCardDismissed`. The badge used to stay permanently suppressed
+    // for those users. Suppression must gate on whether the card would
+    // actually render, not on the dismiss flag in isolation.
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+    mockWelcomeCardDismissed = false;
+    mockSeenAgentIds = ["claude"];
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-discovery-badge")).toBeTruthy();
+    expect(queryByTestId("agent-tray-new-pill-gemini")).toBeTruthy();
   });
 
   it("hides the discovery badge once all ready agents are in seenAgentIds", () => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -19,6 +19,22 @@ let mockActiveWorktreeId: string | null = null;
 let mockHasRealData = true;
 let mockActionMruList: string[] = [];
 
+const markAgentsSeenMock = vi.fn().mockResolvedValue(undefined);
+const dismissWelcomeCardMock = vi.fn().mockResolvedValue(undefined);
+let mockSeenAgentIds: string[] = [];
+let mockWelcomeCardDismissed = true;
+let mockOnboardingLoaded = true;
+
+vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  useAgentDiscoveryOnboarding: () => ({
+    loaded: mockOnboardingLoaded,
+    seenAgentIds: mockSeenAgentIds,
+    welcomeCardDismissed: mockWelcomeCardDismissed,
+    markAgentsSeen: markAgentsSeenMock,
+    dismissWelcomeCard: dismissWelcomeCardMock,
+  }),
+}));
+
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
 }));
@@ -203,6 +219,11 @@ describe("AgentTrayButton", () => {
     mockActiveWorktreeId = null;
     mockHasRealData = true;
     mockActionMruList = [];
+    markAgentsSeenMock.mockClear();
+    dismissWelcomeCardMock.mockClear();
+    mockSeenAgentIds = [];
+    mockWelcomeCardDismissed = true;
+    mockOnboardingLoaded = true;
   });
 
   afterEach(() => {
@@ -622,6 +643,74 @@ describe("AgentTrayButton", () => {
     const preventDefault = vi.fn();
     closeAutoFocusSpy!({ preventDefault });
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  // --- Discovery badge (#5111) ---
+
+  it("shows a discovery badge dot when a ready agent has not been seen", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = ["gemini"];
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-discovery-badge")).toBeTruthy();
+    expect(queryByTestId("agent-tray-new-pill-claude")).toBeTruthy();
+    expect(queryByTestId("agent-tray-new-pill-gemini")).toBeNull();
+  });
+
+  it("suppresses the discovery badge while the welcome card has not been dismissed", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = false;
+    mockSeenAgentIds = [];
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-discovery-badge")).toBeNull();
+    expect(queryByTestId("agent-tray-new-pill-claude")).toBeNull();
+  });
+
+  it("hides the discovery badge once all ready agents are in seenAgentIds", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = ["claude", "gemini"];
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-discovery-badge")).toBeNull();
+  });
+
+  it("calls markAgentsSeen with all ready agent ids on tray open", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    expect(openChangeSpy).toBeTruthy();
+    markAgentsSeenMock.mockClear();
+
+    openChangeSpy!(true);
+    expect(markAgentsSeenMock).toHaveBeenCalledTimes(1);
+    const [ids] = markAgentsSeenMock.mock.calls[0] as [string[]];
+    expect(ids.sort()).toEqual(["claude", "gemini"]);
+  });
+
+  it("does not call markAgentsSeen when no agents are ready on tray open", () => {
+    const availability = {
+      claude: "missing",
+      gemini: "missing",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    markAgentsSeenMock.mockClear();
+
+    openChangeSpy!(true);
+    expect(markAgentsSeenMock).not.toHaveBeenCalled();
   });
 
   it("ignores panels from other worktrees for session detection", () => {

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -14,6 +14,8 @@ const defaultOnboardingState: OnboardingState = {
   firstRunToastSeen: false,
   newsletterPromptSeen: false,
   waitingNudgeSeen: false,
+  seenAgentIds: [],
+  welcomeCardDismissed: false,
   checklist: {
     dismissed: false,
     celebrationShown: false,

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   FolderOpen,
   FolderPlus,
@@ -8,16 +8,26 @@ import {
   Newspaper,
   ExternalLink,
   GitBranch,
+  X,
+  Plug,
+  Pin,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DaintreeIcon } from "@/components/icons";
 import { useProjectStore } from "@/store/projectStore";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
-import { getProjectGradient } from "@/lib/colorUtils";
+import { getProjectGradient, getBrandColorHex } from "@/lib/colorUtils";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { CHECKLIST_ITEMS } from "@/components/Onboarding/checklistItems";
+import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
+import { getAgentConfig } from "@/config/agents";
+import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import { isAgentReady } from "../../../shared/utils/agentAvailability";
+import { isAgentPinned } from "../../../shared/utils/agentPinned";
 import type { GettingStartedChecklistState } from "@/hooks/app/useGettingStartedChecklist";
 
 interface WelcomeScreenProps {
@@ -55,6 +65,8 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
   const progressTotal = 4; // 3 real items + endowed "Install Daintree"
   const progressDone = 1 + completedCount; // endowed item always complete
 
+  const welcomeCard = <AgentWelcomeCard />;
+
   return (
     <div className="flex flex-col items-center h-full w-full overflow-y-auto animate-in fade-in duration-500">
       <div className="max-w-2xl w-full flex flex-col items-center px-8 py-12 gap-10">
@@ -73,6 +85,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
         {hasProjects ? (
           <>
             <RecentProjects projects={recentProjects} onSelect={switchProject} />
+            {welcomeCard}
             {showChecklist && (
               <InlineChecklist
                 checklist={checklist}
@@ -83,6 +96,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
           </>
         ) : (
           <>
+            {welcomeCard}
             {showChecklist && (
               <InlineChecklist
                 checklist={checklist}
@@ -212,6 +226,113 @@ function RecentProjects({
             </span>
           </button>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function AgentWelcomeCard() {
+  const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
+  const availability = useCliAvailabilityStore((s) => s.availability);
+  const hasRealData = useCliAvailabilityStore((s) => s.hasRealData);
+  const { loaded, welcomeCardDismissed, markAgentsSeen, dismissWelcomeCard } =
+    useAgentDiscoveryOnboarding();
+
+  const [busy, setBusy] = useState(false);
+
+  const readyAgentIds = useMemo<BuiltInAgentId[]>(() => {
+    return BUILT_IN_AGENT_IDS.filter((id) => isAgentReady(availability?.[id]));
+  }, [availability]);
+
+  const hasNoPinnedAgents = useMemo(() => {
+    if (!agentSettings?.agents) return true;
+    return !BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agentSettings.agents[id]));
+  }, [agentSettings]);
+
+  if (!hasRealData || !loaded) return null;
+  if (welcomeCardDismissed) return null;
+  if (readyAgentIds.length === 0 || !hasNoPinnedAgents) return null;
+
+  const handlePinAll = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await Promise.all(
+        readyAgentIds
+          .filter((id) => !isAgentPinned(agentSettings?.agents?.[id]))
+          .map((id) => setAgentPinned(id, true).catch(() => {}))
+      );
+      await markAgentsSeen(readyAgentIds);
+      await dismissWelcomeCard();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    void markAgentsSeen(readyAgentIds);
+    void dismissWelcomeCard();
+  };
+
+  return (
+    <div className="w-full">
+      <div className="relative w-full rounded-[var(--radius-md)] border border-daintree-border/60 bg-daintree-sidebar/40 px-4 py-3.5">
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss welcome card"
+          className="absolute top-2 right-2 inline-flex h-6 w-6 items-center justify-center rounded-sm text-daintree-text/40 transition-colors hover:bg-overlay-emphasis hover:text-daintree-text/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+        <div className="flex items-start gap-3 pr-6">
+          <Plug className="h-4 w-4 text-daintree-accent mt-0.5 shrink-0" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-semibold text-daintree-text/90">
+              We detected your installed agents
+            </h3>
+            <p className="text-xs text-daintree-text/60 mt-1 leading-relaxed">
+              Pin them to your toolbar for one-click launching.
+            </p>
+            <ul className="mt-3 flex flex-wrap gap-2">
+              {readyAgentIds.map((id) => {
+                const config = getAgentConfig(id);
+                if (!config) return null;
+                const Icon = config.icon;
+                return (
+                  <li
+                    key={id}
+                    className="inline-flex items-center gap-1.5 rounded-[var(--radius-xs)] border border-daintree-border/60 bg-daintree-bg/40 px-2 py-1 text-xs text-daintree-text/80"
+                  >
+                    <span className="inline-flex h-3.5 w-3.5 items-center justify-center">
+                      <Icon brandColor={getBrandColorHex(id)} />
+                    </span>
+                    {config.name}
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="mt-4 flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() => void handlePinAll()}
+                disabled={busy}
+                data-testid="welcome-card-pin-all"
+              >
+                <Pin className="h-3.5 w-3.5" />
+                Pin all to toolbar
+              </Button>
+              <button
+                type="button"
+                onClick={handleDismiss}
+                className="text-xs text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
+              >
+                Not now
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -254,15 +254,22 @@ function AgentWelcomeCard() {
   if (welcomeCardDismissed) return null;
   if (readyAgentIds.length === 0 || !hasNoPinnedAgents) return null;
 
+  const [pinError, setPinError] = useState(false);
+
   const handlePinAll = async () => {
     if (busy) return;
     setBusy(true);
+    setPinError(false);
     try {
-      await Promise.all(
-        readyAgentIds
-          .filter((id) => !isAgentPinned(agentSettings?.agents?.[id]))
-          .map((id) => setAgentPinned(id, true).catch(() => {}))
-      );
+      const targets = readyAgentIds.filter((id) => !isAgentPinned(agentSettings?.agents?.[id]));
+      const results = await Promise.allSettled(targets.map((id) => setAgentPinned(id, true)));
+      const allOk = results.every((r) => r.status === "fulfilled");
+      if (!allOk) {
+        // Keep the card visible so the user can retry; surface an inline
+        // error instead of silently dropping their "Pin all" click.
+        setPinError(true);
+        return;
+      }
       await markAgentsSeen(readyAgentIds);
       await dismissWelcomeCard();
     } finally {
@@ -271,8 +278,13 @@ function AgentWelcomeCard() {
   };
 
   const handleDismiss = () => {
-    void markAgentsSeen(readyAgentIds);
-    void dismissWelcomeCard();
+    // Await seen-before-dismiss so a crash or quit between the two IPCs
+    // can't leave `welcomeCardDismissed: true` + `seenAgentIds: []` —
+    // which would mark every ready agent as "new" on next launch.
+    void (async () => {
+      await markAgentsSeen(readyAgentIds);
+      await dismissWelcomeCard();
+    })();
   };
 
   return (
@@ -331,6 +343,15 @@ function AgentWelcomeCard() {
                 Not now
               </button>
             </div>
+            {pinError && (
+              <p
+                role="alert"
+                data-testid="welcome-card-pin-error"
+                className="mt-2 text-xs text-red-400"
+              >
+                Couldn&apos;t pin all agents. Please try again.
+              </p>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -240,6 +240,7 @@ function AgentWelcomeCard() {
     useAgentDiscoveryOnboarding();
 
   const [busy, setBusy] = useState(false);
+  const [pinError, setPinError] = useState(false);
 
   const readyAgentIds = useMemo<BuiltInAgentId[]>(() => {
     return BUILT_IN_AGENT_IDS.filter((id) => isAgentReady(availability?.[id]));
@@ -253,8 +254,6 @@ function AgentWelcomeCard() {
   if (!hasRealData || !loaded) return null;
   if (welcomeCardDismissed) return null;
   if (readyAgentIds.length === 0 || !hasNoPinnedAgents) return null;
-
-  const [pinError, setPinError] = useState(false);
 
   const handlePinAll = async () => {
     if (busy) return;

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const { dispatchMock } = vi.hoisted(() => ({
@@ -44,6 +44,63 @@ vi.mock("@/lib/utils", () => ({
 
 vi.mock("@/lib/colorUtils", () => ({
   getProjectGradient: (color?: string) => (color ? `gradient(${color})` : undefined),
+  getBrandColorHex: () => "#000000",
+}));
+
+const {
+  markAgentsSeenMock,
+  dismissWelcomeCardMock,
+  setAgentPinnedMock,
+  agentDiscoveryState,
+  agentSettingsState,
+  cliAvailabilityState,
+} = vi.hoisted(() => ({
+  markAgentsSeenMock: vi.fn(() => Promise.resolve()),
+  dismissWelcomeCardMock: vi.fn(() => Promise.resolve()),
+  setAgentPinnedMock: vi.fn(() => Promise.resolve()),
+  agentDiscoveryState: {
+    loaded: true,
+    seenAgentIds: [] as string[],
+    welcomeCardDismissed: false,
+  },
+  agentSettingsState: {
+    settings: null as { agents: Record<string, { pinned?: boolean }> } | null,
+  },
+  cliAvailabilityState: {
+    availability: {} as Record<string, "ready" | "installed" | "missing">,
+    hasRealData: false,
+  },
+}));
+
+vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  useAgentDiscoveryOnboarding: () => ({
+    loaded: agentDiscoveryState.loaded,
+    seenAgentIds: agentDiscoveryState.seenAgentIds,
+    welcomeCardDismissed: agentDiscoveryState.welcomeCardDismissed,
+    markAgentsSeen: markAgentsSeenMock,
+    dismissWelcomeCard: dismissWelcomeCardMock,
+  }),
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (
+    selector: (
+      s: typeof agentSettingsState & { setAgentPinned: typeof setAgentPinnedMock }
+    ) => unknown
+  ) => selector({ ...agentSettingsState, setAgentPinned: setAgentPinnedMock }),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: typeof cliAvailabilityState) => unknown) =>
+    selector(cliAvailabilityState),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (id: string) => ({
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    icon: () => null,
+    iconId: id,
+  }),
 }));
 
 vi.mock("@/utils/timeAgo", () => ({
@@ -202,6 +259,12 @@ describe("WelcomeScreen", () => {
       openCreateFolderDialog: openCreateFolderDialogMock,
       switchProject: switchProjectMock,
     };
+    agentDiscoveryState.loaded = true;
+    agentDiscoveryState.seenAgentIds = [];
+    agentDiscoveryState.welcomeCardDismissed = false;
+    agentSettingsState.settings = null;
+    cliAvailabilityState.availability = {};
+    cliAvailabilityState.hasRealData = false;
   });
 
   it("renders hero section with icon, title, and tagline", () => {
@@ -444,5 +507,84 @@ describe("WelcomeScreen", () => {
 
     expect(screen.queryByText("Recent Projects")).toBeNull();
     expect(screen.getByText("Getting Started")).toBeTruthy();
+  });
+
+  // --- Agent Welcome Card (#5111) ---
+
+  describe("agent welcome card", () => {
+    it("does not render while availability has no real data", () => {
+      cliAvailabilityState.hasRealData = false;
+      cliAvailabilityState.availability = { claude: "ready" };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.queryByText(/We detected your installed agents/)).toBeNull();
+    });
+
+    it("does not render when no agents are ready", () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = { claude: "missing", codex: "missing" };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.queryByText(/We detected your installed agents/)).toBeNull();
+    });
+
+    it("does not render when any agent is already pinned", () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+      agentSettingsState.settings = { agents: { claude: { pinned: true } } };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.queryByText(/We detected your installed agents/)).toBeNull();
+    });
+
+    it("does not render when the card has been dismissed", () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = { claude: "ready" };
+      agentSettingsState.settings = { agents: {} };
+      agentDiscoveryState.welcomeCardDismissed = true;
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.queryByText(/We detected your installed agents/)).toBeNull();
+    });
+
+    it("renders with ready agent names when conditions are met", () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = {
+        claude: "ready",
+        codex: "ready",
+        gemini: "missing",
+      };
+      agentSettingsState.settings = { agents: {} };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.getByText(/We detected your installed agents/)).toBeTruthy();
+      expect(screen.getByText("Claude")).toBeTruthy();
+      expect(screen.getByText("Codex")).toBeTruthy();
+      expect(screen.queryByText("Gemini")).toBeNull();
+    });
+
+    it("pins all ready agents then dismisses when Pin all is clicked", async () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+      agentSettingsState.settings = { agents: {} };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+      const btn = screen.getByTestId("welcome-card-pin-all");
+      await act(async () => {
+        fireEvent.click(btn);
+      });
+
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", true);
+      expect(markAgentsSeenMock).toHaveBeenCalled();
+      expect(dismissWelcomeCardMock).toHaveBeenCalled();
+    });
+
+    it("does not pin agents when the Not now link is clicked but still dismisses", () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = { claude: "ready" };
+      agentSettingsState.settings = { agents: {} };
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+      fireEvent.click(screen.getByText("Not now"));
+      expect(setAgentPinnedMock).not.toHaveBeenCalled();
+      expect(markAgentsSeenMock).toHaveBeenCalled();
+      expect(dismissWelcomeCardMock).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -575,16 +575,36 @@ describe("WelcomeScreen", () => {
       expect(dismissWelcomeCardMock).toHaveBeenCalled();
     });
 
-    it("does not pin agents when the Not now link is clicked but still dismisses", () => {
+    it("does not pin agents when the Not now link is clicked but still dismisses", async () => {
       cliAvailabilityState.hasRealData = true;
       cliAvailabilityState.availability = { claude: "ready" };
       agentSettingsState.settings = { agents: {} };
       render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-      fireEvent.click(screen.getByText("Not now"));
+      await act(async () => {
+        fireEvent.click(screen.getByText("Not now"));
+      });
       expect(setAgentPinnedMock).not.toHaveBeenCalled();
       expect(markAgentsSeenMock).toHaveBeenCalled();
       expect(dismissWelcomeCardMock).toHaveBeenCalled();
+    });
+
+    it("keeps the card visible and surfaces an error if any pin fails", async () => {
+      cliAvailabilityState.hasRealData = true;
+      cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+      agentSettingsState.settings = { agents: {} };
+      setAgentPinnedMock.mockImplementationOnce(() => Promise.reject(new Error("IPC down")));
+
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("welcome-card-pin-all"));
+      });
+
+      // First call rejected — card should stay visible with an inline error,
+      // and dismiss should NOT have been called.
+      expect(screen.getByTestId("welcome-card-pin-error")).toBeTruthy();
+      expect(dismissWelcomeCardMock).not.toHaveBeenCalled();
+      expect(markAgentsSeenMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/app/__tests__/useAgentWaitingNudge.test.tsx
+++ b/src/hooks/app/__tests__/useAgentWaitingNudge.test.tsx
@@ -13,6 +13,8 @@ const onboardingMock = {
       firstRunToastSeen: false,
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
+      seenAgentIds: [] as string[],
+      welcomeCardDismissed: false,
       checklist: {
         dismissed: false,
         celebrationShown: false,
@@ -122,6 +124,8 @@ describe("useAgentWaitingNudge", () => {
       firstRunToastSeen: false,
       newsletterPromptSeen: false,
       waitingNudgeSeen: true,
+      seenAgentIds: [],
+      welcomeCardDismissed: false,
       checklist: {
         dismissed: false,
         celebrationShown: false,
@@ -146,6 +150,8 @@ describe("useAgentWaitingNudge", () => {
       firstRunToastSeen: false,
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
+      seenAgentIds: [],
+      welcomeCardDismissed: false,
       checklist: {
         dismissed: false,
         celebrationShown: false,

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -1,80 +1,124 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
+import { create } from "zustand";
 import type { OnboardingState } from "@shared/types";
 import { isElectronAvailable } from "@/hooks/useElectron";
 
-interface AgentDiscoveryOnboarding {
+interface AgentDiscoveryState {
   loaded: boolean;
   seenAgentIds: string[];
   welcomeCardDismissed: boolean;
+}
+
+const useAgentDiscoveryStore = create<AgentDiscoveryState>(() => ({
+  loaded: false,
+  seenAgentIds: [],
+  welcomeCardDismissed: false,
+}));
+
+let hydrating: Promise<void> | null = null;
+
+async function hydrate(): Promise<void> {
+  if (useAgentDiscoveryStore.getState().loaded) return;
+  if (hydrating) return hydrating;
+
+  hydrating = (async () => {
+    if (!isElectronAvailable()) {
+      useAgentDiscoveryStore.setState({ loaded: true });
+      return;
+    }
+    const api = window.electron?.onboarding;
+    if (!api?.get) {
+      useAgentDiscoveryStore.setState({ loaded: true });
+      return;
+    }
+    try {
+      const state: OnboardingState = await api.get();
+      useAgentDiscoveryStore.setState({
+        loaded: true,
+        seenAgentIds: Array.isArray(state.seenAgentIds) ? state.seenAgentIds : [],
+        welcomeCardDismissed: state.welcomeCardDismissed === true,
+      });
+    } catch {
+      useAgentDiscoveryStore.setState({ loaded: true });
+    }
+  })();
+
+  try {
+    await hydrating;
+  } finally {
+    hydrating = null;
+  }
+}
+
+export async function markAgentsSeen(agentIds: string[]): Promise<void> {
+  if (agentIds.length === 0) return;
+  useAgentDiscoveryStore.setState((s) => {
+    const merged = new Set(s.seenAgentIds);
+    let changed = false;
+    for (const id of agentIds) {
+      if (!merged.has(id)) {
+        merged.add(id);
+        changed = true;
+      }
+    }
+    return changed ? { ...s, seenAgentIds: Array.from(merged) } : s;
+  });
+  const api = window.electron?.onboarding;
+  if (!api?.markAgentsSeen) return;
+  try {
+    await api.markAgentsSeen(agentIds);
+  } catch {
+    // Best-effort; optimistic local state stands.
+  }
+}
+
+export async function dismissWelcomeCard(): Promise<void> {
+  if (useAgentDiscoveryStore.getState().welcomeCardDismissed) return;
+  useAgentDiscoveryStore.setState({ welcomeCardDismissed: true });
+  const api = window.electron?.onboarding;
+  if (!api?.dismissWelcomeCard) return;
+  try {
+    await api.dismissWelcomeCard();
+  } catch {
+    // Best-effort; optimistic local state stands.
+  }
+}
+
+interface AgentDiscoveryOnboarding extends AgentDiscoveryState {
   markAgentsSeen: (agentIds: string[]) => Promise<void>;
   dismissWelcomeCard: () => Promise<void>;
 }
 
 /**
- * Reads the discovery-related onboarding fields once on mount and exposes
- * optimistic mutations. Local state updates before the IPC round-trip so the
- * welcome card and tray badge clear immediately when the user acts, avoiding
- * a visible flicker while the main process acknowledges the write.
+ * Reads the discovery-related onboarding fields from a shared Zustand store
+ * and exposes optimistic mutations. Hydration fires once on first mount and
+ * is shared across all subscribers — critical for keeping the welcome card
+ * (`WelcomeScreen`) and the tray badge (`AgentTrayButton`) in sync within a
+ * session; see review on #5111.
  */
 export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
-  const [seenAgentIds, setSeenAgentIds] = useState<string[]>([]);
-  const [welcomeCardDismissed, setWelcomeCardDismissed] = useState<boolean>(false);
-  const [loaded, setLoaded] = useState(false);
+  const loaded = useAgentDiscoveryStore((s) => s.loaded);
+  const seenAgentIds = useAgentDiscoveryStore((s) => s.seenAgentIds);
+  const welcomeCardDismissed = useAgentDiscoveryStore((s) => s.welcomeCardDismissed);
 
   useEffect(() => {
-    if (!isElectronAvailable()) {
-      setLoaded(true);
-      return;
-    }
-    let disposed = false;
-    const api = window.electron?.onboarding;
-    if (!api?.get) {
-      setLoaded(true);
-      return;
-    }
-    api
-      .get()
-      .then((state: OnboardingState) => {
-        if (disposed) return;
-        setSeenAgentIds(Array.isArray(state.seenAgentIds) ? state.seenAgentIds : []);
-        setWelcomeCardDismissed(state.welcomeCardDismissed === true);
-        setLoaded(true);
-      })
-      .catch(() => {
-        if (disposed) return;
-        setLoaded(true);
-      });
-    return () => {
-      disposed = true;
-    };
+    void hydrate();
   }, []);
 
-  const markAgentsSeen = useCallback(async (agentIds: string[]) => {
-    if (agentIds.length === 0) return;
-    setSeenAgentIds((prev) => {
-      const merged = new Set(prev);
-      for (const id of agentIds) merged.add(id);
-      return Array.from(merged);
-    });
-    const api = window.electron?.onboarding;
-    if (!api?.markAgentsSeen) return;
-    try {
-      await api.markAgentsSeen(agentIds);
-    } catch {
-      // best-effort — local optimistic state stands; next reload will reconcile.
-    }
-  }, []);
+  return {
+    loaded,
+    seenAgentIds,
+    welcomeCardDismissed,
+    markAgentsSeen,
+    dismissWelcomeCard,
+  };
+}
 
-  const dismissWelcomeCard = useCallback(async () => {
-    setWelcomeCardDismissed(true);
-    const api = window.electron?.onboarding;
-    if (!api?.dismissWelcomeCard) return;
-    try {
-      await api.dismissWelcomeCard();
-    } catch {
-      // best-effort — local optimistic state stands; next reload will reconcile.
-    }
-  }, []);
-
-  return { loaded, seenAgentIds, welcomeCardDismissed, markAgentsSeen, dismissWelcomeCard };
+export function resetAgentDiscoveryStoreForTests(): void {
+  hydrating = null;
+  useAgentDiscoveryStore.setState({
+    loaded: false,
+    seenAgentIds: [],
+    welcomeCardDismissed: false,
+  });
 }

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from "react";
+import type { OnboardingState } from "@shared/types";
+import { isElectronAvailable } from "@/hooks/useElectron";
+
+interface AgentDiscoveryOnboarding {
+  loaded: boolean;
+  seenAgentIds: string[];
+  welcomeCardDismissed: boolean;
+  markAgentsSeen: (agentIds: string[]) => Promise<void>;
+  dismissWelcomeCard: () => Promise<void>;
+}
+
+/**
+ * Reads the discovery-related onboarding fields once on mount and exposes
+ * optimistic mutations. Local state updates before the IPC round-trip so the
+ * welcome card and tray badge clear immediately when the user acts, avoiding
+ * a visible flicker while the main process acknowledges the write.
+ */
+export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
+  const [seenAgentIds, setSeenAgentIds] = useState<string[]>([]);
+  const [welcomeCardDismissed, setWelcomeCardDismissed] = useState<boolean>(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!isElectronAvailable()) {
+      setLoaded(true);
+      return;
+    }
+    let disposed = false;
+    const api = window.electron?.onboarding;
+    if (!api?.get) {
+      setLoaded(true);
+      return;
+    }
+    api
+      .get()
+      .then((state: OnboardingState) => {
+        if (disposed) return;
+        setSeenAgentIds(Array.isArray(state.seenAgentIds) ? state.seenAgentIds : []);
+        setWelcomeCardDismissed(state.welcomeCardDismissed === true);
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (disposed) return;
+        setLoaded(true);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, []);
+
+  const markAgentsSeen = useCallback(async (agentIds: string[]) => {
+    if (agentIds.length === 0) return;
+    setSeenAgentIds((prev) => {
+      const merged = new Set(prev);
+      for (const id of agentIds) merged.add(id);
+      return Array.from(merged);
+    });
+    const api = window.electron?.onboarding;
+    if (!api?.markAgentsSeen) return;
+    try {
+      await api.markAgentsSeen(agentIds);
+    } catch {
+      // best-effort — local optimistic state stands; next reload will reconcile.
+    }
+  }, []);
+
+  const dismissWelcomeCard = useCallback(async () => {
+    setWelcomeCardDismissed(true);
+    const api = window.electron?.onboarding;
+    if (!api?.dismissWelcomeCard) return;
+    try {
+      await api.dismissWelcomeCard();
+    } catch {
+      // best-effort — local optimistic state stands; next reload will reconcile.
+    }
+  }, []);
+
+  return { loaded, seenAgentIds, welcomeCardDismissed, markAgentsSeen, dismissWelcomeCard };
+}

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -191,7 +191,7 @@ describe("agentSettingsStore adversarial", () => {
     expect(state.settings?.agents.codex?.pinned).toBe(false);
   });
 
-  it("initialize synthesizes pinned from CLI availability when real data is present", async () => {
+  it("initialize seeds pinned:false for agents without explicit values (opt-in model #5109)", async () => {
     registryMock.getEffectiveAgentIds.mockReturnValue(["claude", "codex"]);
     setAvailability({ claude: "ready", codex: "missing" }, true);
     clientMock.get.mockResolvedValue({
@@ -204,7 +204,9 @@ describe("agentSettingsStore adversarial", () => {
     await useAgentSettingsStore.getState().initialize();
 
     const state = useAgentSettingsStore.getState();
-    expect(state.settings?.agents.claude?.pinned).toBe(true);
+    // Opt-in model: availability no longer auto-synthesizes pinned:true.
+    // Users must explicitly pin agents via the welcome card or tray.
+    expect(state.settings?.agents.claude?.pinned).toBe(false);
     expect(state.settings?.agents.codex?.pinned).toBe(false);
   });
 

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -191,7 +191,7 @@ describe("agentSettingsStore adversarial", () => {
     expect(state.settings?.agents.codex?.pinned).toBe(false);
   });
 
-  it("initialize seeds pinned:false for agents without explicit values (opt-in model #5109)", async () => {
+  it("initialize synthesizes pinned from availability for pre-existing entries (upgrader path)", async () => {
     registryMock.getEffectiveAgentIds.mockReturnValue(["claude", "codex"]);
     setAvailability({ claude: "ready", codex: "missing" }, true);
     clientMock.get.mockResolvedValue({
@@ -204,9 +204,10 @@ describe("agentSettingsStore adversarial", () => {
     await useAgentSettingsStore.getState().initialize();
 
     const state = useAgentSettingsStore.getState();
-    // Opt-in model: availability no longer auto-synthesizes pinned:true.
-    // Users must explicitly pin agents via the welcome card or tray.
-    expect(state.settings?.agents.claude?.pinned).toBe(false);
+    // Existing entries (upgraders from 0.7.x) preserve the implicit pin:
+    // installed/ready → true, missing → false. Only agents without any
+    // persisted entry default to pinned:false under the new opt-in model.
+    expect(state.settings?.agents.claude?.pinned).toBe(true);
     expect(state.settings?.agents.codex?.pinned).toBe(false);
   });
 

--- a/src/store/__tests__/normalizeAgentSelection.test.ts
+++ b/src/store/__tests__/normalizeAgentSelection.test.ts
@@ -33,40 +33,38 @@ describe("normalizeAgentSelection", () => {
     expect(result.agents.gemini.pinned).toBe(true);
   });
 
-  it("synthesizes pinned: true for installed agents when hasRealData is true", () => {
+  it("seeds pinned: false for installed agents when hasRealData is true (opt-in model #5109)", () => {
     const settings = makeSettings({ claude: {} });
     const availability = availabilityFor({ claude: "installed" });
     const result = normalizeAgentSelection(settings, availability, true);
-    expect(result.agents.claude.pinned).toBe(true);
+    expect(result.agents.claude.pinned).toBe(false);
   });
 
-  it("synthesizes pinned: true for ready agents when hasRealData is true", () => {
+  it("seeds pinned: false for ready agents when hasRealData is true (opt-in model #5109)", () => {
     const settings = makeSettings({ claude: {} });
     const availability = availabilityFor({ claude: "ready" });
     const result = normalizeAgentSelection(settings, availability, true);
-    expect(result.agents.claude.pinned).toBe(true);
+    expect(result.agents.claude.pinned).toBe(false);
   });
 
-  it("synthesizes pinned: false for missing agents when hasRealData is true (issue #5158)", () => {
+  it("seeds pinned: false for missing agents when hasRealData is true (issue #5158)", () => {
     const settings = makeSettings({ claude: {} });
     const availability = availabilityFor({ claude: "missing" });
     const result = normalizeAgentSelection(settings, availability, true);
     expect(result.agents.claude.pinned).toBe(false);
   });
 
-  it("creates entries only for installed agents when store is empty and hasRealData is true", () => {
+  it("creates pinned:false entries for every agent when store is empty and hasRealData is true", () => {
     const settings: AgentSettings = { agents: {} };
     const allIds = getEffectiveAgentIds();
     const [firstInstalled] = allIds;
     const availability = availabilityFor({ [firstInstalled]: "installed" });
     const result = normalizeAgentSelection(settings, availability, true);
 
+    // Opt-in model: availability no longer seeds pinned:true automatically.
+    // Users pin explicitly via the welcome card or tray.
     for (const id of allIds) {
-      if (id === firstInstalled) {
-        expect(result.agents[id]).toEqual({ pinned: true });
-      } else {
-        expect(result.agents[id]).toEqual({ pinned: false });
-      }
+      expect(result.agents[id]).toEqual({ pinned: false });
     }
   });
 

--- a/src/store/__tests__/normalizeAgentSelection.test.ts
+++ b/src/store/__tests__/normalizeAgentSelection.test.ts
@@ -33,36 +33,39 @@ describe("normalizeAgentSelection", () => {
     expect(result.agents.gemini.pinned).toBe(true);
   });
 
-  it("seeds pinned: false for installed agents when hasRealData is true (opt-in model #5109)", () => {
+  it("synthesizes pinned:true for installed agents with an existing entry (upgrader path)", () => {
+    // Upgrader: entry exists from prior sessions but was persisted without
+    // a `pinned` field. Preserve the implicit pin so their toolbar doesn't
+    // collapse on upgrade.
     const settings = makeSettings({ claude: {} });
     const availability = availabilityFor({ claude: "installed" });
     const result = normalizeAgentSelection(settings, availability, true);
-    expect(result.agents.claude.pinned).toBe(false);
+    expect(result.agents.claude.pinned).toBe(true);
   });
 
-  it("seeds pinned: false for ready agents when hasRealData is true (opt-in model #5109)", () => {
+  it("synthesizes pinned:true for ready agents with an existing entry (upgrader path)", () => {
     const settings = makeSettings({ claude: {} });
     const availability = availabilityFor({ claude: "ready" });
     const result = normalizeAgentSelection(settings, availability, true);
-    expect(result.agents.claude.pinned).toBe(false);
+    expect(result.agents.claude.pinned).toBe(true);
   });
 
-  it("seeds pinned: false for missing agents when hasRealData is true (issue #5158)", () => {
+  it("synthesizes pinned:false for missing agents with an existing entry (issue #5158)", () => {
     const settings = makeSettings({ claude: {} });
     const availability = availabilityFor({ claude: "missing" });
     const result = normalizeAgentSelection(settings, availability, true);
     expect(result.agents.claude.pinned).toBe(false);
   });
 
-  it("creates pinned:false entries for every agent when store is empty and hasRealData is true", () => {
+  it("creates pinned:false entries for every agent when store is empty (fresh-install opt-in)", () => {
+    // Fresh install: no entries in the persisted store. Opt-in model means
+    // nothing is pinned until the user acts (welcome card, tray, etc).
     const settings: AgentSettings = { agents: {} };
     const allIds = getEffectiveAgentIds();
     const [firstInstalled] = allIds;
     const availability = availabilityFor({ [firstInstalled]: "installed" });
     const result = normalizeAgentSelection(settings, availability, true);
 
-    // Opt-in model: availability no longer seeds pinned:true automatically.
-    // Users pin explicitly via the welcome card or tray.
     for (const id of allIds) {
       expect(result.agents[id]).toEqual({ pinned: false });
     }

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -4,23 +4,20 @@ import { agentSettingsClient } from "@/clients";
 import { DEFAULT_AGENT_SETTINGS } from "@shared/types";
 import { getEffectiveAgentIds } from "../../shared/config/agentRegistry";
 import { isAgentPinned } from "../../shared/utils/agentPinned";
-import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
 
 /**
- * In-memory normalization: seeds `pinned` for any registered agent missing an
- * explicit value, using the current CLI availability snapshot as the source of
- * truth. Installed/ready agents default to `pinned: true` so they surface in
- * the toolbar; missing agents default to `pinned: false` so uninstalled CLIs
- * never phantom-pin (see issue #5158). When availability data has not yet
- * loaded (`hasRealData === false`), the pinned flag stays absent — the
- * renderer orchestrator re-runs normalization once real availability arrives.
- * Explicit `pinned: true` / `pinned: false` values from the persisted store
- * are always preserved. Does NOT persist.
+ * In-memory normalization: seeds `pinned: false` for any registered agent
+ * missing an explicit value, once real availability data has landed. This
+ * keeps the toolbar empty until the user deliberately pins (opt-in model —
+ * see #5109). Before real data (`hasRealData === false`) the flag stays
+ * absent so the renderer can re-run normalization once the first probe
+ * completes. Explicit `pinned: true` / `pinned: false` values from the
+ * persisted store are always preserved. Does NOT persist.
  */
 export function normalizeAgentSelection(
   settings: AgentSettings,
-  availability?: CliAvailability | null,
+  _availability?: CliAvailability | null,
   hasRealData: boolean = false
 ): AgentSettings {
   const registeredIds = getEffectiveAgentIds();
@@ -32,14 +29,14 @@ export function normalizeAgentSelection(
 
     if (!entry) {
       if (hasRealData) {
-        agents[id] = { pinned: isAgentInstalled(availability?.[id]) };
+        agents[id] = { pinned: false };
         changed = true;
       }
       continue;
     }
 
     if (entry.pinned === undefined && hasRealData) {
-      agents[id] = { ...entry, pinned: isAgentInstalled(availability?.[id]) };
+      agents[id] = { ...entry, pinned: false };
       changed = true;
     }
   }

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -4,20 +4,31 @@ import { agentSettingsClient } from "@/clients";
 import { DEFAULT_AGENT_SETTINGS } from "@shared/types";
 import { getEffectiveAgentIds } from "../../shared/config/agentRegistry";
 import { isAgentPinned } from "../../shared/utils/agentPinned";
+import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
 
 /**
- * In-memory normalization: seeds `pinned: false` for any registered agent
- * missing an explicit value, once real availability data has landed. This
- * keeps the toolbar empty until the user deliberately pins (opt-in model —
- * see #5109). Before real data (`hasRealData === false`) the flag stays
- * absent so the renderer can re-run normalization once the first probe
- * completes. Explicit `pinned: true` / `pinned: false` values from the
- * persisted store are always preserved. Does NOT persist.
+ * In-memory normalization with two distinct paths:
+ *
+ *  - No entry at all for a registered agent → seed `pinned: false` (opt-in
+ *    default — see #5109 and the welcome card in #5111). Fresh installs
+ *    show an empty toolbar until the user pins via the welcome card or
+ *    the tray.
+ *  - Entry exists but `pinned` is undefined → synthesize from current
+ *    availability (installed/ready → true, missing → false). This
+ *    preserves the implicit pin for 0.7.x upgraders who already have
+ *    agent-settings entries from prior sessions — otherwise their
+ *    toolbar would collapse and the AgentSetupWizard would auto-open on
+ *    every launch (see #5158 and review on #5111).
+ *
+ * Before real data (`hasRealData === false`) the flag stays absent so
+ * the renderer can re-run normalization once the first probe completes.
+ * Explicit `pinned: true` / `pinned: false` values from the persisted
+ * store are always preserved. Does NOT persist.
  */
 export function normalizeAgentSelection(
   settings: AgentSettings,
-  _availability?: CliAvailability | null,
+  availability?: CliAvailability | null,
   hasRealData: boolean = false
 ): AgentSettings {
   const registeredIds = getEffectiveAgentIds();
@@ -36,7 +47,7 @@ export function normalizeAgentSelection(
     }
 
     if (entry.pinned === undefined && hasRealData) {
-      agents[id] = { ...entry, pinned: false };
+      agents[id] = { ...entry, pinned: isAgentInstalled(availability?.[id]) };
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary

- Adds a first-run welcome card to the Welcome Screen that prompts new users to set up their first AI agent, only shown before any agents are configured
- Adds a discovery badge on the agent tray button that nudges users toward agent setup when agents are waiting (with badge-suppression so it doesn't appear once dismissed or during active work)
- Onboarding state (welcome card dismissed, discovery badge dismissed) is shared via a dedicated Zustand store backed by persisted IPC channels

Resolves #5111

## Changes

- `src/components/Project/WelcomeScreen.tsx` — welcome card rendering, dismiss flow, first-run gating
- `src/hooks/app/useAgentDiscoveryOnboarding.ts` — hook managing discovery badge visibility logic and shared dismissal state
- `src/components/Layout/AgentTrayButton.tsx` — discovery badge overlay, pin-error inline UX (hoisted above early returns)
- `electron/ipc/handlers/onboarding.ts` — IPC handlers for persisting `welcomeCardDismissed` and `discoveryBadgeDismissed`
- `electron/ipc/channels.ts` + `electron/preload.cts` — new onboarding channels registered in both the channel map and the preload inline CHANNELS copy
- `src/store/agentSettingsStore.ts` — shared Zustand store for onboarding dismissal flags
- Tests for all new components and handlers

## Testing

Unit tests pass for `WelcomeScreen`, `AgentTrayButton`, `useAgentDiscoveryOnboarding`, and the onboarding IPC handlers. Upgrader regression verified (existing users with agents already configured see neither card nor badge). Badge suppression confirmed: dismissed state persists across reloads and the badge doesn't appear when an agent is actively running.