### PR TITLE
feat(plugin): per-plugin unregister for contribution registries

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -6,9 +6,15 @@ import { app } from "electron";
 import * as semver from "semver";
 import { PluginManifestSchema } from "../schemas/plugin.js";
 import type { PluginManifest, PluginIpcHandler } from "../../shared/types/plugin.js";
-import { registerPanelKind } from "../../shared/config/panelKindRegistry.js";
-import { registerToolbarButton } from "../../shared/config/toolbarButtonRegistry.js";
-import { registerPluginMenuItem } from "./pluginMenuRegistry.js";
+import {
+  registerPanelKind,
+  unregisterPluginPanelKinds,
+} from "../../shared/config/panelKindRegistry.js";
+import {
+  registerToolbarButton,
+  unregisterPluginToolbarButtons,
+} from "../../shared/config/toolbarButtonRegistry.js";
+import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
@@ -233,6 +239,15 @@ export class PluginService {
         this.handlerMap.delete(key);
       }
     }
+  }
+
+  unloadPlugin(pluginId: string): void {
+    if (!this.plugins.has(pluginId)) return;
+    this.removeHandlers(pluginId);
+    unregisterPluginMenuItems(pluginId);
+    unregisterPluginToolbarButtons(pluginId);
+    unregisterPluginPanelKinds(pluginId);
+    this.plugins.delete(pluginId);
   }
 
   listPlugins(): LoadedPluginInfo[] {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -16,18 +16,27 @@ vi.mock("../../ipc/utils.js", () => ({
 }));
 vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
   registerPanelKind: vi.fn(),
+  unregisterPluginPanelKinds: vi.fn(),
 }));
 vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
   registerToolbarButton: vi.fn(),
+  unregisterPluginToolbarButtons: vi.fn(),
 }));
 vi.mock("../pluginMenuRegistry.js", () => ({
   registerPluginMenuItem: vi.fn(),
+  unregisterPluginMenuItems: vi.fn(),
 }));
 
 import { PluginService } from "../PluginService.js";
-import { registerPanelKind } from "../../../shared/config/panelKindRegistry.js";
-import { registerToolbarButton } from "../../../shared/config/toolbarButtonRegistry.js";
-import { registerPluginMenuItem } from "../pluginMenuRegistry.js";
+import {
+  registerPanelKind,
+  unregisterPluginPanelKinds,
+} from "../../../shared/config/panelKindRegistry.js";
+import {
+  registerToolbarButton,
+  unregisterPluginToolbarButtons,
+} from "../../../shared/config/toolbarButtonRegistry.js";
+import { registerPluginMenuItem, unregisterPluginMenuItems } from "../pluginMenuRegistry.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
 let tmpDir: string;
