### PR TITLE
feat(plugin-schema): require scoped publisher.name plugin IDs

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -90,8 +90,11 @@ describe("registerPluginHandlers", () => {
     )![1] as (...args: unknown[]) => unknown;
 
     const trustedEvent = { senderFrame: { url: "app://daintree/" } };
-    const result = await invokeHandler(trustedEvent, "my-plugin", "get-data", "arg1", "arg2");
-    expect(mockDispatchHandler).toHaveBeenCalledWith("my-plugin", "get-data", ["arg1", "arg2"]);
+    const result = await invokeHandler(trustedEvent, "acme.my-plugin", "get-data", "arg1", "arg2");
+    expect(mockDispatchHandler).toHaveBeenCalledWith("acme.my-plugin", "get-data", [
+      "arg1",
+      "arg2",
+    ]);
     expect(result).toEqual({ data: "hello" });
   });
 
@@ -116,9 +119,9 @@ describe("registerPluginHandlers", () => {
     )![1] as (...args: unknown[]) => unknown;
 
     const untrustedEvent = { senderFrame: { url: "https://evil.com/attack.html" } };
-    await expect(invokeHandler(untrustedEvent, "my-plugin", "get-data", "arg1")).rejects.toThrow(
-      "plugin:invoke rejected: untrusted sender"
-    );
+    await expect(
+      invokeHandler(untrustedEvent, "acme.my-plugin", "get-data", "arg1")
+    ).rejects.toThrow("plugin:invoke rejected: untrusted sender");
     expect(mockDispatchHandler).not.toHaveBeenCalled();
   });
 
@@ -129,7 +132,7 @@ describe("registerPluginHandlers", () => {
     )![1] as (...args: unknown[]) => unknown;
 
     const nullFrameEvent = { senderFrame: null };
-    await expect(invokeHandler(nullFrameEvent, "my-plugin", "get-data")).rejects.toThrow(
+    await expect(invokeHandler(nullFrameEvent, "acme.my-plugin", "get-data")).rejects.toThrow(
       "plugin:invoke rejected: untrusted sender"
     );
     expect(mockDispatchHandler).not.toHaveBeenCalled();
@@ -160,7 +163,7 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
       iconId: "icon",
       actionId: "action.known",
       priority: 3,
-      pluginId: "my-plugin",
+      pluginId: "acme.my-plugin",
     });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const handler = getValidateHandler();
@@ -177,14 +180,14 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
       iconId: "icon",
       actionId: "action.missing",
       priority: 3,
-      pluginId: "my-plugin",
+      pluginId: "acme.my-plugin",
     });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const handler = getValidateHandler();
     await handler({}, ["action.known"]);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      '[Plugin] Unknown actionId "action.missing" on toolbar button "plugin.my.button" (plugin: my-plugin)'
+      '[Plugin] Unknown actionId "action.missing" on toolbar button "plugin.my.button" (plugin: acme.my-plugin)'
     );
     warn.mockRestore();
   });
