### PR TITLE
fix(pty): bound pendingSpawns to prevent restart-storm amplification

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -868,6 +868,15 @@ export class PtyClient extends EventEmitter {
       logWarn(
         `[PtyClient] spawn rejected — pendingSpawns at cap (${this.MAX_PENDING_SPAWNS}), id=${id}`
       );
+      const result: SpawnResult = {
+        success: false,
+        id,
+        error: {
+          code: "PENDING_SPAWNS_CAPPED",
+          message: `Too many pending terminal spawns (cap ${this.MAX_PENDING_SPAWNS}); close some terminals and try again.`,
+        },
+      };
+      this.emit("spawn-result", id, result);
       return;
     }
 

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -169,6 +169,14 @@ export class PtyClient extends EventEmitter {
   private missedHeartbeats = 0;
   private readonly MAX_MISSED_HEARTBEATS = 3;
 
+  /**
+   * Cap on pendingSpawns to prevent restart-storm amplification. If the host
+   * crashes during spawn and respawnPending() replays the map, an unbounded map
+   * lets the next crash grow the replay burst. Capping admission keeps the
+   * respawn fan-out bounded under repeated crashes.
+   */
+  private readonly MAX_PENDING_SPAWNS = 250;
+
   /** Unified request/response broker for all async operations */
   private broker = new RequestResponseBroker({
     defaultTimeoutMs: 5000,
@@ -856,6 +864,13 @@ export class PtyClient extends EventEmitter {
   }
 
   spawn(id: string, options: PtyHostSpawnOptions): void {
+    if (!this.pendingSpawns.has(id) && this.pendingSpawns.size >= this.MAX_PENDING_SPAWNS) {
+      logWarn(
+        `[PtyClient] spawn rejected — pendingSpawns at cap (${this.MAX_PENDING_SPAWNS}), id=${id}`
+      );
+      return;
+    }
+
     const activeProjectId = this.activeProjectId ?? undefined;
     const normalizedProjectId =
       typeof options.projectId === "string" && options.projectId.trim()

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -489,9 +489,7 @@ describe("PtyClient adversarial", () => {
         (call[0] as { id?: string })?.id === "t-0"
     );
     expect(updatedSpawns).toHaveLength(1);
-    expect(
-      (updatedSpawns[0][0] as { options: PtyHostSpawnOptions }).options.cwd
-    ).toBe("/updated");
+    expect((updatedSpawns[0][0] as { options: PtyHostSpawnOptions }).options.cwd).toBe("/updated");
   });
 
   it("RESPAWN_AFTER_CRASH_DOES_NOT_EXCEED_CAP", () => {

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { EventEmitter } from "events";
+import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
 
 const shared = vi.hoisted(() => ({
   forkMock: vi.fn(),
@@ -23,6 +24,11 @@ vi.mock("electron", () => ({
 
 vi.mock("../TrashedPidTracker.js", () => ({
   getTrashedPidTracker: () => shared.tracker,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
 }));
 
 interface MockUtilityProcess extends EventEmitter {
@@ -391,5 +397,105 @@ describe("PtyClient adversarial", () => {
 
     vi.advanceTimersByTime(1000);
     expect(mockChild.kill).toHaveBeenCalledTimes(1);
+  });
+
+  const MAX_PENDING_SPAWNS = 250;
+
+  function baseSpawnOptions(overrides: Partial<PtyHostSpawnOptions> = {}): PtyHostSpawnOptions {
+    return {
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+      ...overrides,
+    };
+  }
+
+  function countSpawnMessages(child: MockUtilityProcess): number {
+    return child.postMessage.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "spawn"
+    ).length;
+  }
+
+  it("PENDING_SPAWNS_REJECTED_AT_CAP", async () => {
+    const client = createReadyClient();
+    const { logWarn } = await import("../../utils/logger.js");
+    mockChild.postMessage.mockClear();
+
+    for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
+      client.spawn(`t-${i}`, baseSpawnOptions());
+    }
+    expect(countSpawnMessages(mockChild)).toBe(MAX_PENDING_SPAWNS);
+
+    client.spawn("t-overflow", baseSpawnOptions());
+
+    expect(client.hasTerminal("t-overflow")).toBe(false);
+    expect(countSpawnMessages(mockChild)).toBe(MAX_PENDING_SPAWNS);
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("spawn rejected")
+    );
+  });
+
+  it("KILL_FREES_SLOT_BELOW_CAP", () => {
+    const client = createReadyClient();
+    mockChild.postMessage.mockClear();
+
+    for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
+      client.spawn(`t-${i}`, baseSpawnOptions());
+    }
+    expect(countSpawnMessages(mockChild)).toBe(MAX_PENDING_SPAWNS);
+
+    client.kill("t-0");
+    client.spawn("t-new", baseSpawnOptions());
+
+    expect(client.hasTerminal("t-new")).toBe(true);
+    expect(client.hasTerminal("t-0")).toBe(false);
+    const spawnIds = mockChild.postMessage.mock.calls
+      .filter((call: unknown[]) => (call[0] as { type?: string })?.type === "spawn")
+      .map((call: unknown[]) => (call[0] as { id?: string })?.id);
+    expect(spawnIds).toContain("t-new");
+  });
+
+  it("SAME_ID_AT_CAP_IS_UPDATED_NOT_REJECTED", async () => {
+    const client = createReadyClient();
+    const { logWarn } = await import("../../utils/logger.js");
+
+    for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
+      client.spawn(`t-${i}`, baseSpawnOptions());
+    }
+    (logWarn as Mock).mockClear();
+    mockChild.postMessage.mockClear();
+
+    client.spawn("t-0", baseSpawnOptions({ cwd: "/updated" }));
+
+    expect(logWarn).not.toHaveBeenCalledWith(expect.stringContaining("spawn rejected"));
+    const updatedSpawns = mockChild.postMessage.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[0] as { type?: string })?.type === "spawn" &&
+        (call[0] as { id?: string })?.id === "t-0"
+    );
+    expect(updatedSpawns).toHaveLength(1);
+    expect(
+      (updatedSpawns[0][0] as { options: PtyHostSpawnOptions }).options.cwd
+    ).toBe("/updated");
+  });
+
+  it("RESPAWN_AFTER_CRASH_DOES_NOT_EXCEED_CAP", () => {
+    const client = createReadyClient();
+    const restartedChild = createMockChild();
+
+    for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
+      client.spawn(`t-${i}`, baseSpawnOptions());
+    }
+    client.spawn("t-overflow", baseSpawnOptions());
+
+    shared.forkMock.mockReturnValue(restartedChild);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(2000);
+    restartedChild.emit("message", { type: "ready" });
+
+    expect(countSpawnMessages(restartedChild)).toBe(MAX_PENDING_SPAWNS);
+    expect(client.hasTerminal("t-overflow")).toBe(false);
+    // dispose to avoid leaking timers/listeners across tests
+    client.dispose();
   });
 });

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { EventEmitter } from "events";
-import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+import type { PtyHostSpawnOptions, SpawnResult } from "../../../shared/types/pty-host.js";
 
 const shared = vi.hoisted(() => ({
   forkMock: vi.fn(),
@@ -419,20 +419,30 @@ describe("PtyClient adversarial", () => {
   it("PENDING_SPAWNS_REJECTED_AT_CAP", async () => {
     const client = createReadyClient();
     const { logWarn } = await import("../../utils/logger.js");
+    const results: Array<{ id: string; result: SpawnResult }> = [];
+    client.on("spawn-result", (id: string, result: SpawnResult) => {
+      results.push({ id, result });
+    });
     mockChild.postMessage.mockClear();
 
     for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
       client.spawn(`t-${i}`, baseSpawnOptions());
     }
     expect(countSpawnMessages(mockChild)).toBe(MAX_PENDING_SPAWNS);
+    expect(results).toHaveLength(0);
 
     client.spawn("t-overflow", baseSpawnOptions());
 
     expect(client.hasTerminal("t-overflow")).toBe(false);
     expect(countSpawnMessages(mockChild)).toBe(MAX_PENDING_SPAWNS);
-    expect(logWarn).toHaveBeenCalledWith(
-      expect.stringContaining("spawn rejected")
-    );
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("spawn rejected"));
+
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe("t-overflow");
+    expect(results[0].result.success).toBe(false);
+    expect(results[0].result.id).toBe("t-overflow");
+    expect(results[0].result.error?.code).toBe("PENDING_SPAWNS_CAPPED");
+    expect(results[0].result.error?.message).toEqual(expect.stringContaining("250"));
   });
 
   it("KILL_FREES_SLOT_BELOW_CAP", () => {
@@ -458,6 +468,10 @@ describe("PtyClient adversarial", () => {
   it("SAME_ID_AT_CAP_IS_UPDATED_NOT_REJECTED", async () => {
     const client = createReadyClient();
     const { logWarn } = await import("../../utils/logger.js");
+    const results: Array<{ id: string; result: SpawnResult }> = [];
+    client.on("spawn-result", (id: string, result: SpawnResult) => {
+      results.push({ id, result });
+    });
 
     for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
       client.spawn(`t-${i}`, baseSpawnOptions());
@@ -467,7 +481,8 @@ describe("PtyClient adversarial", () => {
 
     client.spawn("t-0", baseSpawnOptions({ cwd: "/updated" }));
 
-    expect(logWarn).not.toHaveBeenCalledWith(expect.stringContaining("spawn rejected"));
+    expect(logWarn).not.toHaveBeenCalled();
+    expect(results).toHaveLength(0);
     const updatedSpawns = mockChild.postMessage.mock.calls.filter(
       (call: unknown[]) =>
         (call[0] as { type?: string })?.type === "spawn" &&
@@ -484,7 +499,7 @@ describe("PtyClient adversarial", () => {
     const restartedChild = createMockChild();
 
     for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
-      client.spawn(`t-${i}`, baseSpawnOptions());
+      client.spawn(`t-${i}`, baseSpawnOptions({ cwd: `/cwd/${i}` }));
     }
     client.spawn("t-overflow", baseSpawnOptions());
 
@@ -493,9 +508,61 @@ describe("PtyClient adversarial", () => {
     vi.advanceTimersByTime(2000);
     restartedChild.emit("message", { type: "ready" });
 
-    expect(countSpawnMessages(restartedChild)).toBe(MAX_PENDING_SPAWNS);
+    const replayedSpawns = restartedChild.postMessage.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "spawn"
+    ) as Array<[{ type: "spawn"; id: string; options: PtyHostSpawnOptions }]>;
+    expect(replayedSpawns).toHaveLength(MAX_PENDING_SPAWNS);
+
+    const replayedIds = replayedSpawns.map(([msg]) => msg.id);
+    const expectedIds = Array.from({ length: MAX_PENDING_SPAWNS }, (_, i) => `t-${i}`);
+    expect(new Set(replayedIds)).toEqual(new Set(expectedIds));
+    expect(replayedIds).not.toContain("t-overflow");
+    expect(new Set(replayedIds).size).toBe(replayedIds.length); // no duplicates
+
+    for (const [msg] of replayedSpawns) {
+      const idx = Number(msg.id.slice(2));
+      expect(msg.options.cwd).toBe(`/cwd/${idx}`);
+    }
+
     expect(client.hasTerminal("t-overflow")).toBe(false);
     // dispose to avoid leaking timers/listeners across tests
     client.dispose();
+  });
+
+  it("REJECTED_THEN_SUCCEEDING_SAME_ID_EMITS_FAILURE_THEN_SUCCESS", () => {
+    const client = createReadyClient();
+    const results: Array<{ id: string; result: SpawnResult }> = [];
+    client.on("spawn-result", (id: string, result: SpawnResult) => {
+      results.push({ id, result });
+    });
+
+    for (let i = 0; i < MAX_PENDING_SPAWNS; i++) {
+      client.spawn(`t-${i}`, baseSpawnOptions());
+    }
+    client.spawn("t-overflow", baseSpawnOptions());
+    expect(results).toHaveLength(1);
+    expect(results[0].result.success).toBe(false);
+
+    client.kill("t-0");
+    client.spawn("t-overflow", baseSpawnOptions());
+    expect(client.hasTerminal("t-overflow")).toBe(true);
+
+    // Host eventually replies with success for the admitted spawn
+    mockChild.emit("message", {
+      type: "spawn-result",
+      id: "t-overflow",
+      result: { success: true, id: "t-overflow" } satisfies SpawnResult,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      id: "t-overflow",
+      result: { success: false, id: "t-overflow" },
+    });
+    expect(results[0].result.error?.code).toBe("PENDING_SPAWNS_CAPPED");
+    expect(results[1]).toMatchObject({
+      id: "t-overflow",
+      result: { success: true, id: "t-overflow" },
+    });
   });
 });

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -329,6 +329,7 @@ export type SpawnErrorCode =
   | "ENOTDIR" // Working directory does not exist (or path component is not a directory)
   | "EIO" // I/O error (e.g., PTY allocation failure)
   | "DISCONNECTED" // Terminal process no longer exists in backend (e.g., after project switch)
+  | "PENDING_SPAWNS_CAPPED" // PtyClient.pendingSpawns admission cap hit (restart-storm guard)
   | "UNKNOWN"; // Unknown error
 
 /** Result of a spawn operation */


### PR DESCRIPTION
## Summary

- Caps `pendingSpawns` at 250 entries in `PtyClient` so `respawnPending` fan-out is naturally bounded after repeated PTY host crashes
- Admission guard at the top of `spawn()` emits a `spawn-result` failure event with `PENDING_SPAWNS_CAPPED` error code, so the existing failure paths in `DevPreviewSessionService` and the renderer still fire correctly
- Same-id updates at capacity are allowed through (`!has(id) && size >= MAX`) so respawn operations on an already-tracked terminal aren't rejected

Resolves #5206

## Changes

- `electron/services/PtyClient.ts`: `MAX_PENDING_SPAWNS = 250` constant, admission guard in `spawn()`
- `shared/types/pty-host.ts`: `PENDING_SPAWNS_CAPPED` added to the `SpawnErrorCode` union
- `electron/services/__tests__/PtyClient.adversarial.test.ts`: 5 adversarial tests covering cap rejection, kill reclaiming a slot, same-id at cap, bounded respawn replay, and the reject-then-succeed event sequence

Filed follow-up issues #5319 (pendingKillCount) and #5320 (terminal retry false-success) for related unbounded maps.

## Testing

All 5 adversarial tests pass. The cap and error path are fully covered without touching the pacing logic, keeping the change minimal and reviewable.