@@ -719,5 +728,114 @@ describe("engines.daintree compatibility gate", () => {
 
     expect(service.listPlugins()).toEqual([]);
     expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Plugin unload lifecycle", () => {
+  it("unloadPlugin calls all registry unregister functions for the plugin", async () => {
+    await writePlugin("unloadable", {
+      name: "unloadable",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
+        toolbarButtons: [{ id: "btn", label: "Btn", iconId: "icon", actionId: "x.y" }],
+        menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+      },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(service.hasPlugin("unloadable")).toBe(true);
+
+    service.unloadPlugin("unloadable");
+
+    expect(unregisterPluginMenuItems).toHaveBeenCalledWith("unloadable");
+    expect(unregisterPluginToolbarButtons).toHaveBeenCalledWith("unloadable");
+    expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("unloadable");
+  });
+
+  it("unloadPlugin removes the plugin from hasPlugin and listPlugins", async () => {
+    await writePlugin("goodbye", { name: "goodbye", version: "1.0.0" });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    expect(service.hasPlugin("goodbye")).toBe(true);
+
+    service.unloadPlugin("goodbye");
+
+    expect(service.hasPlugin("goodbye")).toBe(false);
+    expect(service.listPlugins()).toEqual([]);
+  });
+
+  it("unloadPlugin removes IPC handlers registered for the plugin", async () => {
+    await writePlugin("handler-host", { name: "handler-host", version: "1.0.0" });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    service.registerHandler("handler-host", "ping", () => "pong");
+    expect(await service.dispatchHandler("handler-host", "ping", [])).toBe("pong");
+
+    service.unloadPlugin("handler-host");
+
+    await expect(service.dispatchHandler("handler-host", "ping", [])).rejects.toThrow(
+      "No plugin handler registered for handler-host:ping"
+    );
+  });
+
+  it("unloadPlugin is a no-op when the plugin is not loaded", async () => {
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    expect(() => service.unloadPlugin("never-loaded")).not.toThrow();
+    expect(unregisterPluginMenuItems).not.toHaveBeenCalled();
+    expect(unregisterPluginToolbarButtons).not.toHaveBeenCalled();
+    expect(unregisterPluginPanelKinds).not.toHaveBeenCalled();
+  });
+
+  it("unloadPlugin is idempotent across repeated calls", async () => {
+    await writePlugin("twice", { name: "twice", version: "1.0.0" });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    service.unloadPlugin("twice");
+    expect(service.hasPlugin("twice")).toBe(false);
+
+    // Second call finds nothing to remove and stays silent.
+    service.unloadPlugin("twice");
+    expect(unregisterPluginMenuItems).toHaveBeenCalledTimes(1);
+    expect(unregisterPluginToolbarButtons).toHaveBeenCalledTimes(1);
+    expect(unregisterPluginPanelKinds).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports load → unload → reload lifecycle via fresh service instance", async () => {
+    await writePlugin("lifecycle", {
+      name: "lifecycle",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
+      },
+    });
+
+    const first = new PluginService(tmpDir);
+    await first.initialize();
+    expect(registerPanelKind).toHaveBeenCalledTimes(1);
+
+    first.unloadPlugin("lifecycle");
+    expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("lifecycle");
+    expect(first.hasPlugin("lifecycle")).toBe(false);
+
+    // A fresh service instance re-reads the plugin directory and re-registers.
+    vi.clearAllMocks();
+    const second = new PluginService(tmpDir);
+    await second.initialize();
+
+    expect(second.hasPlugin("lifecycle")).toBe(true);
+    expect(registerPanelKind).toHaveBeenCalledTimes(1);
+    expect(registerPanelKind).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "lifecycle.viewer", extensionId: "lifecycle" })
+    );
   });
 });

--- a/electron/services/__tests__/pluginMenuRegistry.test.ts
+++ b/electron/services/__tests__/pluginMenuRegistry.test.ts
@@ -46,6 +46,13 @@ describe("pluginMenuRegistry", () => {
     expect(getPluginMenuItems()).toHaveLength(1);
   });
 
