### PR TITLE
fix(persistence): preserve unknown-kind panel fields through save cycles

### DIFF
--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -67,6 +67,7 @@ vi.mock("../slices", () => ({
 vi.mock("../persistence/panelPersistence", () => ({
   panelPersistence: {
     setProjectIdGetter: vi.fn(),
+    getPreviousSnapshotMap: vi.fn(() => undefined),
   },
   panelToSnapshot: vi.fn((t: { id: string; kind: string }) => ({
     id: t.id,
@@ -285,6 +286,59 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
     expect(outgoing.tabGroups).toEqual([
       { id: "g1", location: "grid", activeTabId: "a", panelIds: ["a", "b"] },
     ]);
+  });
+
+  it("threads previousSnapshot into panelToSnapshot for unknown-kind preservation (#5201)", async () => {
+    const { setPanelStoreGetter } = await import("../projectStore");
+    const { panelPersistence, panelToSnapshot } = await import("../persistence/panelPersistence");
+
+    const extPanel = {
+      id: "ext-1",
+      kind: "custom-widget",
+      title: "Custom",
+      location: "grid",
+    };
+    setPanelStoreGetter(() => ({
+      panelsById: { "ext-1": extPanel } as never,
+      panelIds: ["ext-1"],
+      tabGroups: new Map(),
+    }));
+
+    const previousSnapshot = {
+      id: "ext-1",
+      kind: "custom-widget",
+      title: "Custom",
+      location: "grid",
+      browserUrl: "https://example.com",
+    };
+    vi.mocked(panelPersistence.getPreviousSnapshotMap).mockReturnValueOnce(
+      new Map([["ext-1", previousSnapshot as never]])
+    );
+    // Override panelToSnapshot for this test to exercise preservation end-to-end.
+    vi.mocked(panelToSnapshot).mockImplementationOnce(((t: unknown, prev?: unknown) => ({
+      ...(prev as Record<string, unknown> | undefined),
+      id: (t as { id: string }).id,
+      kind: (t as { kind: string }).kind,
+    })) as typeof panelToSnapshot);
+
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await Promise.resolve();
+
+    // Without the fix, outgoing terminals would be base-only. With it, the
+    // preserved fragment (browserUrl) reaches the main-process pre-apply.
+    expect(panelPersistence.getPreviousSnapshotMap).toHaveBeenCalledWith(projectA.id);
+    const outgoing = projectClientMock.switch.mock.calls[0][1];
+    expect(outgoing.terminals).toHaveLength(1);
+    expect(outgoing.terminals[0]).toEqual(
+      expect.objectContaining({
+        id: "ext-1",
+        kind: "custom-widget",
+        browserUrl: "https://example.com",
+      })
+    );
   });
 
   it("sends empty tabGroups array to clear stale groups when none exist", async () => {

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { initBuiltInPanelKinds } from "@/panels/registry";
-import { PanelPersistence } from "../panelPersistence";
+import { PanelPersistence, panelToSnapshot } from "../panelPersistence";
 import type { TerminalInstance, TerminalSnapshot } from "@/types";
 
 initBuiltInPanelKinds();
@@ -727,6 +727,112 @@ describe("PanelPersistence", () => {
       expect(secondSave[0]).toEqual(
         expect.objectContaining({ id: "ext-unknown", title: "Second" })
       );
+    });
+
+    it("getPreviousSnapshotMap exposes preserved fragments to external callers", () => {
+      // Regression test for the project-switch outgoing-state path. The main
+      // process pre-applies outgoing terminals to persisted state, so a
+      // synchronous capture during switch must also thread previousSnapshot
+      // through panelToSnapshot — not just the debounced save path.
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "custom-widget",
+          title: "Custom",
+          location: "grid",
+          browserUrl: "https://example.com",
+          notePath: "/notes/custom.md",
+        },
+      ]);
+
+      const prevMap = persistence.getPreviousSnapshotMap(projectId);
+      expect(prevMap).toBeDefined();
+      expect(prevMap?.get("ext-unknown")).toEqual(
+        expect.objectContaining({
+          browserUrl: "https://example.com",
+          notePath: "/notes/custom.md",
+        })
+      );
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "custom-widget",
+        title: "Custom",
+        location: "grid",
+      });
+
+      const snapshot = panelToSnapshot(panel, prevMap?.get(panel.id));
+      expect(snapshot).toEqual(
+        expect.objectContaining({
+          id: "ext-unknown",
+          kind: "custom-widget",
+          browserUrl: "https://example.com",
+          notePath: "/notes/custom.md",
+        })
+      );
+    });
+
+    it("getPreviousSnapshotMap returns undefined for unknown projects", () => {
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+      expect(persistence.getPreviousSnapshotMap("nonexistent")).toBeUndefined();
+    });
+
+    it("preserves fragment via queued state when debounce has not flushed", async () => {
+      // Covers the queuedTerminalsByProject branch of getPreviousSnapshotMap.
+      // Make the first persist hang so queued state stays present while a
+      // second save runs; the second save must still see the preserved
+      // fragment via queued, not fall back to an empty fragment.
+      const client = createMockProjectClient();
+      let resolveFirstPersist: (() => void) | null = null;
+      const firstPersistPromise = new Promise<void>((resolve) => {
+        resolveFirstPersist = resolve;
+      });
+      client.setTerminals.mockImplementationOnce(() => firstPersistPromise);
+
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "custom-widget",
+          title: "Custom",
+          location: "grid",
+          browserUrl: "https://example.com",
+        },
+      ]);
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "custom-widget",
+        title: "Custom",
+        location: "grid",
+      });
+
+      persistence.save([panel], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+      // First persist is still pending; queued has been flushed into the
+      // persist promise but queuedTerminalsByProject remains primed.
+      expect(client.setTerminals).toHaveBeenCalledTimes(1);
+
+      persistence.save([createMockTerminal({ ...panel, title: "Renamed" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTerminals).toHaveBeenCalledTimes(2);
+      const secondSave = client.setTerminals.mock.calls[1][1] as TerminalSnapshot[];
+      expect(secondSave[0]).toEqual(
+        expect.objectContaining({
+          id: "ext-unknown",
+          title: "Renamed",
+          browserUrl: "https://example.com",
+        })
+      );
+
+      resolveFirstPersist?.();
+      await persistence.whenIdle();
     });
   });
 

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -502,7 +502,9 @@ describe("PanelPersistence", () => {
   });
 
   describe("unregistered extension kind", () => {
-    it("produces base-only snapshot without crashing for unknown kinds", async () => {
+    it("falls back to base-only when no previous snapshot exists", async () => {
+      // First-save scenario: no prior state to preserve, no serializer registered.
+      // Base fields (including extensionState) survive; kind-specific fragment is empty.
       const client = createMockProjectClient();
       const persistence = new PanelPersistence(client, { debounceMs: 100 });
 
@@ -527,6 +529,204 @@ describe("PanelPersistence", () => {
         location: "grid",
         extensionState: { key: "value" },
       });
+    });
+
+    it("preserves previously-persisted kind-specific fields across save cycles", async () => {
+      // Regression test for #5201. A panel whose kind has no registered
+      // serializer (extension disabled mid-session, plugin not yet loaded,
+      // kind renamed) must retain its kind-specific fields through saves.
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "custom-widget",
+        title: "Custom",
+        location: "grid",
+      });
+
+      // Prime persistence with a snapshot that includes kind-specific fields,
+      // as if hydrated from disk after an app launch where the extension
+      // hasn't registered its serializer yet.
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "custom-widget",
+          title: "Custom",
+          location: "grid",
+          // Kind-specific fields the (now-gone) serializer had written.
+          browserUrl: "https://example.com",
+          notePath: "/notes/custom.md",
+        },
+      ]);
+
+      persistence.save([panel], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const saved = client.setTerminals.mock.calls[0][1] as TerminalSnapshot[];
+      expect(saved).toHaveLength(1);
+      expect(saved[0]).toEqual(
+        expect.objectContaining({
+          id: "ext-unknown",
+          kind: "custom-widget",
+          browserUrl: "https://example.com",
+          notePath: "/notes/custom.md",
+        })
+      );
+    });
+
+    it("preserves fields across two successive save cycles", async () => {
+      // Save once after priming, then save again — the second save should
+      // consult persisted state (not stale previous "base-only" output) and
+      // still preserve the kind-specific fields.
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "custom-widget",
+        title: "Custom",
+        location: "grid",
+      });
+
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "custom-widget",
+          title: "Custom",
+          location: "grid",
+          browserUrl: "https://example.com",
+        },
+      ]);
+
+      persistence.save([panel], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Trigger a second save with a title change so the snapshot differs
+      // from the queued/persisted state and the debounce actually fires.
+      persistence.save([createMockTerminal({ ...panel, title: "Custom Renamed" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(client.setTerminals).toHaveBeenCalledTimes(2);
+      const secondSave = client.setTerminals.mock.calls[1][1] as TerminalSnapshot[];
+      expect(secondSave[0]).toEqual(
+        expect.objectContaining({
+          id: "ext-unknown",
+          title: "Custom Renamed",
+          browserUrl: "https://example.com",
+        })
+      );
+    });
+
+    it("does not preserve fields across a kind change for the same id", async () => {
+      // Same panel id but a different kind — the previously-persisted
+      // fragment belongs to the old kind and must NOT leak into the new kind.
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "old-kind",
+          title: "Custom",
+          location: "grid",
+          browserUrl: "https://old.example.com",
+        },
+      ]);
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "new-kind",
+        title: "Custom",
+        location: "grid",
+      });
+
+      persistence.save([panel], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const saved = client.setTerminals.mock.calls[0][1] as TerminalSnapshot[];
+      expect(saved[0]).not.toHaveProperty("browserUrl");
+      expect(saved[0]).toEqual(expect.objectContaining({ id: "ext-unknown", kind: "new-kind" }));
+    });
+
+    it("bypasses preservation when a custom transform is provided", async () => {
+      // Custom `transform` is an external extension point. Preservation logic
+      // is tied to the default transform (panelToSnapshot); custom transforms
+      // own their own output entirely.
+      const client = createMockProjectClient();
+      const customTransform = vi.fn(
+        (t: TerminalInstance): TerminalSnapshot => ({
+          id: t.id,
+          kind: t.kind,
+          title: t.title,
+          location: t.location === "trash" ? "grid" : t.location,
+        })
+      );
+      const persistence = new PanelPersistence(client, {
+        debounceMs: 100,
+        transform: customTransform,
+      });
+
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "custom-widget",
+          title: "Custom",
+          location: "grid",
+          browserUrl: "https://example.com",
+        },
+      ]);
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "custom-widget",
+        title: "Custom",
+        location: "grid",
+      });
+
+      persistence.save([panel], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(customTransform).toHaveBeenCalledTimes(1);
+      const saved = client.setTerminals.mock.calls[0][1] as TerminalSnapshot[];
+      expect(saved[0]).not.toHaveProperty("browserUrl");
+    });
+
+    it("primeProject is a no-op when state is already tracked", async () => {
+      // If a real save has already run (persisted state exists), a late
+      // hydration prime must not clobber live data.
+      const client = createMockProjectClient();
+      const persistence = new PanelPersistence(client, { debounceMs: 100 });
+
+      const panel = createMockTerminal({
+        id: "ext-unknown",
+        kind: "custom-widget",
+        title: "First",
+        location: "grid",
+      });
+
+      persistence.save([panel], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Late prime with a different snapshot — should be ignored.
+      persistence.primeProject(projectId, [
+        {
+          id: "ext-unknown",
+          kind: "custom-widget",
+          title: "Stale",
+          location: "grid",
+          browserUrl: "https://stale.example.com",
+        },
+      ]);
+
+      persistence.save([createMockTerminal({ ...panel, title: "Second" })], projectId);
+      await vi.advanceTimersByTimeAsync(100);
+
+      const secondSave = client.setTerminals.mock.calls[1][1] as TerminalSnapshot[];
+      expect(secondSave[0]).not.toHaveProperty("browserUrl");
+      expect(secondSave[0]).toEqual(
+        expect.objectContaining({ id: "ext-unknown", title: "Second" })
+      );
     });
   });
 

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -787,7 +787,7 @@ describe("PanelPersistence", () => {
       // second save runs; the second save must still see the preserved
       // fragment via queued, not fall back to an empty fragment.
       const client = createMockProjectClient();
-      let resolveFirstPersist: (() => void) | null = null;
+      let resolveFirstPersist: (() => void) | undefined;
       const firstPersistPromise = new Promise<void>((resolve) => {
         resolveFirstPersist = resolve;
       });

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -48,7 +48,7 @@ export function panelToSnapshot(
     // so a save cycle doesn't silently erase extension state.
     if (previousSnapshot && previousSnapshot.id === t.id && previousSnapshot.kind === t.kind) {
       const preserved: Record<string, unknown> = {};
-      const prev = previousSnapshot as Record<string, unknown>;
+      const prev = previousSnapshot as unknown as Record<string, unknown>;
       for (const key of Object.keys(prev)) {
         if (!BASE_PANEL_FIELDS.has(key) && prev[key] !== undefined) {
           preserved[key] = prev[key];

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -14,7 +14,23 @@ export interface PanelPersistenceOptions {
   getProjectId?: () => string | null;
 }
 
-export function panelToSnapshot(t: TerminalInstance): PanelSnapshot {
+// Base fields that panelToSnapshot always writes. Used to isolate kind-specific
+// fields when preserving a previous snapshot for an unregistered kind. If new
+// base fields are added to the `base` object below, they MUST be added here too,
+// or unknown-kind snapshots will silently carry stale copies of the new field.
+const BASE_PANEL_FIELDS = new Set<string>([
+  "id",
+  "kind",
+  "title",
+  "worktreeId",
+  "location",
+  "extensionState",
+]);
+
+export function panelToSnapshot(
+  t: TerminalInstance,
+  previousSnapshot?: PanelSnapshot
+): PanelSnapshot {
   const base: PanelSnapshot = {
     id: t.id,
     kind: t.kind,
@@ -25,8 +41,26 @@ export function panelToSnapshot(t: TerminalInstance): PanelSnapshot {
   };
 
   const config = getPanelKindConfig(t.kind ?? "terminal");
-  const fragment = config?.serialize?.(t) ?? {};
 
+  if (!config?.serialize) {
+    // Unregistered kind (extension disabled mid-session, plugin not yet loaded,
+    // or renamed in code). Preserve previously-persisted kind-specific fields
+    // so a save cycle doesn't silently erase extension state.
+    if (previousSnapshot && previousSnapshot.id === t.id && previousSnapshot.kind === t.kind) {
+      const preserved: Record<string, unknown> = {};
+      const prev = previousSnapshot as Record<string, unknown>;
+      for (const key of Object.keys(prev)) {
+        if (!BASE_PANEL_FIELDS.has(key) && prev[key] !== undefined) {
+          preserved[key] = prev[key];
+        }
+      }
+      // Spread order: live base wins over stale preserved fields if any overlap.
+      return { ...preserved, ...base };
+    }
+    return base;
+  }
+
+  const fragment = config.serialize(t);
   return { ...base, ...fragment };
 }
 
@@ -242,7 +276,22 @@ export class PanelPersistence {
     }
 
     const filtered = terminals.filter(this.options.filter);
-    const transformed = filtered.map(this.options.transform);
+    // When using the default transform (panelToSnapshot), thread the previously-
+    // persisted snapshot per panel so unregistered kinds preserve their
+    // kind-specific fields across save cycles. Prefer queued state (reflects
+    // the most recent save, even if debounce hasn't flushed) over persisted.
+    const transformed =
+      this.options.transform === panelToSnapshot
+        ? (() => {
+            const prevSnapshots =
+              this.queuedTerminalsByProject.get(resolvedProjectId) ??
+              this.persistedTerminalsByProject.get(resolvedProjectId);
+            const prevById = prevSnapshots
+              ? new Map(prevSnapshots.map((s) => [s.id, s]))
+              : undefined;
+            return filtered.map((t) => panelToSnapshot(t, prevById?.get(t.id)));
+          })()
+        : filtered.map(this.options.transform);
     if (snapshotsEqual(this.queuedTerminalsByProject.get(resolvedProjectId), transformed)) {
       return;
     }
@@ -300,6 +349,19 @@ export class PanelPersistence {
 
   setProjectIdGetter(getter: () => string | null | undefined): void {
     this.options.getProjectId = () => getter() ?? null;
+  }
+
+  /**
+   * Seed the previously-persisted snapshot cache for a project from hydration.
+   * Without this, the first save after app launch has no "previous" snapshot
+   * to preserve kind-specific fields from, and an unregistered kind's state
+   * would be dropped on the very first save. Only primes if not already
+   * present to avoid clobbering a post-hydration save that may have already
+   * run through `save()`.
+   */
+  primeProject(projectId: string, snapshots: PanelSnapshot[]): void {
+    if (this.persistedTerminalsByProject.has(projectId)) return;
+    this.persistedTerminalsByProject.set(projectId, snapshots);
   }
 }
 

--- a/src/store/persistence/panelPersistence.ts
+++ b/src/store/persistence/panelPersistence.ts
@@ -278,20 +278,15 @@ export class PanelPersistence {
     const filtered = terminals.filter(this.options.filter);
     // When using the default transform (panelToSnapshot), thread the previously-
     // persisted snapshot per panel so unregistered kinds preserve their
-    // kind-specific fields across save cycles. Prefer queued state (reflects
-    // the most recent save, even if debounce hasn't flushed) over persisted.
-    const transformed =
-      this.options.transform === panelToSnapshot
-        ? (() => {
-            const prevSnapshots =
-              this.queuedTerminalsByProject.get(resolvedProjectId) ??
-              this.persistedTerminalsByProject.get(resolvedProjectId);
-            const prevById = prevSnapshots
-              ? new Map(prevSnapshots.map((s) => [s.id, s]))
-              : undefined;
-            return filtered.map((t) => panelToSnapshot(t, prevById?.get(t.id)));
-          })()
-        : filtered.map(this.options.transform);
+    // kind-specific fields across save cycles. Custom transforms own their
+    // output entirely and bypass preservation.
+    let transformed: PanelSnapshot[];
+    if (this.options.transform === panelToSnapshot) {
+      const prevById = this.getPreviousSnapshotMap(resolvedProjectId);
+      transformed = filtered.map((t) => panelToSnapshot(t, prevById?.get(t.id)));
+    } else {
+      transformed = filtered.map(this.options.transform);
+    }
     if (snapshotsEqual(this.queuedTerminalsByProject.get(resolvedProjectId), transformed)) {
       return;
     }
@@ -362,6 +357,22 @@ export class PanelPersistence {
   primeProject(projectId: string, snapshots: PanelSnapshot[]): void {
     if (this.persistedTerminalsByProject.has(projectId)) return;
     this.persistedTerminalsByProject.set(projectId, snapshots);
+  }
+
+  /**
+   * Returns a map of panel id → most-recent snapshot for the given project,
+   * or `undefined` if no snapshots are tracked. Used by callers outside the
+   * debounced save path (e.g., the synchronous outgoing-state capture on
+   * project switch) so they can thread `previousSnapshot` into
+   * `panelToSnapshot` and preserve unregistered-kind fragments. Prefers
+   * queued (in-flight) state over persisted (on-disk) state.
+   */
+  getPreviousSnapshotMap(projectId: string): Map<string, PanelSnapshot> | undefined {
+    const snapshots =
+      this.queuedTerminalsByProject.get(projectId) ??
+      this.persistedTerminalsByProject.get(projectId);
+    if (!snapshots) return undefined;
+    return new Map(snapshots.map((s) => [s.id, s]));
   }
 }
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -79,13 +79,17 @@ function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
 
   const { panelsById, panelIds, tabGroups } = terminalState;
 
+  // Thread previously-persisted snapshots per panel so the outgoing state
+  // preserves kind-specific fields for unregistered kinds (issue #5201).
+  // The main process pre-applies this payload to the previous project's
+  // persisted state during PROJECT_SWITCH (see projectCrud.ts:184-217), so
+  // without preservation here a switch would silently overwrite an extension
+  // panel's on-disk fields with a base-only snapshot.
+  const prevSnapshotMap = panelPersistence.getPreviousSnapshotMap(projectId);
   const terminals = panelIds
     .map((id) => panelsById[id])
     .filter((t): t is TerminalInstance => t != null && shouldPersistTerminal(t))
-    // No previousSnapshot threaded here — this synchronous capture has no
-    // access to persistence caches. Unknown-kind preservation for the steady
-    // state is handled by PanelPersistence.save() after hydration priming.
-    .map((t) => panelToSnapshot(t));
+    .map((t) => panelToSnapshot(t, prevSnapshotMap?.get(t.id)));
 
   const tabGroupArray = Array.from(tabGroups.values()).filter((g) => g.panelIds.length > 1);
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -82,7 +82,10 @@ function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   const terminals = panelIds
     .map((id) => panelsById[id])
     .filter((t): t is TerminalInstance => t != null && shouldPersistTerminal(t))
-    .map(panelToSnapshot);
+    // No previousSnapshot threaded here — this synchronous capture has no
+    // access to persistence caches. Unknown-kind preservation for the steady
+    // state is handled by PanelPersistence.save() after hydration priming.
+    .map((t) => panelToSnapshot(t));
 
   const tabGroupArray = Array.from(tabGroups.values()).filter((g) => g.panelIds.length > 1);
 

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/types";
 import { keybindingService } from "@/services/KeybindingService";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { panelPersistence } from "@/store/persistence/panelPersistence";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { logDebug, logInfo, logWarn, logError } from "@/utils/logger";
@@ -349,6 +350,14 @@ export async function hydrateAppState(
 
         // Restore all panels in saved order (mix of PTY reconnects and non-PTY recreations)
         if (appState.terminals && appState.terminals.length > 0) {
+          // Seed the persistence cache so the first save after launch can
+          // preserve kind-specific fields for unregistered kinds (e.g., an
+          // extension that hasn't re-registered yet). Without this priming,
+          // a first save cycle would drop those fields — see issue #5201.
+          if (currentProjectId) {
+            panelPersistence.primeProject(currentProjectId, appState.terminals);
+          }
+
           panelRestoreStartedAt = Date.now();
           panelRestoreCount = appState.terminals.length;
           markRendererPerformance(PERF_MARKS.HYDRATE_RESTORE_PANELS_START, {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -8,6 +8,7 @@ import type {
   TerminalType,
   AgentState,
   PanelKind,
+  PanelSnapshot,
   TerminalReconnectError,
   TabGroup,
 } from "@/types";
@@ -354,8 +355,14 @@ export async function hydrateAppState(
           // preserve kind-specific fields for unregistered kinds (e.g., an
           // extension that hasn't re-registered yet). Without this priming,
           // a first save cycle would drop those fields — see issue #5201.
+          // appState.terminals is TerminalState[] (IPC wire type, more
+          // lenient); the on-disk data was written by panelToSnapshot so is
+          // structurally PanelSnapshot[].
           if (currentProjectId) {
-            panelPersistence.primeProject(currentProjectId, appState.terminals);
+            panelPersistence.primeProject(
+              currentProjectId,
+              appState.terminals as unknown as PanelSnapshot[]
+            );
           }
 
           panelRestoreStartedAt = Date.now();


### PR DESCRIPTION
## Summary

- `panelToSnapshot` previously fell back to an empty object when no serializer was registered for a panel kind, silently erasing kind-specific fields (custom config, disabled extension state) on the next save cycle.
- The fix threads an optional `previousSnapshot` parameter through the save and project-switch paths so those fields are carried forward when the kind is unregistered.
- `BASE_PANEL_FIELDS` is the single source of truth for what counts as "base" vs "kind-specific", and a double-guard on `id + kind` prevents any cross-panel or cross-kind bleed.

Resolves #5201

## Changes

- `panelToSnapshot(t, previousSnapshot?)` accepts an optional previous snapshot and preserves non-base fields when no serializer is found
- `PanelPersistence.save()` builds a per-panel previous-snapshot map from queued or persisted state before running the transform
- `PanelPersistence.primeProject(projectId, snapshots)` seeds the cache from hydration so the first save after launch preserves fields even before the extension re-registers
- `PanelPersistence.getPreviousSnapshotMap(projectId)` exposes the cache for synchronous callers outside the debounced save path
- `buildOutgoingState` in `projectStore.ts` threads `getPreviousSnapshotMap` into `panelToSnapshot` so project-switch pre-apply also preserves fields
- State hydration primes the cache from `appState.terminals`
- Spread order `{ ...preserved, ...base }` ensures live base fields always win over stale previous values

## Testing

10 new unit tests across `panelPersistence.test.ts` and `projectStore.switching.test.ts` cover: first-save fallback, core regression, successive saves, kind-change invalidation, custom-transform bypass, primeProject no-op-when-tracked, `getPreviousSnapshotMap` end-to-end, unknown-project handling, queued-state fallback, and the project-switch path. All 1025 store and hydration tests pass. Typecheck, lint, and format all clean.