### PR TITLE
test(a11y): raise axe audit to WCAG 2.1 and 2.2 AA tags

### DIFF
--- a/e2e/full/core-accessibility.spec.ts
+++ b/e2e/full/core-accessibility.spec.ts
@@ -17,6 +17,8 @@ function buildAxeScanner(page: import("@playwright/test").Page) {
     new AxeBuilder({ page })
       .setLegacyMode(true) // Required for Electron — default mode uses Target.createTarget which Electron doesn't support
       // axe WCAG tags are non-hierarchical; retain 2.0 tags alongside 2.1/2.2 tags.
+      // Note: in axe-core 4.11 the only 2.2 AA rule (target-size) is disabled by default
+      // and would need .enableRules(["target-size"]) to fire.
       .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
       .disableRules([
         // aria-command-name: Radix UI renders div[role="button"] without accessible names

--- a/e2e/full/core-accessibility.spec.ts
+++ b/e2e/full/core-accessibility.spec.ts
@@ -13,22 +13,25 @@ let ctx: AppContext;
 const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 function buildAxeScanner(page: import("@playwright/test").Page) {
-  return new AxeBuilder({ page })
-    .setLegacyMode(true) // Required for Electron — default mode uses Target.createTarget which Electron doesn't support
-    .withTags(["wcag2a", "wcag2aa"])
-    .disableRules([
-      // aria-command-name: Radix UI renders div[role="button"] without accessible names
-      // on internal menu primitives. Third-party issue, not fixable without upstream changes.
-      "aria-command-name",
-      // color-contrast: Dark theme color ratios are intentional design choices. xterm.js
-      // canvas content also triggers false positives. Fires across the entire app, so
-      // .exclude() on individual selectors is impractical.
-      "color-contrast",
-      // nested-interactive: Worktree cards wrap real <button> descendants in a
-      // role="button" container (WorktreeCard, WorktreeDetailsSection, FileStageRow).
-      // Fixing this requires restructuring the card components, which is out of scope.
-      "nested-interactive",
-    ]);
+  return (
+    new AxeBuilder({ page })
+      .setLegacyMode(true) // Required for Electron — default mode uses Target.createTarget which Electron doesn't support
+      // axe WCAG tags are non-hierarchical; retain 2.0 tags alongside 2.1/2.2 tags.
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+      .disableRules([
+        // aria-command-name: Radix UI renders div[role="button"] without accessible names
+        // on internal menu primitives. Third-party issue, not fixable without upstream changes.
+        "aria-command-name",
+        // color-contrast: Dark theme color ratios are intentional design choices. xterm.js
+        // canvas content also triggers false positives. Fires across the entire app, so
+        // .exclude() on individual selectors is impractical.
+        "color-contrast",
+        // nested-interactive: Worktree cards wrap real <button> descendants in a
+        // role="button" container (WorktreeCard, WorktreeDetailsSection, FileStageRow).
+        // Fixing this requires restructuring the card components, which is out of scope.
+        "nested-interactive",
+      ])
+  );
 }
 
 function formatViolations(violations: import("axe-core").Result[]): string {
@@ -49,10 +52,10 @@ test.describe.serial("Core: Accessibility", () => {
     if (ctx?.app) await closeApp(ctx.app);
   });
 
-  // -- Axe WCAG 2.0 AA Audits --
+  // -- Axe WCAG 2.2 AA Audits --
 
   test.describe.serial("Axe Audits", () => {
-    test("welcome screen passes WCAG 2.0 AA audit", async () => {
+    test("welcome screen passes WCAG 2.2 AA audit", async () => {
       const { window } = ctx;
       await window.getByRole("button", { name: "Open Folder" }).waitFor({
         state: "visible",
@@ -74,7 +77,7 @@ test.describe.serial("Core: Accessibility", () => {
         );
       });
 
-      test("worktree dashboard passes WCAG 2.0 AA audit", async () => {
+      test("worktree dashboard passes WCAG 2.2 AA audit", async () => {
         const { window } = ctx;
         await window
           .locator("[data-worktree-branch]")
@@ -85,7 +88,7 @@ test.describe.serial("Core: Accessibility", () => {
         expect(results.violations, formatViolations(results.violations)).toEqual([]);
       });
 
-      test("settings dialog passes WCAG 2.0 AA audit", async () => {
+      test("settings dialog passes WCAG 2.2 AA audit", async () => {
         const { window } = ctx;
 
         await openSettings(window);
@@ -98,7 +101,7 @@ test.describe.serial("Core: Accessibility", () => {
         await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
       });
 
-      test("terminal panel passes WCAG 2.0 AA audit", async () => {
+      test("terminal panel passes WCAG 2.2 AA audit", async () => {
         const { window } = ctx;
         const before = await getGridPanelCount(window);
 
@@ -122,7 +125,7 @@ test.describe.serial("Core: Accessibility", () => {
         await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(before);
       });
 
-      test("action palette passes WCAG 2.0 AA audit", async () => {
+      test("action palette passes WCAG 2.2 AA audit", async () => {
         const { window } = ctx;
 
         await window.keyboard.press(`${mod}+Shift+P`);
@@ -142,7 +145,7 @@ test.describe.serial("Core: Accessibility", () => {
         });
       });
 
-      test("quick switcher passes WCAG 2.0 AA audit", async () => {
+      test("quick switcher passes WCAG 2.2 AA audit", async () => {
         const { window } = ctx;
 
         await window.keyboard.press(`${mod}+P`);


### PR DESCRIPTION
## Summary

- Expanded `buildAxeScanner` `withTags` from `["wcag2a", "wcag2aa"]` to include `wcag21a`, `wcag21aa`, and `wcag22aa`, bringing the automated check in line with WCAG 2.2 AA as the documented compliance target. axe-core tags are non-hierarchical, so all older tags are retained alongside the new ones.
- Updated 7 occurrences of "WCAG 2.0 AA" in test names and a section comment to "WCAG 2.2 AA" for consistency.
- Added an inline guardrail comment explaining why all tags are listed explicitly, and noting that axe-core 4.11's only WCAG 2.2 AA rule (`target-size`) is disabled by default.

Resolves #5239

## Changes

- `e2e/full/core-accessibility.spec.ts`: single call-site change to `withTags`, plus test name and comment updates

## Testing

This test lives in `e2e/full/` which runs nightly. Any violations newly surfaced by the expanded WCAG 2.1/2.2 rule set will show up in the next nightly run. The existing `disableRules` entries (`aria-command-name`, `color-contrast`, `nested-interactive`) are untouched. Per the issue acceptance criteria, any net-new violations can either be fixed or added to `disableRules` with a justification comment.