### PR TITLE
perf(store): migrate orchestrator to subscribeWithSelector (#5247)

### DIFF
--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
 import type { CliAvailability, AgentAvailabilityState } from "@shared/types";
 import { cliAvailabilityClient } from "@/clients";
 import { getAgentIds } from "@/config/agents";
@@ -115,127 +116,129 @@ let epoch = 0;
 let initPromise: Promise<void> | null = null;
 let refreshPromise: Promise<void> | null = null;
 
-export const useCliAvailabilityStore = create<CliAvailabilityStore>()((set, get) => ({
-  availability: defaultAvailability(),
-  isLoading: true,
-  isRefreshing: false,
-  error: null,
-  isInitialized: false,
-  lastCheckedAt: null,
-  hasRealData: false,
+export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
+  subscribeWithSelector((set, get) => ({
+    availability: defaultAvailability(),
+    isLoading: true,
+    isRefreshing: false,
+    error: null,
+    isInitialized: false,
+    lastCheckedAt: null,
+    hasRealData: false,
 
-  initialize: () => {
-    if (get().isInitialized) return Promise.resolve();
-    if (initPromise) return initPromise;
+    initialize: () => {
+      if (get().isInitialized) return Promise.resolve();
+      if (initPromise) return initPromise;
 
-    // Hydrate from localStorage before kicking off the IPC call. This kills
-    // the first-paint toolbar flicker: cached pins render immediately and
-    // only reconcile when the fresh result lands.
-    //
-    // Deliberately omit `lastCheckedAt` so the 30s refresh throttle only
-    // kicks in after a successful *live* probe this session. Persisting
-    // the cached timestamp would mute the first mid-session refresh after
-    // a relaunch (and, with clock skew, could suppress refreshes
-    // indefinitely).
-    const cached = loadCache();
-    if (cached) {
-      set({
-        availability: cached.availability,
-        hasRealData: true,
-      });
-    }
-
-    if (!isElectronAvailable()) {
-      set({ isLoading: false, isInitialized: true });
-      return Promise.resolve();
-    }
-
-    const myEpoch = epoch;
-    initPromise = (async () => {
-      try {
-        set({ isLoading: true, error: null });
-        const availability = await cliAvailabilityClient.refresh();
-        if (epoch === myEpoch) {
-          const now = Date.now();
-          saveCache(availability, now);
-          set({
-            availability,
-            isLoading: false,
-            isInitialized: true,
-            lastCheckedAt: now,
-            hasRealData: true,
-          });
-        }
-      } catch (e) {
-        if (epoch === myEpoch) {
-          set({
-            error: e instanceof Error ? e.message : "Failed to check CLI availability",
-            isLoading: false,
-            isInitialized: true,
-          });
-        }
-      } finally {
-        if (epoch === myEpoch) {
-          initPromise = null;
-        }
+      // Hydrate from localStorage before kicking off the IPC call. This kills
+      // the first-paint toolbar flicker: cached pins render immediately and
+      // only reconcile when the fresh result lands.
+      //
+      // Deliberately omit `lastCheckedAt` so the 30s refresh throttle only
+      // kicks in after a successful *live* probe this session. Persisting
+      // the cached timestamp would mute the first mid-session refresh after
+      // a relaunch (and, with clock skew, could suppress refreshes
+      // indefinitely).
+      const cached = loadCache();
+      if (cached) {
+        set({
+          availability: cached.availability,
+          hasRealData: true,
+        });
       }
-    })();
 
-    return initPromise;
-  },
-
-  refresh: (force = false) => {
-    // If init is still in-flight, join it rather than firing a duplicate IPC call.
-    if (initPromise) return initPromise;
-
-    // Skip if the last successful probe landed within the throttle window.
-    // Failed refreshes do not set lastCheckedAt, so they stay retryable.
-    // Explicit user gestures pass `force: true` to bypass the window.
-    if (!force) {
-      const { lastCheckedAt } = get();
-      if (lastCheckedAt !== null && Date.now() - lastCheckedAt < REFRESH_THROTTLE_MS) {
+      if (!isElectronAvailable()) {
+        set({ isLoading: false, isInitialized: true });
         return Promise.resolve();
       }
-    }
 
-    if (refreshPromise) return refreshPromise;
-
-    if (!isElectronAvailable()) return Promise.resolve();
-
-    const myEpoch = epoch;
-    refreshPromise = (async () => {
-      try {
-        set({ isRefreshing: true, error: null });
-        const availability = await cliAvailabilityClient.refresh();
-        if (epoch === myEpoch) {
-          const now = Date.now();
-          saveCache(availability, now);
-          set({
-            availability,
-            isRefreshing: false,
-            error: null,
-            lastCheckedAt: now,
-            hasRealData: true,
-          });
+      const myEpoch = epoch;
+      initPromise = (async () => {
+        try {
+          set({ isLoading: true, error: null });
+          const availability = await cliAvailabilityClient.refresh();
+          if (epoch === myEpoch) {
+            const now = Date.now();
+            saveCache(availability, now);
+            set({
+              availability,
+              isLoading: false,
+              isInitialized: true,
+              lastCheckedAt: now,
+              hasRealData: true,
+            });
+          }
+        } catch (e) {
+          if (epoch === myEpoch) {
+            set({
+              error: e instanceof Error ? e.message : "Failed to check CLI availability",
+              isLoading: false,
+              isInitialized: true,
+            });
+          }
+        } finally {
+          if (epoch === myEpoch) {
+            initPromise = null;
+          }
         }
-      } catch (e) {
-        if (epoch === myEpoch) {
-          set({
-            error: e instanceof Error ? e.message : "Failed to refresh CLI availability",
-            isRefreshing: false,
-          });
-        }
-        throw e;
-      } finally {
-        if (epoch === myEpoch) {
-          refreshPromise = null;
+      })();
+
+      return initPromise;
+    },
+
+    refresh: (force = false) => {
+      // If init is still in-flight, join it rather than firing a duplicate IPC call.
+      if (initPromise) return initPromise;
+
+      // Skip if the last successful probe landed within the throttle window.
+      // Failed refreshes do not set lastCheckedAt, so they stay retryable.
+      // Explicit user gestures pass `force: true` to bypass the window.
+      if (!force) {
+        const { lastCheckedAt } = get();
+        if (lastCheckedAt !== null && Date.now() - lastCheckedAt < REFRESH_THROTTLE_MS) {
+          return Promise.resolve();
         }
       }
-    })();
 
-    return refreshPromise;
-  },
-}));
+      if (refreshPromise) return refreshPromise;
+
+      if (!isElectronAvailable()) return Promise.resolve();
+
+      const myEpoch = epoch;
+      refreshPromise = (async () => {
+        try {
+          set({ isRefreshing: true, error: null });
+          const availability = await cliAvailabilityClient.refresh();
+          if (epoch === myEpoch) {
+            const now = Date.now();
+            saveCache(availability, now);
+            set({
+              availability,
+              isRefreshing: false,
+              error: null,
+              lastCheckedAt: now,
+              hasRealData: true,
+            });
+          }
+        } catch (e) {
+          if (epoch === myEpoch) {
+            set({
+              error: e instanceof Error ? e.message : "Failed to refresh CLI availability",
+              isRefreshing: false,
+            });
+          }
+          throw e;
+        } finally {
+          if (epoch === myEpoch) {
+            refreshPromise = null;
+          }
+        }
+      })();
+
+      return refreshPromise;
+    },
+  }))
+);
 
 export function cleanupCliAvailabilityStore() {
   epoch++;

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -4,6 +4,7 @@
  */
 
 import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
 import {
   createPanelRegistrySlice,
   createTerminalFocusSlice,
@@ -96,442 +97,459 @@ export interface PanelGridState
   restoreLastTrashed: () => void;
 }
 
-export const usePanelStore = create<PanelGridState>()((set, get, api) => {
-  const getTerminals = () => selectOrderedTerminals(get().panelsById, get().panelIds);
-  const getTerminal = (id: string) => get().panelsById[id];
+export const usePanelStore = create<PanelGridState>()(
+  subscribeWithSelector((set, get, api) => {
+    const getTerminals = () => selectOrderedTerminals(get().panelsById, get().panelIds);
+    const getTerminal = (id: string) => get().panelsById[id];
 
-  const registrySlice = createPanelRegistrySlice({
-    onTerminalRemoved: (id, removedIndex, remainingIds, _removedTerminal) => {
-      clearTerminalRestartGuard(id);
-      get().clearQueue(id);
-      // Build remaining terminals array for the focus slice
-      const state = get();
-      const remainingTerminals = remainingIds.map((tid) => state.panelsById[tid]).filter(Boolean);
-      get().handleTerminalRemoved(id, remainingTerminals, removedIndex);
+    const registrySlice = createPanelRegistrySlice({
+      onTerminalRemoved: (id, removedIndex, remainingIds, _removedTerminal) => {
+        clearTerminalRestartGuard(id);
+        get().clearQueue(id);
+        // Build remaining terminals array for the focus slice
+        const state = get();
+        const remainingTerminals = remainingIds.map((tid) => state.panelsById[tid]).filter(Boolean);
+        get().handleTerminalRemoved(id, remainingTerminals, removedIndex);
 
-      // Auto-clear watch if panel is removed while watched
-      get().unwatchPanel(id);
-    },
-  })(set, get, api);
+        // Auto-clear watch if panel is removed while watched
+        get().unwatchPanel(id);
+      },
+    })(set, get, api);
 
-  const getActiveWorktreeId = () => useWorktreeSelectionStore.getState().activeWorktreeId;
-  const focusSlice = createTerminalFocusSlice(getTerminals, getActiveWorktreeId)(set, get, api);
-  const commandQueueSlice = createTerminalCommandQueueSlice(getTerminal)(set, get, api);
-  const mruSlice = createTerminalMruSlice(set, get, api);
-  const watchedPanelsSlice = createWatchedPanelsSlice()(set, get, api);
-  const bulkActionsSlice = createTerminalBulkActionsSlice(
-    getTerminals,
-    (id) => get().removePanel(id),
-    (id) => get().restartTerminal(id),
-    (id) => get().trashPanel(id),
-    (id) => get().moveTerminalToDock(id),
-    (id) => get().moveTerminalToGrid(id),
-    () => get().focusedId,
-    (id) => set({ focusedId: id }),
-    getActiveWorktreeId
-  )(set, get, api);
+    const getActiveWorktreeId = () => useWorktreeSelectionStore.getState().activeWorktreeId;
+    const focusSlice = createTerminalFocusSlice(getTerminals, getActiveWorktreeId)(set, get, api);
+    const commandQueueSlice = createTerminalCommandQueueSlice(getTerminal)(set, get, api);
+    const mruSlice = createTerminalMruSlice(set, get, api);
+    const watchedPanelsSlice = createWatchedPanelsSlice()(set, get, api);
+    const bulkActionsSlice = createTerminalBulkActionsSlice(
+      getTerminals,
+      (id) => get().removePanel(id),
+      (id) => get().restartTerminal(id),
+      (id) => get().trashPanel(id),
+      (id) => get().moveTerminalToDock(id),
+      (id) => get().moveTerminalToGrid(id),
+      () => get().focusedId,
+      (id) => set({ focusedId: id }),
+      getActiveWorktreeId
+    )(set, get, api);
 
-  return {
-    ...registrySlice,
-    ...focusSlice,
-    ...commandQueueSlice,
-    ...bulkActionsSlice,
-    ...mruSlice,
-    ...watchedPanelsSlice,
+    return {
+      ...registrySlice,
+      ...focusSlice,
+      ...commandQueueSlice,
+      ...bulkActionsSlice,
+      ...mruSlice,
+      ...watchedPanelsSlice,
 
-    backendStatus: "connected" as BackendStatus,
-    lastCrashType: null as CrashType | null,
-    lastClosedConfig: null as AddPanelOptions | null,
-    setBackendStatus: (status: BackendStatus) => set({ backendStatus: status }),
-    setLastCrashType: (crashType: CrashType | null) => set({ lastCrashType: crashType }),
+      backendStatus: "connected" as BackendStatus,
+      lastCrashType: null as CrashType | null,
+      lastClosedConfig: null as AddPanelOptions | null,
+      setBackendStatus: (status: BackendStatus) => set({ backendStatus: status }),
+      setLastCrashType: (crashType: CrashType | null) => set({ lastCrashType: crashType }),
 
-    addPanel: async (options: AddPanelOptions) => {
-      const id = await registrySlice.addPanel(options);
-      if (id === null) return null;
-      // Skip the per-panel focus mutation while a hydration batch is collecting panels:
-      // firing `set({ focusedId })` here would schedule one extra render per panel and
-      // defeat the batch's single-render guarantee. The arbitrary "last panel added"
-      // focus also isn't meaningful during restore — focus is resolved elsewhere once
-      // the active worktree is set.
-      if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
-        set({ focusedId: id });
-      }
-      return id;
-    },
-
-    moveTerminalToDock: (id: string) => {
-      const state = get();
-      registrySlice.moveTerminalToDock(id);
-
-      const updates: Partial<PanelGridState> = {};
-
-      if (state.focusedId === id) {
-        const activeWt = getActiveWorktreeId() ?? undefined;
-        const gridTerminals: TerminalInstance[] = [];
-        for (const tid of state.panelIds) {
-          const t = state.panelsById[tid];
-          if (t && t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt)
-            gridTerminals.push(t);
+      addPanel: async (options: AddPanelOptions) => {
+        const id = await registrySlice.addPanel(options);
+        if (id === null) return null;
+        // Skip the per-panel focus mutation while a hydration batch is collecting panels:
+        // firing `set({ focusedId })` here would schedule one extra render per panel and
+        // defeat the batch's single-render guarantee. The arbitrary "last panel added"
+        // focus also isn't meaningful during restore — focus is resolved elsewhere once
+        // the active worktree is set.
+        if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
+          set({ focusedId: id });
         }
-        updates.focusedId = gridTerminals[0]?.id ?? null;
-      }
+        return id;
+      },
 
-      if (state.maximizedId) {
-        const group = registrySlice.getPanelGroup(id);
-        if (state.maximizedId === id || (group && group.panelIds.includes(state.maximizedId))) {
-          updates.maximizedId = null;
-          updates.maximizeTarget = null;
-          updates.preMaximizeLayout = null;
+      moveTerminalToDock: (id: string) => {
+        const state = get();
+        registrySlice.moveTerminalToDock(id);
+
+        const updates: Partial<PanelGridState> = {};
+
+        if (state.focusedId === id) {
+          const activeWt = getActiveWorktreeId() ?? undefined;
+          const gridTerminals: TerminalInstance[] = [];
+          for (const tid of state.panelIds) {
+            const t = state.panelsById[tid];
+            if (
+              t &&
+              t.id !== id &&
+              t.location === "grid" &&
+              (t.worktreeId ?? undefined) === activeWt
+            )
+              gridTerminals.push(t);
+          }
+          updates.focusedId = gridTerminals[0]?.id ?? null;
         }
-      }
 
-      if (Object.keys(updates).length > 0) {
-        set(updates);
-      }
-    },
-
-    moveTerminalToGrid: (id: string) => {
-      const moveSucceeded = registrySlice.moveTerminalToGrid(id);
-      if (moveSucceeded) {
-        set({ focusedId: id, activeDockTerminalId: null });
-      }
-      return moveSucceeded;
-    },
-
-    trashPanel: (id: string) => {
-      const state = get();
-      const terminalToTrash = state.panelsById[id];
-      if (terminalToTrash && terminalToTrash.location !== "trash") {
-        const snapshot = buildPanelSnapshotOptions(terminalToTrash);
-        if (snapshot !== null) {
-          set({ lastClosedConfig: snapshot });
-        }
-      }
-
-      registrySlice.trashPanel(id);
-
-      // Clear watch when panel is trashed (onTerminalRemoved only fires on full removal)
-      get().unwatchPanel(id);
-
-      const updates: Partial<PanelGridState> = {};
-
-      if (state.focusedId === id) {
-        const activeWt = getActiveWorktreeId() ?? undefined;
-        const gridTerminals: TerminalInstance[] = [];
-        for (const tid of state.panelIds) {
-          const t = state.panelsById[tid];
-          if (t && t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt)
-            gridTerminals.push(t);
-        }
-        const trashedTerminal = state.panelsById[id];
-        const wasAgent =
-          trashedTerminal &&
-          isAgentTerminal(trashedTerminal.kind ?? trashedTerminal.type, trashedTerminal.agentId);
-        const nextAgent = wasAgent
-          ? gridTerminals.find((t) => isAgentTerminal(t.kind ?? t.type, t.agentId))
-          : undefined;
-        updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
-      }
-
-      if (state.maximizedId === id) {
-        updates.maximizedId = null;
-      }
-
-      if (state.activeDockTerminalId === id) {
-        updates.activeDockTerminalId = null;
-      }
-
-      if (Object.keys(updates).length > 0) {
-        set(updates);
-      }
-    },
-
-    trashPanelGroup: (panelId: string) => {
-      const state = get();
-      const group = registrySlice.getPanelGroup(panelId);
-      const panelIdsInGroup = group?.panelIds ?? [panelId];
-
-      const snapshotSourceId =
-        group && panelIdsInGroup.includes(state.focusedId ?? "") ? state.focusedId! : panelId;
-      const snapshotSource = state.panelsById[snapshotSourceId];
-      if (snapshotSource && snapshotSource.location !== "trash") {
-        const snapshot = buildPanelSnapshotOptions(snapshotSource);
-        if (snapshot !== null) {
-          set({ lastClosedConfig: snapshot });
-        }
-      }
-
-      registrySlice.trashPanelGroup(panelId);
-
-      const updates: Partial<PanelGridState> = {};
-
-      if (panelIdsInGroup.includes(state.focusedId ?? "")) {
-        const activeWt = getActiveWorktreeId() ?? undefined;
-        const groupSet = new Set(panelIdsInGroup);
-        const gridTerminals: TerminalInstance[] = [];
-        for (const tid of state.panelIds) {
-          const t = state.panelsById[tid];
-          if (
-            t &&
-            !groupSet.has(t.id) &&
-            t.location === "grid" &&
-            (t.worktreeId ?? undefined) === activeWt
-          )
-            gridTerminals.push(t);
-        }
-        const focusedTerminal = state.panelsById[state.focusedId!];
-        const wasAgent =
-          focusedTerminal &&
-          isAgentTerminal(focusedTerminal.kind ?? focusedTerminal.type, focusedTerminal.agentId);
-        const nextAgent = wasAgent
-          ? gridTerminals.find((t) => isAgentTerminal(t.kind ?? t.type, t.agentId))
-          : undefined;
-        updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
-      }
-
-      if (state.maximizedId && panelIdsInGroup.includes(state.maximizedId)) {
-        updates.maximizedId = null;
-      }
-
-      if (state.activeDockTerminalId && panelIdsInGroup.includes(state.activeDockTerminalId)) {
-        updates.activeDockTerminalId = null;
-      }
-
-      if (Object.keys(updates).length > 0) {
-        set(updates);
-      }
-    },
-
-    restoreTerminal: (id: string, targetWorktreeId?: string) => {
-      registrySlice.restoreTerminal(id, targetWorktreeId);
-      set({ focusedId: id, activeDockTerminalId: null });
-    },
-
-    restoreTrashedGroup: (groupRestoreId: string, targetWorktreeId?: string) => {
-      const trashedTerminals = get().trashedTerminals;
-
-      let anchorPanel: ReturnType<typeof trashedTerminals.get> | undefined;
-      const groupPanelIds: string[] = [];
-      for (const [id, trashed] of trashedTerminals.entries()) {
-        if (trashed.groupRestoreId === groupRestoreId) {
-          groupPanelIds.push(id);
-          if (trashed.groupMetadata) {
-            anchorPanel = trashed;
+        if (state.maximizedId) {
+          const group = registrySlice.getPanelGroup(id);
+          if (state.maximizedId === id || (group && group.panelIds.includes(state.maximizedId))) {
+            updates.maximizedId = null;
+            updates.maximizeTarget = null;
+            updates.preMaximizeLayout = null;
           }
         }
-      }
 
-      if (groupPanelIds.length === 0) return;
+        if (Object.keys(updates).length > 0) {
+          set(updates);
+        }
+      },
 
-      registrySlice.restoreTrashedGroup(groupRestoreId, targetWorktreeId);
+      moveTerminalToGrid: (id: string) => {
+        const moveSucceeded = registrySlice.moveTerminalToGrid(id);
+        if (moveSucceeded) {
+          set({ focusedId: id, activeDockTerminalId: null });
+        }
+        return moveSucceeded;
+      },
 
-      const focusId =
-        anchorPanel?.groupMetadata?.activeTabId &&
-        groupPanelIds.includes(anchorPanel.groupMetadata.activeTabId)
-          ? anchorPanel.groupMetadata.activeTabId
-          : groupPanelIds[0];
-      set({ focusedId: focusId, activeDockTerminalId: null });
+      trashPanel: (id: string) => {
+        const state = get();
+        const terminalToTrash = state.panelsById[id];
+        if (terminalToTrash && terminalToTrash.location !== "trash") {
+          const snapshot = buildPanelSnapshotOptions(terminalToTrash);
+          if (snapshot !== null) {
+            set({ lastClosedConfig: snapshot });
+          }
+        }
 
-      const group = get().getPanelGroup(focusId);
-      if (group) {
-        get().setActiveTab(group.id, focusId);
-      }
-    },
+        registrySlice.trashPanel(id);
 
-    restoreLastTrashed: () => {
-      const trashedTerminals = get().trashedTerminals;
-      const trashedIds = Array.from(trashedTerminals.keys());
-      if (trashedIds.length === 0) return;
+        // Clear watch when panel is trashed (onTerminalRemoved only fires on full removal)
+        get().unwatchPanel(id);
 
-      const lastId = trashedIds[trashedIds.length - 1];
-      const lastTrashed = trashedTerminals.get(lastId);
+        const updates: Partial<PanelGridState> = {};
 
-      if (lastTrashed?.groupRestoreId) {
-        get().restoreTrashedGroup(lastTrashed.groupRestoreId);
-      } else {
-        get().restoreTerminal(lastId);
-      }
-    },
+        if (state.focusedId === id) {
+          const activeWt = getActiveWorktreeId() ?? undefined;
+          const gridTerminals: TerminalInstance[] = [];
+          for (const tid of state.panelIds) {
+            const t = state.panelsById[tid];
+            if (
+              t &&
+              t.id !== id &&
+              t.location === "grid" &&
+              (t.worktreeId ?? undefined) === activeWt
+            )
+              gridTerminals.push(t);
+          }
+          const trashedTerminal = state.panelsById[id];
+          const wasAgent =
+            trashedTerminal &&
+            isAgentTerminal(trashedTerminal.kind ?? trashedTerminal.type, trashedTerminal.agentId);
+          const nextAgent = wasAgent
+            ? gridTerminals.find((t) => isAgentTerminal(t.kind ?? t.type, t.agentId))
+            : undefined;
+          updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
+        }
 
-    moveTerminalToPosition: (
-      id: string,
-      toIndex: number,
-      location: "grid" | "dock",
-      worktreeId?: string | null
-    ) => {
-      const state = get();
-      registrySlice.moveTerminalToPosition(id, toIndex, location, worktreeId);
+        if (state.maximizedId === id) {
+          updates.maximizedId = null;
+        }
 
-      if (location === "grid") {
+        if (state.activeDockTerminalId === id) {
+          updates.activeDockTerminalId = null;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          set(updates);
+        }
+      },
+
+      trashPanelGroup: (panelId: string) => {
+        const state = get();
+        const group = registrySlice.getPanelGroup(panelId);
+        const panelIdsInGroup = group?.panelIds ?? [panelId];
+
+        const snapshotSourceId =
+          group && panelIdsInGroup.includes(state.focusedId ?? "") ? state.focusedId! : panelId;
+        const snapshotSource = state.panelsById[snapshotSourceId];
+        if (snapshotSource && snapshotSource.location !== "trash") {
+          const snapshot = buildPanelSnapshotOptions(snapshotSource);
+          if (snapshot !== null) {
+            set({ lastClosedConfig: snapshot });
+          }
+        }
+
+        registrySlice.trashPanelGroup(panelId);
+
+        const updates: Partial<PanelGridState> = {};
+
+        if (panelIdsInGroup.includes(state.focusedId ?? "")) {
+          const activeWt = getActiveWorktreeId() ?? undefined;
+          const groupSet = new Set(panelIdsInGroup);
+          const gridTerminals: TerminalInstance[] = [];
+          for (const tid of state.panelIds) {
+            const t = state.panelsById[tid];
+            if (
+              t &&
+              !groupSet.has(t.id) &&
+              t.location === "grid" &&
+              (t.worktreeId ?? undefined) === activeWt
+            )
+              gridTerminals.push(t);
+          }
+          const focusedTerminal = state.panelsById[state.focusedId!];
+          const wasAgent =
+            focusedTerminal &&
+            isAgentTerminal(focusedTerminal.kind ?? focusedTerminal.type, focusedTerminal.agentId);
+          const nextAgent = wasAgent
+            ? gridTerminals.find((t) => isAgentTerminal(t.kind ?? t.type, t.agentId))
+            : undefined;
+          updates.focusedId = nextAgent?.id ?? gridTerminals[0]?.id ?? null;
+        }
+
+        if (state.maximizedId && panelIdsInGroup.includes(state.maximizedId)) {
+          updates.maximizedId = null;
+        }
+
+        if (state.activeDockTerminalId && panelIdsInGroup.includes(state.activeDockTerminalId)) {
+          updates.activeDockTerminalId = null;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          set(updates);
+        }
+      },
+
+      restoreTerminal: (id: string, targetWorktreeId?: string) => {
+        registrySlice.restoreTerminal(id, targetWorktreeId);
         set({ focusedId: id, activeDockTerminalId: null });
-      } else if (state.focusedId === id) {
-        const activeWt = getActiveWorktreeId() ?? undefined;
-        const gridTerminals: TerminalInstance[] = [];
+      },
+
+      restoreTrashedGroup: (groupRestoreId: string, targetWorktreeId?: string) => {
+        const trashedTerminals = get().trashedTerminals;
+
+        let anchorPanel: ReturnType<typeof trashedTerminals.get> | undefined;
+        const groupPanelIds: string[] = [];
+        for (const [id, trashed] of trashedTerminals.entries()) {
+          if (trashed.groupRestoreId === groupRestoreId) {
+            groupPanelIds.push(id);
+            if (trashed.groupMetadata) {
+              anchorPanel = trashed;
+            }
+          }
+        }
+
+        if (groupPanelIds.length === 0) return;
+
+        registrySlice.restoreTrashedGroup(groupRestoreId, targetWorktreeId);
+
+        const focusId =
+          anchorPanel?.groupMetadata?.activeTabId &&
+          groupPanelIds.includes(anchorPanel.groupMetadata.activeTabId)
+            ? anchorPanel.groupMetadata.activeTabId
+            : groupPanelIds[0];
+        set({ focusedId: focusId, activeDockTerminalId: null });
+
+        const group = get().getPanelGroup(focusId);
+        if (group) {
+          get().setActiveTab(group.id, focusId);
+        }
+      },
+
+      restoreLastTrashed: () => {
+        const trashedTerminals = get().trashedTerminals;
+        const trashedIds = Array.from(trashedTerminals.keys());
+        if (trashedIds.length === 0) return;
+
+        const lastId = trashedIds[trashedIds.length - 1];
+        const lastTrashed = trashedTerminals.get(lastId);
+
+        if (lastTrashed?.groupRestoreId) {
+          get().restoreTrashedGroup(lastTrashed.groupRestoreId);
+        } else {
+          get().restoreTerminal(lastId);
+        }
+      },
+
+      moveTerminalToPosition: (
+        id: string,
+        toIndex: number,
+        location: "grid" | "dock",
+        worktreeId?: string | null
+      ) => {
+        const state = get();
+        registrySlice.moveTerminalToPosition(id, toIndex, location, worktreeId);
+
+        if (location === "grid") {
+          set({ focusedId: id, activeDockTerminalId: null });
+        } else if (state.focusedId === id) {
+          const activeWt = getActiveWorktreeId() ?? undefined;
+          const gridTerminals: TerminalInstance[] = [];
+          for (const tid of state.panelIds) {
+            const t = state.panelsById[tid];
+            if (
+              t &&
+              t.id !== id &&
+              t.location === "grid" &&
+              (t.worktreeId ?? undefined) === activeWt
+            )
+              gridTerminals.push(t);
+          }
+          set({ focusedId: gridTerminals[0]?.id ?? null });
+        }
+      },
+
+      focusNext: () => {
+        focusSlice.focusNext();
+        const focusedId = get().focusedId;
+        if (focusedId) {
+          const terminal = get().panelsById[focusedId];
+          if (terminal?.location === "dock") {
+            const group = get().getPanelGroup(focusedId);
+            if (group) get().setActiveTab(group.id, focusedId);
+          }
+        }
+      },
+
+      focusPrevious: () => {
+        focusSlice.focusPrevious();
+        const focusedId = get().focusedId;
+        if (focusedId) {
+          const terminal = get().panelsById[focusedId];
+          if (terminal?.location === "dock") {
+            const group = get().getPanelGroup(focusedId);
+            if (group) get().setActiveTab(group.id, focusedId);
+          }
+        }
+      },
+
+      reset: async () => {
+        const state = get();
+
         for (const tid of state.panelIds) {
-          const t = state.panelsById[tid];
-          if (t && t.id !== id && t.location === "grid" && (t.worktreeId ?? undefined) === activeWt)
-            gridTerminals.push(t);
+          try {
+            terminalInstanceService.destroy(tid);
+          } catch (error) {
+            logWarn(`Failed to destroy terminal instance ${tid}`, { error });
+          }
         }
-        set({ focusedId: gridTerminals[0]?.id ?? null });
-      }
-    },
 
-    focusNext: () => {
-      focusSlice.focusNext();
-      const focusedId = get().focusedId;
-      if (focusedId) {
-        const terminal = get().panelsById[focusedId];
-        if (terminal?.location === "dock") {
-          const group = get().getPanelGroup(focusedId);
-          if (group) get().setActiveTab(group.id, focusedId);
+        const killPromises = state.panelIds.map((tid) =>
+          terminalRegistryController.kill(tid).catch((error) => {
+            logError(`Failed to kill terminal ${tid}`, error);
+          })
+        );
+
+        await Promise.all(killPromises);
+
+        const { useTerminalInputStore: inputStore } = await import("./terminalInputStore");
+        inputStore.getState().clearAllDraftInputs();
+
+        set({
+          panelsById: {},
+          panelIds: [],
+          trashedTerminals: new Map(),
+          backgroundedTerminals: new Map(),
+          tabGroups: new Map(),
+          focusedId: null,
+          maximizedId: null,
+          activeDockTerminalId: null,
+          pingedId: null,
+          preMaximizeLayout: null,
+          commandQueue: [],
+          commandQueueCountById: {},
+          backendStatus: "connected",
+          lastCrashType: null,
+          lastClosedConfig: null,
+          mruList: [],
+        });
+      },
+
+      resetWithoutKilling: async (_options) => {
+        const state = get();
+
+        flushPanelPersistence();
+
+        const allTerminalIds = [...state.panelIds];
+        terminalInstanceService.suppressResizesDuringProjectSwitch(
+          allTerminalIds,
+          PROJECT_SWITCH_RESIZE_SUPPRESSION_MS
+        );
+
+        for (const tid of state.panelIds) {
+          try {
+            terminalInstanceService.detachForProjectSwitch(tid);
+          } catch (error) {
+            logWarn(`Failed to detach terminal instance ${tid}`, { error });
+          }
         }
-      }
-    },
 
-    focusPrevious: () => {
-      focusSlice.focusPrevious();
-      const focusedId = get().focusedId;
-      if (focusedId) {
-        const terminal = get().panelsById[focusedId];
-        if (terminal?.location === "dock") {
-          const group = get().getPanelGroup(focusedId);
-          if (group) get().setActiveTab(group.id, focusedId);
+        logInfo(
+          `Detached ${state.panelIds.length} terminal instances for project switch (processes preserved)`
+        );
+
+        set({
+          panelsById: {},
+          panelIds: [],
+          trashedTerminals: new Map(),
+          backgroundedTerminals: new Map(),
+          tabGroups: new Map(),
+          focusedId: null,
+          maximizedId: null,
+          activeDockTerminalId: null,
+          pingedId: null,
+          preMaximizeLayout: null,
+          commandQueue: [],
+          commandQueueCountById: {},
+          backendStatus: "connected",
+          lastCrashType: null,
+          lastClosedConfig: null,
+          mruList: [],
+        });
+      },
+
+      detachTerminalsForProjectSwitch: () => {
+        const state = get();
+
+        flushPanelPersistence();
+
+        const allTerminalIds = [...state.panelIds];
+        terminalInstanceService.suppressResizesDuringProjectSwitch(
+          allTerminalIds,
+          PROJECT_SWITCH_RESIZE_SUPPRESSION_MS
+        );
+
+        for (const tid of state.panelIds) {
+          try {
+            terminalInstanceService.detachForProjectSwitch(tid);
+          } catch (error) {
+            logWarn(`Failed to detach terminal instance ${tid}`, { error });
+          }
         }
-      }
-    },
 
-    reset: async () => {
-      const state = get();
+        logInfo(
+          `Detached ${state.panelIds.length} terminal instances for project switch (processes preserved, state retained)`
+        );
+      },
 
-      for (const tid of state.panelIds) {
-        try {
-          terminalInstanceService.destroy(tid);
-        } catch (error) {
-          logWarn(`Failed to destroy terminal instance ${tid}`, { error });
-        }
-      }
-
-      const killPromises = state.panelIds.map((tid) =>
-        terminalRegistryController.kill(tid).catch((error) => {
-          logError(`Failed to kill terminal ${tid}`, error);
-        })
-      );
-
-      await Promise.all(killPromises);
-
-      const { useTerminalInputStore: inputStore } = await import("./terminalInputStore");
-      inputStore.getState().clearAllDraftInputs();
-
-      set({
-        panelsById: {},
-        panelIds: [],
-        trashedTerminals: new Map(),
-        backgroundedTerminals: new Map(),
-        tabGroups: new Map(),
-        focusedId: null,
-        maximizedId: null,
-        activeDockTerminalId: null,
-        pingedId: null,
-        preMaximizeLayout: null,
-        commandQueue: [],
-        commandQueueCountById: {},
-        backendStatus: "connected",
-        lastCrashType: null,
-        lastClosedConfig: null,
-        mruList: [],
-      });
-    },
-
-    resetWithoutKilling: async (_options) => {
-      const state = get();
-
-      flushPanelPersistence();
-
-      const allTerminalIds = [...state.panelIds];
-      terminalInstanceService.suppressResizesDuringProjectSwitch(
-        allTerminalIds,
-        PROJECT_SWITCH_RESIZE_SUPPRESSION_MS
-      );
-
-      for (const tid of state.panelIds) {
-        try {
-          terminalInstanceService.detachForProjectSwitch(tid);
-        } catch (error) {
-          logWarn(`Failed to detach terminal instance ${tid}`, { error });
-        }
-      }
-
-      logInfo(
-        `Detached ${state.panelIds.length} terminal instances for project switch (processes preserved)`
-      );
-
-      set({
-        panelsById: {},
-        panelIds: [],
-        trashedTerminals: new Map(),
-        backgroundedTerminals: new Map(),
-        tabGroups: new Map(),
-        focusedId: null,
-        maximizedId: null,
-        activeDockTerminalId: null,
-        pingedId: null,
-        preMaximizeLayout: null,
-        commandQueue: [],
-        commandQueueCountById: {},
-        backendStatus: "connected",
-        lastCrashType: null,
-        lastClosedConfig: null,
-        mruList: [],
-      });
-    },
-
-    detachTerminalsForProjectSwitch: () => {
-      const state = get();
-
-      flushPanelPersistence();
-
-      const allTerminalIds = [...state.panelIds];
-      terminalInstanceService.suppressResizesDuringProjectSwitch(
-        allTerminalIds,
-        PROJECT_SWITCH_RESIZE_SUPPRESSION_MS
-      );
-
-      for (const tid of state.panelIds) {
-        try {
-          terminalInstanceService.detachForProjectSwitch(tid);
-        } catch (error) {
-          logWarn(`Failed to detach terminal instance ${tid}`, { error });
-        }
-      }
-
-      logInfo(
-        `Detached ${state.panelIds.length} terminal instances for project switch (processes preserved, state retained)`
-      );
-    },
-
-    clearTerminalStoreForSwitch: () => {
-      set({
-        panelsById: {},
-        panelIds: [],
-        trashedTerminals: new Map(),
-        backgroundedTerminals: new Map(),
-        tabGroups: new Map(),
-        focusedId: null,
-        maximizedId: null,
-        activeDockTerminalId: null,
-        pingedId: null,
-        preMaximizeLayout: null,
-        commandQueue: [],
-        commandQueueCountById: {},
-        backendStatus: "connected",
-        lastCrashType: null,
-        lastClosedConfig: null,
-        mruList: [],
-        watchedPanels: new Set(),
-      });
-    },
-  };
-});
+      clearTerminalStoreForSwitch: () => {
+        set({
+          panelsById: {},
+          panelIds: [],
+          trashedTerminals: new Map(),
+          backgroundedTerminals: new Map(),
+          tabGroups: new Map(),
+          focusedId: null,
+          maximizedId: null,
+          activeDockTerminalId: null,
+          pingedId: null,
+          preMaximizeLayout: null,
+          commandQueue: [],
+          commandQueueCountById: {},
+          backendStatus: "connected",
+          lastCrashType: null,
+          lastClosedConfig: null,
+          mruList: [],
+          watchedPanels: new Set(),
+        });
+      },
+    };
+  })
+);
 
 // Break circular dependency: inject terminal store getter into projectStore
 // so buildOutgoingState() can synchronously snapshot terminal state.

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -1,3 +1,4 @@
+import { shallow } from "zustand/shallow";
 import { usePanelStore } from "./panelStore";
 import {
   useWorktreeSelectionStore,
@@ -23,31 +24,54 @@ export function initStoreOrchestrator(): () => void {
 
   const disposables = new DisposableStore();
 
-  // 1. Focus-to-worktree reaction: when focusedId changes, track focus,
-  //    switch worktree if needed, and record terminal MRU.
+  // 1a. Worktree focus tracking: remember which terminal was last focused
+  //     inside each worktree, so switching back restores that selection.
   disposables.add(
     toDisposable(
-      usePanelStore.subscribe((state, prevState) => {
-        if (state.focusedId === prevState.focusedId) return;
+      usePanelStore.subscribe(
+        (state) => state.focusedId,
+        (focusedId) => {
+          if (!focusedId) return;
+          const terminal = usePanelStore.getState().panelsById[focusedId];
+          if (!terminal?.worktreeId) return;
+          useWorktreeSelectionStore.getState().trackTerminalFocus(terminal.worktreeId, focusedId);
+        }
+      )
+    )
+  );
 
-        const focusedId = state.focusedId;
-        if (!focusedId) return;
-
-        const terminal = state.panelsById[focusedId];
-        if (terminal?.worktreeId) {
+  // 1b. Active worktree switch: focusing a terminal that lives in a
+  //     different worktree promotes that worktree to active.
+  disposables.add(
+    toDisposable(
+      usePanelStore.subscribe(
+        (state) => state.focusedId,
+        (focusedId) => {
+          if (!focusedId) return;
+          const terminal = usePanelStore.getState().panelsById[focusedId];
+          if (!terminal?.worktreeId) return;
           const worktreeState = useWorktreeSelectionStore.getState();
-          worktreeState.trackTerminalFocus(terminal.worktreeId, focusedId);
-
           if (terminal.worktreeId !== worktreeState.activeWorktreeId) {
             worktreeState.selectWorktree(terminal.worktreeId);
           }
         }
+      )
+    )
+  );
 
-        if (!isMruRecordingSuppressed()) {
-          state.recordMru(`terminal:${focusedId}`);
+  // 1c. Terminal MRU recording: append the newly focused terminal to the
+  //     global MRU list and persist it (debounced) unless suppressed.
+  disposables.add(
+    toDisposable(
+      usePanelStore.subscribe(
+        (state) => state.focusedId,
+        (focusedId) => {
+          if (!focusedId) return;
+          if (isMruRecordingSuppressed()) return;
+          usePanelStore.getState().recordMru(`terminal:${focusedId}`);
           debouncedPersistMruList(usePanelStore.getState().mruList);
         }
-      })
+      )
     )
   );
 
@@ -55,81 +79,83 @@ export function initStoreOrchestrator(): () => void {
   //    focused, automatically restore it to the grid.
   disposables.add(
     toDisposable(
-      usePanelStore.subscribe((state, prevState) => {
-        if (state.focusedId === prevState.focusedId) return;
+      usePanelStore.subscribe(
+        (state) => state.focusedId,
+        (focusedId) => {
+          if (!focusedId) return;
+          const panel = usePanelStore.getState().panelsById[focusedId];
+          if (panel?.location !== "background") return;
 
-        const focusedId = state.focusedId;
-        if (!focusedId) return;
+          usePanelStore.getState().restoreBackgroundTerminal(focusedId);
 
-        const panel = state.panelsById[focusedId];
-        if (panel?.location !== "background") return;
-
-        state.restoreBackgroundTerminal(focusedId);
-
-        // If the panel was restored to dock, fix activeDockTerminalId since
-        // activateTerminal() saw "background" and cleared it.
-        const restored = usePanelStore.getState().panelsById[focusedId];
-        if (restored?.location === "dock") {
-          usePanelStore.setState({ activeDockTerminalId: focusedId });
+          // If the panel was restored to dock, fix activeDockTerminalId since
+          // activateTerminal() saw "background" and cleared it.
+          const restored = usePanelStore.getState().panelsById[focusedId];
+          if (restored?.location === "dock") {
+            usePanelStore.setState({ activeDockTerminalId: focusedId });
+          }
         }
-      })
+      )
     )
   );
 
   // 3. Terminal-removal cleanup: when terminals are removed, clean up
   //    input store, console capture store, and worktree focus tracking.
-  let prevTerminalIds = usePanelStore.getState().panelIds;
-  let prevTerminalsById = usePanelStore.getState().panelsById;
-
+  //    Selector pulls both `panelIds` (for diff) and `panelsById` (to read
+  //    the removed panel's worktreeId). Shallow equality fires on either
+  //    ref change; inner guard bails when only `panelsById` changed so
+  //    metadata updates do not trigger phantom cleanup runs.
   disposables.add(
     toDisposable(
-      usePanelStore.subscribe((state) => {
-        const currentIds = state.panelIds;
-        if (currentIds === prevTerminalIds) {
-          prevTerminalsById = state.panelsById;
-          return;
-        }
+      usePanelStore.subscribe(
+        (state) => ({ panelIds: state.panelIds, panelsById: state.panelsById }),
+        (selected, prevSelected) => {
+          if (selected.panelIds === prevSelected.panelIds) return;
 
-        const currentIdSet = new Set(currentIds);
-        const removedIds = prevTerminalIds.filter((id) => !currentIdSet.has(id));
-        const prevById = prevTerminalsById;
-        prevTerminalIds = currentIds;
-        prevTerminalsById = state.panelsById;
+          const currentIdSet = new Set(selected.panelIds);
+          const removedIds = prevSelected.panelIds.filter((id) => !currentIdSet.has(id));
+          if (removedIds.length === 0) return;
 
-        for (const removedId of removedIds) {
-          useTerminalInputStore.getState().clearTerminalState(removedId);
-          useConsoleCaptureStore.getState().removePane(removedId);
-          useVoiceRecordingStore.getState().clearPanelBuffer(removedId);
-          unregisterInputController(removedId);
-          semanticAnalysisService.unregisterTerminal(removedId);
+          const prevById = prevSelected.panelsById;
 
-          const removed = prevById[removedId];
-          if (removed?.worktreeId) {
-            const worktreeState = useWorktreeSelectionStore.getState();
-            const lastFocused = worktreeState.lastFocusedTerminalByWorktree.get(removed.worktreeId);
-            if (lastFocused === removedId) {
-              worktreeState.clearWorktreeFocusTracking(removed.worktreeId);
+          for (const removedId of removedIds) {
+            useTerminalInputStore.getState().clearTerminalState(removedId);
+            useConsoleCaptureStore.getState().removePane(removedId);
+            useVoiceRecordingStore.getState().clearPanelBuffer(removedId);
+            unregisterInputController(removedId);
+            semanticAnalysisService.unregisterTerminal(removedId);
+
+            const removed = prevById[removedId];
+            if (removed?.worktreeId) {
+              const worktreeState = useWorktreeSelectionStore.getState();
+              const lastFocused = worktreeState.lastFocusedTerminalByWorktree.get(
+                removed.worktreeId
+              );
+              if (lastFocused === removedId) {
+                worktreeState.clearWorktreeFocusTracking(removed.worktreeId);
+              }
             }
           }
-        }
-      })
+        },
+        { equalityFn: shallow }
+      )
     )
   );
 
-  // 4. Layout undo history invalidation: when terminal set changes (add/remove),
-  //    clear the undo stack since snapshots reference a different terminal universe.
-  let prevIdSet = new Set(usePanelStore.getState().panelIds);
-
+  // 4. Layout undo history invalidation: when terminal set changes
+  //    (add/remove), clear the undo stack since snapshots reference a
+  //    different terminal universe.
   disposables.add(
     toDisposable(
-      usePanelStore.subscribe((state) => {
-        const currentIds = state.panelIds;
-        const currentIdSet = new Set(currentIds);
-        if (currentIdSet.size !== prevIdSet.size || currentIds.some((id) => !prevIdSet.has(id))) {
-          useLayoutUndoStore.getState().clearHistory();
+      usePanelStore.subscribe(
+        (state) => state.panelIds,
+        (panelIds, prevPanelIds) => {
+          const prevIdSet = new Set(prevPanelIds);
+          if (panelIds.length !== prevIdSet.size || panelIds.some((id) => !prevIdSet.has(id))) {
+            useLayoutUndoStore.getState().clearHistory();
+          }
         }
-        prevIdSet = currentIdSet;
-      })
+      )
     )
   );
 
@@ -144,14 +170,18 @@ export function initStoreOrchestrator(): () => void {
   //    on real IPC completion, so ref equality is a reliable trigger.
   disposables.add(
     toDisposable(
-      useCliAvailabilityStore.subscribe((state, prevState) => {
-        const realDataLanded = state.hasRealData && !prevState.hasRealData;
-        const availabilityChanged = state.availability !== prevState.availability;
-        if (!realDataLanded && !availabilityChanged) return;
-        const { isInitialized, isLoading } = useAgentSettingsStore.getState();
-        if (!isInitialized || isLoading) return;
-        void useAgentSettingsStore.getState().refresh();
-      })
+      useCliAvailabilityStore.subscribe(
+        (state) => ({ hasRealData: state.hasRealData, availability: state.availability }),
+        (selected, prevSelected) => {
+          const realDataLanded = selected.hasRealData && !prevSelected.hasRealData;
+          const availabilityChanged = selected.availability !== prevSelected.availability;
+          if (!realDataLanded && !availabilityChanged) return;
+          const { isInitialized, isLoading } = useAgentSettingsStore.getState();
+          if (!isInitialized || isLoading) return;
+          void useAgentSettingsStore.getState().refresh();
+        },
+        { equalityFn: shallow }
+      )
     )
   );
 


### PR DESCRIPTION
## Summary

- Wrapped `usePanelStore` and `useCliAvailabilityStore` with `subscribeWithSelector` middleware so subscription callbacks only fire when the selected slice actually changes, cutting redundant re-evaluations in the orchestrator.
- Rewrote `rendererStoreOrchestrator.ts` to use selector-based subscriptions throughout. Rule 1 is split into three named rules (focus tracking, active worktree switch, MRU recording) and the module-level `prevTerminalIds`, `prevTerminalsById`, and `prevIdSet` closures are gone entirely.
- Compound selectors in Rules 3 and 5 use `shallow` equality from `zustand/shallow` to avoid unnecessary callbacks on unrelated state updates.

Resolves #5247

## Changes

- `src/store/panelStore.ts` — added `subscribeWithSelector` middleware wrapper
- `src/store/cliAvailabilityStore.ts` — same middleware addition
- `src/store/rendererStoreOrchestrator.ts` — fully rewritten subscription logic; 5 rules now use selector-based subscriptions with no module-level mutable closures

## Testing

908-line orchestrator test suite passes unchanged (29/29 tests). All 941 store tests green. Typecheck, lint (401/401 ratchet), and format checks clean.