### PR TITLE
feat(telemetry): add persistence perf marks to localStorage reads and writes

### DIFF
--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -296,32 +296,36 @@ describe("persistence boundary hardening", () => {
     expect(matching).toBeDefined();
   });
 
-  it("createResilientStorage emits a set mark with ok:true on successful write", async () => {
+  it("createResilientStorage emits a set mark with ok:true and storage:'localStorage' on successful write", async () => {
     installLocalStorage(createStorageMock());
     const marks = seedPerfMarks();
 
     const { createSafeJSONStorage } = await import("../persistence/safeStorage");
     const storage = createSafeJSONStorage<{ value: number }>();
 
-    storage.setItem("tel-set-key", { state: { value: 42 }, version: 1 });
+    const payload = { state: { value: 42 }, version: 1 };
+    storage.setItem("tel-set-key", payload);
 
     const setMarks = marks.filter((m) => m.mark === "persistence_localstorage_set");
     expect(setMarks).toHaveLength(1);
     const meta = setMarks[0]?.meta ?? {};
     expect(meta.key).toBe("tel-set-key");
     expect(meta.ok).toBe(true);
+    expect(meta.storage).toBe("localStorage");
+    expect(meta.payloadBytes).toBe(new TextEncoder().encode(JSON.stringify(payload)).length);
     expect(typeof meta.durationMs).toBe("number");
-    expect(typeof meta.payloadBytes).toBe("number");
-    expect((meta.payloadBytes as number) > 0).toBe(true);
+    expect(Number.isFinite(meta.durationMs as number)).toBe(true);
+    expect((meta.durationMs as number) >= 0).toBe(true);
   });
 
-  it("createResilientStorage emits a get mark with ok:true on successful read", async () => {
+  it("createResilientStorage emits a get mark with ok:true and storage:'localStorage' on successful read", async () => {
     installLocalStorage(createStorageMock());
     const marks = seedPerfMarks();
 
     const { createSafeJSONStorage } = await import("../persistence/safeStorage");
     const storage = createSafeJSONStorage<{ value: number }>();
-    storage.setItem("tel-get-key", { state: { value: 1 }, version: 1 });
+    const payload = { state: { value: 1 }, version: 1 };
+    storage.setItem("tel-get-key", payload);
     marks.length = 0;
 
     storage.getItem("tel-get-key");
@@ -331,12 +335,14 @@ describe("persistence boundary hardening", () => {
     const meta = getMarks[0]?.meta ?? {};
     expect(meta.key).toBe("tel-get-key");
     expect(meta.ok).toBe(true);
+    expect(meta.storage).toBe("localStorage");
+    expect(meta.payloadBytes).toBe(new TextEncoder().encode(JSON.stringify(payload)).length);
     expect(typeof meta.durationMs).toBe("number");
-    expect(typeof meta.payloadBytes).toBe("number");
-    expect((meta.payloadBytes as number) > 0).toBe(true);
+    expect(Number.isFinite(meta.durationMs as number)).toBe(true);
+    expect((meta.durationMs as number) >= 0).toBe(true);
   });
 
-  it("createResilientStorage emits a set mark with ok:false when localStorage.setItem throws", async () => {
+  it("createResilientStorage emits a set mark with ok:false and storage:'localStorage' when the localStorage write throws", async () => {
     installLocalStorage(
       createStorageMock({
         setItem: () => {
@@ -358,15 +364,18 @@ describe("persistence boundary hardening", () => {
     const meta = setMarks[0]?.meta ?? {};
     expect(meta.key).toBe("tel-fail-key");
     expect(meta.ok).toBe(false);
+    expect(meta.storage).toBe("localStorage");
     expect(typeof meta.durationMs).toBe("number");
+    expect(Number.isFinite(meta.durationMs as number)).toBe(true);
   });
 
-  it("createResilientStorage emits a get mark with ok:false when localStorage.getItem throws", async () => {
+  it("createResilientStorage emits a get mark with ok:false and storage:'localStorage' when the localStorage read throws", async () => {
+    const throwingGetItem = vi.fn(() => {
+      throw new Error("SecurityError");
+    });
     installLocalStorage(
       createStorageMock({
-        getItem: () => {
-          throw new Error("SecurityError");
-        },
+        getItem: throwingGetItem,
       })
     );
     const marks = seedPerfMarks();
@@ -377,12 +386,49 @@ describe("persistence boundary hardening", () => {
     expect(() => storage.getItem("tel-err-key")).not.toThrow();
 
     const getMarks = marks.filter((m) => m.mark === "persistence_localstorage_get");
-    expect(getMarks.length).toBeGreaterThanOrEqual(1);
-    const failing = getMarks.find((m) => m.meta?.ok === false);
-    expect(failing).toBeDefined();
-    expect(failing?.meta?.key).toBe("tel-err-key");
-    expect(typeof failing?.meta?.durationMs).toBe("number");
-    expect(failing?.meta?.payloadBytes).toBeNull();
+    expect(getMarks).toHaveLength(1);
+    const meta = getMarks[0]?.meta ?? {};
+    expect(meta.key).toBe("tel-err-key");
+    expect(meta.ok).toBe(false);
+    expect(meta.storage).toBe("localStorage");
+    expect(meta.payloadBytes).toBeNull();
+    expect(typeof meta.durationMs).toBe("number");
+    expect(Number.isFinite(meta.durationMs as number)).toBe(true);
+  });
+
+  it("createResilientStorage flips storage to 'memory' and stops hitting broken localStorage after fallback", async () => {
+    const throwingSetItem = vi.fn(() => {
+      throw new Error("QuotaExceededError");
+    });
+    installLocalStorage(
+      createStorageMock({
+        setItem: throwingSetItem,
+      })
+    );
+    const marks = seedPerfMarks();
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("fallback-key", { state: { value: 1 }, version: 1 });
+    storage.setItem("fallback-key-2", { state: { value: 2 }, version: 1 });
+
+    const setMarks = marks.filter((m) => m.mark === "persistence_localstorage_set");
+    expect(setMarks).toHaveLength(2);
+    expect(setMarks[0]?.meta?.storage).toBe("localStorage");
+    expect(setMarks[0]?.meta?.ok).toBe(false);
+    expect(setMarks[1]?.meta?.storage).toBe("memory");
+    expect(setMarks[1]?.meta?.ok).toBe(true);
+
+    // Broken localStorage.setItem must only be called once — fallback sticks
+    expect(throwingSetItem).toHaveBeenCalledTimes(1);
+
+    // Subsequent reads of the in-memory value also emit storage:'memory'
+    storage.getItem("fallback-key");
+    const getMarks = marks.filter((m) => m.mark === "persistence_localstorage_get");
+    expect(getMarks).toHaveLength(1);
+    expect(getMarks[0]?.meta?.storage).toBe("memory");
+    expect(getMarks[0]?.meta?.ok).toBe(true);
   });
 
   it("createResilientStorage emits no marks when DAINTREE_PERF_MARKS is absent and capture is disabled", async () => {

--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -54,8 +54,25 @@ function createStorageMock(overrides: Partial<StorageMock> = {}): StorageMock {
   };
 }
 
+type PerfMarkRecord = {
+  mark: string;
+  meta?: Record<string, unknown>;
+};
+
+function seedPerfMarks(): PerfMarkRecord[] {
+  const buffer: PerfMarkRecord[] = [];
+  (window as Window & typeof globalThis).__DAINTREE_PERF_MARKS__ =
+    buffer as unknown as typeof window.__DAINTREE_PERF_MARKS__;
+  return buffer;
+}
+
+function clearPerfMarks(): void {
+  delete (window as Window & typeof globalThis).__DAINTREE_PERF_MARKS__;
+}
+
 afterEach(() => {
   restoreLocalStorage();
+  clearPerfMarks();
   vi.resetModules();
   vi.restoreAllMocks();
 });
@@ -277,5 +294,106 @@ describe("persistence boundary hardening", () => {
       (call) => (call[1] as Record<string, unknown> | undefined)?.store === "cliAvailabilityStore"
     );
     expect(matching).toBeDefined();
+  });
+
+  it("createResilientStorage emits a set mark with ok:true on successful write", async () => {
+    installLocalStorage(createStorageMock());
+    const marks = seedPerfMarks();
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("tel-set-key", { state: { value: 42 }, version: 1 });
+
+    const setMarks = marks.filter((m) => m.mark === "persistence_localstorage_set");
+    expect(setMarks).toHaveLength(1);
+    const meta = setMarks[0]?.meta ?? {};
+    expect(meta.key).toBe("tel-set-key");
+    expect(meta.ok).toBe(true);
+    expect(typeof meta.durationMs).toBe("number");
+    expect(typeof meta.payloadBytes).toBe("number");
+    expect((meta.payloadBytes as number) > 0).toBe(true);
+  });
+
+  it("createResilientStorage emits a get mark with ok:true on successful read", async () => {
+    installLocalStorage(createStorageMock());
+    const marks = seedPerfMarks();
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+    storage.setItem("tel-get-key", { state: { value: 1 }, version: 1 });
+    marks.length = 0;
+
+    storage.getItem("tel-get-key");
+
+    const getMarks = marks.filter((m) => m.mark === "persistence_localstorage_get");
+    expect(getMarks).toHaveLength(1);
+    const meta = getMarks[0]?.meta ?? {};
+    expect(meta.key).toBe("tel-get-key");
+    expect(meta.ok).toBe(true);
+    expect(typeof meta.durationMs).toBe("number");
+    expect(typeof meta.payloadBytes).toBe("number");
+    expect((meta.payloadBytes as number) > 0).toBe(true);
+  });
+
+  it("createResilientStorage emits a set mark with ok:false when localStorage.setItem throws", async () => {
+    installLocalStorage(
+      createStorageMock({
+        setItem: () => {
+          throw new Error("QuotaExceededError");
+        },
+      })
+    );
+    const marks = seedPerfMarks();
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    expect(() => {
+      storage.setItem("tel-fail-key", { state: { value: 9 }, version: 1 });
+    }).not.toThrow();
+
+    const setMarks = marks.filter((m) => m.mark === "persistence_localstorage_set");
+    expect(setMarks).toHaveLength(1);
+    const meta = setMarks[0]?.meta ?? {};
+    expect(meta.key).toBe("tel-fail-key");
+    expect(meta.ok).toBe(false);
+    expect(typeof meta.durationMs).toBe("number");
+  });
+
+  it("createResilientStorage emits a get mark with ok:false when localStorage.getItem throws", async () => {
+    installLocalStorage(
+      createStorageMock({
+        getItem: () => {
+          throw new Error("SecurityError");
+        },
+      })
+    );
+    const marks = seedPerfMarks();
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    expect(() => storage.getItem("tel-err-key")).not.toThrow();
+
+    const getMarks = marks.filter((m) => m.mark === "persistence_localstorage_get");
+    expect(getMarks.length).toBeGreaterThanOrEqual(1);
+    const failing = getMarks.find((m) => m.meta?.ok === false);
+    expect(failing).toBeDefined();
+    expect(failing?.meta?.key).toBe("tel-err-key");
+    expect(typeof failing?.meta?.durationMs).toBe("number");
+    expect(failing?.meta?.payloadBytes).toBeNull();
+  });
+
+  it("createResilientStorage emits no marks when DAINTREE_PERF_MARKS is absent and capture is disabled", async () => {
+    installLocalStorage(createStorageMock());
+
+    const { createSafeJSONStorage } = await import("../persistence/safeStorage");
+    const storage = createSafeJSONStorage<{ value: number }>();
+
+    storage.setItem("no-mark-key", { state: { value: 5 }, version: 1 });
+    storage.getItem("no-mark-key");
+
+    expect((window as Window & typeof globalThis).__DAINTREE_PERF_MARKS__).toBeUndefined();
   });
 });

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -67,6 +67,8 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
     getItem: (name) => {
       const collectPerf = shouldCollectPersistencePerf();
       const startedAt = collectPerf ? perfNow() : 0;
+      const storage: "localStorage" | "memory" =
+        activeStorage === memoryStorage ? "memory" : "localStorage";
       try {
         const value = activeStorage.getItem(name);
         if (collectPerf && !(value instanceof Promise)) {
@@ -75,6 +77,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
             payloadBytes: estimateStringBytes(value),
             durationMs: Number((perfNow() - startedAt).toFixed(3)),
             ok: true,
+            storage,
           });
         }
         return value;
@@ -85,6 +88,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
             payloadBytes: null,
             durationMs: Number((perfNow() - startedAt).toFixed(3)),
             ok: false,
+            storage,
           });
         }
         return switchToMemoryStorage().getItem(name);
@@ -94,6 +98,8 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
       const collectPerf = shouldCollectPersistencePerf();
       const startedAt = collectPerf ? perfNow() : 0;
       const payloadBytes = collectPerf ? estimateStringBytes(value) : null;
+      const storage: "localStorage" | "memory" =
+        activeStorage === memoryStorage ? "memory" : "localStorage";
       try {
         activeStorage.setItem(name, value);
         if (collectPerf) {
@@ -102,6 +108,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
             payloadBytes,
             durationMs: Number((perfNow() - startedAt).toFixed(3)),
             ok: true,
+            storage,
           });
         }
       } catch {
@@ -111,6 +118,7 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
             payloadBytes,
             durationMs: Number((perfNow() - startedAt).toFixed(3)),
             ok: false,
+            storage,
           });
         }
         switchToMemoryStorage().setItem(name, value);

--- a/src/store/persistence/safeStorage.ts
+++ b/src/store/persistence/safeStorage.ts
@@ -1,6 +1,27 @@
 import type { PersistStorage, StateStorage, StorageValue } from "zustand/middleware";
+import { isRendererPerfCaptureEnabled, markRendererPerformance } from "@/utils/performance";
 
 const fallbackStorageData = new Map<string, string>();
+
+function shouldCollectPersistencePerf(): boolean {
+  if (typeof window === "undefined") return false;
+  return isRendererPerfCaptureEnabled() || Array.isArray(window.__DAINTREE_PERF_MARKS__);
+}
+
+const PERF_TEXT_ENCODER = new TextEncoder();
+
+function estimateStringBytes(value: string | null): number | null {
+  if (value === null) return null;
+  try {
+    return PERF_TEXT_ENCODER.encode(value).length;
+  } catch {
+    return null;
+  }
+}
+
+function perfNow(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
 
 const memoryStorage: StateStorage = {
   getItem: (name) => fallbackStorageData.get(name) ?? null,
@@ -44,16 +65,54 @@ function createResilientStorage(baseStorage: StateStorage | undefined): StateSto
 
   return {
     getItem: (name) => {
+      const collectPerf = shouldCollectPersistencePerf();
+      const startedAt = collectPerf ? perfNow() : 0;
       try {
-        return activeStorage.getItem(name);
+        const value = activeStorage.getItem(name);
+        if (collectPerf && !(value instanceof Promise)) {
+          markRendererPerformance("persistence_localstorage_get", {
+            key: name,
+            payloadBytes: estimateStringBytes(value),
+            durationMs: Number((perfNow() - startedAt).toFixed(3)),
+            ok: true,
+          });
+        }
+        return value;
       } catch {
+        if (collectPerf) {
+          markRendererPerformance("persistence_localstorage_get", {
+            key: name,
+            payloadBytes: null,
+            durationMs: Number((perfNow() - startedAt).toFixed(3)),
+            ok: false,
+          });
+        }
         return switchToMemoryStorage().getItem(name);
       }
     },
     setItem: (name, value) => {
+      const collectPerf = shouldCollectPersistencePerf();
+      const startedAt = collectPerf ? perfNow() : 0;
+      const payloadBytes = collectPerf ? estimateStringBytes(value) : null;
       try {
         activeStorage.setItem(name, value);
+        if (collectPerf) {
+          markRendererPerformance("persistence_localstorage_set", {
+            key: name,
+            payloadBytes,
+            durationMs: Number((perfNow() - startedAt).toFixed(3)),
+            ok: true,
+          });
+        }
       } catch {
+        if (collectPerf) {
+          markRendererPerformance("persistence_localstorage_set", {
+            key: name,
+            payloadBytes,
+            durationMs: Number((perfNow() - startedAt).toFixed(3)),
+            ok: false,
+          });
+        }
         switchToMemoryStorage().setItem(name, value);
       }
     },


### PR DESCRIPTION
## Summary

- Instruments `createResilientStorage` in `src/store/persistence/safeStorage.ts` with `markRendererPerformance` marks for every `getItem` and `setItem` call, capturing key, payload size in bytes, duration, success/failure, and which storage backend (`localStorage` or `memory`) actually handled the call.
- The `storage` field is captured before `switchToMemoryStorage` can flip, so post-fallback calls correctly report `'memory'` rather than the original backend.
- Gated behind `shouldCollectPersistencePerf()` so there's zero overhead when telemetry capture is disabled. Instrumented at the resilient layer only to avoid double-counting calls from `createSafeJSONStorage`.

Resolves #5186

## Changes

- `src/store/persistence/safeStorage.ts` — perf mark instrumentation on `getItem`/`setItem` with `{key, payloadBytes, durationMs, ok, storage}` meta
- `src/store/persistence/__tests__/persistenceBoundaryHardening.test.ts` — 6 new Vitest cases covering ok:true/false reads and writes, fallback-sticks regression, and no-marks-when-disabled

## Testing

19/19 tests pass. Covers the happy path (marks emitted with correct fields), error path (ok:false on quota/security errors), fallback regression (memory backend correctly labelled after localStorage throws), and the disabled path (no marks when the perf gate is off).