### PR TITLE
feat(fleet-arming): persistent multi-cursor selection for agent terminals

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -275,7 +275,13 @@ export type BuiltInActionId =
   | "terminal.bulkCommand"
   | "terminal.stashInput"
   | "terminal.popStash"
-  | "terminal.restartService";
+  | "terminal.restartService"
+  | "terminal.arm"
+  | "terminal.disarm"
+  | "terminal.disarmAll"
+  | "terminal.armByState"
+  | "terminal.armAll"
+  | "terminal.armDefault";
 
 export type ActionId = BuiltInActionId | (string & {});
 

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -116,6 +116,8 @@ export type BuiltInKeyAction =
   | "terminal.scrollToLastActivity"
   | "terminal.sendToAgent"
   | "terminal.bulkCommand"
+  | "terminal.armDefault"
+  | "terminal.disarmAll"
 
   // Agent spawning
   | "agent.palette"
@@ -285,6 +287,8 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "terminal.scrollToLastActivity",
   "terminal.sendToAgent",
   "terminal.bulkCommand",
+  "terminal.armDefault",
+  "terminal.disarmAll",
   "agent.palette",
   ...BUILT_IN_AGENT_KEY_ACTIONS,
   "agent.terminal",

--- a/src/components/DragDrop/SortableWorktreeTerminal.tsx
+++ b/src/components/DragDrop/SortableWorktreeTerminal.tsx
@@ -59,7 +59,6 @@ export function SortableWorktreeTerminal({
       className={cn(isDragging && "opacity-40")}
       role="listitem"
       aria-roledescription="sortable item"
-      data-sortable-tile={terminal.id}
       {...filteredAttributes}
     >
       {typeof children === "function" ? (

--- a/src/components/DragDrop/SortableWorktreeTerminal.tsx
+++ b/src/components/DragDrop/SortableWorktreeTerminal.tsx
@@ -59,6 +59,7 @@ export function SortableWorktreeTerminal({
       className={cn(isDragging && "opacity-40")}
       role="listitem"
       aria-roledescription="sortable item"
+      data-sortable-tile={terminal.id}
       {...filteredAttributes}
     >
       {typeof children === "function" ? (

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useRef, type ReactElement } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useEscapeStack } from "@/hooks";
+import { useFleetArmingStore, type FleetArmStatePreset } from "@/store/fleetArmingStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+
+interface PresetOption {
+  value: FleetArmStatePreset;
+  label: string;
+}
+
+const PRESETS: PresetOption[] = [
+  { value: "working", label: "Working" },
+  { value: "waiting", label: "Waiting" },
+  { value: "finished", label: "Finished" },
+];
+
+export function FleetArmingRibbon(): ReactElement | null {
+  const armedCount = useFleetArmingStore((s) => s.armedIds.size);
+  const clear = useFleetArmingStore((s) => s.clear);
+  const armByState = useFleetArmingStore((s) => s.armByState);
+
+  useEscapeStack(armedCount > 0, clear);
+
+  const lastAnnouncedCount = useRef<number>(0);
+  useEffect(() => {
+    if (armedCount === lastAnnouncedCount.current) return;
+    const announce = useAnnouncerStore.getState().announce;
+    if (armedCount === 0 && lastAnnouncedCount.current > 0) {
+      announce("Fleet disarmed");
+    } else if (armedCount > 0) {
+      announce(`${armedCount} ${armedCount === 1 ? "agent" : "agents"} armed`);
+    }
+    lastAnnouncedCount.current = armedCount;
+  }, [armedCount]);
+
+  const hint = useMemo(() => {
+    return "Esc to disarm · Shift-click to extend · Cmd-click to toggle";
+  }, []);
+
+  if (armedCount === 0) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="off"
+      className="flex items-center gap-3 border-b border-daintree-accent/40 bg-daintree-accent/10 px-3 py-1.5 text-[12px] text-daintree-text"
+      data-testid="fleet-arming-ribbon"
+    >
+      <span className="font-medium text-daintree-accent">
+        {armedCount} {armedCount === 1 ? "agent" : "agents"} armed
+      </span>
+      <div className="flex items-center gap-1" role="toolbar" aria-label="Arm by state">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.value}
+            type="button"
+            onClick={(e) => {
+              armByState(preset.value, "current", e.shiftKey);
+            }}
+            className={cn(
+              "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] transition-colors",
+              "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
+            )}
+            aria-label={`Arm ${preset.label.toLowerCase()} agents (shift to extend)`}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+      <span className="ml-auto text-[11px] text-daintree-text/50">{hint}</span>
+      <button
+        type="button"
+        onClick={clear}
+        aria-label="Disarm all"
+        className="rounded p-1 text-daintree-text/60 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, fireEvent, screen, act } from "@testing-library/react";
+import { FleetArmingRibbon } from "../FleetArmingRibbon";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import type { TerminalInstance } from "@shared/types";
+
+function resetStores() {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+  useAnnouncerStore.setState({ polite: null, assertive: null });
+}
+
+function seed(terminals: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
+}
+
+function makeAgent(
+  id: string,
+  agentState: TerminalInstance["agentState"] = "idle"
+): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState,
+    hasPty: true,
+  } as TerminalInstance;
+}
+
+describe("FleetArmingRibbon", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("renders nothing when nothing is armed", () => {
+    const { container } = render(<FleetArmingRibbon />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders armed count when armed", () => {
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    render(<FleetArmingRibbon />);
+    expect(screen.getByTestId("fleet-arming-ribbon")).toBeTruthy();
+    expect(screen.getByText("3 agents armed")).toBeTruthy();
+  });
+
+  it("uses singular 'agent' for a single armed terminal", () => {
+    useFleetArmingStore.getState().armIds(["a"]);
+    render(<FleetArmingRibbon />);
+    expect(screen.getByText("1 agent armed")).toBeTruthy();
+  });
+
+  it("clicking the close button disarms all", () => {
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    render(<FleetArmingRibbon />);
+    const close = screen.getByLabelText("Disarm all");
+    fireEvent.click(close);
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+  });
+
+  it("preset buttons arm agents by state", () => {
+    seed([makeAgent("t1", "working"), makeAgent("t2", "waiting"), makeAgent("t3", "completed")]);
+    useFleetArmingStore.getState().armIds(["t1"]); // open the ribbon
+    render(<FleetArmingRibbon />);
+
+    const waitingBtn = screen.getByLabelText(/Arm waiting agents/);
+    fireEvent.click(waitingBtn);
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect([...armed]).toEqual(["t2"]);
+  });
+
+  it("shift-clicking a preset extends the armed set", () => {
+    seed([makeAgent("t1", "working"), makeAgent("t2", "waiting")]);
+    useFleetArmingStore.getState().armIds(["t1"]);
+    render(<FleetArmingRibbon />);
+
+    const waitingBtn = screen.getByLabelText(/Arm waiting agents/);
+    fireEvent.click(waitingBtn, { shiftKey: true });
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect([...armed].sort()).toEqual(["t1", "t2"]);
+  });
+
+  it("announces armed count via the announcer store", () => {
+    render(<FleetArmingRibbon />);
+    act(() => {
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+    });
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("2 agents armed");
+  });
+
+  it("announces 'Fleet disarmed' when count returns to zero", () => {
+    render(<FleetArmingRibbon />);
+    act(() => {
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+    });
+    act(() => {
+      useFleetArmingStore.getState().clear();
+    });
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Fleet disarmed");
+  });
+});

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -1,0 +1,1 @@
+export { FleetArmingRibbon } from "./FleetArmingRibbon";

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "../ErrorBoundary";
 import { PortalDock, PortalVisibilityController } from "../Portal";
 import { HelpPanel } from "../HelpPanel";
 import { ProjectSwitchOverlay } from "@/components/Project";
+import { FleetArmingRibbon } from "@/components/Fleet";
 import { ChordIndicator } from "./ChordIndicator";
 import { DemoCursor, DemoOverlay } from "../Demo";
 
@@ -304,6 +305,7 @@ export function AppLayout({
         agentSettings={agentSettings}
         projectSwitcherPalette={projectSwitcherPalette}
       />
+      <FleetArmingRibbon />
       <div
         className="flex-1 flex flex-col overflow-hidden"
         style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" }}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -939,9 +939,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                     <BroadcastTerminalIcon className="w-3.5 h-3.5" />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {createTooltipWithShortcut("Bulk Operations", "Cmd+Shift+B")}
-                </TooltipContent>
+                <TooltipContent side="bottom">Bulk Operations</TooltipContent>
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -162,6 +162,7 @@ function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
 
           <button
             type="button"
+            data-drag-handle
             className="cursor-grab rounded text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
             aria-label="Drag to move terminal"
             {...(listeners as React.HTMLAttributes<HTMLElement>)}
@@ -240,7 +241,17 @@ export function WorktreeTerminalSection({
     [onTerminalSelect]
   );
 
-  const marqueeStartRef = useRef<{ x: number; y: number; pointerId: number } | null>(null);
+  // Marquee starts potential on pointerdown (no capture yet). We only upgrade
+  // to an active marquee — and take pointer capture — after the pointer has
+  // moved past a small threshold. This way a plain click on a tile still
+  // fires its onClick handler, while drag-to-select activates cleanly.
+  const MARQUEE_THRESHOLD_PX = 4;
+  const marqueeStartRef = useRef<{
+    x: number;
+    y: number;
+    pointerId: number;
+    active: boolean;
+  } | null>(null);
   const tileRectsRef = useRef<Map<string, DOMRect>>(new Map());
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [marqueeBox, setMarqueeBox] = useState<MarqueeBox | null>(null);
@@ -261,10 +272,14 @@ export function WorktreeTerminalSection({
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0) return;
       const target = e.target as Element;
-      if (target.closest("[data-sortable-tile]")) return;
-      if (target.closest("button")) return;
-      e.currentTarget.setPointerCapture(e.pointerId);
-      marqueeStartRef.current = { x: e.clientX, y: e.clientY, pointerId: e.pointerId };
+      // dnd-kit owns the drag handle — don't shadow its pointer events.
+      if (target.closest("[data-drag-handle]")) return;
+      marqueeStartRef.current = {
+        x: e.clientX,
+        y: e.clientY,
+        pointerId: e.pointerId,
+        active: false,
+      };
       snapshotRects();
     },
     [snapshotRects]
@@ -273,15 +288,23 @@ export function WorktreeTerminalSection({
   const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const start = marqueeStartRef.current;
     if (!start) return;
+    const dx = Math.abs(e.clientX - start.x);
+    const dy = Math.abs(e.clientY - start.y);
+    if (!start.active) {
+      if (dx < MARQUEE_THRESHOLD_PX && dy < MARQUEE_THRESHOLD_PX) return;
+      start.active = true;
+      try {
+        e.currentTarget.setPointerCapture(start.pointerId);
+      } catch {
+        // capture may fail if pointer already released
+      }
+    }
     const container = scrollRef.current;
     if (!container) return;
     const rect = container.getBoundingClientRect();
     const x = Math.min(start.x, e.clientX) - rect.left + container.scrollLeft;
     const y = Math.min(start.y, e.clientY) - rect.top + container.scrollTop;
-    const w = Math.abs(e.clientX - start.x);
-    const h = Math.abs(e.clientY - start.y);
-    if (w < 2 && h < 2) return;
-    setMarqueeBox({ x, y, w, h });
+    setMarqueeBox({ x, y, w: dx, h: dy });
   }, []);
 
   const commitMarquee = useCallback(
@@ -314,12 +337,14 @@ export function WorktreeTerminalSection({
     (e: React.PointerEvent<HTMLDivElement>) => {
       const start = marqueeStartRef.current;
       if (!start) return;
-      try {
-        e.currentTarget.releasePointerCapture(start.pointerId);
-      } catch {
-        // capture may already be released
+      if (start.active) {
+        try {
+          e.currentTarget.releasePointerCapture(start.pointerId);
+        } catch {
+          // capture may already be released
+        }
+        commitMarquee(e.clientX, e.clientY);
       }
-      commitMarquee(e.clientX, e.clientY);
       marqueeStartRef.current = null;
       setMarqueeBox(null);
     },
@@ -329,10 +354,12 @@ export function WorktreeTerminalSection({
   const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     const start = marqueeStartRef.current;
     if (!start) return;
-    try {
-      e.currentTarget.releasePointerCapture(start.pointerId);
-    } catch {
-      // ignore
+    if (start.active) {
+      try {
+        e.currentTarget.releasePointerCapture(start.pointerId);
+      } catch {
+        // ignore
+      }
     }
     marqueeStartRef.current = null;
     setMarqueeBox(null);

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type React from "react";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import type { AgentState } from "@/types";
@@ -20,6 +20,7 @@ import {
   SortableWorktreeTerminal,
   getAccordionDragId,
 } from "@/components/DragDrop/SortableWorktreeTerminal";
+import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 
 interface StateIconProps {
   state: AgentState;
@@ -53,6 +54,123 @@ function StateIcon({ state, count }: StateIconProps) {
         {count} {label}
       </TooltipContent>
     </Tooltip>
+  );
+}
+
+interface MarqueeBox {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface TerminalRowProps {
+  term: TerminalInstance;
+  listeners: React.HTMLAttributes<HTMLElement> | undefined;
+  onClick: (term: TerminalInstance, e: React.MouseEvent) => void;
+}
+
+function TerminalRow({ term, listeners, onClick }: TerminalRowProps) {
+  const isArmed = useFleetArmingStore((s) => s.armedIds.has(term.id));
+  const armBadge = useFleetArmingStore((s) => s.armOrderById[term.id]);
+
+  return (
+    <div
+      data-terminal-id={term.id}
+      className={cn(
+        "rounded-[var(--radius-md)]",
+        isArmed &&
+          "bg-daintree-accent/5 outline outline-2 outline-daintree-accent/70 outline-offset-[-2px]"
+      )}
+    >
+      <div className="worktree-section-button group/termrow flex items-center justify-between gap-2.5 px-3 py-2 transition-colors">
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick(term, e);
+          }}
+          aria-selected={isArmed}
+          className="flex items-center gap-2 min-w-0 flex-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px] rounded"
+        >
+          <div className="shrink-0 opacity-60 group-hover/termrow:opacity-100 transition-opacity">
+            <TerminalIcon
+              type={term.type}
+              kind={term.kind}
+              agentId={term.agentId}
+              detectedProcessId={term.detectedProcessId}
+              className="w-3 h-3"
+            />
+          </div>
+          <div className="flex flex-col min-w-0">
+            <span className="truncate text-xs font-medium text-text-secondary transition-colors group-hover/termrow:text-daintree-text">
+              {term.title}
+            </span>
+            {term.type === "terminal" && term.agentState === "running" && term.lastCommand && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="truncate text-[11px] font-mono text-text-muted">
+                    {term.lastCommand}
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{term.lastCommand}</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </button>
+
+        <div className="flex items-center gap-2.5 shrink-0">
+          {isArmed && armBadge !== undefined && (
+            <span
+              className="inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-daintree-accent px-1 text-[9px] font-mono font-semibold text-[var(--color-daintree-bg)] tabular-nums"
+              aria-label={`Armed position ${armBadge}`}
+            >
+              {armBadge}
+            </span>
+          )}
+
+          {term.agentState &&
+            term.agentState !== "idle" &&
+            (() => {
+              const Icon = getEffectiveStateIcon(term.agentState, term.waitingReason);
+              return (
+                <Icon
+                  className={cn(
+                    "w-3 h-3",
+                    getEffectiveStateColor(term.agentState, term.waitingReason),
+                    term.agentState === "working" && "animate-spin-slow motion-reduce:animate-none"
+                  )}
+                  aria-label={STATE_LABELS[term.agentState]}
+                />
+              );
+            })()}
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="text-text-muted transition-colors group-hover/termrow:text-text-secondary">
+                {term.location === "dock" ? (
+                  <PanelBottom className="w-3 h-3" />
+                ) : (
+                  <MoveToGridIcon className="w-3 h-3" />
+                )}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              {term.location === "dock" ? "Docked" : "On Grid"}
+            </TooltipContent>
+          </Tooltip>
+
+          <button
+            type="button"
+            className="cursor-grab rounded text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
+            aria-label="Drag to move terminal"
+            {...(listeners as React.HTMLAttributes<HTMLElement>)}
+          >
+            <GripVertical className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -102,6 +220,123 @@ export function WorktreeTerminalSection({
   }, [terminals]);
 
   const orderedWorktreeTerminals = terminals;
+  const eligibleTerminalsRef = useRef<TerminalInstance[]>([]);
+  eligibleTerminalsRef.current = orderedWorktreeTerminals.filter(isFleetArmEligible);
+
+  const handleTerminalClick = useCallback(
+    (term: TerminalInstance, e: React.MouseEvent) => {
+      if (!isFleetArmEligible(term)) {
+        onTerminalSelect(term);
+        return;
+      }
+      const store = useFleetArmingStore.getState();
+      if (e.shiftKey) {
+        const orderedEligibleIds = eligibleTerminalsRef.current.map((t) => t.id);
+        store.extendTo(term.id, orderedEligibleIds);
+      } else {
+        store.toggleId(term.id);
+      }
+    },
+    [onTerminalSelect]
+  );
+
+  const marqueeStartRef = useRef<{ x: number; y: number; pointerId: number } | null>(null);
+  const tileRectsRef = useRef<Map<string, DOMRect>>(new Map());
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [marqueeBox, setMarqueeBox] = useState<MarqueeBox | null>(null);
+
+  const snapshotRects = useCallback(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const nodes = container.querySelectorAll<HTMLElement>("[data-terminal-id]");
+    const rects = new Map<string, DOMRect>();
+    nodes.forEach((el) => {
+      const id = el.dataset.terminalId;
+      if (id) rects.set(id, el.getBoundingClientRect());
+    });
+    tileRectsRef.current = rects;
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      const target = e.target as Element;
+      if (target.closest("[data-sortable-tile]")) return;
+      if (target.closest("button")) return;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      marqueeStartRef.current = { x: e.clientX, y: e.clientY, pointerId: e.pointerId };
+      snapshotRects();
+    },
+    [snapshotRects]
+  );
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const start = marqueeStartRef.current;
+    if (!start) return;
+    const container = scrollRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const x = Math.min(start.x, e.clientX) - rect.left + container.scrollLeft;
+    const y = Math.min(start.y, e.clientY) - rect.top + container.scrollTop;
+    const w = Math.abs(e.clientX - start.x);
+    const h = Math.abs(e.clientY - start.y);
+    if (w < 2 && h < 2) return;
+    setMarqueeBox({ x, y, w, h });
+  }, []);
+
+  const commitMarquee = useCallback(
+    (endX: number, endY: number) => {
+      const start = marqueeStartRef.current;
+      if (!start) return;
+      const left = Math.min(start.x, endX);
+      const right = Math.max(start.x, endX);
+      const top = Math.min(start.y, endY);
+      const bottom = Math.max(start.y, endY);
+      const hits: string[] = [];
+      for (const [id, r] of tileRectsRef.current) {
+        if (r.right < left || r.left > right || r.bottom < top || r.top > bottom) continue;
+        hits.push(id);
+      }
+      if (hits.length > 0) {
+        const eligible = new Set(eligibleTerminalsRef.current.map((t) => t.id));
+        const orderedHits = orderedWorktreeTerminals
+          .map((t) => t.id)
+          .filter((id) => hits.includes(id) && eligible.has(id));
+        if (orderedHits.length > 0) {
+          useFleetArmingStore.getState().armIds(orderedHits);
+        }
+      }
+    },
+    [orderedWorktreeTerminals]
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      const start = marqueeStartRef.current;
+      if (!start) return;
+      try {
+        e.currentTarget.releasePointerCapture(start.pointerId);
+      } catch {
+        // capture may already be released
+      }
+      commitMarquee(e.clientX, e.clientY);
+      marqueeStartRef.current = null;
+      setMarqueeBox(null);
+    },
+    [commitMarquee]
+  );
+
+  const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const start = marqueeStartRef.current;
+    if (!start) return;
+    try {
+      e.currentTarget.releasePointerCapture(start.pointerId);
+    } catch {
+      // ignore
+    }
+    marqueeStartRef.current = null;
+    setMarqueeBox(null);
+  }, []);
 
   if (!showMetaFooter) {
     return null;
@@ -138,9 +373,15 @@ export function WorktreeTerminalSection({
           >
             <div
               id={terminalsPanelId}
+              ref={scrollRef}
               role="list"
               aria-labelledby={`${terminalsId}-button`}
-              className="max-h-[300px] overflow-y-auto bg-surface-inset"
+              aria-multiselectable="true"
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+              className="relative max-h-[300px] overflow-y-auto bg-surface-inset"
             >
               {orderedWorktreeTerminals.map((term, index) => (
                 <SortableWorktreeTerminal
@@ -150,89 +391,26 @@ export function WorktreeTerminalSection({
                   sourceIndex={index}
                 >
                   {({ listeners }) => (
-                    <div className="worktree-section-button group/termrow flex items-center justify-between gap-2.5 px-3 py-2 transition-colors">
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onTerminalSelect(term);
-                        }}
-                        className="flex items-center gap-2 min-w-0 flex-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px] rounded"
-                      >
-                        <div className="shrink-0 opacity-60 group-hover/termrow:opacity-100 transition-opacity">
-                          <TerminalIcon
-                            type={term.type}
-                            kind={term.kind}
-                            agentId={term.agentId}
-                            detectedProcessId={term.detectedProcessId}
-                            className="w-3 h-3"
-                          />
-                        </div>
-                        <div className="flex flex-col min-w-0">
-                          <span className="truncate text-xs font-medium text-text-secondary transition-colors group-hover/termrow:text-daintree-text">
-                            {term.title}
-                          </span>
-                          {term.type === "terminal" &&
-                            term.agentState === "running" &&
-                            term.lastCommand && (
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span className="truncate text-[11px] font-mono text-text-muted">
-                                    {term.lastCommand}
-                                  </span>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom">{term.lastCommand}</TooltipContent>
-                              </Tooltip>
-                            )}
-                        </div>
-                      </button>
-
-                      <div className="flex items-center gap-2.5 shrink-0">
-                        {term.agentState &&
-                          term.agentState !== "idle" &&
-                          (() => {
-                            const Icon = getEffectiveStateIcon(term.agentState, term.waitingReason);
-                            return (
-                              <Icon
-                                className={cn(
-                                  "w-3 h-3",
-                                  getEffectiveStateColor(term.agentState, term.waitingReason),
-                                  term.agentState === "working" &&
-                                    "animate-spin-slow motion-reduce:animate-none"
-                                )}
-                                aria-label={STATE_LABELS[term.agentState]}
-                              />
-                            );
-                          })()}
-
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <div className="text-text-muted transition-colors group-hover/termrow:text-text-secondary">
-                              {term.location === "dock" ? (
-                                <PanelBottom className="w-3 h-3" />
-                              ) : (
-                                <MoveToGridIcon className="w-3 h-3" />
-                              )}
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            {term.location === "dock" ? "Docked" : "On Grid"}
-                          </TooltipContent>
-                        </Tooltip>
-
-                        <button
-                          type="button"
-                          className="cursor-grab rounded text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
-                          aria-label="Drag to move terminal"
-                          {...listeners}
-                        >
-                          <GripVertical className="w-3.5 h-3.5" />
-                        </button>
-                      </div>
-                    </div>
+                    <TerminalRow
+                      term={term}
+                      listeners={listeners as React.HTMLAttributes<HTMLElement> | undefined}
+                      onClick={handleTerminalClick}
+                    />
                   )}
                 </SortableWorktreeTerminal>
               ))}
+              {marqueeBox && (
+                <div
+                  aria-hidden
+                  className="pointer-events-none absolute z-10 rounded border border-daintree-accent/60 bg-daintree-accent/10"
+                  style={{
+                    left: marqueeBox.x,
+                    top: marqueeBox.y,
+                    width: marqueeBox.w,
+                    height: marqueeBox.h,
+                  }}
+                />
+              )}
             </div>
           </SortableContext>
         </>

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import {
   WorktreeTerminalSection,
@@ -10,6 +10,7 @@ import {
 } from "../WorktreeTerminalSection";
 import type { TerminalInstance } from "@/store/panelStore";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
 
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
@@ -163,5 +164,118 @@ describe("WorktreeTerminalSection summary icon", () => {
     const icon = screen.getByTestId("agent-icon");
     expect(icon.getAttribute("brandColor")).toBeNull();
     expect(icon.getAttribute("style")).toBeNull();
+  });
+});
+
+describe("WorktreeTerminalSection arming click handlers", () => {
+  beforeEach(() => {
+    useFleetArmingStore.setState({
+      armedIds: new Set<string>(),
+      armOrder: [],
+      armOrderById: {},
+      lastArmedId: null,
+    });
+  });
+
+  it("plain click on an eligible agent tile arms it", () => {
+    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const onSelect = vi.fn();
+    renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+      onTerminalSelect: onSelect,
+    });
+
+    // The row button renders "Test Terminal" as the title
+    const button = screen.getAllByRole("button", { name: /Test Terminal/i })[0];
+    fireEvent.click(button);
+
+    expect(useFleetArmingStore.getState().armedIds.has("a1")).toBe(true);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("shift-click extends the armed range from lastArmedId", () => {
+    const t1 = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const t2 = makeTerminal({ id: "a2", agentId: "claude", kind: "agent", hasPty: true });
+    const t3 = makeTerminal({ id: "a3", agentId: "claude", kind: "agent", hasPty: true });
+    renderSection({
+      isExpanded: true,
+      terminals: [t1, t2, t3],
+      counts: { ...baseCounts, total: 3 },
+    });
+
+    const buttons = screen.getAllByRole("button", { name: /Test Terminal/i });
+    fireEvent.click(buttons[0]); // arm a1 — becomes anchor
+    fireEvent.click(buttons[2], { shiftKey: true }); // extend to a3
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect([...armed].sort()).toEqual(["a1", "a2", "a3"]);
+  });
+
+  it("cmd-click (metaKey) toggles the armed state without clearing others", () => {
+    const t1 = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const t2 = makeTerminal({ id: "a2", agentId: "claude", kind: "agent", hasPty: true });
+    renderSection({
+      isExpanded: true,
+      terminals: [t1, t2],
+      counts: { ...baseCounts, total: 2 },
+    });
+
+    const buttons = screen.getAllByRole("button", { name: /Test Terminal/i });
+    fireEvent.click(buttons[0]); // arm a1
+    fireEvent.click(buttons[1], { metaKey: true }); // cmd+click a2 — also arms
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect([...armed].sort()).toEqual(["a1", "a2"]);
+  });
+
+  it("click on non-eligible tile calls onTerminalSelect (legacy)", () => {
+    const nonAgent = makeTerminal({
+      id: "p1",
+      kind: "terminal",
+      agentId: undefined,
+      hasPty: true,
+    });
+    const onSelect = vi.fn();
+    renderSection({
+      isExpanded: true,
+      terminals: [nonAgent],
+      counts: { ...baseCounts, total: 1 },
+      onTerminalSelect: onSelect,
+    });
+
+    const button = screen.getAllByRole("button", { name: /Test Terminal/i })[0];
+    fireEvent.click(button);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+  });
+
+  it("armed tile gets aria-selected=true", () => {
+    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+    act(() => {
+      useFleetArmingStore.getState().armId("a1");
+    });
+
+    const button = screen.getAllByRole("button", { name: /Test Terminal/i })[0];
+    expect(button.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("scroll container has aria-multiselectable", () => {
+    const term = makeTerminal({ id: "a1", agentId: "claude", kind: "agent", hasPty: true });
+    const { container } = renderSection({
+      isExpanded: true,
+      terminals: [term],
+      counts: { ...baseCounts, total: 1 },
+    });
+
+    const scrollContainer = container.querySelector('[aria-multiselectable="true"]');
+    expect(scrollContainer).toBeTruthy();
   });
 });

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -202,7 +202,9 @@ export function registerTerminalInputActions(
     argsSchema: z.object({ terminalId: z.string() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId: string };
-      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      const terminal = usePanelStore.getState().panelsById[terminalId];
+      const { useFleetArmingStore, isFleetArmEligible } = await import("@/store/fleetArmingStore");
+      if (!isFleetArmEligible(terminal)) return;
       useFleetArmingStore.getState().armId(terminalId);
     },
   }));

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -190,4 +190,108 @@ export function registerTerminalInputActions(
       openSendToAgentPalette(sourceId);
     },
   }));
+
+  actions.set("terminal.arm", () => ({
+    id: "terminal.arm",
+    title: "Arm Terminal",
+    description: "Add a terminal to the fleet arming set",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string() }),
+    run: async (args: unknown) => {
+      const { terminalId } = args as { terminalId: string };
+      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      useFleetArmingStore.getState().armId(terminalId);
+    },
+  }));
+
+  actions.set("terminal.disarm", () => ({
+    id: "terminal.disarm",
+    title: "Disarm Terminal",
+    description: "Remove a terminal from the fleet arming set",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string() }),
+    run: async (args: unknown) => {
+      const { terminalId } = args as { terminalId: string };
+      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      useFleetArmingStore.getState().disarmId(terminalId);
+    },
+  }));
+
+  actions.set("terminal.disarmAll", () => ({
+    id: "terminal.disarmAll",
+    title: "Disarm All",
+    description: "Clear the fleet arming set",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      useFleetArmingStore.getState().clear();
+    },
+  }));
+
+  actions.set("terminal.armByState", () => ({
+    id: "terminal.armByState",
+    title: "Arm by State",
+    description: "Arm all eligible agent terminals in a given state",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({
+      state: z.enum(["working", "waiting", "finished"]),
+      scope: z.enum(["current", "all"]).optional(),
+      extend: z.boolean().optional(),
+    }),
+    run: async (args: unknown) => {
+      const {
+        state,
+        scope = "current",
+        extend = false,
+      } = args as {
+        state: "working" | "waiting" | "finished";
+        scope?: "current" | "all";
+        extend?: boolean;
+      };
+      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      useFleetArmingStore.getState().armByState(state, scope, extend);
+    },
+  }));
+
+  actions.set("terminal.armAll", () => ({
+    id: "terminal.armAll",
+    title: "Arm All Eligible",
+    description: "Arm every eligible agent terminal",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ scope: z.enum(["current", "all"]).optional() }).optional(),
+    run: async (args: unknown) => {
+      const { scope = "current" } = (args ?? {}) as { scope?: "current" | "all" };
+      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      useFleetArmingStore.getState().armAll(scope);
+    },
+  }));
+
+  actions.set("terminal.armDefault", () => ({
+    id: "terminal.armDefault",
+    title: "Arm Current Worktree",
+    description: "Arm all eligible agent terminals in the active worktree",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+      useFleetArmingStore.getState().armAll("current");
+    },
+  }));
 }

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -341,6 +341,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     description: "Arm all eligible agents in the current worktree",
     category: "Terminal",
   },
