### PR TITLE
feat(store): persisted-store registry for diagnostics introspection

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -174,6 +174,7 @@ export type BuiltInActionId =
   | "action.palette.open"
   | "actions.list"
   | "actions.getContext"
+  | "actions.persistedStores"
   | "terminal.moveToDock"
   | "terminal.moveToGrid"
   | "terminal.toggleDock"

--- a/src/services/actions/definitions/__tests__/introspectionActions.test.ts
+++ b/src/services/actions/definitions/__tests__/introspectionActions.test.ts
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionDefinition, ActionContext } from "@shared/types/actions";
+
+// Stubs for other actions' dependencies (actions.list, actions.getContext). These
+// are not exercised by the persistedStores tests but must load without errors.
+vi.mock("@/store/panelStore", () => ({ usePanelStore: { getState: () => ({}) } }));
+vi.mock("@/store/projectStore", () => ({ useProjectStore: { getState: () => ({}) } }));
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStore: () => ({ getState: () => ({ worktrees: new Map() }) }),
+}));
+
+import {
+  _resetPersistedStoreRegistryForTests,
+  registerPersistedStore,
+  type StoreWithPersist,
+} from "@/store/persistence/persistedStoreRegistry";
+
+type ActionFactory = () => ActionDefinition;
+
+function makeStore(options: {
+  name?: string;
+  version?: number;
+  partialize?: unknown;
+  migrate?: unknown;
+  merge?: unknown;
+}): StoreWithPersist {
+  return {
+    persist: {
+      getOptions: () => options,
+    },
+  };
+}
+
+const stubCtx: ActionContext = {};
+const registry = new Map<string, ActionFactory>();
+
+beforeAll(async () => {
+  const { registerIntrospectionActions } = await import("../introspectionActions");
+  registerIntrospectionActions(registry as never, {} as never);
+});
+
+beforeEach(() => {
+  _resetPersistedStoreRegistryForTests();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("actions.persistedStores", () => {
+  it("is registered with the expected metadata", () => {
+    expect(registry.has("actions.persistedStores")).toBe(true);
+    const def = registry.get("actions.persistedStores")!();
+    expect(def.id).toBe("actions.persistedStores");
+    expect(def.kind).toBe("query");
+    expect(def.danger).toBe("safe");
+    expect(def.category).toBe("introspection");
+    expect(def.scope).toBe("renderer");
+  });
+
+  it("returns storeCount and an entry per registered store", async () => {
+    registerPersistedStore({
+      storeId: "alpha",
+      store: makeStore({ name: "daintree-alpha", version: 2 }),
+      persistedStateType: "AlphaState",
+    });
+    registerPersistedStore({
+      storeId: "beta",
+      store: makeStore({ name: "daintree-beta" }),
+      persistedStateType: "BetaState",
+    });
+
+    const def = registry.get("actions.persistedStores")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      storeCount: number;
+      stores: Array<{ storeId: string }>;
+    };
+
+    expect(result.storeCount).toBe(2);
+    expect(result.stores.map((s) => s.storeId)).toEqual(["alpha", "beta"]);
+  });
+
+  it("flips hasMigrate / hasMerge / hasPartialize based on options", async () => {
+    registerPersistedStore({
+      storeId: "withAll",
+      store: makeStore({
+        name: "daintree-with-all",
+        partialize: () => ({}),
+        migrate: () => ({}),
+        merge: () => ({}),
+      }),
+      persistedStateType: "State",
+    });
+    registerPersistedStore({
+      storeId: "bare",
+      store: makeStore({ name: "daintree-bare" }),
+      persistedStateType: "State",
+    });
+
+    const def = registry.get("actions.persistedStores")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      stores: Array<{
+        storeId: string;
+        hasMigrate: boolean;
+        hasMerge: boolean;
+        hasPartialize: boolean;
+      }>;
+    };
+
+    const withAll = result.stores.find((s) => s.storeId === "withAll")!;
+    const bare = result.stores.find((s) => s.storeId === "bare")!;
+
+    expect(withAll).toMatchObject({ hasMigrate: true, hasMerge: true, hasPartialize: true });
+    expect(bare).toMatchObject({ hasMigrate: false, hasMerge: false, hasPartialize: false });
+  });
+
+  it("reports declaredVersion as null when the store has no version option", async () => {
+    registerPersistedStore({
+      storeId: "versionless",
+      store: makeStore({ name: "daintree-versionless" }),
+      persistedStateType: "State",
+    });
+
+    const def = registry.get("actions.persistedStores")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      stores: Array<{ storeId: string; declaredVersion: number | null }>;
+    };
+
+    expect(result.stores[0].declaredVersion).toBeNull();
+  });
+
+  it("reads persistedBlobVersion and sizeBytes lazily from localStorage at call time", async () => {
+    registerPersistedStore({
+      storeId: "lazy",
+      store: makeStore({ name: "daintree-lazy", version: 3 }),
+      persistedStateType: "State",
+    });
+
+    const def = registry.get("actions.persistedStores")!();
+
+    // Empty localStorage: missing status, zero bytes
+    const firstResult = (await def.run(undefined, stubCtx)) as {
+      stores: Array<{
+        hasPersistedValue: boolean;
+        sizeBytes: number;
+        parseStatus: string;
+        persistedBlobVersion: number | null;
+      }>;
+    };
+    expect(firstResult.stores[0]).toMatchObject({
+      hasPersistedValue: false,
+      sizeBytes: 0,
+      parseStatus: "missing",
+      persistedBlobVersion: null,
+    });
+
+    // Populate the key: second call should see the new value
+    const raw = JSON.stringify({ state: { foo: "bar" }, version: 2 });
+    localStorage.setItem("daintree-lazy", raw);
+
+    const secondResult = (await def.run(undefined, stubCtx)) as {
+      stores: Array<{
+        hasPersistedValue: boolean;
+        sizeBytes: number;
+        parseStatus: string;
+        persistedBlobVersion: number | null;
+      }>;
+    };
+    expect(secondResult.stores[0]).toMatchObject({
+      hasPersistedValue: true,
+      sizeBytes: raw.length * 2,
+      parseStatus: "ok",
+      persistedBlobVersion: 2,
+    });
+  });
+
+  it("reports parseStatus: 'corrupt' for malformed JSON without throwing", async () => {
+    registerPersistedStore({
+      storeId: "broken",
+      store: makeStore({ name: "daintree-broken" }),
+      persistedStateType: "State",
+    });
+    localStorage.setItem("daintree-broken", "{not-json");
+
+    const def = registry.get("actions.persistedStores")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      stores: Array<{
+        hasPersistedValue: boolean;
+        parseStatus: string;
+        persistedBlobVersion: number | null;
+        sizeBytes: number;
+      }>;
+    };
+
+    expect(result.stores[0]).toMatchObject({
+      hasPersistedValue: true,
+      parseStatus: "corrupt",
+      persistedBlobVersion: null,
+    });
+    expect(result.stores[0].sizeBytes).toBe("{not-json".length * 2);
+  });
+
+  it("does not log or throw when parsing corrupt JSON", async () => {
+    registerPersistedStore({
+      storeId: "silent",
+      store: makeStore({ name: "daintree-silent" }),
+      persistedStateType: "State",
+    });
+    localStorage.setItem("daintree-silent", "{broken");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const def = registry.get("actions.persistedStores")!();
+    await expect(def.run(undefined, stubCtx)).resolves.toBeDefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports persistedBlobVersion: null when the blob is valid JSON but has no version field", async () => {
+    registerPersistedStore({
+      storeId: "noBlobVersion",
+      store: makeStore({ name: "daintree-no-blob-version", version: 1 }),
+      persistedStateType: "State",
+    });
+    localStorage.setItem(
+      "daintree-no-blob-version",
+      JSON.stringify({ state: { x: 1 } }) // no version key
+    );
+
+    const def = registry.get("actions.persistedStores")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      stores: Array<{ persistedBlobVersion: number | null; declaredVersion: number | null }>;
+    };
+
+    expect(result.stores[0].persistedBlobVersion).toBeNull();
+    expect(result.stores[0].declaredVersion).toBe(1);
+  });
+
+  it("falls back gracefully when localStorage access throws", async () => {
+    registerPersistedStore({
+      storeId: "blocked",
+      store: makeStore({ name: "daintree-blocked" }),
+      persistedStateType: "State",
+    });
+
+    const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("SecurityError");
+      },
+    });
+
+    try {
+      const def = registry.get("actions.persistedStores")!();
+      const result = (await def.run(undefined, stubCtx)) as {
+        stores: Array<{ hasPersistedValue: boolean; parseStatus: string }>;
+      };
+      expect(result.stores[0]).toMatchObject({
+        hasPersistedValue: false,
+        parseStatus: "missing",
+      });
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(globalThis, "localStorage", originalDescriptor);
+      } else {
+        delete (globalThis as Partial<typeof globalThis>).localStorage;
+      }
+    }
+  });
+
+  it("returns an empty stores array when no stores are registered", async () => {
+    const def = registry.get("actions.persistedStores")!();
+    const result = (await def.run(undefined, stubCtx)) as {
+      storeCount: number;
+      stores: unknown[];
+    };
+    expect(result.storeCount).toBe(0);
+    expect(result.stores).toEqual([]);
+  });
+});

