### PR TITLE
feat(agent-sessions): persist closed agent sessions with observed title for post-trash resumption

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -57,6 +57,7 @@ export const CHANNELS = {
   TERMINAL_BACKEND_READY: "terminal:backend-ready",
   TERMINAL_SEND_KEY: "terminal:send-key",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
+  TERMINAL_UPDATE_OBSERVED_TITLE: "terminal:update-observed-title",
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",
   TERMINAL_RESTORE_SCROLLBACK: "terminal:restore-scrollback",
   TERMINAL_RESTART_SERVICE: "terminal:restart-service",

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -240,7 +240,7 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
     expect(spawnArgs.cwd).toBe(os.homedir());
   });
 
-  it("does not forward worktreeId to the pty client (renderer-owned layout state)", async () => {
+  it("forwards worktreeId to the pty client for session-history persistence (#5182)", async () => {
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
 
@@ -252,13 +252,11 @@ describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer
         cwd: os.homedir(),
         cols: 80,
         rows: 24,
-        // Even if a caller sends worktreeId it should be stripped by the Zod schema
-        // and never reach the pty client spawn options.
         worktreeId: "wt-123",
       } as unknown as Parameters<typeof handler>[1]
     );
 
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.worktreeId).toBeUndefined();
+    expect(spawnArgs.worktreeId).toBe("wt-123");
   });
 });

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -145,6 +145,30 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     ipcMain.removeListener(CHANNELS.TERMINAL_AGENT_TITLE_STATE, handleTerminalAgentTitleState)
   );
 
+  const handleTerminalUpdateObservedTitle = (
+    _event: Electron.IpcMainEvent,
+    payload: { id: string; title: string }
+  ) => {
+    try {
+      if (!payload || typeof payload !== "object") return;
+      const { id, title } = payload;
+      if (typeof id !== "string" || !id) return;
+      if (typeof title !== "string") return;
+      const trimmed = title.trim();
+      if (!trimmed) return;
+      ptyClient.updateObservedTitle(id, trimmed);
+    } catch (error) {
+      console.error("[IPC] Error handling observed title update:", error);
+    }
+  };
+  ipcMain.on(CHANNELS.TERMINAL_UPDATE_OBSERVED_TITLE, handleTerminalUpdateObservedTitle);
+  handlers.push(() =>
+    ipcMain.removeListener(
+      CHANNELS.TERMINAL_UPDATE_OBSERVED_TITLE,
+      handleTerminalUpdateObservedTitle
+    )
+  );
+
   const handleTerminalForceResume = async (
     _event: Electron.IpcMainInvokeEvent,
     id: string

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -8,6 +8,7 @@ import type { HandlerDependencies } from "../../types.js";
 import type { TerminalResizePayload } from "../../../types/index.js";
 import { TerminalResizePayloadSchema } from "../../../schemas/ipc.js";
 import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
+import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
 
 export function registerTerminalIOHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -153,10 +154,9 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       if (!payload || typeof payload !== "object") return;
       const { id, title } = payload;
       if (typeof id !== "string" || !id) return;
-      if (typeof title !== "string") return;
-      const trimmed = title.trim();
-      if (!trimmed) return;
-      ptyClient.updateObservedTitle(id, trimmed);
+      const normalized = normalizeObservedTitle(title);
+      if (!normalized) return;
+      ptyClient.updateObservedTitle(id, normalized);
     } catch (error) {
       console.error("[IPC] Error handling observed title update:", error);
     }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -193,6 +193,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         isEphemeral: validatedOptions.isEphemeral,
         agentLaunchFlags: validatedOptions.agentLaunchFlags,
         agentModelId: validatedOptions.agentModelId,