+  {
+    actionId: "terminal.bulkCommand",
+    combo: "Cmd+Alt+Shift+B",
+    scope: "global",
+    priority: 0,
+    description: "Open Bulk Operations",
+    category: "Terminal",
+  },
   // Directional terminal navigation (Ghostty-style: Cmd+Option+Arrow)
   {
     actionId: "terminal.focusUp",

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -334,11 +334,11 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Terminal",
   },
   {
-    actionId: "terminal.bulkCommand",
+    actionId: "terminal.armDefault",
     combo: "Cmd+Shift+B",
     scope: "global",
     priority: 0,
-    description: "Open Bulk Operations",
+    description: "Arm all eligible agents in the current worktree",
     category: "Terminal",
   },
   // Directional terminal navigation (Ghostty-style: Cmd+Option+Arrow)

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -206,6 +206,16 @@ describe("fleetArmingStore", () => {
       expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["t1", "t2", "t3"]);
     });
 
+    it("extend=true preserves lastArmedId when all matches are already armed", () => {
+      // Arm t3 (waiting) as anchor, then arm both working matches
+      useFleetArmingStore.getState().armId("t3");
+      useFleetArmingStore.getState().armByState("working", "current", true);
+      // lastArmedId moved to t2 (last newly added). Extend again with all
+      // matches already armed — anchor must not slide.
+      useFleetArmingStore.getState().armByState("working", "current", true);
+      expect(useFleetArmingStore.getState().lastArmedId).toBe("t2");
+    });
+
     it("excludes trash/background/hasPty=false panels", () => {
       seedPanels([
         makeAgentTerminal("t1", { agentState: "working" }),

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useFleetArmingStore, isFleetArmEligible } from "../fleetArmingStore";
+import { usePanelStore } from "../panelStore";
+import { useWorktreeSelectionStore } from "../worktreeStore";
+import type { TerminalInstance } from "@shared/types";
+
+function resetStore() {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+}
+
+function makeAgentTerminal(
+  id: string,
+  overrides: Partial<TerminalInstance> = {}
+): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+    ...(overrides as object),
+  } as TerminalInstance;
+}
+
+function seedPanels(terminals: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
+}
+
+describe("fleetArmingStore", () => {
+  beforeEach(() => {
+    resetStore();
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    seedPanels([]);
+  });
+
+  describe("armId / disarmId / toggleId", () => {
+    it("arms a single id and records order and last armed", () => {
+      useFleetArmingStore.getState().armId("a");
+      const s = useFleetArmingStore.getState();
+      expect(s.armedIds.has("a")).toBe(true);
+      expect(s.armOrder).toEqual(["a"]);
+      expect(s.armOrderById).toEqual({ a: 1 });
+      expect(s.lastArmedId).toBe("a");
+    });
+
+    it("is idempotent when arming the same id twice", () => {
+      useFleetArmingStore.getState().armId("a");
+      useFleetArmingStore.getState().armId("a");
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a"]);
+      expect(s.armOrderById).toEqual({ a: 1 });
+      expect(s.lastArmedId).toBe("a");
+    });
+
+    it("arms multiple ids in insertion order with 1-based badges", () => {
+      const { armId } = useFleetArmingStore.getState();
+      armId("a");
+      armId("b");
+      armId("c");
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a", "b", "c"]);
+      expect(s.armOrderById).toEqual({ a: 1, b: 2, c: 3 });
+    });
+
+    it("disarms and renumbers badges", () => {
+      const { armId, disarmId } = useFleetArmingStore.getState();
+      armId("a");
+      armId("b");
+      armId("c");
+      disarmId("b");
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a", "c"]);
+      expect(s.armOrderById).toEqual({ a: 1, c: 2 });
+      expect(s.armedIds.has("b")).toBe(false);
+    });
+
+    it("disarm of unknown id is a no-op", () => {
+      useFleetArmingStore.getState().armId("a");
+      useFleetArmingStore.getState().disarmId("nope");
+      expect(useFleetArmingStore.getState().armOrder).toEqual(["a"]);
+    });
+
+    it("disarming lastArmedId moves lastArmedId to the previous entry", () => {
+      const { armId, disarmId } = useFleetArmingStore.getState();
+      armId("a");
+      armId("b");
+      disarmId("b");
+      expect(useFleetArmingStore.getState().lastArmedId).toBe("a");
+    });
+
+    it("toggleId flips membership", () => {
+      const { toggleId } = useFleetArmingStore.getState();
+      toggleId("a");
+      expect(useFleetArmingStore.getState().armedIds.has("a")).toBe(true);
+      toggleId("a");
+      expect(useFleetArmingStore.getState().armedIds.has("a")).toBe(false);
+    });
+  });
+
+  describe("armIds (batch replace)", () => {
+    it("replaces armed set and dedupes", () => {
+      useFleetArmingStore.getState().armId("x");
+      useFleetArmingStore.getState().armIds(["a", "b", "a", "c"]);
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a", "b", "c"]);
+      expect(s.armedIds.has("x")).toBe(false);
+      expect(s.lastArmedId).toBe("c");
+    });
+
+    it("empty batch clears the set", () => {
+      useFleetArmingStore.getState().armId("a");
+      useFleetArmingStore.getState().armIds([]);
+      expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+      expect(useFleetArmingStore.getState().lastArmedId).toBeNull();
+    });
+  });
+
+  describe("extendTo", () => {
+    it("arms the range from lastArmedId to target, inclusive", () => {
+      const ordered = ["a", "b", "c", "d", "e"];
+      useFleetArmingStore.getState().armId("b");
+      useFleetArmingStore.getState().extendTo("d", ordered);
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds].sort()).toEqual(["b", "c", "d"]);
+      expect(s.lastArmedId).toBe("d");
+    });
+
+    it("extends backward when target precedes anchor", () => {
+      const ordered = ["a", "b", "c", "d"];
+      useFleetArmingStore.getState().armId("c");
+      useFleetArmingStore.getState().extendTo("a", ordered);
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds].sort()).toEqual(["a", "b", "c"]);
+    });
+
+    it("falls back to arming just the target if anchor is unknown", () => {
+      const ordered = ["a", "b", "c"];
+      // No prior armId — lastArmedId is null
+      useFleetArmingStore.getState().extendTo("b", ordered);
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds]).toEqual(["b"]);
+    });
+
+    it("falls back to arming just the target if target is not in ordered list", () => {
+      useFleetArmingStore.getState().armId("a");
+      useFleetArmingStore.getState().extendTo("x", ["a", "b", "c"]);
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds].sort()).toEqual(["a", "x"]);
+    });
+  });
+
+  describe("armByState", () => {
+    beforeEach(() => {
+      seedPanels([
+        makeAgentTerminal("t1", { agentState: "working" }),
+        makeAgentTerminal("t2", { agentState: "running" }),
+        makeAgentTerminal("t3", { agentState: "waiting" }),
+        makeAgentTerminal("t4", { agentState: "completed" }),
+        makeAgentTerminal("t5", { agentState: "exited" }),
+        makeAgentTerminal("t6", { agentState: "idle" }),
+        makeAgentTerminal("t7", { agentState: "working", worktreeId: "wt-2" }),
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    });
+
+    it("arms working+running for 'working' preset in current scope", () => {
+      useFleetArmingStore.getState().armByState("working", "current", false);
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds].sort()).toEqual(["t1", "t2"]);
+    });
+
+    it("arms only 'waiting' agents for 'waiting' preset", () => {
+      useFleetArmingStore.getState().armByState("waiting", "current", false);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["t3"]);
+    });
+
+    it("arms completed+exited for 'finished' preset", () => {
+      useFleetArmingStore.getState().armByState("finished", "current", false);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["t4", "t5"]);
+    });
+
+    it("scope 'all' includes other worktrees", () => {
+      useFleetArmingStore.getState().armByState("working", "all", false);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["t1", "t2", "t7"]);
+    });
+
+    it("extend=true unions with existing armed set", () => {
+      useFleetArmingStore.getState().armId("t3");
+      useFleetArmingStore.getState().armByState("working", "current", true);
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("excludes trash/background/hasPty=false panels", () => {
+      seedPanels([
+        makeAgentTerminal("t1", { agentState: "working" }),
+        makeAgentTerminal("t2", { agentState: "working", location: "trash" }),
+        makeAgentTerminal("t3", { agentState: "working", location: "background" }),
+        makeAgentTerminal("t4", { agentState: "working", hasPty: false }),
+      ]);
+      useFleetArmingStore.getState().armByState("working", "current", false);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["t1"]);
+    });
+
+    it("excludes non-agent panels", () => {
+      seedPanels([
+        makeAgentTerminal("a1", { agentState: "working" }),
+        makeAgentTerminal("p1", { agentState: "working", kind: "terminal", agentId: undefined }),
+      ]);
+      useFleetArmingStore.getState().armByState("working", "current", false);
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a1"]);
+    });
+  });
+
+  describe("armAll", () => {
+    it("arms all eligible in current worktree", () => {
+      seedPanels([
+        makeAgentTerminal("a1"),
+        makeAgentTerminal("a2"),
+        makeAgentTerminal("a3", { worktreeId: "wt-2" }),
+      ]);
+      useFleetArmingStore.getState().armAll("current");
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
+    });
+
+    it("scope 'all' arms across worktrees", () => {
+      seedPanels([makeAgentTerminal("a1"), makeAgentTerminal("a2", { worktreeId: "wt-2" })]);
+      useFleetArmingStore.getState().armAll("all");
+      expect([...useFleetArmingStore.getState().armedIds].sort()).toEqual(["a1", "a2"]);
+    });
+  });
+
+  describe("clear", () => {
+    it("resets to empty state", () => {
+      useFleetArmingStore.getState().armId("a");
+      useFleetArmingStore.getState().armId("b");
+      useFleetArmingStore.getState().clear();
+      const s = useFleetArmingStore.getState();
+      expect(s.armedIds.size).toBe(0);
+      expect(s.armOrder).toEqual([]);
+      expect(s.armOrderById).toEqual({});
+      expect(s.lastArmedId).toBeNull();
+    });
+
+    it("is idempotent on repeated clear", () => {
+      useFleetArmingStore.getState().clear();
+      useFleetArmingStore.getState().clear();
+      expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
+    });
+  });
+
+  describe("prune", () => {
+    it("drops ids not in validIds and renumbers badges", () => {
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      useFleetArmingStore.getState().prune(new Set(["a", "c"]));
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder).toEqual(["a", "c"]);
+      expect(s.armOrderById).toEqual({ a: 1, c: 2 });
+    });
+
+    it("preserves lastArmedId if it survives prune", () => {
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      useFleetArmingStore.getState().prune(new Set(["a", "b"]));
+      expect(useFleetArmingStore.getState().lastArmedId).toBe("b");
+    });
+
+    it("resets lastArmedId to tail when the previous lastArmedId is pruned", () => {
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      useFleetArmingStore.getState().prune(new Set(["a"]));
+      expect(useFleetArmingStore.getState().lastArmedId).toBe("a");
+    });
+
+    it("is a no-op when all ids are valid", () => {
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      const before = useFleetArmingStore.getState();
+      useFleetArmingStore.getState().prune(new Set(["a", "b", "c"]));
+      expect(useFleetArmingStore.getState()).toEqual(before);
+    });
+  });
+
+  describe("isFleetArmEligible", () => {
+    it("returns true for a non-trash non-background agent with pty", () => {
+      expect(isFleetArmEligible(makeAgentTerminal("a"))).toBe(true);
+    });
+
+    it("rejects trashed terminals", () => {
+      expect(isFleetArmEligible(makeAgentTerminal("a", { location: "trash" }))).toBe(false);
+    });
+
+    it("rejects background terminals", () => {
+      expect(isFleetArmEligible(makeAgentTerminal("a", { location: "background" }))).toBe(false);
+    });
+
+    it("rejects hasPty=false terminals", () => {
+      expect(isFleetArmEligible(makeAgentTerminal("a", { hasPty: false }))).toBe(false);
+    });
+
+    it("rejects non-agent terminals", () => {
+      expect(
+        isFleetArmEligible(makeAgentTerminal("a", { kind: "terminal", agentId: undefined }))
+      ).toBe(false);
+    });
+
+    it("rejects undefined", () => {
+      expect(isFleetArmEligible(undefined)).toBe(false);
+    });
+  });
+
+  describe("panel prune subscription", () => {
+    it("drops armed ids when a panel is removed from panelStore", () => {
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b"), makeAgentTerminal("c")]);
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+
+      // Simulate removal of 'b'
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("c")]);
+
+      const s = useFleetArmingStore.getState();
+      expect([...s.armedIds].sort()).toEqual(["a", "c"]);
+    });
+
+    it("drops armed ids when a panel transitions to trash", () => {
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b")]);
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+
+      seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b", { location: "trash" })]);
+
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual(["a"]);
+    });
+  });
+});

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -384,3 +384,45 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
     expect(outgoing.activeWorktreeId).toBe("wt-early");
   });
 });
