### PR TITLE
refactor(demo): remove ffmpeg encoding from main process

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -582,8 +582,6 @@ export const CHANNELS = {
   DEMO_EXEC_DISMISS_ANNOTATION: "demo:exec-dismiss-annotation",
   DEMO_WAIT_FOR_IDLE: "demo:wait-for-idle",
   DEMO_EXEC_WAIT_FOR_IDLE: "demo:exec-wait-for-idle",
-  DEMO_ENCODE: "demo:encode",
-  DEMO_ENCODE_PROGRESS: "demo:encode:progress",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/electron/ipc/handlers/__tests__/demo.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/demo.handlers.test.ts
@@ -15,7 +15,6 @@ vi.mock("crypto", () => ({
 }));
 
 vi.mock("fs", () => ({
-  readdirSync: vi.fn(() => ["frame-000001.png", "frame-000002.png", "frame-000003.png"]),
   mkdirSync: vi.fn(),
 }));
 
@@ -25,21 +24,15 @@ class MockStdin extends EventEmitter {
 }
 
 let mockProc: EventEmitter & {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
   stdin: MockStdin;
   kill: ReturnType<typeof vi.fn>;
 };
 
 function createMockProc() {
   const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
     stdin: MockStdin;
     kill: ReturnType<typeof vi.fn>;
   };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
   proc.stdin = new MockStdin();
   proc.kill = vi.fn();
   return proc;
@@ -121,6 +114,7 @@ describe("registerDemoHandlers", () => {
     expect(channels).toContain("demo:start-capture");
     expect(channels).toContain("demo:stop-capture");
     expect(channels).toContain("demo:get-capture-status");
+    expect(channels).not.toContain("demo:encode");
     expect(channels).toContain("demo:scroll");
     expect(channels).toContain("demo:drag");
     expect(channels).toContain("demo:press-key");
@@ -156,6 +150,7 @@ describe("registerDemoHandlers", () => {
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:start-capture");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:stop-capture");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:get-capture-status");
+    expect(ipcMainMock.removeHandler).not.toHaveBeenCalledWith("demo:encode");
   });
 
   it("screenshot handler returns Uint8Array with PNG magic bytes", async () => {

--- a/electron/ipc/handlers/__tests__/demo.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/demo.handlers.test.ts
@@ -100,9 +100,9 @@ describe("registerDemoHandlers", () => {
     cleanup();
   });
 
-  it("registers 21 IPC handlers when isDemoMode is true", () => {
+  it("registers 20 IPC handlers when isDemoMode is true", () => {
     const cleanup = registerDemoHandlers(makeDeps(true));
-    expect(ipcMainMock.handle).toHaveBeenCalledTimes(21);
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(20);
     cleanup();
   });
 
@@ -121,7 +121,6 @@ describe("registerDemoHandlers", () => {
     expect(channels).toContain("demo:start-capture");
     expect(channels).toContain("demo:stop-capture");
     expect(channels).toContain("demo:get-capture-status");
-    expect(channels).toContain("demo:encode");
     expect(channels).toContain("demo:scroll");
     expect(channels).toContain("demo:drag");
     expect(channels).toContain("demo:press-key");
@@ -133,10 +132,10 @@ describe("registerDemoHandlers", () => {
     cleanup();
   });
 
-  it("cleanup removes all 21 handlers", () => {
+  it("cleanup removes all 20 handlers", () => {
     const cleanup = registerDemoHandlers(makeDeps(true));
     cleanup();
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(21);
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(20);
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:move-to");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:move-to-selector");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:click");
@@ -157,7 +156,6 @@ describe("registerDemoHandlers", () => {
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:start-capture");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:stop-capture");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:get-capture-status");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:encode");
   });
 
   it("screenshot handler returns Uint8Array with PNG magic bytes", async () => {
@@ -174,229 +172,6 @@ describe("registerDemoHandlers", () => {
     expect(result.data[3]).toBe(0x47);
     expect(result.width).toBe(1920);
     expect(result.height).toBe(1080);
-  });
-
-  describe("handleEncode", () => {
-    function getEncodeHandler() {
-      registerDemoHandlers(makeDeps(true));
-      const [, handler] =
-        ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:encode") ?? [];
-      return handler;
-    }
-
-    function makeEvent(isDestroyed = false) {
-      return {
-        sender: {
-          send: vi.fn(),
-          isDestroyed: vi.fn(() => isDestroyed),
-        },
-      };
-    }
-
-    it("resolves with outputPath and durationMs on success", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-
-      mockProc.emit("close", 0);
-      const result = await promise;
-
-      expect(result.outputPath).toBe("/tmp/out.mp4");
-      expect(typeof result.durationMs).toBe("number");
-    });
-
-    it("rejects when no PNG frames found", async () => {
-      const fsMod = await import("fs");
-      (fsMod.readdirSync as ReturnType<typeof vi.fn>).mockReturnValueOnce([]);
-
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      await expect(
-        handler(event, {
-          framesDir: "/tmp/empty",
-          outputPath: "/tmp/out.mp4",
-          preset: "youtube-4k",
-        })
-      ).rejects.toThrow("No PNG frames matching frame-NNNNNN.png found");
-    });
-
-    it("rejects old underscore-format frame names", async () => {
-      const fsMod = await import("fs");
-      (fsMod.readdirSync as ReturnType<typeof vi.fn>).mockReturnValueOnce([
-        "frame_0001.png",
-        "frame_0002.png",
-        "frame_0003.png",
-      ]);
-
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      await expect(
-        handler(event, {
-          framesDir: "/tmp/old-format",
-          outputPath: "/tmp/out.mp4",
-          preset: "youtube-4k",
-        })
-      ).rejects.toThrow("No PNG frames matching frame-NNNNNN.png found");
-    });
-
-    it("rejects on spawn error event", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "web-webm",
-      });
-
-      mockProc.emit("error", new Error("spawn ENOENT"));
-      await expect(promise).rejects.toThrow("Encode failed: spawn ENOENT");
-    });
-
-    it("rejects on non-zero exit code with stderr", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "web-webm",
-      });
-
-      mockProc.stderr.emit("data", Buffer.from("Unknown encoder libx264"));
-      mockProc.emit("close", 1);
-      await expect(promise).rejects.toThrow("ffmpeg exited with code 1");
-    });
-
-    it("creates output directory before encoding", async () => {
-      const fsMod = await import("fs");
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/output/video.mp4",
-        preset: "youtube-1080p",
-      });
-
-      mockProc.emit("close", 0);
-      await promise;
-
-      expect(fsMod.mkdirSync).toHaveBeenCalledWith("/tmp/output", { recursive: true });
-    });
-
-    it("sends progress events via IPC", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent(false);
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-
-      mockProc.stdout.emit("data", Buffer.from("frame=2\nfps=30\nprogress=continue\n"));
-      mockProc.emit("close", 0);
-      await promise;
-
-      expect(event.sender.send).toHaveBeenCalledWith(
-        "demo:encode:progress",
-        expect.objectContaining({
-          frame: 2,
-          fps: 30,
-          percentComplete: expect.any(Number),
-          etaSeconds: expect.any(Number),
-        })
-      );
-    });
-
-    it("does not send progress when sender is destroyed", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent(true);
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-
-      mockProc.stdout.emit("data", Buffer.from("frame=2\nfps=30\nprogress=continue\n"));
-      mockProc.emit("close", 0);
-      await promise;
-
-      expect(event.sender.send).not.toHaveBeenCalled();
-    });
-
-    it("uses yuv444p and high444 profile for youtube presets", async () => {
-      const { spawn: spawnMock } = await import("child_process");
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-
-      mockProc.emit("close", 0);
-      await promise;
-
-      const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[];
-      expect(args).toContain("yuv444p");
-      expect(args).toContain("high444");
-      expect(args).not.toContain("yuv420p");
-    });
-
-    it("uses yuv444p for web-webm preset with row-mt", async () => {
-      const { spawn: spawnMock } = await import("child_process");
-      // Need a fresh mockProc since the encode handler uses the current one
-      mockProc = createMockProc();
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.webm",
-        preset: "web-webm",
-      });
-
-      mockProc.emit("close", 0);
-      await promise;
-
-      const lastCall = (spawnMock as ReturnType<typeof vi.fn>).mock.calls.at(-1)!;
-      const args = lastCall[1] as string[];
-      expect(args).toContain("yuv444p");
-      expect(args).toContain("1");
-      const rowMtIdx = args.indexOf("-row-mt");
-      expect(rowMtIdx).toBeGreaterThan(-1);
-    });
-
-    it("uses frame-%06d.png input pattern matching capture output", async () => {
-      const { spawn: spawnMock } = await import("child_process");
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-
-      mockProc.emit("close", 0);
-      await promise;
-
-      const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string[];
-      const inputIdx = args.indexOf("-i");
-      expect(inputIdx).toBeGreaterThan(-1);
-      expect(args[inputIdx + 1]).toContain("frame-%06d.png");
-    });
   });
 
   it("moveTo handler sends exec event with requestId and awaits done", async () => {

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -17,9 +17,6 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
-  DemoEncodePayload,
-  DemoEncodeProgressEvent,
-  DemoEncodeResult,
   DemoEncodePreset,
   DemoScrollPayload,
   DemoDragPayload,
@@ -490,185 +487,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     },
   };
 