+        worktreeId: validatedOptions.worktreeId,
       });
 
       // For non-agent terminals (or Windows agent terminals), write command to stdin

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -541,6 +541,7 @@ const CHANNELS = {
   TERMINAL_BACKEND_READY: "terminal:backend-ready",
   TERMINAL_SEND_KEY: "terminal:send-key",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
+  TERMINAL_UPDATE_OBSERVED_TITLE: "terminal:update-observed-title",
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",
   TERMINAL_RESTORE_SCROLLBACK: "terminal:restore-scrollback",
   TERMINAL_RESTART_SERVICE: "terminal:restart-service",
@@ -1343,6 +1344,9 @@ const api: ElectronAPI = {
 
     reportTitleState: (id: string, state: "working" | "waiting") =>
       ipcRenderer.send(CHANNELS.TERMINAL_AGENT_TITLE_STATE, { id, state }),
+
+    updateObservedTitle: (id: string, title: string) =>
+      ipcRenderer.send(CHANNELS.TERMINAL_UPDATE_OBSERVED_TITLE, { id, title }),
 
     onSpawnResult: (callback: (id: string, result: SpawnResultPayload) => void): (() => void) => {
       const handler = (_event: Electron.IpcRendererEvent, id: unknown, result: unknown) => {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1167,6 +1167,10 @@ port.on("message", async (rawMsg: any) => {
         ptyManager.markChecked(msg.id);
         break;
 
+      case "update-observed-title":
+        ptyManager.updateObservedTitle(msg.id, msg.title);
+        break;
+
       case "transition-state": {
         const success = ptyManager.transitionState(
           msg.id,

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -248,6 +248,7 @@ export const TerminalSpawnOptionsSchema = z.object({
   isEphemeral: z.boolean().optional(),
   agentLaunchFlags: z.array(z.string()).optional(),
   agentModelId: z.string().optional(),
+  worktreeId: z.string().optional(),
 });
 
 export const TerminalResizePayloadSchema = z.object({

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1394,6 +1394,10 @@ export class PtyClient extends EventEmitter {
     this.send({ type: "mark-checked", id });
   }
 
+  updateObservedTitle(id: string, title: string): void {
+    this.send({ type: "update-observed-title", id, title });
+  }
+
   async transitionState(
     id: string,
     event: { type: string; [key: string]: unknown },

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -343,8 +343,8 @@ export class PtyManager extends EventEmitter {
             await persistAgentSession({
               sessionId,
               agentId: info.agentId,
-              worktreeId: null,
-              title: info.title ?? null,
+              worktreeId: info.worktreeId ?? null,
+              title: info.lastObservedTitle ?? info.title ?? null,
               projectId: info.projectId ?? null,
               agentLaunchFlags: info.agentLaunchFlags,
               agentModelId: info.agentModelId,
@@ -520,6 +520,17 @@ export class PtyManager extends EventEmitter {
    */
   markChecked(id: string): void {
     this.registry.markChecked(id);
+  }
+
+  /**
+   * Store the last observed (non-useless) OSC title for a terminal so that
+   * persistAgentSession can capture a meaningful label even if the agent
+   * clears its title right before shutdown.
+   */
+  updateObservedTitle(id: string, title: string): void {
+    const terminal = this.registry.get(id);
+    if (!terminal) return;
+    terminal.setObservedTitle(title);
   }
 
   /**

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -301,6 +301,7 @@ export class TerminalProcess {
       analysisEnabled: this.isAgentTerminal,
       agentLaunchFlags: options.agentLaunchFlags,
       agentModelId: options.agentModelId,
+      worktreeId: options.worktreeId,
       spawnArgs,
     };
 
@@ -454,6 +455,8 @@ export class TerminalProcess {
       agentModelId: t.agentModelId,
       spawnArgs: t.spawnArgs,
       exitCode: t.exitCode,
+      worktreeId: t.worktreeId,
+      lastObservedTitle: t.lastObservedTitle,
     };
   }
 
@@ -474,6 +477,10 @@ export class TerminalProcess {
 
   setAnalysisEnabled(enabled: boolean): void {
     this.terminalInfo.analysisEnabled = enabled;
+  }
+
+  setObservedTitle(title: string): void {
+    this.terminalInfo.lastObservedTitle = title;
   }
 
   acknowledgeData(_charCount: number): void {

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -55,6 +55,10 @@ export interface TerminalPublicState {
   spawnArgs?: string[];
   /** Exit code from the PTY process (set on clean exit) */
   exitCode?: number;
+  /** Worktree the terminal was spawned in; used when persisting agent session history */
+  worktreeId?: string;
+  /** Last non-useless title observed from xterm OSC updates (renderer-synced) */
+  lastObservedTitle?: string;
 }
 
 /**

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -259,6 +259,7 @@ export interface ElectronAPI {
     onBackendReady(callback: () => void): () => void;
     sendKey(id: string, key: string): void;
     reportTitleState(id: string, state: "working" | "waiting"): void;
+    updateObservedTitle(id: string, title: string): void;
     onSpawnResult(callback: (id: string, result: SpawnResult) => void): () => void;
     onReduceScrollback(
       callback: (data: { terminalIds: string[]; targetLines: number }) => void

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -36,6 +36,8 @@ export interface TerminalSpawnOptions {
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time */
   agentModelId?: string;
+  /** Worktree the terminal is spawned in; persisted in agent session history */
+  worktreeId?: string;
 }
 
 /** Terminal state for app state persistence */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -339,6 +339,8 @@ export interface TerminalInstance {
   type?: TerminalType;
   agentId?: AgentId;
   title: string;
+  /** Last meaningful OSC title observed from the running agent — survives the trash window for display. */
+  lastObservedTitle?: string;
   /** Working directory - only present for PTY panels */
   cwd?: string;
   pid?: number;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -34,6 +34,8 @@ export interface PtyHostSpawnOptions {
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time for per-panel model selection */
   agentModelId?: string;
+  /** Worktree the terminal was spawned in; used when persisting agent session history */
+  worktreeId?: string;
 }
 
 /**
@@ -70,6 +72,7 @@ export type PtyHostRequest =
   | { type: "get-snapshot"; id: string; requestId: string }
   | { type: "get-all-snapshots"; requestId: string }
   | { type: "mark-checked"; id: string }
+  | { type: "update-observed-title"; id: string; title: string }
   | {
       type: "transition-state";
       id: string;
@@ -269,6 +272,8 @@ export interface PtyHostTerminalInfo {
   agentLaunchFlags?: string[];
   /** Model ID selected at launch time for per-panel model selection */
   agentModelId?: string;
+  /** Worktree the terminal was spawned in; used when persisting agent session history */
+  worktreeId?: string;
 }
 
 /** Payload for agent:spawned event */

--- a/shared/utils/__tests__/isUselessTitle.test.ts
+++ b/shared/utils/__tests__/isUselessTitle.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isUselessTitle } from "../isUselessTitle.js";
+import {
+  isUselessTitle,
+  normalizeObservedTitle,
+  MAX_OBSERVED_TITLE_LENGTH,
+} from "../isUselessTitle.js";
 
 describe("isUselessTitle", () => {
   it("treats null/undefined/empty as useless", () => {
@@ -37,8 +41,19 @@ describe("isUselessTitle", () => {
   it("filters shell prompts", () => {
     expect(isUselessTitle("alice@host:~/project$ ")).toBe(true);
     expect(isUselessTitle("alice@host:~")).toBe(true);
-    expect(isUselessTitle("some/path$")).toBe(true);
-    expect(isUselessTitle("root@box#")).toBe(true);
+    expect(isUselessTitle("root@box:~#")).toBe(true);
+    expect(isUselessTitle("PS C:\\Users\\alice>")).toBe(true);
+    expect(isUselessTitle("/home/user$")).toBe(true);
+    expect(isUselessTitle("~$")).toBe(true);
+  });
+
+  it("keeps meaningful titles with trailing punctuation", () => {
+    // Prompt-character heuristic should NOT reject these
+    expect(isUselessTitle("Fix >")).toBe(false);
+    expect(isUselessTitle("C#")).toBe(false);
+    expect(isUselessTitle("Budget $")).toBe(false);
+    expect(isUselessTitle("PR #5182 >")).toBe(false);
+    expect(isUselessTitle("alice@example.com: OAuth notes")).toBe(false);
   });
 
   it("keeps meaningful titles", () => {
@@ -52,5 +67,31 @@ describe("isUselessTitle", () => {
   it("trims whitespace before evaluating", () => {
     expect(isUselessTitle("  claude  ")).toBe(true);
     expect(isUselessTitle("  Fixing bug  ")).toBe(false);
+  });
+});
+
+describe("normalizeObservedTitle", () => {
+  it("returns null for non-string, empty, or whitespace input", () => {
+    expect(normalizeObservedTitle(undefined)).toBeNull();
+    expect(normalizeObservedTitle(null)).toBeNull();
+    expect(normalizeObservedTitle(42)).toBeNull();
+    expect(normalizeObservedTitle({})).toBeNull();
+    expect(normalizeObservedTitle("")).toBeNull();
+    expect(normalizeObservedTitle("   ")).toBeNull();
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeObservedTitle("  hello  ")).toBe("hello");
+  });
+
+  it("clamps strings longer than the cap", () => {
+    const huge = "A".repeat(MAX_OBSERVED_TITLE_LENGTH + 500);
+    const result = normalizeObservedTitle(huge);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(MAX_OBSERVED_TITLE_LENGTH);
+  });
+
+  it("passes normal-length strings through unchanged", () => {
+    expect(normalizeObservedTitle("Fixing auth bug")).toBe("Fixing auth bug");
   });
 });

--- a/shared/utils/__tests__/isUselessTitle.test.ts
+++ b/shared/utils/__tests__/isUselessTitle.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { isUselessTitle } from "../isUselessTitle.js";
+
+describe("isUselessTitle", () => {
+  it("treats null/undefined/empty as useless", () => {
+    expect(isUselessTitle(null)).toBe(true);
+    expect(isUselessTitle(undefined)).toBe(true);
+    expect(isUselessTitle("")).toBe(true);
+    expect(isUselessTitle("   ")).toBe(true);
+  });
+
+  it("filters shell binary names", () => {
+    expect(isUselessTitle("bash")).toBe(true);
+    expect(isUselessTitle("zsh")).toBe(true);
+    expect(isUselessTitle("fish")).toBe(true);
+    expect(isUselessTitle("sh")).toBe(true);
+    expect(isUselessTitle("cmd")).toBe(true);
+    expect(isUselessTitle("powershell")).toBe(true);
+    expect(isUselessTitle("pwsh")).toBe(true);
+    expect(isUselessTitle("cmd.exe")).toBe(true);
+    expect(isUselessTitle("Bash")).toBe(true);
+  });
+
+  it("filters agent binary names", () => {
+    expect(isUselessTitle("claude")).toBe(true);
+    expect(isUselessTitle("Claude")).toBe(true);
+    expect(isUselessTitle("codex")).toBe(true);
+    expect(isUselessTitle("gemini")).toBe(true);
+  });
+
+  it("filters path-like strings", () => {
+    expect(isUselessTitle("/Users/alice/project")).toBe(true);
+    expect(isUselessTitle("~/project")).toBe(true);
+    expect(isUselessTitle("C:\\Users\\alice\\project")).toBe(true);
+  });
+
+  it("filters shell prompts", () => {
+    expect(isUselessTitle("alice@host:~/project$ ")).toBe(true);
+    expect(isUselessTitle("alice@host:~")).toBe(true);
+    expect(isUselessTitle("some/path$")).toBe(true);
+    expect(isUselessTitle("root@box#")).toBe(true);
+  });
+
+  it("keeps meaningful titles", () => {
+    expect(isUselessTitle("Fixing auth bug")).toBe(false);
+    expect(isUselessTitle("Thinking about caching strategy")).toBe(false);
+    expect(isUselessTitle("Running tests")).toBe(false);
+    expect(isUselessTitle("✨ Applied patch")).toBe(false);
+    expect(isUselessTitle("PR #5182 — Persist closed agent sessions")).toBe(false);
+  });
+
+  it("trims whitespace before evaluating", () => {
+    expect(isUselessTitle("  claude  ")).toBe(true);
+    expect(isUselessTitle("  Fixing bug  ")).toBe(false);
+  });
+});

--- a/shared/utils/isUselessTitle.ts
+++ b/shared/utils/isUselessTitle.ts
@@ -1,0 +1,31 @@
+/**
+ * Heuristic filter for OSC-emitted terminal titles.
+ *
+ * Agents (Claude, Codex, Gemini) often reset the terminal title to the binary
+ * name or a path right before shutdown. Those labels aren't useful for
+ * disambiguating closed sessions in the trash bin or resume history. We track
+ * the last _non-useless_ title so the UI can surface a meaningful label like
+ * "Fixing auth bug" instead of "claude".
+ */
+const USELESS_TITLE_PATTERNS: readonly RegExp[] = [
+  // Shell binaries
+  /^(bash|zsh|fish|sh|cmd|powershell|pwsh|dash)(\.exe)?$/i,
+  // Agent binary names
+  /^claude$/i,
+  /^codex$/i,
+  /^gemini$/i,
+  // Absolute/home paths
+  /^[~/]/,
+  /^[A-Z]:\\/i,
+  // user@host:path shell prompts
+  /^[\w.-]+@[\w.-]+:/,
+  // Trailing shell prompt characters
+  /[~$#>]\s*$/,
+];
+
+export function isUselessTitle(title: string | null | undefined): boolean {
+  if (!title) return true;
+  const trimmed = title.trim();
+  if (trimmed.length === 0) return true;
+  return USELESS_TITLE_PATTERNS.some((re) => re.test(trimmed));
+}

--- a/shared/utils/isUselessTitle.ts
+++ b/shared/utils/isUselessTitle.ts
@@ -14,18 +14,37 @@ const USELESS_TITLE_PATTERNS: readonly RegExp[] = [
   /^claude$/i,
   /^codex$/i,
   /^gemini$/i,
-  // Absolute/home paths
-  /^[~/]/,
-  /^[A-Z]:\\/i,
-  // user@host:path shell prompts
-  /^[\w.-]+@[\w.-]+:/,
-  // Trailing shell prompt characters
-  /[~$#>]\s*$/,
+  // Absolute/home paths (reject only when the whole string is path-shaped)
+  /^(?:~\/?|\/)[^\s]*$/,
+  /^[A-Z]:\\[^\s]*$/i,
+  // user@host:path shell prompts followed by path/prompt char (not plain "user@domain: subject")
+  /^[\w.-]+@[\w.-]+:[~/][^\s]*[#$>]?\s*$/,
+  // PowerShell-style prompts: "PS C:\path>"
+  /^PS\s+[A-Z]:\\[^\s]*[#$>]\s*$/i,
+  // Path-anchored trailing prompt (e.g. "/home/user#", "~$")
+  /^(?:~|\/|[A-Z]:\\)[^\s]*[#$>]\s*$/i,
 ];
+
+export const MAX_OBSERVED_TITLE_LENGTH = 256;
 
 export function isUselessTitle(title: string | null | undefined): boolean {
   if (!title) return true;
   const trimmed = title.trim();
   if (trimmed.length === 0) return true;
   return USELESS_TITLE_PATTERNS.some((re) => re.test(trimmed));
+}
+
+/**
+ * Clamp and normalize an OSC title before we store it. The trust boundary is
+ * the IPC handler — a misbehaving or hostile agent can emit arbitrary-length
+ * title strings, which would then persist into the 30-day session history
+ * file and inflate synchronous reads on every palette open.
+ */
+export function normalizeObservedTitle(title: unknown): string | null {
+  if (typeof title !== "string") return null;
+  const trimmed = title.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.length > MAX_OBSERVED_TITLE_LENGTH
+    ? trimmed.slice(0, MAX_OBSERVED_TITLE_LENGTH)
+    : trimmed;
 }

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -6,6 +6,8 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TrashedTerminal } from "@/store/slices";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { isUselessTitle } from "@shared/utils/isUselessTitle";
+import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 
 interface TrashBinItemProps {
   terminal: TerminalInstance;
@@ -53,7 +55,17 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
     removePanel(terminal.id);
   }, [removePanel, terminal.id]);
 
-  const terminalName = terminal.title || terminal.type || "Terminal";
+  const terminalName = (() => {
+    const observed = terminal.lastObservedTitle;
+    if (observed && !isUselessTitle(observed)) return observed;
+    if (terminal.kind === "agent" || terminal.agentId) {
+      if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
+      const agentConfig = terminal.agentId ? getEffectiveAgentConfig(terminal.agentId) : undefined;
+      const agentName = agentConfig?.name ?? terminal.agentId ?? terminal.type ?? "Agent";
+      return worktreeName ? `${agentName} · ${worktreeName}` : agentName;
+    }
+    return terminal.title || terminal.type || "Terminal";
+  })();
 
   return (
     <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-[var(--radius-sm)] bg-transparent hover:bg-tint/5 transition-colors group">

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -61,8 +61,7 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
     if (terminal.kind === "agent" || terminal.agentId) {
       if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
       const agentConfig = terminal.agentId ? getEffectiveAgentConfig(terminal.agentId) : undefined;
-      const agentName = agentConfig?.name ?? terminal.agentId ?? terminal.type ?? "Agent";
-      return worktreeName ? `${agentName} · ${worktreeName}` : agentName;
+      return agentConfig?.name ?? terminal.agentId ?? terminal.type ?? "Agent";
     }
     return terminal.title || terminal.type || "Terminal";
   })();

--- a/src/components/Layout/__tests__/TrashBinItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashBinItem.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { TrashBinItem } from "../TrashBinItem";
+import type { TerminalInstance } from "@/store";
+import type { TrashedTerminal } from "@/store/slices";
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: unknown) => unknown) =>
+    selector({ restoreTerminal: vi.fn(), removePanel: vi.fn() }),
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: unknown) => unknown) =>
+    selector({ activeWorktreeId: "wt-active" }),
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => null,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.HTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => {
+  const Pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Tooltip: Pass,
+    TooltipContent: Pass,
+    TooltipProvider: Pass,
+    TooltipTrigger: Pass,
+  };
+});
+
+vi.mock("@shared/config/agentRegistry", () => ({
+  getEffectiveAgentConfig: (agentId: string) =>
+    agentId === "claude" ? { name: "Claude" } : undefined,
+}));
+
+function makeAgentTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t1",
+    kind: "agent",
+    agentId: "claude",
+    type: "claude",
+    title: "claude",
+    location: "trash",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+const trashedInfo: TrashedTerminal = {
+  id: "t1",
+  expiresAt: Date.now() + 20000,
+  originalLocation: "grid",
+};
+
+describe("TrashBinItem", () => {
+  it("does not duplicate worktree name when the agent title falls back to agent name", () => {
+    const terminal = makeAgentTerminal({ title: "claude", lastObservedTitle: undefined });
+    const { container } = render(
+      <TrashBinItem terminal={terminal} trashedInfo={trashedInfo} worktreeName="feature-auth" />
+    );
+    const text = container.textContent ?? "";
+    const occurrences = text.split("feature-auth").length - 1;
+    // The render path appends "(feature-auth)" exactly once — never in the name itself.
+    expect(occurrences).toBe(1);
+    expect(text).not.toContain("Claude · feature-auth");
+    expect(text).toContain("Claude");
+    expect(text).toContain("(feature-auth)");
+  });
+
+  it("prefers lastObservedTitle over plain title for agent terminals", () => {
+    const terminal = makeAgentTerminal({
+      title: "claude",
+      lastObservedTitle: "Fixing auth bug",
+    });
+    const { container } = render(
+      <TrashBinItem terminal={terminal} trashedInfo={trashedInfo} worktreeName="feature-auth" />
+    );
+    expect(container.textContent).toContain("Fixing auth bug");
+  });
+
+  it("falls back to agent name alone when both titles are useless", () => {
+    const terminal = makeAgentTerminal({ title: "claude", lastObservedTitle: "claude" });
+    const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+    expect(container.textContent).toContain("Claude");
+  });
+
+  it("passes through a meaningful title on non-agent terminals", () => {
+    const terminal = {
+      id: "t2",
+      kind: "terminal" as const,
+      type: "terminal" as const,
+      title: "my dev shell",
+      location: "trash" as const,
+    } as TerminalInstance;
+    const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+    expect(container.textContent).toContain("my dev shell");
+  });
+});

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -56,6 +56,13 @@ vi.mock("@/store/cliAvailabilityStore", () => {
   return { useCliAvailabilityStore: store };
 });
 
+vi.mock("@/store/worktreeStore", () => {
+  const state = { activeWorktreeId: null as string | null };
+  const store = (selector: (s: typeof state) => unknown) => selector(state);
+  store.getState = () => state;
+  return { useWorktreeSelectionStore: store };
+});
+
 import { usePanelPalette } from "../usePanelPalette";
 
 describe("usePanelPalette", () => {
@@ -166,6 +173,77 @@ describe("usePanelPalette", () => {
       const browserIdx = ids.indexOf("browser");
       const resumeIdx = ids.findIndex((id) => id.startsWith("resume:"));
       expect(resumeIdx).toBeGreaterThan(browserIdx);
+    });
+  });
+
+  it("filters out resume sessions with missing sessionId", async () => {
+    (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        sessionId: "",
+        agentId: "claude",
+        worktreeId: null,
+        title: "Fixing bug",
+        projectId: null,
+        savedAt: Date.now() - 1000,
+      },
+      {
+        sessionId: "valid-session",
+        agentId: "claude",
+        worktreeId: null,
+        title: null,
+        projectId: null,
+        savedAt: Date.now() - 2000,
+      },
+    ]);
+
+    const { result, rerender } = renderHook(() => usePanelPalette());
+    await vi.waitFor(() => {
+      rerender();
+      const resumeItems = result.current.results.filter((item) => item.id.startsWith("resume:"));
+      expect(resumeItems).toHaveLength(1);
+      expect(resumeItems[0].id).toBe("resume:valid-session");
+    });
+  });
+
+  it("prefers a meaningful session title in the resume label", async () => {
+    (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        sessionId: "with-title",
+        agentId: "claude",
+        worktreeId: null,
+        title: "Fixing auth bug",
+        projectId: null,
+        savedAt: Date.now() - 1000,
+      },
+    ]);
+
+    const { result, rerender } = renderHook(() => usePanelPalette());
+    await vi.waitFor(() => {
+      rerender();
+      const resume = result.current.results.find((item) => item.id.startsWith("resume:"));
+      expect(resume).toBeDefined();
+      expect(resume!.name).toBe("Resume: Fixing auth bug");
+    });
+  });
+
+  it("falls back to agent name when session title is useless", async () => {
+    (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        sessionId: "useless-title",
+        agentId: "claude",
+        worktreeId: null,
+        title: "claude",
+        projectId: null,
+        savedAt: Date.now() - 1000,
+      },
+    ]);
+
+    const { result, rerender } = renderHook(() => usePanelPalette());
+    await vi.waitFor(() => {
+      rerender();
+      const resume = result.current.results.find((item) => item.id.startsWith("resume:"));
+      expect(resume).toBeDefined();
+      expect(resume!.name).toBe("Resume Claude");
     });
   });
 

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -5,9 +5,11 @@ import { getPanelKindDefinition } from "@/registry";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { keybindingService } from "@/services/KeybindingService";
 import { formatTimeAgo } from "@/utils/timeAgo";
+import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import type { KeyAction } from "@shared/types/keymap";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 
@@ -66,16 +68,10 @@ export function usePanelPalette(): UsePanelPaletteReturn {
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
   const [keybindingVersion, setKeybindingVersion] = useState(0);
   const [resumeSessions, setResumeSessions] = useState<AgentSessionRecord[]>([]);
+  const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
   useEffect(() => {
     return keybindingService.subscribe(() => setKeybindingVersion((v) => v + 1));
-  }, []);
-
-  useEffect(() => {
-    window.electron?.agentSessionHistory
-      ?.list()
-      .then(setResumeSessions)
-      .catch(() => {});
   }, []);
 
   const availableKinds = useMemo<PanelKindOption[]>(() => {
@@ -141,21 +137,30 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       }
     }
 
-    const resumeOptions: PanelKindOption[] = resumeSessions.slice(0, 5).map((session) => {
-      const agentConfig = getEffectiveAgentConfig(session.agentId);
-      const timeAgo = formatTimeAgo(session.savedAt);
-      const modelPart = session.agentModelId ? prettifyModelId(session.agentModelId) : null;
-      const description = modelPart ? `${modelPart} · ${timeAgo}` : timeAgo;
-      return {
-        id: `resume:${session.sessionId}`,
-        name: `Resume ${agentConfig?.name ?? session.agentId}`,
-        iconId: agentConfig?.iconId ?? "terminal",
-        color: agentConfig?.color ?? "var(--color-daintree-text)",
-        description,
-        category: "resume" as const,
-        resumeSession: session,
-      };
-    });
+    const resumeOptions: PanelKindOption[] = resumeSessions
+      .filter((session) => !!session.sessionId)
+      .slice(0, 5)
+      .map((session) => {
+        const agentConfig = getEffectiveAgentConfig(session.agentId);
+        const timeAgo = formatTimeAgo(session.savedAt);
+        const modelPart = session.agentModelId ? prettifyModelId(session.agentModelId) : null;
+        const agentName = agentConfig?.name ?? session.agentId;
+        const hasMeaningfulTitle = !!session.title && !isUselessTitle(session.title);
+        const name = hasMeaningfulTitle ? `Resume: ${session.title}` : `Resume ${agentName}`;
+        const descriptionParts = [modelPart, hasMeaningfulTitle ? agentName : null, timeAgo].filter(
+          (part): part is string => !!part
+        );
+        const description = descriptionParts.join(" · ");
+        return {
+          id: `resume:${session.sessionId}`,
+          name,
+          iconId: agentConfig?.iconId ?? "terminal",
+          color: agentConfig?.color ?? "var(--color-daintree-text)",
+          description,
+          category: "resume" as const,
+          resumeSession: session,
+        };
+      });
 
     return [
       ...agentDedup.values(),
@@ -192,6 +197,19 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     const isStale = !lastCheckedAt || Date.now() - lastCheckedAt > STALE_THRESHOLD_MS;
     if (isStale) void refresh().catch(() => {});
   }, [isOpen]);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.electron?.agentSessionHistory
+      ?.list(activeWorktreeId ?? undefined)
+      .then((sessions) => {
+        if (!cancelled) setResumeSessions(sessions);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, activeWorktreeId]);
 
   const handleSelect = useCallback(
     (option: PanelKindOption): PanelKindOption | null => {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -35,7 +35,7 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { SCROLLBACK_BACKGROUND } from "@shared/config/scrollback";
 import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
-import { isUselessTitle } from "@shared/utils/isUselessTitle";
+import { isUselessTitle, normalizeObservedTitle } from "@shared/utils/isUselessTitle";
 import { usePanelStore } from "@/store/panelStore";
 import { isNonKeyboardInput } from "./inputUtils";
 
@@ -819,10 +819,10 @@ class TerminalInstanceService {
       const agentConfig = getEffectiveAgentConfig(agentId);
 
       const observedTitleDisposable = terminal.onTitleChange((title: string) => {
-        if (isUselessTitle(title)) return;
-        const trimmed = title.trim();
-        if (trimmed === managed.lastObservedTitleSent) return;
-        managed.pendingObservedTitle = trimmed;
+        const normalized = normalizeObservedTitle(title);
+        if (!normalized || isUselessTitle(normalized)) return;
+        if (normalized === managed.lastObservedTitleSent) return;
+        managed.pendingObservedTitle = normalized;
         if (managed.observedTitleTimer !== undefined) {
           clearTimeout(managed.observedTitleTimer);
         }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -35,6 +35,8 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { SCROLLBACK_BACKGROUND } from "@shared/config/scrollback";
 import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
+import { isUselessTitle } from "@shared/utils/isUselessTitle";
+import { usePanelStore } from "@/store/panelStore";
 import { isNonKeyboardInput } from "./inputUtils";
 
 export { isNonKeyboardInput } from "./inputUtils";
@@ -815,6 +817,46 @@ class TerminalInstanceService {
 
     if (agentId) {
       const agentConfig = getEffectiveAgentConfig(agentId);
+
+      const observedTitleDisposable = terminal.onTitleChange((title: string) => {
+        if (isUselessTitle(title)) return;
+        const trimmed = title.trim();
+        if (trimmed === managed.lastObservedTitleSent) return;
+        managed.pendingObservedTitle = trimmed;
+        if (managed.observedTitleTimer !== undefined) {
+          clearTimeout(managed.observedTitleTimer);
+        }
+        managed.observedTitleTimer = window.setTimeout(() => {
+          managed.observedTitleTimer = undefined;
+          const pending = managed.pendingObservedTitle;
+          managed.pendingObservedTitle = undefined;
+          if (!pending || pending === managed.lastObservedTitleSent) return;
+          managed.lastObservedTitleSent = pending;
+          try {
+            window.electron.terminal.updateObservedTitle(id, pending);
+          } catch (err) {
+            logWarn("[TerminalInstanceService] updateObservedTitle failed", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+          try {
+            usePanelStore.getState().updateLastObservedTitle(id, pending);
+          } catch (err) {
+            logWarn("[TerminalInstanceService] panel store title update failed", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }, 150);
+      });
+      listeners.push(() => {
+        observedTitleDisposable.dispose();
+        if (managed.observedTitleTimer !== undefined) {
+          clearTimeout(managed.observedTitleTimer);
+          managed.observedTitleTimer = undefined;
+          managed.pendingObservedTitle = undefined;
+        }
+      });
+
       const titlePatterns = agentConfig?.detection?.titleStatePatterns;
       if (titlePatterns) {
         let lastReportedTitleState: "working" | "waiting" | undefined;
@@ -1756,6 +1798,11 @@ class TerminalInstanceService {
       clearTimeout(managed.titleReportTimer);
       managed.titleReportTimer = undefined;
       managed.pendingTitleState = undefined;
+    }
+    if (managed.observedTitleTimer !== undefined) {
+      clearTimeout(managed.observedTitleTimer);
+      managed.observedTitleTimer = undefined;
+      managed.pendingObservedTitle = undefined;
     }
     if (managed.resizeSuppressionTimer !== undefined) {
       clearTimeout(managed.resizeSuppressionTimer);

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -93,6 +93,11 @@ export interface ManagedTerminal {
   titleReportTimer?: number;
   pendingTitleState?: "working" | "waiting";
 
+  // Last-meaningful-title tracking for agent session history
+  observedTitleTimer?: number;
+  pendingObservedTitle?: string;
+  lastObservedTitleSent?: string;
+
   // Input lock state (read-only monitor mode)
   isInputLocked?: boolean;
 

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -87,6 +87,7 @@ export const createCorePanelActions = (
   | "addPanel"
   | "removePanel"
   | "updateTitle"
+  | "updateLastObservedTitle"
   | "updateAgentState"
   | "updateActivity"
   | "updateLastCommand"
@@ -335,6 +336,7 @@ export const createCorePanelActions = (
           restore: options.restore,
           agentLaunchFlags: options.agentLaunchFlags,
           agentModelId: options.agentModelId,
+          worktreeId: options.worktreeId,
         });
       }
 
@@ -569,6 +571,21 @@ export const createCorePanelActions = (
       const effectiveTitle =
         newTitle.trim() || getDefaultTitle(terminal.kind, terminal.type, terminal.agentId);
       const newById = { ...state.panelsById, [id]: { ...terminal, title: effectiveTitle } };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  updateLastObservedTitle: (id, title) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      const trimmed = title.trim();
+      if (!trimmed || terminal.lastObservedTitle === trimmed) return state;
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, lastObservedTitle: trimmed },
+      };
       saveNormalized(newById, state.panelIds);
       return { panelsById: newById };
     });

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -54,6 +54,7 @@ export interface PanelRegistrySlice {
   addPanel: (options: AddPanelOptions) => Promise<string | null>;
   removePanel: (id: string) => void;
   updateTitle: (id: string, newTitle: string) => void;
+  updateLastObservedTitle: (id: string, title: string) => void;
   updateAgentState: (
     id: string,
     agentState: AgentState,


### PR DESCRIPTION
## Summary

- Threads `worktreeId` through the spawn options schema all the way to `PtyManager.trash()` so `persistAgentSession` records the correct worktree instead of a hardcoded `null`, scoping session history properly per project.
- Adds a fire-and-forget `terminal:update-observed-title` IPC channel that lets the renderer push the last meaningful OSC title to `TerminalPublicState` before trash-expiry persistence captures the session record.
- Renderer-side 150ms dwell timer in `TerminalInstanceService` filters useless titles (shell binaries, agent binaries, paths, user@host prompts) and syncs meaningful ones to both the main process and the Zustand panel store via a new `lastObservedTitle` field.

Resolves #5182

## Changes

- `shared/utils/isUselessTitle.ts` — regex-based filter for useless terminal titles, clamped to 256 chars at both the IPC boundary and dwell queue
- `electron/ipc/channels.ts` + handlers + preload — new `terminal:update-observed-title` channel
- `electron/services/PtyManager.ts` + `TerminalProcess.ts` + `pty/types.ts` — `worktreeId` threaded through, `lastObservedTitle` stored at trash-expiry
- `src/services/terminal/TerminalInstanceService.ts` — 150ms dwell timer, useless-title filtering, IPC sync on meaningful title changes
- `src/store/slices/panelRegistry/core.ts` — `lastObservedTitle` field + `updateLastObservedTitle` action on panel store
- `src/components/Layout/TrashBinItem.tsx` — prefers `lastObservedTitle` over agent name for agent panels
- `src/hooks/usePanelPalette.ts` — resume sessions scoped to active worktree, sessionId-less records filtered, meaningful title used in label ("Resume: Fixing auth bug" vs "Resume Claude")

## Testing

50+ new test cases across three files: `isUselessTitle` regex + `normalizeObservedTitle` clamp, `TrashBinItem` render variants, and `usePanelPalette` sessionId filtering and title preference logic. All 2706 Electron tests and renderer tests pass.