### PR TITLE
fix(workspace): surface Linux inotify watch-limit degradation as a toast

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -445,6 +445,7 @@ export const CHANNELS = {
   CLIPBOARD_SAVE_IMAGE: "clipboard:save-image",
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",
   CLIPBOARD_WRITE_IMAGE: "clipboard:write-image",
+  CLIPBOARD_WRITE_TEXT: "clipboard:write-text",
 
   APP_THEME_GET: "app-theme:get",
   APP_THEME_SET_COLOR_SCHEME: "app-theme:set-color-scheme",

--- a/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const clipboardMock = vi.hoisted(() => ({
   writeImage: vi.fn(),
   readImage: vi.fn(),
+  writeText: vi.fn(),
 }));
 
 const nativeImageMock = vi.hoisted(() => ({
@@ -118,5 +119,58 @@ describe("clipboard:write-image handler", () => {
     cleanup();
     const removedChannels = vi.mocked(ipcMain.removeHandler).mock.calls.map(([ch]) => ch);
     expect(removedChannels).toContain("clipboard:write-image");
+  });
+});
+
+describe("clipboard:write-text handler", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("registers the clipboard:write-text handler", () => {
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map(([ch]) => ch);
+    expect(channels).toContain("clipboard:write-text");
+  });
+
+  it("writes text to the clipboard and returns ok", async () => {
+    const handler = getHandler("clipboard:write-text");
+    const result = await handler(fakeEvent, "sudo sysctl fs.inotify.max_user_watches=524288");
+
+    expect(clipboardMock.writeText).toHaveBeenCalledWith(
+      "sudo sysctl fs.inotify.max_user_watches=524288"
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects non-string input without calling clipboard", async () => {
+    const handler = getHandler("clipboard:write-text");
+    const result = await handler(fakeEvent, 42 as unknown as string);
+
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: "Text must be a string" });
+  });
+
+  it("returns error when clipboard.writeText throws", async () => {
+    clipboardMock.writeText.mockImplementationOnce(() => {
+      throw new Error("clipboard unavailable");
+    });
+
+    const handler = getHandler("clipboard:write-text");
+    const result = await handler(fakeEvent, "hello");
+
+    expect(result).toEqual({ ok: false, error: "clipboard unavailable" });
+  });
+
+  it("cleanup removes the clipboard:write-text handler", () => {
+    cleanup();
+    const removedChannels = vi.mocked(ipcMain.removeHandler).mock.calls.map(([ch]) => ch);
+    expect(removedChannels).toContain("clipboard:write-text");
   });
 });

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -135,13 +135,31 @@ export function registerClipboardHandlers(): () => void {
     }
   };
 
+  const handleWriteText = (
+    _event: Electron.IpcMainInvokeEvent,
+    text: string
+  ): { ok: true } | { ok: false; error: string } => {
+    try {
+      if (typeof text !== "string") {
+        return { ok: false, error: "Text must be a string" };
+      }
+      clipboard.writeText(text);
+      return { ok: true };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  };
+
   ipcMain.handle(CHANNELS.CLIPBOARD_SAVE_IMAGE, handleSaveImage);
   ipcMain.handle(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, handleThumbnailFromPath);
   ipcMain.handle(CHANNELS.CLIPBOARD_WRITE_IMAGE, handleWriteImage);
+  ipcMain.handle(CHANNELS.CLIPBOARD_WRITE_TEXT, handleWriteText);
 
   return () => {
     ipcMain.removeHandler(CHANNELS.CLIPBOARD_SAVE_IMAGE);
     ipcMain.removeHandler(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH);
     ipcMain.removeHandler(CHANNELS.CLIPBOARD_WRITE_IMAGE);
+    ipcMain.removeHandler(CHANNELS.CLIPBOARD_WRITE_TEXT);
   };
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -962,6 +962,7 @@ const CHANNELS = {
   CLIPBOARD_SAVE_IMAGE: "clipboard:save-image",
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",
   CLIPBOARD_WRITE_IMAGE: "clipboard:write-image",
+  CLIPBOARD_WRITE_TEXT: "clipboard:write-text",
 
   // App Theme channels
   APP_THEME_GET: "app-theme:get",
@@ -2654,6 +2655,7 @@ const api: ElectronAPI = {
     thumbnailFromPath: (filePath: string) =>
       _unwrappingInvoke(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, filePath),
     writeImage: (pngData: Uint8Array) => _unwrappingInvoke(CHANNELS.CLIPBOARD_WRITE_IMAGE, pngData),
+    writeText: (text: string) => _unwrappingInvoke(CHANNELS.CLIPBOARD_WRITE_TEXT, text),
   },
 
   // Web Utils API

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2465,7 +2465,7 @@ const api: ElectronAPI = {
         type: "success" | "error" | "info" | "warning";
         title?: string;
         message: string;
-        action?: { label: string; ipcChannel: string };
+        action?: { label: string; ipcChannel: string; data?: string };
       }) => void
     ) => _typedOn(CHANNELS.NOTIFICATION_SHOW_TOAST, callback),
   },

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -12,6 +12,7 @@ import path from "path";
 import crypto from "crypto";
 import { events } from "./events.js";
 import { CHANNELS } from "../ipc/channels.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
 import { store } from "../store.js";
 
 import { WorkspaceHostProcess } from "./WorkspaceHostProcess.js";
