### PR TITLE
refactor(worktree): extract shared cloneLayout helper in NewWorktreeDialog

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -82,6 +82,38 @@ function HighlightBranchText({
   return <>{nodes}</>;
 }
 
+async function cloneLayout(
+  sourceWorktreeId: string,
+  worktreePath: string,
+  worktreeId: string
+): Promise<void> {
+  try {
+    const terminals = useRecipeStore.getState().generateRecipeFromActiveTerminals(sourceWorktreeId);
+    for (const t of terminals) {
+      const isDevPreview = t.type === "dev-preview";
+      const isAgent = !isDevPreview && t.type !== "terminal";
+      await usePanelStore.getState().addPanel({
+        kind: isDevPreview ? "dev-preview" : isAgent ? "agent" : "terminal",
+        agentId: isAgent ? t.type : undefined,
+        title: t.title,
+        cwd: worktreePath,
+        worktreeId,
+        exitBehavior: t.exitBehavior,
+        devCommand: isDevPreview ? t.devCommand : undefined,
+        agentModelId: isAgent ? t.agentModelId : undefined,
+        agentLaunchFlags: isAgent ? t.agentLaunchFlags : undefined,
+      });
+    }
+  } catch (cloneErr) {
+    const message = cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
+    notify({
+      type: "warning",
+      title: "Could not clone layout",
+      message: `${message} — worktree was created successfully`,
+    });
+  }
+}
+
 interface NewWorktreeDialogProps {
   isOpen: boolean;
   onClose: () => void;
@@ -517,34 +549,7 @@ export function NewWorktreeDialog({
           useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
 
           if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
-            try {
-              const terminals = useRecipeStore
-                .getState()
-                .generateRecipeFromActiveTerminals(sourceWorktreeId);
-              for (const t of terminals) {
-                const isDevPreview = t.type === "dev-preview";
-                const isAgent = !isDevPreview && t.type !== "terminal";
-                await usePanelStore.getState().addPanel({
-                  kind: isDevPreview ? "dev-preview" : isAgent ? "agent" : "terminal",
-                  agentId: isAgent ? t.type : undefined,
-                  title: t.title,
-                  cwd: worktreePath.trim(),
-                  worktreeId,
-                  exitBehavior: t.exitBehavior,
-                  devCommand: isDevPreview ? t.devCommand : undefined,
-                  agentModelId: isAgent ? t.agentModelId : undefined,
-                  agentLaunchFlags: isAgent ? t.agentLaunchFlags : undefined,
-                });
-              }
-            } catch (cloneErr) {
-              const message =
-                cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
-              notify({
-                type: "warning",
-                title: "Could not clone layout",
-                message: `${message} — worktree was created successfully`,
-              });
-            }
+            await cloneLayout(sourceWorktreeId, worktreePath.trim(), worktreeId);
           } else if (selectedRecipe) {
             try {
               await runRecipe(selectedRecipe.id, worktreePath.trim(), worktreeId, {
@@ -699,33 +704,7 @@ export function NewWorktreeDialog({
         }
 
         if (selectedRecipeId === CLONE_LAYOUT_ID && sourceWorktreeId) {
-          try {
-            const terminals = useRecipeStore
-              .getState()
-              .generateRecipeFromActiveTerminals(sourceWorktreeId);
-            for (const t of terminals) {
-              const isDevPreview = t.type === "dev-preview";
-              const isAgent = !isDevPreview && t.type !== "terminal";
-              await usePanelStore.getState().addPanel({
-                kind: isDevPreview ? "dev-preview" : isAgent ? "agent" : "terminal",
-                agentId: isAgent ? t.type : undefined,
-                title: t.title,
-                cwd: worktreePath.trim(),
-                worktreeId,
-                exitBehavior: t.exitBehavior,
-                devCommand: isDevPreview ? t.devCommand : undefined,
-                agentModelId: isAgent ? t.agentModelId : undefined,
-                agentLaunchFlags: isAgent ? t.agentLaunchFlags : undefined,
-              });
-            }
-          } catch (cloneErr) {
-            const message = cloneErr instanceof Error ? cloneErr.message : "Failed to clone layout";
-            notify({
-              type: "warning",
-              title: "Could not clone layout",
-              message: `${message} — worktree was created successfully`,
-            });
-          }
+          await cloneLayout(sourceWorktreeId, worktreePath.trim(), worktreeId);
         } else if (selectedRecipe) {
           const worktreeId = result.result as string | undefined;
           try {

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -510,17 +510,35 @@ describe("NewWorktreeDialog — clone layout", () => {
     await advanceTimersGradually(500);
   }
 
+  async function createWithNewBranch(branchName: string) {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value: branchName } });
+    });
+
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    await advanceTimersGradually(500);
+  }
+
   it("clones layout by adding a panel per recipe terminal", async () => {
     mockGenerateRecipeFromActiveTerminals.mockReturnValue([
       {
         type: "terminal",
         title: "Shell",
-        exitBehavior: "persistent",
+        exitBehavior: "keep",
       },
       {
         type: "claude",
         title: "Claude",
-        exitBehavior: "persistent",
+        exitBehavior: "keep",
         agentModelId: "claude-opus-4-7",
         agentLaunchFlags: ["--thinking"],
       },
@@ -537,7 +555,7 @@ describe("NewWorktreeDialog — clone layout", () => {
       title: "Shell",
       cwd: expect.stringContaining("feature/existing-work"),
       worktreeId: "new-wt-id",
-      exitBehavior: "persistent",
+      exitBehavior: "keep",
       devCommand: undefined,
       agentModelId: undefined,
       agentLaunchFlags: undefined,
@@ -549,7 +567,7 @@ describe("NewWorktreeDialog — clone layout", () => {
       title: "Claude",
       cwd: expect.stringContaining("feature/existing-work"),
       worktreeId: "new-wt-id",
-      exitBehavior: "persistent",
+      exitBehavior: "keep",
       devCommand: undefined,
       agentModelId: "claude-opus-4-7",
       agentLaunchFlags: ["--thinking"],
@@ -578,10 +596,28 @@ describe("NewWorktreeDialog — clone layout", () => {
     expect(mockAddTerminal).not.toHaveBeenCalled();
   });
 
+  it("clones layout when creating a new branch", async () => {
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "Shell", exitBehavior: "keep" },
+    ]);
+
+    await createWithNewBranch("feature/new-work");
+
+    expect(mockGenerateRecipeFromActiveTerminals).toHaveBeenCalledWith("main-wt");
+    expect(mockAddTerminal).toHaveBeenCalledTimes(1);
+    expect(mockAddTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "terminal",
+        title: "Shell",
+        worktreeId: "new-wt-id",
+      })
+    );
+  });
+
   it("skips clone when no active source worktree is available", async () => {
     mockActiveWorktreeId = null;
     mockGenerateRecipeFromActiveTerminals.mockReturnValue([
-      { type: "terminal", title: "Shell", exitBehavior: "persistent" },
+      { type: "terminal", title: "Shell", exitBehavior: "keep" },
     ]);
 
     await createWithExistingBranch();

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -101,19 +101,22 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 
 const mockSetPendingWorktree = vi.fn();
 const mockSelectWorktree = vi.fn();
+let mockActiveWorktreeId: string | null = "main-wt";
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: {
     getState: () => ({
       setPendingWorktree: mockSetPendingWorktree,
       selectWorktree: mockSelectWorktree,
+      activeWorktreeId: mockActiveWorktreeId,
     }),
   },
 }));
 
+let mockSelectedRecipeId: string | null = null;
 vi.mock("@/components/Worktree/hooks/useRecipePicker", () => ({
   CLONE_LAYOUT_ID: "__clone_layout__",
   useRecipePicker: () => ({
-    selectedRecipeId: null,
+    selectedRecipeId: mockSelectedRecipeId,
     setSelectedRecipeId: vi.fn(),
     recipePickerOpen: false,
     setRecipePickerOpen: vi.fn(),
@@ -240,6 +243,7 @@ vi.mock("@/components/Worktree/worktreeCreationErrors", () => ({
 Element.prototype.scrollIntoView = vi.fn();
 
 import { NewWorktreeDialog } from "../NewWorktreeDialog";
+import { notify } from "@/lib/notify";
 
 const TEST_BRANCHES: BranchInfo[] = [
   { name: "main", current: true, commit: "abc123" },
@@ -455,5 +459,134 @@ describe("NewWorktreeDialog — existing branch mode", () => {
 
     const createButton = screen.getByTestId("create-worktree-button");
     expect(createButton.hasAttribute("disabled")).toBe(true);
+  });
+});
+
+describe("NewWorktreeDialog — clone layout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockListBranches.mockResolvedValue(TEST_BRANCHES);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: "new-wt-id" });
+    mockSelectedRecipeId = "__clone_layout__";
+    mockActiveWorktreeId = "main-wt";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+    mockSelectedRecipeId = null;
+    mockActiveWorktreeId = "main-wt";
+  });
+
+  async function createWithExistingBranch() {
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("radio", { name: /existing branch/i }));
+    });
+
+    const branchOption = screen
+      .getAllByRole("option")
+      .find((el) => el.textContent === "feature/existing-work");
+    await act(async () => {
+      fireEvent.click(branchOption!);
+    });
+
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+
+    await advanceTimersGradually(500);
+  }
+
+  it("clones layout by adding a panel per recipe terminal", async () => {
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      {
+        type: "terminal",
+        title: "Shell",
+        exitBehavior: "persistent",
+      },
+      {
+        type: "claude",
+        title: "Claude",
+        exitBehavior: "persistent",
+        agentModelId: "claude-opus-4-7",
+        agentLaunchFlags: ["--thinking"],
+      },
+    ]);
+
+    await createWithExistingBranch();
+
+    expect(mockGenerateRecipeFromActiveTerminals).toHaveBeenCalledWith("main-wt");
+    expect(mockAddTerminal).toHaveBeenCalledTimes(2);
+
+    expect(mockAddTerminal).toHaveBeenNthCalledWith(1, {
+      kind: "terminal",
+      agentId: undefined,
+      title: "Shell",
+      cwd: expect.stringContaining("feature/existing-work"),
+      worktreeId: "new-wt-id",
+      exitBehavior: "persistent",
+      devCommand: undefined,
+      agentModelId: undefined,
+      agentLaunchFlags: undefined,
+    });
+
+    expect(mockAddTerminal).toHaveBeenNthCalledWith(2, {
+      kind: "agent",
+      agentId: "claude",
+      title: "Claude",
+      cwd: expect.stringContaining("feature/existing-work"),
+      worktreeId: "new-wt-id",
+      exitBehavior: "persistent",
+      devCommand: undefined,
+      agentModelId: "claude-opus-4-7",
+      agentLaunchFlags: ["--thinking"],
+    });
+  });
+
+  it("notifies on clone failure without aborting worktree creation", async () => {
+    mockGenerateRecipeFromActiveTerminals.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    await createWithExistingBranch();
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "worktree.create",
+      expect.objectContaining({ rootPath: "/test/root" }),
+      { source: "user" }
+    );
+    expect(vi.mocked(notify)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "warning",
+        title: "Could not clone layout",
+        message: expect.stringContaining("boom"),
+      })
+    );
+    expect(mockAddTerminal).not.toHaveBeenCalled();
+  });
+
+  it("skips clone when no active source worktree is available", async () => {
+    mockActiveWorktreeId = null;
+    mockGenerateRecipeFromActiveTerminals.mockReturnValue([
+      { type: "terminal", title: "Shell", exitBehavior: "persistent" },
+    ]);
+
+    await createWithExistingBranch();
+
+    expect(mockGenerateRecipeFromActiveTerminals).not.toHaveBeenCalled();
+    expect(mockAddTerminal).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Extracted a `cloneLayout` helper at module scope in `NewWorktreeDialog.tsx`, collapsing two byte-identical clone-layout blocks (lines ~519 and ~701) into a single shared function. Both the create-from-scratch and create-from-issue flows now delegate with a single call each.
- The helper owns the `generateRecipeFromActiveTerminals → addPanel` loop and its `try/catch + notify` fallback. Any future fix to this logic lands once instead of twice.
- `BulkCreateWorktreeDialog.tsx` is intentionally untouched. Its PQueue concurrency, per-panel error tracking, and progress events make it a meaningfully different contract.

Resolves #5202

## Changes

- `src/components/Worktree/NewWorktreeDialog.tsx`: extracted `cloneLayout` module-scope helper, replaced two duplicate blocks with single-line delegates
- `src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx`: added 4 tests covering happy-path (existing-branch), happy-path (new-branch), failure-path (notify fires, worktree creation still succeeds), and no-source-worktree skip

## Testing

All 13 tests in `NewWorktreeDialog.test.tsx` pass. Typecheck, lint ratchet, and format all clean.