--- a/src/services/actions/definitions/introspectionActions.ts
+++ b/src/services/actions/definitions/introspectionActions.ts
@@ -4,6 +4,22 @@ import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
 import { useProjectStore } from "@/store/projectStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import { listPersistedStores } from "@/store/persistence/persistedStoreRegistry";
+import { readLocalStorageItemSafely } from "@/store/persistence/safeStorage";
+
+interface PersistedStoreInfo {
+  storeId: string;
+  storageKey: string;
+  declaredVersion: number | null;
+  persistedBlobVersion: number | null;
+  hasMigrate: boolean;
+  hasMerge: boolean;
+  hasPartialize: boolean;
+  persistedStateType: string;
+  hasPersistedValue: boolean;
+  sizeBytes: number;
+  parseStatus: "ok" | "missing" | "corrupt";
+}
 
 export function registerIntrospectionActions(
   actions: ActionRegistry,
@@ -107,6 +123,59 @@ export function registerIntrospectionActions(
         ).length,
         worktreeCount: worktrees.size,
       };
+    },
+  }));
+
+  actions.set("actions.persistedStores", () => ({
+    id: "actions.persistedStores",
+    title: "List Persisted Stores",
+    description:
+      "Enumerate renderer-side Zustand stores that persist to localStorage (storage key, persist version, migrate/merge/partialize flags, current size). Intended for diagnostics and support dumps; does not modify persisted state.",
+    category: "introspection",
+    kind: "query",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const registrations = listPersistedStores();
+      const stores: PersistedStoreInfo[] = registrations.map((reg) => {
+        const options = reg.store.persist.getOptions();
+        const storageKey = typeof options.name === "string" ? options.name : "";
+        const declaredVersion = typeof options.version === "number" ? options.version : null;
+
+        const raw = storageKey ? readLocalStorageItemSafely(storageKey) : null;
+        const hasPersistedValue = raw !== null;
+        const sizeBytes = raw !== null ? raw.length * 2 : 0;
+
+        let persistedBlobVersion: number | null = null;
+        let parseStatus: "ok" | "missing" | "corrupt" = "missing";
+        if (raw !== null) {
+          try {
+            const parsed = JSON.parse(raw) as { version?: unknown };
+            parseStatus = "ok";
+            if (typeof parsed?.version === "number") {
+              persistedBlobVersion = parsed.version;
+            }
+          } catch {
+            parseStatus = "corrupt";
+          }
+        }
+
+        return {
+          storeId: reg.storeId,
+          storageKey,
+          declaredVersion,
+          persistedBlobVersion,
+          hasMigrate: typeof options.migrate === "function",
+          hasMerge: typeof options.merge === "function",
+          hasPartialize: typeof options.partialize === "function",
+          persistedStateType: reg.persistedStateType,
+          hasPersistedValue,
+          sizeBytes,
+          parseStatus,
+        };
+      });
+
+      return { storeCount: stores.length, stores };
     },
   }));
 }

