### PR TITLE
test(theme): WCAG contrast checks for built-in themes in CI

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { BUILT_IN_THEME_SOURCES } from "../builtInThemes/index.js";
+import { getThemeContrastWarnings } from "../contrast.js";
 import { BUILT_IN_APP_SCHEMES } from "../themes.js";
 import { APP_THEME_TOKEN_KEYS } from "../types.js";
 
@@ -19,6 +20,14 @@ describe("built-in themes", () => {
     const ids = BUILT_IN_APP_SCHEMES.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
+
+  it.each(BUILT_IN_APP_SCHEMES.map((s) => [s.id, s] as const))(
+    "scheme %s passes WCAG contrast checks",
+    (_id, scheme) => {
+      const warnings = getThemeContrastWarnings(scheme);
+      expect(warnings, warnings.map((w) => w.message).join("; ")).toHaveLength(0);
+    }
+  );
 
   it("every compiled scheme has all required token keys", () => {
     for (const scheme of BUILT_IN_APP_SCHEMES) {

--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -6,6 +6,7 @@ import { APP_THEME_TOKEN_KEYS } from "../types.js";
 
 describe("built-in themes", () => {
   it("every source compiles to a valid AppColorScheme", () => {
+    expect(BUILT_IN_THEME_SOURCES.length).toBeGreaterThan(0);
     expect(BUILT_IN_APP_SCHEMES).toHaveLength(BUILT_IN_THEME_SOURCES.length);
     for (const scheme of BUILT_IN_APP_SCHEMES) {
       expect(scheme.id).toBeTruthy();

--- a/shared/theme/builtInThemes/arashiyama.ts
+++ b/shared/theme/builtInThemes/arashiyama.ts
@@ -75,6 +75,7 @@ export const theme: BuiltInThemeSource = {
     },
   },
   tokens: {
+    "accent-foreground": "#0D0C0B",
     "border-strong": "rgba(241,235,228,0.14)",
     "border-subtle": "rgba(241,235,228,0.07)",
     "focus-ring": "rgba(196,98,64,0.30)",


### PR DESCRIPTION
## Summary

- Adds an `it.each` test in `shared/theme/__tests__/builtInThemes.test.ts` that iterates every entry in `BUILT_IN_APP_SCHEMES` and asserts `getThemeContrastWarnings` returns no failures. Each theme gets a named test case in CI output, so a regression is immediately obvious.
- Adds a guard that asserts `BUILT_IN_THEME_SOURCES.length > 0` so the suite can't go vacuously green if the array ever gets accidentally emptied.
- Fixes arashiyama's `accent-foreground` token, which was falling through to the text-inverse default (`#1B1715`, 4.38:1 against the accent surface). Explicit override to `#0D0C0B` brings it to ~4.81:1, clearing the 4.5:1 AA threshold.

Resolves #5246

## Changes

- `shared/theme/__tests__/builtInThemes.test.ts` — 14 new per-theme WCAG test cases + empty-array guard
- `shared/theme/builtInThemes/arashiyama.ts` — explicit `accent-foreground` override

## Testing

21/21 tests pass in `shared/theme/__tests__/builtInThemes.test.ts` (7 original + 14 new). Lint ratchet holds at 401/401 baseline warnings, 0 errors. Typecheck and format both clean.