### PR TITLE
fix(worktree): wire aria-invalid and error descriptions on NewWorktreeDialog inputs

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -182,6 +182,9 @@ export function NewWorktreeDialog({
   const [loading, setLoading] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [errorField, setErrorField] = useState<
+    "base-branch" | "new-branch" | "worktree-path" | null
+  >(null);
   const [creationError, setCreationError] = useState<WorktreeCreationError | null>(null);
   const [baseBranch, setBaseBranch] = useState("");
   const [prBranchResolved, setPrBranchResolved] = useState<boolean | null>(null);
@@ -322,6 +325,7 @@ export function NewWorktreeDialog({
     setSelectedExistingBranch(null);
     setExistingBranchQuery("");
     setValidationError(null);
+    setErrorField(null);
     setCreationError(null);
   }, []);
 
@@ -384,6 +388,7 @@ export function NewWorktreeDialog({
 
     setLoading(true);
     setValidationError(null);
+    setErrorField(null);
     setCreationError(null);
     setPrBranchResolved(null);
     setBranches([]);
@@ -476,6 +481,7 @@ export function NewWorktreeDialog({
       .catch((err) => {
         if (!isCurrent) return;
         setValidationError(`Failed to load branches: ${err.message}`);
+        setErrorField(null);
         setBranches([]);
         setBaseBranch("");
         setFromRemote(false);
@@ -556,14 +562,17 @@ export function NewWorktreeDialog({
     if (isExistingMode) {
       if (!selectedExistingBranch) {
         setValidationError("Please select a branch");
+        setErrorField(null);
         return;
       }
       if (!worktreePath.trim()) {
         setValidationError("Please enter a worktree path");
+        setErrorField("worktree-path");
         return;
       }
 
       setValidationError(null);
+      setErrorField(null);
       setCreationError(null);
 
       startTransition(async () => {
@@ -653,12 +662,14 @@ export function NewWorktreeDialog({
 
     if (!baseBranch) {
       setValidationError("Please select a base branch");
+      setErrorField("base-branch");
       return;
     }
 
     const trimmedInput = branchInput.trim();
     if (!trimmedInput) {
       setValidationError("Please enter a branch name");
+      setErrorField("new-branch");
       return;
     }
 
@@ -667,6 +678,7 @@ export function NewWorktreeDialog({
     if (parsed.hasPrefix) {
       if (!parsed.slug || !parsed.slug.trim()) {
         setValidationError("Please enter a branch name after the prefix");
+        setErrorField("new-branch");
         return;
       }
       if (
@@ -675,35 +687,42 @@ export function NewWorktreeDialog({
         parsed.prefix.includes("..")
       ) {
         setValidationError("Branch prefix contains invalid characters");
+        setErrorField("new-branch");
         return;
       }
       if (/[\s.]$/.test(parsed.slug) || /^[.-]/.test(parsed.slug)) {
         setValidationError("Branch name cannot start with '.', '-' or end with space or '.'");
+        setErrorField("new-branch");
         return;
       }
       if (/[\\:]/.test(parsed.slug) || parsed.slug.includes("..")) {
         setValidationError("Branch name contains invalid characters");
+        setErrorField("new-branch");
         return;
       }
     } else {
       if (/[\s.]$/.test(trimmedInput) || /^[.-]/.test(trimmedInput)) {
         setValidationError("Branch name cannot start with '.', '-' or end with space or '.'");
+        setErrorField("new-branch");
         return;
       }
       if (/[/\\:]/.test(trimmedInput) || trimmedInput.includes("..")) {
         setValidationError("Branch name contains invalid characters");
+        setErrorField("new-branch");
         return;
       }
     }
 
     if (!worktreePath.trim()) {
       setValidationError("Please enter a worktree path");
+      setErrorField("worktree-path");
       return;
     }
 
     const fullBranchName = parsed.fullBranchName;
 
     setValidationError(null);
+    setErrorField(null);
     setCreationError(null);
 
     startTransition(async () => {
@@ -1014,6 +1033,10 @@ export function NewWorktreeDialog({
                         role="combobox"
                         aria-expanded={branchPickerOpen}
                         aria-haspopup="listbox"
+                        aria-invalid={errorField === "base-branch" ? true : undefined}
+                        aria-describedby={
+                          errorField === "base-branch" ? "validation-error" : undefined
+                        }
                         className="w-full justify-between bg-daintree-bg border-daintree-border text-daintree-text hover:bg-daintree-bg hover:text-daintree-text"
                         disabled={isPending}
                       >
@@ -1201,6 +1224,7 @@ export function NewWorktreeDialog({
                                 setExistingBranchPickerOpen(false);
                                 setExistingBranchQuery("");
                                 setValidationError(null);
+                                setErrorField(null);
                                 setCreationError(null);
                               }}
                               className={cn(
@@ -1240,14 +1264,21 @@ export function NewWorktreeDialog({
                             setBranchInput(e.target.value);
                             markBranchInputTouched();
                             setValidationError(null);
+                            setErrorField(null);
                             setCreationError(null);
                           }}
                           onKeyDown={handlePrefixKeyDown}
                           placeholder="feature/add-user-auth"
                           className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-none focus:ring-2 focus:ring-daintree-accent font-mono text-sm"
                           disabled={isPending}
+                          aria-invalid={errorField === "new-branch" ? true : undefined}
                           aria-describedby={
-                            branchWasAutoResolved ? "branch-resolved-hint" : undefined
+                            [
+                              errorField === "new-branch" ? "validation-error" : null,
+                              branchWasAutoResolved ? "branch-resolved-hint" : null,
+                            ]
+                              .filter(Boolean)
+                              .join(" ") || undefined
                           }
                           role="combobox"
                           aria-autocomplete="list"
@@ -1365,11 +1396,16 @@ export function NewWorktreeDialog({
                         setWorktreePath(e.target.value);
                         pathTouchedRef.current = true;
                         setValidationError(null);
+                        setErrorField(null);
                         setCreationError(null);
                       }}
                       placeholder="/path/to/worktree"
                       className="w-full px-3 pr-10 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-none focus:ring-2 focus:ring-daintree-accent"
                       disabled={isPending}
+                      aria-invalid={errorField === "worktree-path" ? true : undefined}
+                      aria-describedby={
+                        errorField === "worktree-path" ? "validation-error" : undefined
+                      }
                     />
                     {isGeneratingPath && (
                       <Spinner
@@ -1394,12 +1430,14 @@ export function NewWorktreeDialog({
                           setWorktreePath(result.result as string);
                           pathTouchedRef.current = true;
                           setValidationError(null);
+                          setErrorField(null);
                           setCreationError(null);
                         }
                       } catch (err: unknown) {
                         console.error("Failed to open directory picker:", err);
                         const message = err instanceof Error ? err.message : "Unknown error";
                         setValidationError(`Failed to open directory picker: ${message}`);
+                        setErrorField(null);
                       }
                     }}
                     disabled={isPending}
@@ -1715,6 +1753,7 @@ export function NewWorktreeDialog({
 
               {validationError && (
                 <div
+                  id="validation-error"
                   role="alert"
                   className="flex items-start gap-2 p-3 bg-status-error/10 border border-status-error/20 rounded-[var(--radius-md)]"
                 >

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -472,3 +472,152 @@ describe("NewWorktreeDialog — existing branch mode", () => {
     expect(createButton.hasAttribute("disabled")).toBe(true);
   });
 });
+
+describe("NewWorktreeDialog — ARIA validation wiring", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockListBranches.mockResolvedValue(TEST_BRANCHES);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: "new-wt-id" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("sets aria-invalid and aria-describedby on the new-branch input when branch name is empty", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    expect(branchInput.getAttribute("aria-invalid")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert.id).toBe("validation-error");
+    expect(alert.textContent).toContain("Please enter a branch name");
+
+    expect(branchInput.getAttribute("aria-invalid")).toBe("true");
+    expect(branchInput.getAttribute("aria-describedby") ?? "").toContain("validation-error");
+
+    const pathInput = screen.getByTestId("worktree-path-input");
+    expect(pathInput.getAttribute("aria-invalid")).toBeNull();
+
+    const baseBranchButton = document.getElementById("base-branch");
+    expect(baseBranchButton?.getAttribute("aria-invalid")).toBeNull();
+  });
+
+  it("sets aria-invalid on the worktree-path input when path is empty after valid branch name", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value: "feature/new-feature" } });
+    });
+    await advanceTimersGradually(1000);
+
+    const pathInput = screen.getByTestId("worktree-path-input") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(pathInput, { target: { value: "" } });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    expect(screen.getByRole("alert").textContent).toContain("Please enter a worktree path");
+    expect(pathInput.getAttribute("aria-invalid")).toBe("true");
+    expect(pathInput.getAttribute("aria-describedby")).toBe("validation-error");
+    expect(branchInput.getAttribute("aria-invalid")).toBeNull();
+  });
+
+  it("sets aria-invalid on the base-branch combobox when no base branch is selected", async () => {
+    mockListBranches.mockRejectedValueOnce(new Error("no branches"));
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value: "feature/new" } });
+    });
+    await advanceTimersGradually(500);
+
+    const baseBranchButton = document.getElementById("base-branch");
+    expect(baseBranchButton?.getAttribute("aria-invalid")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    const alerts = screen.getAllByRole("alert");
+    const validationAlert = alerts.find((el) => el.id === "validation-error");
+    expect(validationAlert).toBeDefined();
+    expect(validationAlert?.textContent).toContain("Please select a base branch");
+
+    expect(baseBranchButton?.getAttribute("aria-invalid")).toBe("true");
+    expect(baseBranchButton?.getAttribute("aria-describedby")).toBe("validation-error");
+  });
+
+  it("clears aria-invalid when the user types in the failing field", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    const branchInput = screen.getByTestId("branch-name-input") as HTMLInputElement;
+    expect(branchInput.getAttribute("aria-invalid")).toBe("true");
+
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value: "f" } });
+    });
+
+    expect(branchInput.getAttribute("aria-invalid")).toBeNull();
+    expect(branchInput.getAttribute("aria-describedby") ?? "").not.toContain("validation-error");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("clears aria-invalid on the failing field when switching modes", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    expect(branchInput.getAttribute("aria-invalid")).toBe("true");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("radio", { name: /existing branch/i }));
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("does not set aria-invalid on any input on initial render", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    const pathInput = screen.getByTestId("worktree-path-input");
+    const baseBranchButton = document.getElementById("base-branch");
+
+    expect(branchInput.getAttribute("aria-invalid")).toBeNull();
+    expect(pathInput.getAttribute("aria-invalid")).toBeNull();
+    expect(baseBranchButton?.getAttribute("aria-invalid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Added `errorField` state to `NewWorktreeDialog` to attribute validation errors to specific fields (base-branch, new-branch, worktree-path), keeping it in sync across all 21 `setValidationError` call sites.
- Added `id="validation-error"` to the validation alert div so inputs can reference it via `aria-describedby`. The `creationError` alert is left without an id as it's not field-specific.
- Wired `aria-invalid` and `aria-describedby` on all three inputs: the base-branch combobox (`PopoverTrigger asChild`), the new-branch input (merged describedby with the branch-resolved hint), and the worktree-path input. Used `aria-invalid={cond ? true : undefined}` to omit the attribute when there's no error, matching the `SettingsInput.tsx` convention.
- Added 6 unit tests covering empty-branch, empty-path, missing base-branch, clear-on-input, mode-switch clear, and no-invalid on initial render.

Resolves #5236.

## Changes

- `src/components/Worktree/NewWorktreeDialog.tsx` — `errorField` state, id on validation alert, aria attributes on three inputs
- `src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx` — 6 new ARIA accessibility tests

## Testing

Unit tests pass. Covered the main failure paths: submitting with each field empty or missing, clearing state when the user starts typing, and confirming no spurious `aria-invalid` on a clean initial render.