### PR TITLE
fix(github): default issues/PRs to Newest and honour sort selection in search (#5264)

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -1074,8 +1074,10 @@ export async function listIssues(
       if (options.search) {
         const stateFilter =
           options.state === "closed" ? "is:closed" : options.state === "all" ? "" : "is:open";
+        const sortQualifier =
+          resolvedSortOrder === "updated" ? "sort:updated-desc" : "sort:created-desc";
         const searchQuery =
-          `repo:${context.owner}/${context.repo} is:issue ${stateFilter} sort:updated-desc ${options.search}`.trim();
+          `repo:${context.owner}/${context.repo} is:issue ${stateFilter} ${sortQualifier} ${options.search}`.trim();
 
         const response = (await client(SEARCH_QUERY, {
           searchQuery,
@@ -1191,8 +1193,10 @@ export async function listPullRequests(
         else if (options.state === "closed") stateFilter = "is:closed is:unmerged";
         else if (options.state === "merged") stateFilter = "is:merged";
 
+        const sortQualifier =
+          resolvedSortOrder === "updated" ? "sort:updated-desc" : "sort:created-desc";
         const searchQuery =
-          `repo:${context.owner}/${context.repo} is:pr ${stateFilter} sort:updated-desc ${options.search}`.trim();
+          `repo:${context.owner}/${context.repo} is:pr ${stateFilter} ${sortQualifier} ${options.search}`.trim();
 
         const response = (await client(SEARCH_QUERY, {
           searchQuery,

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -275,6 +275,66 @@ describe("GitHubService adversarial", () => {
     );
   });
 
+  it("LISTISSUES_SEARCH_OMITTED_SORTORDER_USES_CREATED_DESC", async () => {
+    shared.graphqlClient.mockResolvedValueOnce({
+      search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
+
+    await github.listIssues({ cwd: "/repo", search: "label:bug" });
+
+    const searchQuery = shared.graphqlClient.mock.calls[0]?.[1]?.searchQuery as string;
+    expect(searchQuery).toContain("sort:created-desc");
+    expect(searchQuery).not.toContain("sort:updated-desc");
+  });
+
+  it("LISTISSUES_SEARCH_CREATED_SORTORDER_USES_CREATED_DESC", async () => {
+    shared.graphqlClient.mockResolvedValueOnce({
+      search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
+
+    await github.listIssues({ cwd: "/repo", search: "label:bug", sortOrder: "created" });
+
+    const searchQuery = shared.graphqlClient.mock.calls[0]?.[1]?.searchQuery as string;
+    expect(searchQuery).toContain("sort:created-desc");
+    expect(searchQuery).not.toContain("sort:updated-desc");
+  });
+
+  it("LISTISSUES_SEARCH_UPDATED_SORTORDER_USES_UPDATED_DESC", async () => {
+    shared.graphqlClient.mockResolvedValueOnce({
+      search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
+
+    await github.listIssues({ cwd: "/repo", search: "label:bug", sortOrder: "updated" });
+
+    const searchQuery = shared.graphqlClient.mock.calls[0]?.[1]?.searchQuery as string;
+    expect(searchQuery).toContain("sort:updated-desc");
+    expect(searchQuery).not.toContain("sort:created-desc");
+  });
+
+  it("LISTPRS_SEARCH_OMITTED_SORTORDER_USES_CREATED_DESC", async () => {
+    shared.graphqlClient.mockResolvedValueOnce({
+      search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
+
+    await github.listPullRequests({ cwd: "/repo", search: "label:bug" });
+
+    const searchQuery = shared.graphqlClient.mock.calls[0]?.[1]?.searchQuery as string;
+    expect(searchQuery).toContain("sort:created-desc");
+    expect(searchQuery).not.toContain("sort:updated-desc");
+  });
+
+  it("LISTPRS_SEARCH_UPDATED_SORTORDER_USES_UPDATED_DESC", async () => {
+    shared.graphqlClient.mockResolvedValueOnce({
+      search: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+    });
+
+    await github.listPullRequests({ cwd: "/repo", search: "label:bug", sortOrder: "updated" });
+
+    const searchQuery = shared.graphqlClient.mock.calls[0]?.[1]?.searchQuery as string;
+    expect(searchQuery).toContain("sort:updated-desc");
+    expect(searchQuery).not.toContain("sort:created-desc");
+  });
+
   it("NULLABLE_MISSING_FIELDS_SAFE_DEFAULTS", async () => {
     shared.graphqlClient
       .mockResolvedValueOnce({

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -617,11 +617,11 @@ export function GitHubResourceList({
                   "relative flex items-center justify-center w-7 h-7 rounded shrink-0",
                   "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
                   "transition-colors",
-                  sortOrder !== "updated" && "text-daintree-accent"
+                  sortOrder !== "created" && "text-daintree-accent"
                 )}
               >
                 <Filter className="w-3.5 h-3.5" />
-                {sortOrder !== "updated" && (
+                {sortOrder !== "created" && (
                   <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-daintree-accent" />
                 )}
               </button>

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -113,7 +113,7 @@ describe("GitHubResourceList SWR behavior", () => {
   });
 
   it("shows cached data immediately on warm remount (no skeleton)", async () => {
-    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "updated");
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(10), makeIssue(11)],
       endCursor: null,
@@ -133,7 +133,7 @@ describe("GitHubResourceList SWR behavior", () => {
   });
 
   it("background refresh updates data in place when response differs", async () => {
-    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "updated");
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(10)],
       endCursor: null,
@@ -157,7 +157,7 @@ describe("GitHubResourceList SWR behavior", () => {
   });
 
   it("preserves cached data when background refresh fails", async () => {
-    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "updated");
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(20)],
       endCursor: null,
@@ -180,7 +180,7 @@ describe("GitHubResourceList SWR behavior", () => {
   });
 
   it("different project paths use separate cache entries", async () => {
-    const keyA = buildCacheKey("/proj-a", "issue", "open", "updated");
+    const keyA = buildCacheKey("/proj-a", "issue", "open", "created");
     setCache(keyA, {
       items: [makeIssue(50)],
       endCursor: null,

--- a/src/store/__tests__/githubFilterStore.test.ts
+++ b/src/store/__tests__/githubFilterStore.test.ts
@@ -98,41 +98,41 @@ describe("githubFilterStore", () => {
     expect(state.prSearchQuery).toBe("");
   });
 
-  it("defaults sort orders to updated", () => {
+  it("defaults sort orders to created", () => {
     const state = useGitHubFilterStore.getState();
-    expect(state.issueSortOrder).toBe("updated");
-    expect(state.prSortOrder).toBe("updated");
+    expect(state.issueSortOrder).toBe("created");
+    expect(state.prSortOrder).toBe("created");
   });
 
   it("setIssueSortOrder updates only issueSortOrder", () => {
-    useGitHubFilterStore.getState().setIssueSortOrder("created");
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
     const state = useGitHubFilterStore.getState();
-    expect(state.issueSortOrder).toBe("created");
-    expect(state.prSortOrder).toBe("updated");
+    expect(state.issueSortOrder).toBe("updated");
+    expect(state.prSortOrder).toBe("created");
   });
 
   it("setPrSortOrder updates only prSortOrder", () => {
-    useGitHubFilterStore.getState().setPrSortOrder("created");
+    useGitHubFilterStore.getState().setPrSortOrder("updated");
     const state = useGitHubFilterStore.getState();
-    expect(state.prSortOrder).toBe("created");
-    expect(state.issueSortOrder).toBe("updated");
+    expect(state.prSortOrder).toBe("updated");
+    expect(state.issueSortOrder).toBe("created");
   });
 
   it("issue and PR sort orders are fully independent", () => {
-    useGitHubFilterStore.getState().setIssueSortOrder("created");
-    useGitHubFilterStore.getState().setPrSortOrder("created");
-    const state = useGitHubFilterStore.getState();
-    expect(state.issueSortOrder).toBe("created");
-    expect(state.prSortOrder).toBe("created");
-  });
-
-  it("resetGitHubFilterStore resets sort orders to updated", () => {
-    useGitHubFilterStore.getState().setIssueSortOrder("created");
-    useGitHubFilterStore.getState().setPrSortOrder("created");
-    resetGitHubFilterStore();
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    useGitHubFilterStore.getState().setPrSortOrder("updated");
     const state = useGitHubFilterStore.getState();
     expect(state.issueSortOrder).toBe("updated");
     expect(state.prSortOrder).toBe("updated");
+  });
+
+  it("resetGitHubFilterStore resets sort orders to created", () => {
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    useGitHubFilterStore.getState().setPrSortOrder("updated");
+    resetGitHubFilterStore();
+    const state = useGitHubFilterStore.getState();
+    expect(state.issueSortOrder).toBe("created");
+    expect(state.prSortOrder).toBe("created");
   });
 
   it("changing sort order does not disturb filters or search queries", () => {
@@ -140,8 +140,8 @@ describe("githubFilterStore", () => {
     useGitHubFilterStore.getState().setPrFilter("merged");
     useGitHubFilterStore.getState().setIssueSearchQuery("bug");
     useGitHubFilterStore.getState().setPrSearchQuery("feat");
-    useGitHubFilterStore.getState().setIssueSortOrder("created");
-    useGitHubFilterStore.getState().setPrSortOrder("created");
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    useGitHubFilterStore.getState().setPrSortOrder("updated");
     const state = useGitHubFilterStore.getState();
     expect(state.issueFilter).toBe("closed");
     expect(state.prFilter).toBe("merged");
@@ -154,15 +154,15 @@ describe("githubFilterStore", () => {
     useGitHubFilterStore.getState().setPrFilter("closed");
     useGitHubFilterStore.getState().setIssueSearchQuery("search1");
     useGitHubFilterStore.getState().setPrSearchQuery("search2");
-    useGitHubFilterStore.getState().setIssueSortOrder("created");
-    useGitHubFilterStore.getState().setPrSortOrder("created");
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+    useGitHubFilterStore.getState().setPrSortOrder("updated");
     resetGitHubFilterStore();
     const state = useGitHubFilterStore.getState();
     expect(state.issueFilter).toBe("open");
     expect(state.prFilter).toBe("open");
     expect(state.issueSearchQuery).toBe("");
     expect(state.prSearchQuery).toBe("");
-    expect(state.issueSortOrder).toBe("updated");
-    expect(state.prSortOrder).toBe("updated");
+    expect(state.issueSortOrder).toBe("created");
+    expect(state.prSortOrder).toBe("created");
   });
 });

--- a/src/store/githubFilterStore.ts
+++ b/src/store/githubFilterStore.ts
@@ -24,8 +24,8 @@ export const useGitHubFilterStore = create<GitHubFilterState>()((set) => ({
   prFilter: "open",
   issueSearchQuery: "",
   prSearchQuery: "",
-  issueSortOrder: "updated",
-  prSortOrder: "updated",
+  issueSortOrder: "created",
+  prSortOrder: "created",
   setIssueFilter: (filter) => set({ issueFilter: filter }),
   setPrFilter: (filter) => set({ prFilter: filter }),
   setIssueSearchQuery: (query) => set({ issueSearchQuery: query }),
@@ -40,7 +40,7 @@ export function resetGitHubFilterStore() {
     prFilter: "open",
     issueSearchQuery: "",
     prSearchQuery: "",
-    issueSortOrder: "updated",
-    prSortOrder: "updated",
+    issueSortOrder: "created",
+    prSortOrder: "created",
   });
 }


### PR DESCRIPTION
## Summary

- GitHub panel was defaulting to "Recently updated" for both issues and PRs. This flips the default to "Newest", matching github.com's convention so users don't see different orderings when switching between Daintree and the web.
- Fixed a latent bug in the GraphQL search path where `sort:updated-desc` was hardcoded, meaning the user's selected sort order was silently ignored whenever they typed a search term. Sort now honours `resolvedSortOrder` in both `listIssues` and `listPullRequests`.

Resolves #5264

## Changes

- `src/store/githubFilterStore.ts` — initial and reset defaults changed to `"created"` (newest-first)
- `electron/services/GitHubService.ts` — search-path sort qualifier now derives from `resolvedSortOrder` instead of hardcoded `updated-desc`
- `src/components/GitHub/GitHubResourceList.tsx` — accent baseline flipped to reflect new default (accent now highlights "Recently updated" as the non-default active state)
- `src/store/__tests__/githubFilterStore.test.ts` — existing assertions updated
- `electron/services/__tests__/GitHubService.adversarial.test.ts` — 5 new regression tests covering search-path sort qualifier permutations
- `src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx` — cache-key tests updated to new default

## Testing

36/36 tests green across store, SWR, and adversarial test files. All 4 checks clean (typecheck, lint ratchet 401/401, format, no debug artifacts).