--- a/src/store/agentPreferencesStore.ts
+++ b/src/store/agentPreferencesStore.ts
@@ -74,5 +74,5 @@ export const useAgentPreferencesStore = create<AgentPreferencesState>()(
 registerPersistedStore({
   storeId: "agentPreferencesStore",
   store: useAgentPreferencesStore,
-  persistedStateType: "AgentPreferences",
+  persistedStateType: "{ defaultAgent: DefaultAgentId | undefined }",
 });

--- a/src/store/agentPreferencesStore.ts
+++ b/src/store/agentPreferencesStore.ts
@@ -5,6 +5,7 @@ import {
   readLocalStorageItemSafely,
   safeJSONParse,
 } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 
 export type DefaultAgentId = BuiltInAgentId;
@@ -69,3 +70,9 @@ export const useAgentPreferencesStore = create<AgentPreferencesState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "agentPreferencesStore",
+  store: useAgentPreferencesStore,
+  persistedStateType: "AgentPreferences",
+});

--- a/src/store/commandHistoryStore.ts
+++ b/src/store/commandHistoryStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_HISTORY_SIZE = 100;
 
@@ -72,3 +73,9 @@ export const useCommandHistoryStore = create<CommandHistoryState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "commandHistoryStore",
+  store: useCommandHistoryStore,
+  persistedStateType: "{ history: Record<string, PromptHistoryEntry[]> }",
+});

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export const HELP_PANEL_MIN_WIDTH = 320;
 export const HELP_PANEL_MAX_WIDTH = 800;