+  it("is a no-op for empty or non-string pluginId (defensive input guard)", () => {
+    registerPluginMenuItem("plugin-a", makeItem("A1"));
+    expect(() => unregisterPluginMenuItems("")).not.toThrow();
+    expect(() => unregisterPluginMenuItems(undefined as unknown as string)).not.toThrow();
+    expect(getPluginMenuItems()).toHaveLength(1);
+  });
+
   it("is a no-op when unregistering the same plugin twice", () => {
     registerPluginMenuItem("plugin-a", makeItem("A1"));
     unregisterPluginMenuItems("plugin-a");

--- a/electron/services/__tests__/pluginMenuRegistry.test.ts
+++ b/electron/services/__tests__/pluginMenuRegistry.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { MenuItemContribution } from "../../../shared/types/plugin.js";
+import {
+  clearPluginMenuRegistry,
+  getPluginMenuItems,
+  registerPluginMenuItem,
+  unregisterPluginMenuItems,
+} from "../pluginMenuRegistry.js";
+
+beforeEach(() => {
+  clearPluginMenuRegistry();
+});
+
+const makeItem = (label: string): MenuItemContribution => ({
+  label,
+  actionId: `test.${label.toLowerCase().replace(/\s+/g, "-")}`,
+  location: "terminal",
+});
+
+describe("pluginMenuRegistry", () => {
+  it("registers items under a plugin and retrieves them", () => {
+    registerPluginMenuItem("plugin-a", makeItem("Open"));
+    registerPluginMenuItem("plugin-a", makeItem("Close"));
+
+    const items = getPluginMenuItems();
+    expect(items).toHaveLength(2);
+    expect(items.every((entry) => entry.pluginId === "plugin-a")).toBe(true);
+  });
+
+  it("unregisters only the target plugin's items", () => {
+    registerPluginMenuItem("plugin-a", makeItem("A1"));
+    registerPluginMenuItem("plugin-a", makeItem("A2"));
+    registerPluginMenuItem("plugin-b", makeItem("B1"));
+
+    unregisterPluginMenuItems("plugin-a");
+
+    const items = getPluginMenuItems();
+    expect(items).toHaveLength(1);
+    expect(items[0].pluginId).toBe("plugin-b");
+    expect(items[0].item.label).toBe("B1");
+  });
+
+  it("is a no-op when unregistering an unknown pluginId", () => {
+    registerPluginMenuItem("plugin-a", makeItem("A1"));
+    expect(() => unregisterPluginMenuItems("never-loaded")).not.toThrow();
+    expect(getPluginMenuItems()).toHaveLength(1);
+  });
+
+  it("is a no-op when unregistering the same plugin twice", () => {
+    registerPluginMenuItem("plugin-a", makeItem("A1"));
+    unregisterPluginMenuItems("plugin-a");
+    expect(() => unregisterPluginMenuItems("plugin-a")).not.toThrow();
+    expect(getPluginMenuItems()).toHaveLength(0);
+  });
+
+  it("supports register → unregister → re-register round-trip", () => {
+    registerPluginMenuItem("plugin-a", makeItem("Initial"));
+    unregisterPluginMenuItems("plugin-a");
+    expect(getPluginMenuItems()).toHaveLength(0);
+
+    registerPluginMenuItem("plugin-a", makeItem("Fresh"));
+    const items = getPluginMenuItems();
+    expect(items).toHaveLength(1);
+    expect(items[0].item.label).toBe("Fresh");
+  });
+
+  it("clearPluginMenuRegistry removes all plugins' items", () => {
+    registerPluginMenuItem("plugin-a", makeItem("A"));
+    registerPluginMenuItem("plugin-b", makeItem("B"));
+
+    clearPluginMenuRegistry();
+    expect(getPluginMenuItems()).toHaveLength(0);
+  });
+});

--- a/electron/services/pluginMenuRegistry.ts
+++ b/electron/services/pluginMenuRegistry.ts
@@ -19,6 +19,7 @@ export function getPluginMenuItems(): Array<{ pluginId: string; item: MenuItemCo
 }
 
 export function unregisterPluginMenuItems(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
   PLUGIN_MENU_ITEMS.delete(pluginId);
 }
 

--- a/electron/services/pluginMenuRegistry.ts
+++ b/electron/services/pluginMenuRegistry.ts
@@ -18,6 +18,10 @@ export function getPluginMenuItems(): Array<{ pluginId: string; item: MenuItemCo
   return result;
 }
 
+export function unregisterPluginMenuItems(pluginId: string): void {
+  PLUGIN_MENU_ITEMS.delete(pluginId);
+}
+
 export function clearPluginMenuRegistry(): void {
   PLUGIN_MENU_ITEMS.clear();
 }

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -80,10 +80,13 @@ describe("unregisterPluginPanelKinds", () => {
   it("never removes built-in panel kinds", () => {
     registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
 
-    // Calling with any plugin ID (even matching no entries) must preserve built-ins.
+    // Calling with any plugin ID (even matching no entries, empty string, or
+    // a typecast undefined) must preserve built-ins. The input guard blocks the
+    // dangerous `undefined` case where built-ins' extensionId is also undefined.
     unregisterPluginPanelKinds("ext-a");
     unregisterPluginPanelKinds("never-loaded");
     unregisterPluginPanelKinds("");
+    unregisterPluginPanelKinds(undefined as unknown as string);
 
     for (const kind of BUILT_IN_KINDS) {
       const config = getPanelKindConfig(kind);

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -1,8 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   getPanelKindConfig,
   getExtensionFallbackDefaults,
+  getPanelKindIds,
   panelKindUsesTerminalUi,
+  registerPanelKind,
+  unregisterPluginPanelKinds,
+  type PanelKindConfig,
 } from "../panelKindRegistry.js";
 
 describe("panelKindRegistry metadata", () => {
@@ -38,5 +42,86 @@ describe("panelKindRegistry metadata", () => {
 
   it("returns undefined for unknown kind", () => {
     expect(getPanelKindConfig("unknown-kind")).toBeUndefined();
+  });
+});
+
+const BUILT_IN_KINDS = ["terminal", "agent", "browser", "notes", "dev-preview"] as const;
+
+const makeExtensionConfig = (id: string, extensionId: string): PanelKindConfig => ({
+  id,
+  name: `${extensionId}:${id}`,
+  iconId: "puzzle",
+  color: "#123456",
+  hasPty: false,
+  canRestart: false,
+  canConvert: false,
+  extensionId,
+});
+
+describe("unregisterPluginPanelKinds", () => {
+  // Use afterEach so cleanup still runs when a test fails.
+  afterEach(() => {
+    unregisterPluginPanelKinds("ext-a");
+    unregisterPluginPanelKinds("ext-b");
+  });
+
+  it("removes only entries owned by the target plugin", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.one", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-a.two", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-b.three", "ext-b"));
+
+    unregisterPluginPanelKinds("ext-a");
+
+    expect(getPanelKindConfig("ext-a.one")).toBeUndefined();
+    expect(getPanelKindConfig("ext-a.two")).toBeUndefined();
+    expect(getPanelKindConfig("ext-b.three")?.extensionId).toBe("ext-b");
+  });
+
+  it("never removes built-in panel kinds", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+
+    // Calling with any plugin ID (even matching no entries) must preserve built-ins.
+    unregisterPluginPanelKinds("ext-a");
+    unregisterPluginPanelKinds("never-loaded");
+    unregisterPluginPanelKinds("");
+
+    for (const kind of BUILT_IN_KINDS) {
+      const config = getPanelKindConfig(kind);
+      expect(config, `built-in panel kind "${kind}" must survive unregister`).toBeDefined();
+      expect(config!.id).toBe(kind);
+      expect(config!.extensionId).toBeUndefined();
+    }
+  });
+
+  it("is a no-op when unregistering an unknown pluginId", () => {
+    const before = getPanelKindIds().length;
+    expect(() => unregisterPluginPanelKinds("never-loaded")).not.toThrow();
+    expect(getPanelKindIds()).toHaveLength(before);
+  });
+
+  it("is a no-op when unregistering the same plugin twice", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    unregisterPluginPanelKinds("ext-a");
+    expect(() => unregisterPluginPanelKinds("ext-a")).not.toThrow();
+    expect(getPanelKindConfig("ext-a.viewer")).toBeUndefined();
+  });
+
+  it("supports register → unregister → re-register round-trip", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    unregisterPluginPanelKinds("ext-a");
+    expect(getPanelKindConfig("ext-a.viewer")).toBeUndefined();
+
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), name: "Refreshed" });
+    expect(getPanelKindConfig("ext-a.viewer")?.name).toBe("Refreshed");
+  });
+
+  it("leaves other plugins' entries intact when one plugin is unregistered", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.panel", "ext-a"));
+    registerPanelKind(makeExtensionConfig("ext-b.panel", "ext-b"));
+
+    unregisterPluginPanelKinds("ext-a");
+
+    expect(getPanelKindConfig("ext-a.panel")).toBeUndefined();
+    expect(getPanelKindConfig("ext-b.panel")?.extensionId).toBe("ext-b");
   });
 });

