### PR TITLE
perf(store): lazy-load migration modules when schema is current

### DIFF
--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -2,6 +2,8 @@ import Store from "electron-store";
 import type { StoreSchema } from "../store.js";
 import fs from "fs";
 
+export const LATEST_SCHEMA_VERSION = 14;
+
 export interface Migration {
   version: number;
   description: string;

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -2,8 +2,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
+
+// The migrations barrel transitively imports modules that touch `electron.app`
+// at module load (ProjectStore in migration003). Mock it before the barrel
+// import so the drift-guard test can read the full migrations list.
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => os.tmpdir()),
+    on: vi.fn(),
+    getName: vi.fn(() => "daintree-test"),
+  },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), removeAllListeners: vi.fn() },
+}));
+
 import type { Migration } from "../StoreMigrations.js";
-import { MigrationRunner } from "../StoreMigrations.js";
+import { LATEST_SCHEMA_VERSION, MigrationRunner } from "../StoreMigrations.js";
+import { migrations } from "../migrations/index.js";
 import { migration004 } from "../migrations/004-upgrade-correction-model.js";
 import { migration006 } from "../migrations/006-rename-theme-canopy-to-daintree.js";
 import { migration007 } from "../migrations/007-reduce-default-terminal-scrollback.js";
@@ -392,6 +407,11 @@ describe("MigrationRunner", () => {
       const after2 = store.data.notificationSettings as Record<string, unknown>;
       expect(after2).toEqual(after1);
     });
+  });
+
+  it("LATEST_SCHEMA_VERSION matches the highest version in the migrations barrel", () => {
+    const highest = Math.max(...migrations.map((m) => m.version));
+    expect(LATEST_SCHEMA_VERSION).toBe(highest);
   });
 
   it("does nothing when there are no pending migrations", async () => {

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -22,8 +22,7 @@ import { ProjectSwitchService } from "../services/ProjectSwitchService.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { taskQueueService } from "../services/TaskQueueService.js";
 import { store } from "../store.js";
-import { MigrationRunner } from "../services/StoreMigrations.js";
-import { migrations } from "../services/migrations/index.js";
+import { LATEST_SCHEMA_VERSION, MigrationRunner } from "../services/StoreMigrations.js";
 import { initializeTelemetry } from "../services/TelemetryService.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { secureStorage } from "../services/SecureStorage.js";
@@ -282,12 +281,20 @@ export async function setupWindowServices(
     globalServicesInitialized = true;
     markPerformance(PERF_MARKS.SERVICE_INIT_START);
 
-    // Store migrations
-    console.log("[MAIN] Running store migrations...");
+    // Store migrations — lazy-load the migrations barrel only when the store is
+    // out of sync with the latest schema version. In the common case (already up
+    // to date), this skips parsing ~15KB of migration modules on startup.
     try {
       const migrationRunner = new MigrationRunner(store);
-      await migrationRunner.runMigrations(migrations);
-      console.log("[MAIN] Store migrations completed");
+      const currentVersion = migrationRunner.getCurrentVersion();
+      if (currentVersion !== LATEST_SCHEMA_VERSION) {
+        console.log(
+          `[MAIN] Running store migrations (v${currentVersion} -> v${LATEST_SCHEMA_VERSION})...`
+        );
+        const { migrations } = await import("../services/migrations/index.js");
+        await migrationRunner.runMigrations(migrations);
+        console.log("[MAIN] Store migrations completed");
+      }
       markPerformance(PERF_MARKS.SERVICE_INIT_MIGRATIONS_DONE);
     } catch (error) {
       console.error("[MAIN] Store migration failed:", error);


### PR DESCRIPTION
## Summary

- Adds `LATEST_SCHEMA_VERSION = 14` to `StoreMigrations.ts` and gates the migrations import behind a version check, so the 13 migration modules are only loaded when a migration is actually pending.
- Replaces the static `import { migrations }` in `windowServices.ts` with a dynamic `await import()` inside the existing try/catch, preserving the "newer than supported" throw for downgraded stores.
- Adds a drift-guard unit test asserting `LATEST_SCHEMA_VERSION` equals `Math.max(...migrations.map(m => m.version))`, so forgetting to bump the constant is caught at test time.

Verified via `npm run build:main` that esbuild splits the migrations into a separate `chunks/migrations-*.js` (~5.8KB) chunk referenced only via dynamic import from `main.js`. Up-to-date users pay zero parse cost for migrations.

Resolves #5311.

## Changes

- `electron/services/StoreMigrations.ts` — export `LATEST_SCHEMA_VERSION = 14`
- `electron/window/windowServices.ts` — remove static migrations import, gate dynamic import on `currentVersion !== LATEST_SCHEMA_VERSION`
- `electron/services/__tests__/StoreMigrations.test.ts` — add drift-guard assertion

## Testing

Unit tests pass. Build confirmed to produce a separate migrations chunk, so the lazy-load works end-to-end in the packaged bundle.