@@ -75,3 +76,9 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "helpPanelStore",
+  store: useHelpPanelStore,
+  persistedStateType: "Pick<HelpPanelState, 'width' | 'preferredAgentId'>",
+});

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export const DEFAULT_SOFT_WARNING_LIMIT = 12;
 export const DEFAULT_CONFIRMATION_LIMIT = 20;
@@ -194,6 +195,13 @@ export const usePanelLimitStore = create<PanelLimitState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "panelLimitStore",
+  store: usePanelLimitStore,
+  persistedStateType:
+    "Pick<PanelLimitState, 'softWarningLimit' | 'confirmationLimit' | 'hardLimit' | 'warningsDisabled' | 'hardwareDefaultsApplied' | 'lastSoftWarningDismissedAt'>",
+});
 
 export function _resetInitPromise(): void {
   _initPromise = null;

--- a/src/store/persistence/__tests__/persistedStoreInventory.test.ts
+++ b/src/store/persistence/__tests__/persistedStoreInventory.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  _resetPersistedStoreRegistryForTests,
+  listPersistedStores,
+} from "../persistedStoreRegistry";
+
+/**
+ * Regression guard: importing the store barrel must populate the registry with
+ * every persisted Zustand store. If someone deletes a `registerPersistedStore`
+ * call (or adds a new persisted store without one), this test fails and the
+ * new `actions.persistedStores` diagnostic silently drops the missing entry.
+ */
+
+const EXPECTED_STORE_IDS = [
+  "worktreeFilterStore",
+  "commandHistoryStore",
+  "helpPanelStore",
+  "portalStore",
+  "twoPaneSplitStore",
+  "preferencesStore",
+  "panelLimitStore",
+  "agentPreferencesStore",
+  "toolbarPreferencesStore",
+  "projectStore",
+  "urlHistoryStore",
+] as const;
+
+const EXPECTED_STORAGE_KEYS: Record<(typeof EXPECTED_STORE_IDS)[number], string> = {
+  worktreeFilterStore: "daintree-worktree-filters",
+  commandHistoryStore: "daintree-command-history",
+  helpPanelStore: "help-panel-storage",
+  portalStore: "portal-storage",
+  twoPaneSplitStore: "daintree-two-pane-split",
+  preferencesStore: "daintree-preferences",
+  panelLimitStore: "daintree-panel-limits",
+  agentPreferencesStore: "daintree-agent-preferences",
+  toolbarPreferencesStore: "daintree-toolbar-preferences",
+  projectStore: "project-storage",
+  urlHistoryStore: "daintree-url-history",
+};
+
+beforeAll(async () => {
+  _resetPersistedStoreRegistryForTests();
+
+  await Promise.all([
+    import("../../worktreeFilterStore"),
+    import("../../commandHistoryStore"),
+    import("../../helpPanelStore"),
+    import("../../portalStore"),
+    import("../../twoPaneSplitStore"),
+    import("../../preferencesStore"),
+    import("../../panelLimitStore"),
+    import("../../agentPreferencesStore"),
+    import("../../toolbarPreferencesStore"),
+    import("../../projectStore"),
+    import("../../urlHistoryStore"),
+  ]);
+});
+
+afterAll(() => {
+  _resetPersistedStoreRegistryForTests();
+});
+
+describe("persisted store inventory", () => {
+  it("registers every known persisted store", () => {
+    const registeredIds = listPersistedStores()
+      .map((r) => r.storeId)
+      .sort();
+    const expected = [...EXPECTED_STORE_IDS].sort();
+    expect(registeredIds).toEqual(expected);
+  });
+
+  it("exposes each store's localStorage key through persist.getOptions()", () => {
+    const entries = listPersistedStores();
+    for (const storeId of EXPECTED_STORE_IDS) {
+      const entry = entries.find((r) => r.storeId === storeId);
+      expect(entry, `missing registration for ${storeId}`).toBeDefined();
+      expect(entry!.store.persist.getOptions().name).toBe(EXPECTED_STORAGE_KEYS[storeId]);
+    }
+  });
+
+  it("preserves .persist.getOptions() for stores wrapped in additional middleware", () => {
+    // projectStore nests persist inside subscribeWithSelector. This test fails
+    // if middleware composition ever drops the persist mutator surface.
+    const entry = listPersistedStores().find((r) => r.storeId === "projectStore");
+    expect(entry).toBeDefined();
+    expect(typeof entry!.store.persist.getOptions).toBe("function");
+    const options = entry!.store.persist.getOptions();
+    expect(options.name).toBe("project-storage");
+    expect(typeof options.merge).toBe("function");
+    expect(typeof options.partialize).toBe("function");
+  });
+});

