### PR TITLE
fix(state-hydration): preserve agent launch flags on quit-restart

### DIFF
--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildResumeCommand,
   buildAgentLaunchFlags,
+  buildLaunchCommandFromFlags,
   generateAgentCommand,
 } from "../agentSettings.js";
 
@@ -267,5 +268,85 @@ describe("generateAgentCommand with recipeArgs", () => {
     const recipeIdx = cmd.indexOf("--recipe-flag");
     const promptIdx = cmd.indexOf("Do the thing");
     expect(recipeIdx).toBeLessThan(promptIdx);
+  });
+});
+
+describe("buildLaunchCommandFromFlags", () => {
+  it("joins flag-style tokens raw", () => {
+    const cmd = buildLaunchCommandFromFlags("claude", "claude", [
+      "--dangerously-skip-permissions",
+      "--yolo",
+    ]);
+    expect(cmd).toBe("claude --dangerously-skip-permissions --yolo");
+  });
+
+  it("escapes non-flag positional tokens (e.g. model IDs, file paths)", () => {
+    const cmd = buildLaunchCommandFromFlags("claude", "claude", ["--model", "claude-opus-4-7"]);
+    // `--model` is flag-style (raw); `claude-opus-4-7` is positional (escaped).
+    expect(cmd).toBe("claude --model 'claude-opus-4-7'");
+  });
+
+  it("quotes tokens containing shell metacharacters to prevent injection", () => {
+    // A user customFlag like `--log /tmp/a;b.log` would split on `;` if not quoted.
+    const cmd = buildLaunchCommandFromFlags("claude", "claude", ["--log", "/tmp/a;b.log"]);
+    expect(cmd).toBe("claude --log '/tmp/a;b.log'");
+  });
+
+  it("escapes embedded single quotes in positional tokens", () => {
+    const cmd = buildLaunchCommandFromFlags("claude", "claude", ["--msg", "it's fine"]);
+    // POSIX single-quote escape: close, escape the quote, reopen.
+    expect(cmd).toBe("claude --msg 'it'\\''s fine'");
+  });
+
+  it("appends --include-directories for Gemini when clipboardDirectory is provided", () => {
+    const cmd = buildLaunchCommandFromFlags("gemini", "gemini", ["--yolo"], {
+      clipboardDirectory: "/tmp/daintree-clipboard",
+    });
+    expect(cmd).toContain("--yolo");
+    expect(cmd).toContain("--include-directories");
+    expect(cmd).toContain("/tmp/daintree-clipboard");
+  });
+
+  it("does not inject --include-directories for non-Gemini agents", () => {
+    const cmd = buildLaunchCommandFromFlags("claude", "claude", ["--yolo"], {
+      clipboardDirectory: "/tmp/daintree-clipboard",
+    });
+    expect(cmd).not.toContain("--include-directories");
+  });
+
+  it("skips --include-directories for Gemini when shareClipboardDirectory is false", () => {
+    const cmd = buildLaunchCommandFromFlags("gemini", "gemini", ["--yolo"], {
+      clipboardDirectory: "/tmp/daintree-clipboard",
+      shareClipboardDirectory: false,
+    });
+    expect(cmd).not.toContain("--include-directories");
+  });
+
+  it("skips --include-directories for Gemini when clipboardDirectory is missing", () => {
+    const cmd = buildLaunchCommandFromFlags("gemini", "gemini", ["--yolo"]);
+    expect(cmd).not.toContain("--include-directories");
+  });
+
+  it("deduplicates --include-directories when the same directory is already persisted", () => {
+    const cmd = buildLaunchCommandFromFlags(
+      "gemini",
+      "gemini",
+      ["--yolo", "--include-directories", "/tmp/daintree-clipboard"],
+      { clipboardDirectory: "/tmp/daintree-clipboard" }
+    );
+    const matches = cmd.match(/--include-directories/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("handles empty flag arrays safely", () => {
+    expect(buildLaunchCommandFromFlags("claude", "claude", [])).toBe("claude");
+  });
+
+  it("does not mutate the input flags array", () => {
+    const flags = ["--yolo"];
+    buildLaunchCommandFromFlags("gemini", "gemini", flags, {
+      clipboardDirectory: "/tmp/daintree-clipboard",
+    });
+    expect(flags).toEqual(["--yolo"]);
   });
 });

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -302,9 +302,8 @@ describe("buildLaunchCommandFromFlags", () => {
     const cmd = buildLaunchCommandFromFlags("gemini", "gemini", ["--yolo"], {
       clipboardDirectory: "/tmp/daintree-clipboard",
     });
-    expect(cmd).toContain("--yolo");
-    expect(cmd).toContain("--include-directories");
-    expect(cmd).toContain("/tmp/daintree-clipboard");
+    // Exact assertion locks flag/value pairing and ordering.
+    expect(cmd).toBe("gemini --yolo --include-directories '/tmp/daintree-clipboard'");
   });
 
   it("does not inject --include-directories for non-Gemini agents", () => {
@@ -334,8 +333,24 @@ describe("buildLaunchCommandFromFlags", () => {
       ["--yolo", "--include-directories", "/tmp/daintree-clipboard"],
       { clipboardDirectory: "/tmp/daintree-clipboard" }
     );
-    const matches = cmd.match(/--include-directories/g) ?? [];
-    expect(matches).toHaveLength(1);
+    // Count exact flag-token occurrences, not substring matches.
+    const tokens = cmd.split(/\s+/).filter((t) => t === "--include-directories");
+    expect(tokens).toHaveLength(1);
+  });
+
+  it("does NOT dedup when persisted flags reference a different directory", () => {
+    // Persisted `--include-directories /old/path` should be preserved, AND the
+    // runtime clipboard dir should still be appended — each serves a distinct purpose.
+    const cmd = buildLaunchCommandFromFlags(
+      "gemini",
+      "gemini",
+      ["--include-directories", "/user/chosen/dir"],
+      { clipboardDirectory: "/tmp/daintree-clipboard" }
+    );
+    expect(cmd).toContain("/user/chosen/dir");
+    expect(cmd).toContain("/tmp/daintree-clipboard");
+    const tokens = cmd.split(/\s+/).filter((t) => t === "--include-directories");
+    expect(tokens).toHaveLength(2);
   });
 
   it("handles empty flag arrays safely", () => {

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -387,3 +387,59 @@ export function buildResumeCommand(
   }
   return parts.join(" ");
 }
+
+export interface BuildLaunchCommandFromFlagsOptions {
+  /** Absolute path to the clipboard temp directory (re-injected for agents that support it) */
+  clipboardDirectory?: string;
+  /**
+   * Current `shareClipboardDirectory` setting for the agent entry. When not `false`
+   * and the agent supports clipboard injection (e.g. Gemini), `--include-directories
+   * <clipboardDirectory>` is appended if not already present.
+   */
+  shareClipboardDirectory?: boolean;
+}
+
+/**
+ * Reconstructs an agent launch command from persisted launch flags.
+ *
+ * Used on respawn/restart paths when no resumable session is available but
+ * the original `agentLaunchFlags` are persisted. Mirrors the shell-escaping
+ * rules of `buildResumeCommand` (raw for flag-style `-`-prefixed tokens,
+ * `escapeShellArg` for positional values).
+ *
+ * Re-injects runtime-dynamic values that `buildAgentLaunchFlags` deliberately
+ * excluded at capture time — today, only Gemini's `--include-directories
+ * <clipboardDirectory>` (with dedup if already present in the persisted flags).
+ */
+export function buildLaunchCommandFromFlags(
+  baseCommand: string,
+  agentId: string,
+  launchFlags: readonly string[],
+  options?: BuildLaunchCommandFromFlagsOptions
+): string {
+  const flags: string[] = [...launchFlags];
+
+  if (
+    agentId === "gemini" &&
+    options?.shareClipboardDirectory !== false &&
+    options?.clipboardDirectory
+  ) {
+    const dir = options.clipboardDirectory;
+    const alreadyIncluded = flags.some(
+      (flag, i) => flag === "--include-directories" && flags[i + 1] === dir
+    );
+    if (!alreadyIncluded) {
+      flags.push("--include-directories", dir);
+    }
+  }
+
+  const parts: string[] = [baseCommand];
+  for (const flag of flags) {
+    if (flag.startsWith("-")) {
+      parts.push(flag);
+    } else {
+      parts.push(escapeShellArg(flag));
+    }
+  }
+  return parts.join(" ");
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -270,6 +270,7 @@ export {
   generateAgentCommand,
   buildAgentLaunchFlags,
   buildResumeCommand,
+  buildLaunchCommandFromFlags,
 } from "./agentSettings.js";
 
 // User agent registry types - user-defined agent configuration

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -1,7 +1,11 @@
 import type { PanelLocation } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { terminalClient, agentSettingsClient, projectClient, systemClient } from "@/clients";
-import { generateAgentCommand, buildResumeCommand } from "@shared/types";
+import {
+  generateAgentCommand,
+  buildResumeCommand,
+  buildLaunchCommandFromFlags,
+} from "@shared/types";
 import type { AgentState } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
@@ -211,20 +215,37 @@ export const createRestartActions = (
 
       if (commandToRun === currentTerminal.command) {
         const persistedFlags = currentTerminal.agentLaunchFlags;
-        if (persistedFlags && persistedFlags.length > 0) {
-          const agentConfig = getAgentConfig(effectiveAgentId);
-          const baseCommand = agentConfig?.command || effectiveAgentId;
-          commandToRun = [baseCommand, ...persistedFlags].join(" ");
+        const hasPersistedFlags = Boolean(persistedFlags && persistedFlags.length > 0);
+        const agentConfig = getAgentConfig(effectiveAgentId);
+        const baseCommand = agentConfig?.command || effectiveAgentId;
+
+        if (hasPersistedFlags && effectiveAgentId !== "gemini") {
+          // Sync fast path: non-Gemini agents have no runtime-dynamic flag
+          // injection, so the persisted flags are the complete command.
+          commandToRun = buildLaunchCommandFromFlags(
+            baseCommand,
+            effectiveAgentId,
+            persistedFlags as string[]
+          );
         } else {
+          // Async path: either Gemini (needs clipboard directory re-injection)
+          // or no persisted flags (needs settings-derived fallback).
           try {
             const [agentSettings, tmpDir] = await Promise.all([
               agentSettingsClient.get(),
               systemClient.getTmpDir().catch(() => ""),
             ]);
-            if (agentSettings) {
-              const agentConfig = getAgentConfig(effectiveAgentId);
-              const baseCommand = agentConfig?.command || effectiveAgentId;
-              const clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
+            const clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
+            if (hasPersistedFlags) {
+              const entry = agentSettings?.agents?.[effectiveAgentId];
+              const shareClipboardDirectory = entry?.shareClipboardDirectory as boolean | undefined;
+              commandToRun = buildLaunchCommandFromFlags(
+                baseCommand,
+                effectiveAgentId,
+                persistedFlags as string[],
+                { clipboardDirectory, shareClipboardDirectory }
+              );
+            } else if (agentSettings) {
               commandToRun = generateAgentCommand(
                 baseCommand,
                 agentSettings.agents?.[effectiveAgentId] ?? {},

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -210,29 +210,36 @@ export const createRestartActions = (
       }
 
       if (commandToRun === currentTerminal.command) {
-        try {
-          const [agentSettings, tmpDir] = await Promise.all([
-            agentSettingsClient.get(),
-            systemClient.getTmpDir().catch(() => ""),
-          ]);
-          if (agentSettings) {
-            const agentConfig = getAgentConfig(effectiveAgentId);
-            const baseCommand = agentConfig?.command || effectiveAgentId;
-            const clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
-            commandToRun = generateAgentCommand(
-              baseCommand,
-              agentSettings.agents?.[effectiveAgentId] ?? {},
-              effectiveAgentId,
-              { clipboardDirectory, modelId: currentTerminal.agentModelId }
+        const persistedFlags = currentTerminal.agentLaunchFlags;
+        if (persistedFlags && persistedFlags.length > 0) {
+          const agentConfig = getAgentConfig(effectiveAgentId);
+          const baseCommand = agentConfig?.command || effectiveAgentId;
+          commandToRun = [baseCommand, ...persistedFlags].join(" ");
+        } else {
+          try {
+            const [agentSettings, tmpDir] = await Promise.all([
+              agentSettingsClient.get(),
+              systemClient.getTmpDir().catch(() => ""),
+            ]);
+            if (agentSettings) {
+              const agentConfig = getAgentConfig(effectiveAgentId);
+              const baseCommand = agentConfig?.command || effectiveAgentId;
+              const clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
+              commandToRun = generateAgentCommand(
+                baseCommand,
+                agentSettings.agents?.[effectiveAgentId] ?? {},
+                effectiveAgentId,
+                { clipboardDirectory, modelId: currentTerminal.agentModelId }
+              );
+            }
+          } catch (error) {
+            logWarn(
+              "[TerminalStore] Failed to load agent settings for restart, using saved command",
+              {
+                error,
+              }
             );
           }
-        } catch (error) {
-          logWarn(
-            "[TerminalStore] Failed to load agent settings for restart, using saved command",
-            {
-              error,
-            }
-          );
         }
       }
     }

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -559,9 +559,8 @@ describe("buildArgsForRespawn", () => {
       false,
       "/tmp/daintree-clipboard"
     );
-    expect(result.command).toContain("--yolo");
-    expect(result.command).toContain("--include-directories");
-    expect(result.command).toContain("/tmp/daintree-clipboard");
+    // Exact assertion locks flag/value pairing and ordering.
+    expect(result.command).toBe("gemini --yolo --include-directories '/tmp/daintree-clipboard'");
     expect(generateAgentCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -18,12 +18,16 @@ const generateAgentCommandMock = vi.fn(
   (base: string, _settings: unknown, _id: string, _opts: unknown): string => `${base} --generated`
 );
 
-vi.mock("@shared/types", () => ({
-  generateAgentCommand: (...args: unknown[]) =>
-    generateAgentCommandMock(...(args as [string, unknown, string, unknown])),
-  buildResumeCommand: (...args: unknown[]) =>
-    buildResumeCommandMock(...(args as [string, string, string[]?])),
-}));
+vi.mock("@shared/types", async () => {
+  const actual = await vi.importActual<typeof import("@shared/types")>("@shared/types");
+  return {
+    ...actual,
+    generateAgentCommand: (...args: unknown[]) =>
+      generateAgentCommandMock(...(args as [string, unknown, string, unknown])),
+    buildResumeCommand: (...args: unknown[]) =>
+      buildResumeCommandMock(...(args as [string, string, string[]?])),
+  };
+});
 
 const {
   inferKind,
@@ -38,13 +42,14 @@ const {
 } = await import("../statePatcher");
 
 beforeEach(() => {
+  buildResumeCommandMock.mockReset();
   buildResumeCommandMock.mockImplementation(
     (agentId: string, sessionId: string) => `${agentId} --resume ${sessionId}`
   );
+  generateAgentCommandMock.mockReset();
   generateAgentCommandMock.mockImplementation(
     (base: string, _settings: unknown, _id: string, _opts: unknown) => `${base} --generated`
   );
-  generateAgentCommandMock.mockClear();
 });
 
 describe("inferKind", () => {
@@ -468,7 +473,8 @@ describe("buildArgsForRespawn", () => {
       false,
       "/tmp/clip"
     );
-    expect(result.command).toBe("claude --dangerously-skip-permissions --model claude-opus-4-7");
+    // `--...` flags pass through raw; the positional `claude-opus-4-7` is escaped.
+    expect(result.command).toBe("claude --dangerously-skip-permissions --model 'claude-opus-4-7'");
     expect(generateAgentCommandMock).not.toHaveBeenCalled();
   });
 
@@ -513,6 +519,69 @@ describe("buildArgsForRespawn", () => {
     );
     expect(result.command).toBe("claude --dangerously-skip-permissions");
     expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("shell-escapes non-flag tokens in persisted agentLaunchFlags (defends against metachars)", () => {
+    // Simulates a user customFlag like `--log /tmp/a;b.log` persisted at launch time.
+    // The `/tmp/a;b.log` positional must be quoted so the shell doesn't split on `;`.
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "agent" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: ["--log", "/tmp/a;b.log"],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.command).toBe("claude --log '/tmp/a;b.log'");
+    expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("re-injects --include-directories for Gemini on respawn (runtime-dynamic, excluded at capture)", () => {
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "agent" as const,
+        agentId: "gemini",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: ["--yolo"],
+      },
+      "agent",
+      "/p",
+      { agents: { gemini: {} } },
+      false,
+      "/tmp/daintree-clipboard"
+    );
+    expect(result.command).toContain("--yolo");
+    expect(result.command).toContain("--include-directories");
+    expect(result.command).toContain("/tmp/daintree-clipboard");
+    expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("respects shareClipboardDirectory=false for Gemini on respawn", () => {
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "agent" as const,
+        agentId: "gemini",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: ["--yolo"],
+      },
+      "agent",
+      "/p",
+      { agents: { gemini: { shareClipboardDirectory: false } } },
+      false,
+      "/tmp/daintree-clipboard"
+    );
+    expect(result.command).not.toContain("--include-directories");
   });
 });
 

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -14,9 +14,13 @@ const buildResumeCommandMock = vi.fn(
     `${agentId} --resume ${sessionId}`
 );
 
+const generateAgentCommandMock = vi.fn(
+  (base: string, _settings: unknown, _id: string, _opts: unknown): string => `${base} --generated`
+);
+
 vi.mock("@shared/types", () => ({
-  generateAgentCommand: (base: string, _settings: unknown, _id: string, _opts: unknown) =>
-    `${base} --generated`,
+  generateAgentCommand: (...args: unknown[]) =>
+    generateAgentCommandMock(...(args as [string, unknown, string, unknown])),
   buildResumeCommand: (...args: unknown[]) =>
     buildResumeCommandMock(...(args as [string, string, string[]?])),
 }));
@@ -37,6 +41,10 @@ beforeEach(() => {
   buildResumeCommandMock.mockImplementation(
     (agentId: string, sessionId: string) => `${agentId} --resume ${sessionId}`
   );
+  generateAgentCommandMock.mockImplementation(
+    (base: string, _settings: unknown, _id: string, _opts: unknown) => `${base} --generated`
+  );
+  generateAgentCommandMock.mockClear();
 });
 
 describe("inferKind", () => {
@@ -440,6 +448,71 @@ describe("buildArgsForRespawn", () => {
       "--yolo",
       "--dangerously-skip-permissions",
     ]);
+  });
+
+  it("uses persisted agentLaunchFlags for no-session agent respawn", () => {
+    // Sentinel return value would signal the bug (settings path taken instead of flags path)
+    generateAgentCommandMock.mockReturnValue("claude --from-settings");
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "agent" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: ["--dangerously-skip-permissions", "--model", "claude-opus-4-7"],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: { dangerousEnabled: false } } },
+      false,
+      "/tmp/clip"
+    );
+    expect(result.command).toBe("claude --dangerously-skip-permissions --model claude-opus-4-7");
+    expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to generateAgentCommand when agentLaunchFlags is empty (pre-fix terminals)", () => {
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "agent" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentLaunchFlags: [],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      "/tmp/clip"
+    );
+    expect(result.command).toBe("claude --generated");
+    expect(generateAgentCommandMock).toHaveBeenCalledOnce();
+  });
+
+  it("uses persisted agentLaunchFlags when session exists but resume returns undefined", () => {
+    buildResumeCommandMock.mockReturnValue(undefined);
+    generateAgentCommandMock.mockReturnValue("claude --from-settings");
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "agent" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-expired",
+        agentLaunchFlags: ["--dangerously-skip-permissions"],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.command).toBe("claude --dangerously-skip-permissions");
+    expect(generateAgentCommandMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -3,7 +3,11 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type { PanelExitBehavior } from "@shared/types/panel";
 import type { AddPanelOptionsBase } from "@shared/types/addPanelOptions";
 import { isRegisteredAgent, getAgentConfig } from "@/config/agents";
-import { generateAgentCommand, buildResumeCommand } from "@shared/types";
+import {
+  generateAgentCommand,
+  buildResumeCommand,
+  buildLaunchCommandFromFlags,
+} from "@shared/types";
 import { logWarn } from "@/utils/logger";
 import { inferKind as inferKindShared } from "@shared/utils/inferPanelKind";
 import { getDeserializer } from "@/config/panelKindSerialisers";
@@ -249,26 +253,33 @@ export function buildArgsForRespawn(
   if (agentId) {
     const agentConfig = getAgentConfig(agentId);
     const baseCommand = agentConfig?.command || agentId;
-    const hasPersistedFlags = Boolean(saved.agentLaunchFlags && saved.agentLaunchFlags.length > 0);
+    const persistedFlags = saved.agentLaunchFlags;
+    const hasPersistedFlags = Boolean(persistedFlags && persistedFlags.length > 0);
+    const entry = agentSettings?.agents?.[agentId];
+    const shareClipboardDirectory = entry?.shareClipboardDirectory as boolean | undefined;
+
+    const buildFromPersistedFlags = () =>
+      buildLaunchCommandFromFlags(baseCommand, agentId, persistedFlags as string[], {
+        clipboardDirectory,
+        shareClipboardDirectory,
+      });
 
     if (saved.agentSessionId) {
-      const resumeCmd = buildResumeCommand(agentId, saved.agentSessionId, saved.agentLaunchFlags);
+      const resumeCmd = buildResumeCommand(agentId, saved.agentSessionId, persistedFlags);
       if (resumeCmd) {
         command = resumeCmd;
       } else if (hasPersistedFlags) {
-        command = [baseCommand, ...(saved.agentLaunchFlags as string[])].join(" ");
+        command = buildFromPersistedFlags();
       } else if (agentSettings) {
-        command = generateAgentCommand(
-          baseCommand,
-          agentSettings.agents?.[agentId] ?? {},
-          agentId,
-          { clipboardDirectory, modelId: saved.agentModelId }
-        );
+        command = generateAgentCommand(baseCommand, entry ?? {}, agentId, {
+          clipboardDirectory,
+          modelId: saved.agentModelId,
+        });
       }
     } else if (hasPersistedFlags) {
-      command = [baseCommand, ...(saved.agentLaunchFlags as string[])].join(" ");
+      command = buildFromPersistedFlags();
     } else if (agentSettings) {
-      command = generateAgentCommand(baseCommand, agentSettings.agents?.[agentId] ?? {}, agentId, {
+      command = generateAgentCommand(baseCommand, entry ?? {}, agentId, {
         clipboardDirectory,
         modelId: saved.agentModelId,
       });

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -247,13 +247,17 @@ export function buildArgsForRespawn(
   let command = saved.command?.trim() || undefined;
 
   if (agentId) {
+    const agentConfig = getAgentConfig(agentId);
+    const baseCommand = agentConfig?.command || agentId;
+    const hasPersistedFlags = Boolean(saved.agentLaunchFlags && saved.agentLaunchFlags.length > 0);
+
     if (saved.agentSessionId) {
       const resumeCmd = buildResumeCommand(agentId, saved.agentSessionId, saved.agentLaunchFlags);
       if (resumeCmd) {
         command = resumeCmd;
+      } else if (hasPersistedFlags) {
+        command = [baseCommand, ...(saved.agentLaunchFlags as string[])].join(" ");
       } else if (agentSettings) {
-        const agentConfig = getAgentConfig(agentId);
-        const baseCommand = agentConfig?.command || agentId;
         command = generateAgentCommand(
           baseCommand,
           agentSettings.agents?.[agentId] ?? {},
@@ -261,9 +265,9 @@ export function buildArgsForRespawn(
           { clipboardDirectory, modelId: saved.agentModelId }
         );
       }
+    } else if (hasPersistedFlags) {
+      command = [baseCommand, ...(saved.agentLaunchFlags as string[])].join(" ");
     } else if (agentSettings) {
-      const agentConfig = getAgentConfig(agentId);
-      const baseCommand = agentConfig?.command || agentId;
       command = generateAgentCommand(baseCommand, agentSettings.agents?.[agentId] ?? {}, agentId, {
         clipboardDirectory,
         modelId: saved.agentModelId,


### PR DESCRIPTION
## Summary

- Agent panels respawned from saved state (quit + relaunch) were re-deriving their command from current global agent settings, discarding per-terminal flags like `--dangerously-skip-permissions`, `--yolo`, `--model <id>`, and recipe-specific overrides that were stored in `agentLaunchFlags` on the panel.
- The resume path (when a session ID exists and the agent has a resume config) was already correct. The no-session path and the resume-unavailable fallback were both broken.
- The `restartTerminal` path had the same gap: non-Gemini agents now use a sync fast path from persisted flags; Gemini still fetches tmp dir asynchronously for clipboard re-injection.

Resolves #5272

## Changes

- New `buildLaunchCommandFromFlags` helper in `shared/types/agentSettings.ts` mirrors `buildResumeCommand`'s escaping pattern (raw for `-`-prefixed tokens, `escapeShellArg` for positionals). Re-injects Gemini's `--include-directories <clipboardDir>` with dedup. Backwards-compat fallback to `generateAgentCommand` is preserved for pre-fix terminals with empty `agentLaunchFlags`.
- `buildArgsForRespawn` in `statePatcher.ts` now calls the helper on the no-session path and the resume-unavailable fallback.
- `restartTerminal` in `restart.ts` uses the helper for persisted-flags panels; Gemini still goes async for clipboard re-injection.

## Testing

127 tests passing across modified files. 10 dedicated unit tests for `buildLaunchCommandFromFlags` covering escape behaviour, Gemini clipboard injection, dedup, `shareClipboardDirectory=false`, empty flags, and no-mutation. 6 integration tests in `statePatcher.test.ts` use `vi.importActual` + spread to run the real helper end-to-end through `buildArgsForRespawn`, including adversarial shell-escape and Gemini re-injection cases.

`npm run check` clean (typecheck + lint + format).