-  // --- Encode presets for offline re-encode (PNG files from disk) ---
-
-  const ENCODE_PRESETS = {
-    "youtube-4k": {
-      outputOptions: [
-        "-vf",
-        "scale=3840:2160:flags=lanczos",
-        "-c:v",
-        "libx264",
-        "-profile:v",
-        "high444",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv444p",
-        "-preset",
-        "slow",
-        "-g",
-        "15",
-        "-bf",
-        "2",
-        "-movflags",
-        "+faststart",
-        "-an",
-      ],
-    },
-    "youtube-1080p": {
-      outputOptions: [
-        "-vf",
-        "scale=1920:1080:flags=lanczos",
-        "-c:v",
-        "libx264",
-        "-profile:v",
-        "high444",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv444p",
-        "-preset",
-        "slow",
-        "-g",
-        "15",
-        "-bf",
-        "2",
-        "-movflags",
-        "+faststart",
-        "-an",
-      ],
-    },
-    "web-webm": {
-      outputOptions: [
-        "-c:v",
-        "libvpx-vp9",
-        "-crf",
-        "20",
-        "-b:v",
-        "0",
-        "-deadline",
-        "good",
-        "-cpu-used",
-        "1",
-        "-row-mt",
-        "1",
-        "-pix_fmt",
-        "yuv444p",
-        "-an",
-      ],
-    },
-  } as const;
-
-  let activeEncode: { kill: () => void } | null = null;
-
-  const handleEncode = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: DemoEncodePayload
-  ): Promise<DemoEncodeResult> => {
-    if (activeEncode) {
-      throw new Error("An encode is already in progress");
-    }
-
-    const ffmpegBin = resolveFfmpegPath();
-    const { framesDir, outputPath, preset, fps = 30 } = payload;
-    const presetConfig = ENCODE_PRESETS[preset];
-
-    const framePattern = /^frame-\d{6}\.png$/;
-    const pngFiles = fs
-      .readdirSync(framesDir)
-      .filter((f) => framePattern.test(f))
-      .sort();
-    if (pngFiles.length === 0) {
-      throw new Error(`No PNG frames matching frame-NNNNNN.png found in ${framesDir}`);
-    }
-    const totalFrames = pngFiles.length;
-
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-
-    const startTime = Date.now();
-    const inputPattern = path.join(framesDir, "frame-%06d.png");
-
-    const args = [
-      "-y",
-      "-framerate",
-      String(fps),
-      "-i",
-      inputPattern,
-      ...presetConfig.outputOptions,
-      "-progress",
-      "pipe:1",
-      "-nostats",
-      outputPath,
-    ];
-
-    return new Promise<DemoEncodeResult>((resolve, reject) => {
-      const proc: ChildProcess = spawn(ffmpegBin, args, { stdio: ["ignore", "pipe", "pipe"] });
-
-      activeEncode = {
-        kill: () => {
-          proc.kill("SIGKILL");
-        },
-      };
-
-      let stdoutBuffer = "";
-      let currentFrame = 0;
-      let currentFps = 0;
-
-      proc.stdout?.on("data", (chunk: Buffer) => {
-        stdoutBuffer += chunk.toString();
-        const lines = stdoutBuffer.split("\n");
-        stdoutBuffer = lines.pop() ?? "";
-
-        for (const line of lines) {
-          const eqIdx = line.indexOf("=");
-          if (eqIdx === -1) continue;
-          const key = line.slice(0, eqIdx).trim();
-          const value = line.slice(eqIdx + 1).trim();
-
-          if (key === "frame") {
-            currentFrame = parseInt(value, 10) || 0;
-          } else if (key === "fps") {
-            currentFps = parseFloat(value) || 0;
-          } else if (key === "progress") {
-            if (currentFrame > 0 && !event.sender.isDestroyed()) {
-              const percentComplete = Math.min((currentFrame / totalFrames) * 100, 100);
-              const etaSeconds = currentFps > 0 ? (totalFrames - currentFrame) / currentFps : 0;
-
-              const progressEvent: DemoEncodeProgressEvent = {
-                frame: currentFrame,
-                fps: currentFps,
-                percentComplete: Math.round(percentComplete * 100) / 100,
-                etaSeconds: Math.round(etaSeconds * 10) / 10,
-              };
-              event.sender.send(CHANNELS.DEMO_ENCODE_PROGRESS, progressEvent);
-            }
-          }
-        }
-      });
-
-      let stderrOutput = "";
-      proc.stderr?.on("data", (chunk: Buffer) => {
-        stderrOutput += chunk.toString();
-      });
-
-      proc.on("error", (err: Error) => {
-        activeEncode = null;
-        reject(new Error(`Encode failed: ${err.message}`));
-      });
-
-      proc.on("close", (code) => {
-        activeEncode = null;
-        if (code === 0) {
-          resolve({ outputPath, durationMs: Date.now() - startTime });
-        } else {
-          const lastLines = stderrOutput.trim().split("\n").slice(-3).join("\n");
-          reject(new Error(`ffmpeg exited with code ${code}: ${lastLines}`));
-        }
-      });
-    });
-  };
-
   ipcMain.handle(CHANNELS.DEMO_MOVE_TO, handleMoveTo);
   ipcMain.handle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector);
   ipcMain.handle(CHANNELS.DEMO_CLICK, handleClick);