--- a/src/store/persistence/__tests__/persistedStoreRegistry.test.ts
+++ b/src/store/persistence/__tests__/persistedStoreRegistry.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  _resetPersistedStoreRegistryForTests,
+  listPersistedStores,
+  registerPersistedStore,
+  type StoreWithPersist,
+} from "../persistedStoreRegistry";
+
+function makeStore(options: {
+  name?: string;
+  version?: number;
+  partialize?: unknown;
+  migrate?: unknown;
+  merge?: unknown;
+}): StoreWithPersist {
+  return {
+    persist: {
+      getOptions: () => options,
+    },
+  };
+}
+
+afterEach(() => {
+  _resetPersistedStoreRegistryForTests();
+  vi.restoreAllMocks();
+});
+
+describe("persistedStoreRegistry", () => {
+  it("adds a registration and surfaces it via listPersistedStores", () => {
+    const store = makeStore({ name: "daintree-test-a", version: 2 });
+
+    registerPersistedStore({ storeId: "testStoreA", store, persistedStateType: "TestStateA" });
+
+    const entries = listPersistedStores();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      storeId: "testStoreA",
+      persistedStateType: "TestStateA",
+    });
+  });
+
+  it("returns entries in insertion order", () => {
+    registerPersistedStore({
+      storeId: "storeA",
+      store: makeStore({ name: "daintree-test-a" }),
+      persistedStateType: "StateA",
+    });
+    registerPersistedStore({
+      storeId: "storeB",
+      store: makeStore({ name: "daintree-test-b" }),
+      persistedStateType: "StateB",
+    });
+    registerPersistedStore({
+      storeId: "storeC",
+      store: makeStore({ name: "daintree-test-c" }),
+      persistedStateType: "StateC",
+    });
+
+    expect(listPersistedStores().map((e) => e.storeId)).toEqual(["storeA", "storeB", "storeC"]);
+  });
+
+  it("throws in dev when a storeId is registered twice", () => {
+    registerPersistedStore({
+      storeId: "duplicate",
+      store: makeStore({ name: "daintree-dup-1" }),
+      persistedStateType: "StateX",
+    });
+
+    expect(() =>
+      registerPersistedStore({
+        storeId: "duplicate",
+        store: makeStore({ name: "daintree-dup-2" }),
+        persistedStateType: "StateY",
+      })
+    ).toThrow(/duplicate storeId/);
+
+    expect(listPersistedStores()).toHaveLength(1);
+  });
+
+  it("throws in dev when a storage key collides across store IDs", () => {
+    registerPersistedStore({
+      storeId: "firstOwner",
+      store: makeStore({ name: "daintree-shared-key" }),
+      persistedStateType: "StateX",
+    });
+
+    expect(() =>
+      registerPersistedStore({
+        storeId: "secondOwner",
+        store: makeStore({ name: "daintree-shared-key" }),
+        persistedStateType: "StateY",
+      })
+    ).toThrow(/storage key collision/);
+
+    expect(listPersistedStores().map((e) => e.storeId)).toEqual(["firstOwner"]);
+  });
+
+  it("allows stores with no name option (no collision check triggered)", () => {
+    registerPersistedStore({
+      storeId: "noNameA",
+      store: makeStore({}),
+      persistedStateType: "StateA",
+    });
+    registerPersistedStore({
+      storeId: "noNameB",
+      store: makeStore({}),
+      persistedStateType: "StateB",
+    });
+
+    expect(listPersistedStores()).toHaveLength(2);
+  });
+
+  it("_resetPersistedStoreRegistryForTests clears all entries", () => {
+    registerPersistedStore({
+      storeId: "ephemeral",
+      store: makeStore({ name: "daintree-ephemeral" }),
+      persistedStateType: "State",
+    });
+
+    expect(listPersistedStores()).toHaveLength(1);
+    _resetPersistedStoreRegistryForTests();
+    expect(listPersistedStores()).toHaveLength(0);
+  });
+});