--- a/shared/config/__tests__/toolbarButtonRegistry.test.ts
+++ b/shared/config/__tests__/toolbarButtonRegistry.test.ts
@@ -102,6 +102,13 @@ describe("unregisterPluginToolbarButtons", () => {
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
   });
 
+  it("is a no-op for empty or non-string pluginId (defensive input guard)", () => {
+    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    expect(() => unregisterPluginToolbarButtons("")).not.toThrow();
+    expect(() => unregisterPluginToolbarButtons(undefined as unknown as string)).not.toThrow();
+    expect(getPluginToolbarButtonIds()).toHaveLength(1);
+  });
+
   it("is a no-op when unregistering the same plugin twice", () => {
     registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
     unregisterPluginToolbarButtons("owner-a");

--- a/shared/config/__tests__/toolbarButtonRegistry.test.ts
+++ b/shared/config/__tests__/toolbarButtonRegistry.test.ts
@@ -4,6 +4,7 @@ import {
   getToolbarButtonConfig,
   getPluginToolbarButtonIds,
   isRegisteredPluginButton,
+  unregisterPluginToolbarButtons,
   clearToolbarButtonRegistry,
   type ToolbarButtonConfig,
 } from "../toolbarButtonRegistry.js";
@@ -77,5 +78,43 @@ describe("toolbarButtonRegistry", () => {
 
     clearToolbarButtonRegistry();
     expect(getPluginToolbarButtonIds()).toHaveLength(0);
+  });
+});
+
+describe("unregisterPluginToolbarButtons", () => {
+  it("removes only buttons owned by the target plugin", () => {
+    registerToolbarButton(makeConfig("plugin.owner-a.one", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("plugin.owner-a.two", { pluginId: "owner-a" }));
+    registerToolbarButton(makeConfig("plugin.owner-b.three", { pluginId: "owner-b" }));
+
+    unregisterPluginToolbarButtons("owner-a");
+
+    const remaining = getPluginToolbarButtonIds();
+    expect(remaining).toEqual(["plugin.owner-b.three"]);
+    expect(getToolbarButtonConfig("plugin.owner-a.one")).toBeUndefined();
+    expect(getToolbarButtonConfig("plugin.owner-a.two")).toBeUndefined();
+    expect(getToolbarButtonConfig("plugin.owner-b.three")?.pluginId).toBe("owner-b");
+  });
+
+  it("is a no-op when unregistering an unknown pluginId", () => {
+    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    expect(() => unregisterPluginToolbarButtons("never-loaded")).not.toThrow();
+    expect(getPluginToolbarButtonIds()).toHaveLength(1);
+  });
+
+  it("is a no-op when unregistering the same plugin twice", () => {
+    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a" }));
+    unregisterPluginToolbarButtons("owner-a");
+    expect(() => unregisterPluginToolbarButtons("owner-a")).not.toThrow();
+    expect(getPluginToolbarButtonIds()).toHaveLength(0);
+  });
+
+  it("supports register → unregister → re-register round-trip", () => {
+    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a", label: "V1" }));
+    unregisterPluginToolbarButtons("owner-a");
+    expect(getPluginToolbarButtonIds()).toHaveLength(0);
+
+    registerToolbarButton(makeConfig("plugin.owner-a.btn", { pluginId: "owner-a", label: "V2" }));
+    expect(getToolbarButtonConfig("plugin.owner-a.btn")?.label).toBe("V2");
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -143,11 +143,15 @@ export function registerPanelKind(config: PanelKindConfig): void {
 /**
  * Unregister all panel kinds owned by a given plugin.
  * Only removes entries whose `extensionId` matches. Built-in panel kinds
- * have no `extensionId` and will never match a real plugin ID.
+ * have no `extensionId` and will never match a real plugin ID. The input
+ * guard rejects empty or non-string pluginIds so a caller that accidentally
+ * passes `undefined` (via a type cast or JS-side mistake) cannot match
+ * built-in entries whose `extensionId` is also `undefined`.
  *
  * @param pluginId - The plugin whose contributed panel kinds should be removed
  */
 export function unregisterPluginPanelKinds(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
   for (const [key, config] of Object.entries(PANEL_KIND_REGISTRY)) {
     if (config.extensionId === pluginId) {
       delete PANEL_KIND_REGISTRY[key];

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -141,6 +141,21 @@ export function registerPanelKind(config: PanelKindConfig): void {
 }
 
 /**
+ * Unregister all panel kinds owned by a given plugin.
+ * Only removes entries whose `extensionId` matches. Built-in panel kinds
+ * have no `extensionId` and will never match a real plugin ID.
+ *
+ * @param pluginId - The plugin whose contributed panel kinds should be removed
+ */
+export function unregisterPluginPanelKinds(pluginId: string): void {
+  for (const [key, config] of Object.entries(PANEL_KIND_REGISTRY)) {
+    if (config.extensionId === pluginId) {
+      delete PANEL_KIND_REGISTRY[key];
+    }
+  }
+}
+
+/**
  * Get the configuration for a panel kind.
  *
  * @param kind - The panel kind to look up

--- a/shared/config/toolbarButtonRegistry.ts
+++ b/shared/config/toolbarButtonRegistry.ts
@@ -31,6 +31,7 @@ export function isRegisteredPluginButton(id: string): boolean {
 }
 
 export function unregisterPluginToolbarButtons(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
   for (const [key, config] of Object.entries(TOOLBAR_BUTTON_REGISTRY)) {
     if (config.pluginId === pluginId) {
       delete TOOLBAR_BUTTON_REGISTRY[key];

--- a/shared/config/toolbarButtonRegistry.ts
+++ b/shared/config/toolbarButtonRegistry.ts
@@ -30,6 +30,14 @@ export function isRegisteredPluginButton(id: string): boolean {
   return id.startsWith("plugin.") && id in TOOLBAR_BUTTON_REGISTRY;
 }
 
+export function unregisterPluginToolbarButtons(pluginId: string): void {
+  for (const [key, config] of Object.entries(TOOLBAR_BUTTON_REGISTRY)) {
+    if (config.pluginId === pluginId) {
+      delete TOOLBAR_BUTTON_REGISTRY[key];
+    }
+  }
+}
+
 export function clearToolbarButtonRegistry(): void {
   for (const key of Object.keys(TOOLBAR_BUTTON_REGISTRY)) {
     delete TOOLBAR_BUTTON_REGISTRY[key];


### PR DESCRIPTION
## Summary

- Adds `unregisterPlugin(pluginId)` to `pluginMenuRegistry`, `toolbarButtonRegistry`, and `panelKindRegistry` so plugins can be cleanly removed without affecting built-ins or other plugins.
- Introduces `PluginService.unloadPlugin(pluginId)` as the single entry point: removes IPC handlers, unregisters all contributions, and drops the plugin from the service map.
- Defensive input guards across all three unregister functions reject empty or non-string plugin IDs, preventing accidental mass-wipe when a typecast `undefined` matches built-in entries (whose `extensionId` is also undefined). The `panelKindRegistry` filter is guarded on `extensionId` so the five built-in panel kinds are never touched.

Resolves #5212

## Changes

- `electron/services/PluginService.ts` — added `unloadPlugin(pluginId)` lifecycle method (idempotent for unknown IDs)
- `electron/services/pluginMenuRegistry.ts` — added `unregisterPlugin(pluginId)` with input guard
- `shared/config/toolbarButtonRegistry.ts` — added `unregisterPlugin(pluginId)` with input guard
- `shared/config/panelKindRegistry.ts` — added `unregisterPlugin(pluginId)` with input guard; filter scoped to entries where `extensionId` matches

## Testing

84 tests pass across 4 targeted files. New coverage includes direct registry unregister tests and a `PluginService` load/unload/reload lifecycle block. Typecheck clean, lint holds at baseline (401 warnings, no new), format clean.