### PR TITLE
feat(onboarding): demote agent setup wizard to inline banner

### DIFF
--- a/e2e/core/core-first-run-onboarding.spec.ts
+++ b/e2e/core/core-first-run-onboarding.spec.ts
@@ -26,7 +26,7 @@ test.describe.serial("First-run onboarding flow", () => {
     rmSync(userDataDir, { recursive: true, force: true });
   });
 
-  test("completes onboarding wizard on first launch", async () => {
+  test("welcome screen is non-blocking on first launch and agent setup is opt-in", async () => {
     ctx = await launchApp({
       userDataDir,
       env: FIRST_RUN_ENV,
@@ -34,51 +34,55 @@ test.describe.serial("First-run onboarding flow", () => {
     });
     const { window } = ctx;
 
-    // Welcome + agent selection are consolidated into a single Agent Setup dialog.
-    // First-run shows the Welcome heading (not "Choose your AI agents").
+    // The welcome screen should render and the toolbar should be interactive
+    // simultaneously — no blocking modal prevents access to the app.
     await expect(window.locator(SEL.firstRun.welcomeTitle)).toBeVisible({ timeout: T_MEDIUM });
-    await expect(window.locator(SEL.firstRun.agentSetupTitle)).toBeVisible({ timeout: T_MEDIUM });
-    await window.locator('button:has-text("Skip")').click();
-
-    // Onboarding complete — toolbar should become visible
     await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible({ timeout: T_MEDIUM });
+    await expect(window.locator(SEL.toolbar.openSettings)).toBeEnabled();
 
-    // Clean close for persistence
+    // The wizard must NOT auto-open — it is opt-in via the banner CTA.
+    await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible();
+
+    // The setup banner is visible and invites the user in.
+    await expect(window.locator(SEL.firstRun.agentSetupBanner)).toBeVisible({ timeout: T_MEDIUM });
+
+    // Clicking the banner CTA opens the wizard on demand.
+    await window.locator(SEL.firstRun.agentSetupBannerCta).click();
+    await expect(window.locator(SEL.firstRun.agentSetupTitle)).toBeVisible({ timeout: T_MEDIUM });
+
+    // Skip closes the wizard and the toolbar remains interactive.
+    await window.locator('button:has-text("Skip")').click();
+    await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible({
+      timeout: T_SETTLE,
+    });
+    await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible();
+
+    // Clean close for persistence across the second-launch test below.
     const pid = ctx.app.process().pid!;
     await closeApp(ctx.app);
     await waitForProcessExit(pid);
     ctx = null;
   });
 
-  test("does not show onboarding on second launch", async () => {
-    // App renders a blank screen on the second launch when first-run was
-    // completed by skipping without selecting an agent. Likely interaction
-    // between OnboardingFlow's auto-open wizard and the new projectStore
-    // concurrency guards. Tracked separately.
-    test.fixme();
+  test("second launch does not reshow the banner or auto-open the wizard", async () => {
     ctx = await launchApp({
       userDataDir,
       env: FIRST_RUN_ENV,
     });
     const { window } = ctx;
 
-    // Toolbar should be visible (first-run completed previously)
+    // Toolbar should be visible (first-run completed previously).
     await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible({ timeout: T_MEDIUM });
 
-    // Allow onboarding hydration to complete
+    // Allow onboarding hydration to complete.
     await window.waitForTimeout(T_SETTLE);
 
-    // First-run welcome must NOT appear again.
-    await expect(window.locator(SEL.firstRun.welcomeTitle)).not.toBeVisible();
+    // The first-run banner must NOT reappear: the user completed the wizard
+    // on first launch, which persists the onboarding-complete flag.
+    await expect(window.locator(SEL.firstRun.agentSetupBanner)).not.toBeVisible();
 
-    // The Agent Setup wizard auto-opens on subsequent launches when no agents are
-    // installed/selected (see OnboardingFlow auto-open effect). Dismiss it and verify
-    // the toolbar remains usable.
-    const agentSetupDialog = window.locator(SEL.firstRun.agentSetupTitle);
-    if (await agentSetupDialog.isVisible()) {
-      await window.keyboard.press("Escape");
-      await expect(agentSetupDialog).not.toBeVisible({ timeout: T_SETTLE });
-    }
-    await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible();
+    // The wizard must not auto-open either — the old returning-user
+    // auto-open effect is gone.
+    await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible();
   });
 });

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -173,9 +173,12 @@ export const SEL = {
     openFolder: 'button:has-text("Open Folder")',
   },
   firstRun: {
-    welcomeTitle: 'role=dialog >> text="Welcome to Daintree"',
+    welcomeTitle: 'h1:has-text("Welcome to Daintree")',
     agentTitle: 'text="Choose your AI agents"',
     agentSetupTitle: 'text="Agent Setup"',
+    agentSetupBanner: '[data-testid="agent-setup-banner"]',
+    agentSetupBannerCta: '[data-testid="agent-setup-banner-cta"]',
+    agentSetupBannerDismiss: '[data-testid="agent-setup-banner-dismiss"]',
   },
   onboarding: {
     heading: 'h2:has-text("Set up your project")',

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -519,6 +519,7 @@ export const CHANNELS = {
   ONBOARDING_MARK_WAITING_NUDGE_SEEN: "onboarding:mark-waiting-nudge-seen",
   ONBOARDING_MARK_AGENTS_SEEN: "onboarding:mark-agents-seen",
   ONBOARDING_DISMISS_WELCOME_CARD: "onboarding:dismiss-welcome-card",
+  ONBOARDING_DISMISS_SETUP_BANNER: "onboarding:dismiss-setup-banner",
   ONBOARDING_CHECKLIST_GET: "onboarding:checklist-get",
   ONBOARDING_CHECKLIST_DISMISS: "onboarding:checklist-dismiss",
   ONBOARDING_CHECKLIST_MARK_ITEM: "onboarding:checklist-mark-item",

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -173,6 +173,55 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     expect(result.welcomeCardDismissed).toBe(true);
   });
 
+  it("get treats completed onboarding as implicit setupBannerDismissed (upgrade path)", () => {
+    registerOnboardingHandlers();
+    // Pre-#5131 completed state: no setupBannerDismissed field, completed=true.
+    seedOnboarding({ completed: true });
+    delete (storeMock._data["onboarding"] as Record<string, unknown>).setupBannerDismissed;
+    const get = getHandler("onboarding:get");
+    const state = get(null) as { completed: boolean; setupBannerDismissed: boolean };
+    expect(state.completed).toBe(true);
+    expect(state.setupBannerDismissed).toBe(true);
+  });
+
+  it("get keeps setupBannerDismissed false when onboarding is incomplete", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ completed: false });
+    delete (storeMock._data["onboarding"] as Record<string, unknown>).setupBannerDismissed;
+    const get = getHandler("onboarding:get");
+    const state = get(null) as { completed: boolean; setupBannerDismissed: boolean };
+    expect(state.completed).toBe(false);
+    expect(state.setupBannerDismissed).toBe(false);
+  });
+
+  it("migrate sets setupBannerDismissed: true when all legacy keys are complete", () => {
+    storeMock._data["privacy"] = { hasSeenPrompt: true };
+    registerOnboardingHandlers();
+    seedOnboarding({ migratedFromLocalStorage: false });
+    const migrate = getHandler("onboarding:migrate");
+    const result = migrate(null, {
+      agentSelectionDismissed: true,
+      agentSetupComplete: true,
+      firstRunToastSeen: true,
+    }) as { completed: boolean; setupBannerDismissed: boolean };
+    expect(result.completed).toBe(true);
+    expect(result.setupBannerDismissed).toBe(true);
+  });
+
+  it("migrate leaves setupBannerDismissed false when legacy state is partial", () => {
+    storeMock._data["privacy"] = { hasSeenPrompt: false };
+    registerOnboardingHandlers();
+    seedOnboarding({ migratedFromLocalStorage: false });
+    const migrate = getHandler("onboarding:migrate");
+    const result = migrate(null, {
+      agentSelectionDismissed: true,
+      agentSetupComplete: false,
+      firstRunToastSeen: true,
+    }) as { completed: boolean; setupBannerDismissed: boolean };
+    expect(result.completed).toBe(false);
+    expect(result.setupBannerDismissed).toBe(false);
+  });
+
   it("dismissSetupBanner flips the flag and returns the updated state", () => {
     registerOnboardingHandlers();
     seedOnboarding({ setupBannerDismissed: false });

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -38,6 +38,9 @@ function seedOnboarding(partial: Record<string, unknown> = {}) {
     firstRunToastSeen: false,
     newsletterPromptSeen: false,
     waitingNudgeSeen: false,
+    seenAgentIds: [],
+    welcomeCardDismissed: false,
+    setupBannerDismissed: false,
     migratedFromLocalStorage: false,
     checklist: {
       dismissed: false,
@@ -61,17 +64,38 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     }
   });
 
-  it("get normalizes missing seenAgentIds and welcomeCardDismissed to defaults", () => {
+  it("get normalizes missing seenAgentIds, welcomeCardDismissed, and setupBannerDismissed to defaults", () => {
     registerOnboardingHandlers();
-    // Raw store is missing the new fields entirely (pre-existing state).
-    seedOnboarding({});
+    // Raw store intentionally missing the new fields (pre-existing state).
+    storeMock._data["onboarding"] = {
+      schemaVersion: 1,
+      completed: false,
+      currentStep: null,
+      agentSetupIds: [],
+      firstRunToastSeen: false,
+      newsletterPromptSeen: false,
+      waitingNudgeSeen: false,
+      migratedFromLocalStorage: false,
+      checklist: {
+        dismissed: false,
+        celebrationShown: false,
+        items: {
+          openedProject: false,
+          launchedAgent: false,
+          createdWorktree: false,
+          subscribedNewsletter: false,
+        },
+      },
+    };
     const get = getHandler("onboarding:get");
     const state = get(null) as {
       seenAgentIds: string[];
       welcomeCardDismissed: boolean;
+      setupBannerDismissed: boolean;
     };
     expect(state.seenAgentIds).toEqual([]);
     expect(state.welcomeCardDismissed).toBe(false);
+    expect(state.setupBannerDismissed).toBe(false);
   });
 
   it("get filters out non-string values from seenAgentIds", () => {
@@ -149,10 +173,31 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     expect(result.welcomeCardDismissed).toBe(true);
   });
 
-  it("cleanup removes both discovery handlers", () => {
+  it("dismissSetupBanner flips the flag and returns the updated state", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ setupBannerDismissed: false });
+    const dismiss = getHandler("onboarding:dismiss-setup-banner");
+    const result = dismiss(null) as { setupBannerDismissed: boolean };
+    expect(result.setupBannerDismissed).toBe(true);
+    expect(storeMock.set).toHaveBeenCalledWith(
+      "onboarding",
+      expect.objectContaining({ setupBannerDismissed: true })
+    );
+  });
+
+  it("dismissSetupBanner is idempotent once dismissed", () => {
+    registerOnboardingHandlers();
+    seedOnboarding({ setupBannerDismissed: true });
+    const dismiss = getHandler("onboarding:dismiss-setup-banner");
+    const result = dismiss(null) as { setupBannerDismissed: boolean };
+    expect(result.setupBannerDismissed).toBe(true);
+  });
+
+  it("cleanup removes discovery handlers", () => {
     const cleanup = registerOnboardingHandlers();
     cleanup();
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:mark-agents-seen");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:dismiss-welcome-card");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:dismiss-setup-banner");
   });
 });

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -77,7 +77,10 @@ function getOnboardingState(): OnboardingState {
       ? (raw.seenAgentIds as string[]).filter((id) => typeof id === "string")
       : [],
     welcomeCardDismissed: raw.welcomeCardDismissed === true,
-    setupBannerDismissed: raw.setupBannerDismissed === true,
+    // Treat any already-completed onboarding as implicit banner dismissal —
+    // without this, upgraded users who finished onboarding before #5131 see
+    // the new "Set up your AI agents" banner on every launch.
+    setupBannerDismissed: raw.setupBannerDismissed === true || raw.completed === true,
     checklist: {
       ...DEFAULT_CHECKLIST,
       ...checklist,
@@ -119,6 +122,10 @@ export function registerOnboardingHandlers(): () => void {
       completed: allPreviouslyComplete,
       currentStep: allPreviouslyComplete ? null : state.currentStep,
       firstRunToastSeen: firstRunToastSeen || state.firstRunToastSeen,
+      // If the legacy Canopy onboarding was fully completed, the #5131 setup
+      // banner should also be considered dismissed — these users have already
+      // made their agent/telemetry decisions.
+      setupBannerDismissed: allPreviouslyComplete || state.setupBannerDismissed,
       migratedFromLocalStorage: true,
       checklist: allPreviouslyComplete
         ? {

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -37,6 +37,7 @@ function getOnboardingState(): OnboardingState {
       waitingNudgeSeen: true,
       seenAgentIds: [],
       welcomeCardDismissed: true,
+      setupBannerDismissed: true,
       migratedFromLocalStorage: true,
       checklist: {
         dismissed: true,
@@ -62,6 +63,7 @@ function getOnboardingState(): OnboardingState {
       waitingNudgeSeen: false,
       seenAgentIds: [],
       welcomeCardDismissed: false,
+      setupBannerDismissed: false,
       migratedFromLocalStorage: false,
       checklist: DEFAULT_CHECKLIST,
     };
@@ -75,6 +77,7 @@ function getOnboardingState(): OnboardingState {
       ? (raw.seenAgentIds as string[]).filter((id) => typeof id === "string")
       : [],
     welcomeCardDismissed: raw.welcomeCardDismissed === true,
+    setupBannerDismissed: raw.setupBannerDismissed === true,
     checklist: {
       ...DEFAULT_CHECKLIST,
       ...checklist,
@@ -219,6 +222,14 @@ export function registerOnboardingHandlers(): () => void {
     return updated;
   });
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD));
+
+  ipcMain.handle(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER, () => {
+    const state = getOnboardingState();
+    const updated: OnboardingState = { ...state, setupBannerDismissed: true };
+    store.set("onboarding", updated);
+    return updated;
+  });
+  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER));
 
   ipcMain.handle(CHANNELS.ONBOARDING_CHECKLIST_GET, () => getChecklistState());
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_CHECKLIST_GET));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1048,6 +1048,7 @@ const CHANNELS = {
   ONBOARDING_MARK_WAITING_NUDGE_SEEN: "onboarding:mark-waiting-nudge-seen",
   ONBOARDING_MARK_AGENTS_SEEN: "onboarding:mark-agents-seen",
   ONBOARDING_DISMISS_WELCOME_CARD: "onboarding:dismiss-welcome-card",
+  ONBOARDING_DISMISS_SETUP_BANNER: "onboarding:dismiss-setup-banner",
   ONBOARDING_CHECKLIST_GET: "onboarding:checklist-get",
   ONBOARDING_CHECKLIST_DISMISS: "onboarding:checklist-dismiss",
   ONBOARDING_CHECKLIST_MARK_ITEM: "onboarding:checklist-mark-item",
@@ -2750,6 +2751,7 @@ const api: ElectronAPI = {
     markAgentsSeen: (agentIds: string[]) =>
       _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, agentIds),
     dismissWelcomeCard: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD),
+    dismissSetupBanner: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER),
     getChecklist: () => _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_GET),
     dismissChecklist: () => _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_DISMISS),
     markChecklistItem: (item: ChecklistItemId) =>

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -185,6 +185,7 @@ export interface StoreSchema {
     waitingNudgeSeen: boolean;
     seenAgentIds: string[];
     welcomeCardDismissed: boolean;
+    setupBannerDismissed: boolean;
     // TODO(0.9.0): Remove after deleting onboarding:migrate and the renderer
     // localStorage import path for old Canopy onboarding keys.
     migratedFromLocalStorage: boolean;
@@ -312,6 +313,7 @@ const storeOptions = {
       waitingNudgeSeen: false,
       seenAgentIds: [],
       welcomeCardDismissed: false,
+      setupBannerDismissed: false,
       migratedFromLocalStorage: false,
       checklist: {
         dismissed: false,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1144,6 +1144,7 @@ export interface ElectronAPI {
     markWaitingNudgeSeen(): Promise<void>;
     markAgentsSeen(agentIds: string[]): Promise<OnboardingState>;
     dismissWelcomeCard(): Promise<OnboardingState>;
+    dismissSetupBanner(): Promise<OnboardingState>;
     getChecklist(): Promise<ChecklistState>;
     dismissChecklist(): Promise<void>;
     markChecklistItem(item: ChecklistItemId): Promise<void>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -183,6 +183,7 @@ export interface OnboardingState {
   waitingNudgeSeen: boolean;
   seenAgentIds: string[];
   welcomeCardDismissed: boolean;
+  setupBannerDismissed: boolean;
   // TODO(0.9.0): Remove after deleting onboarding:migrate and the renderer
   // localStorage import path for old Canopy onboarding keys.
   migratedFromLocalStorage: boolean;
@@ -1589,6 +1590,10 @@ export interface IpcInvokeMap {
     result: OnboardingState;
   };
   "onboarding:dismiss-welcome-card": {
+    args: [];
+    result: OnboardingState;
+  };
+  "onboarding:dismiss-setup-banner": {
     args: [];
     result: OnboardingState;
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Profiler, Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
+import { Profiler, Suspense, lazy, useCallback, useEffect, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
 import {
   isElectronAvailable,
@@ -128,7 +128,6 @@ import { useMacroFocusStore } from "./store/macroFocusStore";
 import { useSafeModeStore } from "./store/safeModeStore";
 import type { BuiltInPanelKind } from "./types";
 import type { TerminalType } from "@shared/types";
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { actionService } from "./services/ActionService";
 import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { terminalInstanceService } from "./services/terminal/TerminalInstanceService";
@@ -186,13 +185,6 @@ function App() {
   );
 
   const { launchAgent, availability, agentSettings, refreshSettings } = useAgentLauncher();
-  const normalizedAgentSettings = useAgentSettingsStore((s) => s.settings);
-
-  const hasAnySelectedAgent = useMemo(() => {
-    if (normalizedAgentSettings === null) return null;
-    const agents = normalizedAgentSettings.agents ?? {};
-    return BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agents[id]));
-  }, [normalizedAgentSettings]);
 
   useTerminalConfig();
   useAppThemeConfig();
@@ -788,7 +780,6 @@ function App() {
       <OnboardingFlow
         availability={availability}
         onRefreshSettings={refreshSettings}
-        hasAnySelectedAgent={hasAnySelectedAgent}
         onComplete={gettingStarted.notifyOnboardingComplete}
       />
       {currentProject !== null && gettingStarted.visible && gettingStarted.checklist && (

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -21,8 +21,10 @@ let mockActionMruList: string[] = [];
 
 const markAgentsSeenMock = vi.fn().mockResolvedValue(undefined);
 const dismissWelcomeCardMock = vi.fn().mockResolvedValue(undefined);
+const dismissSetupBannerMock = vi.fn().mockResolvedValue(undefined);
 let mockSeenAgentIds: string[] = [];
 let mockWelcomeCardDismissed = true;
+const mockSetupBannerDismissed = true;
 let mockOnboardingLoaded = true;
 
 vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
@@ -30,8 +32,10 @@ vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
     loaded: mockOnboardingLoaded,
     seenAgentIds: mockSeenAgentIds,
     welcomeCardDismissed: mockWelcomeCardDismissed,
+    setupBannerDismissed: mockSetupBannerDismissed,
     markAgentsSeen: markAgentsSeenMock,
     dismissWelcomeCard: dismissWelcomeCardMock,
+    dismissSetupBanner: dismissSetupBannerMock,
   }),
 }));
 

--- a/src/components/Onboarding/OnboardingFlow.tsx
+++ b/src/components/Onboarding/OnboardingFlow.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { isDaintreeEnvEnabled } from "@/utils/env";
 import { AgentSetupWizard } from "@/components/Setup/AgentSetupWizard";
 import { actionService } from "@/services/ActionService";
+import { dismissSetupBanner as dismissSetupBannerFromHook } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import type { OnboardingState } from "@shared/types";
 import type { CliAvailability } from "@shared/types";
 
@@ -140,14 +141,17 @@ export function OnboardingFlow({
         setCurrentStep(nextStep);
         await window.electron.onboarding.setStep(nextStep);
       } else {
-        // Flow complete
+        // Flow complete — persist first so a failing IPC doesn't leave us in a
+        // half-committed state with completion telemetry fired but no
+        // persisted flag. Only flip completedRef (which suppresses the
+        // abandonment-on-unmount hook) after the persistence succeeds.
+        await window.electron.onboarding.complete();
         completedRef.current = true;
         trackOnboarding("onboarding_completed", {
           totalSteps: STEP_ORDER.length,
           durationMs: flowStartTimeRef.current > 0 ? Date.now() - flowStartTimeRef.current : 0,
         });
         setCurrentStep(null);
-        await window.electron.onboarding.complete();
         setState((prev) => (prev ? { ...prev, completed: true, currentStep: null } : prev));
         onComplete?.();
       }
@@ -164,14 +168,17 @@ export function OnboardingFlow({
     setManualWizardIsFirstRun(false);
     // If this open originated from the first-run welcome banner, mark the
     // onboarding flow complete so the first-run prompts (theme / telemetry)
-    // are not shown again and the banner stays dismissed on next launch.
+    // are not shown again, and dismiss the banner via the shared hook so
+    // WelcomeScreen's AgentSetupBannerCard hides immediately (raw IPC would
+    // update electron-store but not the Zustand store the banner reads).
     if (wasFirstRun && state && !state.completed) {
-      await advanceStep("agentSetup");
       try {
-        await window.electron?.onboarding?.dismissSetupBanner?.();
+        await advanceStep("agentSetup");
       } catch {
-        // Best-effort; the banner's own dismiss action can recover this.
+        // If persistence fails, still dismiss the banner in the current
+        // session so the user isn't stuck staring at an already-opened flow.
       }
+      await dismissSetupBannerFromHook();
     } else {
       setCurrentStep(null);
     }

--- a/src/components/Onboarding/OnboardingFlow.tsx
+++ b/src/components/Onboarding/OnboardingFlow.tsx
@@ -21,8 +21,12 @@ const STEP_ORDER: OnboardingStep[] = ["agentSetup"];
 interface OnboardingFlowProps {
   availability: CliAvailability;
   onRefreshSettings: () => Promise<void>;
-  hasAnySelectedAgent: boolean | null;
   onComplete?: () => void;
+}
+
+interface OpenAgentSetupWizardDetail {
+  returnToPanelPalette?: boolean;
+  isFirstRun?: boolean;
 }
 
 function trackOnboarding(event: string, properties: Record<string, unknown> = {}): void {
@@ -32,17 +36,16 @@ function trackOnboarding(event: string, properties: Record<string, unknown> = {}
 export function OnboardingFlow({
   availability,
   onRefreshSettings,
-  hasAnySelectedAgent,
   onComplete,
 }: OnboardingFlowProps) {
   const [state, setState] = useState<OnboardingState | null>(null);
   const [currentStep, setCurrentStep] = useState<OnboardingStep | null>(null);
   const [manualWizardOpen, setManualWizardOpen] = useState(false);
+  const [manualWizardIsFirstRun, setManualWizardIsFirstRun] = useState(false);
   const returnToPaletteRef = useRef(false);
   const flowStartTimeRef = useRef<number>(0);
   const completedRef = useRef(false);
   const currentStepRef = useRef<OnboardingStep | null>(null);
-  const autoOpenedRef = useRef(false);
 
   // Hydrate state from electron-store and run localStorage migration
   useEffect(() => {
@@ -83,42 +86,24 @@ export function OnboardingFlow({
       }
 
       setState(onboardingState);
-
-      if (!onboardingState.completed) {
-        const rawStep = onboardingState.currentStep;
-        const resumeStep = rawStep as OnboardingStep | null;
-        if (resumeStep && STEP_ORDER.includes(resumeStep)) {
-          setCurrentStep(resumeStep);
-        } else if (rawStep === "agentSelection" || rawStep === "welcome") {
-          // TODO(0.9.0): Remove this temporary resume-step mapping when the
-          // old Canopy onboarding flow is no longer supported.
-          setCurrentStep("agentSetup");
-        } else {
-          setCurrentStep(STEP_ORDER[0]);
-        }
-      }
     })().catch(console.error);
   }, []);
 
-  // Listen for manual wizard open events (from Settings / toolbar button / panel palette)
+  // Listen for manual wizard open events (from Settings / toolbar / panel palette / welcome banner).
+  // The `isFirstRun` flag in the event detail lets the welcome-screen banner preserve the first-run
+  // theme-picker and telemetry prompts when opening the wizard for a user who hasn't finished
+  // onboarding yet.
   useEffect(() => {
     const handleOpenWizard = (e: Event) => {
-      const detail = (e as CustomEvent<{ returnToPanelPalette?: boolean }>).detail;
+      const detail = (e as CustomEvent<OpenAgentSetupWizardDetail>).detail;
       returnToPaletteRef.current = detail?.returnToPanelPalette === true;
+      setManualWizardIsFirstRun(detail?.isFirstRun === true);
+      setCurrentStep("agentSetup");
       setManualWizardOpen(true);
     };
     window.addEventListener("daintree:open-agent-setup-wizard", handleOpenWizard);
     return () => window.removeEventListener("daintree:open-agent-setup-wizard", handleOpenWizard);
   }, []);
-
-  // Auto-open wizard when onboarding is complete but no agents are selected
-  useEffect(() => {
-    if (hasAnySelectedAgent !== false) return;
-    if (!state?.completed) return;
-    if (autoOpenedRef.current) return;
-    autoOpenedRef.current = true;
-    setManualWizardOpen(true);
-  }, [hasAnySelectedAgent, state?.completed]);
 
   // Track step views and keep ref in sync
   useEffect(() => {
@@ -170,21 +155,30 @@ export function OnboardingFlow({
     [onComplete]
   );
 
-  const handleManualWizardClose = useCallback(() => {
+  const handleManualWizardClose = useCallback(async () => {
     void onRefreshSettings();
     const shouldReturn = returnToPaletteRef.current;
+    const wasFirstRun = manualWizardIsFirstRun;
     returnToPaletteRef.current = false;
     setManualWizardOpen(false);
+    setManualWizardIsFirstRun(false);
+    // If this open originated from the first-run welcome banner, mark the
+    // onboarding flow complete so the first-run prompts (theme / telemetry)
+    // are not shown again and the banner stays dismissed on next launch.
+    if (wasFirstRun && state && !state.completed) {
+      await advanceStep("agentSetup");
+      try {
+        await window.electron?.onboarding?.dismissSetupBanner?.();
+      } catch {
+        // Best-effort; the banner's own dismiss action can recover this.
+      }
+    } else {
+      setCurrentStep(null);
+    }
     if (shouldReturn) {
       void actionService.dispatch("panel.palette", undefined, { source: "user" });
     }
-  }, [onRefreshSettings]);
-
-  // Agent setup wizard close
-  const handleAgentSetupClose = useCallback(async () => {
-    void onRefreshSettings();
-    await advanceStep("agentSetup");
-  }, [advanceStep, onRefreshSettings]);
+  }, [advanceStep, manualWizardIsFirstRun, onRefreshSettings, state]);
 
   // Render nothing until hydration completes or if E2E skip is enabled
   if (SKIP_FIRST_RUN_DIALOGS) {
@@ -193,6 +187,7 @@ export function OnboardingFlow({
         isOpen
         onClose={handleManualWizardClose}
         initialAvailability={availability}
+        isFirstRun={manualWizardIsFirstRun}
       />
     ) : null;
   }
@@ -200,26 +195,17 @@ export function OnboardingFlow({
   // Still hydrating
   if (state === null) return null;
 
-  // Manual wizard re-open (from Settings / toolbar / panel palette)
+  // Manual wizard open (from Settings / toolbar / panel palette / welcome banner)
   if (manualWizardOpen) {
     return (
       <AgentSetupWizard
         isOpen
         onClose={handleManualWizardClose}
         initialAvailability={availability}
+        isFirstRun={manualWizardIsFirstRun}
       />
     );
   }
 
-  // Onboarding already complete
-  if (state.completed || !currentStep) return null;
-
-  return (
-    <AgentSetupWizard
-      isOpen
-      onClose={handleAgentSetupClose}
-      initialAvailability={availability}
-      isFirstRun
-    />
-  );
+  return null;
 }

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -16,6 +16,7 @@ const defaultOnboardingState: OnboardingState = {
   waitingNudgeSeen: false,
   seenAgentIds: [],
   welcomeCardDismissed: false,
+  setupBannerDismissed: false,
   checklist: {
     dismissed: false,
     celebrationShown: false,
@@ -35,6 +36,7 @@ const onboardingMock = {
   migrate: vi.fn(() => Promise.resolve({ ...defaultOnboardingState })),
   markToastSeen: vi.fn(() => Promise.resolve()),
   markNewsletterSeen: vi.fn(() => Promise.resolve()),
+  dismissSetupBanner: vi.fn(() => Promise.resolve({ ...defaultOnboardingState })),
 };
 
 const telemetryMock = {
@@ -48,6 +50,10 @@ const privacyMock = {
   setTelemetryLevel: vi.fn(() => Promise.resolve()),
 };
 
+// Capture the real addEventListener so the component can actually subscribe to
+// the open-wizard custom event within the jsdom window.
+const openWizardListeners = new Set<(e: Event) => void>();
+
 vi.stubGlobal("window", {
   ...globalThis.window,
   electron: {
@@ -55,9 +61,28 @@ vi.stubGlobal("window", {
     telemetry: telemetryMock,
     privacy: privacyMock,
   },
-  addEventListener: vi.fn(),
-  removeEventListener: vi.fn(),
+  addEventListener: vi.fn((name: string, listener: (e: Event) => void) => {
+    if (name === "daintree:open-agent-setup-wizard") {
+      openWizardListeners.add(listener);
+    }
+  }),
+  removeEventListener: vi.fn((name: string, listener: (e: Event) => void) => {
+    if (name === "daintree:open-agent-setup-wizard") {
+      openWizardListeners.delete(listener);
+    }
+  }),
+  dispatchEvent: vi.fn((event: Event) => {
+    if (event.type === "daintree:open-agent-setup-wizard") {
+      for (const l of openWizardListeners) l(event);
+    }
+    return true;
+  }),
 });
+
+function fireOpenWizard(detail?: { isFirstRun?: boolean; returnToPanelPalette?: boolean }) {
+  const evt = new CustomEvent("daintree:open-agent-setup-wizard", { detail });
+  for (const l of openWizardListeners) l(evt);
+}
 
 const { isDaintreeEnvEnabledMock } = vi.hoisted(() => ({
   isDaintreeEnvEnabledMock: vi.fn((_key: string): boolean => false),
@@ -84,34 +109,74 @@ describe("OnboardingFlow first-run", () => {
   const defaultProps = {
     availability: {} as import("@shared/types").CliAvailability,
     onRefreshSettings: vi.fn(() => Promise.resolve()),
-    hasAnySelectedAgent: true as boolean | null,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-
+    openWizardListeners.clear();
     onboardingMock.get.mockResolvedValue({ ...defaultOnboardingState });
   });
 
-  it("renders AgentSetupWizard with isFirstRun=true on first run", async () => {
-    const { getByTestId } = await act(async () => {
+  it("does NOT render AgentSetupWizard on first run", async () => {
+    const { baseElement } = await act(async () => {
       return render(<OnboardingFlow {...defaultProps} />);
     });
 
-    await vi.waitFor(() => {
-      const wizard = getByTestId("agent-setup-wizard");
-      expect(wizard).toBeTruthy();
-      expect(wizard.getAttribute("data-first-run")).toBe("true");
+    // Give hydration a tick to complete.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
     });
+
+    expect(
+      baseElement.ownerDocument.querySelector('[data-testid="agent-setup-wizard"]')
+    ).toBeNull();
   });
 
-  it("completes onboarding when wizard closes", async () => {
+  it("opens wizard with isFirstRun=true when banner fires event with that detail", async () => {
     const { getByTestId } = await act(async () => {
       return render(<OnboardingFlow {...defaultProps} />);
     });
 
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
+    });
+
+    const wizard = getByTestId("agent-setup-wizard");
+    expect(wizard.getAttribute("data-first-run")).toBe("true");
+  });
+
+  it("opens wizard with isFirstRun=false when event has no detail (e.g. Settings)", async () => {
+    const { getByTestId } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard();
+    });
+
+    const wizard = getByTestId("agent-setup-wizard");
+    expect(wizard.getAttribute("data-first-run")).toBe("false");
+  });
+
+  it("completes onboarding when wizard closes after first-run banner open", async () => {
+    const { getByTestId } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
     });
 
     await act(async () => {
@@ -124,6 +189,35 @@ describe("OnboardingFlow first-run", () => {
         expect.objectContaining({ totalSteps: 1 })
       );
     });
+    expect(onboardingMock.complete).toHaveBeenCalled();
+  });
+
+  it("does NOT call onboarding.complete when a non-first-run wizard closes", async () => {
+    // Simulates Settings/toolbar re-opening the wizard after onboarding was
+    // already completed. Those opens should not re-fire first-run telemetry.
+    onboardingMock.get.mockResolvedValue({ ...defaultOnboardingState, completed: true });
+
+    const { getByTestId } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard();
+    });
+
+    await act(async () => {
+      getByTestId("close-wizard").click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(onboardingMock.complete).not.toHaveBeenCalled();
   });
 
   it("calls onRefreshSettings when wizard closes", async () => {
@@ -131,8 +225,12 @@ describe("OnboardingFlow first-run", () => {
       return render(<OnboardingFlow {...defaultProps} />);
     });
 
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
     });
 
     await act(async () => {
@@ -149,18 +247,25 @@ describe("OnboardingFlow telemetry tracking", () => {
   const defaultProps = {
     availability: {} as import("@shared/types").CliAvailability,
     onRefreshSettings: vi.fn(() => Promise.resolve()),
-    hasAnySelectedAgent: true as boolean | null,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-
+    openWizardListeners.clear();
     onboardingMock.get.mockResolvedValue({ ...defaultOnboardingState });
   });
 
-  it("emits onboarding_step_viewed when agentSetup step renders", async () => {
+  it("emits onboarding_step_viewed when the banner opens the wizard", async () => {
     await act(async () => {
       render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
     });
 
     await vi.waitFor(() => {
@@ -171,9 +276,29 @@ describe("OnboardingFlow telemetry tracking", () => {
     });
   });
 
-  it("emits onboarding_abandoned on unmount when flow is incomplete", async () => {
+  it("does NOT emit onboarding_step_viewed on first paint (no wizard yet)", async () => {
+    await act(async () => {
+      render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    expect(trackMock).not.toHaveBeenCalledWith("onboarding_step_viewed", expect.any(Object));
+  });
+
+  it("emits onboarding_abandoned on unmount when wizard was opened but not completed", async () => {
     const { unmount } = await act(async () => {
       return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
     });
 
     await vi.waitFor(() => {
@@ -194,8 +319,12 @@ describe("OnboardingFlow telemetry tracking", () => {
       return render(<OnboardingFlow {...defaultProps} />);
     });
 
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
     });
 
     await act(async () => {
@@ -213,79 +342,16 @@ describe("OnboardingFlow telemetry tracking", () => {
   });
 });
 
-describe("OnboardingFlow resume and legacy steps", () => {
+describe("OnboardingFlow E2E skip", () => {
   const defaultProps = {
     availability: {} as import("@shared/types").CliAvailability,
     onRefreshSettings: vi.fn(() => Promise.resolve()),
-    hasAnySelectedAgent: true as boolean | null,
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-
+    openWizardListeners.clear();
     onboardingMock.get.mockResolvedValue({ ...defaultOnboardingState });
-  });
-
-  it("resumes at agentSetup when persisted step is agentSetup", async () => {
-    onboardingMock.get.mockResolvedValue({
-      ...defaultOnboardingState,
-      currentStep: "agentSetup",
-      agentSetupIds: ["claude", "gemini"],
-    });
-
-    const { getByTestId } = await act(async () => {
-      return render(<OnboardingFlow {...defaultProps} />);
-    });
-
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
-    });
-  });
-
-  it("resumes at agentSetup when persisted step is legacy agentSelection", async () => {
-    onboardingMock.get.mockResolvedValue({
-      ...defaultOnboardingState,
-      currentStep: "agentSelection",
-      agentSetupIds: [],
-    });
-
-    const { getByTestId } = await act(async () => {
-      return render(<OnboardingFlow {...defaultProps} />);
-    });
-
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
-    });
-  });
-
-  it("falls back to agentSetup step when resuming with unknown step name", async () => {
-    onboardingMock.get.mockResolvedValue({
-      ...defaultOnboardingState,
-      currentStep: "themeSelection",
-    });
-
-    const { getByTestId } = await act(async () => {
-      return render(<OnboardingFlow {...defaultProps} />);
-    });
-
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
-    });
-  });
-
-  it("maps legacy 'welcome' step to agentSetup", async () => {
-    onboardingMock.get.mockResolvedValue({
-      ...defaultOnboardingState,
-      currentStep: "welcome",
-    });
-
-    const { getByTestId } = await act(async () => {
-      return render(<OnboardingFlow {...defaultProps} />);
-    });
-
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
-    });
   });
 
   it("renders nothing and skips hydration when DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS is enabled", async () => {
@@ -303,10 +369,6 @@ describe("OnboardingFlow resume and legacy steps", () => {
       expect(
         baseElement.ownerDocument.querySelector('[data-testid="agent-setup-wizard"]')
       ).toBeNull();
-      expect(baseElement.ownerDocument.querySelector('[data-testid="welcome-step"]')).toBeNull();
-      expect(
-        baseElement.ownerDocument.querySelector('[data-testid="onboarding-progress"]')
-      ).toBeNull();
 
       // IPC hydration should be skipped entirely
       expect(onboardingMock.get).not.toHaveBeenCalled();
@@ -314,119 +376,5 @@ describe("OnboardingFlow resume and legacy steps", () => {
       isDaintreeEnvEnabledMock.mockReturnValue(false);
       vi.resetModules();
     }
-  });
-});
-
-describe("OnboardingFlow auto-open wizard on no selected agents", () => {
-  const completedOnboardingState: OnboardingState = {
-    ...defaultOnboardingState,
-    completed: true,
-    currentStep: null,
-  };
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    onboardingMock.get.mockResolvedValue({ ...completedOnboardingState });
-  });
-
-  it("auto-opens wizard with isFirstRun=false when onboarding complete and no agents selected", async () => {
-    const { getByTestId } = await act(async () => {
-      return render(
-        <OnboardingFlow
-          availability={{} as import("@shared/types").CliAvailability}
-          onRefreshSettings={vi.fn(() => Promise.resolve())}
-          hasAnySelectedAgent={false}
-        />
-      );
-    });
-
-    await vi.waitFor(() => {
-      const wizard = getByTestId("agent-setup-wizard");
-      expect(wizard).toBeTruthy();
-      expect(wizard.getAttribute("data-first-run")).toBe("false");
-    });
-  });
-
-  it("calls onRefreshSettings when auto-opened wizard is closed", async () => {
-    const refreshMock = vi.fn(() => Promise.resolve());
-    const { getByTestId } = await act(async () => {
-      return render(
-        <OnboardingFlow
-          availability={{} as import("@shared/types").CliAvailability}
-          onRefreshSettings={refreshMock}
-          hasAnySelectedAgent={false}
-        />
-      );
-    });
-
-    await vi.waitFor(() => {
-      expect(getByTestId("agent-setup-wizard")).toBeTruthy();
-    });
-
-    await act(async () => {
-      getByTestId("close-wizard").click();
-    });
-
-    expect(refreshMock).toHaveBeenCalled();
-  });
-
-  it("does NOT auto-open wizard when hasAnySelectedAgent is null (loading)", async () => {
-    const { baseElement } = await act(async () => {
-      return render(
-        <OnboardingFlow
-          availability={{} as import("@shared/types").CliAvailability}
-          onRefreshSettings={vi.fn(() => Promise.resolve())}
-          hasAnySelectedAgent={null}
-        />
-      );
-    });
-
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
-    });
-
-    const wizard = baseElement.ownerDocument.querySelector('[data-testid="agent-setup-wizard"]');
-    expect(wizard).toBeNull();
-  });
-
-  it("does NOT auto-open wizard when agents are selected", async () => {
-    const { baseElement } = await act(async () => {
-      return render(
-        <OnboardingFlow
-          availability={{} as import("@shared/types").CliAvailability}
-          onRefreshSettings={vi.fn(() => Promise.resolve())}
-          hasAnySelectedAgent={true}
-        />
-      );
-    });
-
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 50));
-    });
-
-    const wizard = baseElement.ownerDocument.querySelector('[data-testid="agent-setup-wizard"]');
-    expect(wizard).toBeNull();
-  });
-
-  it("does NOT auto-open wizard when onboarding is not complete", async () => {
-    onboardingMock.get.mockResolvedValue({ ...defaultOnboardingState, completed: false });
-
-    const { getByTestId } = await act(async () => {
-      return render(
-        <OnboardingFlow
-          availability={{} as import("@shared/types").CliAvailability}
-          onRefreshSettings={vi.fn(() => Promise.resolve())}
-          hasAnySelectedAgent={false}
-        />
-      );
-    });
-
-    // With completed=false, it starts the first-run flow directly at agentSetup
-    await vi.waitFor(() => {
-      const wizard = getByTestId("agent-setup-wizard");
-      expect(wizard).toBeTruthy();
-      expect(wizard.getAttribute("data-first-run")).toBe("true");
-    });
   });
 });

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -103,6 +103,13 @@ vi.mock("@/components/Setup/AgentSetupWizard", () => ({
   }),
 }));
 
+const { dismissSetupBannerHookMock } = vi.hoisted(() => ({
+  dismissSetupBannerHookMock: vi.fn(() => Promise.resolve()),
+}));
+vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  dismissSetupBanner: dismissSetupBannerHookMock,
+}));
+
 import { OnboardingFlow } from "../OnboardingFlow";
 
 describe("OnboardingFlow first-run", () => {
@@ -190,6 +197,28 @@ describe("OnboardingFlow first-run", () => {
       );
     });
     expect(onboardingMock.complete).toHaveBeenCalled();
+  });
+
+  it("dismisses the setup banner via the shared hook when first-run wizard closes", async () => {
+    const { getByTestId } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
+    });
+
+    await act(async () => {
+      getByTestId("close-wizard").click();
+    });
+
+    await vi.waitFor(() => {
+      expect(dismissSetupBannerHookMock).toHaveBeenCalled();
+    });
   });
 
   it("does NOT call onboarding.complete when a non-first-run wizard closes", async () => {
@@ -312,6 +341,39 @@ describe("OnboardingFlow telemetry tracking", () => {
       lastStep: "agentSetup",
       lastStepIndex: 0,
     });
+  });
+
+  it("does NOT emit onboarding_completed when complete() persistence rejects", async () => {
+    onboardingMock.complete.mockRejectedValueOnce(new Error("IPC down"));
+
+    const { getByTestId, unmount } = await act(async () => {
+      return render(<OnboardingFlow {...defaultProps} />);
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    await act(async () => {
+      fireOpenWizard({ isFirstRun: true });
+    });
+
+    await act(async () => {
+      getByTestId("close-wizard").click();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    // Telemetry fires only after successful persistence.
+    expect(trackMock).not.toHaveBeenCalledWith("onboarding_completed", expect.any(Object));
+
+    // Abandonment telemetry still fires on unmount since completedRef was not
+    // flipped when persistence failed.
+    trackMock.mockClear();
+    unmount();
+    expect(trackMock).toHaveBeenCalledWith("onboarding_abandoned", expect.any(Object));
   });
 
   it("does NOT emit onboarding_abandoned after completion", async () => {

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -11,6 +11,7 @@ import {
   X,
   Plug,
   Pin,
+  Sparkles,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { DaintreeIcon } from "@/components/icons";
@@ -65,6 +66,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
   const progressTotal = 4; // 3 real items + endowed "Install Daintree"
   const progressDone = 1 + completedCount; // endowed item always complete
 
+  const setupBanner = <AgentSetupBannerCard />;
   const welcomeCard = <AgentWelcomeCard />;
 
   return (
@@ -85,6 +87,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
         {hasProjects ? (
           <>
             <RecentProjects projects={recentProjects} onSelect={switchProject} />
+            {setupBanner}
             {welcomeCard}
             {showChecklist && (
               <InlineChecklist
@@ -96,6 +99,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
           </>
         ) : (
           <>
+            {setupBanner}
             {welcomeCard}
             {showChecklist && (
               <InlineChecklist
@@ -226,6 +230,66 @@ function RecentProjects({
             </span>
           </button>
         ))}
+      </div>
+    </div>
+  );
+}
+
+function AgentSetupBannerCard() {
+  const { loaded, setupBannerDismissed, dismissSetupBanner } = useAgentDiscoveryOnboarding();
+
+  // Gate on hydration to prevent flash-of-content before the persisted
+  // dismiss flag arrives from electron-store (see #5111 review).
+  if (!loaded) return null;
+  if (setupBannerDismissed) return null;
+
+  const handleStartSetup = () => {
+    window.dispatchEvent(
+      new CustomEvent("daintree:open-agent-setup-wizard", {
+        detail: { isFirstRun: true },
+      })
+    );
+  };
+
+  const handleDismiss = () => {
+    void dismissSetupBanner();
+  };
+
+  return (
+    <div className="w-full" data-testid="agent-setup-banner">
+      <div className="relative w-full rounded-[var(--radius-md)] border border-daintree-border/60 bg-daintree-sidebar/40 px-4 py-3.5">
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss agent setup banner"
+          data-testid="agent-setup-banner-dismiss"
+          className="absolute top-2 right-2 inline-flex h-6 w-6 items-center justify-center rounded-sm text-daintree-text/40 transition-colors hover:bg-overlay-emphasis hover:text-daintree-text/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+        <div className="flex items-start gap-3 pr-6">
+          <Sparkles className="h-4 w-4 text-daintree-accent mt-0.5 shrink-0" aria-hidden="true" />
+          <div className="flex-1 min-w-0">
+            <h3 className="text-sm font-semibold text-daintree-text/90">Set up your AI agents</h3>
+            <p className="text-xs text-daintree-text/60 mt-1 leading-relaxed">
+              Pick a theme, opt into telemetry, and choose which agents to install. You can skip
+              this and come back anytime.
+            </p>
+            <div className="mt-4 flex items-center gap-2">
+              <Button size="sm" onClick={handleStartSetup} data-testid="agent-setup-banner-cta">
+                <Sparkles className="h-3.5 w-3.5" />
+                Set up agents
+              </Button>
+              <button
+                type="button"
+                onClick={handleDismiss}
+                className="text-xs text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
+              >
+                Not now
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@/lib/colorUtils", () => ({
 const {
   markAgentsSeenMock,
   dismissWelcomeCardMock,
+  dismissSetupBannerMock,
   setAgentPinnedMock,
   agentDiscoveryState,
   agentSettingsState,
@@ -57,11 +58,13 @@ const {
 } = vi.hoisted(() => ({
   markAgentsSeenMock: vi.fn(() => Promise.resolve()),
   dismissWelcomeCardMock: vi.fn(() => Promise.resolve()),
+  dismissSetupBannerMock: vi.fn(() => Promise.resolve()),
   setAgentPinnedMock: vi.fn(() => Promise.resolve()),
   agentDiscoveryState: {
     loaded: true,
     seenAgentIds: [] as string[],
     welcomeCardDismissed: false,
+    setupBannerDismissed: false,
   },
   agentSettingsState: {
     settings: null as { agents: Record<string, { pinned?: boolean }> } | null,
@@ -77,8 +80,10 @@ vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
     loaded: agentDiscoveryState.loaded,
     seenAgentIds: agentDiscoveryState.seenAgentIds,
     welcomeCardDismissed: agentDiscoveryState.welcomeCardDismissed,
+    setupBannerDismissed: agentDiscoveryState.setupBannerDismissed,
     markAgentsSeen: markAgentsSeenMock,
     dismissWelcomeCard: dismissWelcomeCardMock,
+    dismissSetupBanner: dismissSetupBannerMock,
   }),
 }));
 
@@ -262,6 +267,9 @@ describe("WelcomeScreen", () => {
     agentDiscoveryState.loaded = true;
     agentDiscoveryState.seenAgentIds = [];
     agentDiscoveryState.welcomeCardDismissed = false;
+    // Default to dismissed in existing card/layout suites so they continue
+    // to exercise only the behavior they were written for.
+    agentDiscoveryState.setupBannerDismissed = true;
     agentSettingsState.settings = null;
     cliAvailabilityState.availability = {};
     cliAvailabilityState.hasRealData = false;
@@ -605,6 +613,78 @@ describe("WelcomeScreen", () => {
       expect(screen.getByTestId("welcome-card-pin-error")).toBeTruthy();
       expect(dismissWelcomeCardMock).not.toHaveBeenCalled();
       expect(markAgentsSeenMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Agent Setup Banner (#5131) ---
+
+  describe("agent setup banner", () => {
+    it("does not render until onboarding state is hydrated", () => {
+      agentDiscoveryState.loaded = false;
+      agentDiscoveryState.setupBannerDismissed = false;
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.queryByTestId("agent-setup-banner")).toBeNull();
+    });
+
+    it("renders when hydrated and not dismissed", () => {
+      agentDiscoveryState.loaded = true;
+      agentDiscoveryState.setupBannerDismissed = false;
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.getByTestId("agent-setup-banner")).toBeTruthy();
+      expect(screen.getByText("Set up your AI agents")).toBeTruthy();
+    });
+
+    it("does not render when dismissed", () => {
+      agentDiscoveryState.loaded = true;
+      agentDiscoveryState.setupBannerDismissed = true;
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+      expect(screen.queryByTestId("agent-setup-banner")).toBeNull();
+    });
+
+    it("calls dismissSetupBanner when the X button is clicked", async () => {
+      agentDiscoveryState.loaded = true;
+      agentDiscoveryState.setupBannerDismissed = false;
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("agent-setup-banner-dismiss"));
+      });
+      expect(dismissSetupBannerMock).toHaveBeenCalled();
+    });
+
+    it("calls dismissSetupBanner when the Not now link is clicked", async () => {
+      agentDiscoveryState.loaded = true;
+      agentDiscoveryState.setupBannerDismissed = false;
+      render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Not now"));
+      });
+      expect(dismissSetupBannerMock).toHaveBeenCalled();
+    });
+
+    it("dispatches daintree:open-agent-setup-wizard with isFirstRun: true when CTA is clicked", async () => {
+      agentDiscoveryState.loaded = true;
+      agentDiscoveryState.setupBannerDismissed = false;
+
+      const dispatched: CustomEvent[] = [];
+      const dispatchSpy = vi.spyOn(window, "dispatchEvent").mockImplementation((e: Event) => {
+        dispatched.push(e as CustomEvent);
+        return true;
+      });
+
+      try {
+        render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("agent-setup-banner-cta"));
+        });
+
+        const openEvt = dispatched.find((e) => e.type === "daintree:open-agent-setup-wizard");
+        expect(openEvt).toBeTruthy();
+        expect(openEvt?.detail).toEqual({ isFirstRun: true });
+      } finally {
+        dispatchSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -7,12 +7,14 @@ interface AgentDiscoveryState {
   loaded: boolean;
   seenAgentIds: string[];
   welcomeCardDismissed: boolean;
+  setupBannerDismissed: boolean;
 }
 
 const useAgentDiscoveryStore = create<AgentDiscoveryState>(() => ({
   loaded: false,
   seenAgentIds: [],
   welcomeCardDismissed: false,
+  setupBannerDismissed: false,
 }));
 
 let hydrating: Promise<void> | null = null;
@@ -37,6 +39,7 @@ async function hydrate(): Promise<void> {
         loaded: true,
         seenAgentIds: Array.isArray(state.seenAgentIds) ? state.seenAgentIds : [],
         welcomeCardDismissed: state.welcomeCardDismissed === true,
+        setupBannerDismissed: state.setupBannerDismissed === true,
       });
     } catch {
       useAgentDiscoveryStore.setState({ loaded: true });
@@ -84,9 +87,22 @@ export async function dismissWelcomeCard(): Promise<void> {
   }
 }
 
+export async function dismissSetupBanner(): Promise<void> {
+  if (useAgentDiscoveryStore.getState().setupBannerDismissed) return;
+  useAgentDiscoveryStore.setState({ setupBannerDismissed: true });
+  const api = window.electron?.onboarding;
+  if (!api?.dismissSetupBanner) return;
+  try {
+    await api.dismissSetupBanner();
+  } catch {
+    // Best-effort; optimistic local state stands.
+  }
+}
+
 interface AgentDiscoveryOnboarding extends AgentDiscoveryState {
   markAgentsSeen: (agentIds: string[]) => Promise<void>;
   dismissWelcomeCard: () => Promise<void>;
+  dismissSetupBanner: () => Promise<void>;
 }
 
 /**
@@ -100,6 +116,7 @@ export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
   const loaded = useAgentDiscoveryStore((s) => s.loaded);
   const seenAgentIds = useAgentDiscoveryStore((s) => s.seenAgentIds);
   const welcomeCardDismissed = useAgentDiscoveryStore((s) => s.welcomeCardDismissed);
+  const setupBannerDismissed = useAgentDiscoveryStore((s) => s.setupBannerDismissed);
 
   useEffect(() => {
     void hydrate();
@@ -109,8 +126,10 @@ export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
     loaded,
     seenAgentIds,
     welcomeCardDismissed,
+    setupBannerDismissed,
     markAgentsSeen,
     dismissWelcomeCard,
+    dismissSetupBanner,
   };
 }
 
@@ -120,5 +139,6 @@ export function resetAgentDiscoveryStoreForTests(): void {
     loaded: false,
     seenAgentIds: [],
     welcomeCardDismissed: false,
+    setupBannerDismissed: false,
   });
 }


### PR DESCRIPTION
## Summary

- Replaces the blocking first-run AgentSetupWizard modal with an opt-in `AgentSetupBannerCard` on the WelcomeScreen, so users land directly in the app on first launch
- The wizard itself is untouched and remains reachable from Settings, the toolbar, and the new banner CTA
- Dismiss state persists via a new `setupBannerDismissed` field on `OnboardingState`, wired through a new `onboarding:dismiss-setup-banner` IPC channel

Resolves #5131

## Changes

- `src/components/Project/WelcomeScreen.tsx` — new `AgentSetupBannerCard` component with dismiss and open-wizard CTA
- `src/components/Onboarding/OnboardingFlow.tsx` — removed the auto-open nudge (lines 114–121) and the `hasAnySelectedAgent` prop; the flow now only opens the wizard when explicitly triggered
- `src/App.tsx` — removed the `hasAnySelectedAgent` memo and prop threading
- `src/hooks/app/useAgentDiscoveryOnboarding.ts` — shared hook that handles optimistic Zustand dismiss and calls `onboarding.complete()` when the wizard closes from a banner-triggered flow
- `electron/ipc/handlers/onboarding.ts` + `channels.ts` + `preload.cts` — new `dismiss-setup-banner` IPC channel mirroring the existing `dismiss-welcome-card` pattern
- `electron/store.ts` + `shared/types/ipc/api.ts` / `maps.ts` — `setupBannerDismissed` field on `OnboardingState`; `getOnboardingState` treats `raw.completed === true` as implicit `setupBannerDismissed` so returning users aren't shown the banner

## Testing

Full unit test suite: 10909 passed. E2E core onboarding spec updated to cover the new banner flow. The banner CTA dispatches the existing `daintree:open-agent-setup-wizard` custom event with `{ isFirstRun: true }` so first-run theme-picker and telemetry prompts still fire correctly for fresh installs.