--- a/src/store/persistence/persistedStoreRegistry.ts
+++ b/src/store/persistence/persistedStoreRegistry.ts
@@ -1,0 +1,77 @@
+/**
+ * Read-only registry for diagnosing renderer-side Zustand stores that persist
+ * to localStorage. Stores opt in at module-load time by passing a reference to
+ * the live store; the registry derives `name`/`version`/`partialize`/`migrate`/
+ * `merge` lazily from `store.persist.getOptions()` so there is no duplicated
+ * metadata to keep in sync.
+ *
+ * Registration has no effect on persistence behavior — the registry is a pure
+ * lookup surface for the `actions.persistedStores` diagnostic action.
+ */
+
+interface PersistOptionsShape {
+  name?: string;
+  version?: number;
+  partialize?: unknown;
+  migrate?: unknown;
+  merge?: unknown;
+}
+
+export interface StoreWithPersist {
+  persist: {
+    getOptions: () => Partial<PersistOptionsShape>;
+  };
+}
+
+export interface PersistedStoreRegistration {
+  /** Stable identifier for the store module (e.g. "preferencesStore"). */
+  storeId: string;
+  /** Live reference to the Zustand store; used for `persist.getOptions()`. */
+  store: StoreWithPersist;
+  /** TypeScript type name of the persisted shape (documentation-only). */
+  persistedStateType: string;
+}
+
+const registry = new Map<string, PersistedStoreRegistration>();
+
+function isDev(): boolean {
+  try {
+    return Boolean(import.meta.env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+export function registerPersistedStore(registration: PersistedStoreRegistration): void {
+  const existing = registry.get(registration.storeId);
+  if (existing) {
+    const message = `[persistedStoreRegistry] duplicate storeId: "${registration.storeId}"`;
+    if (isDev()) throw new Error(message);
+    console.warn(message);
+    return;
+  }
+
+  const incomingKey = registration.store.persist.getOptions().name;
+  if (typeof incomingKey === "string") {
+    for (const entry of registry.values()) {
+      if (entry.store.persist.getOptions().name === incomingKey) {
+        const message =
+          `[persistedStoreRegistry] storage key collision: "${incomingKey}" ` +
+          `already registered by "${entry.storeId}" (new: "${registration.storeId}")`;
+        if (isDev()) throw new Error(message);
+        console.warn(message);
+        return;
+      }
+    }
+  }
+
+  registry.set(registration.storeId, registration);
+}
+
+export function listPersistedStores(): readonly PersistedStoreRegistration[] {
+  return Array.from(registry.values());
+}
+
+export function _resetPersistedStoreRegistryForTests(): void {
+  registry.clear();
+}

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_SYSTEM_LINKS,
 } from "@shared/types";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 interface PortalState {
   isOpen: boolean;
@@ -468,3 +469,9 @@ const portalStoreCreator: StateCreator<
 });
 
 export const usePortalStore = create<PortalState & PortalActions>()(portalStoreCreator);
+
+registerPersistedStore({
+  storeId: "portalStore",
+  store: usePortalStore,
+  persistedStateType: "Partial<PortalState> (links, width, tabs, defaultNewTabUrl)",
+});

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -85,5 +85,6 @@ export const usePreferencesStore = create<PreferencesState>()(
 registerPersistedStore({
   storeId: "preferencesStore",
   store: usePreferencesStore,
-  persistedStateType: "PreferencesState",
+  persistedStateType:
+    "{ showProjectPulse: boolean; showDeveloperTools: boolean; showGridAgentHighlights: boolean; showDockAgentHighlights: boolean; dockDensity: DockDensity; assignWorktreeToSelf: boolean; lastSelectedWorktreeRecipeIdByProject: Record<string, string | null | undefined> }",
 });

--- a/src/store/preferencesStore.ts
+++ b/src/store/preferencesStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export type DockDensity = "compact" | "normal" | "comfortable";
 
@@ -80,3 +81,9 @@ export const usePreferencesStore = create<PreferencesState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "preferencesStore",
+  store: usePreferencesStore,
+  persistedStateType: "PreferencesState",
+});

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -7,6 +7,7 @@ import { logErrorWithContext } from "@/utils/errorContext";
 import { logDebug } from "@/utils/logger";
 import { useUrlHistoryStore } from "./urlHistoryStore";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistence";
 import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
