### PR TITLE
feat(project-state): add size and latency telemetry to project state writes

### DIFF
--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -4,6 +4,8 @@ import { existsSync } from "fs";
 import { resilientAtomicWriteFile, resilientRename, resilientUnlink } from "../utils/fs.js";
 import { TerminalSnapshotSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 import { getProjectStateDir, stateFilePath } from "./projectStorePaths.js";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
+import { markPerformance, withPerformanceSpan } from "../utils/performance.js";
 
 const PROJECT_STATE_CACHE_TTL_MS = 60_000;
 
@@ -69,11 +71,18 @@ export class ProjectStateManager {
       ),
     };
 
+    const jsonString = JSON.stringify(validatedState, null, 2);
+    const bytes = Buffer.byteLength(jsonString, "utf-8");
+
     const attemptSave = async (ensureDir: boolean): Promise<void> => {
       if (ensureDir) {
         await fs.mkdir(stateDir, { recursive: true });
       }
-      await resilientAtomicWriteFile(filePath, JSON.stringify(validatedState, null, 2), "utf-8");
+      await withPerformanceSpan(
+        PERF_MARKS.PROJECT_STATE_WRITE,
+        () => resilientAtomicWriteFile(filePath, jsonString, "utf-8"),
+        { projectId, bytes }
+      );
     };
 
     try {
@@ -115,7 +124,11 @@ export class ProjectStateManager {
     }
 
     try {
-      const content = await fs.readFile(filePath, "utf-8");
+      const content = await withPerformanceSpan(
+        PERF_MARKS.PROJECT_STATE_READ,
+        () => fs.readFile(filePath, "utf-8"),
+        { projectId }
+      );
       const parsed = JSON.parse(content);
 
       const rawTerminals = Array.isArray(parsed.terminals) ? parsed.terminals : [];
@@ -162,6 +175,7 @@ export class ProjectStateManager {
       console.error(`[ProjectStateManager] Failed to load state for project ${projectId}:`, error);
       try {
         const quarantinePath = `${filePath}.corrupted`;
+        markPerformance(PERF_MARKS.PROJECT_STATE_QUARANTINE, { projectId });
         await resilientRename(filePath, quarantinePath);
         console.warn(`[ProjectStateManager] Corrupted state file moved to ${quarantinePath}`);
       } catch {

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -1,10 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { ProjectStateManager } from "../ProjectStateManager.js";
-import { generateProjectId } from "../projectStorePaths.js";
+import { generateProjectId, stateFilePath } from "../projectStorePaths.js";
 import type { ProjectState } from "../../types/index.js";
+import { markPerformance, withPerformanceSpan } from "../../utils/performance.js";
+import { PERF_MARKS } from "../../../shared/perf/marks.js";
+
+vi.mock("../../utils/performance.js", () => ({
+  markPerformance: vi.fn(),
+  withPerformanceSpan: vi.fn(async (_mark: string, task: () => Promise<unknown>) => task()),
+}));
 
 function makeState(overrides?: Partial<ProjectState>): ProjectState {
   return {
@@ -88,5 +95,67 @@ describe("ProjectStateManager clone isolation", () => {
     const result = await manager.getProjectState(projectId);
     expect(result!.terminals[0].title).toBe("Terminal 1");
     expect(result!.sidebarWidth).toBe(350);
+  });
+});
+
+describe("ProjectStateManager telemetry", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(async () => {
+    vi.mocked(withPerformanceSpan).mockClear();
+    vi.mocked(markPerformance).mockClear();
+
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-state-telemetry-"));
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/telemetry-project");
+
+    await fs.mkdir(path.join(tempDir, projectId), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("records a PROJECT_STATE_WRITE span with projectId and non-zero bytes on save", async () => {
+    await manager.saveProjectState(projectId, makeState());
+
+    const writeCall = vi
+      .mocked(withPerformanceSpan)
+      .mock.calls.find((call) => call[0] === PERF_MARKS.PROJECT_STATE_WRITE);
+
+    expect(writeCall).toBeDefined();
+    const meta = writeCall![2] as { projectId: string; bytes: number };
+    expect(meta.projectId).toBe(projectId);
+    expect(meta.bytes).toBeGreaterThan(0);
+  });
+
+  it("records a PROJECT_STATE_READ span with projectId on disk-read load", async () => {
+    await manager.saveProjectState(projectId, makeState());
+    manager.invalidateProjectStateCache(projectId);
+    vi.mocked(withPerformanceSpan).mockClear();
+
+    await manager.getProjectState(projectId);
+
+    const readCall = vi
+      .mocked(withPerformanceSpan)
+      .mock.calls.find((call) => call[0] === PERF_MARKS.PROJECT_STATE_READ);
+
+    expect(readCall).toBeDefined();
+    const meta = readCall![2] as { projectId: string };
+    expect(meta.projectId).toBe(projectId);
+  });
+
+  it("emits PROJECT_STATE_QUARANTINE when a corrupted state file is quarantined", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+
+    const result = await manager.getProjectState(projectId);
+
+    expect(result).toBeNull();
+    expect(vi.mocked(markPerformance)).toHaveBeenCalledWith(PERF_MARKS.PROJECT_STATE_QUARANTINE, {
+      projectId,
+    });
   });
 });

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -147,6 +147,31 @@ describe("ProjectStateManager telemetry", () => {
     expect(meta.projectId).toBe(projectId);
   });
 
+  it("does not emit PROJECT_STATE_READ on a cache hit", async () => {
+    await manager.saveProjectState(projectId, makeState());
+    await manager.getProjectState(projectId);
+    vi.mocked(withPerformanceSpan).mockClear();
+
+    await manager.getProjectState(projectId);
+
+    const readCall = vi
+      .mocked(withPerformanceSpan)
+      .mock.calls.find((call) => call[0] === PERF_MARKS.PROJECT_STATE_READ);
+    expect(readCall).toBeUndefined();
+  });
+
+  it("does not emit PROJECT_STATE_READ when no state file exists", async () => {
+    const missingId = generateProjectId("/missing/telemetry-project");
+
+    const result = await manager.getProjectState(missingId);
+
+    expect(result).toBeNull();
+    const readCall = vi
+      .mocked(withPerformanceSpan)
+      .mock.calls.find((call) => call[0] === PERF_MARKS.PROJECT_STATE_READ);
+    expect(readCall).toBeUndefined();
+  });
+
   it("emits PROJECT_STATE_QUARANTINE when a corrupted state file is quarantined", async () => {
     const filePath = stateFilePath(tempDir, projectId)!;
     await fs.writeFile(filePath, "{ not valid json", "utf-8");

--- a/shared/perf/__tests__/marks.test.ts
+++ b/shared/perf/__tests__/marks.test.ts
@@ -27,6 +27,10 @@ describe("PERF_MARKS", () => {
     expect(PERF_MARKS.HYDRATE_RESTORE_SNAPSHOTS_CRITICAL).toBe(
       "hydrate_restore_snapshots_critical"
     );
+
+    expect(PERF_MARKS.PROJECT_STATE_WRITE).toBe("project_state_write");
+    expect(PERF_MARKS.PROJECT_STATE_READ).toBe("project_state_read");
+    expect(PERF_MARKS.PROJECT_STATE_QUARANTINE).toBe("project_state_quarantine");
   });
 
   it("has unique values", () => {

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -29,6 +29,10 @@ export const PERF_MARKS = {
   WORKTREE_SWITCH_START: "worktree_switch_start",
   WORKTREE_SWITCH_END: "worktree_switch_end",
 
+  PROJECT_STATE_WRITE: "project_state_write",
+  PROJECT_STATE_READ: "project_state_read",
+  PROJECT_STATE_QUARANTINE: "project_state_quarantine",
+
   DEVPREVIEW_ENSURE_START: "devpreview_ensure_start",
   DEVPREVIEW_TERMINAL_SPAWNED: "devpreview_terminal_spawned",
   DEVPREVIEW_URL_DETECTED: "devpreview_url_detected",


### PR DESCRIPTION
## Summary

- Instruments `saveProjectState` and `getProjectState` in `ProjectStateManager` with `withPerformanceSpan` calls, capturing write latency and pre-computed UTF-8 byte size on every successful save, read latency per project, and a quarantine mark when a corrupted file is renamed away.
- Adds `PROJECT_STATE_WRITE`, `PROJECT_STATE_READ`, and `PROJECT_STATE_QUARANTINE` to `shared/perf/marks.ts` alongside the existing mark registry.
- Purely observability — no behaviour changes to the state read/write path.

Resolves #5187

## Changes

- `shared/perf/marks.ts` — three new mark constants
- `electron/services/ProjectStateManager.ts` — `withPerformanceSpan` wrapping save and read, `markPerformance` on quarantine
- `electron/services/__tests__/ProjectStateManager.test.ts` — 5 new telemetry tests covering write size, write latency, read latency, quarantine emission, and cache-hit/missing-file guard
- `shared/perf/__tests__/marks.test.ts` — 3 mark registry assertions for the new constants

## Testing

All 8 new tests pass. Typecheck, lint, and format are clean.