### PR TITLE
perf(panels): batch panel-store mutations during hydration

### DIFF
--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -50,6 +50,27 @@ export function useAppHydration(enabled = true) {
           beginHydrationBatch,
           flushHydrationBatch,
         });
+
+        // Pick an initial focused panel now that hydration is done. The legacy
+        // path set focus opportunistically inside `panelStore.addPanel` on every
+        // grid panel, ending on whichever was added last. The batched path skips
+        // that set (it would defeat the batch), so `focusedId` would otherwise be
+        // null after hydration — breaking any action keyed off the focused panel.
+        const panelState = usePanelStore.getState();
+        const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+        if (panelState.focusedId === null && panelState.panelIds.length > 0) {
+          const firstGridPanelId = panelState.panelIds.find((panelId) => {
+            const panel = panelState.panelsById[panelId];
+            return (
+              panel &&
+              panel.location === "grid" &&
+              (panel.worktreeId ?? null) === (activeWorktreeId ?? null)
+            );
+          });
+          if (firstGridPanelId) {
+            panelState.setFocused(firstGridPanelId);
+          }
+        }
       } catch (error) {
         console.error("Failed to restore app state:", error);
       } finally {

--- a/src/hooks/app/useAppHydration.ts
+++ b/src/hooks/app/useAppHydration.ts
@@ -16,6 +16,8 @@ export function useAppHydration(enabled = true) {
   const hydrateTabGroups = usePanelStore((s) => s.hydrateTabGroups);
   const restoreTerminalOrder = usePanelStore((s) => s.restoreTerminalOrder);
   const hydrateMru = usePanelStore((s) => s.hydrateMru);
+  const beginHydrationBatch = usePanelStore((s) => s.beginHydrationBatch);
+  const flushHydrationBatch = usePanelStore((s) => s.flushHydrationBatch);
   const setActiveWorktree = useWorktreeSelectionStore((s) => s.setActiveWorktree);
   const loadRecipes = useRecipeStore((s) => s.loadRecipes);
   const openDiagnosticsDock = useDiagnosticsStore((s) => s.openDock);
@@ -45,6 +47,8 @@ export function useAppHydration(enabled = true) {
           restoreTerminalOrder,
           hydrateMru,
           hydrateActionMru,
+          beginHydrationBatch,
+          flushHydrationBatch,
         });
       } catch (error) {
         console.error("Failed to restore app state:", error);
@@ -67,6 +71,8 @@ export function useAppHydration(enabled = true) {
     restoreTerminalOrder,
     hydrateMru,
     hydrateActionMru,
+    beginHydrationBatch,
+    flushHydrationBatch,
   ]);
 
   return { isStateLoaded };

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -153,10 +153,7 @@ export const usePanelStore = create<PanelGridState>()((set, get, api) => {
       // defeat the batch's single-render guarantee. The arbitrary "last panel added"
       // focus also isn't meaningful during restore — focus is resolved elsewhere once
       // the active worktree is set.
-      if (
-        (!options.location || options.location === "grid") &&
-        !isHydrationBatchActive()
-      ) {
+      if ((!options.location || options.location === "grid") && !isHydrationBatchActive()) {
         set({ focusedId: id });
       }
       return id;

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -12,6 +12,7 @@ import {
   createTerminalMruSlice,
   createWatchedPanelsSlice,
   flushPanelPersistence,
+  isHydrationBatchActive,
   selectOrderedTerminals,
   type PanelRegistrySlice,
   type TerminalFocusSlice,
@@ -147,7 +148,15 @@ export const usePanelStore = create<PanelGridState>()((set, get, api) => {
     addPanel: async (options: AddPanelOptions) => {
       const id = await registrySlice.addPanel(options);
       if (id === null) return null;
-      if (!options.location || options.location === "grid") {
+      // Skip the per-panel focus mutation while a hydration batch is collecting panels:
+      // firing `set({ focusedId })` here would schedule one extra render per panel and
+      // defeat the batch's single-render guarantee. The arbitrary "last panel added"
+      // focus also isn't meaningful during restore — focus is resolved elsewhere once
+      // the active worktree is set.
+      if (
+        (!options.location || options.location === "grid") &&
+        !isHydrationBatchActive()
+      ) {
         set({ focusedId: id });
       }
       return id;

--- a/src/store/slices/index.ts
+++ b/src/store/slices/index.ts
@@ -1,6 +1,7 @@
 export {
   createPanelRegistrySlice,
   flushPanelPersistence,
+  isHydrationBatchActive,
   selectOrderedTerminals,
   type PanelRegistrySlice,
   type TerminalInstance,

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -1,17 +1,18 @@
 /**
  * Tests for hydration batching (#5196)
  *
- * beginHydrationBatch / flushHydrationBatch collapse N `addPanel` mutations within
- * a restore phase into a single Zustand `set()` call — so a project with N panels
- * produces 1 render per phase instead of N. The batch also runs `saveNormalized`
- * exactly once at flush time rather than once per panel.
+ * `beginHydrationBatch` / `flushHydrationBatch` commit each panel to `panelsById`
+ * immediately (so event handlers can look panels up by id) but defer the
+ * `panelIds` append until flush — collapsing the N-panel high-fanout render
+ * (worktree dashboard, dock, grid) into a single `panelIds` update. Also
+ * collapses the N `saveNormalized` calls into 1.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
-    spawn: vi.fn(),
+    spawn: vi.fn(async ({ id }: { id?: string }) => id ?? "spawn-id"),
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn().mockResolvedValue(undefined),
@@ -79,36 +80,64 @@ describe("hydration batch (#5196)", () => {
     await reset();
   });
 
-  it("defers panel mutations until flushHydrationBatch is called", async () => {
-    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+  describe("panelsById commits immediately, panelIds defers to flush", () => {
+    it("makes non-PTY panels findable via panelsById before flush", async () => {
+      const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
 
-    const token = beginHydrationBatch();
+      const token = beginHydrationBatch();
+      await addPanel({
+        kind: "browser",
+        requestedId: "browser-1",
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
+      await addPanel({
+        kind: "browser",
+        requestedId: "browser-2",
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
 
-    // Non-PTY panels use the sync branch of addPanel; during a batch they should
-    // not appear in the store yet.
-    await addPanel({
-      kind: "browser",
-      requestedId: "browser-1",
-      cwd: "/",
-      bypassLimits: true,
-      browserUrl: "about:blank",
+      // Event handlers that look up by id must succeed before flush.
+      expect(usePanelStore.getState().panelsById["browser-1"]).toBeDefined();
+      expect(usePanelStore.getState().panelsById["browser-2"]).toBeDefined();
+      // But panelIds subscribers see the panels only after flush.
+      expect(usePanelStore.getState().panelIds).toEqual([]);
+
+      flushHydrationBatch(token);
+
+      expect(usePanelStore.getState().panelIds).toEqual(["browser-1", "browser-2"]);
     });
-    await addPanel({
-      kind: "browser",
-      requestedId: "browser-2",
-      cwd: "/",
-      bypassLimits: true,
-      browserUrl: "about:blank",
+
+    it("makes PTY panels findable via panelsById before flush", async () => {
+      const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+      const token = beginHydrationBatch();
+      await addPanel({
+        kind: "terminal",
+        type: "terminal",
+        requestedId: "term-1",
+        cwd: "/",
+        bypassLimits: true,
+      });
+      await addPanel({
+        kind: "terminal",
+        type: "terminal",
+        requestedId: "term-2",
+        cwd: "/",
+        bypassLimits: true,
+      });
+
+      expect(usePanelStore.getState().panelsById["term-1"]).toBeDefined();
+      expect(usePanelStore.getState().panelsById["term-2"]).toBeDefined();
+      expect(usePanelStore.getState().panelIds).toEqual([]);
+
+      flushHydrationBatch(token);
+
+      expect(usePanelStore.getState().panelIds).toEqual(["term-1", "term-2"]);
     });
-
-    expect(usePanelStore.getState().panelIds).toEqual([]);
-    expect(usePanelStore.getState().panelsById).toEqual({});
-
-    flushHydrationBatch(token);
-
-    expect(usePanelStore.getState().panelIds).toEqual(["browser-1", "browser-2"]);
-    expect(usePanelStore.getState().panelsById["browser-1"]).toBeDefined();
-    expect(usePanelStore.getState().panelsById["browser-2"]).toBeDefined();
   });
 
   it("calls saveNormalized exactly once per flush, regardless of panel count", async () => {
@@ -124,17 +153,14 @@ describe("hydration batch (#5196)", () => {
         browserUrl: "about:blank",
       });
     }
-    saveNormalizedMock.mockClear();
+    // `saveNormalized` must not fire for the per-panel `panelsById` updates.
+    expect(saveNormalizedMock).not.toHaveBeenCalled();
+
     flushHydrationBatch(token);
 
     expect(saveNormalizedMock).toHaveBeenCalledTimes(1);
-    // Full final state was persisted — all 5 panels should be in the saved bag.
-    const [savedById, savedIds] = saveNormalizedMock.mock.calls[0] as [
-      Record<string, unknown>,
-      string[],
-    ];
+    const [, savedIds] = saveNormalizedMock.mock.calls[0] as [Record<string, unknown>, string[]];
     expect(savedIds).toEqual(["browser-0", "browser-1", "browser-2", "browser-3", "browser-4"]);
-    expect(Object.keys(savedById)).toHaveLength(5);
   });
 
   it("ignores flushes made with a stale or mismatched token", async () => {
@@ -149,7 +175,7 @@ describe("hydration batch (#5196)", () => {
       browserUrl: "about:blank",
     });
 
-    // A new hydration starts and discards the previous batch.
+    // A new hydration starts and discards the previous batch's pending-id queue.
     const secondToken = beginHydrationBatch();
     await addPanel({
       kind: "browser",
@@ -164,6 +190,8 @@ describe("hydration batch (#5196)", () => {
     expect(usePanelStore.getState().panelIds).toEqual([]);
 
     flushHydrationBatch(secondToken);
+    // Only the second batch's id appears — the first batch's id was committed to
+    // panelsById but never appended to panelIds (cancelled).
     expect(usePanelStore.getState().panelIds).toEqual(["browser-2"]);
   });
 
@@ -174,12 +202,13 @@ describe("hydration batch (#5196)", () => {
     saveNormalizedMock.mockClear();
     flushHydrationBatch(token);
 
-    expect(saveNormalizedMock).not.toHaveBeenCalled();
+    // An empty batch still fires saveNormalized via the set() updater, but the
+    // returned state has no changed keys, so subscribers aren't re-rendered.
     expect(usePanelStore.getState().panelsById).toBe(before.panelsById);
     expect(usePanelStore.getState().panelIds).toBe(before.panelIds);
   });
 
-  it("appends only ids that aren't already in the store (update-in-place on conflict)", async () => {
+  it("updates panels in place when the id already exists in panelsById (dedup)", async () => {
     const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
 
     // Seed a panel outside any batch.
@@ -215,15 +244,67 @@ describe("hydration batch (#5196)", () => {
     expect(usePanelStore.getState().panelsById["browser-1"]?.title).toBe("updated title");
   });
 
-  it("collapses N panel additions into one store mutation", async () => {
+  it("preserves runtime fields on PTY reconnect when the snapshot has them unset", async () => {
     const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
 
-    let notifyCount = 0;
-    const unsubscribe = usePanelStore.subscribe(() => {
-      notifyCount++;
+    // Seed an existing terminal with runtime state the "reconnect" branch must preserve.
+    usePanelStore.setState((state) => ({
+      panelsById: {
+        ...state.panelsById,
+        "term-1": {
+          id: "term-1",
+          kind: "agent",
+          type: "terminal",
+          title: "Agent",
+          cwd: "/",
+          cols: 80,
+          rows: 24,
+          location: "grid" as const,
+          isVisible: true,
+          runtimeStatus: "running" as const,
+          agentState: "working",
+          lastStateChange: 1234,
+          exitBehavior: "restart",
+          extensionState: { foo: "bar" },
+        } as import("../types").TerminalInstance,
+      },
+      panelIds: [...state.panelIds, "term-1"],
+    }));
+
+    const token = beginHydrationBatch();
+    await addPanel({
+      kind: "agent",
+      existingId: "term-1",
+      cwd: "/",
+      bypassLimits: true,
+      // Omit agentState/lastStateChange/exitBehavior/extensionState so the merge
+      // kicks in and preserves the seeded values.
+    });
+    flushHydrationBatch(token);
+
+    const result = usePanelStore.getState().panelsById["term-1"];
+    expect(result?.agentState).toBe("working");
+    expect(result?.lastStateChange).toBe(1234);
+    expect(result?.exitBehavior).toBe("restart");
+    expect(result?.extensionState).toEqual({ foo: "bar" });
+  });
+
+  it("collapses N panel additions into a single panelIds render", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    let panelIdsNotifyCount = 0;
+    let lastPanelIds: string[] | undefined;
+    const unsubscribe = usePanelStore.subscribe((state) => {
+      if (state.panelIds !== lastPanelIds) {
+        panelIdsNotifyCount++;
+        lastPanelIds = state.panelIds;
+      }
     });
 
     try {
+      // Prime the baseline.
+      lastPanelIds = usePanelStore.getState().panelIds;
+
       const token = beginHydrationBatch();
       for (let i = 0; i < 10; i++) {
         await addPanel({
@@ -234,14 +315,14 @@ describe("hydration batch (#5196)", () => {
           browserUrl: "about:blank",
         });
       }
-      // No store commits during the batch — no subscriber notifications.
-      expect(notifyCount).toBe(0);
+      // panelIds reference stayed the same throughout — no high-fanout render.
+      expect(panelIdsNotifyCount).toBe(0);
 
       flushHydrationBatch(token);
 
-      // Exactly one notification for 10 panels. With the legacy per-panel path,
-      // this would be 10 (one per addPanel) + 10 from the panelStore focus wrapper.
-      expect(notifyCount).toBe(1);
+      // Exactly one panelIds change for 10 panels. The legacy per-panel path
+      // produced one per addPanel.
+      expect(panelIdsNotifyCount).toBe(1);
     } finally {
       unsubscribe();
     }

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -289,6 +289,83 @@ describe("hydration batch (#5196)", () => {
     expect(result?.extensionState).toEqual({ foo: "bar" });
   });
 
+  it("lets store updaters find a panel by id before flush (event-handler invariant)", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel, updateAgentState, updateActivity } =
+      usePanelStore.getState();
+
+    const token = beginHydrationBatch();
+    await addPanel({
+      kind: "agent",
+      type: "terminal",
+      requestedId: "term-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    // Simulate an IPC event arriving for this panel BEFORE the phase's flush —
+    // both handlers look panels up by id via `state.panelsById[id]` and bail if
+    // missing. With deferred `panelIds`, the entry is already in `panelsById`,
+    // so the updates must stick.
+    updateAgentState("term-1", "waiting");
+    updateActivity("term-1", "writing code", "working", "interactive", 100);
+
+    const mid = usePanelStore.getState().panelsById["term-1"];
+    expect(mid?.agentState).toBe("waiting");
+    expect(mid?.activityHeadline).toBe("writing code");
+
+    flushHydrationBatch(token);
+
+    const after = usePanelStore.getState().panelsById["term-1"];
+    expect(after?.agentState).toBe("waiting");
+    expect(after?.activityHeadline).toBe("writing code");
+  });
+
+  it("does not append ids whose addPanel failed before reaching panelsById", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    // Make spawn reject for one id, succeed for the next.
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn
+      .mockImplementationOnce(async () => {
+        throw new Error("spawn failed");
+      })
+      .mockImplementationOnce(async ({ id }: { id?: string }) => id ?? "ok");
+
+    const token = beginHydrationBatch();
+    // First addPanel: spawn throws, caught by addPanel's outer try/catch and re-thrown.
+    await expect(
+      addPanel({
+        kind: "terminal",
+        type: "terminal",
+        requestedId: "fail-1",
+        cwd: "/",
+        bypassLimits: true,
+      })
+    ).rejects.toThrow("spawn failed");
+    // Second addPanel succeeds.
+    await addPanel({
+      kind: "terminal",
+      type: "terminal",
+      requestedId: "ok-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    saveNormalizedMock.mockClear();
+    flushHydrationBatch(token);
+
+    // Only the successful id lands in panelIds.
+    expect(usePanelStore.getState().panelIds).toEqual(["ok-1"]);
+    expect(usePanelStore.getState().panelsById["fail-1"]).toBeUndefined();
+
+    // saveNormalized fired once with the correct id list.
+    expect(saveNormalizedMock).toHaveBeenCalledTimes(1);
+    const [, savedIds] = saveNormalizedMock.mock.calls[0] as [Record<string, unknown>, string[]];
+    expect(savedIds).toEqual(["ok-1"]);
+  });
+
   it("collapses N panel additions into a single panelIds render", async () => {
     const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
 

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -274,6 +274,8 @@ describe("hydration batch (#5196)", () => {
     const token = beginHydrationBatch();
     await addPanel({
       kind: "agent",
+      agentId: "claude",
+      command: "claude",
       existingId: "term-1",
       cwd: "/",
       bypassLimits: true,
@@ -296,6 +298,8 @@ describe("hydration batch (#5196)", () => {
     const token = beginHydrationBatch();
     await addPanel({
       kind: "agent",
+      agentId: "claude",
+      command: "claude",
       type: "terminal",
       requestedId: "term-1",
       cwd: "/",

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for hydration batching (#5196)
+ *
+ * beginHydrationBatch / flushHydrationBatch collapse N `addPanel` mutations within
+ * a restore phase into a single Zustand `set()` call — so a project with N panels
+ * produces 1 render per phase instead of N. The batch also runs `saveNormalized`
+ * exactly once at flush time rather than once per panel.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+  },
+}));
+
+const saveNormalizedMock = vi.fn();
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: (...args: unknown[]) => saveNormalizedMock(...args),
+  };
+});
+
+// `window.electron.globalEnv.get()` is awaited on the PTY path; stub it so tests
+// don't have to set up a full electron shim.
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+
+describe("hydration batch (#5196)", () => {
+  beforeEach(async () => {
+    saveNormalizedMock.mockClear();
+    const { reset } = usePanelStore.getState();
+    await reset();
+  });
+
+  it("defers panel mutations until flushHydrationBatch is called", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    const token = beginHydrationBatch();
+
+    // Non-PTY panels use the sync branch of addPanel; during a batch they should
+    // not appear in the store yet.
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-1",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+    });
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-2",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+    });
+
+    expect(usePanelStore.getState().panelIds).toEqual([]);
+    expect(usePanelStore.getState().panelsById).toEqual({});
+
+    flushHydrationBatch(token);
+
+    expect(usePanelStore.getState().panelIds).toEqual(["browser-1", "browser-2"]);
+    expect(usePanelStore.getState().panelsById["browser-1"]).toBeDefined();
+    expect(usePanelStore.getState().panelsById["browser-2"]).toBeDefined();
+  });
+
+  it("calls saveNormalized exactly once per flush, regardless of panel count", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    const token = beginHydrationBatch();
+    for (let i = 0; i < 5; i++) {
+      await addPanel({
+        kind: "browser",
+        requestedId: `browser-${i}`,
+        cwd: "/",
+        bypassLimits: true,
+        browserUrl: "about:blank",
+      });
+    }
+    saveNormalizedMock.mockClear();
+    flushHydrationBatch(token);
+
+    expect(saveNormalizedMock).toHaveBeenCalledTimes(1);
+    // Full final state was persisted — all 5 panels should be in the saved bag.
+    const [savedById, savedIds] = saveNormalizedMock.mock.calls[0] as [
+      Record<string, unknown>,
+      string[],
+    ];
+    expect(savedIds).toEqual(["browser-0", "browser-1", "browser-2", "browser-3", "browser-4"]);
+    expect(Object.keys(savedById)).toHaveLength(5);
+  });
+
+  it("ignores flushes made with a stale or mismatched token", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    const firstToken = beginHydrationBatch();
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-1",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+    });
+
+    // A new hydration starts and discards the previous batch.
+    const secondToken = beginHydrationBatch();
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-2",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+    });
+
+    // Late flush from the cancelled hydration must not corrupt the live batch.
+    flushHydrationBatch(firstToken);
+    expect(usePanelStore.getState().panelIds).toEqual([]);
+
+    flushHydrationBatch(secondToken);
+    expect(usePanelStore.getState().panelIds).toEqual(["browser-2"]);
+  });
+
+  it("is a no-op when flushing an empty batch", () => {
+    const { beginHydrationBatch, flushHydrationBatch } = usePanelStore.getState();
+    const before = usePanelStore.getState();
+    const token = beginHydrationBatch();
+    saveNormalizedMock.mockClear();
+    flushHydrationBatch(token);
+
+    expect(saveNormalizedMock).not.toHaveBeenCalled();
+    expect(usePanelStore.getState().panelsById).toBe(before.panelsById);
+    expect(usePanelStore.getState().panelIds).toBe(before.panelIds);
+  });
+
+  it("appends only ids that aren't already in the store (update-in-place on conflict)", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    // Seed a panel outside any batch.
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-1",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+    });
+    expect(usePanelStore.getState().panelIds).toEqual(["browser-1"]);
+
+    // Batch that re-adds the same id + adds a new one: panelIds must remain unique.
+    const token = beginHydrationBatch();
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-1",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+      title: "updated title",
+    });
+    await addPanel({
+      kind: "browser",
+      requestedId: "browser-2",
+      cwd: "/",
+      bypassLimits: true,
+      browserUrl: "about:blank",
+    });
+    flushHydrationBatch(token);
+
+    expect(usePanelStore.getState().panelIds).toEqual(["browser-1", "browser-2"]);
+    expect(usePanelStore.getState().panelsById["browser-1"]?.title).toBe("updated title");
+  });
+
+  it("collapses N panel additions into one store mutation", async () => {
+    const { beginHydrationBatch, flushHydrationBatch, addPanel } = usePanelStore.getState();
+
+    let notifyCount = 0;
+    const unsubscribe = usePanelStore.subscribe(() => {
+      notifyCount++;
+    });
+
+    try {
+      const token = beginHydrationBatch();
+      for (let i = 0; i < 10; i++) {
+        await addPanel({
+          kind: "browser",
+          requestedId: `browser-${i}`,
+          cwd: "/",
+          bypassLimits: true,
+          browserUrl: "about:blank",
+        });
+      }
+      // No store commits during the batch — no subscriber notifications.
+      expect(notifyCount).toBe(0);
+
+      flushHydrationBatch(token);
+
+      // Exactly one notification for 10 panels. With the legacy per-panel path,
+      // this would be 10 (one per addPanel) + 10 from the panelStore focus wrapper.
+      expect(notifyCount).toBe(1);
+    } finally {
+      unsubscribe();
+    }
+  });
+});

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -56,17 +56,25 @@ async function resolveProjectStore() {
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
 
-interface HydrationBatchEntry {
-  terminal: TerminalInstance;
-  /** Reconnect entries preserve existing runtime fields (agentState, exitBehavior, …) during merge. */
-  isReconnect: boolean;
-}
-
-// Module-level singleton: hydration runs sequentially (guarded by `isCurrent()` checks),
-// so at most one batch is active at a time. The token identity prevents a late flush from
-// a cancelled hydration from colliding with a fresh batch started by the new hydration.
-let activeHydrationBatch: { token: HydrationBatchToken; entries: HydrationBatchEntry[] } | null =
-  null;
+/**
+ * Hydration batch state. Each restore phase runs inside begin/flush, and during
+ * that window `addPanel` commits the per-panel `panelsById` entry immediately
+ * (so IPC event listeners that look panels up by id always find them) but defers
+ * the `panelIds` append. Flush applies a single `panelIds` update per phase —
+ * which is the high-fanout subscription that the worktree dashboard, dock, and
+ * grid subscribe to. Net: a phase of N panels triggers 1 `panelIds` render
+ * instead of N, while never leaving spawned panels invisible to event handlers.
+ *
+ * Singleton: hydration is guarded by `isCurrent()` so at most one batch is active
+ * at a time. `HydrationBatchToken` protects against stale flushes from cancelled
+ * hydrations colliding with a fresh batch started by the superseding hydration.
+ */
+let activeHydrationBatch: {
+  token: HydrationBatchToken;
+  /** Ids pending append to `panelIds`; deduplicated via `seenIds`. */
+  pendingIds: string[];
+  seenIds: Set<string>;
+} | null = null;
 
 /**
  * Exposed so higher-level `addPanel` wrappers (e.g. the focus-setting wrapper in
@@ -77,9 +85,12 @@ export function isHydrationBatchActive(): boolean {
   return activeHydrationBatch !== null;
 }
 
-function collectForBatch(entry: HydrationBatchEntry): void {
+/** Record a new panel id for append to `panelIds` at flush time. Dedup-safe. */
+function collectPanelIdForBatch(id: string): void {
   if (activeHydrationBatch === null) return;
-  activeHydrationBatch.entries.push(entry);
+  if (activeHydrationBatch.seenIds.has(id)) return;
+  activeHydrationBatch.seenIds.add(id);
+  activeHydrationBatch.pendingIds.push(id);
 }
 
 function countNonTrashTerminals(state: PanelRegistrySlice): number {
@@ -130,46 +141,28 @@ export const createCorePanelActions = (
     // A leftover batch from a cancelled hydration is discarded — we prioritize the
     // fresh hydration and never flush stale panels into the store.
     const token: HydrationBatchToken = Symbol("hydration-batch");
-    activeHydrationBatch = { token, entries: [] };
+    activeHydrationBatch = { token, pendingIds: [], seenIds: new Set() };
     return token;
   },
 
   flushHydrationBatch: (token) => {
     // Token mismatch means the batch was superseded or already flushed — ignore.
     if (activeHydrationBatch === null || activeHydrationBatch.token !== token) return;
-    const entries = activeHydrationBatch.entries;
+    const pendingIds = activeHydrationBatch.pendingIds;
     activeHydrationBatch = null;
-    if (entries.length === 0) return;
 
     set((state) => {
-      const newById = { ...state.panelsById };
-      let newIds = state.panelIds;
-      let idsChanged = false;
-      for (const { terminal, isReconnect } of entries) {
-        const existing = newById[terminal.id];
-        if (existing) {
-          // Matches the single-panel reconnect merge in addPanel's PTY path: keep the
-          // existing runtime fields when the restored snapshot has them unset.
-          newById[terminal.id] = isReconnect
-            ? {
-                ...terminal,
-                agentState: terminal.agentState ?? existing.agentState,
-                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                extensionState: terminal.extensionState ?? existing.extensionState,
-              }
-            : terminal;
-        } else {
-          newById[terminal.id] = terminal;
-          if (!idsChanged) {
-            newIds = [...newIds];
-            idsChanged = true;
-          }
-          newIds.push(terminal.id);
-        }
-      }
-      saveNormalized(newById, newIds);
-      return idsChanged ? { panelsById: newById, panelIds: newIds } : { panelsById: newById };
+      // `panelsById` was already updated per panel during the batch, so this
+      // final `set` only reveals `panelIds` to subscribers and persists once.
+      // Filter: reconnect ids are already in `panelIds`, and a failed addPanel
+      // might have been collected but never landed in `panelsById`.
+      const existing = new Set(state.panelIds);
+      const additions = pendingIds.filter(
+        (id) => !existing.has(id) && state.panelsById[id] !== undefined
+      );
+      const newIds = additions.length > 0 ? [...state.panelIds, ...additions] : state.panelIds;
+      saveNormalized(state.panelsById, newIds);
+      return additions.length > 0 ? { panelIds: newIds } : {};
     });
   },
 
@@ -266,7 +259,15 @@ export const createCorePanelActions = (
       };
 
       if (isHydrationBatchActive()) {
-        collectForBatch({ terminal, isReconnect: false });
+        // Batched path: commit `panelsById` immediately (event listeners can find
+        // the panel by id) and defer the `panelIds` append + persist to flush.
+        set((state) => {
+          if (state.panelsById[id]) {
+            logDebug("[TerminalStore] Panel already exists, updating instead of adding", { id });
+          }
+          return { panelsById: { ...state.panelsById, [id]: terminal } };
+        });
+        collectPanelIdForBatch(id);
       } else {
         set((state) => {
           const existing = state.panelsById[id];
@@ -420,6 +421,96 @@ export const createCorePanelActions = (
         });
       }
 
+      const isAgent = kind === "agent";
+      const isReconnect = !!options.existingId;
+
+      // For reconnects, use the backend's state directly - don't default to "working".
+      // For new spawns, start with "working" in UI to show spinner immediately during boot.
+      const agentState = isReconnect
+        ? options.agentState
+        : (options.agentState ?? (isAgent ? "working" : undefined));
+      const lastStateChange = isReconnect
+        ? options.lastStateChange
+        : (options.lastStateChange ?? (agentState !== undefined ? Date.now() : undefined));
+
+      const terminal: TerminalInstance = {
+        id,
+        kind,
+        type: legacyType,
+        agentId,
+        title,
+        worktreeId: options.worktreeId,
+        cwd: options.cwd ?? "",
+        cols: 80,
+        rows: 24,
+        agentState,
+        lastStateChange,
+        location,
+        command: options.command,
+        // Initialize grid terminals as visible to avoid initial under-throttling
+        // IntersectionObserver will update this once mounted
+        isVisible: location === "grid" ? true : false,
+        runtimeStatus,
+        isInputLocked: options.isInputLocked,
+        exitBehavior: options.exitBehavior,
+        agentSessionId: options.agentSessionId,
+        agentLaunchFlags: options.agentLaunchFlags,
+        agentModelId: options.agentModelId,
+        extensionState: options.extensionState,
+        spawnedBy: options.spawnedBy,
+        startedAt: Date.now(),
+      };
+
+      // Commit the panel to `panelsById` BEFORE prewarm so IPC event listeners
+      // (onAgentStateChanged, onExit, onAgentDetected, activity flushes, etc.)
+      // that look panels up by id always find the entry — even during the
+      // spawn/prewarm window of concurrent panels in the same hydration batch.
+      // Prewarm is synchronous so any React render from this `set` runs after
+      // the managed terminal instance is created.
+      if (isHydrationBatchActive()) {
+        // Batched path: commit `panelsById` immediately; defer `panelIds` append.
+        set((state) => {
+          const existing = state.panelsById[id];
+          const preservedTerminal =
+            existing && isReconnect
+              ? {
+                  ...terminal,
+                  agentState: terminal.agentState ?? existing.agentState,
+                  lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                  exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
+                  extensionState: terminal.extensionState ?? existing.extensionState,
+                }
+              : terminal;
+          return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
+        });
+        collectPanelIdForBatch(id);
+      } else {
+        set((state) => {
+          const existing = state.panelsById[id];
+          if (existing) {
+            // Update existing terminal in place (reconnection case or double hydration)
+            logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
+            // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
+            const preservedTerminal = isReconnect
+              ? {
+                  ...terminal,
+                  agentState: terminal.agentState ?? existing.agentState,
+                  lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                  exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
+                  extensionState: terminal.extensionState ?? existing.extensionState,
+                }
+              : terminal;
+            const newById = { ...state.panelsById, [id]: preservedTerminal };
+            saveNormalized(newById, state.panelIds);
+            return { panelsById: newById };
+          }
+          const newById = { ...state.panelsById, [id]: terminal };
+          const newIds = [...state.panelIds, id];
+          saveNormalized(newById, newIds);
+          return { panelsById: newById, panelIds: newIds };
+        });
+      }
+
       // Prewarm renderer-side xterm immediately so we never drop startup output/ANSI while hidden.
       // For docked terminals, also open + fit offscreen so the PTY starts with correct dimensions.
       try {
@@ -491,75 +582,6 @@ export const createCorePanelActions = (
         }
       } catch (error) {
         logWarn("[TerminalStore] Failed to prewarm terminal", { id, error });
-      }
-
-      const isAgent = kind === "agent";
-      const isReconnect = !!options.existingId;
-
-      // For reconnects, use the backend's state directly - don't default to "working".
-      // For new spawns, start with "working" in UI to show spinner immediately during boot.
-      const agentState = isReconnect
-        ? options.agentState
-        : (options.agentState ?? (isAgent ? "working" : undefined));
-      const lastStateChange = isReconnect
-        ? options.lastStateChange
-        : (options.lastStateChange ?? (agentState !== undefined ? Date.now() : undefined));
-
-      const terminal: TerminalInstance = {
-        id,
-        kind,
-        type: legacyType,
-        agentId,
-        title,
-        worktreeId: options.worktreeId,
-        cwd: options.cwd ?? "",
-        cols: 80,
-        rows: 24,
-        agentState,
-        lastStateChange,
-        location,
-        command: options.command,
-        // Initialize grid terminals as visible to avoid initial under-throttling
-        // IntersectionObserver will update this once mounted
-        isVisible: location === "grid" ? true : false,
-        runtimeStatus,
-        isInputLocked: options.isInputLocked,
-        exitBehavior: options.exitBehavior,
-        agentSessionId: options.agentSessionId,
-        agentLaunchFlags: options.agentLaunchFlags,
-        agentModelId: options.agentModelId,
-        extensionState: options.extensionState,
-        spawnedBy: options.spawnedBy,
-        startedAt: Date.now(),
-      };
-
-      if (isHydrationBatchActive()) {
-        collectForBatch({ terminal, isReconnect });
-      } else {
-        set((state) => {
-          const existing = state.panelsById[id];
-          if (existing) {
-            // Update existing terminal in place (reconnection case or double hydration)
-            logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
-            // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
-            const preservedTerminal = isReconnect
-              ? {
-                  ...terminal,
-                  agentState: terminal.agentState ?? existing.agentState,
-                  lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                  exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                  extensionState: terminal.extensionState ?? existing.extensionState,
-                }
-              : terminal;
-            const newById = { ...state.panelsById, [id]: preservedTerminal };
-            saveNormalized(newById, state.panelIds);
-            return { panelsById: newById };
-          }
-          const newById = { ...state.panelsById, [id]: terminal };
-          const newIds = [...state.panelIds, id];
-          saveNormalized(newById, newIds);
-          return { panelsById: newById, panelIds: newIds };
-        });
       }
 
       // Determine if terminal should start backgrounded:

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -69,11 +69,13 @@ type Get = PanelRegistryStoreApi["getState"];
  * at a time. `HydrationBatchToken` protects against stale flushes from cancelled
  * hydrations colliding with a fresh batch started by the superseding hydration.
  */
+// `globalThis.Set` qualifier avoids a collision with the local `type Set` alias
+// above (which is the Zustand `setState` function type).
 let activeHydrationBatch: {
   token: HydrationBatchToken;
   /** Ids pending append to `panelIds`; deduplicated via `seenIds`. */
   pendingIds: string[];
-  seenIds: Set<string>;
+  seenIds: globalThis.Set<string>;
 } | null = null;
 
 /**

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -4,6 +4,7 @@ import type {
   PanelRegistrySlice,
   PanelRegistryMiddleware,
   TerminalInstance,
+  HydrationBatchToken,
 } from "./types";
 import { terminalClient, projectClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -55,6 +56,32 @@ async function resolveProjectStore() {
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
 
+interface HydrationBatchEntry {
+  terminal: TerminalInstance;
+  /** Reconnect entries preserve existing runtime fields (agentState, exitBehavior, …) during merge. */
+  isReconnect: boolean;
+}
+
+// Module-level singleton: hydration runs sequentially (guarded by `isCurrent()` checks),
+// so at most one batch is active at a time. The token identity prevents a late flush from
+// a cancelled hydration from colliding with a fresh batch started by the new hydration.
+let activeHydrationBatch: { token: HydrationBatchToken; entries: HydrationBatchEntry[] } | null =
+  null;
+
+/**
+ * Exposed so higher-level `addPanel` wrappers (e.g. the focus-setting wrapper in
+ * `panelStore.ts`) can skip their own `set()` calls while a batch is active —
+ * otherwise they'd trigger one render per panel and defeat the batching.
+ */
+export function isHydrationBatchActive(): boolean {
+  return activeHydrationBatch !== null;
+}
+
+function collectForBatch(entry: HydrationBatchEntry): void {
+  if (activeHydrationBatch === null) return;
+  activeHydrationBatch.entries.push(entry);
+}
+
 function countNonTrashTerminals(state: PanelRegistrySlice): number {
   let count = 0;
   for (const id of state.panelIds) {
@@ -85,6 +112,8 @@ export const createCorePanelActions = (
 ): Pick<
   PanelRegistrySlice,
   | "addPanel"
+  | "beginHydrationBatch"
+  | "flushHydrationBatch"
   | "removePanel"
   | "updateTitle"
   | "updateLastObservedTitle"
@@ -97,6 +126,53 @@ export const createCorePanelActions = (
   | "moveTerminalToGrid"
   | "toggleTerminalLocation"
 > => ({
+  beginHydrationBatch: () => {
+    // A leftover batch from a cancelled hydration is discarded — we prioritize the
+    // fresh hydration and never flush stale panels into the store.
+    const token: HydrationBatchToken = Symbol("hydration-batch");
+    activeHydrationBatch = { token, entries: [] };
+    return token;
+  },
+
+  flushHydrationBatch: (token) => {
+    // Token mismatch means the batch was superseded or already flushed — ignore.
+    if (activeHydrationBatch === null || activeHydrationBatch.token !== token) return;
+    const entries = activeHydrationBatch.entries;
+    activeHydrationBatch = null;
+    if (entries.length === 0) return;
+
+    set((state) => {
+      const newById = { ...state.panelsById };
+      let newIds = state.panelIds;
+      let idsChanged = false;
+      for (const { terminal, isReconnect } of entries) {
+        const existing = newById[terminal.id];
+        if (existing) {
+          // Matches the single-panel reconnect merge in addPanel's PTY path: keep the
+          // existing runtime fields when the restored snapshot has them unset.
+          newById[terminal.id] = isReconnect
+            ? {
+                ...terminal,
+                agentState: terminal.agentState ?? existing.agentState,
+                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
+                extensionState: terminal.extensionState ?? existing.extensionState,
+              }
+            : terminal;
+        } else {
+          newById[terminal.id] = terminal;
+          if (!idsChanged) {
+            newIds = [...newIds];
+            idsChanged = true;
+          }
+          newIds.push(terminal.id);
+        }
+      }
+      saveNormalized(newById, newIds);
+      return idsChanged ? { panelsById: newById, panelIds: newIds } : { panelsById: newById };
+    });
+  },
+
   addPanel: async (options) => {
     // Panel limit enforcement (Tier 2: confirmation, Tier 3: hard block)
     if (!options.bypassLimits) {
@@ -189,19 +265,23 @@ export const createCorePanelActions = (
         ...kindFields,
       };
 
-      set((state) => {
-        const existing = state.panelsById[id];
-        if (existing) {
-          logDebug("[TerminalStore] Panel already exists, updating instead of adding", { id });
+      if (isHydrationBatchActive()) {
+        collectForBatch({ terminal, isReconnect: false });
+      } else {
+        set((state) => {
+          const existing = state.panelsById[id];
+          if (existing) {
+            logDebug("[TerminalStore] Panel already exists, updating instead of adding", { id });
+            const newById = { ...state.panelsById, [id]: terminal };
+            saveNormalized(newById, state.panelIds);
+            return { panelsById: newById };
+          }
           const newById = { ...state.panelsById, [id]: terminal };
-          saveNormalized(newById, state.panelIds);
-          return { panelsById: newById };
-        }
-        const newById = { ...state.panelsById, [id]: terminal };
-        const newIds = [...state.panelIds, id];
-        saveNormalized(newById, newIds);
-        return { panelsById: newById, panelIds: newIds };
-      });
+          const newIds = [...state.panelIds, id];
+          saveNormalized(newById, newIds);
+          return { panelsById: newById, panelIds: newIds };
+        });
+      }
 
       return id;
     }
@@ -453,30 +533,34 @@ export const createCorePanelActions = (
         startedAt: Date.now(),
       };
 
-      set((state) => {
-        const existing = state.panelsById[id];
-        if (existing) {
-          // Update existing terminal in place (reconnection case or double hydration)
-          logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
-          // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
-          const preservedTerminal = isReconnect
-            ? {
-                ...terminal,
-                agentState: terminal.agentState ?? existing.agentState,
-                lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
-                exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
-                extensionState: terminal.extensionState ?? existing.extensionState,
-              }
-            : terminal;
-          const newById = { ...state.panelsById, [id]: preservedTerminal };
-          saveNormalized(newById, state.panelIds);
-          return { panelsById: newById };
-        }
-        const newById = { ...state.panelsById, [id]: terminal };
-        const newIds = [...state.panelIds, id];
-        saveNormalized(newById, newIds);
-        return { panelsById: newById, panelIds: newIds };
-      });
+      if (isHydrationBatchActive()) {
+        collectForBatch({ terminal, isReconnect });
+      } else {
+        set((state) => {
+          const existing = state.panelsById[id];
+          if (existing) {
+            // Update existing terminal in place (reconnection case or double hydration)
+            logDebug("[TerminalStore] Terminal already exists, updating instead of adding", { id });
+            // Preserve existing agentState/lastStateChange/exitBehavior if new values are undefined
+            const preservedTerminal = isReconnect
+              ? {
+                  ...terminal,
+                  agentState: terminal.agentState ?? existing.agentState,
+                  lastStateChange: terminal.lastStateChange ?? existing.lastStateChange,
+                  exitBehavior: terminal.exitBehavior ?? existing.exitBehavior,
+                  extensionState: terminal.extensionState ?? existing.extensionState,
+                }
+              : terminal;
+            const newById = { ...state.panelsById, [id]: preservedTerminal };
+            saveNormalized(newById, state.panelIds);
+            return { panelsById: newById };
+          }
+          const newById = { ...state.panelsById, [id]: terminal };
+          const newIds = [...state.panelIds, id];
+          saveNormalized(newById, newIds);
+          return { panelsById: newById, panelIds: newIds };
+        });
+      }
 
       // Determine if terminal should start backgrounded:
       // 1. Dock terminals are always backgrounded (offscreen)

--- a/src/store/slices/panelRegistry/index.ts
+++ b/src/store/slices/panelRegistry/index.ts
@@ -24,6 +24,7 @@ export type {
 export { MAX_GRID_TERMINALS, deriveRuntimeStatus, getDefaultTitle } from "./helpers";
 export { flushPanelPersistence } from "./persistence";
 export { selectOrderedTerminals } from "./selectors";
+export { isHydrationBatchActive } from "./core";
 
 export const createPanelRegistrySlice =
   (

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -43,6 +43,13 @@ export interface BackgroundedTerminal {
   groupMetadata?: TrashedTerminalGroupMetadata;
 }
 
+/**
+ * Opaque token returned by `beginHydrationBatch`. Callers must pass the same token
+ * to `flushHydrationBatch` so a stale batch from a cancelled hydration cannot be
+ * flushed by a later, unrelated caller.
+ */
+export type HydrationBatchToken = symbol;
+
 export interface PanelRegistrySlice {
   panelsById: Record<string, TerminalInstance>;
   panelIds: string[];
@@ -52,6 +59,17 @@ export interface PanelRegistrySlice {
   tabGroups: Map<string, TabGroup>;
 
   addPanel: (options: AddPanelOptions) => Promise<string | null>;
+  /**
+   * Hydration-only: collect subsequent `addPanel` mutations into one batched commit
+   * instead of applying each individually. Every `addPanel` between begin and flush
+   * still returns its final id and runs per-panel side effects, but store mutations
+   * are deferred until `flushHydrationBatch` fires exactly one `set()` +
+   * `saveNormalized()` for all collected panels. Collapses an N-panel restore phase
+   * from N re-renders into 1.
+   */
+  beginHydrationBatch: () => HydrationBatchToken;
+  /** Apply all panels collected since `beginHydrationBatch` in a single `set()` call. */
+  flushHydrationBatch: (token: HydrationBatchToken) => void;
   removePanel: (id: string) => void;
   updateTitle: (id: string, newTitle: string) => void;
   updateLastObservedTitle: (id: string, title: string) => void;

--- a/src/store/slices/panelRegistrySlice.ts
+++ b/src/store/slices/panelRegistrySlice.ts
@@ -2,6 +2,7 @@
 export {
   createPanelRegistrySlice,
   flushPanelPersistence,
+  isHydrationBatchActive,
   selectOrderedTerminals,
   MAX_GRID_TERMINALS,
   deriveRuntimeStatus,

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -2658,4 +2658,135 @@ describe("hydrateAppState", () => {
       expect(appClientMock.hydrate).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("hydration batching (#5196)", () => {
+    it("pairs beginHydrationBatch and flushHydrationBatch for each non-empty restore phase", async () => {
+      // Three panel kinds exercise three phases simultaneously: browser (non-PTY),
+      // a saved terminal without a backend process (background PTY respawn), and
+      // an orphan backend terminal not in the saved list.
+      appClientMock.hydrate.mockResolvedValue({
+        appState: {
+          terminals: [
+            {
+              id: "browser-1",
+              kind: "browser",
+              title: "Browser",
+              cwd: "/project",
+              location: "grid",
+            },
+            {
+              id: "terminal-1",
+              kind: "terminal",
+              type: "terminal",
+              title: "Terminal",
+              cwd: "/project",
+              location: "grid",
+              worktreeId: "wt-other",
+            },
+          ],
+          activeWorktreeId: "wt-active",
+        },
+        terminalConfig,
+        project,
+        agentSettings,
+      });
+
+      terminalClientMock.getForProject.mockResolvedValue([
+        { id: "orphan-1", kind: "terminal", type: "terminal", cwd: "/project", hasPty: true },
+      ]);
+      terminalClientMock.reconnect.mockResolvedValue({ exists: false });
+
+      const beginHydrationBatch = vi.fn(() => Symbol("batch"));
+      const flushHydrationBatch = vi.fn();
+
+      await hydrateAppState({
+        addPanel: vi.fn().mockResolvedValue("panel-id"),
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+        beginHydrationBatch,
+        flushHydrationBatch,
+      });
+
+      // Every begin must be matched by a flush with the same token.
+      expect(flushHydrationBatch).toHaveBeenCalledTimes(beginHydrationBatch.mock.calls.length);
+      const tokens = beginHydrationBatch.mock.results.map((r) => r.value);
+      tokens.forEach((token, i) => {
+        expect(flushHydrationBatch.mock.calls[i]?.[0]).toBe(token);
+      });
+
+      // Non-PTY + background-PTY + orphan phases each fire at least one begin/flush.
+      expect(beginHydrationBatch.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("falls through to legacy per-panel commits when batch hooks are omitted", async () => {
+      // Regression guard: existing callers (and tests) that don't pass begin/flush
+      // must still hydrate correctly. This is the same shape as the first test in
+      // this suite, but without any batch hooks in the options object.
+      appClientMock.hydrate.mockResolvedValue({
+        appState: {
+          terminals: [
+            {
+              id: "browser-1",
+              kind: "browser",
+              title: "Browser",
+              cwd: "/project",
+              location: "grid",
+            },
+          ],
+        },
+        terminalConfig,
+        project,
+        agentSettings,
+      });
+
+      const addPanel = vi.fn().mockResolvedValue("browser-1");
+      await hydrateAppState({
+        addPanel,
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+      });
+
+      expect(addPanel).toHaveBeenCalledTimes(1);
+    });
+
+    it("flushes the batch even if a panel addition throws mid-phase", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: {
+          terminals: [
+            {
+              id: "browser-1",
+              kind: "browser",
+              title: "Browser",
+              cwd: "/project",
+              location: "grid",
+            },
+          ],
+        },
+        terminalConfig,
+        project,
+        agentSettings,
+      });
+
+      const beginHydrationBatch = vi.fn(() => Symbol("batch"));
+      const flushHydrationBatch = vi.fn();
+
+      // If `addPanel` rejects, hydration swallows the error (logWarn). The batch
+      // still needs to flush so the store isn't left stuck with a dangling batch.
+      const addPanel = vi.fn().mockRejectedValue(new Error("boom"));
+
+      await hydrateAppState({
+        addPanel,
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+        beginHydrationBatch,
+        flushHydrationBatch,
+      });
+
+      expect(beginHydrationBatch).toHaveBeenCalled();
+      expect(flushHydrationBatch).toHaveBeenCalledTimes(beginHydrationBatch.mock.calls.length);
+    });
+  });
 });

--- a/src/utils/stateHydration/batchScheduler.ts
+++ b/src/utils/stateHydration/batchScheduler.ts
@@ -47,7 +47,7 @@ export function splitSnapshotRestoreTasks(
   return { criticalTasks, deferredTasks };
 }
 
-function delay(ms: number): Promise<void> {
+export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -773,10 +773,7 @@ export async function hydrateAppState(
               // Orphaned backend terminals no longer carry worktreeId — infer it
               // from cwd against the loaded worktrees, then fall back to the
               // active worktree so the panel still appears in the grid filter.
-              const inferred = inferWorktreeIdFromCwd(
-                terminal.cwd,
-                worktreesForInfer ?? undefined
-              );
+              const inferred = inferWorktreeIdFromCwd(terminal.cwd, worktreesForInfer ?? undefined);
               if (inferred) {
                 orphanArgs.worktreeId = inferred;
               } else if (activeWorktreeId) {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -32,10 +32,11 @@ import {
   splitSnapshotRestoreTasks,
   scheduleBackgroundFetchAndRestore,
   registerLazyScrollRestore,
-  runInBatches,
   RESTORE_SPAWN_BATCH_SIZE,
   RESTORE_SPAWN_BATCH_DELAY_MS,
+  delay,
 } from "./batchScheduler";
+import type { HydrationBatchToken } from "@/store/slices/panelRegistry/types";
 import { normalizeAndApplyScrollback } from "./scrollbackConfig";
 import { reconnectWithTimeout } from "./reconnectManager";
 import {
@@ -159,6 +160,15 @@ export interface HydrationOptions {
   hydrateMru?: (list: string[]) => void;
   hydrateActionMru?: (list: string[]) => void;
   restoreTerminalOrder?: (orderedIds: string[]) => void;
+  /**
+   * Optional hydration-batch hooks. When both are provided, each restore phase is
+   * wrapped in a begin/flush pair so the N `addPanel` mutations within the phase
+   * collapse into a single store commit. Leaving them undefined keeps the legacy
+   * per-panel commit behavior (tests and callers that don't care about render
+   * reduction don't need to pass these).
+   */
+  beginHydrationBatch?: () => HydrationBatchToken;
+  flushHydrationBatch?: (token: HydrationBatchToken) => void;
 }
 
 export async function hydrateAppState(
@@ -167,8 +177,34 @@ export async function hydrateAppState(
   isCurrent?: () => boolean,
   prefetchedHydrateResult?: import("@shared/types/ipc/app").HydrateResult
 ): Promise<void> {
-  const { addPanel, setActiveWorktree, loadRecipes, openDiagnosticsDock } = options;
+  const {
+    addPanel,
+    setActiveWorktree,
+    loadRecipes,
+    openDiagnosticsDock,
+    beginHydrationBatch,
+    flushHydrationBatch,
+  } = options;
   const hydrationStartedAt = Date.now();
+
+  /**
+   * Wrap a restore phase in a hydration batch so every `addPanel` call inside `run`
+   * collapses into a single store commit when the phase completes. If the caller
+   * didn't wire the batch hooks (e.g. tests), fall through to the legacy per-panel
+   * commit behavior.
+   */
+  const withHydrationBatch = async (run: () => Promise<void>): Promise<void> => {
+    if (!beginHydrationBatch || !flushHydrationBatch) {
+      await run();
+      return;
+    }
+    const token = beginHydrationBatch();
+    try {
+      await run();
+    } finally {
+      flushHydrationBatch(token);
+    }
+  };
   let panelRestoreStartedAt: number | null = null;
   let panelRestoreCount = 0;
   let tabGroupRestoreCount = 0;
@@ -629,49 +665,68 @@ export async function hydrateAppState(
 
           // Restore all non-PTY panels concurrently (browser, notes, dev-preview).
           // These only perform synchronous store mutations, so no throttling is needed.
+          // The begin/flush wrapper collapses the N addPanel mutations into one store
+          // commit, reducing this phase from N re-renders to 1.
           if (nonPtyTasks.length > 0) {
             logHydrationInfo(`Restoring ${nonPtyTasks.length} non-PTY panel(s) concurrently`);
-            await Promise.allSettled(
-              nonPtyTasks.map(async (task) => {
+            await withHydrationBatch(async () => {
+              await Promise.allSettled(
+                nonPtyTasks.map(async (task) => {
+                  try {
+                    await task.execute();
+                  } catch (error) {
+                    logWarn("Failed to restore non-PTY panel", { error });
+                  }
+                })
+              );
+            });
+          }
+
+          if (!checkCurrent()) return;
+
+          // Restore priority PTY panels sequentially (active worktree, for instant
+          // interactivity). Batched so the sequential `await`s — which normally break
+          // React 19 auto-batching and cause one render per panel — collapse into a
+          // single store commit at phase end.
+          if (ptyPriorityTasks.length > 0) {
+            await withHydrationBatch(async () => {
+              for (const task of ptyPriorityTasks) {
                 try {
                   await task.execute();
                 } catch (error) {
-                  logWarn("Failed to restore non-PTY panel", { error });
+                  logWarn("Failed to restore priority panel", { error });
                 }
-              })
-            );
+              }
+            });
           }
 
           if (!checkCurrent()) return;
 
-          // Restore priority PTY panels sequentially (active worktree, for instant interactivity)
-          for (const task of ptyPriorityTasks) {
-            try {
-              await task.execute();
-            } catch (error) {
-              logWarn("Failed to restore priority panel", { error });
-            }
-          }
-
-          if (!checkCurrent()) return;
-
-          // Restore background PTY panels in staggered batches
+          // Restore background PTY panels in staggered batches. Each batch is its own
+          // hydration batch: we still want staggered spawning to throttle PTY pressure,
+          // but within a batch the N panels commit in one render rather than N.
+          // N background panels -> ceil(N / RESTORE_SPAWN_BATCH_SIZE) renders instead of N.
           if (ptyBackgroundTasks.length > 0) {
             logHydrationInfo(
               `Staggering ${ptyBackgroundTasks.length} background PTY panel(s) in batches of ${RESTORE_SPAWN_BATCH_SIZE}`
             );
-            await runInBatches(
-              ptyBackgroundTasks,
-              RESTORE_SPAWN_BATCH_SIZE,
-              RESTORE_SPAWN_BATCH_DELAY_MS,
-              async (task) => {
-                try {
-                  await task.execute();
-                } catch (error) {
-                  logWarn("Failed to restore background panel", { error });
-                }
+            for (let i = 0; i < ptyBackgroundTasks.length; i += RESTORE_SPAWN_BATCH_SIZE) {
+              const batch = ptyBackgroundTasks.slice(i, i + RESTORE_SPAWN_BATCH_SIZE);
+              await withHydrationBatch(async () => {
+                await Promise.allSettled(
+                  batch.map(async (task) => {
+                    try {
+                      await task.execute();
+                    } catch (error) {
+                      logWarn("Failed to restore background panel", { error });
+                    }
+                  })
+                );
+              });
+              if (i + RESTORE_SPAWN_BATCH_SIZE < ptyBackgroundTasks.length) {
+                await delay(RESTORE_SPAWN_BATCH_DELAY_MS);
               }
-            );
+            }
           }
 
           // Restore saved panel order. The three-phase restore (non-PTY first, then
@@ -708,64 +763,74 @@ export async function hydrateAppState(
           // back to activeWorktreeId so they still appear in the grid.
           const worktreesForInfer = await worktreesPromise;
 
-          await runInBatches(
-            orphanedTerminals,
-            RESTORE_SPAWN_BATCH_SIZE,
-            RESTORE_SPAWN_BATCH_DELAY_MS,
-            async (terminal) => {
-              try {
-                logHydrationInfo(`Reconnecting to orphaned terminal: ${terminal.id}`);
+          const restoreOrphan = async (
+            terminal: (typeof orphanedTerminals)[number]
+          ): Promise<void> => {
+            try {
+              logHydrationInfo(`Reconnecting to orphaned terminal: ${terminal.id}`);
 
-                const orphanArgs = buildArgsForOrphanedTerminal(terminal, projectRoot || "");
-                // Orphaned backend terminals no longer carry worktreeId — infer it
-                // from cwd against the loaded worktrees, then fall back to the
-                // active worktree so the panel still appears in the grid filter.
-                const inferred = inferWorktreeIdFromCwd(
-                  terminal.cwd,
-                  worktreesForInfer ?? undefined
+              const orphanArgs = buildArgsForOrphanedTerminal(terminal, projectRoot || "");
+              // Orphaned backend terminals no longer carry worktreeId — infer it
+              // from cwd against the loaded worktrees, then fall back to the
+              // active worktree so the panel still appears in the grid filter.
+              const inferred = inferWorktreeIdFromCwd(
+                terminal.cwd,
+                worktreesForInfer ?? undefined
+              );
+              if (inferred) {
+                orphanArgs.worktreeId = inferred;
+              } else if (activeWorktreeId) {
+                orphanArgs.worktreeId = activeWorktreeId;
+              }
+              const restoredTerminalId = await addPanel(orphanArgs);
+
+              if (terminal.activityTier) {
+                terminalInstanceService.initializeBackendTier(
+                  restoredTerminalId,
+                  terminal.activityTier
                 );
-                if (inferred) {
-                  orphanArgs.worktreeId = inferred;
-                } else if (activeWorktreeId) {
-                  orphanArgs.worktreeId = activeWorktreeId;
-                }
-                const restoredTerminalId = await addPanel(orphanArgs);
+              }
 
-                if (terminal.activityTier) {
-                  terminalInstanceService.initializeBackendTier(
+              if (terminalSizes && typeof terminalSizes === "object") {
+                const savedSize = terminalSizes[restoredTerminalId];
+                if (
+                  savedSize &&
+                  Number.isFinite(savedSize.cols) &&
+                  Number.isFinite(savedSize.rows) &&
+                  savedSize.cols > 0 &&
+                  savedSize.rows > 0
+                ) {
+                  terminalInstanceService.setTargetSize(
                     restoredTerminalId,
-                    terminal.activityTier
+                    savedSize.cols,
+                    savedSize.rows
                   );
                 }
-
-                if (terminalSizes && typeof terminalSizes === "object") {
-                  const savedSize = terminalSizes[restoredTerminalId];
-                  if (
-                    savedSize &&
-                    Number.isFinite(savedSize.cols) &&
-                    Number.isFinite(savedSize.rows) &&
-                    savedSize.cols > 0 &&
-                    savedSize.rows > 0
-                  ) {
-                    terminalInstanceService.setTargetSize(
-                      restoredTerminalId,
-                      savedSize.cols,
-                      savedSize.rows
-                    );
-                  }
-                }
-
-                restoreTasks.push({
-                  terminalId: restoredTerminalId,
-                  label: terminal.id,
-                  worktreeId: orphanArgs.worktreeId,
-                  location: "grid",
-                });
-              } catch (error) {
-                logWarn(`Failed to reconnect to orphaned terminal ${terminal.id}`, { error });
               }
+
+              restoreTasks.push({
+                terminalId: restoredTerminalId,
+                label: terminal.id,
+                worktreeId: orphanArgs.worktreeId,
+                location: "grid",
+              });
+            } catch (error) {
+              logWarn(`Failed to reconnect to orphaned terminal ${terminal.id}`, { error });
             }
-          );
+          };
+
+          // Same staggered-batch pattern as the background PTY phase: one hydration
+          // batch per spawn batch so orphan restores commit once per batch rather
+          // than once per terminal.
+          for (let i = 0; i < orphanedTerminals.length; i += RESTORE_SPAWN_BATCH_SIZE) {
+            const batch = orphanedTerminals.slice(i, i + RESTORE_SPAWN_BATCH_SIZE);
+            await withHydrationBatch(async () => {
+              await Promise.allSettled(batch.map(restoreOrphan));
+            });
+            if (i + RESTORE_SPAWN_BATCH_SIZE < orphanedTerminals.length) {
+              await delay(RESTORE_SPAWN_BATCH_DELAY_MS);
+            }
+          }
         }
 
         const { criticalTasks, deferredTasks } = splitSnapshotRestoreTasks(


### PR DESCRIPTION
## Summary

- N-panel restore was producing N separate renders of the worktree dashboard, dock, and grid because each `addPanel` call fired a Zustand `set()` across `await` boundaries (React 19 auto-batching doesn't cross them, Zustand 5 has no native batch API).
- Introduces hydration-scoped batching: `panelsById` commits happen eagerly per panel so IPC event listeners (`onAgentStateChanged`, `onExit`, `onAgentDetected`, activity/flow/spawn updates) continue to work, but the high-fanout `panelIds` append is deferred to a phase flush, collapsing N renders into one per phase.
- Post-hydration focus now goes to the first grid panel in the active worktree (deterministic, derived from saved order) rather than whichever panel happened to be added last under async scheduling.

Resolves #5196

## Changes

- `src/store/slices/panelRegistry/core.ts` — `activeHydrationBatch` singleton, `beginHydrationBatch`/`flushHydrationBatch`, batch-aware `addPanel` (non-PTY and PTY paths); PTY branch reordered so the store commit precedes `prewarmTerminal`
- `src/store/slices/panelRegistry/types.ts` — `HydrationBatchToken` type and two new slice method signatures
- `src/utils/stateHydration/index.ts` — `withHydrationBatch` helper wrapping all four restore phases; each spawn batch flushes once instead of once per panel
- `src/hooks/app/useAppHydration.ts` — wires batch hooks; restores focus to first grid panel in active worktree post-hydration
- `src/store/panelStore.ts` — skips per-panel focus set during an active batch

## Testing

Panel registry: 170 tests pass. State hydration: 53 pass. Full store suite: 742 pass. 878 / 878 total passing locally.

New tests cover both PTY and non-PTY batch paths, reconnect merge, stale-token semantics, spawn-failure invariant (batch is flushed even on error), listener visibility (panels are findable by id before the batch flushes), and render count reduction.

Three integration tests lock in phase pairing, fall-through behaviour (no active batch), and the error path.