@@ -645,6 +646,12 @@ export const useProjectStore = create<ProjectState>()(
     )
   )
 );
+
+registerPersistedStore({
+  storeId: "projectStore",
+  store: useProjectStore,
+  persistedStateType: "{ projects: Project[] }",
+});
 
 // Break circular dependency by injecting project ID getter
 panelPersistence.setProjectIdGetter(() => useProjectStore.getState().currentProject?.id);

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -250,5 +250,6 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
 registerPersistedStore({
   storeId: "toolbarPreferencesStore",
   store: useToolbarPreferencesStore,
-  persistedStateType: "ToolbarPreferences",
+  persistedStateType:
+    "{ layout: ToolbarPreferences['layout']; launcher: Pick<ToolbarPreferences['launcher'], 'alwaysShowDevServer' | 'defaultSelection'> }",
 });

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -6,6 +6,7 @@ import type {
   AnyToolbarButtonId,
 } from "@/../../shared/types/toolbar";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 
 const DEFAULT_LEFT_BUTTONS: ToolbarButtonId[] = [
@@ -245,3 +246,9 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "toolbarPreferencesStore",
+  store: useToolbarPreferencesStore,
+  persistedStateType: "ToolbarPreferences",
+});

--- a/src/store/twoPaneSplitStore.ts
+++ b/src/store/twoPaneSplitStore.ts
@@ -156,5 +156,6 @@ export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
 registerPersistedStore({
   storeId: "twoPaneSplitStore",
   store: useTwoPaneSplitStore,
-  persistedStateType: "TwoPaneSplitState",
+  persistedStateType:
+    "{ config: TwoPaneSplitConfig; ratioByWorktreeId: Record<string, WorktreeRatioEntry> }",
 });

