### PR TITLE
fix(pty-client): route UtilityProcess crashes via child-process-gone

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -112,6 +112,29 @@ const PTY_TIMEOUTS = {
 } as const satisfies Record<string, number>;
 
 /**
+ * Map an authoritative `child-process-gone` reason (Electron 37+) to our CrashType.
+ * Used when `app.on("child-process-gone")` fires for the PTY host — the reason
+ * string is more reliable than the exit code heuristic in `classifyCrash()`.
+ */
+function mapGoneReasonToCrashType(reason: string): CrashType {
+  switch (reason) {
+    case "oom":
+    case "memory-eviction":
+      return "OUT_OF_MEMORY";
+    case "killed":
+      return "SIGNAL_TERMINATED";
+    case "clean-exit":
+      return "CLEAN_EXIT";
+    case "crashed":
+    case "abnormal-exit":
+    case "launch-failed":
+    case "integrity-failure":
+    default:
+      return "UNKNOWN_CRASH";
+  }
+}
+
+/**
  * Classify crash type based on exit code and signal.
  * Exit codes 137 (128+9=SIGKILL) and 134 (128+6=SIGABRT) often indicate OOM.
  */
@@ -196,6 +219,18 @@ export class PtyClient extends EventEmitter {
   private hostStdoutBuffer = "";
   private hostStderrBuffer = "";
 
+  /**
+   * Authoritative crash reason captured from `app.on("child-process-gone")`.
+   * Consumed by the next `exit` handler via `setImmediate` deferral, since
+   * Electron 37-41 has a documented race where `exit` often fires before
+   * `child-process-gone` for utility-process crashes.
+   */
+  private pendingChildProcessGoneReason: { reason: string; exitCode: number } | null = null;
+  /** Stored handler reference so dispose() can deregister via app.off(). */
+  private childProcessGoneHandler:
+    | ((event: Electron.Event, details: Electron.Details) => void)
+    | null = null;
+
   constructor(config: PtyClientConfig = {}) {
     super();
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -211,7 +246,29 @@ export class PtyClient extends EventEmitter {
     // that affects all platforms. Use IPC fallback for terminal I/O.
     console.log("[PtyClient] Using IPC mode (SharedArrayBuffer not supported in UtilityProcess)");
 
+    this.registerChildProcessGoneListener();
     this.startHost();
+  }
+
+  /**
+   * Register a single app-level listener for `child-process-gone`, scoped to
+   * our PTY host by `type === "Utility"` and `name === "daintree-pty-host"`.
+   * The handler only records the authoritative reason; the `exit` handler
+   * consumes it via `setImmediate` deferral to handle the Electron 37-41 race
+   * where `exit` can fire before `child-process-gone`.
+   */
+  private registerChildProcessGoneListener(): void {
+    if (this.childProcessGoneHandler) return;
+    const handler = (_event: Electron.Event, details: Electron.Details): void => {
+      if (this.isDisposed) return;
+      if (details.type !== "Utility" || details.name !== "daintree-pty-host") return;
+      this.pendingChildProcessGoneReason = {
+        reason: details.reason,
+        exitCode: details.exitCode,
+      };
+    };
+    this.childProcessGoneHandler = handler;
+    app.on("child-process-gone", handler);
   }
 
   private forwardHostOutput(kind: "stdout" | "stderr", chunk: Buffer): void {
@@ -294,6 +351,12 @@ export class PtyClient extends EventEmitter {
       this.restartTimer = null;
     }
 
+    // Defensive: clear any stale crash reason from a prior host cycle. Under
+    // normal flow the `exit` handler's setImmediate consumes this, but a missed
+    // exit event (or out-of-band listener fire) would otherwise leak into the
+    // next crash.
+    this.pendingChildProcessGoneReason = null;
+
     // Reset initialization state for restart
     this.isInitialized = false;
     this.readyPromise = new Promise((resolve, reject) => {
@@ -339,12 +402,7 @@ export class PtyClient extends EventEmitter {
       this.flushHostOutputBuffers();
       // Note: UtilityProcess exit event doesn't provide signal, but we can infer from code
       const signal = code !== null && code > 128 ? `SIG${code - 128}` : null;
-      const crashType = classifyCrash(code, signal);
-
-      console.error(
-        `[PtyClient] Pty Host exited with code ${code}` +
-          (crashType !== "CLEAN_EXIT" ? ` (${crashType})` : "")
-      );
+      const fallbackCrashType = classifyCrash(code, signal);
 
       // Clear health check
       if (this.healthCheckInterval) {
@@ -358,7 +416,8 @@ export class PtyClient extends EventEmitter {
       this.child = null; // Prevent posting to dead process
 
       if (this.isDisposed) {
-        // Expected shutdown
+        // Expected shutdown - drop any buffered reason so it can't leak.
+        this.pendingChildProcessGoneReason = null;
         return;
       }
 
@@ -374,37 +433,61 @@ export class PtyClient extends EventEmitter {
       this.broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
       this.shouldResyncProjectContext = true;
 
-      // Emit crash payload with classification for downstream consumers
-      if (crashType !== "CLEAN_EXIT") {
-        const crashPayload: HostCrashPayload = {
-          code,
-          signal,
-          crashType,
-          timestamp: Date.now(),
-        };
-        this.emit("host-crash-details", crashPayload);
-      }
+      // Electron 37-41 race: `exit` often fires before `child-process-gone`
+      // for utility-process crashes. Defer crash classification by one event
+      // loop tick so the authoritative reason can arrive; fall back to the
+      // exit-code heuristic when no reason was captured in time.
+      setImmediate(() => {
+        if (this.isDisposed) {
+          this.pendingChildProcessGoneReason = null;
+          return;
+        }
 
-      // Try to restart
-      if (this.restartAttempts < this.config.maxRestartAttempts) {
-        this.restartAttempts++;
-        const delay = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
-        console.log(
-          `[PtyClient] Restarting Host in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
+        const gone = this.pendingChildProcessGoneReason;
+        this.pendingChildProcessGoneReason = null;
+        const crashType: CrashType = gone
+          ? mapGoneReasonToCrashType(gone.reason)
+          : fallbackCrashType;
+
+        console.error(
+          `[PtyClient] Pty Host exited with code ${code}` +
+            (crashType !== "CLEAN_EXIT" ? ` (${crashType})` : "")
         );
 
-        if (this.restartTimer) {
-          clearTimeout(this.restartTimer);
+        this.cleanupOrphanedPtys(crashType);
+
+        // Emit crash payload with classification for downstream consumers
+        if (crashType !== "CLEAN_EXIT") {
+          const crashPayload: HostCrashPayload = {
+            code,
+            signal,
+            crashType,
+            timestamp: Date.now(),
+          };
+          this.emit("host-crash-details", crashPayload);
         }
-        this.restartTimer = setTimeout(() => {
-          this.restartTimer = null;
-          this.needsRespawn = true;
-          this.startHost();
-        }, delay);
-      } else {
-        console.error("[PtyClient] Max restart attempts reached, giving up");
-        this.emit("host-crash", code);
-      }
+
+        // Try to restart
+        if (this.restartAttempts < this.config.maxRestartAttempts) {
+          this.restartAttempts++;
+          const delay = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
+          console.log(
+            `[PtyClient] Restarting Host in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
+          );
+
+          if (this.restartTimer) {
+            clearTimeout(this.restartTimer);
+          }
+          this.restartTimer = setTimeout(() => {
+            this.restartTimer = null;
+            this.needsRespawn = true;
+            this.startHost();
+          }, delay);
+        } else {
+          console.error("[PtyClient] Max restart attempts reached, giving up");
+          this.emit("host-crash", code);
+        }
+      });
     });
 
     // Start health check with watchdog (only if not paused by system sleep)
@@ -1446,6 +1529,12 @@ export class PtyClient extends EventEmitter {
         }
       }, 1000);
     }
+
+    if (this.childProcessGoneHandler) {
+      app.off("child-process-gone", this.childProcessGoneHandler);
+      this.childProcessGoneHandler = null;
+    }
+    this.pendingChildProcessGoneReason = null;
 
     // Clean up all pending requests via broker (rejects pending promises with
     // "Broker disposed"; callers convert to sentinel values via .catch()).

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -261,7 +261,13 @@ export class PtyClient extends EventEmitter {
     if (this.childProcessGoneHandler) return;
     const handler = (_event: Electron.Event, details: Electron.Details): void => {
       if (this.isDisposed) return;
-      if (details.type !== "Utility" || details.name !== "daintree-pty-host") return;
+      if (details.type !== "Utility") return;
+      // Electron 41 populates `name` from `serviceName` at runtime, but both
+      // fields are typed as optional. Accept either to stay resilient to
+      // future runtime changes or edge cases where only one is set.
+      const matchesHost =
+        details.name === "daintree-pty-host" || details.serviceName === "daintree-pty-host";
+      if (!matchesHost) return;
       this.pendingChildProcessGoneReason = {
         reason: details.reason,
         exitCode: details.exitCode,
@@ -448,9 +454,13 @@ export class PtyClient extends EventEmitter {
         const crashType: CrashType = gone
           ? mapGoneReasonToCrashType(gone.reason)
           : fallbackCrashType;
+        // Prefer the authoritative exit code from `child-process-gone` over the
+        // (sometimes unreliable) one from `exit` — Electron 40-41 has a known
+        // signed/unsigned mangling bug on Windows for the exit event.
+        const reportedCode = gone ? gone.exitCode : code;
 
         console.error(
-          `[PtyClient] Pty Host exited with code ${code}` +
+          `[PtyClient] Pty Host exited with code ${reportedCode}` +
             (crashType !== "CLEAN_EXIT" ? ` (${crashType})` : "")
         );
 
@@ -459,13 +469,20 @@ export class PtyClient extends EventEmitter {
         // Emit crash payload with classification for downstream consumers
         if (crashType !== "CLEAN_EXIT") {
           const crashPayload: HostCrashPayload = {
-            code,
-            signal,
+            code: reportedCode,
+            // When we have an authoritative reason, trust it and clear the
+            // derived-from-exit-code signal string.
+            signal: gone ? null : signal,
             crashType,
             timestamp: Date.now(),
           };
           this.emit("host-crash-details", crashPayload);
         }
+
+        // If `manualRestart()` already spawned a new host during the defer
+        // window (possible via the renderer TERMINAL_RESTART_SERVICE IPC call),
+        // don't schedule a second auto-restart — it would orphan that host.
+        if (this.child !== null) return;
 
         // Try to restart
         if (this.restartAttempts < this.config.maxRestartAttempts) {
@@ -480,12 +497,13 @@ export class PtyClient extends EventEmitter {
           }
           this.restartTimer = setTimeout(() => {
             this.restartTimer = null;
+            if (this.isDisposed || this.child !== null) return;
             this.needsRespawn = true;
             this.startHost();
           }, delay);
         } else {
           console.error("[PtyClient] Max restart attempts reached, giving up");
-          this.emit("host-crash", code);
+          this.emit("host-crash", reportedCode);
         }
       });
     });

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -2,14 +2,22 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 import { EventEmitter } from "events";
 import type { PtyHostSpawnOptions, SpawnResult } from "../../../shared/types/pty-host.js";
 
-const shared = vi.hoisted(() => ({
-  forkMock: vi.fn(),
-  tracker: {
-    removeTrashed: vi.fn(),
-    persistTrashed: vi.fn(),
-    clearAll: vi.fn(),
-  },
-}));
+const shared = vi.hoisted(() => {
+  const { EventEmitter } = require("events") as typeof import("events");
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+  });
+  return {
+    forkMock: vi.fn(),
+    tracker: {
+      removeTrashed: vi.fn(),
+      persistTrashed: vi.fn(),
+      clearAll: vi.fn(),
+    },
+    appMock,
+  };
+});
 
 vi.mock("electron", () => ({
   utilityProcess: {
@@ -17,9 +25,7 @@ vi.mock("electron", () => ({
   },
   UtilityProcess: EventEmitter,
   MessagePortMain: class {},
-  app: {
-    getPath: vi.fn().mockReturnValue("/mock/user/data"),
-  },
+  app: shared.appMock,
 }));
 
 vi.mock("../TrashedPidTracker.js", () => ({
@@ -73,6 +79,7 @@ describe("PtyClient adversarial", () => {
     vi.useFakeTimers();
     vi.resetModules();
     vi.clearAllMocks();
+    shared.appMock.removeAllListeners();
     mockChild = createMockChild();
     shared.forkMock.mockReturnValue(mockChild);
 
@@ -370,6 +377,180 @@ describe("PtyClient adversarial", () => {
     await expect(allSnapshotsPromise).resolves.toEqual([]);
     await expect(transitionPromise).resolves.toBe(false);
     await expect(serializedPromise).resolves.toBeNull();
+  });
+
+  describe("child-process-gone crash routing", () => {
+    function emitGone(
+      details: Partial<{
+        type: string;
+        reason: string;
+        exitCode: number;
+        name: string;
+        serviceName: string;
+      }> = {}
+    ): void {
+      shared.appMock.emit(
+        "child-process-gone",
+        {},
+        {
+          type: "Utility",
+          reason: "crashed",
+          exitCode: 1,
+          name: "daintree-pty-host",
+          serviceName: "daintree-pty-host",
+          ...details,
+        }
+      );
+    }
+
+    function captureCrash(client: import("../PtyClient.js").PtyClient): {
+      payloads: Array<{ code: number | null; signal: string | null; crashType: string }>;
+    } {
+      const payloads: Array<{ code: number | null; signal: string | null; crashType: string }> = [];
+      client.on(
+        "host-crash-details",
+        (payload: { code: number | null; signal: string | null; crashType: string }) => {
+          payloads.push(payload);
+        }
+      );
+      return { payloads };
+    }
+
+    it("GONE_BEFORE_EXIT_ROUTES_AUTHORITATIVE_REASON", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      emitGone({ reason: "oom", exitCode: 0 });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
+    });
+
+    it("EXIT_BEFORE_GONE_ORDERING_RACE", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      // Reverse order: exit first (incorrect code 0), gone arrives after.
+      mockChild.emit("exit", 0);
+      emitGone({ reason: "oom", exitCode: 0 });
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
+    });
+
+    it("NO_GONE_EVENT_FALLS_BACK_TO_EXIT_CODE_HEURISTIC", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      mockChild.emit("exit", 137);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
+      expect(payloads[0].code).toBe(137);
+    });
+
+    it("GONE_WRONG_TYPE_IGNORED", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      emitGone({ type: "GPU", reason: "oom" });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      // exit code 0 + no authoritative reason → CLEAN_EXIT → nothing emitted
+      expect(payloads).toHaveLength(0);
+    });
+
+    it("GONE_WRONG_NAME_IGNORED", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      emitGone({ name: "some-other-host", reason: "oom" });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(0);
+    });
+
+    it("STARTHOST_CLEARS_STALE_GONE_BEFORE_NEW_HOST", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+      const restartedChild = createMockChild();
+      restartedChild.pid = 999;
+      shared.forkMock.mockReturnValue(restartedChild);
+
+      // First crash cycle — gone arrives, then exit consumes it.
+      emitGone({ reason: "oom" });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+      expect(payloads[payloads.length - 1].crashType).toBe("OUT_OF_MEMORY");
+
+      // Advance past the restart delay so startHost() runs (defensive reset).
+      vi.advanceTimersByTime(10000);
+      restartedChild.emit("message", { type: "ready" });
+
+      // New host exits cleanly with no gone event. If the prior gone reason
+      // had leaked, this would be misclassified as OUT_OF_MEMORY.
+      restartedChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      // Only one crash payload total — the new host's clean exit emits nothing.
+      expect(payloads).toHaveLength(1);
+    });
+
+    it("DISPOSE_DEREGISTERS_APP_LISTENER", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      expect(shared.appMock.listenerCount("child-process-gone")).toBe(1);
+      client.dispose();
+      expect(shared.appMock.listenerCount("child-process-gone")).toBe(0);
+
+      // Post-dispose gone event must not emit anything.
+      emitGone({ reason: "oom" });
+      vi.advanceTimersByTime(1);
+      expect(payloads).toHaveLength(0);
+    });
+
+    it("MEMORY_EVICTION_MAPS_TO_OOM", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      emitGone({ reason: "memory-eviction" });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
+    });
+
+    it("UNKNOWN_REASON_MAPS_TO_UNKNOWN_CRASH", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      emitGone({ reason: "something-new-from-electron-42" });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("UNKNOWN_CRASH");
+    });
+
+    it("KILLED_REASON_MAPS_TO_SIGNAL_TERMINATED", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      emitGone({ reason: "killed" });
+      mockChild.emit("exit", 143);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("SIGNAL_TERMINATED");
+    });
   });
 
   it("DISPOSE_RESOLVES_ORPHANED_PENDING_OPS", async () => {

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -3,6 +3,9 @@ import { EventEmitter } from "events";
 import type { PtyHostSpawnOptions, SpawnResult } from "../../../shared/types/pty-host.js";
 
 const shared = vi.hoisted(() => {
+  // vi.hoisted runs before module imports resolve, so use require() to load
+  // the Node stdlib synchronously.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { EventEmitter } = require("events") as typeof import("events");
   const appEmitter = new EventEmitter();
   const appMock = Object.assign(appEmitter, {

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -469,11 +469,90 @@ describe("PtyClient adversarial", () => {
       const client = createReadyClient();
       const { payloads } = captureCrash(client);
 
-      emitGone({ name: "some-other-host", reason: "oom" });
+      // Clear both name and serviceName so the filter can't fall through.
+      emitGone({ name: "some-other-host", serviceName: "some-other-host", reason: "oom" });
       mockChild.emit("exit", 0);
       vi.advanceTimersByTime(1);
 
       expect(payloads).toHaveLength(0);
+    });
+
+    it("SERVICE_NAME_MATCHES_WHEN_NAME_IS_UNDEFINED", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      // Electron 41 populates both `name` and `serviceName`, but the `Details`
+      // type flags both as optional. Make sure we still match if only
+      // `serviceName` is present.
+      shared.appMock.emit(
+        "child-process-gone",
+        {},
+        {
+          type: "Utility",
+          reason: "oom",
+          exitCode: 0,
+          serviceName: "daintree-pty-host",
+        }
+      );
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
+    });
+
+    it("MANUAL_RESTART_DURING_EXIT_DEFER_DOES_NOT_DOUBLE_START", () => {
+      const client = createReadyClient();
+      const restartedChild = createMockChild();
+      restartedChild.pid = 777;
+
+      // Exit fires — synchronous part nulls this.child, setImmediate is queued.
+      mockChild.emit("exit", 1);
+
+      // Before setImmediate runs, the renderer triggers manualRestart(). It
+      // sees this.child === null and forks a new host immediately.
+      shared.forkMock.mockReturnValue(restartedChild);
+      client.manualRestart();
+      expect(shared.forkMock).toHaveBeenCalledTimes(2);
+
+      // Now let the deferred setImmediate run. It must NOT schedule another
+      // restart, because a new host is already alive.
+      vi.advanceTimersByTime(1);
+
+      // And if a restart timer had been armed, draining timers would have
+      // triggered a third fork. Advance well past the max restart delay.
+      vi.advanceTimersByTime(30000);
+
+      expect(shared.forkMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("AUTHORITATIVE_REASON_CARRIES_AUTHORITATIVE_EXIT_CODE", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      // Gone reports the authoritative exitCode; exit reports a mangled 0.
+      emitGone({ reason: "oom", exitCode: -1 });
+      mockChild.emit("exit", 0);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].code).toBe(-1);
+      expect(payloads[0].signal).toBeNull();
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
+    });
+
+    it("CRASH_PAYLOAD_FIELDS_ARE_COMPLETE_ON_FALLBACK", () => {
+      const client = createReadyClient();
+      const { payloads } = captureCrash(client);
+
+      // No gone event — use exit-code heuristic. Payload should include all fields.
+      mockChild.emit("exit", 137);
+      vi.advanceTimersByTime(1);
+
+      expect(payloads).toHaveLength(1);
+      expect(payloads[0].code).toBe(137);
+      expect(payloads[0].signal).toBe("SIG9");
+      expect(payloads[0].crashType).toBe("OUT_OF_MEMORY");
     });
 
     it("STARTHOST_CLEARS_STALE_GONE_BEFORE_NEW_HOST", () => {

--- a/electron/services/__tests__/PtyClient.handshake.test.ts
+++ b/electron/services/__tests__/PtyClient.handshake.test.ts
@@ -12,6 +12,8 @@ vi.mock("electron", () => ({
   },
   app: {
     getPath: vi.fn().mockReturnValue("/mock/user/data"),
+    on: vi.fn(),
+    off: vi.fn(),
   },
 }));
 
@@ -55,6 +57,8 @@ describe("PtyClient Handshake Protocol", () => {
       },
       app: {
         getPath: vi.fn().mockReturnValue("/mock/user/data"),
+        on: vi.fn(),
+        off: vi.fn(),
       },
     }));
 

--- a/electron/services/__tests__/PtyClient.multiPort.test.ts
+++ b/electron/services/__tests__/PtyClient.multiPort.test.ts
@@ -10,6 +10,8 @@ vi.mock("electron", () => ({
   },
   app: {
     getPath: vi.fn().mockReturnValue("/mock/user/data"),
+    on: vi.fn(),
+    off: vi.fn(),
   },
 }));
 
@@ -54,6 +56,8 @@ describe("PtyClient multi-port support", () => {
       },
       app: {
         getPath: vi.fn().mockReturnValue("/mock/user/data"),
+        on: vi.fn(),
+        off: vi.fn(),
       },
     }));
 

--- a/electron/services/__tests__/PtyClient.projectId.test.ts
+++ b/electron/services/__tests__/PtyClient.projectId.test.ts
@@ -10,6 +10,8 @@ vi.mock("electron", () => ({
   },
   app: {
     getPath: vi.fn().mockReturnValue("/mock/user/data"),
+    on: vi.fn(),
+    off: vi.fn(),
   },
 }));
 
@@ -48,6 +50,8 @@ describe("PtyClient projectId assignment", () => {
       },
       app: {
         getPath: vi.fn().mockReturnValue("/mock/user/data"),
+        on: vi.fn(),
+        off: vi.fn(),
       },
     }));
 


### PR DESCRIPTION
## Summary

- `app.on('child-process-gone')` now feeds authoritative crash details into `PtyClient`'s existing `host-crash-details` emit path, replacing the heuristic-only approach
- `mapGoneReasonToCrashType()` maps all 8 Electron `GoneReason` values to `CrashType`, with `setImmediate` deferral to handle the Electron 37-41 race where `exit` fires before `child-process-gone`
- `classifyCrash()` is preserved as a fallback for the rare case the gone event never arrives, and a guard prevents a manual-restart/deferred-restart race

Resolves #5192

## Changes

- `electron/services/PtyClient.ts`: Added `child-process-gone` listener registration, `mapGoneReasonToCrashType()`, deferred exit handling, and authoritative `exitCode` propagation into crash payload
- `electron/services/__tests__/PtyClient.adversarial.test.ts`: 13 new adversarial tests covering ordering races, filter boundaries, dispose cleanup, manual restart safety, and reason-to-crashType mapping (20/20 passing)

## Testing

All 20 adversarial tests pass. The `setImmediate` deferral is the key correctness invariant: on Electron 37+, `exit` can fire before `child-process-gone`, so the fallback path only runs when no gone event arrives in the next tick.