### PR TITLE
feat(rpc): typed BrokerError with clear-reason codes so callers can retry intelligently

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -33,7 +33,7 @@ import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 import { logInfo, logWarn } from "../utils/logger.js";
 import { getTrashedPidTracker } from "./TrashedPidTracker.js";
-import { RequestResponseBroker } from "./rpc/index.js";
+import { RequestResponseBroker, BrokerError } from "./rpc/index.js";
 import { bridgePtyEvent } from "./pty/PtyEventsBridge.js";
 import type {
   PtyHostRequest,
@@ -363,7 +363,7 @@ export class PtyClient extends EventEmitter {
 
       this.cleanupOrphanedPtys(crashType);
 
-      this.broker.clear(new Error("Pty host restarted"));
+      this.broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
       this.shouldResyncProjectContext = true;
 
       // Emit crash payload with classification for downstream consumers
@@ -1024,7 +1024,12 @@ export class PtyClient extends EventEmitter {
       timeoutMs: PTY_TIMEOUTS["graceful-kill"],
     });
     this.send({ type: "graceful-kill", id, requestId });
-    return promise.catch(() => {
+    return promise.catch((error: unknown) => {
+      // Broker-cleared rejections (host exit, app shutdown) mean the host is
+      // already gone — sending another kill would only mutate local state.
+      if (error instanceof BrokerError) {
+        return null;
+      }
       this.kill(id, "graceful-kill-timeout");
       return null;
     });

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1025,9 +1025,12 @@ export class PtyClient extends EventEmitter {
     });
     this.send({ type: "graceful-kill", id, requestId });
     return promise.catch((error: unknown) => {
-      // Broker-cleared rejections (host exit, app shutdown) mean the host is
-      // already gone — sending another kill would only mutate local state.
-      if (error instanceof BrokerError) {
+      // Sending a kill to a host that isn't there only mutates local bookkeeping.
+      // Skip whenever the host is known to be gone — either because the broker
+      // clear told us (typed BrokerError), or because we notice it ourselves
+      // (null child or disposed client, e.g. restart pending, max restarts
+      // exhausted, or app quit arriving during the 5s timeout window).
+      if (error instanceof BrokerError || !this.child || this.isDisposed) {
         return null;
       }
       this.kill(id, "graceful-kill-timeout");

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -274,6 +274,52 @@ describe("PtyClient adversarial", () => {
     });
   });
 
+  it("GRACEFUL_KILL_SKIPS_KILL_WHEN_BROKER_CLEARED_BY_HOST_EXIT", async () => {
+    const client = createReadyClient();
+    shared.forkMock.mockReturnValue(createMockChild());
+
+    const promise = client.gracefulKill("t1");
+
+    const postedRequest = mockChild.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "graceful-kill"
+    );
+    expect(postedRequest).toBeDefined();
+
+    shared.tracker.removeTrashed.mockClear();
+    mockChild.emit("exit", 1);
+
+    await expect(promise).resolves.toBeNull();
+
+    // this.kill() would call getTrashedPidTracker().removeTrashed(id) — it must
+    // not fire when the broker clear carries a BrokerError reason.
+    expect(shared.tracker.removeTrashed).not.toHaveBeenCalled();
+  });
+
+  it("GRACEFUL_KILL_CALLS_KILL_ON_TIMEOUT_WHEN_HOST_STILL_ALIVE", async () => {
+    const client = createReadyClient();
+
+    const promise = client.gracefulKill("t1");
+    shared.tracker.removeTrashed.mockClear();
+    mockChild.postMessage.mockClear();
+
+    vi.advanceTimersByTime(6000);
+
+    await expect(promise).resolves.toBeNull();
+
+    // On timeout (non-BrokerError rejection), gracefulKill must still send
+    // a kill message and remove the trashed PID.
+    expect(shared.tracker.removeTrashed).toHaveBeenCalledWith("t1");
+    const killCall = mockChild.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "kill"
+    );
+    expect(killCall).toBeDefined();
+    expect(killCall?.[0]).toMatchObject({
+      type: "kill",
+      id: "t1",
+      reason: "graceful-kill-timeout",
+    });
+  });
+
   it("HOST_RESTART_CLEARS_MIGRATED_REQUESTS_TO_SENTINELS", async () => {
     const client = createReadyClient();
 

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -40,6 +40,7 @@ interface MockMessagePortMain {
 interface PtyClientPrivateAccess {
   child: MockUtilityProcess | null;
   pendingMessagePorts: Map<number, MockMessagePortMain>;
+  pendingKillCount: Map<string, number>;
 }
 
 function createMockChild(): MockUtilityProcess {
@@ -276,6 +277,7 @@ describe("PtyClient adversarial", () => {
 
   it("GRACEFUL_KILL_SKIPS_KILL_WHEN_BROKER_CLEARED_BY_HOST_EXIT", async () => {
     const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
     shared.forkMock.mockReturnValue(createMockChild());
 
     const promise = client.gracefulKill("t1");
@@ -286,13 +288,41 @@ describe("PtyClient adversarial", () => {
     expect(postedRequest).toBeDefined();
 
     shared.tracker.removeTrashed.mockClear();
+    mockChild.postMessage.mockClear();
     mockChild.emit("exit", 1);
 
     await expect(promise).resolves.toBeNull();
 
-    // this.kill() would call getTrashedPidTracker().removeTrashed(id) — it must
-    // not fire when the broker clear carries a BrokerError reason.
+    // this.kill() would call getTrashedPidTracker().removeTrashed(id), post a
+    // kill-typed IPC message, and bump pendingKillCount. None of that should
+    // happen when the broker clear carries a BrokerError reason.
     expect(shared.tracker.removeTrashed).not.toHaveBeenCalled();
+    expect(privateAccess.pendingKillCount.get("t1") ?? 0).toBe(0);
+    const killCall = mockChild.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "kill"
+    );
+    expect(killCall).toBeUndefined();
+  });
+
+  it("GRACEFUL_KILL_SKIPS_KILL_WHEN_TIMEOUT_FIRES_AFTER_HOST_GONE", async () => {
+    // When the host exits and restarts are exhausted, a subsequent gracefulKill
+    // will time out with a plain Error('Request timeout: …') — not a
+    // BrokerError. Without the null-child guard, the catch would fall through
+    // to this.kill() and mutate local state on a dead client.
+    const client = createReadyClient({ maxRestartAttempts: 0 });
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+
+    mockChild.emit("exit", 1);
+    expect(privateAccess.child).toBeNull();
+
+    shared.tracker.removeTrashed.mockClear();
+    const latePromise = client.gracefulKill("t1");
+
+    vi.advanceTimersByTime(6000);
+    await expect(latePromise).resolves.toBeNull();
+
+    expect(shared.tracker.removeTrashed).not.toHaveBeenCalled();
+    expect(privateAccess.pendingKillCount.get("t1") ?? 0).toBe(0);
   });
 
   it("GRACEFUL_KILL_CALLS_KILL_ON_TIMEOUT_WHEN_HOST_STILL_ALIVE", async () => {
@@ -306,8 +336,8 @@ describe("PtyClient adversarial", () => {
 
     await expect(promise).resolves.toBeNull();
 
-    // On timeout (non-BrokerError rejection), gracefulKill must still send
-    // a kill message and remove the trashed PID.
+    // On timeout (non-BrokerError rejection) with a live host, gracefulKill
+    // must still send a kill message and remove the trashed PID.
     expect(shared.tracker.removeTrashed).toHaveBeenCalledWith("t1");
     const killCall = mockChild.postMessage.mock.calls.find(
       (call: unknown[]) => (call[0] as { type?: string })?.type === "kill"

--- a/electron/services/rpc/RequestResponseBroker.ts
+++ b/electron/services/rpc/RequestResponseBroker.ts
@@ -5,6 +5,23 @@
  * supporting timeouts and automatic cleanup. Used by PtyClient and WorkspaceClient.
  */
 
+/**
+ * Discriminator for broker clear reasons so callers can distinguish a
+ * transient host exit (retry may be appropriate) from a terminal app shutdown.
+ */
+export type BrokerErrorCode = "HOST_EXITED" | "APP_SHUTDOWN";
+
+export class BrokerError extends Error {
+  constructor(
+    public readonly code: BrokerErrorCode,
+    message?: string
+  ) {
+    super(message ?? code);
+    this.name = this.constructor.name;
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
 export interface PendingRequest<T = unknown> {
   resolve: (value: T) => void;
   reject: (error: Error) => void;
@@ -181,7 +198,7 @@ export class RequestResponseBroker {
    * Dispose of the broker, rejecting all pending requests.
    */
   dispose(): void {
-    this.clear(new Error("Broker disposed"));
+    this.clear(new BrokerError("APP_SHUTDOWN", "Broker disposed"));
   }
 }
 

--- a/electron/services/rpc/__tests__/RequestResponseBroker.test.ts
+++ b/electron/services/rpc/__tests__/RequestResponseBroker.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { RequestResponseBroker } from "../RequestResponseBroker.js";
+import { BrokerError, RequestResponseBroker } from "../RequestResponseBroker.js";
 
 describe("RequestResponseBroker", () => {
   beforeEach(() => {
@@ -114,12 +114,14 @@ describe("RequestResponseBroker", () => {
     expect(broker.size).toBe(0);
   });
 
-  it("dispose rejects pending requests with broker disposed error", async () => {
+  it("dispose rejects pending requests with typed APP_SHUTDOWN BrokerError", async () => {
     const broker = new RequestResponseBroker();
     const p = broker.register("a");
     broker.dispose();
 
     await expect(p).rejects.toThrow("Broker disposed");
+    await expect(p).rejects.toBeInstanceOf(BrokerError);
+    await expect(p).rejects.toMatchObject({ code: "APP_SHUTDOWN" });
     expect(broker.size).toBe(0);
   });
 
@@ -155,5 +157,25 @@ describe("RequestResponseBroker", () => {
 
     vi.advanceTimersByTime(11);
     await expect(promise).rejects.toThrow("Request timeout: req-opts-invalid");
+  });
+
+  it("clear(BrokerError HOST_EXITED) tags all pending rejections with the code", async () => {
+    const broker = new RequestResponseBroker();
+    const p1 = broker.register("a");
+    const p2 = broker.register("b");
+
+    broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
+
+    await expect(p1).rejects.toBeInstanceOf(BrokerError);
+    await expect(p1).rejects.toMatchObject({ code: "HOST_EXITED" });
+    await expect(p2).rejects.toMatchObject({ code: "HOST_EXITED" });
+    expect(broker.size).toBe(0);
+  });
+
+  it("BrokerError defaults message to the code when none provided", () => {
+    const err = new BrokerError("HOST_EXITED");
+    expect(err.message).toBe("HOST_EXITED");
+    expect(err.name).toBe("BrokerError");
+    expect(err).toBeInstanceOf(Error);
   });
 });

--- a/electron/services/rpc/__tests__/RequestResponseBroker.test.ts
+++ b/electron/services/rpc/__tests__/RequestResponseBroker.test.ts
@@ -119,9 +119,10 @@ describe("RequestResponseBroker", () => {
     const p = broker.register("a");
     broker.dispose();
 
-    await expect(p).rejects.toThrow("Broker disposed");
-    await expect(p).rejects.toBeInstanceOf(BrokerError);
-    await expect(p).rejects.toMatchObject({ code: "APP_SHUTDOWN" });
+    const err = await p.catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(BrokerError);
+    expect((err as BrokerError).code).toBe("APP_SHUTDOWN");
+    expect((err as BrokerError).message).toBe("Broker disposed");
     expect(broker.size).toBe(0);
   });
 
@@ -166,9 +167,12 @@ describe("RequestResponseBroker", () => {
 
     broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
 
-    await expect(p1).rejects.toBeInstanceOf(BrokerError);
-    await expect(p1).rejects.toMatchObject({ code: "HOST_EXITED" });
-    await expect(p2).rejects.toMatchObject({ code: "HOST_EXITED" });
+    const e1 = await p1.catch((e: unknown) => e);
+    const e2 = await p2.catch((e: unknown) => e);
+    expect(e1).toBeInstanceOf(BrokerError);
+    expect((e1 as BrokerError).code).toBe("HOST_EXITED");
+    expect(e2).toBeInstanceOf(BrokerError);
+    expect((e2 as BrokerError).code).toBe("HOST_EXITED");
     expect(broker.size).toBe(0);
   });
 

--- a/electron/services/rpc/index.ts
+++ b/electron/services/rpc/index.ts
@@ -1,2 +1,7 @@
-export { RequestResponseBroker } from "./RequestResponseBroker.js";
-export type { PendingRequest, BrokerOptions, RegisterOptions } from "./RequestResponseBroker.js";
+export { RequestResponseBroker, BrokerError } from "./RequestResponseBroker.js";
+export type {
+  PendingRequest,
+  BrokerOptions,
+  RegisterOptions,
+  BrokerErrorCode,
+} from "./RequestResponseBroker.js";


### PR DESCRIPTION
## Summary

- Adds a `BrokerError` class with a `code` discriminant (`'HOST_EXITED' | 'APP_SHUTDOWN'`) so callers can tell a transient restart from a terminal shutdown and decide whether to retry or bail.
- `PtyClient.gracefulKill()` now skips the redundant local `kill()` fallback when the broker signals the host is already gone — avoids mutating bookkeeping state against a dead process after max restart attempts or app quit.
- Exports `BrokerError` and `BrokerErrorCode` from the `rpc` index so consumers don't have to reach into internals.

Resolves #5208

## Changes

- `RequestResponseBroker.ts` — `BrokerError` class; `dispose()` rejects with `APP_SHUTDOWN`, host-exit clear rejects with `HOST_EXITED`
- `PtyClient.ts` — `gracefulKill()` catch guard checks `BrokerError` code (or self-detected dead child) before falling through to local kill
- `rpc/index.ts` — exports `BrokerError`, `BrokerErrorCode`
- New unit tests: `RequestResponseBroker.test.ts` (HOST_EXITED, APP_SHUTDOWN, default message) and `PtyClient.adversarial.test.ts` (broker-clear-after-gracefulKill, timeout-after-host-gone, timeout-while-host-alive)

## Testing

38/38 tests pass across `RequestResponseBroker`, `PtyClient.adversarial`, and `PtyClient.handshake`. Typecheck clean, lint at 401 warnings (no new ones), format clean.