--- a/src/store/twoPaneSplitStore.ts
+++ b/src/store/twoPaneSplitStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 export interface TwoPaneSplitConfig {
   enabled: boolean;
@@ -151,3 +152,9 @@ export const useTwoPaneSplitStore = create<TwoPaneSplitState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "twoPaneSplitStore",
+  store: useTwoPaneSplitStore,
+  persistedStateType: "TwoPaneSplitState",
+});

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { UrlHistoryEntry } from "@shared/types/browser";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_ENTRIES_PER_PROJECT = 500;
 
@@ -101,3 +102,9 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "urlHistoryStore",
+  store: useUrlHistoryStore,
+  persistedStateType: "{ entries: Record<string, UrlHistoryEntry[]> }",
+});

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import type { QuickStateFilter } from "@/lib/worktreeFilters";
 
 export type OrderBy = "recent" | "created" | "alpha" | "manual";
@@ -310,3 +311,9 @@ export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
     }
   )
 );
+
+registerPersistedStore({
+  storeId: "worktreeFilterStore",
+  store: useWorktreeFilterStore,
+  persistedStateType: "PersistedState",
+});


### PR DESCRIPTION
## Summary

- Adds a central `persistedStoreRegistry` module so any code (actions, support dumps, agent diagnostics) can enumerate all persisted Zustand stores and inspect their configuration without touching localStorage directly.
- All 11 persisted stores register themselves at module scope immediately after `create(persist(...))`. No behaviour change to any store.
- New `actions.persistedStores` diagnostic action (introspection category, read-only) queries the registry at dispatch time and returns per-store metadata: storage key, declared and persisted blob versions, middleware flags, current size in bytes, and parse status.

Resolves #5199

## Changes

- `src/store/persistence/persistedStoreRegistry.ts` — new registry with `registerPersistedStore`, `listPersistedStores`, and a test-reset helper. Deduplicates by storeId and storage key; throws in dev on collision, warns in prod.
- 11 store files updated to call `registerPersistedStore` at module scope.
- `src/services/actions/definitions/introspectionActions.ts` — `actions.persistedStores` action added.
- `shared/types/actions.ts` — `"actions.persistedStores"` added to `BuiltInActionId`.
- Three new test files: `persistedStoreRegistry.test.ts` (6 tests), `introspectionActions.test.ts` (10 tests), `persistedStoreInventory.test.ts` (3 tests verifying all 11 real stores register correctly).

## Testing

- Typecheck clean, lint at baseline (401/401 warnings, 0 errors), format check clean.
- `persistedStoreInventory.test.ts` imports all 11 real stores and asserts registration and middleware composition — this is the regression guard if a new persisted store is added without registering.
- Existing `persistenceBoundaryHardening.test.ts` still passes 13/13 with no changes required.