@@ -192,7 +195,7 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
   it("warns with the exact message when a menu item actionId is unknown", async () => {
     mockGetPluginMenuItems.mockReturnValue([
       {
-        pluginId: "my-plugin",
+        pluginId: "acme.my-plugin",
         item: {
           label: "Do Thing",
           actionId: "action.missing",
@@ -205,7 +208,7 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
     await handler({}, ["action.known"]);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledWith(
-      '[Plugin] Unknown actionId "action.missing" on menu item "Do Thing" (plugin: my-plugin)'
+      '[Plugin] Unknown actionId "action.missing" on menu item "Do Thing" (plugin: acme.my-plugin)'
     );
     warn.mockRestore();
   });
@@ -324,14 +327,14 @@ describe("PLUGIN_VALIDATE_ACTION_IDS handler", () => {
 describe("registerPluginHandler", () => {
   it("delegates to pluginService.registerHandler", () => {
     const handler = vi.fn();
-    registerPluginHandler("my-plugin", "my-channel", handler);
-    expect(mockRegisterHandler).toHaveBeenCalledWith("my-plugin", "my-channel", handler);
+    registerPluginHandler("acme.my-plugin", "my-channel", handler);
+    expect(mockRegisterHandler).toHaveBeenCalledWith("acme.my-plugin", "my-channel", handler);
   });
 });
 
 describe("removePluginHandlers", () => {
   it("delegates to pluginService.removeHandlers", () => {
-    removePluginHandlers("my-plugin");
-    expect(mockRemoveHandlers).toHaveBeenCalledWith("my-plugin");
+    removePluginHandlers("acme.my-plugin");
+    expect(mockRemoveHandlers).toHaveBeenCalledWith("acme.my-plugin");
   });
 });

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -9,6 +9,8 @@ import type {
 
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
+export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
 export const PanelContributionSchema = z.object({
   id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
   name: z.string().min(1),
@@ -38,7 +40,9 @@ export const MenuItemContributionSchema = z.object({
 });
 
 export const PluginManifestSchema = z.object({
-  name: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+  name: z.string().min(1).max(64).regex(SCOPED_PLUGIN_NAME_PATTERN, {
+    error: 'Plugin name must be in publisher.name format (e.g. "acme.linear-context")',
+  }),
   version: z.string().min(1),
   displayName: z.string().optional(),
   description: z.string().optional(),

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -791,7 +791,7 @@ describe("engines.daintree compatibility gate", () => {
 describe("Plugin unload lifecycle", () => {
   it("unloadPlugin calls all registry unregister functions for the plugin", async () => {
     await writePlugin("unloadable", {
-      name: "unloadable",
+      name: "acme.unloadable",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
@@ -803,41 +803,41 @@ describe("Plugin unload lifecycle", () => {
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    expect(service.hasPlugin("unloadable")).toBe(true);
+    expect(service.hasPlugin("acme.unloadable")).toBe(true);
 
-    service.unloadPlugin("unloadable");
+    service.unloadPlugin("acme.unloadable");
 
-    expect(unregisterPluginMenuItems).toHaveBeenCalledWith("unloadable");
-    expect(unregisterPluginToolbarButtons).toHaveBeenCalledWith("unloadable");
-    expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("unloadable");
+    expect(unregisterPluginMenuItems).toHaveBeenCalledWith("acme.unloadable");
+    expect(unregisterPluginToolbarButtons).toHaveBeenCalledWith("acme.unloadable");
+    expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("acme.unloadable");
   });
 
   it("unloadPlugin removes the plugin from hasPlugin and listPlugins", async () => {
-    await writePlugin("goodbye", { name: "goodbye", version: "1.0.0" });
+    await writePlugin("goodbye", { name: "acme.goodbye", version: "1.0.0" });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
-    expect(service.hasPlugin("goodbye")).toBe(true);
+    expect(service.hasPlugin("acme.goodbye")).toBe(true);
 
-    service.unloadPlugin("goodbye");
+    service.unloadPlugin("acme.goodbye");
 
-    expect(service.hasPlugin("goodbye")).toBe(false);
+    expect(service.hasPlugin("acme.goodbye")).toBe(false);
     expect(service.listPlugins()).toEqual([]);
   });
 
   it("unloadPlugin removes IPC handlers registered for the plugin", async () => {
-    await writePlugin("handler-host", { name: "handler-host", version: "1.0.0" });
+    await writePlugin("handler-host", { name: "acme.handler-host", version: "1.0.0" });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    service.registerHandler("handler-host", "ping", () => "pong");
-    expect(await service.dispatchHandler("handler-host", "ping", [])).toBe("pong");
+    service.registerHandler("acme.handler-host", "ping", () => "pong");
+    expect(await service.dispatchHandler("acme.handler-host", "ping", [])).toBe("pong");
 
-    service.unloadPlugin("handler-host");
+    service.unloadPlugin("acme.handler-host");
 
-    await expect(service.dispatchHandler("handler-host", "ping", [])).rejects.toThrow(
-      "No plugin handler registered for handler-host:ping"
+    await expect(service.dispatchHandler("acme.handler-host", "ping", [])).rejects.toThrow(
+      "No plugin handler registered for acme.handler-host:ping"
     );
   });
 
@@ -845,23 +845,23 @@ describe("Plugin unload lifecycle", () => {
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    expect(() => service.unloadPlugin("never-loaded")).not.toThrow();
+    expect(() => service.unloadPlugin("acme.never-loaded")).not.toThrow();
     expect(unregisterPluginMenuItems).not.toHaveBeenCalled();
     expect(unregisterPluginToolbarButtons).not.toHaveBeenCalled();
     expect(unregisterPluginPanelKinds).not.toHaveBeenCalled();
   });
 
   it("unloadPlugin is idempotent across repeated calls", async () => {
-    await writePlugin("twice", { name: "twice", version: "1.0.0" });
+    await writePlugin("twice", { name: "acme.twice", version: "1.0.0" });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    service.unloadPlugin("twice");
-    expect(service.hasPlugin("twice")).toBe(false);
+    service.unloadPlugin("acme.twice");
+    expect(service.hasPlugin("acme.twice")).toBe(false);
 
     // Second call finds nothing to remove and stays silent.
-    service.unloadPlugin("twice");
+    service.unloadPlugin("acme.twice");
     expect(unregisterPluginMenuItems).toHaveBeenCalledTimes(1);
     expect(unregisterPluginToolbarButtons).toHaveBeenCalledTimes(1);
     expect(unregisterPluginPanelKinds).toHaveBeenCalledTimes(1);
@@ -869,7 +869,7 @@ describe("Plugin unload lifecycle", () => {
 
   it("supports load → unload → reload lifecycle via fresh service instance", async () => {
     await writePlugin("lifecycle", {
-      name: "lifecycle",
+      name: "acme.lifecycle",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
@@ -880,19 +880,19 @@ describe("Plugin unload lifecycle", () => {
     await first.initialize();
     expect(registerPanelKind).toHaveBeenCalledTimes(1);
 
-    first.unloadPlugin("lifecycle");
-    expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("lifecycle");
-    expect(first.hasPlugin("lifecycle")).toBe(false);
+    first.unloadPlugin("acme.lifecycle");
+    expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("acme.lifecycle");
+    expect(first.hasPlugin("acme.lifecycle")).toBe(false);
 
     // A fresh service instance re-reads the plugin directory and re-registers.
     vi.clearAllMocks();
     const second = new PluginService(tmpDir);
     await second.initialize();
 
-    expect(second.hasPlugin("lifecycle")).toBe(true);
+    expect(second.hasPlugin("acme.lifecycle")).toBe(true);
     expect(registerPanelKind).toHaveBeenCalledTimes(1);
     expect(registerPanelKind).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "lifecycle.viewer", extensionId: "lifecycle" })
+      expect.objectContaining({ id: "acme.lifecycle.viewer", extensionId: "acme.lifecycle" })
     );
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -28,6 +28,7 @@ vi.mock("../pluginMenuRegistry.js", () => ({
 }));
 
 import { PluginService } from "../PluginService.js";
+import { PluginManifestSchema } from "../../schemas/plugin.js";
 import {
   registerPanelKind,
   unregisterPluginPanelKinds,
@@ -57,6 +58,50 @@ afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true });
 });
 
+describe("PluginManifestSchema name validation", () => {
+  const validBase = { version: "1.0.0" };
+
+  it.each([
+    "acme.linear-context",
+    "a.b",
+    "daintreehq.dev-tools",
+    "daintree-hq.my-cool-plugin",
+    "acme.good-1",
+  ])("accepts scoped name %j", (name) => {
+    const result = PluginManifestSchema.safeParse({ name, ...validBase });
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    "linear-context",
+    "test-plugin",
+    "Acme.linear-context",
+    "acme.Linear",
+    "acme..tools",
+    ".acme.tools",
+    "acme.tools.",
+    "acme.team.tools",
+    "acme/tools",
+    "acme_tools",
+    "acme.-foo",
+    "acme.foo-",
+    "-acme.foo",
+    "",
+  ])("rejects unscoped or malformed name %j", (name) => {
+    const result = PluginManifestSchema.safeParse({ name, ...validBase });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejection includes an explanatory error message", () => {
+    const result = PluginManifestSchema.safeParse({ name: "bare-plugin", ...validBase });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const nameIssue = result.error.issues.find((i) => i.path[0] === "name");
+      expect(nameIssue?.message).toContain("publisher.name");
+    }
+  });
+});
+
 describe("PluginService", () => {
   it("returns empty list when plugins directory does not exist", async () => {
     const service = new PluginService(path.join(tmpDir, "nonexistent"));
@@ -72,7 +117,7 @@ describe("PluginService", () => {
 
   it("loads a valid plugin and registers panel kinds", async () => {
     await writePlugin("test-plugin", {
-      name: "test-plugin",
+      name: "acme.test-plugin",
       version: "1.0.0",
       displayName: "Test Plugin",
       contributes: {
@@ -92,13 +137,13 @@ describe("PluginService", () => {
 
     const plugins = service.listPlugins();
     expect(plugins).toHaveLength(1);
-    expect(plugins[0].manifest.name).toBe("test-plugin");
+    expect(plugins[0].manifest.name).toBe("acme.test-plugin");
     expect(plugins[0].manifest.displayName).toBe("Test Plugin");
     expect(plugins[0].dir).toBe(path.join(tmpDir, "test-plugin"));
 
     expect(registerPanelKind).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "test-plugin.viewer",
+        id: "acme.test-plugin.viewer",
         name: "Test Viewer",
         iconId: "eye",
         color: "#ff0000",
@@ -106,7 +151,7 @@ describe("PluginService", () => {
         canRestart: false,
         canConvert: false,
         showInPalette: true,
-        extensionId: "test-plugin",
+        extensionId: "acme.test-plugin",
       })
     );
   });
@@ -141,9 +186,9 @@ describe("PluginService", () => {
   });
 
   it("loads multiple plugins and skips invalid ones", async () => {
-    await writePlugin("good-1", { name: "good-1", version: "1.0.0" });
+    await writePlugin("good-1", { name: "acme.good-1", version: "1.0.0" });
     await writePlugin("bad", { version: "1.0.0" }); // missing name
-    await writePlugin("good-2", { name: "good-2", version: "2.0.0" });
+    await writePlugin("good-2", { name: "acme.good-2", version: "2.0.0" });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
@@ -151,11 +196,11 @@ describe("PluginService", () => {
     const plugins = service.listPlugins();
     expect(plugins).toHaveLength(2);
     const names = plugins.map((p) => p.manifest.name).sort();
-    expect(names).toEqual(["good-1", "good-2"]);
+    expect(names).toEqual(["acme.good-1", "acme.good-2"]);
   });
 
   it("is idempotent — second initialize is a no-op", async () => {
-    await writePlugin("test-plugin", { name: "test-plugin", version: "1.0.0" });
+    await writePlugin("test-plugin", { name: "acme.test-plugin", version: "1.0.0" });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
@@ -167,7 +212,7 @@ describe("PluginService", () => {
 
   it("namespaces panel IDs as pluginName.panelId", async () => {
     await writePlugin("my-plugin", {
-      name: "my-plugin",
+      name: "acme.my-plugin",
       version: "1.0.0",
       contributes: {
         panels: [
@@ -182,16 +227,16 @@ describe("PluginService", () => {
 
     expect(registerPanelKind).toHaveBeenCalledTimes(2);
     expect(registerPanelKind).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "my-plugin.viewer" })
+      expect.objectContaining({ id: "acme.my-plugin.viewer" })
     );
     expect(registerPanelKind).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "my-plugin.editor" })
+      expect.objectContaining({ id: "acme.my-plugin.editor" })
     );
   });
 
   it("rejects main entry paths that escape the plugin directory", async () => {
     await writePlugin("escape-test", {
-      name: "escape-test",
+      name: "acme.escape-test",
       version: "1.0.0",
       main: "../evil.js",
       renderer: "dist/renderer.js",
@@ -212,7 +257,7 @@ describe("PluginService", () => {
 
   it("resolves valid renderer entry path", async () => {
     await writePlugin("renderer-test", {
-      name: "renderer-test",
+      name: "acme.renderer-test",
       version: "1.0.0",
       renderer: "dist/renderer.js",
     });
@@ -229,7 +274,7 @@ describe("PluginService", () => {
 
   it("does not include resolvedMain in listPlugins output", async () => {
     await writePlugin("main-test", {
-      name: "main-test",
+      name: "acme.main-test",
       version: "1.0.0",
       main: "dist/main.js",
     });
@@ -261,7 +306,7 @@ describe("PluginService", () => {
 
   it("rejects panel with invalid ID characters", async () => {
     await writePlugin("bad-panel", {
-      name: "bad-panel",
+      name: "acme.bad-panel",
       version: "1.0.0",
       contributes: {
         panels: [{ id: "../../hack", name: "Hack", iconId: "x", color: "#000" }],
@@ -274,21 +319,21 @@ describe("PluginService", () => {
   });
 
   it("warns on duplicate plugin names and keeps the last one", async () => {
-    await writePlugin("dir-a", { name: "same-name", version: "1.0.0", description: "first" });
-    await writePlugin("dir-b", { name: "same-name", version: "2.0.0", description: "second" });
+    await writePlugin("dir-a", { name: "acme.same-name", version: "1.0.0", description: "first" });
+    await writePlugin("dir-b", { name: "acme.same-name", version: "2.0.0", description: "second" });
 
     const service = new PluginService(tmpDir);
     await service.initialize();
 
     const plugins = service.listPlugins();
     expect(plugins).toHaveLength(1);
-    expect(plugins[0].manifest.name).toBe("same-name");
+    expect(plugins[0].manifest.name).toBe("acme.same-name");
   });
 
   it("allows retry after non-ENOENT initialize failure", async () => {
     const badRoot = path.join(tmpDir, "unreadable");
     await fs.mkdir(badRoot);
-    await writePlugin("good", { name: "good", version: "1.0.0" });
+    await writePlugin("good", { name: "acme.good", version: "1.0.0" });
 
     const service = new PluginService(tmpDir);
 
@@ -303,7 +348,7 @@ describe("PluginService", () => {
 
   it("registers toolbar buttons from plugin manifest", async () => {
     await writePlugin("toolbar-test", {
-      name: "toolbar-test",
+      name: "acme.toolbar-test",
       version: "1.0.0",
       contributes: {
         toolbarButtons: [
@@ -311,7 +356,7 @@ describe("PluginService", () => {
             id: "my-btn",
             label: "My Button",
             iconId: "puzzle",
-            actionId: "toolbar-test.doThing",
+            actionId: "acme.toolbar-test.doThing",
             priority: 4,
           },
         ],
@@ -323,19 +368,19 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "plugin.toolbar-test.my-btn",
+        id: "plugin.acme.toolbar-test.my-btn",
         label: "My Button",
         iconId: "puzzle",
-        actionId: "toolbar-test.doThing",
+        actionId: "acme.toolbar-test.doThing",
         priority: 4,
-        pluginId: "toolbar-test",
+        pluginId: "acme.toolbar-test",
       })
     );
   });
 
   it("uses default priority 3 when not specified in toolbar button", async () => {
     await writePlugin("default-priority", {
-      name: "default-priority",
+      name: "acme.default-priority",
       version: "1.0.0",
       contributes: {
         toolbarButtons: [
@@ -354,7 +399,7 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: "plugin.default-priority.btn",
+        id: "plugin.acme.default-priority.btn",
         priority: 3,
       })
     );
@@ -362,13 +407,13 @@ describe("PluginService", () => {
 
   it("registers menu items from plugin manifest", async () => {
     await writePlugin("menu-test", {
-      name: "menu-test",
+      name: "acme.menu-test",
       version: "1.0.0",
       contributes: {
         menuItems: [
           {
             label: "Do Something",
-            actionId: "menu-test.doSomething",
+            actionId: "acme.menu-test.doSomething",
             location: "terminal",
           },
         ],
@@ -378,16 +423,16 @@ describe("PluginService", () => {
     const service = new PluginService(tmpDir);
     await service.initialize();
 
-    expect(registerPluginMenuItem).toHaveBeenCalledWith("menu-test", {
+    expect(registerPluginMenuItem).toHaveBeenCalledWith("acme.menu-test", {
       label: "Do Something",
-      actionId: "menu-test.doSomething",
+      actionId: "acme.menu-test.doSomething",
       location: "terminal",
     });
   });
 
   it("does not call toolbar/menu registration when no contributions", async () => {
     await writePlugin("empty-contribs", {
-      name: "empty-contribs",
+      name: "acme.empty-contribs",
       version: "1.0.0",
     });
 
@@ -403,89 +448,89 @@ describe("Plugin IPC handler registration", () => {
   let service: PluginService;
 
   beforeEach(async () => {
-    await writePlugin("test-plugin", { name: "test-plugin", version: "1.0.0" });
+    await writePlugin("test-plugin", { name: "acme.test-plugin", version: "1.0.0" });
     service = new PluginService(tmpDir);
     await service.initialize();
   });
 
   it("registerHandler succeeds for a loaded plugin with valid channel", () => {
     const handler = vi.fn();
-    expect(() => service.registerHandler("test-plugin", "get-data", handler)).not.toThrow();
+    expect(() => service.registerHandler("acme.test-plugin", "get-data", handler)).not.toThrow();
   });
 
   it("registerHandler throws when pluginId is not loaded", () => {
-    expect(() => service.registerHandler("unknown-plugin", "get-data", vi.fn())).toThrow(
-      "Unknown plugin: unknown-plugin"
+    expect(() => service.registerHandler("acme.unknown-plugin", "get-data", vi.fn())).toThrow(
+      "Unknown plugin: acme.unknown-plugin"
     );
   });
 
   it("registerHandler throws when channel contains a colon", () => {
-    expect(() => service.registerHandler("test-plugin", "bad:channel", vi.fn())).toThrow(
+    expect(() => service.registerHandler("acme.test-plugin", "bad:channel", vi.fn())).toThrow(
       "Plugin channel must not contain colons: bad:channel"
     );
   });
 
   it("registerHandler throws when handler is not a function", () => {
     expect(() =>
-      service.registerHandler("test-plugin", "get-data", "not-a-function" as never)
+      service.registerHandler("acme.test-plugin", "get-data", "not-a-function" as never)
     ).toThrow("Plugin handler must be a function, got string");
   });
 
   it("dispatchHandler calls the registered handler and returns its result", async () => {
     const handler = vi.fn().mockResolvedValue({ value: 42 });
-    service.registerHandler("test-plugin", "get-data", handler);
+    service.registerHandler("acme.test-plugin", "get-data", handler);
 
-    const result = await service.dispatchHandler("test-plugin", "get-data", ["arg1", "arg2"]);
+    const result = await service.dispatchHandler("acme.test-plugin", "get-data", ["arg1", "arg2"]);
     expect(handler).toHaveBeenCalledWith("arg1", "arg2");
     expect(result).toEqual({ value: 42 });
   });
 
   it("dispatchHandler throws when no handler is found", async () => {
-    await expect(service.dispatchHandler("test-plugin", "unknown", [])).rejects.toThrow(
-      "No plugin handler registered for test-plugin:unknown"
+    await expect(service.dispatchHandler("acme.test-plugin", "unknown", [])).rejects.toThrow(
+      "No plugin handler registered for acme.test-plugin:unknown"
     );
   });
 
   it("registering same (pluginId, channel) twice overwrites the handler", async () => {
     const handler1 = vi.fn().mockReturnValue("first");
     const handler2 = vi.fn().mockReturnValue("second");
-    service.registerHandler("test-plugin", "get-data", handler1);
-    service.registerHandler("test-plugin", "get-data", handler2);
+    service.registerHandler("acme.test-plugin", "get-data", handler1);
+    service.registerHandler("acme.test-plugin", "get-data", handler2);
 
-    const result = await service.dispatchHandler("test-plugin", "get-data", []);
+    const result = await service.dispatchHandler("acme.test-plugin", "get-data", []);
     expect(result).toBe("second");
     expect(handler1).not.toHaveBeenCalled();
   });
 
   it("removeHandlers removes all handlers for a plugin, leaving others intact", async () => {
-    await writePlugin("other-plugin", { name: "other-plugin", version: "1.0.0" });
+    await writePlugin("other-plugin", { name: "acme.other-plugin", version: "1.0.0" });
     const service2 = new PluginService(tmpDir);
     await service2.initialize();
 
-    service2.registerHandler("test-plugin", "ch-a", vi.fn().mockReturnValue("a"));
-    service2.registerHandler("test-plugin", "ch-b", vi.fn().mockReturnValue("b"));
-    service2.registerHandler("other-plugin", "ch-c", vi.fn().mockReturnValue("c"));
+    service2.registerHandler("acme.test-plugin", "ch-a", vi.fn().mockReturnValue("a"));
+    service2.registerHandler("acme.test-plugin", "ch-b", vi.fn().mockReturnValue("b"));
+    service2.registerHandler("acme.other-plugin", "ch-c", vi.fn().mockReturnValue("c"));
 
-    service2.removeHandlers("test-plugin");
+    service2.removeHandlers("acme.test-plugin");
 
-    await expect(service2.dispatchHandler("test-plugin", "ch-a", [])).rejects.toThrow();
-    await expect(service2.dispatchHandler("test-plugin", "ch-b", [])).rejects.toThrow();
-    expect(await service2.dispatchHandler("other-plugin", "ch-c", [])).toBe("c");
+    await expect(service2.dispatchHandler("acme.test-plugin", "ch-a", [])).rejects.toThrow();
+    await expect(service2.dispatchHandler("acme.test-plugin", "ch-b", [])).rejects.toThrow();
+    expect(await service2.dispatchHandler("acme.other-plugin", "ch-c", [])).toBe("c");
   });
 
   it("hasPlugin returns true for loaded plugins and false otherwise", () => {
-    expect(service.hasPlugin("test-plugin")).toBe(true);
+    expect(service.hasPlugin("acme.test-plugin")).toBe(true);
     expect(service.hasPlugin("nonexistent")).toBe(false);
   });
 
   it("registerHandler throws for empty channel", () => {
-    expect(() => service.registerHandler("test-plugin", "", vi.fn())).not.toThrow();
+    expect(() => service.registerHandler("acme.test-plugin", "", vi.fn())).not.toThrow();
     // Empty channel is technically valid — no colons
   });
 
   it("dispatchHandler handles synchronous handlers", async () => {
-    service.registerHandler("test-plugin", "sync", () => "sync-result");
-    const result = await service.dispatchHandler("test-plugin", "sync", []);
+    service.registerHandler("acme.test-plugin", "sync", () => "sync-result");
+    const result = await service.dispatchHandler("acme.test-plugin", "sync", []);
     expect(result).toBe("sync-result");
   });
 });
@@ -506,7 +551,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("loads a plugin when app version satisfies engines.daintree", async () => {
     await writePlugin("compatible", {
-      name: "compatible",
+      name: "acme.compatible",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
     });
@@ -520,7 +565,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("rejects a plugin when app version does not satisfy engines.daintree", async () => {
     await writePlugin("incompatible", {
-      name: "incompatible",
+      name: "acme.incompatible",
       displayName: "Incompatible Plugin",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
@@ -535,7 +580,7 @@ describe("engines.daintree compatibility gate", () => {
     expect(service.listPlugins()).toEqual([]);
     expect(registerPanelKind).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Plugin "incompatible" requires Daintree ^0.7.0')
+      expect.stringContaining('Plugin "acme.incompatible" requires Daintree ^0.7.0')
     );
     expect(broadcastToRendererMock).toHaveBeenCalledWith(
       CHANNELS.NOTIFICATION_SHOW_TOAST,
@@ -549,7 +594,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("treats app prerelease versions as satisfying their release-series range", async () => {
     await writePlugin("prerelease-compatible", {
-      name: "prerelease-compatible",
+      name: "acme.prerelease-compatible",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
     });
@@ -562,21 +607,21 @@ describe("engines.daintree compatibility gate", () => {
   });
 
   it("loads plugins that omit engines.daintree with a warning", async () => {
-    await writePlugin("no-engines", { name: "no-engines", version: "1.0.0" });
+    await writePlugin("no-engines", { name: "acme.no-engines", version: "1.0.0" });
 
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Plugin "no-engines" does not declare engines.daintree')
+      expect.stringContaining('Plugin "acme.no-engines" does not declare engines.daintree')
     );
     expect(broadcastToRendererMock).not.toHaveBeenCalled();
   });
 
   it("loads plugins with empty engines object (daintree absent) with a warning", async () => {
     await writePlugin("empty-engines", {
-      name: "empty-engines",
+      name: "acme.empty-engines",
       version: "1.0.0",
       engines: {},
     });
@@ -586,13 +631,13 @@ describe("engines.daintree compatibility gate", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Plugin "empty-engines" does not declare engines.daintree')
+      expect.stringContaining('Plugin "acme.empty-engines" does not declare engines.daintree')
     );
   });
 
   it("rejects manifests with an invalid semver range at schema level", async () => {
     await writePlugin("bad-range", {
-      name: "bad-range",
+      name: "acme.bad-range",
       version: "1.0.0",
       engines: { daintree: "not-a-range" },
     });
@@ -606,7 +651,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("rejects plugins requiring a future major version", async () => {
     await writePlugin("future", {
-      name: "future",
+      name: "acme.future",
       version: "1.0.0",
       engines: { daintree: "^1.0.0" },
     });
@@ -620,7 +665,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("does not attempt main import or register contributions for incompatible plugins", async () => {
     await writePlugin("skip-side-effects", {
-      name: "skip-side-effects",
+      name: "acme.skip-side-effects",
       version: "1.0.0",
       main: "dist/main.js",
       engines: { daintree: "^1.0.0" },
@@ -642,12 +687,12 @@ describe("engines.daintree compatibility gate", () => {
 
   it("loads only the compatible plugins in a mixed batch", async () => {
     await writePlugin("good", {
-      name: "good",
+      name: "acme.good",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
     });
     await writePlugin("bad", {
-      name: "bad",
+      name: "acme.bad",
       version: "1.0.0",
       engines: { daintree: "^1.0.0" },
     });
@@ -656,13 +701,13 @@ describe("engines.daintree compatibility gate", () => {
     await service.initialize();
 
     const names = service.listPlugins().map((p) => p.manifest.name);
-    expect(names).toEqual(["good"]);
+    expect(names).toEqual(["acme.good"]);
     expect(broadcastToRendererMock).toHaveBeenCalledTimes(1);
   });
 
   it("accepts the wildcard range '*'", async () => {
     await writePlugin("wildcard", {
-      name: "wildcard",
+      name: "acme.wildcard",
       version: "1.0.0",
       engines: { daintree: "*" },
     });
@@ -676,7 +721,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("rejects whitespace-only range strings at the schema layer", async () => {
     await writePlugin("whitespace-range", {
-      name: "whitespace-range",
+      name: "acme.whitespace-range",
       version: "1.0.0",
       engines: { daintree: "   " },
     });
@@ -690,7 +735,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("rejects an app prerelease that is below a non-prerelease range's lower bound", async () => {
     await writePlugin("prerelease-too-early", {
-      name: "prerelease-too-early",
+      name: "acme.prerelease-too-early",
       version: "1.0.0",
       engines: { daintree: ">=0.7.0" },
     });
@@ -704,7 +749,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("accepts an exact-version range when the app matches precisely", async () => {
     await writePlugin("exact-match", {
-      name: "exact-match",
+      name: "acme.exact-match",
       version: "1.0.0",
       engines: { daintree: "0.7.5" },
     });
@@ -718,7 +763,7 @@ describe("engines.daintree compatibility gate", () => {
 
   it("rejects an exact-version range when the app does not match", async () => {
     await writePlugin("exact-mismatch", {
-      name: "exact-mismatch",
+      name: "acme.exact-mismatch",
       version: "1.0.0",
       engines: { daintree: "0.7.5" },
     });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -60,6 +60,8 @@ afterEach(async () => {
 
 describe("PluginManifestSchema name validation", () => {
   const validBase = { version: "1.0.0" };
+  const sixtyFourCharName = `a.${"b".repeat(62)}`; // 1 + 1 + 62 = 64 chars
+  const sixtyFiveCharName = `a.${"b".repeat(63)}`; // 1 + 1 + 63 = 65 chars
 
   it.each([
     "acme.linear-context",
@@ -67,6 +69,7 @@ describe("PluginManifestSchema name validation", () => {
     "daintreehq.dev-tools",
     "daintree-hq.my-cool-plugin",
     "acme.good-1",
+    sixtyFourCharName,
   ])("accepts scoped name %j", (name) => {
     const result = PluginManifestSchema.safeParse({ name, ...validBase });
     expect(result.success).toBe(true);
@@ -86,10 +89,19 @@ describe("PluginManifestSchema name validation", () => {
     "acme.-foo",
     "acme.foo-",
     "-acme.foo",
+    "---.foo",
+    "acme.---",
+    " acme.foo",
+    "acme.foo ",
+    "acme.foo\n",
+    sixtyFiveCharName,
     "",
   ])("rejects unscoped or malformed name %j", (name) => {
     const result = PluginManifestSchema.safeParse({ name, ...validBase });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "name")).toBe(true);
+    }
   });
 
   it("rejection includes an explanatory error message", () => {

--- a/shared/config/__tests__/toolbarButtonRegistry.test.ts
+++ b/shared/config/__tests__/toolbarButtonRegistry.test.ts
@@ -19,17 +19,17 @@ const makeConfig = (id: string, overrides?: Partial<ToolbarButtonConfig>): Toolb
   iconId: "puzzle",
   actionId: "test.action",
   priority: 3,
-  pluginId: "test-plugin",
+  pluginId: "acme.test-plugin",
   ...overrides,
 });
 
 describe("toolbarButtonRegistry", () => {
   it("registers a button and retrieves it by ID", () => {
-    const config = makeConfig("plugin.test-plugin.viewer");
+    const config = makeConfig("plugin.acme.test-plugin.viewer");
     registerToolbarButton(config);
 
-    expect(getToolbarButtonConfig("plugin.test-plugin.viewer")).toEqual(config);
-    expect(getPluginToolbarButtonIds()).toEqual(["plugin.test-plugin.viewer"]);
+    expect(getToolbarButtonConfig("plugin.acme.test-plugin.viewer")).toEqual(config);
+    expect(getPluginToolbarButtonIds()).toEqual(["plugin.acme.test-plugin.viewer"]);
   });
 
   it("returns undefined for unregistered IDs", () => {
@@ -42,24 +42,24 @@ describe("toolbarButtonRegistry", () => {
 
   it("warns and overwrites on duplicate registration", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const first = makeConfig("plugin.test-plugin.btn", { label: "First" });
-    const second = makeConfig("plugin.test-plugin.btn", { label: "Second" });
+    const first = makeConfig("plugin.acme.test-plugin.btn", { label: "First" });
+    const second = makeConfig("plugin.acme.test-plugin.btn", { label: "Second" });
 
     registerToolbarButton(first);
     registerToolbarButton(second);
 
     expect(spy).toHaveBeenCalledWith(
-      'Toolbar button "plugin.test-plugin.btn" already registered, overwriting'
+      'Toolbar button "plugin.acme.test-plugin.btn" already registered, overwriting'
     );
-    expect(getToolbarButtonConfig("plugin.test-plugin.btn")?.label).toBe("Second");
+    expect(getToolbarButtonConfig("plugin.acme.test-plugin.btn")?.label).toBe("Second");
     expect(getPluginToolbarButtonIds()).toHaveLength(1);
 
     spy.mockRestore();
   });
 
   it("isRegisteredPluginButton returns true for registered plugin buttons", () => {
-    registerToolbarButton(makeConfig("plugin.my-plugin.action"));
-    expect(isRegisteredPluginButton("plugin.my-plugin.action")).toBe(true);
+    registerToolbarButton(makeConfig("plugin.acme.my-plugin.action"));
+    expect(isRegisteredPluginButton("plugin.acme.my-plugin.action")).toBe(true);
   });
 
   it("isRegisteredPluginButton returns false for built-in IDs", () => {

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -443,7 +443,7 @@ describe("PanelPersistence", () => {
 
       const extensionPanel = createMockTerminal({
         id: "ext-1",
-        kind: "my-plugin",
+        kind: "acme.my-plugin.viewer",
         title: "My Plugin",
         extensionState: { activeTab: "overview", zoom: 1.5 },
         location: "grid",
@@ -457,7 +457,7 @@ describe("PanelPersistence", () => {
       expect(savedTerminals[0]).toEqual(
         expect.objectContaining({
           id: "ext-1",
-          kind: "my-plugin",
+          kind: "acme.my-plugin.viewer",
           extensionState: { activeTab: "overview", zoom: 1.5 },
         })
       );


### PR DESCRIPTION
## Summary

- Tightens `PluginManifestSchema.name` validation to require `publisher.name` format (e.g. `acme.linear-context`) using a new `SCOPED_PLUGIN_NAME_PATTERN` regex, preventing silent collision when two plugins share a bare ID
- Contribution IDs (panel, toolbar button) keep the existing `SAFE_ID_PATTERN` since they're already namespaced by `PluginService` via `${pluginName}.${contributionId}`
- Updates all test fixtures from bare IDs (`test-plugin`, `my-plugin`) to scoped form and adds a dedicated validation test block with 26 cases covering the accept/reject boundary and error message wording

Resolves #5214

## Changes

- `electron/schemas/plugin.ts` — new `SCOPED_PLUGIN_NAME_PATTERN`, applied to `PluginManifestSchema.name` with a descriptive Zod 4 error message
- `electron/services/__tests__/PluginService.test.ts` — migrated fixtures to scoped names; added `describe("PluginManifestSchema name validation")` block
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` — fixture names scoped
- `shared/config/__tests__/toolbarButtonRegistry.test.ts` — fixture names scoped
- `electron/persistence/__tests__/panelPersistence.test.ts` — fixture names scoped

## Testing

All 10920 tests pass. The new validation block covers 6 valid scoped names, 20 invalid forms (bare IDs, double dots, uppercase, hyphens in publisher segment, etc.), error message content, and path-narrowed assertions on the `name` field.