@@ -266,6 +267,24 @@ export class WorkspaceClient extends EventEmitter {
       case "copytree:progress": {
         const callback = this.copyTreeProgressCallbacks.get(event.operationId);
         callback?.(event.progress);
+        break;
+      }
+
+      case "inotify-limit-reached": {
+        // System-wide Linux condition — notify every active window, not just
+        // this entry's project views. Each host fires this once per lifetime,
+        // so broadcasting is cheap.
+        broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+          type: "warning",
+          title: "File watching degraded",
+          message:
+            "Linux inotify watch limit reached. Some files may not auto-refresh until you raise it.",
+          action: {
+            label: "Copy fix command",
+            ipcChannel: CHANNELS.CLIPBOARD_WRITE_TEXT,
+            data: "sudo sysctl fs.inotify.max_user_watches=524288",
+          },
+        });
         break;
       }
     }

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -650,6 +650,187 @@ describe("GitFileWatcher", () => {
     Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
   });
 
+  it("onInotifyLimitReached fires alongside onWatcherFailed on Linux ENOSPC at runtime", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onInotifyLimitReached = vi.fn();
+    let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
+          if (event === "error") {
+            errorHandler = handler as (error: NodeJS.ErrnoException) => void;
+          }
+          return w;
+        }) as unknown as typeof w.on);
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onInotifyLimitReached,
+    });
+
+    gitWatcher.start();
+    const enospcError = new Error("ENOSPC") as NodeJS.ErrnoException;
+    enospcError.code = "ENOSPC";
+    errorHandler?.(enospcError);
+
+    expect(onInotifyLimitReached).toHaveBeenCalledTimes(1);
+    expect(onWatcherFailed).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
+  it("does not call onInotifyLimitReached for non-ENOSPC runtime errors on Linux", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onInotifyLimitReached = vi.fn();
+    let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
+          if (event === "error") {
+            errorHandler = handler as (error: NodeJS.ErrnoException) => void;
+          }
+          return w;
+        }) as unknown as typeof w.on);
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onInotifyLimitReached,
+    });
+
+    gitWatcher.start();
+    const otherError = new Error("permission denied") as NodeJS.ErrnoException;
+    otherError.code = "EACCES";
+    errorHandler?.(otherError);
+
+    expect(onInotifyLimitReached).not.toHaveBeenCalled();
+    expect(onWatcherFailed).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
+  it("startup ENOSPC on Linux calls both onInotifyLimitReached and onWatcherFailed", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onInotifyLimitReached = vi.fn();
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+    // Only the recursive watcher throws on construction; the non-recursive
+    // git-internal watchers constructed earlier in start() succeed.
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      if (opts?.recursive) {
+        const err = new Error("ENOSPC") as NodeJS.ErrnoException;
+        err.code = "ENOSPC";
+        throw err;
+      }
+      return createMockWatcher();
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onInotifyLimitReached,
+    });
+
+    // start() should not throw — the catch absorbs the ENOSPC into callbacks.
+    expect(gitWatcher.start()).toBe(true);
+    expect(onInotifyLimitReached).toHaveBeenCalledTimes(1);
+    expect(onWatcherFailed).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
+  it("does not signal inotify-limit on non-Linux platforms for ENOSPC", () => {
+    const onChange = vi.fn();
+    const onWatcherFailed = vi.fn();
+    const onInotifyLimitReached = vi.fn();
+    let errorHandler: ((error: NodeJS.ErrnoException) => void) | undefined;
+
+    const origPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    vi.mocked(watch).mockImplementation(((
+      _path: string,
+      opts: Record<string, unknown>,
+      _cb?: unknown
+    ) => {
+      const w = createMockWatcher();
+      if (opts?.recursive) {
+        vi.mocked(w.on).mockImplementation(((event: string, handler: unknown) => {
+          if (event === "error") {
+            errorHandler = handler as (error: NodeJS.ErrnoException) => void;
+          }
+          return w;
+        }) as unknown as typeof w.on);
+      }
+      return w;
+    }) as unknown as typeof watch);
+
+    const gitWatcher = new GitFileWatcher({
+      worktreePath: "/repo",
+      branch: "main",
+      debounceMs: 300,
+      onChange,
+      watchWorktree: true,
+      onWatcherFailed,
+      onInotifyLimitReached,
+    });
+
+    gitWatcher.start();
+    const enospcError = new Error("ENOSPC") as NodeJS.ErrnoException;
+    enospcError.code = "ENOSPC";
+    errorHandler?.(enospcError);
+
+    expect(onInotifyLimitReached).not.toHaveBeenCalled();
+
+    Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+  });
+
   it("detects commits via branch ref changes", async () => {
     const gitDir = pathJoin("/repo", ".git");
     const onChange = vi.fn();

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -777,8 +777,11 @@ describe("GitFileWatcher", () => {
       onInotifyLimitReached,
     });
 
-    // start() should not throw — the catch absorbs the ENOSPC into callbacks.
-    expect(gitWatcher.start()).toBe(true);
+    // start() reports the recursive watcher failure via `false` so the
+    // monitor takes its retry branch (instead of treating the watcher as
+    // healthy and resetting the retry counter). Callbacks still fire exactly
+    // once so the toast dedup remains correct.
+    expect(gitWatcher.start()).toBe(false);
     expect(onInotifyLimitReached).toHaveBeenCalledTimes(1);
     expect(onWatcherFailed).toHaveBeenCalledTimes(1);
 

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -25,6 +25,9 @@ export interface GitFileWatcherOptions {
   worktreeMaxWaitMs?: number;
   /** Called when the recursive worktree watcher fails at runtime (error or startup). */
   onWatcherFailed?: () => void;
+  /** Called when the recursive worktree watcher fails specifically because of
+   *  the Linux inotify watch limit (ENOSPC). Fires in addition to `onWatcherFailed`. */
+  onInotifyLimitReached?: () => void;
 }
 
 export class GitFileWatcher {
@@ -44,6 +47,7 @@ export class GitFileWatcher {
   private readonly worktreeDebounceRampMs = 10;
   private readonly onChange: () => void;
   private readonly onWatcherFailed: (() => void) | undefined;
+  private readonly onInotifyLimitReached: (() => void) | undefined;
   private readonly watchWorktree: boolean;
   private currentBranch?: string;
 
@@ -55,6 +59,7 @@ export class GitFileWatcher {
     this.worktreeMaxWaitMs = options.worktreeMaxWaitMs;
     this.onChange = options.onChange;
     this.onWatcherFailed = options.onWatcherFailed;
+    this.onInotifyLimitReached = options.onInotifyLimitReached;
     this.currentBranch = options.branch;
     this.watchWorktree = options.watchWorktree ?? false;
   }
@@ -203,6 +208,7 @@ export class GitFileWatcher {
           } catch {
             // Ignore close errors on already-broken watcher
           }
+          this.onInotifyLimitReached?.();
           this.onWatcherFailed?.();
         } else {
           logWarn("Worktree recursive watcher error", {
@@ -222,6 +228,8 @@ export class GitFileWatcher {
             "Permanent fix: echo 'fs.inotify.max_user_watches=524288' | sudo tee /etc/sysctl.d/99-inotify.conf && sudo sysctl --system",
           { path: this.worktreePath }
         );
+        this.onInotifyLimitReached?.();
+        this.onWatcherFailed?.();
       } else {
         logWarn("Failed to start recursive worktree watcher", {
           path: this.worktreePath,

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -96,7 +96,13 @@ export class GitFileWatcher {
       }
 
       if (this.watchWorktree) {
-        this.startWorktreeWatcher(gitDir);
+        const worktreeWatcherStarted = this.startWorktreeWatcher(gitDir);
+        // Surface startup failure of the recursive watcher (e.g. Linux
+        // ENOSPC) so WorktreeMonitor routes into its retry branch instead
+        // of treating the watcher as healthy and disabling the retry loop.
+        if (!worktreeWatcherStarted) {
+          return false;
+        }
       }
 
       return true;
@@ -152,7 +158,7 @@ export class GitFileWatcher {
     }
   }
 
-  private startWorktreeWatcher(_gitDir: string): void {
+  private startWorktreeWatcher(_gitDir: string): boolean {
     try {
       // Always filter ".git" — for linked worktrees the gitDir resolves to the
       // main repo's .git/worktrees/<name>, but the worktree root still has a
@@ -219,6 +225,7 @@ export class GitFileWatcher {
       });
 
       this.watchers.push(watcher);
+      return true;
     } catch (error) {
       const errno = error as NodeJS.ErrnoException;
       if (process.platform === "linux" && errno.code === "ENOSPC") {
@@ -236,6 +243,7 @@ export class GitFileWatcher {
           error: errno.message,
         });
       }
+      return false;
     }
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -78,6 +78,9 @@ export class WorkspaceService {
   private _shutdownController = new AbortController();
   private resourceActionQueues = new Map<string, PQueue>();
   private resourceActionAbortControllers = new Map<string, AbortController>();
+  /** Session-scoped guard so we notify the user about Linux inotify limits
+   *  only once, even if many worktrees hit ENOSPC concurrently. */
+  private inotifyLimitNotified = false;
 
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.prService = new PRIntegrationService(pullRequestService, events, {
@@ -379,6 +382,7 @@ export class WorkspaceService {
             { origin: "auto-poll" }
           );
         },
+        onInotifyLimitReached: () => this.handleInotifyLimitReached(),
       },
       this.mainBranch,
       this.pollQueue
@@ -498,6 +502,13 @@ export class WorkspaceService {
       worktree: snapshot,
     });
     events.emit("sys:worktree:update", snapshot as any);
+  }
+
+  private handleInotifyLimitReached(): void {
+    if (process.platform !== "linux") return;
+    if (this.inotifyLimitNotified) return;
+    this.inotifyLimitNotified = true;
+    this.sendEvent({ type: "inotify-limit-reached" });
   }
 
   private handleExternalWorktreeRemoval(worktreeId: string): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -46,6 +46,7 @@ export interface WorktreeMonitorCallbacks {
   onBranchChanged?: (worktreeId: string, newBranch: string) => void;
   onExternalRemoval?: (worktreeId: string) => void;
   onResourceStatusPoll?: (worktreeId: string) => Promise<unknown> | void;
+  onInotifyLimitReached?: (worktreeId: string) => void;
 }
 
 export class WorktreeMonitor {
@@ -668,6 +669,7 @@ export class WorktreeMonitor {
       worktreeMaxDebounceMs: WATCHER_WORKTREE_MAX_DEBOUNCE_MS,
       worktreeMaxWaitMs: WATCHER_WORKTREE_MAX_WAIT_MS,
       onWatcherFailed: () => this.handleWatcherFailed(),
+      onInotifyLimitReached: () => this.callbacks.onInotifyLimitReached?.(this.id),
     });
 
     const started = watcher.start();

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -301,4 +301,40 @@ describe("WorkspaceService adversarial", () => {
       expect(argv).not.toContain("--track");
     }
   });
+
+  describe("handleInotifyLimitReached", () => {
+    const setPlatform = (value: NodeJS.Platform) => {
+      Object.defineProperty(process, "platform", { value, configurable: true });
+    };
+
+    it("sends a single inotify-limit-reached event on Linux even when called many times", () => {
+      const origPlatform = process.platform;
+      setPlatform("linux");
+      try {
+        const privateService = service as unknown as { handleInotifyLimitReached: () => void };
+        privateService.handleInotifyLimitReached();
+        privateService.handleInotifyLimitReached();
+        privateService.handleInotifyLimitReached();
+
+        const inotifyEvents = sentEvents.filter((e) => e.type === "inotify-limit-reached");
+        expect(inotifyEvents).toHaveLength(1);
+      } finally {
+        setPlatform(origPlatform);
+      }
+    });
+
+    it("does not emit on non-Linux platforms", () => {
+      const origPlatform = process.platform;
+      setPlatform("darwin");
+      try {
+        const privateService = service as unknown as { handleInotifyLimitReached: () => void };
+        privateService.handleInotifyLimitReached();
+
+        const inotifyEvents = sentEvents.filter((e) => e.type === "inotify-limit-reached");
+        expect(inotifyEvents).toHaveLength(0);
+      } finally {
+        setPlatform(origPlatform);
+      }
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -39,13 +39,20 @@ vi.mock("../../utils/gitUtils.js", () => ({
 
 let mockWatcherStartResult = false;
 let capturedOnWatcherFailed: (() => void) | undefined;
+let capturedOnInotifyLimitReached: (() => void) | undefined;
 let capturedWatcherOptions: Record<string, unknown> | undefined;
 
 vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
-      constructor(opts: { onWatcherFailed?: () => void } & Record<string, unknown>) {
+      constructor(
+        opts: {
+          onWatcherFailed?: () => void;
+          onInotifyLimitReached?: () => void;
+        } & Record<string, unknown>
+      ) {
         capturedOnWatcherFailed = opts.onWatcherFailed;
+        capturedOnInotifyLimitReached = opts.onInotifyLimitReached;
         capturedWatcherOptions = opts;
       }
       start() {
@@ -111,6 +118,7 @@ describe("WorktreeMonitor", () => {
     vi.clearAllMocks();
     mockWatcherStartResult = false;
     capturedOnWatcherFailed = undefined;
+    capturedOnInotifyLimitReached = undefined;
     capturedWatcherOptions = undefined;
   });
 
@@ -476,6 +484,29 @@ describe("WorktreeMonitor", () => {
       // After retry interval, watcher should restart
       await vi.advanceTimersByTimeAsync(30_000);
       expect(monitor.hasWatcher).toBe(true);
+
+      monitor.stop();
+    });
+
+    it("forwards inotify-limit signal to callbacks with the worktree id", async () => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const onInotifyLimitReached = vi.fn();
+      const callbacks = makeCallbacks({ onInotifyLimitReached });
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(capturedOnInotifyLimitReached).toBeDefined();
+      capturedOnInotifyLimitReached?.();
+      expect(onInotifyLimitReached).toHaveBeenCalledWith(TEST_WORKTREE.id);
+      expect(onInotifyLimitReached).toHaveBeenCalledTimes(1);
 
       monitor.stop();
     });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -510,6 +510,35 @@ describe("WorktreeMonitor", () => {
 
       monitor.stop();
     });
+
+    it("startup ENOSPC that fires onWatcherFailed AND returns false still schedules one retry", async () => {
+      // Regression guard: before the fix, startWorktreeWatcher() returned
+      // undefined (coerced to true), WorktreeMonitor assigned gitWatcher
+      // and reset watcherRetryCount = 0, neutralizing the retry scheduled
+      // from inside the synchronous onWatcherFailed callback.
+      mockWatcherStartResult = false;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      // Watcher is absent after start — exactly the failure branch we want.
+      expect(monitor.hasWatcher).toBe(false);
+
+      // Retry fires after WATCHER_RETRY_INTERVAL_MS and succeeds this time.
+      mockWatcherStartResult = true;
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(monitor.hasWatcher).toBe(true);
+
+      monitor.stop();
+    });
   });
 
   describe("poll queue concurrency", () => {

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -38,24 +38,34 @@ vi.mock("../../utils/gitUtils.js", () => ({
 }));
 
 let mockWatcherStartResult = false;
+/** When true, the stub's `start()` synchronously invokes `onWatcherFailed`
+ *  before returning — mirroring the real startup-ENOSPC catch path. */
+let mockWatcherStartFiresFailure = false;
 let capturedOnWatcherFailed: (() => void) | undefined;
 let capturedOnInotifyLimitReached: (() => void) | undefined;
 let capturedWatcherOptions: Record<string, unknown> | undefined;
+let watcherStartCallCount = 0;
 
 vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
+      private readonly onWatcherFailed?: () => void;
       constructor(
         opts: {
           onWatcherFailed?: () => void;
           onInotifyLimitReached?: () => void;
         } & Record<string, unknown>
       ) {
+        this.onWatcherFailed = opts.onWatcherFailed;
         capturedOnWatcherFailed = opts.onWatcherFailed;
         capturedOnInotifyLimitReached = opts.onInotifyLimitReached;
         capturedWatcherOptions = opts;
       }
       start() {
+        watcherStartCallCount++;
+        if (mockWatcherStartFiresFailure && !mockWatcherStartResult) {
+          this.onWatcherFailed?.();
+        }
         return mockWatcherStartResult;
       }
       dispose() {}
@@ -117,6 +127,8 @@ describe("WorktreeMonitor", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     mockWatcherStartResult = false;
+    mockWatcherStartFiresFailure = false;
+    watcherStartCallCount = 0;
     capturedOnWatcherFailed = undefined;
     capturedOnInotifyLimitReached = undefined;
     capturedWatcherOptions = undefined;
@@ -511,12 +523,21 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
-    it("startup ENOSPC that fires onWatcherFailed AND returns false still schedules one retry", async () => {
-      // Regression guard: before the fix, startWorktreeWatcher() returned
-      // undefined (coerced to true), WorktreeMonitor assigned gitWatcher
-      // and reset watcherRetryCount = 0, neutralizing the retry scheduled
-      // from inside the synchronous onWatcherFailed callback.
+    it("startup ENOSPC that fires onWatcherFailed AND returns false schedules exactly one retry", async () => {
+      // Regression guard for the startup-ENOSPC retry fix. Before the fix,
+      // GitFileWatcher.start() returned undefined (coerced to true), so
+      // WorktreeMonitor assigned gitWatcher and reset watcherRetryCount = 0,
+      // neutralizing the retry scheduled from inside the synchronous
+      // onWatcherFailed callback.
+      //
+      // Now start() returns false AND onWatcherFailed fires inside it, so
+      // WorktreeMonitor's handleWatcherFailed runs scheduleWatcherRetry
+      // first, then the else branch of startWatcher() runs it again. This
+      // test proves the two calls collapse onto a single retry via the
+      // `watcherRetryTimer` guard — regressing that guard would fire the
+      // retry twice (watcherStartCallCount would reach 3, not 2).
       mockWatcherStartResult = false;
+      mockWatcherStartFiresFailure = true;
       mockGetWorktreeChangesWithStats.mockResolvedValue({
         worktreeId: "/test/worktree",
         rootPath: "/test",
@@ -529,12 +550,18 @@ describe("WorktreeMonitor", () => {
       const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
       await monitor.start();
 
-      // Watcher is absent after start — exactly the failure branch we want.
+      // Initial start failed → no active watcher, exactly one start attempt.
       expect(monitor.hasWatcher).toBe(false);
+      expect(watcherStartCallCount).toBe(1);
 
-      // Retry fires after WATCHER_RETRY_INTERVAL_MS and succeeds this time.
+      // Flip to success for the retry attempt.
+      mockWatcherStartFiresFailure = false;
       mockWatcherStartResult = true;
       await vi.advanceTimersByTimeAsync(30_000);
+
+      // Only ONE retry fires — 2 total start() calls, not 3. A regression
+      // that removed the watcherRetryTimer guard would produce 3.
+      expect(watcherStartCallCount).toBe(2);
       expect(monitor.hasWatcher).toBe(true);
 
       monitor.stop();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1075,6 +1075,7 @@ export interface ElectronAPI {
       { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
     >;
     writeImage(pngData: Uint8Array): Promise<{ ok: true } | { ok: false; error: string }>;
+    writeText(text: string): Promise<{ ok: true } | { ok: false; error: string }>;
   };
   webUtils: {
     getPathForFile(file: File): string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -198,6 +198,9 @@ export interface MainProcessToastPayload {
     label: string;
     /** IPC channel to invoke when the action button is clicked */
     ipcChannel: string;
+    /** Optional payload passed to the renderer-side action handler
+     *  (e.g. the text to copy for a "clipboard:write-text" action). */
+    data?: string;
   };
 }
 
@@ -1387,6 +1390,10 @@ export interface IpcInvokeMap {
   };
   "clipboard:write-image": {
     args: [pngData: Uint8Array];
+    result: { ok: true } | { ok: false; error: string };
+  };
+  "clipboard:write-text": {
+    args: [text: string];
     result: { ok: true } | { ok: false; error: string };
   };
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -322,6 +322,9 @@ export type WorkspaceHostEvent =
   // Spontaneous updates (no requestId - these are pushed events)
   | { type: "worktree-update"; worktree: WorktreeSnapshot }
   | { type: "worktree-removed"; worktreeId: string }
+  // Linux-only: fired once per host-process lifetime when the recursive file
+  // watcher hits the inotify watch limit (ENOSPC).
+  | { type: "inotify-limit-reached" }
   // PR events
   | {
       type: "pr-detected";

--- a/src/hooks/useMainProcessToastListener.ts
+++ b/src/hooks/useMainProcessToastListener.ts
@@ -11,12 +11,13 @@ export function useMainProcessToastListener(): void {
         ? {
             label: payload.action.label,
             onClick: () => {
-              if (payload.action!.ipcChannel === "update:check-for-updates") {
+              const { ipcChannel, data } = payload.action!;
+              if (ipcChannel === "update:check-for-updates") {
                 window.electron.update.checkForUpdates();
+              } else if (ipcChannel === "clipboard:write-text") {
+                void window.electron.clipboard.writeText(data ?? "");
               } else {
-                console.warn(
-                  `[MainProcessToast] Unknown IPC channel for action: ${payload.action!.ipcChannel}`
-                );
+                console.warn(`[MainProcessToast] Unknown IPC channel for action: ${ipcChannel}`);
               }
             },
           }

--- a/src/hooks/useMainProcessToastListener.ts
+++ b/src/hooks/useMainProcessToastListener.ts
@@ -15,7 +15,13 @@ export function useMainProcessToastListener(): void {
               if (ipcChannel === "update:check-for-updates") {
                 window.electron.update.checkForUpdates();
               } else if (ipcChannel === "clipboard:write-text") {
-                void window.electron.clipboard.writeText(data ?? "");
+                // Guard against a main-process payload that forgot `data` —
+                // silently clearing the clipboard would be a footgun.
+                if (!data) {
+                  console.warn("[MainProcessToast] clipboard:write-text missing data payload");
+                  return;
+                }
+                void window.electron.clipboard.writeText(data);
               } else {
                 console.warn(`[MainProcessToast] Unknown IPC channel for action: ${ipcChannel}`);
               }


### PR DESCRIPTION
## Summary

- When the Linux inotify watch limit is hit (`ENOSPC`), the file watcher now routes a one-time toast notification to the renderer with a \"Copy fix command\" action, rather than silently falling back to polling.
- New signal chain: `GitFileWatcher.onInotifyLimitReached` → `WorktreeMonitor` callback → `WorkspaceService` (host-process-scoped dedup) → `WorkspaceHostEvent(\"inotify-limit-reached\")` → `WorkspaceClient.routeHostEvent` → `broadcastToRenderer(NOTIFICATION_SHOW_TOAST)`.
- Added a `clipboard:write-text` IPC channel so the toast's copy action works correctly on Linux/Electron 41, where `navigator.clipboard` is unavailable in the renderer.

Resolves #5229

## Changes

- `electron/utils/gitFileWatcher.ts` — emit `onInotifyLimitReached` event on `ENOSPC` instead of just logging
- `electron/workspace-host/WorktreeMonitor.ts` — wire `onInotifyLimitReached` callback up to `WorkspaceService`
- `electron/workspace-host/WorkspaceService.ts` — deduplicate across worktrees and broadcast the toast event
- `electron/services/WorkspaceClient.ts` — route new `inotify-limit-reached` host event to renderer
- `electron/ipc/channels.ts` + `electron/ipc/handlers/clipboard.ts` — new `clipboard:write-text` channel backed by main-process `clipboard.writeText`
- `electron/preload.cts` — expose `clipboard.writeText` on the IPC bridge
- `shared/types/ipc/` — type declarations for the new channel and workspace host event
- `src/hooks/useMainProcessToastListener.ts` — handle `clipboard:write-text` toast action with empty-string guard
- Fixed latent bug: startup `ENOSPC` in `startWorktreeWatcher` now returns `false` so the retry scheduler runs correctly

## Testing

11 new tests across 4 files (78 total passing). All typecheck, lint, and format checks clean.

- `electron/utils/__tests__/gitFileWatcher.test.ts` — ENOSPC detection and `onInotifyLimitReached` event emission
- `electron/workspace-host/__tests__/WorktreeMonitor.test.ts` — inotify limit callback wiring and startup-ENOSPC retry regression
- `electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts` — session-scoped dedup (multiple worktrees, rapid calls)
- `electron/ipc/handlers/__tests__/clipboard.handlers.test.ts` — `clipboard:write-text` IPC handler