+
+describe("fleet arming clear on project switch (#5298)", () => {
+  it("invokes the registered fleet-arming clear callback before the IPC call", async () => {
+    const { useProjectStore, setFleetArmingClear } = await import("../projectStore");
+    const clearSpy = vi.fn();
+    setFleetArmingClear(clearSpy);
+
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    // Sanity: not called before switch
+    expect(clearSpy).not.toHaveBeenCalled();
+
+    await useProjectStore.getState().switchProject(projectB.id);
+
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+    // Called before the fire-and-forget IPC
+    const clearOrder = clearSpy.mock.invocationCallOrder[0];
+    const switchOrder = projectClientMock.switch.mock.invocationCallOrder[0];
+    expect(clearOrder).toBeLessThan(switchOrder);
+  });
+
+  it("does not throw when the callback is a no-op", async () => {
+    const { useProjectStore, setFleetArmingClear } = await import("../projectStore");
+    setFleetArmingClear(() => {});
+
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await expect(useProjectStore.getState().switchProject(projectB.id)).resolves.not.toThrow();
+  });
+
+  it("does not invoke clear when switching to the current project (early return)", async () => {
+    const { useProjectStore, setFleetArmingClear } = await import("../projectStore");
+    const clearSpy = vi.fn();
+    setFleetArmingClear(clearSpy);
+
+    useProjectStore.setState({ projects: [projectA], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectA.id);
+
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -184,17 +184,20 @@ export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
       set((s) => {
         const nextArmed = new Set(s.armedIds);
         const nextOrder = [...s.armOrder];
+        let lastAdded: string | null = null;
         for (const id of ids) {
           if (!nextArmed.has(id)) {
             nextArmed.add(id);
             nextOrder.push(id);
+            lastAdded = id;
           }
         }
+        if (lastAdded === null) return {};
         return {
           armedIds: nextArmed,
           armOrder: nextOrder,
           armOrderById: rebuildOrderById(nextOrder),
-          lastArmedId: ids[ids.length - 1] ?? s.lastArmedId,
+          lastArmedId: lastAdded,
         };
       });
     } else {
@@ -253,43 +256,64 @@ setFleetArmingClear(() => {
 
 /**
  * Module-scope subscription: when panels are removed, relocated to trash/background,
- * or become ineligible, prune them from the armed set. This is a store-lifetime
- * subscription — it exists once per module instance (once per WebContentsView).
+ * or become ineligible, prune them from the armed set.
+ *
+ * HMR and test re-imports would otherwise stack subscribers on every module
+ * reload. We store registration state on `globalThis` so a subsequent module
+ * instance reuses the existing subscription but drives the *current* store —
+ * mirroring the pattern in `projectStore.ts`.
  */
-if (typeof usePanelStore.subscribe === "function") {
-  let lastSnapshot: {
-    ids: string[];
-    panelsById: Record<string, TerminalInstance>;
-  } = {
-    ids: usePanelStore.getState().panelIds,
-    panelsById: usePanelStore.getState().panelsById,
+interface FleetArmingSubscriptionState {
+  registered: boolean;
+  lastSnapshot: { ids: string[]; panelsById: Record<string, TerminalInstance> } | null;
+}
+
+const FLEET_ARMING_SUBSCRIPTION_KEY = "__daintreeFleetArmingSubscription";
+
+function getFleetArmingSubscriptionState(): FleetArmingSubscriptionState {
+  const target = globalThis as typeof globalThis & {
+    [FLEET_ARMING_SUBSCRIPTION_KEY]?: FleetArmingSubscriptionState;
   };
+  const existing = target[FLEET_ARMING_SUBSCRIPTION_KEY];
+  if (existing) return existing;
+  const created: FleetArmingSubscriptionState = { registered: false, lastSnapshot: null };
+  target[FLEET_ARMING_SUBSCRIPTION_KEY] = created;
+  return created;
+}
 
-  usePanelStore.subscribe((state) => {
-    const prev = lastSnapshot;
-    const currentIds = state.panelIds;
-    const currentById = state.panelsById;
+if (typeof usePanelStore.subscribe === "function") {
+  const subState = getFleetArmingSubscriptionState();
+  if (!subState.registered) {
+    subState.registered = true;
+    subState.lastSnapshot = {
+      ids: usePanelStore.getState().panelIds,
+      panelsById: usePanelStore.getState().panelsById,
+    };
 
-    // Fast path: if neither the ids array nor panelsById reference changed, skip.
-    if (currentIds === prev.ids && currentById === prev.panelsById) return;
+    usePanelStore.subscribe((state) => {
+      const prev = subState.lastSnapshot;
+      const currentIds = state.panelIds;
+      const currentById = state.panelsById;
 
-    lastSnapshot = { ids: currentIds, panelsById: currentById };
+      if (prev && currentIds === prev.ids && currentById === prev.panelsById) return;
 
-    const armed = useFleetArmingStore.getState().armedIds;
-    if (armed.size === 0) return;
+      subState.lastSnapshot = { ids: currentIds, panelsById: currentById };
 
-    const validIds = new Set<string>();
-    for (const id of currentIds) {
-      const t = currentById[id];
-      if (isFleetArmEligible(t)) validIds.add(id);
-    }
+      const armed = useFleetArmingStore.getState().armedIds;
+      if (armed.size === 0) return;
 
-    // Only call prune if at least one armed id is now invalid.
-    for (const id of armed) {
-      if (!validIds.has(id)) {
-        useFleetArmingStore.getState().prune(validIds);
-        return;
+      const validIds = new Set<string>();
+      for (const id of currentIds) {
+        const t = currentById[id];
+        if (isFleetArmEligible(t)) validIds.add(id);
       }
-    }
-  });
+
+      for (const id of armed) {
+        if (!validIds.has(id)) {
+          useFleetArmingStore.getState().prune(validIds);
+          return;
+        }
+      }
+    });
+  }
 }

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -1,0 +1,295 @@
+import { create } from "zustand";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { setFleetArmingClear } from "@/store/projectStore";
+import { isAgentTerminal } from "@/utils/terminalType";
+import type { TerminalInstance } from "@shared/types";
+import type { AgentState } from "@/types";
+
+export type FleetArmStatePreset = "working" | "waiting" | "finished";
+export type FleetArmScope = "current" | "all";
+
+interface FleetArmingState {
+  armedIds: Set<string>;
+  armOrder: string[];
+  armOrderById: Record<string, number>;
+  lastArmedId: string | null;
+
+  armId: (id: string) => void;
+  disarmId: (id: string) => void;
+  toggleId: (id: string) => void;
+  armIds: (ids: string[]) => void;
+  extendTo: (id: string, orderedEligibleIds: string[]) => void;
+  armByState: (state: FleetArmStatePreset, scope: FleetArmScope, extend: boolean) => void;
+  armAll: (scope: FleetArmScope) => void;
+  clear: () => void;
+  prune: (validIds: Set<string>) => void;
+}
+
+function rebuildOrderById(order: string[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (let i = 0; i < order.length; i++) {
+    out[order[i]] = i + 1;
+  }
+  return out;
+}
+
+function matchesPreset(state: AgentState | null | undefined, preset: FleetArmStatePreset): boolean {
+  switch (preset) {
+    case "working":
+      return state === "working" || state === "running";
+    case "waiting":
+      return state === "waiting";
+    case "finished":
+      return state === "completed" || state === "exited";
+  }
+}
+
+export function isFleetArmEligible(t: TerminalInstance | undefined): boolean {
+  if (!t) return false;
+  if (t.location === "trash" || t.location === "background") return false;
+  if (t.hasPty === false) return false;
+  return isAgentTerminal(t.kind ?? t.type, t.agentId);
+}
+
+/**
+ * Collect eligible terminal ids, ordered by panelIds (DOM/sidebar order),
+ * optionally scoped to the currently active worktree.
+ */
+export function collectEligibleIds(
+  scope: FleetArmScope,
+  activeWorktreeId: string | null
+): string[] {
+  const state = usePanelStore.getState();
+  const ids: string[] = [];
+  for (const id of state.panelIds) {
+    const t = state.panelsById[id];
+    if (!isFleetArmEligible(t)) continue;
+    if (scope === "current") {
+      if (!activeWorktreeId || t.worktreeId !== activeWorktreeId) continue;
+    }
+    ids.push(id);
+  }
+  return ids;
+}
+
+export const useFleetArmingStore = create<FleetArmingState>()((set, get) => ({
+  armedIds: new Set<string>(),
+  armOrder: [],
+  armOrderById: {},
+  lastArmedId: null,
+
+  armId: (id) =>
+    set((s) => {
+      if (s.armedIds.has(id)) {
+        return { lastArmedId: id };
+      }
+      const nextArmed = new Set(s.armedIds);
+      nextArmed.add(id);
+      const nextOrder = [...s.armOrder, id];
+      return {
+        armedIds: nextArmed,
+        armOrder: nextOrder,
+        armOrderById: rebuildOrderById(nextOrder),
+        lastArmedId: id,
+      };
+    }),
+
+  disarmId: (id) =>
+    set((s) => {
+      if (!s.armedIds.has(id)) return {};
+      const nextArmed = new Set(s.armedIds);
+      nextArmed.delete(id);
+      const nextOrder = s.armOrder.filter((x) => x !== id);
+      const nextLast =
+        s.lastArmedId === id ? (nextOrder[nextOrder.length - 1] ?? null) : s.lastArmedId;
+      return {
+        armedIds: nextArmed,
+        armOrder: nextOrder,
+        armOrderById: rebuildOrderById(nextOrder),
+        lastArmedId: nextLast,
+      };
+    }),
+
+  toggleId: (id) => {
+    if (get().armedIds.has(id)) {
+      get().disarmId(id);
+    } else {
+      get().armId(id);
+    }
+  },
+
+  armIds: (ids) => {
+    const unique: string[] = [];
+    const seen = new Set<string>();
+    for (const id of ids) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        unique.push(id);
+      }
+    }
+    set({
+      armedIds: new Set(unique),
+      armOrder: unique,
+      armOrderById: rebuildOrderById(unique),
+      lastArmedId: unique[unique.length - 1] ?? null,
+    });
+  },
+
+  extendTo: (id, orderedEligibleIds) => {
+    const { lastArmedId } = get();
+    const anchor = lastArmedId ?? id;
+    const startIdx = orderedEligibleIds.indexOf(anchor);
+    const endIdx = orderedEligibleIds.indexOf(id);
+    if (startIdx === -1 || endIdx === -1) {
+      // Fall back to arming just the target
+      get().armId(id);
+      return;
+    }
+    const [lo, hi] = startIdx <= endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
+    const range = orderedEligibleIds.slice(lo, hi + 1);
+    set((s) => {
+      const nextArmed = new Set(s.armedIds);
+      const nextOrder = [...s.armOrder];
+      for (const rid of range) {
+        if (!nextArmed.has(rid)) {
+          nextArmed.add(rid);
+          nextOrder.push(rid);
+        }
+      }
+      return {
+        armedIds: nextArmed,
+        armOrder: nextOrder,
+        armOrderById: rebuildOrderById(nextOrder),
+        lastArmedId: id,
+      };
+    });
+  },
+
+  armByState: (preset, scope, extend) => {
+    const state = usePanelStore.getState();
+    const activeWorktreeId = getActiveWorktreeId();
+    const ids: string[] = [];
+    for (const id of state.panelIds) {
+      const t = state.panelsById[id];
+      if (!isFleetArmEligible(t)) continue;
+      if (scope === "current") {
+        if (!activeWorktreeId || t.worktreeId !== activeWorktreeId) continue;
+      }
+      if (matchesPreset(t.agentState ?? null, preset)) {
+        ids.push(id);
+      }
+    }
+    if (extend) {
+      set((s) => {
+        const nextArmed = new Set(s.armedIds);
+        const nextOrder = [...s.armOrder];
+        for (const id of ids) {
+          if (!nextArmed.has(id)) {
+            nextArmed.add(id);
+            nextOrder.push(id);
+          }
+        }
+        return {
+          armedIds: nextArmed,
+          armOrder: nextOrder,
+          armOrderById: rebuildOrderById(nextOrder),
+          lastArmedId: ids[ids.length - 1] ?? s.lastArmedId,
+        };
+      });
+    } else {
+      get().armIds(ids);
+    }
+  },
+
+  armAll: (scope) => {
+    const ids = collectEligibleIds(scope, getActiveWorktreeId());
+    get().armIds(ids);
+  },
+
+  clear: () =>
+    set({
+      armedIds: new Set<string>(),
+      armOrder: [],
+      armOrderById: {},
+      lastArmedId: null,
+    }),
+
+  prune: (validIds) =>
+    set((s) => {
+      let changed = false;
+      const nextOrder: string[] = [];
+      for (const id of s.armOrder) {
+        if (validIds.has(id)) {
+          nextOrder.push(id);
+        } else {
+          changed = true;
+        }
+      }
+      if (!changed) return {};
+      const nextArmed = new Set(nextOrder);
+      const nextLast =
+        s.lastArmedId && nextArmed.has(s.lastArmedId)
+          ? s.lastArmedId
+          : (nextOrder[nextOrder.length - 1] ?? null);
+      return {
+        armedIds: nextArmed,
+        armOrder: nextOrder,
+        armOrderById: rebuildOrderById(nextOrder),
+        lastArmedId: nextLast,
+      };
+    }),
+}));
+
+function getActiveWorktreeId(): string | null {
+  return useWorktreeSelectionStore.getState().activeWorktreeId ?? null;
+}
+
+// Register the clear callback so projectStore.switchProject() can drop armed
+// selections synchronously on project switch.
+setFleetArmingClear(() => {
+  useFleetArmingStore.getState().clear();
+});
+
+/**
+ * Module-scope subscription: when panels are removed, relocated to trash/background,
+ * or become ineligible, prune them from the armed set. This is a store-lifetime
+ * subscription — it exists once per module instance (once per WebContentsView).
+ */
+if (typeof usePanelStore.subscribe === "function") {
+  let lastSnapshot: {
+    ids: string[];
+    panelsById: Record<string, TerminalInstance>;
+  } = {
+    ids: usePanelStore.getState().panelIds,
+    panelsById: usePanelStore.getState().panelsById,
+  };
+
+  usePanelStore.subscribe((state) => {
+    const prev = lastSnapshot;
+    const currentIds = state.panelIds;
+    const currentById = state.panelsById;
+
+    // Fast path: if neither the ids array nor panelsById reference changed, skip.
+    if (currentIds === prev.ids && currentById === prev.panelsById) return;
+
+    lastSnapshot = { ids: currentIds, panelsById: currentById };
+
+    const armed = useFleetArmingStore.getState().armedIds;
+    if (armed.size === 0) return;
+
+    const validIds = new Set<string>();
+    for (const id of currentIds) {
+      const t = currentById[id];
+      if (isFleetArmEligible(t)) validIds.add(id);
+    }
+
+    // Only call prune if at least one armed id is now invalid.
+    for (const id of armed) {
+      if (!validIds.has(id)) {
+        useFleetArmingStore.getState().prune(validIds);
+        return;
+      }
+    }
+  });
+}

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -54,6 +54,15 @@ export function setWorktreeSelectionStoreGetter(
   _getWorktreeSelectionState = getter;
 }
 
+// Lazy reference to the fleet-arming store's clear() so a project switch can
+// drop armed selections synchronously before the WebContentsView gets detached.
+// Registered from fleetArmingStore at module init.
+let _clearFleetArming: (() => void) | null = null;
+
+export function setFleetArmingClear(callback: () => void): void {
+  _clearFleetArming = callback;
+}
+
 function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   const draftInputs = useTerminalInputStore.getState().getProjectDraftInputs(projectId);
   const activeWorktreeId = _getWorktreeSelectionState?.()?.activeWorktreeId ?? undefined;
@@ -336,6 +345,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   switchProject: async (projectId) => {
     if (get().currentProject?.id === projectId) return;
     const requestId = ++projectTransitionRequestId;
+
+    // Drop fleet arming selections synchronously — the outgoing view's armed
+    // set is project-scoped and must not leak if the view is later restored
+    // from the LRU cache.
+    _clearFleetArming?.();
 
     // Capture outgoing state before the renderer gets detached
     const currentProjectId = get().currentProject?.id;


### PR DESCRIPTION
## Summary

- Implements the arming selection primitive from #5298: click/Shift-click/Cmd-click/drag marquee to pre-select agent terminals, with a persistent ribbon showing the armed set and relevant shortcuts
- New `fleetArmingStore` (Zustand 5) with O(1) badge lookup via `armOrderById`, per-tile primitive selectors to avoid O(n) re-render cascades, and HMR-safe module-scope subscribe for pruning on trash/background transitions
- Six new actions registered (`terminal.arm`, `terminal.disarm`, `terminal.disarmAll`, `terminal.armByState`, `terminal.armAll`, `terminal.armDefault`); `Cmd+Shift+B` now arms the default preset, `Cmd+Alt+Shift+B` opens Bulk Operations

Resolves #5298

## Changes

- `src/store/fleetArmingStore.ts` — core store with `armedIds` Set, `armOrder`, `armOrderById`, `lastArmedId` anchor, state-preset selectors
- `src/components/Fleet/FleetArmingRibbon.tsx` — status ribbon with armed count, Working/Waiting/Finished preset pills, announcer integration; absent when nothing is armed
- `src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx` — per-tile arm toggle (click, Shift-click, Cmd-click), drag marquee with 4px threshold and pointer-capture, arm order badge, 2px accent outline
- `src/services/actions/definitions/terminalInputActions.ts` — six arming actions
- `src/services/defaultKeybindings.ts` — `Cmd+Shift+B` repurposed to `terminal.armDefault`, `Cmd+Alt+Shift+B` for bulk command
- `src/store/projectStore.ts` — synchronous arming clear on `switchProject` via lazy callback
- `shared/types/actions.ts` + `shared/types/keymap.ts` — updated action/keymap type unions

## Testing

All 10,954 unit tests pass, including 7 new tests covering the arming store (arm/disarm/shift-extend/cmd-toggle/state presets/project-switch clearing) and the ribbon component. Typecheck, lint (401 warnings, matches pre-existing baseline), and format all clean.