@@ -689,7 +507,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
   ipcMain.handle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture);
   ipcMain.handle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture);
   ipcMain.handle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus);
-  ipcMain.handle(CHANNELS.DEMO_ENCODE, handleEncode);
 
   return () => {
     if (captureSession) {
@@ -716,10 +533,5 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     ipcMain.removeHandler(CHANNELS.DEMO_START_CAPTURE);
     ipcMain.removeHandler(CHANNELS.DEMO_STOP_CAPTURE);
     ipcMain.removeHandler(CHANNELS.DEMO_GET_CAPTURE_STATUS);
-    ipcMain.removeHandler(CHANNELS.DEMO_ENCODE);
-    if (activeEncode) {
-      activeEncode.kill();
-      activeEncode = null;
-    }
   };
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1088,8 +1088,6 @@ const CHANNELS = {
   DEMO_EXEC_DISMISS_ANNOTATION: "demo:exec-dismiss-annotation",
   DEMO_WAIT_FOR_IDLE: "demo:wait-for-idle",
   DEMO_EXEC_WAIT_FOR_IDLE: "demo:exec-wait-for-idle",
-  DEMO_ENCODE: "demo:encode",
-  DEMO_ENCODE_PROGRESS: "demo:encode:progress",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",
@@ -2964,11 +2962,6 @@ const api: ElectronAPI = {
             _unwrappingInvoke(CHANNELS.DEMO_DISMISS_ANNOTATION, { id }),
           waitForIdle: (settleMs?: number, timeoutMs?: number) =>
             _unwrappingInvoke(CHANNELS.DEMO_WAIT_FOR_IDLE, { settleMs, timeoutMs }),
-          encode: (payload: import("../shared/types/ipc/demo.js").DemoEncodePayload) =>
-            _unwrappingInvoke(CHANNELS.DEMO_ENCODE, payload),
-          onEncodeProgress: (
-            callback: (event: import("../shared/types/ipc/demo.js").DemoEncodeProgressEvent) => void
-          ) => _typedOn(CHANNELS.DEMO_ENCODE_PROGRESS, callback),
           onExecCommand: (
             channel: string,
             callback: (payload: Record<string, unknown>) => void

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -50,9 +50,6 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
-  DemoEncodePayload,
-  DemoEncodeProgressEvent,
-  DemoEncodeResult,
   DemoAnnotateResult,
 } from "./demo.js";
 import type {
@@ -1329,8 +1326,6 @@ export interface ElectronAPI {
     startCapture(payload: DemoStartCapturePayload): Promise<DemoStartCaptureResult>;
     stopCapture(): Promise<DemoStopCaptureResult>;
     getCaptureStatus(): Promise<DemoCaptureStatus>;
-    encode(payload: DemoEncodePayload): Promise<DemoEncodeResult>;
-    onEncodeProgress(callback: (event: DemoEncodeProgressEvent) => void): () => void;
     onExecCommand(
       channel: string,
       callback: (payload: Record<string, unknown>) => void

--- a/shared/types/ipc/demo.ts
+++ b/shared/types/ipc/demo.ts
@@ -56,25 +56,6 @@ export interface DemoCaptureStatus {
 
 export type DemoEncodePreset = "youtube-4k" | "youtube-1080p" | "web-webm";
 
-export interface DemoEncodePayload {
-  framesDir: string;
-  outputPath: string;
-  preset: DemoEncodePreset;
-  fps?: number;
-}
-
-export interface DemoEncodeProgressEvent {
-  frame: number;
-  fps: number;
-  percentComplete: number;
-  etaSeconds: number;
-}
-
-export interface DemoEncodeResult {
-  outputPath: string;
-  durationMs: number;
-}
-
 export interface DemoScrollPayload {
   selector: string;
 }

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -152,9 +152,6 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
-  DemoEncodePayload,
-  DemoEncodeProgressEvent,
-  DemoEncodeResult,
 } from "./demo.js";
 
 export type ChecklistItemId =
@@ -1798,10 +1795,6 @@ export interface IpcInvokeMap {
     args: [];
     result: DemoCaptureStatus;
   };
-  "demo:encode": {
-    args: [payload: DemoEncodePayload];
-    result: DemoEncodeResult;
-  };
 }
 
 /**
@@ -1985,7 +1978,6 @@ export interface IpcEventMap {
   "demo:exec-resume": void;
   "demo:exec-wait-for-selector": DemoWaitForSelectorPayload;
   "demo:exec-sleep": DemoSleepPayload;
-  "demo:encode:progress": DemoEncodeProgressEvent;
 
   // Accessibility events
   "accessibility:support-changed": { enabled: boolean };


### PR DESCRIPTION
## Summary

- Strips the `handleEncode` IPC handler, `ENCODE_PRESETS`, `activeEncode` state, `DEMO_ENCODE`/`DEMO_ENCODE_PROGRESS` channel constants, preload bridge entries, and the shared types (`DemoEncodePayload`, `DemoEncodeProgressEvent`, `DemoEncodeResult`) that went with them
- Encoding is now entirely owned by demo-studio, which runs its own ffmpeg + Remotion pipeline against the raw WebM capture output — there's no reason for Daintree's main process to re-encode anything
- Tests tightened accordingly: dropped dead mocks, added negative regression assertions confirming `demo:encode` is absent from the channel list and cleanup surface

Resolves #5270

## Changes

- `electron/ipc/handlers/demo.ts` — removed `handleEncode` and all encode-related state/presets (~188 lines)
- `electron/ipc/channels.ts` — removed `DEMO_ENCODE` and `DEMO_ENCODE_PROGRESS` constants
- `electron/preload.cts` — removed preload bridge entries for the encode channel
- `shared/types/ipc/demo.ts` — removed `DemoEncodePayload`, `DemoEncodeProgressEvent`, `DemoEncodeResult`
- `shared/types/ipc/api.ts` and `maps.ts` — removed encode type references
- `electron/ipc/handlers/__tests__/demo.handlers.test.ts` — dropped the `handleEncode` describe block, tightened mocks, added negative assertions

Net: -463/+6 across 7 files. Handler count updated 21→20.

## Testing

29/29 tests pass. Typecheck, lint, and format all clean. No renderer callers of the removed surface existed, confirmed by grep across `src/`.