### PR TITLE
feat(ipc): adopt typedHandle across IPC handlers (#5223)

### DIFF
--- a/electron/ipc/__tests__/ipcHandleCoverage.test.ts
+++ b/electron/ipc/__tests__/ipcHandleCoverage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Channels that intentionally use raw `ipcMain.handle(...)` instead of
+ * `typedHandle`/`typedHandleWithContext`. Adding to this list requires a
+ * documented reason in the handler file.
+ */
+const RAW_HANDLE_ALLOWLIST = new Set<string>([
+  // plugin:invoke — variadic ...args + senderFrame.url trust check is
+  // incompatible with IpcInvokeMap typing; see electron/ipc/handlers/plugin.ts.
+  "CHANNELS.PLUGIN_INVOKE",
+]);
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await readdir(dir);
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (entry === "__tests__" || entry === "node_modules") continue;
+    const full = path.join(dir, entry);
+    const s = await stat(full);
+    if (s.isDirectory()) {
+      results.push(...(await walk(full)));
+    } else if (entry.endsWith(".ts")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+describe("IPC handler coverage", () => {
+  it("uses typedHandle/typedHandleWithContext for every ipcMain.handle call", async () => {
+    const handlersDir = path.join(__dirname, "..", "handlers");
+    const errorHandlersPath = path.join(__dirname, "..", "errorHandlers.ts");
+    const files = [...(await walk(handlersDir)), errorHandlersPath];
+
+    const violations: Array<{ file: string; line: string }> = [];
+
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+      const lines = source.split("\n");
+      for (const line of lines) {
+        const match = line.match(/ipcMain\.handle\(\s*(CHANNELS\.\w+)/);
+        if (!match) continue;
+        const ref = match[1];
+        if (RAW_HANDLE_ALLOWLIST.has(ref)) continue;
+        violations.push({ file: path.relative(process.cwd(), file), line: line.trim() });
+      }
+    }
+
+    expect(
+      violations,
+      `Handler files must use typedHandle/typedHandleWithContext (see electron/ipc/utils.ts). ` +
+        `Add the channel to RAW_HANDLE_ALLOWLIST only if the channel cannot be expressed ` +
+        `through IpcInvokeMap — document the reason in the handler file.`
+    ).toEqual([]);
+  });
+});

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -3,7 +3,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { ipcMain, BrowserWindow, shell } from "electron";
 import { CHANNELS } from "./channels.js";
 import { getLogFilePath, logError as logErrorUtil } from "../utils/logger.js";
-import { broadcastToRenderer } from "./utils.js";
+import { broadcastToRenderer, typedHandle } from "./utils.js";
 import {
   GitError,
   ProcessError,
@@ -424,7 +424,7 @@ export function registerErrorHandlers(
 
   errorService.initialize(worktreeService, ptyClient);
 
-  const handleRetry = async (_event: Electron.IpcMainInvokeEvent, payload: unknown) => {
+  const handleRetry = async (payload: unknown) => {
     let actionForError: RetryAction | undefined;
     let argsForError: Record<string, unknown> | undefined;
 
@@ -445,8 +445,7 @@ export function registerErrorHandlers(
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.ERROR_RETRY, handleRetry);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.ERROR_RETRY));
+  handlers.push(typedHandle(CHANNELS.ERROR_RETRY, handleRetry));
 
   const handleRetryCancelListener = (_event: Electron.IpcMainEvent, errorId: unknown) => {
     if (typeof errorId === "string") {
@@ -461,14 +460,12 @@ export function registerErrorHandlers(
   const handleOpenLogs = async () => {
     await errorService.openLogs();
   };
-  ipcMain.handle(CHANNELS.ERROR_OPEN_LOGS, handleOpenLogs);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.ERROR_OPEN_LOGS));
+  handlers.push(typedHandle(CHANNELS.ERROR_OPEN_LOGS, handleOpenLogs));
 
   const handleGetPending = () => {
     return errorService.getPendingPersistedErrors();
   };
-  ipcMain.handle(CHANNELS.ERROR_GET_PENDING, handleGetPending);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.ERROR_GET_PENDING));
+  handlers.push(typedHandle(CHANNELS.ERROR_GET_PENDING, handleGetPending));
 
   return () => {
     handlers.forEach((cleanup) => cleanup());

--- a/electron/ipc/handlers/__tests__/agentCli.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/agentCli.adversarial.test.ts
@@ -26,7 +26,30 @@ vi.mock("../../../../shared/config/agentRegistry.js", async (importOriginal) => 
   return { ...actual, getAgentIds: getAgentIdsMock };
 });
 
-vi.mock("../../utils.js", () => ({ sendToRenderer: sendToRendererMock }));
+vi.mock("../../utils.js", () => ({
+  sendToRenderer: sendToRendererMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: getWindowForWebContentsMock(event?.sender),
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+}));
 vi.mock("../../../window/webContentsRegistry.js", () => ({
   getWindowForWebContents: getWindowForWebContentsMock,
 }));

--- a/electron/ipc/handlers/__tests__/ai.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/ai.handlers.test.ts
@@ -46,6 +46,27 @@ vi.mock("../../../services/UserAgentRegistryService.js", () => ({
 
 vi.mock("../../utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../menu.js", () => ({

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -6,20 +6,24 @@ const nativeThemeMock = vi.hoisted(() => ({
   removeListener: vi.fn(),
 }));
 
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const browserWindowMock = vi.hoisted(() => ({
+  fromWebContents: vi.fn() as ReturnType<typeof vi.fn>,
+  getFocusedWindow: vi.fn(),
+  getAllWindows: vi.fn(() => []),
+}));
+
 vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+  ipcMain: ipcMainMock,
   dialog: {
     showOpenDialog: vi.fn(),
     showSaveDialog: vi.fn(),
   },
-  BrowserWindow: {
-    fromWebContents: vi.fn(),
-    getFocusedWindow: vi.fn(),
-    getAllWindows: vi.fn(() => []),
-  },
+  BrowserWindow: browserWindowMock,
   nativeTheme: nativeThemeMock,
 }));
 
@@ -67,6 +71,27 @@ vi.mock("../../../../shared/theme/index.js", () => ({
 
 vi.mock("../../utils.js", () => ({
   typedSend: vi.fn(),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: browserWindowMock.fromWebContents(event?.sender) ?? null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 const fsMock = vi.hoisted(() => ({

--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -12,7 +12,7 @@ const ipcMainMock = vi.hoisted(() => ({
 }));
 
 const browserWindowMock = vi.hoisted(() => ({
-  fromWebContents: vi.fn() as ReturnType<typeof vi.fn>,
+  fromWebContents: vi.fn<(sender: unknown) => unknown>(),
   getFocusedWindow: vi.fn(),
   getAllWindows: vi.fn(() => []),
 }));

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -99,7 +99,7 @@ describe("copyTree handlers", () => {
   it("returns validation errors instead of throwing for invalid test-config payloads", async () => {
     const handler = getInvokeHandler(CHANNELS.COPYTREE_TEST_CONFIG);
 
-    await expect(handler({} as never, null as never)).resolves.toEqual(
+    await expect(handler(mockEvent, null as never)).resolves.toEqual(
       expect.objectContaining({
         error: expect.stringContaining("Invalid payload"),
       })

--- a/electron/ipc/handlers/__tests__/devPreview.session.test.ts
+++ b/electron/ipc/handlers/__tests__/devPreview.session.test.ts
@@ -6,16 +6,38 @@ vi.mock("node:http", () => ({ default: { request: vi.fn() }, request: vi.fn() })
 vi.mock("node:https", () => ({ default: { request: vi.fn() }, request: vi.fn() }));
 
 const broadcastMock = vi.hoisted(() => vi.fn());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
 
 vi.mock("../../utils.js", () => ({
   broadcastToRenderer: broadcastMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+  ipcMain: ipcMainMock,
 }));
 
 const scanOutputMock = vi.fn();

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -52,6 +52,10 @@ vi.mock("node:v8", () => ({
 }));
 
 vi.mock("node:perf_hooks", () => ({
+  performance: {
+    now: () => Date.now(),
+    timeOrigin: Date.now(),
+  },
   monitorEventLoopDelay: () => ({
     enable: vi.fn(),
     disable: vi.fn(),

--- a/electron/ipc/handlers/__tests__/files.search.test.ts
+++ b/electron/ipc/handlers/__tests__/files.search.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+  ipcMain: ipcMainMock,
 }));
 
 const fileSearchServiceMock = vi.hoisted(() => ({
@@ -15,6 +17,27 @@ const checkRateLimitMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../utils.js", () => ({
   checkRateLimit: checkRateLimitMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../services/FileSearchService.js", () => ({

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -52,6 +52,27 @@ vi.mock("electron", () => ({
 
 vi.mock("../../utils.js", () => ({
   checkRateLimit: checkRateLimitMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../services/GitHubService.js", () => gitHubServiceMock);

--- a/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/privacy.handlers.test.ts
@@ -52,6 +52,26 @@ vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
 
 const utilsMock = vi.hoisted(() => ({
   typedBroadcast: vi.fn(),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (...args: unknown[]) => {
+      const event = args[0] as { sender?: { id?: number } } | null | undefined;
+      const rest = args.slice(1);
+      const ctx = {
+        event: event as unknown,
+        webContentsId: event?.sender?.id ?? 0,
+        senderWindow: null,
+        projectId: null,
+      };
+      return (handler as (...a: unknown[]) => unknown)(ctx, ...rest);
+    });
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../utils.js", () => utilsMock);

--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import os from "os";
 
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+  ipcMain: ipcMainMock,
   dialog: {
     showOpenDialog: vi.fn(),
     showErrorBox: vi.fn(),
@@ -28,6 +30,27 @@ vi.mock("../../utils.js", () => ({
   checkRateLimit: checkRateLimitMock,
   broadcastToRenderer: vi.fn(),
   sendToRenderer: vi.fn(),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../services/ProjectStore.js", () => ({

--- a/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
@@ -20,6 +20,27 @@ vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
 
 const utilsMock = vi.hoisted(() => ({
   typedBroadcast: vi.fn(),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../utils.js", () => utilsMock);

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -12,6 +12,7 @@ vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
   systemPreferences: { getMediaAccessStatus: vi.fn(() => "granted") },
   shell: { openExternal: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn(() => null) },
 }));
 
 // ── Shared state container for mocks ───────────────────────────────────────

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -69,6 +69,27 @@ vi.mock("../../utils.js", () => ({
   broadcastToRenderer: vi.fn((channel: string, ...args: unknown[]) => {
     mainWindowMock.webContents.send(channel, ...args);
   }),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 import { registerWebviewHandlers } from "../webview.js";

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -50,6 +50,27 @@ vi.mock("../../../window/webContentsRegistry.js", () => ({
 vi.mock("../../utils.js", () => ({
   checkRateLimit: checkRateLimitMock,
   waitForRateLimitSlot: waitForRateLimitSlotMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: getWindowForWebContentsMock(event?.sender),
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../store.js", () => ({ store: storeMock }));

--- a/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
@@ -18,6 +18,27 @@ vi.mock("electron", () => ({
 vi.mock("../../utils.js", () => ({
   checkRateLimit: checkRateLimitMock,
   waitForRateLimitSlot: waitForRateLimitSlotMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../services/ProjectStore.js", () => ({

--- a/electron/ipc/handlers/accessibility.ts
+++ b/electron/ipc/handlers/accessibility.ts
@@ -1,6 +1,7 @@
-import { app, ipcMain, BrowserWindow } from "electron";
+import { app, BrowserWindow } from "electron";
 import { CHANNELS } from "../channels.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
+import { typedHandle } from "../utils.js";
 
 export function registerAccessibilityHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -8,8 +9,7 @@ export function registerAccessibilityHandlers(): () => void {
   const handleGetEnabled = async () => {
     return app.accessibilitySupportEnabled;
   };
-  ipcMain.handle(CHANNELS.ACCESSIBILITY_GET_ENABLED, handleGetEnabled);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.ACCESSIBILITY_GET_ENABLED));
+  handlers.push(typedHandle(CHANNELS.ACCESSIBILITY_GET_ENABLED, handleGetEnabled));
 
   const onChanged = (_event: Electron.Event, enabled: boolean) => {
     for (const win of BrowserWindow.getAllWindows()) {

--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import {
@@ -10,6 +9,7 @@ import {
 } from "../../../shared/config/agentRegistry.js";
 import type { AgentMetadata } from "../../../shared/types/ipc/agentCapabilities.js";
 import { isAgentPinned } from "../../../shared/utils/agentPinned.js";
+import { typedHandle } from "../utils.js";
 
 function toAgentMetadata(config: AgentConfig, agentId: string): AgentMetadata {
   const isBuiltIn = agentId in AGENT_REGISTRY;
@@ -41,19 +41,14 @@ export function registerAgentCapabilitiesHandlers(): () => void {
   const handleGetRegistry = async () => {
     return getEffectiveRegistry();
   };
-  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_GET_REGISTRY, handleGetRegistry);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_GET_REGISTRY));
+  handlers.push(typedHandle(CHANNELS.AGENT_CAPABILITIES_GET_REGISTRY, handleGetRegistry));
 
   const handleGetAgentIds = async () => {
     return getEffectiveAgentIds();
   };
-  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_IDS, handleGetAgentIds);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_IDS));
+  handlers.push(typedHandle(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_IDS, handleGetAgentIds));
 
-  const handleGetAgentMetadata = async (
-    _event: Electron.IpcMainInvokeEvent,
-    agentId: string
-  ): Promise<AgentMetadata | null> => {
+  const handleGetAgentMetadata = async (agentId: string): Promise<AgentMetadata | null> => {
     if (!agentId || typeof agentId !== "string") {
       throw new Error("Invalid agentId");
     }
@@ -66,13 +61,11 @@ export function registerAgentCapabilitiesHandlers(): () => void {
     }
     return toAgentMetadata(config, agentId);
   };
-  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_METADATA, handleGetAgentMetadata);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_METADATA));
+  handlers.push(
+    typedHandle(CHANNELS.AGENT_CAPABILITIES_GET_AGENT_METADATA, handleGetAgentMetadata)
+  );
 
-  const handleIsAgentEnabled = async (
-    _event: Electron.IpcMainInvokeEvent,
-    agentId: string
-  ): Promise<boolean> => {
+  const handleIsAgentEnabled = async (agentId: string): Promise<boolean> => {
     if (!agentId || typeof agentId !== "string") {
       throw new Error("Invalid agentId");
     }
@@ -87,8 +80,7 @@ export function registerAgentCapabilitiesHandlers(): () => void {
     const agentEntry = agentSettings?.agents?.[agentId];
     return isAgentPinned(agentEntry);
   };
-  ipcMain.handle(CHANNELS.AGENT_CAPABILITIES_IS_AGENT_ENABLED, handleIsAgentEnabled);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_CAPABILITIES_IS_AGENT_ENABLED));
+  handlers.push(typedHandle(CHANNELS.AGENT_CAPABILITIES_IS_AGENT_ENABLED, handleIsAgentEnabled));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -1,12 +1,10 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { getAgentIds } from "../../../shared/config/agentRegistry.js";
 import type {
   AgentAvailabilityState,
   AgentInstallPayload,
 } from "../../../shared/types/ipc/system.js";
-import { sendToRenderer } from "../utils.js";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { sendToRenderer, typedHandle, typedHandleWithContext } from "../utils.js";
 import { runAgentInstall } from "../../services/AgentInstallService.js";
 import type { HandlerDependencies } from "../types.js";
 
@@ -29,8 +27,7 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
 
     return await cliAvailabilityService.checkAvailability();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_CLI_AVAILABILITY, handleSystemGetCliAvailability);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_CLI_AVAILABILITY));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_CLI_AVAILABILITY, handleSystemGetCliAvailability));
 
   const handleSystemRefreshCliAvailability = async () => {
     if (!cliAvailabilityService) {
@@ -42,8 +39,9 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
 
     return await cliAvailabilityService.refresh();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_REFRESH_CLI_AVAILABILITY, handleSystemRefreshCliAvailability);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_REFRESH_CLI_AVAILABILITY));
+  handlers.push(
+    typedHandle(CHANNELS.SYSTEM_REFRESH_CLI_AVAILABILITY, handleSystemRefreshCliAvailability)
+  );
 
   const handleSystemGetAgentVersions = async () => {
     if (!agentVersionService) {
@@ -53,8 +51,7 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
 
     return await agentVersionService.getVersions();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_AGENT_VERSIONS, handleSystemGetAgentVersions);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_AGENT_VERSIONS));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_AGENT_VERSIONS, handleSystemGetAgentVersions));
 
   const handleSystemRefreshAgentVersions = async () => {
     if (!agentVersionService) {
@@ -64,8 +61,9 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
 
     return await agentVersionService.getVersions(true);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_REFRESH_AGENT_VERSIONS, handleSystemRefreshAgentVersions);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_REFRESH_AGENT_VERSIONS));
+  handlers.push(
+    typedHandle(CHANNELS.SYSTEM_REFRESH_AGENT_VERSIONS, handleSystemRefreshAgentVersions)
+  );
 
   const handleSystemGetAgentUpdateSettings = async () => {
     const { store } = await import("../../store.js");
@@ -75,11 +73,11 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
       lastAutoCheck: null,
     });
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_AGENT_UPDATE_SETTINGS, handleSystemGetAgentUpdateSettings);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_AGENT_UPDATE_SETTINGS));
+  handlers.push(
+    typedHandle(CHANNELS.SYSTEM_GET_AGENT_UPDATE_SETTINGS, handleSystemGetAgentUpdateSettings)
+  );
 
   const handleSystemSetAgentUpdateSettings = async (
-    _event: Electron.IpcMainInvokeEvent,
     settings: import("../../types/index.js").AgentUpdateSettings
   ) => {
     if (
@@ -98,11 +96,11 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
     const { store } = await import("../../store.js");
     store.set("agentUpdateSettings", settings);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_SET_AGENT_UPDATE_SETTINGS, handleSystemSetAgentUpdateSettings);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_SET_AGENT_UPDATE_SETTINGS));
+  handlers.push(
+    typedHandle(CHANNELS.SYSTEM_SET_AGENT_UPDATE_SETTINGS, handleSystemSetAgentUpdateSettings)
+  );
 
   const handleSystemStartAgentUpdate = async (
-    _event: Electron.IpcMainInvokeEvent,
     payload: import("../../types/index.js").StartAgentUpdatePayload
   ) => {
     if (!agentUpdateHandler) {
@@ -120,31 +118,21 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
 
     return await agentUpdateHandler.startUpdate(payload);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_START_AGENT_UPDATE, handleSystemStartAgentUpdate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_START_AGENT_UPDATE));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_START_AGENT_UPDATE, handleSystemStartAgentUpdate));
 
-  const handleSystemHealthCheck = async (
-    _event: Electron.IpcMainInvokeEvent,
-    agentIds?: string[]
-  ) => {
+  const handleSystemHealthCheck = async (agentIds?: string[]) => {
     const { runSystemHealthCheck } = await import("../../services/SystemHealthCheck.js");
     return await runSystemHealthCheck(agentIds);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_HEALTH_CHECK, handleSystemHealthCheck);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_HEALTH_CHECK));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_HEALTH_CHECK, handleSystemHealthCheck));
 
-  const handleSystemHealthCheckSpecs = async (
-    _event: Electron.IpcMainInvokeEvent,
-    agentIds?: string[]
-  ) => {
+  const handleSystemHealthCheckSpecs = async (agentIds?: string[]) => {
     const { getHealthCheckSpecs } = await import("../../services/SystemHealthCheck.js");
     return await getHealthCheckSpecs(agentIds);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_HEALTH_CHECK_SPECS, handleSystemHealthCheckSpecs);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_HEALTH_CHECK_SPECS));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_HEALTH_CHECK_SPECS, handleSystemHealthCheckSpecs));
 
   const handleSystemCheckTool = async (
-    _event: Electron.IpcMainInvokeEvent,
     spec: import("../../../shared/types/ipc/system.js").PrerequisiteSpec
   ) => {
     const { checkPrerequisite } = await import("../../services/SystemHealthCheck.js");
@@ -154,14 +142,13 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
       }
     );
   };
-  ipcMain.handle(CHANNELS.SYSTEM_CHECK_TOOL, handleSystemCheckTool);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_CHECK_TOOL));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_CHECK_TOOL, handleSystemCheckTool));
 
   const handleSetupAgentInstall = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../types.js").IpcContext,
     payload: AgentInstallPayload
   ) => {
-    const senderWindow = getWindowForWebContents(event.sender);
+    const senderWindow = ctx.senderWindow;
 
     if (
       !payload ||
@@ -179,8 +166,7 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
       }
     });
   };
-  ipcMain.handle(CHANNELS.SETUP_AGENT_INSTALL, handleSetupAgentInstall);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SETUP_AGENT_INSTALL));
+  handlers.push(typedHandleWithContext(CHANNELS.SETUP_AGENT_INSTALL, handleSetupAgentInstall));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/ai.ts
+++ b/electron/ipc/handlers/ai.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
@@ -6,7 +5,7 @@ import { DEFAULT_AGENT_SETTINGS, type UserAgentConfig } from "../../../shared/ty
 import { AgentHelpService } from "../../services/AgentHelpService.js";
 import { UserAgentRegistryService } from "../../services/UserAgentRegistryService.js";
 import type { AgentHelpRequest, AgentHelpResult } from "../../../shared/types/ipc/agent.js";
-import { broadcastToRenderer } from "../utils.js";
+import { broadcastToRenderer, typedHandle } from "../utils.js";
 import { createApplicationMenu } from "../../menu.js";
 
 const RESERVED_AGENT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -61,16 +60,12 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
   const handleAgentSettingsGet = async () => {
     return store.get("agentSettings");
   };
-  ipcMain.handle(CHANNELS.AGENT_SETTINGS_GET, handleAgentSettingsGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_SETTINGS_GET));
+  handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_GET, handleAgentSettingsGet));
 
-  const handleAgentSettingsSet = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      agentType: string;
-      settings: Record<string, unknown>;
-    }
-  ) => {
+  const handleAgentSettingsSet = async (payload: {
+    agentType: string;
+    settings: Record<string, unknown>;
+  }) => {
     if (!isPlainRecord(payload)) {
       throw new Error("Invalid payload");
     }
@@ -99,13 +94,9 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
     store.set("agentSettings", updatedSettings);
     return updatedSettings;
   };
-  ipcMain.handle(CHANNELS.AGENT_SETTINGS_SET, handleAgentSettingsSet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_SETTINGS_SET));
+  handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_SET, handleAgentSettingsSet));
 
-  const handleAgentSettingsReset = async (
-    _event: Electron.IpcMainInvokeEvent,
-    agentType?: unknown
-  ) => {
+  const handleAgentSettingsReset = async (agentType?: unknown) => {
     if (agentType !== undefined) {
       const safeAgentType = validateAgentType(agentType);
       const currentSettings = normalizeAgentSettings(
@@ -125,13 +116,9 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
       return DEFAULT_AGENT_SETTINGS;
     }
   };
-  ipcMain.handle(CHANNELS.AGENT_SETTINGS_RESET, handleAgentSettingsReset);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_SETTINGS_RESET));
+  handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_RESET, handleAgentSettingsReset));
 
-  const handleAgentHelpGet = async (
-    _event: Electron.IpcMainInvokeEvent,
-    request: AgentHelpRequest
-  ): Promise<AgentHelpResult> => {
+  const handleAgentHelpGet = async (request: AgentHelpRequest): Promise<AgentHelpResult> => {
     if (!request || typeof request !== "object") {
       throw new Error("Invalid request");
     }
@@ -144,31 +131,25 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
     }
     return agentHelpService.getHelp(agentId, refresh);
   };
-  ipcMain.handle(CHANNELS.AGENT_HELP_GET, handleAgentHelpGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_HELP_GET));
+  handlers.push(typedHandle(CHANNELS.AGENT_HELP_GET, handleAgentHelpGet));
 
   const handleUserAgentRegistryGet = async () => {
     return userAgentRegistryService.getRegistry();
   };
-  ipcMain.handle(CHANNELS.USER_AGENT_REGISTRY_GET, handleUserAgentRegistryGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.USER_AGENT_REGISTRY_GET));
+  handlers.push(typedHandle(CHANNELS.USER_AGENT_REGISTRY_GET, handleUserAgentRegistryGet));
 
-  const handleUserAgentRegistryAdd = async (
-    _event: Electron.IpcMainInvokeEvent,
-    config: UserAgentConfig
-  ) => {
+  const handleUserAgentRegistryAdd = async (config: UserAgentConfig) => {
     if (!config || typeof config !== "object") {
       throw new Error("Invalid config");
     }
     return userAgentRegistryService.addAgent(config);
   };
-  ipcMain.handle(CHANNELS.USER_AGENT_REGISTRY_ADD, handleUserAgentRegistryAdd);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.USER_AGENT_REGISTRY_ADD));
+  handlers.push(typedHandle(CHANNELS.USER_AGENT_REGISTRY_ADD, handleUserAgentRegistryAdd));
 
-  const handleUserAgentRegistryUpdate = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { id: string; config: UserAgentConfig }
-  ) => {
+  const handleUserAgentRegistryUpdate = async (payload: {
+    id: string;
+    config: UserAgentConfig;
+  }) => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -181,17 +162,15 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
     }
     return userAgentRegistryService.updateAgent(id, config);
   };
-  ipcMain.handle(CHANNELS.USER_AGENT_REGISTRY_UPDATE, handleUserAgentRegistryUpdate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.USER_AGENT_REGISTRY_UPDATE));
+  handlers.push(typedHandle(CHANNELS.USER_AGENT_REGISTRY_UPDATE, handleUserAgentRegistryUpdate));
 
-  const handleUserAgentRegistryRemove = async (_event: Electron.IpcMainInvokeEvent, id: string) => {
+  const handleUserAgentRegistryRemove = async (id: string) => {
     if (!id || typeof id !== "string") {
       throw new Error("Invalid id");
     }
     return userAgentRegistryService.removeAgent(id);
   };
-  ipcMain.handle(CHANNELS.USER_AGENT_REGISTRY_REMOVE, handleUserAgentRegistryRemove);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.USER_AGENT_REGISTRY_REMOVE));
+  handlers.push(typedHandle(CHANNELS.USER_AGENT_REGISTRY_REMOVE, handleUserAgentRegistryRemove));
 
   const handleReloadConfig = async () => {
     userAgentRegistryService.reload();
@@ -208,8 +187,7 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
 
     return { success: true };
   };
-  ipcMain.handle(CHANNELS.APP_RELOAD_CONFIG, handleReloadConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_RELOAD_CONFIG));
+  handlers.push(typedHandle(CHANNELS.APP_RELOAD_CONFIG, handleReloadConfig));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/app/crashRecovery.ts
+++ b/electron/ipc/handlers/app/crashRecovery.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { getCrashRecoveryService } from "../../../services/CrashRecoveryService.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
@@ -6,45 +5,47 @@ import type {
   CrashRecoveryAction,
   CrashRecoveryConfig,
 } from "../../../../shared/types/ipc/crashRecovery.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerCrashRecoveryHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.CRASH_RECOVERY_GET_PENDING, () => {
-    if (getCrashLoopGuard().isSafeMode()) {
-      return null;
-    }
-    return getCrashRecoveryService().getPendingCrash();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.CRASH_RECOVERY_GET_PENDING));
-
-  ipcMain.handle(CHANNELS.CRASH_RECOVERY_RESOLVE, (_event, action: CrashRecoveryAction) => {
-    const service = getCrashRecoveryService();
-    if (action.kind === "restore") {
-      const ok = service.restoreBackup(action.panelIds);
-      if (ok) {
-        service.setPanelFilter(action.panelIds);
-      } else {
-        console.warn("[CrashRecovery] restoreBackup returned false — no backup or read error");
+  handlers.push(
+    typedHandle(CHANNELS.CRASH_RECOVERY_GET_PENDING, () => {
+      if (getCrashLoopGuard().isSafeMode()) {
+        return null;
       }
-    } else {
-      service.resetToFresh();
-    }
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.CRASH_RECOVERY_RESOLVE));
-
-  ipcMain.handle(CHANNELS.CRASH_RECOVERY_GET_CONFIG, () => {
-    return getCrashRecoveryService().getConfig();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.CRASH_RECOVERY_GET_CONFIG));
-
-  ipcMain.handle(
-    CHANNELS.CRASH_RECOVERY_SET_CONFIG,
-    (_event, config: Partial<CrashRecoveryConfig>) => {
-      return getCrashRecoveryService().setConfig(config);
-    }
+      return getCrashRecoveryService().getPendingCrash();
+    })
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.CRASH_RECOVERY_SET_CONFIG));
+
+  handlers.push(
+    typedHandle(CHANNELS.CRASH_RECOVERY_RESOLVE, (action: CrashRecoveryAction) => {
+      const service = getCrashRecoveryService();
+      if (action.kind === "restore") {
+        const ok = service.restoreBackup(action.panelIds);
+        if (ok) {
+          service.setPanelFilter(action.panelIds);
+        } else {
+          console.warn("[CrashRecovery] restoreBackup returned false — no backup or read error");
+        }
+      } else {
+        service.resetToFresh();
+      }
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.CRASH_RECOVERY_GET_CONFIG, () => {
+      return getCrashRecoveryService().getConfig();
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.CRASH_RECOVERY_SET_CONFIG, (config: Partial<CrashRecoveryConfig>) => {
+      return getCrashRecoveryService().setConfig(config);
+    })
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/app/gpu.ts
+++ b/electron/ipc/handlers/app/gpu.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app } from "electron";
+import { app } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import {
@@ -7,6 +7,7 @@ import {
   clearGpuDisabledFlag,
 } from "../../../services/GpuCrashMonitorService.js";
 import { closeTelemetry } from "../../../services/TelemetryService.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerGpuHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -17,13 +18,9 @@ export function registerGpuHandlers(): () => void {
       hardwareAccelerationDisabled: isGpuDisabledByFlag(userDataPath),
     };
   };
-  ipcMain.handle(CHANNELS.GPU_GET_STATUS, handleGetStatus);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GPU_GET_STATUS));
+  handlers.push(typedHandle(CHANNELS.GPU_GET_STATUS, handleGetStatus));
 
-  const handleSetHardwareAcceleration = async (
-    _event: Electron.IpcMainInvokeEvent,
-    enabled: boolean
-  ) => {
+  const handleSetHardwareAcceleration = async (enabled: boolean) => {
     const userDataPath = app.getPath("userData");
     if (enabled) {
       clearGpuDisabledFlag(userDataPath);
@@ -36,8 +33,7 @@ export function registerGpuHandlers(): () => void {
     await closeTelemetry();
     app.exit(0);
   };
-  ipcMain.handle(CHANNELS.GPU_SET_HARDWARE_ACCELERATION, handleSetHardwareAcceleration);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GPU_SET_HARDWARE_ACCELERATION));
+  handlers.push(typedHandle(CHANNELS.GPU_SET_HARDWARE_ACCELERATION, handleSetHardwareAcceleration));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app } from "electron";
+import { app } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { store, type StoreSchema, consumePendingSettingsRecovery } from "../../../store.js";
 import { projectStore } from "../../../services/ProjectStore.js";
@@ -13,6 +13,7 @@ import { isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
 import { isGpuDisabledByFlag } from "../../../services/GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
 import { inferKind } from "../../../../shared/utils/inferPanelKind.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerAppStateHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -240,24 +241,25 @@ export function registerAppStateHandlers(): () => void {
       settingsRecovery: consumePendingSettingsRecovery(),
     };
   };
-  ipcMain.handle(CHANNELS.APP_HYDRATE, handleAppHydrate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_HYDRATE));
+  handlers.push(typedHandle(CHANNELS.APP_HYDRATE, handleAppHydrate));
 
   const handleAppGetState = async () => {
     return store.get("appState");
   };
-  ipcMain.handle(CHANNELS.APP_GET_STATE, handleAppGetState);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_GET_STATE));
+  handlers.push(typedHandle(CHANNELS.APP_GET_STATE, handleAppGetState));
 
   const handleAppSetState = async (
-    _event: Electron.IpcMainInvokeEvent,
-    partialState: Partial<typeof store.store.appState>
+    incoming: Partial<import("../../../../shared/types/ipc/app.js").AppState>
   ) => {
     try {
-      if (!partialState || typeof partialState !== "object" || Array.isArray(partialState)) {
-        console.error("Invalid app state payload:", partialState);
+      if (!incoming || typeof incoming !== "object" || Array.isArray(incoming)) {
+        console.error("Invalid app state payload:", incoming);
         return;
       }
+
+      // Handler performs its own structural validation before writing; cast to the
+      // store schema to keep the `updates` object compatible with persistence types.
+      const partialState = incoming as Partial<typeof store.store.appState>;
 
       const currentState = store.get("appState");
 
@@ -421,26 +423,22 @@ export function registerAppStateHandlers(): () => void {
       console.error("Failed to set app state:", error);
     }
   };
-  ipcMain.handle(CHANNELS.APP_SET_STATE, handleAppSetState);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_SET_STATE));
+  handlers.push(typedHandle(CHANNELS.APP_SET_STATE, handleAppSetState));
 
   const handleAppGetVersion = async () => {
     return app.getVersion();
   };
-  ipcMain.handle(CHANNELS.APP_GET_VERSION, handleAppGetVersion);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_GET_VERSION));
+  handlers.push(typedHandle(CHANNELS.APP_GET_VERSION, handleAppGetVersion));
 
   const handleAppQuit = async () => {
     app.quit();
   };
-  ipcMain.handle(CHANNELS.APP_QUIT, handleAppQuit);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_QUIT));
+  handlers.push(typedHandle(CHANNELS.APP_QUIT, handleAppQuit));
 
   const handleAppForceQuit = async () => {
     app.exit(0);
   };
-  ipcMain.handle(CHANNELS.APP_FORCE_QUIT, handleAppForceQuit);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_FORCE_QUIT));
+  handlers.push(typedHandle(CHANNELS.APP_FORCE_QUIT, handleAppForceQuit));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/appAgent.ts
+++ b/electron/ipc/handlers/appAgent.ts
@@ -1,9 +1,9 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { appAgentService } from "../../services/AppAgentService.js";
 import type { AppAgentConfig } from "../../../shared/types/appAgent.js";
 import { AppAgentConfigSchema } from "../../../shared/types/appAgent.js";
+import { typedHandle } from "../utils.js";
 
 export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -11,13 +11,9 @@ export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void
   const handleGetConfig = async () => {
     return appAgentService.getConfig();
   };
-  ipcMain.handle(CHANNELS.APP_AGENT_GET_CONFIG, handleGetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_AGENT_GET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.APP_AGENT_GET_CONFIG, handleGetConfig));
 
-  const handleSetConfig = async (
-    _event: Electron.IpcMainInvokeEvent,
-    config: Partial<AppAgentConfig>
-  ) => {
+  const handleSetConfig = async (config: Partial<AppAgentConfig>) => {
     if (!config || typeof config !== "object") {
       throw new Error("Invalid config");
     }
@@ -30,32 +26,28 @@ export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void
     appAgentService.setConfig(configResult.data);
     return appAgentService.getConfig();
   };
-  ipcMain.handle(CHANNELS.APP_AGENT_SET_CONFIG, handleSetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_AGENT_SET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.APP_AGENT_SET_CONFIG, handleSetConfig));
 
   const handleHasApiKey = async () => {
     return appAgentService.hasApiKey();
   };
-  ipcMain.handle(CHANNELS.APP_AGENT_HAS_API_KEY, handleHasApiKey);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_AGENT_HAS_API_KEY));
+  handlers.push(typedHandle(CHANNELS.APP_AGENT_HAS_API_KEY, handleHasApiKey));
 
-  const handleTestApiKey = async (_event: Electron.IpcMainInvokeEvent, apiKey: string) => {
+  const handleTestApiKey = async (apiKey: string) => {
     if (!apiKey || typeof apiKey !== "string") {
       throw new Error("Invalid API key");
     }
     return appAgentService.testApiKey(apiKey.trim());
   };
-  ipcMain.handle(CHANNELS.APP_AGENT_TEST_API_KEY, handleTestApiKey);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_AGENT_TEST_API_KEY));
+  handlers.push(typedHandle(CHANNELS.APP_AGENT_TEST_API_KEY, handleTestApiKey));
 
-  const handleTestModel = async (_event: Electron.IpcMainInvokeEvent, model: string) => {
+  const handleTestModel = async (model: string) => {
     if (!model || typeof model !== "string") {
       throw new Error("Invalid model");
     }
     return appAgentService.testModel(model.trim());
   };
-  ipcMain.handle(CHANNELS.APP_AGENT_TEST_MODEL, handleTestModel);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_AGENT_TEST_MODEL));
+  handlers.push(typedHandle(CHANNELS.APP_AGENT_TEST_MODEL, handleTestModel));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -1,5 +1,4 @@
-import { ipcMain, dialog, BrowserWindow, nativeTheme } from "electron";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { dialog, BrowserWindow, nativeTheme } from "electron";
 import { promises as fs } from "node:fs";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
@@ -9,7 +8,7 @@ import {
   normalizeAppColorScheme,
   normalizeAccentHex,
 } from "../../../shared/theme/index.js";
-import { typedSend } from "../utils.js";
+import { typedHandle, typedHandleWithContext, typedSend } from "../utils.js";
 import type {
   AppThemeConfig,
   AppColorScheme,
@@ -56,197 +55,177 @@ function parseCustomSchemes(config: AppThemeConfig): AppColorScheme[] {
 export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleAppThemeGet = async () => {
-    return getAppThemeConfig();
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_GET, handleAppThemeGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_GET));
+  handlers.push(typedHandle(CHANNELS.APP_THEME_GET, async () => getAppThemeConfig()));
 
-  const handleAppThemeSetColorScheme = async (
-    _event: Electron.IpcMainInvokeEvent,
-    schemeId: string
-  ) => {
-    if (typeof schemeId !== "string" || !schemeId.trim()) {
-      console.warn("Invalid app theme colorSchemeId:", schemeId);
-      return;
-    }
-    const current = getAppThemeConfig();
-    store.set("appTheme", { ...current, colorSchemeId: schemeId.trim() } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_COLOR_SCHEME, handleAppThemeSetColorScheme);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_COLOR_SCHEME));
-
-  const handleAppThemeSetCustomSchemes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    schemesJson: string
-  ) => {
-    if (typeof schemesJson !== "string") {
-      console.warn("Invalid app custom schemes:", schemesJson);
-      return;
-    }
-    const current = getAppThemeConfig();
-    store.set("appTheme", {
-      ...current,
-      customSchemes: schemesJson,
-    } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES, handleAppThemeSetCustomSchemes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES));
-
-  const VALID_COLOR_VISION_MODES = ["default", "red-green", "blue-yellow"];
-  const handleAppThemeSetColorVisionMode = async (
-    _event: Electron.IpcMainInvokeEvent,
-    mode: string
-  ) => {
-    if (typeof mode !== "string" || !VALID_COLOR_VISION_MODES.includes(mode)) {
-      console.warn("Invalid color vision mode:", mode);
-      return;
-    }
-    const current = getAppThemeConfig();
-    store.set("appTheme", {
-      ...current,
-      colorVisionMode: mode as ColorVisionMode,
-    } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_COLOR_VISION_MODE, handleAppThemeSetColorVisionMode);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_COLOR_VISION_MODE));
-
-  const handleAppThemeImport = async (event: Electron.IpcMainInvokeEvent) => {
-    const win = getWindowForWebContents(event.sender) ?? BrowserWindow.getFocusedWindow();
-    const dialogOptions = {
-      title: "Import App Theme",
-      filters: [
-        { name: "Theme Files", extensions: ["json"] },
-        { name: "All Files", extensions: ["*"] },
-      ],
-      properties: ["openFile" as const],
-    };
-    const result = win
-      ? await dialog.showOpenDialog(win, dialogOptions)
-      : await dialog.showOpenDialog(dialogOptions);
-
-    if (result.canceled || result.filePaths.length === 0) {
-      return { ok: false, errors: ["Import cancelled"] };
-    }
-
-    return parseAppThemeFile(result.filePaths[0]);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_IMPORT, handleAppThemeImport);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_IMPORT));
-
-  const handleAppThemeExport = async (
-    event: Electron.IpcMainInvokeEvent,
-    scheme: AppColorScheme
-  ): Promise<boolean> => {
-    if (!scheme || typeof scheme.id !== "string" || typeof scheme.name !== "string") {
-      return false;
-    }
-
-    const safeName =
-      scheme.name
-        .replace(/[\\/:*?"<>|]/g, "")
-        .replace(/\s+/g, " ")
-        .trim()
-        .slice(0, 200) || "theme";
-
-    const win = getWindowForWebContents(event.sender) ?? BrowserWindow.getFocusedWindow();
-    const dialogOptions = {
-      title: "Export App Theme",
-      defaultPath: `${safeName}.json`,
-      filters: [
-        { name: "Theme Files", extensions: ["json"] },
-        { name: "All Files", extensions: ["*"] },
-      ],
-    };
-
-    const { filePath, canceled } = win
-      ? await dialog.showSaveDialog(win, dialogOptions)
-      : await dialog.showSaveDialog(dialogOptions);
-
-    if (canceled || !filePath) return false;
-
-    const { location: _loc, builtin: _builtin, ...exportData } = scheme;
-    await fs.writeFile(filePath, JSON.stringify(exportData, null, 2), "utf-8");
-    return true;
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_EXPORT, handleAppThemeExport);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_EXPORT));
-
-  // Follow system handlers
-  const handleSetFollowSystem = async (_event: Electron.IpcMainInvokeEvent, enabled: boolean) => {
-    if (typeof enabled !== "boolean") return;
-    const current = getAppThemeConfig();
-    store.set("appTheme", { ...current, followSystem: enabled } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_FOLLOW_SYSTEM, handleSetFollowSystem);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_FOLLOW_SYSTEM));
-
-  const handleSetPreferredDarkScheme = async (
-    _event: Electron.IpcMainInvokeEvent,
-    schemeId: string
-  ) => {
-    if (typeof schemeId !== "string" || !schemeId.trim()) return;
-    const current = getAppThemeConfig();
-    store.set("appTheme", {
-      ...current,
-      preferredDarkSchemeId: schemeId.trim(),
-    } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_PREFERRED_DARK_SCHEME, handleSetPreferredDarkScheme);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_PREFERRED_DARK_SCHEME));
-
-  const handleSetPreferredLightScheme = async (
-    _event: Electron.IpcMainInvokeEvent,
-    schemeId: string
-  ) => {
-    if (typeof schemeId !== "string" || !schemeId.trim()) return;
-    const current = getAppThemeConfig();
-    store.set("appTheme", {
-      ...current,
-      preferredLightSchemeId: schemeId.trim(),
-    } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME, handleSetPreferredLightScheme);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME));
-
-  const handleSetRecentSchemeIds = async (_event: Electron.IpcMainInvokeEvent, ids: unknown) => {
-    if (!Array.isArray(ids)) {
-      console.warn("Invalid app theme recentSchemeIds:", ids);
-      return;
-    }
-    const trimmed = ids
-      .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
-      .map((id) => id.trim());
-    const sanitized = Array.from(new Set(trimmed)).slice(0, 5);
-    const current = getAppThemeConfig();
-    store.set("appTheme", {
-      ...current,
-      recentSchemeIds: sanitized,
-    } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS, handleSetRecentSchemeIds);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS));
-
-  const handleSetAccentColorOverride = async (
-    _event: Electron.IpcMainInvokeEvent,
-    color: unknown
-  ) => {
-    let normalized: string | null = null;
-    if (color !== null && color !== undefined) {
-      normalized = normalizeAccentHex(color);
-      if (normalized === null) {
-        console.warn("Invalid accent color override:", color);
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_COLOR_SCHEME, async (schemeId: string) => {
+      if (typeof schemeId !== "string" || !schemeId.trim()) {
+        console.warn("Invalid app theme colorSchemeId:", schemeId);
         return;
       }
-    }
-    const current = getAppThemeConfig();
-    store.set("appTheme", {
-      ...current,
-      accentColorOverride: normalized,
-    } satisfies AppThemeConfig);
-  };
-  ipcMain.handle(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE, handleSetAccentColorOverride);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE));
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        colorSchemeId: schemeId.trim(),
+      } satisfies AppThemeConfig);
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_CUSTOM_SCHEMES, async (schemesJson: string) => {
+      if (typeof schemesJson !== "string") {
+        console.warn("Invalid app custom schemes:", schemesJson);
+        return;
+      }
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        customSchemes: schemesJson,
+      } satisfies AppThemeConfig);
+    })
+  );
+
+  const VALID_COLOR_VISION_MODES = ["default", "red-green", "blue-yellow"];
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_COLOR_VISION_MODE, async (mode: ColorVisionMode) => {
+      if (typeof mode !== "string" || !VALID_COLOR_VISION_MODES.includes(mode)) {
+        console.warn("Invalid color vision mode:", mode);
+        return;
+      }
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        colorVisionMode: mode,
+      } satisfies AppThemeConfig);
+    })
+  );
+
+  handlers.push(
+    typedHandleWithContext(CHANNELS.APP_THEME_IMPORT, async (ctx) => {
+      const win = ctx.senderWindow ?? BrowserWindow.getFocusedWindow();
+      const dialogOptions = {
+        title: "Import App Theme",
+        filters: [
+          { name: "Theme Files", extensions: ["json"] },
+          { name: "All Files", extensions: ["*"] },
+        ],
+        properties: ["openFile" as const],
+      };
+      const result = win
+        ? await dialog.showOpenDialog(win, dialogOptions)
+        : await dialog.showOpenDialog(dialogOptions);
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { ok: false, errors: ["Import cancelled"] };
+      }
+
+      return parseAppThemeFile(result.filePaths[0]);
+    })
+  );
+
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.APP_THEME_EXPORT,
+      async (ctx, scheme: AppColorScheme): Promise<boolean> => {
+        if (!scheme || typeof scheme.id !== "string" || typeof scheme.name !== "string") {
+          return false;
+        }
+
+        const safeName =
+          scheme.name
+            .replace(/[\\/:*?"<>|]/g, "")
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, 200) || "theme";
+
+        const win = ctx.senderWindow ?? BrowserWindow.getFocusedWindow();
+        const dialogOptions = {
+          title: "Export App Theme",
+          defaultPath: `${safeName}.json`,
+          filters: [
+            { name: "Theme Files", extensions: ["json"] },
+            { name: "All Files", extensions: ["*"] },
+          ],
+        };
+
+        const { filePath, canceled } = win
+          ? await dialog.showSaveDialog(win, dialogOptions)
+          : await dialog.showSaveDialog(dialogOptions);
+
+        if (canceled || !filePath) return false;
+
+        const { location: _loc, builtin: _builtin, ...exportData } = scheme;
+        await fs.writeFile(filePath, JSON.stringify(exportData, null, 2), "utf-8");
+        return true;
+      }
+    )
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_FOLLOW_SYSTEM, async (enabled: boolean) => {
+      if (typeof enabled !== "boolean") return;
+      const current = getAppThemeConfig();
+      store.set("appTheme", { ...current, followSystem: enabled } satisfies AppThemeConfig);
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_PREFERRED_DARK_SCHEME, async (schemeId: string) => {
+      if (typeof schemeId !== "string" || !schemeId.trim()) return;
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        preferredDarkSchemeId: schemeId.trim(),
+      } satisfies AppThemeConfig);
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_PREFERRED_LIGHT_SCHEME, async (schemeId: string) => {
+      if (typeof schemeId !== "string" || !schemeId.trim()) return;
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        preferredLightSchemeId: schemeId.trim(),
+      } satisfies AppThemeConfig);
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_RECENT_SCHEME_IDS, async (ids: unknown) => {
+      if (!Array.isArray(ids)) {
+        console.warn("Invalid app theme recentSchemeIds:", ids);
+        return;
+      }
+      const trimmed = ids
+        .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+        .map((id) => id.trim());
+      const sanitized = Array.from(new Set(trimmed)).slice(0, 5);
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        recentSchemeIds: sanitized,
+      } satisfies AppThemeConfig);
+    })
+  );
+
+  handlers.push(
+    typedHandle(CHANNELS.APP_THEME_SET_ACCENT_COLOR_OVERRIDE, async (color: unknown) => {
+      let normalized: string | null = null;
+      if (color !== null && color !== undefined) {
+        normalized = normalizeAccentHex(color);
+        if (normalized === null) {
+          console.warn("Invalid accent color override:", color);
+          return;
+        }
+      }
+      const current = getAppThemeConfig();
+      store.set("appTheme", {
+        ...current,
+        accentColorOverride: normalized,
+      } satisfies AppThemeConfig);
+    })
+  );
 
   // nativeTheme listener for auto-switching
   let appearanceTimer: ReturnType<typeof setTimeout> | null = null;

--- a/electron/ipc/handlers/cli.ts
+++ b/electron/ipc/handlers/cli.ts
@@ -1,19 +1,21 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import * as CliInstallService from "../../services/CliInstallService.js";
+import { typedHandle } from "../utils.js";
 
 export function registerCliHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.CLI_GET_STATUS, async () => {
-    return CliInstallService.getStatus();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.CLI_GET_STATUS));
+  handlers.push(
+    typedHandle(CHANNELS.CLI_GET_STATUS, async () => {
+      return CliInstallService.getStatus();
+    })
+  );
 
-  ipcMain.handle(CHANNELS.CLI_INSTALL, async () => {
-    return CliInstallService.install();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.CLI_INSTALL));
+  handlers.push(
+    typedHandle(CHANNELS.CLI_INSTALL, async () => {
+      return CliInstallService.install();
+    })
+  );
 
   return () => {
     for (const cleanup of handlers) {

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -1,10 +1,11 @@
-import { clipboard, ipcMain, nativeImage } from "electron";
+import { clipboard, nativeImage } from "electron";
 import { CHANNELS } from "../channels.js";
 import * as path from "node:path";
 import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as crypto from "node:crypto";
 import * as os from "node:os";
+import { typedHandle } from "../utils.js";
 
 const CLIPBOARD_DIR_NAME = "daintree-clipboard";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -51,6 +52,8 @@ async function cleanupOldClipboardImages(): Promise<void> {
 }
 
 export function registerClipboardHandlers(): () => void {
+  const handlers: Array<() => void> = [];
+
   // Ensure the clipboard directory exists at startup so agents like Gemini
   // can reference it via --include-directories without errors (#4048)
   fs.mkdir(getClipboardDir(), { recursive: true }).catch((err) => {
@@ -59,9 +62,7 @@ export function registerClipboardHandlers(): () => void {
   cleanupOldClipboardImages().catch((err) => {
     console.warn("[clipboard] Cleanup failed unexpectedly:", err);
   });
-  const handleSaveImage = async (
-    _event: Electron.IpcMainInvokeEvent
-  ): Promise<
+  const handleSaveImage = async (): Promise<
     { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
   > => {
     try {
@@ -93,7 +94,6 @@ export function registerClipboardHandlers(): () => void {
   };
 
   const handleThumbnailFromPath = async (
-    _event: Electron.IpcMainInvokeEvent,
     filePath: string
   ): Promise<
     { ok: true; filePath: string; thumbnailDataUrl: string } | { ok: false; error: string }
@@ -118,7 +118,6 @@ export function registerClipboardHandlers(): () => void {
   };
 
   const handleWriteImage = async (
-    _event: Electron.IpcMainInvokeEvent,
     pngData: Uint8Array
   ): Promise<{ ok: true } | { ok: false; error: string }> => {
     try {
@@ -135,10 +134,7 @@ export function registerClipboardHandlers(): () => void {
     }
   };
 
-  const handleWriteText = (
-    _event: Electron.IpcMainInvokeEvent,
-    text: string
-  ): { ok: true } | { ok: false; error: string } => {
+  const handleWriteText = (text: string): { ok: true } | { ok: false; error: string } => {
     try {
       if (typeof text !== "string") {
         return { ok: false, error: "Text must be a string" };
@@ -151,15 +147,10 @@ export function registerClipboardHandlers(): () => void {
     }
   };
 
-  ipcMain.handle(CHANNELS.CLIPBOARD_SAVE_IMAGE, handleSaveImage);
-  ipcMain.handle(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, handleThumbnailFromPath);
-  ipcMain.handle(CHANNELS.CLIPBOARD_WRITE_IMAGE, handleWriteImage);
-  ipcMain.handle(CHANNELS.CLIPBOARD_WRITE_TEXT, handleWriteText);
+  handlers.push(typedHandle(CHANNELS.CLIPBOARD_SAVE_IMAGE, handleSaveImage));
+  handlers.push(typedHandle(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, handleThumbnailFromPath));
+  handlers.push(typedHandle(CHANNELS.CLIPBOARD_WRITE_IMAGE, handleWriteImage));
+  handlers.push(typedHandle(CHANNELS.CLIPBOARD_WRITE_TEXT, handleWriteText));
 
-  return () => {
-    ipcMain.removeHandler(CHANNELS.CLIPBOARD_SAVE_IMAGE);
-    ipcMain.removeHandler(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH);
-    ipcMain.removeHandler(CHANNELS.CLIPBOARD_WRITE_IMAGE);
-    ipcMain.removeHandler(CHANNELS.CLIPBOARD_WRITE_TEXT);
-  };
+  return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -3,7 +3,6 @@
  * Exposes command registry and execution to the renderer process.
  */
 
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { commandService } from "../../services/CommandService.js";
 import type {
@@ -14,23 +13,19 @@ import type {
   CommandResult,
   DaintreeCommand,
 } from "../../../shared/types/commands.js";
+import { typedHandle } from "../utils.js";
 
 export function registerCommandHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
   // List all commands
-  const handleCommandsList = async (
-    _event: Electron.IpcMainInvokeEvent,
-    context?: CommandContext
-  ): Promise<CommandManifestEntry[]> => {
+  const handleCommandsList = async (context?: CommandContext): Promise<CommandManifestEntry[]> => {
     return await commandService.list(context);
   };
-  ipcMain.handle(CHANNELS.COMMANDS_LIST, handleCommandsList);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_LIST));
+  handlers.push(typedHandle(CHANNELS.COMMANDS_LIST, handleCommandsList));
 
   // Get single command
   const handleCommandsGet = async (
-    _event: Electron.IpcMainInvokeEvent,
     payload: CommandGetPayload
   ): Promise<CommandManifestEntry | null> => {
     if (!payload || typeof payload.commandId !== "string") {
@@ -39,14 +34,10 @@ export function registerCommandHandlers(): () => void {
     }
     return (await commandService.getManifest(payload.commandId, payload.context)) ?? null;
   };
-  ipcMain.handle(CHANNELS.COMMANDS_GET, handleCommandsGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_GET));
+  handlers.push(typedHandle(CHANNELS.COMMANDS_GET, handleCommandsGet));
 
   // Execute command
-  const handleCommandsExecute = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: CommandExecutePayload
-  ): Promise<CommandResult> => {
+  const handleCommandsExecute = async (payload: CommandExecutePayload): Promise<CommandResult> => {
     if (!payload || typeof payload.commandId !== "string") {
       return {
         success: false,
@@ -83,12 +74,10 @@ export function registerCommandHandlers(): () => void {
 
     return commandService.execute(payload.commandId, context, args);
   };
-  ipcMain.handle(CHANNELS.COMMANDS_EXECUTE, handleCommandsExecute);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_EXECUTE));
+  handlers.push(typedHandle(CHANNELS.COMMANDS_EXECUTE, handleCommandsExecute));
 
   // Get command builder
   const handleCommandsGetBuilder = async (
-    _event: Electron.IpcMainInvokeEvent,
     commandId: string
   ): Promise<DaintreeCommand["builder"] | null> => {
     if (typeof commandId !== "string") {
@@ -96,8 +85,7 @@ export function registerCommandHandlers(): () => void {
     }
     return commandService.getBuilder(commandId) ?? null;
   };
-  ipcMain.handle(CHANNELS.COMMANDS_GET_BUILDER, handleCommandsGetBuilder);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COMMANDS_GET_BUILDER));
+  handlers.push(typedHandle(CHANNELS.COMMANDS_GET_BUILDER, handleCommandsGetBuilder));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -1,10 +1,15 @@
-import { ipcMain, clipboard } from "electron";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { clipboard } from "electron";
 import crypto from "crypto";
 import path from "path";
 import { pathToFileURL } from "url";
 import { CHANNELS } from "../channels.js";
-import { broadcastToRenderer, checkRateLimit, sendToRenderer } from "../utils.js";
+import {
+  broadcastToRenderer,
+  checkRateLimit,
+  sendToRenderer,
+  typedHandle,
+  typedHandleWithContext,
+} from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   CopyTreeGeneratePayload,
@@ -175,12 +180,12 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
   const handlers: Array<() => void> = [];
 
   const handleCopyTreeGenerate = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../types.js").IpcContext,
     payload: CopyTreeGeneratePayload
   ): Promise<CopyTreeResult> => {
     checkRateLimit(CHANNELS.COPYTREE_GENERATE, 5, 10_000);
     const traceId = crypto.randomUUID();
-    const senderWindow = getWindowForWebContents(event.sender);
+    const senderWindow = ctx.senderWindow;
     const requestedWorktreeId = getStringField(payload, "worktreeId") ?? "unknown";
     console.log(`[${traceId}] CopyTree generate started for worktree ${requestedWorktreeId}`);
 
@@ -230,16 +235,15 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     return deps.worktreeService.generateContext(worktree.path, mergedOptions, onProgress);
   };
-  ipcMain.handle(CHANNELS.COPYTREE_GENERATE, handleCopyTreeGenerate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GENERATE));
+  handlers.push(typedHandleWithContext(CHANNELS.COPYTREE_GENERATE, handleCopyTreeGenerate));
 
   const handleCopyTreeGenerateAndCopyFile = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../types.js").IpcContext,
     payload: CopyTreeGenerateAndCopyFilePayload
   ): Promise<CopyTreeResult> => {
     checkRateLimit(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, 5, 10_000);
     const traceId = crypto.randomUUID();
-    const senderWindow = getWindowForWebContents(event.sender);
+    const senderWindow = ctx.senderWindow;
     const requestedWorktreeId = getStringField(payload, "worktreeId") ?? "unknown";
     console.log(
       `[${traceId}] CopyTree generate-and-copy-file started for worktree ${requestedWorktreeId}`
@@ -361,16 +365,20 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
   };
-  ipcMain.handle(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE, handleCopyTreeGenerateAndCopyFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE));
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.COPYTREE_GENERATE_AND_COPY_FILE,
+      handleCopyTreeGenerateAndCopyFile
+    )
+  );
 
   const handleCopyTreeInject = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../types.js").IpcContext,
     payload: CopyTreeInjectPayload
   ): Promise<CopyTreeResult> => {
     checkRateLimit(CHANNELS.COPYTREE_INJECT, 5, 10_000);
     const traceId = crypto.randomUUID();
-    const senderWindow = getWindowForWebContents(event.sender);
+    const senderWindow = ctx.senderWindow;
     const requestedTerminalId = getStringField(payload, "terminalId") ?? "unknown";
     const requestedWorktreeId = getStringField(payload, "worktreeId") ?? "unknown";
     console.log(
@@ -486,19 +494,14 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       contextInjectionTracker.finishInjection(validated.terminalId, injectionId);
     }
   };
-  ipcMain.handle(CHANNELS.COPYTREE_INJECT, handleCopyTreeInject);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_INJECT));
+  handlers.push(typedHandleWithContext(CHANNELS.COPYTREE_INJECT, handleCopyTreeInject));
 
   const handleCopyTreeAvailable = async (): Promise<boolean> => {
     return !!deps.worktreeService && deps.worktreeService.isReady();
   };
-  ipcMain.handle(CHANNELS.COPYTREE_AVAILABLE, handleCopyTreeAvailable);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_AVAILABLE));
+  handlers.push(typedHandle(CHANNELS.COPYTREE_AVAILABLE, handleCopyTreeAvailable));
 
-  const handleCopyTreeCancel = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload?: CopyTreeCancelPayload
-  ): Promise<void> => {
+  const handleCopyTreeCancel = async (payload?: CopyTreeCancelPayload): Promise<void> => {
     const parseResult = CopyTreeCancelPayloadSchema.safeParse(payload ?? {});
     if (!parseResult.success) {
       console.warn("Invalid cancel payload, ignoring");
@@ -524,11 +527,9 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       console.log(`[cancel] Marked all ${count} active injections for cancellation`);
     }
   };
-  ipcMain.handle(CHANNELS.COPYTREE_CANCEL, handleCopyTreeCancel);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_CANCEL));
+  handlers.push(typedHandle(CHANNELS.COPYTREE_CANCEL, handleCopyTreeCancel));
 
   const handleCopyTreeGetFileTree = async (
-    _event: Electron.IpcMainInvokeEvent,
     payload: CopyTreeGetFileTreePayload
   ): Promise<FileTreeNode[]> => {
     checkRateLimit(CHANNELS.COPYTREE_GET_FILE_TREE, 5, 10_000);
@@ -561,11 +562,10 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     return deps.worktreeService.getFileTree(monitor.path, validated.dirPath);
   };
-  ipcMain.handle(CHANNELS.COPYTREE_GET_FILE_TREE, handleCopyTreeGetFileTree);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_GET_FILE_TREE));
+  handlers.push(typedHandle(CHANNELS.COPYTREE_GET_FILE_TREE, handleCopyTreeGetFileTree));
 
   const handleCopyTreeTestConfig = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../types.js").IpcContext,
     payload: import("../../types/index.js").CopyTreeTestConfigPayload
   ): Promise<import("../../types/index.js").CopyTreeTestConfigResult> => {
     checkRateLimit(CHANNELS.COPYTREE_TEST_CONFIG, 5, 10_000);
@@ -599,7 +599,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       };
     }
 
-    const senderWindowTestConfig = getWindowForWebContents(event.sender);
+    const senderWindowTestConfig = ctx.senderWindow;
     const states = await deps.worktreeService.getAllStatesAsync(senderWindowTestConfig?.id);
     const worktree = states.find((wt) => wt.id === validated.worktreeId);
 
@@ -618,8 +618,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
     return deps.worktreeService.testConfig(worktree.path, mergedOptions);
   };
-  ipcMain.handle(CHANNELS.COPYTREE_TEST_CONFIG, handleCopyTreeTestConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.COPYTREE_TEST_CONFIG));
+  handlers.push(typedHandleWithContext(CHANNELS.COPYTREE_TEST_CONFIG, handleCopyTreeTestConfig));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -6,6 +6,7 @@ import { spawn, type ChildProcess } from "child_process";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 import type {
   DemoMoveToPayload,
   DemoMoveToSelectorPayload,
@@ -17,6 +18,9 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
+  DemoEncodePayload,
+  DemoEncodeProgressEvent,
+  DemoEncodeResult,
   DemoEncodePreset,
   DemoScrollPayload,
   DemoDragPayload,
@@ -76,17 +80,11 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     });
   }
 
-  const handleMoveTo = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoMoveToPayload
-  ): Promise<void> => {
+  const handleMoveTo = async (payload: DemoMoveToPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_MOVE_TO, payload);
   };
 
-  const handleMoveToSelector = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoMoveToSelectorPayload
-  ): Promise<void> => {
+  const handleMoveToSelector = async (payload: DemoMoveToSelectorPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_MOVE_TO_SELECTOR, payload);
   };
 
@@ -94,10 +92,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_CLICK);
   };
 
-  const handleType = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoTypePayload
-  ): Promise<void> => {
+  const handleType = async (payload: DemoTypePayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_TYPE, payload);
   };
 
@@ -116,10 +111,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     };
   };
 
-  const handleWaitForSelector = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoWaitForSelectorPayload
-  ): Promise<void> => {
+  const handleWaitForSelector = async (payload: DemoWaitForSelectorPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_SELECTOR, payload);
   };
 
@@ -131,38 +123,23 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_RESUME);
   };
 
-  const handleSleep = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoSleepPayload
-  ): Promise<void> => {
+  const handleSleep = async (payload: DemoSleepPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SLEEP, payload);
   };
 
-  const handleScroll = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoScrollPayload
-  ): Promise<void> => {
+  const handleScroll = async (payload: DemoScrollPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SCROLL, payload);
   };
 
-  const handleDrag = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoDragPayload
-  ): Promise<void> => {
+  const handleDrag = async (payload: DemoDragPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DRAG, payload);
   };
 
-  const handlePressKey = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoPressKeyPayload
-  ): Promise<void> => {
+  const handlePressKey = async (payload: DemoPressKeyPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_PRESS_KEY, payload);
   };
 
-  const handleSpotlight = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoSpotlightPayload
-  ): Promise<void> => {
+  const handleSpotlight = async (payload: DemoSpotlightPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SPOTLIGHT, payload);
   };
 
@@ -170,26 +147,17 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DISMISS_SPOTLIGHT);
   };
 
-  const handleAnnotate = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoAnnotatePayload
-  ): Promise<DemoAnnotateResult> => {
+  const handleAnnotate = async (payload: DemoAnnotatePayload): Promise<DemoAnnotateResult> => {
     const id = payload.id ?? randomBytes(8).toString("hex");
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_ANNOTATE, { ...payload, id });
     return { id };
   };
 
-  const handleDismissAnnotation = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoDismissAnnotationPayload
-  ): Promise<void> => {
+  const handleDismissAnnotation = async (payload: DemoDismissAnnotationPayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DISMISS_ANNOTATION, payload);
   };
 
-  const handleWaitForIdle = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DemoWaitForIdlePayload
-  ): Promise<void> => {
+  const handleWaitForIdle = async (payload: DemoWaitForIdlePayload): Promise<void> => {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_IDLE, payload);
   };
 
@@ -280,7 +248,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
   }
 
   const handleStartCapture = async (
-    _event: Electron.IpcMainInvokeEvent,
     payload: DemoStartCapturePayload
   ): Promise<DemoStartCaptureResult> => {
     if (captureSession) {
@@ -487,51 +454,220 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     },
   };
 
-  ipcMain.handle(CHANNELS.DEMO_MOVE_TO, handleMoveTo);
-  ipcMain.handle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector);
-  ipcMain.handle(CHANNELS.DEMO_CLICK, handleClick);
-  ipcMain.handle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot);
-  ipcMain.handle(CHANNELS.DEMO_TYPE, handleType);
-  ipcMain.handle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector);
-  ipcMain.handle(CHANNELS.DEMO_PAUSE, handlePause);
-  ipcMain.handle(CHANNELS.DEMO_RESUME, handleResume);
-  ipcMain.handle(CHANNELS.DEMO_SLEEP, handleSleep);
-  ipcMain.handle(CHANNELS.DEMO_SCROLL, handleScroll);
-  ipcMain.handle(CHANNELS.DEMO_DRAG, handleDrag);
-  ipcMain.handle(CHANNELS.DEMO_PRESS_KEY, handlePressKey);
-  ipcMain.handle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight);
-  ipcMain.handle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight);
-  ipcMain.handle(CHANNELS.DEMO_ANNOTATE, handleAnnotate);
-  ipcMain.handle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation);
-  ipcMain.handle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle);
-  ipcMain.handle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture);
-  ipcMain.handle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture);
-  ipcMain.handle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus);
+  // --- Encode presets for offline re-encode (PNG files from disk) ---
+
+  const ENCODE_PRESETS = {
+    "youtube-4k": {
+      outputOptions: [
+        "-vf",
+        "scale=3840:2160:flags=lanczos",
+        "-c:v",
+        "libx264",
+        "-profile:v",
+        "high444",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv444p",
+        "-preset",
+        "slow",
+        "-g",
+        "15",
+        "-bf",
+        "2",
+        "-movflags",
+        "+faststart",
+        "-an",
+      ],
+    },
+    "youtube-1080p": {
+      outputOptions: [
+        "-vf",
+        "scale=1920:1080:flags=lanczos",
+        "-c:v",
+        "libx264",
+        "-profile:v",
+        "high444",
+        "-crf",
+        "18",
+        "-pix_fmt",
+        "yuv444p",
+        "-preset",
+        "slow",
+        "-g",
+        "15",
+        "-bf",
+        "2",
+        "-movflags",
+        "+faststart",
+        "-an",
+      ],
+    },
+    "web-webm": {
+      outputOptions: [
+        "-c:v",
+        "libvpx-vp9",
+        "-crf",
+        "20",
+        "-b:v",
+        "0",
+        "-deadline",
+        "good",
+        "-cpu-used",
+        "1",
+        "-row-mt",
+        "1",
+        "-pix_fmt",
+        "yuv444p",
+        "-an",
+      ],
+    },
+  } as const;
+
+  let activeEncode: { kill: () => void } | null = null;
+
+  const handleEncode = async (
+    ctx: import("../types.js").IpcContext,
+    payload: DemoEncodePayload
+  ): Promise<DemoEncodeResult> => {
+    if (activeEncode) {
+      throw new Error("An encode is already in progress");
+    }
+
+    const ffmpegBin = resolveFfmpegPath();
+    const { framesDir, outputPath, preset, fps = 30 } = payload;
+    const presetConfig = ENCODE_PRESETS[preset];
+
+    const framePattern = /^frame-\d{6}\.png$/;
+    const pngFiles = fs
+      .readdirSync(framesDir)
+      .filter((f) => framePattern.test(f))
+      .sort();
+    if (pngFiles.length === 0) {
+      throw new Error(`No PNG frames matching frame-NNNNNN.png found in ${framesDir}`);
+    }
+    const totalFrames = pngFiles.length;
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+    const startTime = Date.now();
+    const inputPattern = path.join(framesDir, "frame-%06d.png");
+
+    const args = [
+      "-y",
+      "-framerate",
+      String(fps),
+      "-i",
+      inputPattern,
+      ...presetConfig.outputOptions,
+      "-progress",
+      "pipe:1",
+      "-nostats",
+      outputPath,
+    ];
+
+    return new Promise<DemoEncodeResult>((resolve, reject) => {
+      const proc: ChildProcess = spawn(ffmpegBin, args, { stdio: ["ignore", "pipe", "pipe"] });
+
+      activeEncode = {
+        kill: () => {
+          proc.kill("SIGKILL");
+        },
+      };
+
+      let stdoutBuffer = "";
+      let currentFrame = 0;
+      let currentFps = 0;
+
+      proc.stdout?.on("data", (chunk: Buffer) => {
+        stdoutBuffer += chunk.toString();
+        const lines = stdoutBuffer.split("\n");
+        stdoutBuffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const eqIdx = line.indexOf("=");
+          if (eqIdx === -1) continue;
+          const key = line.slice(0, eqIdx).trim();
+          const value = line.slice(eqIdx + 1).trim();
+
+          if (key === "frame") {
+            currentFrame = parseInt(value, 10) || 0;
+          } else if (key === "fps") {
+            currentFps = parseFloat(value) || 0;
+          } else if (key === "progress") {
+            if (currentFrame > 0 && !ctx.event.sender.isDestroyed()) {
+              const percentComplete = Math.min((currentFrame / totalFrames) * 100, 100);
+              const etaSeconds = currentFps > 0 ? (totalFrames - currentFrame) / currentFps : 0;
+
+              const progressEvent: DemoEncodeProgressEvent = {
+                frame: currentFrame,
+                fps: currentFps,
+                percentComplete: Math.round(percentComplete * 100) / 100,
+                etaSeconds: Math.round(etaSeconds * 10) / 10,
+              };
+              ctx.event.sender.send(CHANNELS.DEMO_ENCODE_PROGRESS, progressEvent);
+            }
+          }
+        }
+      });
+
+      let stderrOutput = "";
+      proc.stderr?.on("data", (chunk: Buffer) => {
+        stderrOutput += chunk.toString();
+      });
+
+      proc.on("error", (err: Error) => {
+        activeEncode = null;
+        reject(new Error(`Encode failed: ${err.message}`));
+      });
+
+      proc.on("close", (code) => {
+        activeEncode = null;
+        if (code === 0) {
+          resolve({ outputPath, durationMs: Date.now() - startTime });
+        } else {
+          const lastLines = stderrOutput.trim().split("\n").slice(-3).join("\n");
+          reject(new Error(`ffmpeg exited with code ${code}: ${lastLines}`));
+        }
+      });
+    });
+  };
+
+  const cleanups: Array<() => void> = [
+    typedHandle(CHANNELS.DEMO_MOVE_TO, handleMoveTo),
+    typedHandle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector),
+    typedHandle(CHANNELS.DEMO_CLICK, handleClick),
+    typedHandle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot),
+    typedHandle(CHANNELS.DEMO_TYPE, handleType),
+    typedHandle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector),
+    typedHandle(CHANNELS.DEMO_PAUSE, handlePause),
+    typedHandle(CHANNELS.DEMO_RESUME, handleResume),
+    typedHandle(CHANNELS.DEMO_SLEEP, handleSleep),
+    typedHandle(CHANNELS.DEMO_SCROLL, handleScroll),
+    typedHandle(CHANNELS.DEMO_DRAG, handleDrag),
+    typedHandle(CHANNELS.DEMO_PRESS_KEY, handlePressKey),
+    typedHandle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight),
+    typedHandle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight),
+    typedHandle(CHANNELS.DEMO_ANNOTATE, handleAnnotate),
+    typedHandle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation),
+    typedHandle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle),
+    typedHandle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture),
+    typedHandle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture),
+    typedHandle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus),
+    typedHandleWithContext(CHANNELS.DEMO_ENCODE, handleEncode),
+  ];
 
   return () => {
     if (captureSession) {
       stopCaptureSession();
       captureSession?.ffmpegProc.kill("SIGKILL");
     }
-    ipcMain.removeHandler(CHANNELS.DEMO_MOVE_TO);
-    ipcMain.removeHandler(CHANNELS.DEMO_MOVE_TO_SELECTOR);
-    ipcMain.removeHandler(CHANNELS.DEMO_CLICK);
-    ipcMain.removeHandler(CHANNELS.DEMO_SCREENSHOT);
-    ipcMain.removeHandler(CHANNELS.DEMO_TYPE);
-    ipcMain.removeHandler(CHANNELS.DEMO_WAIT_FOR_SELECTOR);
-    ipcMain.removeHandler(CHANNELS.DEMO_PAUSE);
-    ipcMain.removeHandler(CHANNELS.DEMO_RESUME);
-    ipcMain.removeHandler(CHANNELS.DEMO_SLEEP);
-    ipcMain.removeHandler(CHANNELS.DEMO_SCROLL);
-    ipcMain.removeHandler(CHANNELS.DEMO_DRAG);
-    ipcMain.removeHandler(CHANNELS.DEMO_PRESS_KEY);
-    ipcMain.removeHandler(CHANNELS.DEMO_SPOTLIGHT);
-    ipcMain.removeHandler(CHANNELS.DEMO_DISMISS_SPOTLIGHT);
-    ipcMain.removeHandler(CHANNELS.DEMO_ANNOTATE);
-    ipcMain.removeHandler(CHANNELS.DEMO_DISMISS_ANNOTATION);
-    ipcMain.removeHandler(CHANNELS.DEMO_WAIT_FOR_IDLE);
-    ipcMain.removeHandler(CHANNELS.DEMO_START_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.DEMO_STOP_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.DEMO_GET_CAPTURE_STATUS);
+    for (const cleanup of cleanups) {
+      cleanup();
+    }
+    if (activeEncode) {
+      activeEncode.kill();
+      activeEncode = null;
+    }
   };
 }

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -6,7 +6,7 @@ import { spawn, type ChildProcess } from "child_process";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
-import { typedHandle, typedHandleWithContext } from "../utils.js";
+import { typedHandle } from "../utils.js";
 import type {
   DemoMoveToPayload,
   DemoMoveToSelectorPayload,
@@ -18,9 +18,6 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
-  DemoEncodePayload,
-  DemoEncodeProgressEvent,
-  DemoEncodeResult,
   DemoEncodePreset,
   DemoScrollPayload,
   DemoDragPayload,
@@ -454,185 +451,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     },
   };
 
-  // --- Encode presets for offline re-encode (PNG files from disk) ---
-
-  const ENCODE_PRESETS = {
-    "youtube-4k": {
-      outputOptions: [
-        "-vf",
-        "scale=3840:2160:flags=lanczos",
-        "-c:v",
-        "libx264",
-        "-profile:v",
-        "high444",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv444p",
-        "-preset",
-        "slow",
-        "-g",
-        "15",
-        "-bf",
-        "2",
-        "-movflags",
-        "+faststart",
-        "-an",
-      ],
-    },
-    "youtube-1080p": {
-      outputOptions: [
-        "-vf",
-        "scale=1920:1080:flags=lanczos",
-        "-c:v",
-        "libx264",
-        "-profile:v",
-        "high444",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv444p",
-        "-preset",
-        "slow",
-        "-g",
-        "15",
-        "-bf",
-        "2",
-        "-movflags",
-        "+faststart",
-        "-an",
-      ],
-    },
-    "web-webm": {
-      outputOptions: [
-        "-c:v",
-        "libvpx-vp9",
-        "-crf",
-        "20",
-        "-b:v",
-        "0",
-        "-deadline",
-        "good",
-        "-cpu-used",
-        "1",
-        "-row-mt",
-        "1",
-        "-pix_fmt",
-        "yuv444p",
-        "-an",
-      ],
-    },
-  } as const;
-
-  let activeEncode: { kill: () => void } | null = null;
-
-  const handleEncode = async (
-    ctx: import("../types.js").IpcContext,
-    payload: DemoEncodePayload
-  ): Promise<DemoEncodeResult> => {
-    if (activeEncode) {
-      throw new Error("An encode is already in progress");
-    }
-
-    const ffmpegBin = resolveFfmpegPath();
-    const { framesDir, outputPath, preset, fps = 30 } = payload;
-    const presetConfig = ENCODE_PRESETS[preset];
-
-    const framePattern = /^frame-\d{6}\.png$/;
-    const pngFiles = fs
-      .readdirSync(framesDir)
-      .filter((f) => framePattern.test(f))
-      .sort();
-    if (pngFiles.length === 0) {
-      throw new Error(`No PNG frames matching frame-NNNNNN.png found in ${framesDir}`);
-    }
-    const totalFrames = pngFiles.length;
-
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-
-    const startTime = Date.now();
-    const inputPattern = path.join(framesDir, "frame-%06d.png");
-
-    const args = [
-      "-y",
-      "-framerate",
-      String(fps),
-      "-i",
-      inputPattern,
-      ...presetConfig.outputOptions,
-      "-progress",
-      "pipe:1",
-      "-nostats",
-      outputPath,
-    ];
-
-    return new Promise<DemoEncodeResult>((resolve, reject) => {
-      const proc: ChildProcess = spawn(ffmpegBin, args, { stdio: ["ignore", "pipe", "pipe"] });
-
-      activeEncode = {
-        kill: () => {
-          proc.kill("SIGKILL");
-        },
-      };
-
-      let stdoutBuffer = "";
-      let currentFrame = 0;
-      let currentFps = 0;
-
-      proc.stdout?.on("data", (chunk: Buffer) => {
-        stdoutBuffer += chunk.toString();
-        const lines = stdoutBuffer.split("\n");
-        stdoutBuffer = lines.pop() ?? "";
-
-        for (const line of lines) {
-          const eqIdx = line.indexOf("=");
-          if (eqIdx === -1) continue;
-          const key = line.slice(0, eqIdx).trim();
-          const value = line.slice(eqIdx + 1).trim();
-
-          if (key === "frame") {
-            currentFrame = parseInt(value, 10) || 0;
-          } else if (key === "fps") {
-            currentFps = parseFloat(value) || 0;
-          } else if (key === "progress") {
-            if (currentFrame > 0 && !ctx.event.sender.isDestroyed()) {
-              const percentComplete = Math.min((currentFrame / totalFrames) * 100, 100);
-              const etaSeconds = currentFps > 0 ? (totalFrames - currentFrame) / currentFps : 0;
-
-              const progressEvent: DemoEncodeProgressEvent = {
-                frame: currentFrame,
-                fps: currentFps,
-                percentComplete: Math.round(percentComplete * 100) / 100,
-                etaSeconds: Math.round(etaSeconds * 10) / 10,
-              };
-              ctx.event.sender.send(CHANNELS.DEMO_ENCODE_PROGRESS, progressEvent);
-            }
-          }
-        }
-      });
-
-      let stderrOutput = "";
-      proc.stderr?.on("data", (chunk: Buffer) => {
-        stderrOutput += chunk.toString();
-      });
-
-      proc.on("error", (err: Error) => {
-        activeEncode = null;
-        reject(new Error(`Encode failed: ${err.message}`));
-      });
-
-      proc.on("close", (code) => {
-        activeEncode = null;
-        if (code === 0) {
-          resolve({ outputPath, durationMs: Date.now() - startTime });
-        } else {
-          const lastLines = stderrOutput.trim().split("\n").slice(-3).join("\n");
-          reject(new Error(`ffmpeg exited with code ${code}: ${lastLines}`));
-        }
-      });
-    });
-  };
-
   const cleanups: Array<() => void> = [
     typedHandle(CHANNELS.DEMO_MOVE_TO, handleMoveTo),
     typedHandle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector),
@@ -654,7 +472,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     typedHandle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture),
     typedHandle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture),
     typedHandle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus),
-    typedHandleWithContext(CHANNELS.DEMO_ENCODE, handleEncode),
   ];
 
   return () => {
@@ -664,10 +481,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     }
     for (const cleanup of cleanups) {
       cleanup();
-    }
-    if (activeEncode) {
-      activeEncode.kill();
-      activeEncode = null;
     }
   };
 }

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -1,6 +1,5 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
-import { broadcastToRenderer } from "../utils.js";
+import { broadcastToRenderer, typedHandle } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   DevPreviewEnsureRequest,
@@ -19,50 +18,30 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     broadcastToRenderer(CHANNELS.DEV_PREVIEW_STATE_CHANGED, payload);
   });
 
-  const handleEnsure = async (
-    _event: Electron.IpcMainInvokeEvent,
-    request: DevPreviewEnsureRequest
-  ) => {
+  const handleEnsure = async (request: DevPreviewEnsureRequest) => {
     return sessionService.ensure(request);
   };
-  ipcMain.handle(CHANNELS.DEV_PREVIEW_ENSURE, handleEnsure);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_ENSURE));
+  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_ENSURE, handleEnsure));
 
-  const handleRestart = async (
-    _event: Electron.IpcMainInvokeEvent,
-    request: DevPreviewSessionRequest
-  ) => {
+  const handleRestart = async (request: DevPreviewSessionRequest) => {
     return sessionService.restart(request);
   };
-  ipcMain.handle(CHANNELS.DEV_PREVIEW_RESTART, handleRestart);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_RESTART));
+  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_RESTART, handleRestart));
 
-  const handleStop = async (
-    _event: Electron.IpcMainInvokeEvent,
-    request: DevPreviewSessionRequest
-  ) => {
+  const handleStop = async (request: DevPreviewSessionRequest) => {
     return sessionService.stop(request);
   };
-  ipcMain.handle(CHANNELS.DEV_PREVIEW_STOP, handleStop);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_STOP));
+  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_STOP, handleStop));
 
-  const handleStopByPanel = async (
-    _event: Electron.IpcMainInvokeEvent,
-    request: DevPreviewStopByPanelRequest
-  ) => {
+  const handleStopByPanel = async (request: DevPreviewStopByPanelRequest) => {
     await sessionService.stopByPanel(request);
   };
-  ipcMain.handle(CHANNELS.DEV_PREVIEW_STOP_BY_PANEL, handleStopByPanel);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_STOP_BY_PANEL));
+  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_STOP_BY_PANEL, handleStopByPanel));
 
-  const handleGetState = async (
-    _event: Electron.IpcMainInvokeEvent,
-    request: DevPreviewSessionRequest
-  ) => {
+  const handleGetState = async (request: DevPreviewSessionRequest) => {
     return sessionService.getState(request);
   };
-  ipcMain.handle(CHANNELS.DEV_PREVIEW_GET_STATE, handleGetState);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DEV_PREVIEW_GET_STATE));
+  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_GET_STATE, handleGetState));
 
   const unsubHibernation = getHibernationService().onProjectHibernated((projectId) => {
     sessionService.stopByProject(projectId).catch((err) => {

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, dialog } from "electron";
+import { app, dialog } from "electron";
 import os from "node:os";
 import v8 from "node:v8";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
@@ -13,6 +13,7 @@ import type {
   DiagnosticsInfo,
 } from "../../../shared/types/ipc/system.js";
 import { collectDiagnostics } from "../../services/DiagnosticsCollector.js";
+import { typedHandle } from "../utils.js";
 
 let eventLoopHistogram: IntervalHistogram | null = null;
 
@@ -41,8 +42,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
       return { totalMemoryMB: 0 };
     }
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_APP_METRICS, handleGetAppMetrics);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_APP_METRICS));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_APP_METRICS, handleGetAppMetrics));
 
   const handleGetProcessMetrics = (): ProcessMetricEntry[] => {
     try {
@@ -60,8 +60,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
       return [];
     }
   };
-  ipcMain.handle(CHANNELS.DIAGNOSTICS_GET_PROCESS_METRICS, handleGetProcessMetrics);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DIAGNOSTICS_GET_PROCESS_METRICS));
+  handlers.push(typedHandle(CHANNELS.DIAGNOSTICS_GET_PROCESS_METRICS, handleGetProcessMetrics));
 
   const handleGetHeapStats = (): HeapStats => {
     try {
@@ -79,8 +78,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
       return { usedMB: 0, limitMB: 0, percent: 0, externalMB: 0 };
     }
   };
-  ipcMain.handle(CHANNELS.DIAGNOSTICS_GET_HEAP_STATS, handleGetHeapStats);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DIAGNOSTICS_GET_HEAP_STATS));
+  handlers.push(typedHandle(CHANNELS.DIAGNOSTICS_GET_HEAP_STATS, handleGetHeapStats));
 
   const handleGetDiagnosticsInfo = (): DiagnosticsInfo => {
     try {
@@ -92,8 +90,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
       return { uptimeSeconds: 0, eventLoopP99Ms: 0 };
     }
   };
-  ipcMain.handle(CHANNELS.DIAGNOSTICS_GET_INFO, handleGetDiagnosticsInfo);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.DIAGNOSTICS_GET_INFO));
+  handlers.push(typedHandle(CHANNELS.DIAGNOSTICS_GET_INFO, handleGetDiagnosticsInfo));
 
   const handleGetHardwareInfo = (): HardwareInfo => {
     try {
@@ -105,8 +102,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
       return { totalMemoryBytes: 0, logicalCpuCount: 0 };
     }
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_HARDWARE_INFO, handleGetHardwareInfo);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_HARDWARE_INFO));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_HARDWARE_INFO, handleGetHardwareInfo));
 
   const handleDownloadDiagnostics = async (): Promise<boolean> => {
     const payload = await collectDiagnostics(deps);
@@ -128,8 +124,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
     await fs.writeFile(filePath, json, "utf-8");
     return true;
   };
-  ipcMain.handle(CHANNELS.SYSTEM_DOWNLOAD_DIAGNOSTICS, handleDownloadDiagnostics);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_DOWNLOAD_DIAGNOSTICS));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_DOWNLOAD_DIAGNOSTICS, handleDownloadDiagnostics));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/editorConfig.ts
+++ b/electron/ipc/handlers/editorConfig.ts
@@ -1,12 +1,12 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../types.js";
+import { typedHandle } from "../utils.js";
 
 export function registerEditorConfigHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleEditorGetConfig = async (_event: Electron.IpcMainInvokeEvent, projectId: unknown) => {
+  const handleEditorGetConfig = async (projectId: unknown) => {
     const { discover } = await import("../../services/EditorService.js");
     const discoveredEditors = discover();
 
@@ -22,10 +22,9 @@ export function registerEditorConfigHandlers(_deps: HandlerDependencies): () => 
 
     return { preferredEditor, discoveredEditors };
   };
-  ipcMain.handle(CHANNELS.EDITOR_GET_CONFIG, handleEditorGetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EDITOR_GET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.EDITOR_GET_CONFIG, handleEditorGetConfig));
 
-  const handleEditorSetConfig = async (_event: Electron.IpcMainInvokeEvent, payload: unknown) => {
+  const handleEditorSetConfig = async (payload: unknown) => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -88,15 +87,13 @@ export function registerEditorConfigHandlers(_deps: HandlerDependencies): () => 
     const settings = await projectStore.getProjectSettings(pid);
     await projectStore.saveProjectSettings(pid, { ...settings, preferredEditor: editorConfig });
   };
-  ipcMain.handle(CHANNELS.EDITOR_SET_CONFIG, handleEditorSetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EDITOR_SET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.EDITOR_SET_CONFIG, handleEditorSetConfig));
 
   const handleEditorDiscover = async () => {
     const { discover } = await import("../../services/EditorService.js");
     return discover();
   };
-  ipcMain.handle(CHANNELS.EDITOR_DISCOVER, handleEditorDiscover);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EDITOR_DISCOVER));
+  handlers.push(typedHandle(CHANNELS.EDITOR_DISCOVER, handleEditorDiscover));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/eventInspector.ts
+++ b/electron/ipc/handlers/eventInspector.ts
@@ -1,8 +1,9 @@
 import { ipcMain, type WebContents } from "electron";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
-import type { FilterOptions as EventFilterOptions } from "../../services/EventBuffer.js";
-import type { EventRecord } from "../../../shared/types/index.js";
+import type { FilterOptions } from "../../services/EventBuffer.js";
+import type { EventFilterOptions, EventRecord } from "../../../shared/types/index.js";
+import { typedHandle } from "../utils.js";
 
 const subscribedWebContents = new Map<WebContents, () => void>();
 let eventBufferUnsubscribe: (() => void) | null = null;
@@ -20,20 +21,18 @@ export function registerEventInspectorHandlers(deps: HandlerDependencies): () =>
     }
     return deps.eventBuffer.getAll();
   };
-  ipcMain.handle(CHANNELS.EVENT_INSPECTOR_GET_EVENTS, handleEventInspectorGetEvents);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENT_INSPECTOR_GET_EVENTS));
+  handlers.push(typedHandle(CHANNELS.EVENT_INSPECTOR_GET_EVENTS, handleEventInspectorGetEvents));
 
-  const handleEventInspectorGetFiltered = async (
-    _event: Electron.IpcMainInvokeEvent,
-    filters: EventFilterOptions
-  ) => {
+  const handleEventInspectorGetFiltered = async (filters: EventFilterOptions) => {
     if (!deps.eventBuffer) {
       return [];
     }
-    return deps.eventBuffer.getFiltered(filters);
+    // Handler accepts the broader shared type; EventBuffer enforces stricter typing internally.
+    return deps.eventBuffer.getFiltered(filters as FilterOptions);
   };
-  ipcMain.handle(CHANNELS.EVENT_INSPECTOR_GET_FILTERED, handleEventInspectorGetFiltered);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENT_INSPECTOR_GET_FILTERED));
+  handlers.push(
+    typedHandle(CHANNELS.EVENT_INSPECTOR_GET_FILTERED, handleEventInspectorGetFiltered)
+  );
 
   const handleEventInspectorClear = async () => {
     if (!deps.eventBuffer) {
@@ -41,8 +40,7 @@ export function registerEventInspectorHandlers(deps: HandlerDependencies): () =>
     }
     deps.eventBuffer.clear();
   };
-  ipcMain.handle(CHANNELS.EVENT_INSPECTOR_CLEAR, handleEventInspectorClear);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENT_INSPECTOR_CLEAR));
+  handlers.push(typedHandle(CHANNELS.EVENT_INSPECTOR_CLEAR, handleEventInspectorClear));
 
   const flushBatch = () => {
     if (batchTimeout) {

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -1,7 +1,7 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import type { DaintreeEventMap } from "../../services/events.js";
+import { typedHandle } from "../utils.js";
 
 const ALLOWED_RENDERER_EVENTS: ReadonlySet<keyof DaintreeEventMap> = new Set(["action:dispatched"]);
 
@@ -76,11 +76,7 @@ export function registerEventsHandlers(deps: HandlerDependencies): () => void {
   const { events } = deps;
   const handlers: Array<() => void> = [];
 
-  const handleEventsEmit = async (
-    _event: Electron.IpcMainInvokeEvent,
-    eventType: string,
-    payload: unknown
-  ) => {
+  const handleEventsEmit = async (eventType: string, payload: unknown) => {
     if (!events) {
       console.warn("[IPC] Event bus not available, cannot emit event:", eventType);
       return;
@@ -106,8 +102,7 @@ export function registerEventsHandlers(deps: HandlerDependencies): () => void {
       payload as DaintreeEventMap[keyof DaintreeEventMap]
     );
   };
-  ipcMain.handle(CHANNELS.EVENTS_EMIT, handleEventsEmit);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.EVENTS_EMIT));
+  handlers.push(typedHandle(CHANNELS.EVENTS_EMIT, handleEventsEmit));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -1,8 +1,7 @@
-import { ipcMain } from "electron";
 import path from "path";
 import fs from "fs/promises";
 import { CHANNELS } from "../channels.js";
-import { checkRateLimit } from "../utils.js";
+import { checkRateLimit, typedHandle } from "../utils.js";
 import { fileSearchService } from "../../services/FileSearchService.js";
 import { FileSearchPayloadSchema, FileReadPayloadSchema } from "../../schemas/ipc.js";
 
@@ -11,10 +10,7 @@ const FILE_SIZE_LIMIT = 512 * 1024; // 500 KB
 export function registerFilesHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleSearch = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ): Promise<{ files: string[] }> => {
+  const handleSearch = async (payload: unknown): Promise<{ files: string[] }> => {
     checkRateLimit(CHANNELS.FILES_SEARCH, 20, 10_000);
 
     const parsed = FileSearchPayloadSchema.safeParse(payload);
@@ -38,11 +34,9 @@ export function registerFilesHandlers(): () => void {
     }
   };
 
-  ipcMain.handle(CHANNELS.FILES_SEARCH, handleSearch);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.FILES_SEARCH));
+  handlers.push(typedHandle(CHANNELS.FILES_SEARCH, handleSearch));
 
   const handleRead = async (
-    _event: Electron.IpcMainInvokeEvent,
     payload: unknown
   ): Promise<
     | { ok: true; content: string }
@@ -101,8 +95,7 @@ export function registerFilesHandlers(): () => void {
     }
   };
 
-  ipcMain.handle(CHANNELS.FILES_READ, handleRead);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.FILES_READ));
+  handlers.push(typedHandle(CHANNELS.FILES_READ, handleRead));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/gemini.ts
+++ b/electron/ipc/handlers/gemini.ts
@@ -1,6 +1,6 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { getGeminiConfigService } from "../../services/gemini/GeminiConfigService.js";
+import { typedHandle } from "../utils.js";
 
 export function registerGeminiHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -9,16 +9,16 @@ export function registerGeminiHandlers(): () => void {
     const service = getGeminiConfigService();
     return service.getStatus();
   };
-  ipcMain.handle(CHANNELS.GEMINI_GET_STATUS, handleGeminiGetStatus);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GEMINI_GET_STATUS));
+  handlers.push(typedHandle(CHANNELS.GEMINI_GET_STATUS, handleGeminiGetStatus));
 
   const handleGeminiEnableAlternateBuffer = async () => {
     const service = getGeminiConfigService();
     await service.enableAlternateBuffer();
     return { success: true };
   };
-  ipcMain.handle(CHANNELS.GEMINI_ENABLE_ALTERNATE_BUFFER, handleGeminiEnableAlternateBuffer);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GEMINI_ENABLE_ALTERNATE_BUFFER));
+  handlers.push(
+    typedHandle(CHANNELS.GEMINI_ENABLE_ALTERNATE_BUFFER, handleGeminiEnableAlternateBuffer)
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/git-read.ts
+++ b/electron/ipc/handlers/git-read.ts
@@ -1,8 +1,7 @@
-import { ipcMain } from "electron";
 import path from "path";
 import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
-import { checkRateLimit } from "../utils.js";
+import { checkRateLimit, typedHandle, typedHandleWithContext } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type { PulseRangeDays, ProjectPulse } from "../../../shared/types/pulse.js";
 import { taskWorktreeService } from "../../services/TaskWorktreeService.js";
@@ -10,16 +9,13 @@ import { taskWorktreeService } from "../../services/TaskWorktreeService.js";
 export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleGitCompareWorktrees = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      cwd: string;
-      branch1: string;
-      branch2: string;
-      filePath?: string;
-      useMergeBase?: boolean;
-    }
-  ) => {
+  const handleGitCompareWorktrees = async (payload: {
+    cwd: string;
+    branch1: string;
+    branch2: string;
+    filePath?: string;
+    useMergeBase?: boolean;
+  }) => {
     checkRateLimit(CHANNELS.GIT_COMPARE_WORKTREES, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
@@ -46,13 +42,13 @@ export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
     const gitService = taskWorktreeService.getGitService(cwd);
     return gitService.compareWorktrees(branch1, branch2, filePath, useMergeBase);
   };
-  ipcMain.handle(CHANNELS.GIT_COMPARE_WORKTREES, handleGitCompareWorktrees);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_COMPARE_WORKTREES));
+  handlers.push(typedHandle(CHANNELS.GIT_COMPARE_WORKTREES, handleGitCompareWorktrees));
 
-  const handleGitGetFileDiff = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; filePath: string; status: string }
-  ): Promise<string> => {
+  const handleGitGetFileDiff = async (payload: {
+    cwd: string;
+    filePath: string;
+    status: string;
+  }): Promise<string> => {
     checkRateLimit(CHANNELS.GIT_GET_FILE_DIFF, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
@@ -82,11 +78,10 @@ export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
       throw new Error(`Failed to get file diff: ${errorMessage}`, { cause: error });
     }
   };
-  ipcMain.handle(CHANNELS.GIT_GET_FILE_DIFF, handleGitGetFileDiff);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_GET_FILE_DIFF));
+  handlers.push(typedHandle(CHANNELS.GIT_GET_FILE_DIFF, handleGitGetFileDiff));
 
   const handleGitGetProjectPulse = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../types.js").IpcContext,
     payload: {
       worktreeId: string;
       rangeDays: PulseRangeDays;
@@ -131,7 +126,7 @@ export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
       throw new Error(`Worktree not found: ${worktreeId}`);
     }
 
-    const senderWindowPulse = getWindowForWebContents(event.sender);
+    const senderWindowPulse = getWindowForWebContents(ctx.event.sender);
     const states = await deps.worktreeService.getAllStatesAsync(senderWindowPulse?.id);
     const mainWorktree = states.find((wt) => wt.isMainWorktree);
     const mainBranch = mainWorktree?.branch ?? "main";
@@ -142,19 +137,15 @@ export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
       forceRefresh,
     });
   };
-  ipcMain.handle(CHANNELS.GIT_GET_PROJECT_PULSE, handleGitGetProjectPulse);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_GET_PROJECT_PULSE));
+  handlers.push(typedHandleWithContext(CHANNELS.GIT_GET_PROJECT_PULSE, handleGitGetProjectPulse));
 
-  const handleGitListCommits = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      cwd: string;
-      search?: string;
-      branch?: string;
-      skip?: number;
-      limit?: number;
-    }
-  ) => {
+  const handleGitListCommits = async (payload: {
+    cwd: string;
+    search?: string;
+    branch?: string;
+    skip?: number;
+    limit?: number;
+  }) => {
     checkRateLimit(CHANNELS.GIT_LIST_COMMITS, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
@@ -173,8 +164,7 @@ export function registerGitReadHandlers(deps: HandlerDependencies): () => void {
 
     return listCommits({ cwd, search, branch, skip, limit });
   };
-  ipcMain.handle(CHANNELS.GIT_LIST_COMMITS, handleGitListCommits);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_LIST_COMMITS));
+  handlers.push(typedHandle(CHANNELS.GIT_LIST_COMMITS, handleGitListCommits));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -1,6 +1,5 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
-import { checkRateLimit } from "../utils.js";
+import { checkRateLimit, typedHandle } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type { GitStatus } from "../../../shared/types/git.js";
 import { validateCwd, createHardenedGit, createAuthenticatedGit } from "../../utils/hardenedGit.js";
@@ -28,10 +27,7 @@ export interface StagingStatus {
 export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleStageFile = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; filePath: string }
-  ): Promise<void> => {
+  const handleStageFile = async (payload: { cwd: string; filePath: string }): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_STAGE_FILE, 30, 10_000);
     validateCwd(payload?.cwd);
     if (typeof payload.filePath !== "string" || !payload.filePath) {
@@ -41,13 +37,9 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     const git = createHardenedGit(payload.cwd);
     await git.add(["--", payload.filePath]);
   };
-  ipcMain.handle(CHANNELS.GIT_STAGE_FILE, handleStageFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_STAGE_FILE));
+  handlers.push(typedHandle(CHANNELS.GIT_STAGE_FILE, handleStageFile));
 
-  const handleUnstageFile = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; filePath: string }
-  ): Promise<void> => {
+  const handleUnstageFile = async (payload: { cwd: string; filePath: string }): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_UNSTAGE_FILE, 30, 10_000);
     validateCwd(payload?.cwd);
     if (typeof payload.filePath !== "string" || !payload.filePath) {
@@ -69,26 +61,18 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       await git.raw(["rm", "--cached", "--", payload.filePath]);
     }
   };
-  ipcMain.handle(CHANNELS.GIT_UNSTAGE_FILE, handleUnstageFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_UNSTAGE_FILE));
+  handlers.push(typedHandle(CHANNELS.GIT_UNSTAGE_FILE, handleUnstageFile));
 
-  const handleStageAll = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string
-  ): Promise<void> => {
+  const handleStageAll = async (cwd: string): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_STAGE_ALL, 10, 10_000);
     validateCwd(cwd);
 
     const git = createHardenedGit(cwd);
     await git.add("-A");
   };
-  ipcMain.handle(CHANNELS.GIT_STAGE_ALL, handleStageAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_STAGE_ALL));
+  handlers.push(typedHandle(CHANNELS.GIT_STAGE_ALL, handleStageAll));
 
-  const handleUnstageAll = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string
-  ): Promise<void> => {
+  const handleUnstageAll = async (cwd: string): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_UNSTAGE_ALL, 10, 10_000);
     validateCwd(cwd);
 
@@ -107,13 +91,12 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       await git.raw(["rm", "--cached", "-r", "."]);
     }
   };
-  ipcMain.handle(CHANNELS.GIT_UNSTAGE_ALL, handleUnstageAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_UNSTAGE_ALL));
+  handlers.push(typedHandle(CHANNELS.GIT_UNSTAGE_ALL, handleUnstageAll));
 
-  const handleCommit = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; message: string }
-  ): Promise<{ hash: string; summary: string }> => {
+  const handleCommit = async (payload: {
+    cwd: string;
+    message: string;
+  }): Promise<{ hash: string; summary: string }> => {
     checkRateLimit(CHANNELS.GIT_COMMIT, 5, 10_000);
     validateCwd(payload?.cwd);
     if (typeof payload.message !== "string" || !payload.message.trim()) {
@@ -130,13 +113,12 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       summary: `${result.summary.changes} changed, ${result.summary.insertions} insertions(+), ${result.summary.deletions} deletions(-)`,
     };
   };
-  ipcMain.handle(CHANNELS.GIT_COMMIT, handleCommit);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_COMMIT));
+  handlers.push(typedHandle(CHANNELS.GIT_COMMIT, handleCommit));
 
-  const handlePush = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; setUpstream?: boolean }
-  ): Promise<{ success: boolean; error?: string }> => {
+  const handlePush = async (payload: {
+    cwd: string;
+    setUpstream?: boolean;
+  }): Promise<{ success: boolean; error?: string }> => {
     checkRateLimit(CHANNELS.GIT_PUSH, 5, 10_000);
     validateCwd(payload?.cwd);
 
@@ -172,13 +154,9 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       return { success: false, error: errorMessage };
     }
   };
-  ipcMain.handle(CHANNELS.GIT_PUSH, handlePush);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_PUSH));
+  handlers.push(typedHandle(CHANNELS.GIT_PUSH, handlePush));
 
-  const handleGetUsername = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string
-  ): Promise<string | null> => {
+  const handleGetUsername = async (cwd: string): Promise<string | null> => {
     checkRateLimit(CHANNELS.GIT_GET_USERNAME, 20, 10_000);
     validateCwd(cwd);
     const git = createHardenedGit(cwd);
@@ -189,13 +167,9 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       return null;
     }
   };
-  ipcMain.handle(CHANNELS.GIT_GET_USERNAME, handleGetUsername);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_GET_USERNAME));
+  handlers.push(typedHandle(CHANNELS.GIT_GET_USERNAME, handleGetUsername));
 
-  const handleGetStagingStatus = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string
-  ): Promise<StagingStatus> => {
+  const handleGetStagingStatus = async (cwd: string): Promise<StagingStatus> => {
     checkRateLimit(CHANNELS.GIT_GET_STAGING_STATUS, 20, 10_000);
     validateCwd(cwd);
 
@@ -275,15 +249,14 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
 
     return { staged, unstaged, conflicted, isDetachedHead, currentBranch, hasRemote };
   };
-  ipcMain.handle(CHANNELS.GIT_GET_STAGING_STATUS, handleGetStagingStatus);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_GET_STAGING_STATUS));
+  handlers.push(typedHandle(CHANNELS.GIT_GET_STAGING_STATUS, handleGetStagingStatus));
 
   const DIFF_LINE_LIMIT = 500;
 
-  const handleGetWorkingDiff = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; type: "unstaged" | "staged" | "head" }
-  ): Promise<string> => {
+  const handleGetWorkingDiff = async (payload: {
+    cwd: string;
+    type: "unstaged" | "staged" | "head";
+  }): Promise<string> => {
     checkRateLimit(CHANNELS.GIT_GET_WORKING_DIFF, 20, 10_000);
     validateCwd(payload?.cwd);
     const diffType = payload?.type;
@@ -318,46 +291,32 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
 
     return raw;
   };
-  ipcMain.handle(CHANNELS.GIT_GET_WORKING_DIFF, handleGetWorkingDiff);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_GET_WORKING_DIFF));
+  handlers.push(typedHandle(CHANNELS.GIT_GET_WORKING_DIFF, handleGetWorkingDiff));
 
   // Snapshot handlers
-  const handleSnapshotGet = async (
-    _event: Electron.IpcMainInvokeEvent,
-    worktreeId: string
-  ): Promise<SnapshotInfo | null> => {
+  const handleSnapshotGet = async (worktreeId: string): Promise<SnapshotInfo | null> => {
     if (typeof worktreeId !== "string" || !worktreeId) return null;
     return preAgentSnapshotService.getSnapshot(worktreeId);
   };
-  ipcMain.handle(CHANNELS.GIT_SNAPSHOT_GET, handleSnapshotGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_SNAPSHOT_GET));
+  handlers.push(typedHandle(CHANNELS.GIT_SNAPSHOT_GET, handleSnapshotGet));
 
   const handleSnapshotList = async (): Promise<SnapshotInfo[]> => {
     return preAgentSnapshotService.listSnapshots();
   };
-  ipcMain.handle(CHANNELS.GIT_SNAPSHOT_LIST, handleSnapshotList);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_SNAPSHOT_LIST));
+  handlers.push(typedHandle(CHANNELS.GIT_SNAPSHOT_LIST, handleSnapshotList));
 
-  const handleSnapshotRevert = async (
-    _event: Electron.IpcMainInvokeEvent,
-    worktreeId: string
-  ): Promise<SnapshotRevertResult> => {
+  const handleSnapshotRevert = async (worktreeId: string): Promise<SnapshotRevertResult> => {
     validateCwd(worktreeId);
     checkRateLimit(CHANNELS.GIT_SNAPSHOT_REVERT, 3, 10_000);
     return preAgentSnapshotService.revertToSnapshot(worktreeId);
   };
-  ipcMain.handle(CHANNELS.GIT_SNAPSHOT_REVERT, handleSnapshotRevert);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_SNAPSHOT_REVERT));
+  handlers.push(typedHandle(CHANNELS.GIT_SNAPSHOT_REVERT, handleSnapshotRevert));
 
-  const handleSnapshotDelete = async (
-    _event: Electron.IpcMainInvokeEvent,
-    worktreeId: string
-  ): Promise<void> => {
+  const handleSnapshotDelete = async (worktreeId: string): Promise<void> => {
     validateCwd(worktreeId);
     await preAgentSnapshotService.deleteSnapshot(worktreeId);
   };
-  ipcMain.handle(CHANNELS.GIT_SNAPSHOT_DELETE, handleSnapshotDelete);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GIT_SNAPSHOT_DELETE));
+  handlers.push(typedHandle(CHANNELS.GIT_SNAPSHOT_DELETE, handleSnapshotDelete));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -1,8 +1,8 @@
-import { ipcMain, shell } from "electron";
+import { shell } from "electron";
 import fs from "fs/promises";
 import path from "path";
 import { CHANNELS } from "../channels.js";
-import { checkRateLimit } from "../utils.js";
+import { checkRateLimit, typedHandle } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   RepositoryStats,
@@ -54,7 +54,6 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
   const handleGitHubGetRepoStats = async (
-    _event: Electron.IpcMainInvokeEvent,
     cwd: string,
     bypassCache = false
   ): Promise<RepositoryStats> => {
@@ -106,11 +105,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       };
     }
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_REPO_STATS, handleGitHubGetRepoStats);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_REPO_STATS));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_REPO_STATS, handleGitHubGetRepoStats));
 
   const handleGitHubGetProjectHealth = async (
-    _event: Electron.IpcMainInvokeEvent,
     cwd: string,
     bypassCache = false
   ): Promise<ProjectHealthData> => {
@@ -181,15 +178,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       };
     }
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_PROJECT_HEALTH, handleGitHubGetProjectHealth);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_PROJECT_HEALTH));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PROJECT_HEALTH, handleGitHubGetProjectHealth));
 
-  const handleGitHubOpenIssues = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string,
-    query?: string,
-    state?: string
-  ) => {
+  const handleGitHubOpenIssues = async (cwd: string, query?: string, state?: string) => {
     checkRateLimit(CHANNELS.GITHUB_OPEN_ISSUES, 20, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
@@ -206,15 +197,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const url = q ? `${repoUrl}/issues?q=${encodeURIComponent(q)}` : `${repoUrl}/issues`;
     await shell.openExternal(url);
   };
-  ipcMain.handle(CHANNELS.GITHUB_OPEN_ISSUES, handleGitHubOpenIssues);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_ISSUES));
+  handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_ISSUES, handleGitHubOpenIssues));
 
-  const handleGitHubOpenPRs = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string,
-    query?: string,
-    state?: string
-  ) => {
+  const handleGitHubOpenPRs = async (cwd: string, query?: string, state?: string) => {
     checkRateLimit(CHANNELS.GITHUB_OPEN_PRS, 20, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
@@ -231,14 +216,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const url = q ? `${repoUrl}/pulls?q=${encodeURIComponent(q)}` : `${repoUrl}/pulls`;
     await shell.openExternal(url);
   };
-  ipcMain.handle(CHANNELS.GITHUB_OPEN_PRS, handleGitHubOpenPRs);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_PRS));
+  handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_PRS, handleGitHubOpenPRs));
 
-  const handleGitHubOpenCommits = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cwd: string,
-    branch?: string
-  ) => {
+  const handleGitHubOpenCommits = async (cwd: string, branch?: string) => {
     checkRateLimit(CHANNELS.GITHUB_OPEN_COMMITS, 20, 10_000);
     if (typeof cwd !== "string" || !cwd) {
       throw new Error("Invalid working directory");
@@ -257,13 +237,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const url = branch ? `${repoUrl}/commits/${encodeURIComponent(branch)}` : `${repoUrl}/commits`;
     await shell.openExternal(url);
   };
-  ipcMain.handle(CHANNELS.GITHUB_OPEN_COMMITS, handleGitHubOpenCommits);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_COMMITS));
+  handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_COMMITS, handleGitHubOpenCommits));
 
-  const handleGitHubOpenIssue = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; issueNumber: number }
-  ) => {
+  const handleGitHubOpenIssue = async (payload: { cwd: string; issueNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_OPEN_ISSUE, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
@@ -284,10 +260,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     }
     await shell.openExternal(issueUrl);
   };
-  ipcMain.handle(CHANNELS.GITHUB_OPEN_ISSUE, handleGitHubOpenIssue);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_ISSUE));
+  handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_ISSUE, handleGitHubOpenIssue));
 
-  const handleGitHubOpenPR = async (_event: Electron.IpcMainInvokeEvent, prUrl: string) => {
+  const handleGitHubOpenPR = async (prUrl: string) => {
     checkRateLimit(CHANNELS.GITHUB_OPEN_PR, 20, 10_000);
     if (typeof prUrl !== "string" || !prUrl) {
       throw new Error("Invalid PR URL");
@@ -302,8 +277,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     }
     await shell.openExternal(prUrl);
   };
-  ipcMain.handle(CHANNELS.GITHUB_OPEN_PR, handleGitHubOpenPR);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_OPEN_PR));
+  handlers.push(typedHandle(CHANNELS.GITHUB_OPEN_PR, handleGitHubOpenPR));
 
   const handleGitHubCheckCli = async (): Promise<GitHubCliStatus> => {
     checkRateLimit(CHANNELS.GITHUB_CHECK_CLI, 10, 10_000);
@@ -313,21 +287,16 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     }
     return { available: false, error: "GitHub token not configured. Set it in Settings." };
   };
-  ipcMain.handle(CHANNELS.GITHUB_CHECK_CLI, handleGitHubCheckCli);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_CHECK_CLI));
+  handlers.push(typedHandle(CHANNELS.GITHUB_CHECK_CLI, handleGitHubCheckCli));
 
   const handleGitHubGetConfig = async (): Promise<GitHubTokenConfig> => {
     checkRateLimit(CHANNELS.GITHUB_GET_CONFIG, 10, 10_000);
     const { getGitHubConfigAsync } = await import("../../services/GitHubService.js");
     return getGitHubConfigAsync();
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_CONFIG, handleGitHubGetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_CONFIG, handleGitHubGetConfig));
 
-  const handleGitHubSetToken = async (
-    _event: Electron.IpcMainInvokeEvent,
-    token: string
-  ): Promise<GitHubTokenValidation> => {
+  const handleGitHubSetToken = async (token: string): Promise<GitHubTokenValidation> => {
     checkRateLimit(CHANNELS.GITHUB_SET_TOKEN, 5, 10_000);
     if (typeof token !== "string" || !token.trim()) {
       return { valid: false, scopes: [], error: "Token is required" };
@@ -361,8 +330,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
     return validation;
   };
-  ipcMain.handle(CHANNELS.GITHUB_SET_TOKEN, handleGitHubSetToken);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_SET_TOKEN));
+  handlers.push(typedHandle(CHANNELS.GITHUB_SET_TOKEN, handleGitHubSetToken));
 
   const handleGitHubClearToken = async (): Promise<void> => {
     checkRateLimit(CHANNELS.GITHUB_CLEAR_TOKEN, 5, 10_000);
@@ -376,13 +344,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       // WorkspaceClient may not be initialized yet
     }
   };
-  ipcMain.handle(CHANNELS.GITHUB_CLEAR_TOKEN, handleGitHubClearToken);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_CLEAR_TOKEN));
+  handlers.push(typedHandle(CHANNELS.GITHUB_CLEAR_TOKEN, handleGitHubClearToken));
 
-  const handleGitHubValidateToken = async (
-    _event: Electron.IpcMainInvokeEvent,
-    token: string
-  ): Promise<GitHubTokenValidation> => {
+  const handleGitHubValidateToken = async (token: string): Promise<GitHubTokenValidation> => {
     checkRateLimit(CHANNELS.GITHUB_VALIDATE_TOKEN, 5, 10_000);
     if (typeof token !== "string" || !token.trim()) {
       return { valid: false, scopes: [], error: "Token is required" };
@@ -391,20 +355,16 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { validateGitHubToken } = await import("../../services/GitHubService.js");
     return validateGitHubToken(token.trim());
   };
-  ipcMain.handle(CHANNELS.GITHUB_VALIDATE_TOKEN, handleGitHubValidateToken);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_VALIDATE_TOKEN));
+  handlers.push(typedHandle(CHANNELS.GITHUB_VALIDATE_TOKEN, handleGitHubValidateToken));
 
-  const handleGitHubListIssues = async (
-    _event: Electron.IpcMainInvokeEvent,
-    options: {
-      cwd: string;
-      search?: string;
-      state?: "open" | "closed" | "all";
-      cursor?: string;
-      bypassCache?: boolean;
-      sortOrder?: "created" | "updated";
-    }
-  ) => {
+  const handleGitHubListIssues = async (options: {
+    cwd: string;
+    search?: string;
+    state?: "open" | "closed" | "all";
+    cursor?: string;
+    bypassCache?: boolean;
+    sortOrder?: "created" | "updated";
+  }) => {
     checkRateLimit(CHANNELS.GITHUB_LIST_ISSUES, 10, 10_000);
     if (!options || typeof options.cwd !== "string" || !options.cwd) {
       throw new Error("Invalid options: cwd is required");
@@ -416,20 +376,16 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { listIssues } = await import("../../services/GitHubService.js");
     return listIssues(options);
   };
-  ipcMain.handle(CHANNELS.GITHUB_LIST_ISSUES, handleGitHubListIssues);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_LIST_ISSUES));
+  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_ISSUES, handleGitHubListIssues));
 
-  const handleGitHubListPRs = async (
-    _event: Electron.IpcMainInvokeEvent,
-    options: {
-      cwd: string;
-      search?: string;
-      state?: "open" | "closed" | "merged" | "all";
-      cursor?: string;
-      bypassCache?: boolean;
-      sortOrder?: "created" | "updated";
-    }
-  ) => {
+  const handleGitHubListPRs = async (options: {
+    cwd: string;
+    search?: string;
+    state?: "open" | "closed" | "merged" | "all";
+    cursor?: string;
+    bypassCache?: boolean;
+    sortOrder?: "created" | "updated";
+  }) => {
     checkRateLimit(CHANNELS.GITHUB_LIST_PRS, 10, 10_000);
     if (!options || typeof options.cwd !== "string" || !options.cwd) {
       throw new Error("Invalid options: cwd is required");
@@ -441,13 +397,13 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { listPullRequests } = await import("../../services/GitHubService.js");
     return listPullRequests(options);
   };
-  ipcMain.handle(CHANNELS.GITHUB_LIST_PRS, handleGitHubListPRs);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_LIST_PRS));
+  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_PRS, handleGitHubListPRs));
 
-  const handleGitHubAssignIssue = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; issueNumber: number; username: string }
-  ): Promise<void> => {
+  const handleGitHubAssignIssue = async (payload: {
+    cwd: string;
+    issueNumber: number;
+    username: string;
+  }): Promise<void> => {
     checkRateLimit(CHANNELS.GITHUB_ASSIGN_ISSUE, 5, 10_000);
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
@@ -473,13 +429,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { assignIssue } = await import("../../services/GitHubService.js");
     await assignIssue(payload.cwd.trim(), payload.issueNumber, trimmedUsername);
   };
-  ipcMain.handle(CHANNELS.GITHUB_ASSIGN_ISSUE, handleGitHubAssignIssue);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_ASSIGN_ISSUE));
+  handlers.push(typedHandle(CHANNELS.GITHUB_ASSIGN_ISSUE, handleGitHubAssignIssue));
 
-  const handleGitHubGetIssueTooltip = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; issueNumber: number }
-  ) => {
+  const handleGitHubGetIssueTooltip = async (payload: { cwd: string; issueNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
@@ -501,13 +453,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getIssueTooltip } = await import("../../services/GitHubService.js");
     return getIssueTooltip(payload.cwd.trim(), payload.issueNumber);
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, handleGitHubGetIssueTooltip);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, handleGitHubGetIssueTooltip));
 
-  const handleGitHubGetPRTooltip = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; prNumber: number }
-  ) => {
+  const handleGitHubGetPRTooltip = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_TOOLTIP, 20, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
@@ -529,13 +477,12 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getPRTooltip } = await import("../../services/GitHubService.js");
     return getPRTooltip(payload.cwd.trim(), payload.prNumber);
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_PR_TOOLTIP, handleGitHubGetPRTooltip);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_PR_TOOLTIP));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_TOOLTIP, handleGitHubGetPRTooltip));
 
-  const handleGitHubGetIssueUrl = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; issueNumber: number }
-  ): Promise<string | null> => {
+  const handleGitHubGetIssueUrl = async (payload: {
+    cwd: string;
+    issueNumber: number;
+  }): Promise<string | null> => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_URL, 10, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
@@ -557,13 +504,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getIssueUrl } = await import("../../services/GitHubService.js");
     return getIssueUrl(payload.cwd.trim(), payload.issueNumber);
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_ISSUE_URL, handleGitHubGetIssueUrl);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_ISSUE_URL));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_URL, handleGitHubGetIssueUrl));
 
-  const handleGitHubGetIssueByNumber = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; issueNumber: number }
-  ) => {
+  const handleGitHubGetIssueByNumber = async (payload: { cwd: string; issueNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, 25, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
@@ -585,13 +528,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getIssueByNumber } = await import("../../services/GitHubService.js");
     return getIssueByNumber(payload.cwd.trim(), payload.issueNumber);
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, handleGitHubGetIssueByNumber);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, handleGitHubGetIssueByNumber));
 
-  const handleGitHubGetPRByNumber = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { cwd: string; prNumber: number }
-  ) => {
+  const handleGitHubGetPRByNumber = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_BY_NUMBER, 25, 10_000);
     if (!payload || typeof payload !== "object") {
       return null;
@@ -613,11 +552,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getPRByNumber } = await import("../../services/GitHubService.js");
     return getPRByNumber(payload.cwd.trim(), payload.prNumber);
   };
-  ipcMain.handle(CHANNELS.GITHUB_GET_PR_BY_NUMBER, handleGitHubGetPRByNumber);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_GET_PR_BY_NUMBER));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_BY_NUMBER, handleGitHubGetPRByNumber));
 
   const handleGitHubListRemotes = async (
-    _event: Electron.IpcMainInvokeEvent,
     cwd: string
   ): Promise<
     Array<{ name: string; fetchUrl: string; parsedRepo: { owner: string; repo: string } | null }>
@@ -649,8 +586,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
     return result;
   };
-  ipcMain.handle(CHANNELS.GITHUB_LIST_REMOTES, handleGitHubListRemotes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GITHUB_LIST_REMOTES));
+  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_REMOTES, handleGitHubListRemotes));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/globalEnv.ts
+++ b/electron/ipc/handlers/globalEnv.ts
@@ -1,7 +1,7 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
+import { typedHandle } from "../utils.js";
 
 export function registerGlobalEnvHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -9,13 +9,9 @@ export function registerGlobalEnvHandlers(_deps: HandlerDependencies): () => voi
   const handleGetEnv = async (): Promise<Record<string, string>> => {
     return store.get("globalEnvironmentVariables") ?? {};
   };
-  ipcMain.handle(CHANNELS.GLOBAL_ENV_GET, handleGetEnv);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GLOBAL_ENV_GET));
+  handlers.push(typedHandle(CHANNELS.GLOBAL_ENV_GET, handleGetEnv));
 
-  const handleSetEnv = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { variables: Record<string, string> }
-  ): Promise<void> => {
+  const handleSetEnv = async (payload: { variables: Record<string, string> }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -30,8 +26,7 @@ export function registerGlobalEnvHandlers(_deps: HandlerDependencies): () => voi
     }
     return store.set("globalEnvironmentVariables", variables);
   };
-  ipcMain.handle(CHANNELS.GLOBAL_ENV_SET, handleSetEnv);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GLOBAL_ENV_SET));
+  handlers.push(typedHandle(CHANNELS.GLOBAL_ENV_SET, handleSetEnv));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/globalRecipes.ts
+++ b/electron/ipc/handlers/globalRecipes.ts
@@ -1,8 +1,8 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalRecipe } from "../../types/index.js";
+import { typedHandle } from "../utils.js";
 
 export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -10,13 +10,9 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
   const handleGetRecipes = async (): Promise<TerminalRecipe[]> => {
     return projectStore.getGlobalRecipes();
   };
-  ipcMain.handle(CHANNELS.GLOBAL_GET_RECIPES, handleGetRecipes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GLOBAL_GET_RECIPES));
+  handlers.push(typedHandle(CHANNELS.GLOBAL_GET_RECIPES, handleGetRecipes));
 
-  const handleAddRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { recipe: TerminalRecipe }
-  ): Promise<void> => {
+  const handleAddRecipe = async (payload: { recipe: TerminalRecipe }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -44,16 +40,12 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
     }
     return projectStore.addGlobalRecipe(recipe);
   };
-  ipcMain.handle(CHANNELS.GLOBAL_ADD_RECIPE, handleAddRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GLOBAL_ADD_RECIPE));
+  handlers.push(typedHandle(CHANNELS.GLOBAL_ADD_RECIPE, handleAddRecipe));
 
-  const handleUpdateRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      recipeId: string;
-      updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
-    }
-  ): Promise<void> => {
+  const handleUpdateRecipe = async (payload: {
+    recipeId: string;
+    updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -76,13 +68,9 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
     }
     return projectStore.updateGlobalRecipe(recipeId, updates);
   };
-  ipcMain.handle(CHANNELS.GLOBAL_UPDATE_RECIPE, handleUpdateRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GLOBAL_UPDATE_RECIPE));
+  handlers.push(typedHandle(CHANNELS.GLOBAL_UPDATE_RECIPE, handleUpdateRecipe));
 
-  const handleDeleteRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { recipeId: string }
-  ): Promise<void> => {
+  const handleDeleteRecipe = async (payload: { recipeId: string }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -92,8 +80,7 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
     }
     return projectStore.deleteGlobalRecipe(recipeId);
   };
-  ipcMain.handle(CHANNELS.GLOBAL_DELETE_RECIPE, handleDeleteRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.GLOBAL_DELETE_RECIPE));
+  handlers.push(typedHandle(CHANNELS.GLOBAL_DELETE_RECIPE, handleDeleteRecipe));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -1,31 +1,28 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import * as HelpService from "../../services/HelpService.js";
 import { getAgentAvailabilityStore } from "../../services/AgentAvailabilityStore.js";
+import { typedHandle } from "../utils.js";
 
 export function registerHelpHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.HELP_GET_FOLDER_PATH, async () => {
-    return HelpService.getHelpFolderPath();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.HELP_GET_FOLDER_PATH));
+  handlers.push(
+    typedHandle(CHANNELS.HELP_GET_FOLDER_PATH, async () => {
+      return HelpService.getHelpFolderPath();
+    })
+  );
 
-  ipcMain.handle(
-    CHANNELS.HELP_MARK_TERMINAL,
-    (_event: Electron.IpcMainInvokeEvent, terminalId: string) => {
+  handlers.push(
+    typedHandle(CHANNELS.HELP_MARK_TERMINAL, (terminalId: string) => {
       getAgentAvailabilityStore().markAsHelp(terminalId);
-    }
+    })
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.HELP_MARK_TERMINAL));
 
-  ipcMain.handle(
-    CHANNELS.HELP_UNMARK_TERMINAL,
-    (_event: Electron.IpcMainInvokeEvent, terminalId: string) => {
+  handlers.push(
+    typedHandle(CHANNELS.HELP_UNMARK_TERMINAL, (terminalId: string) => {
       getAgentAvailabilityStore().unmarkAsHelp(terminalId);
-    }
+    })
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.HELP_UNMARK_TERMINAL));
 
   return () => {
     for (const cleanup of handlers) {

--- a/electron/ipc/handlers/hibernation.ts
+++ b/electron/ipc/handlers/hibernation.ts
@@ -1,10 +1,10 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import {
   getHibernationService,
   type HibernationConfig,
 } from "../../services/HibernationService.js";
 import type { HandlerDependencies } from "../types.js";
+import { typedHandle } from "../utils.js";
 
 export function registerHibernationHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -13,11 +13,9 @@ export function registerHibernationHandlers(_deps: HandlerDependencies): () => v
   const handleGetConfig = async (): Promise<HibernationConfig> => {
     return hibernationService.getConfig();
   };
-  ipcMain.handle(CHANNELS.HIBERNATION_GET_CONFIG, handleGetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.HIBERNATION_GET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.HIBERNATION_GET_CONFIG, handleGetConfig));
 
   const handleUpdateConfig = async (
-    _event: Electron.IpcMainInvokeEvent,
     config: Partial<HibernationConfig>
   ): Promise<HibernationConfig> => {
     if (typeof config !== "object" || config === null || Array.isArray(config)) {
@@ -44,8 +42,7 @@ export function registerHibernationHandlers(_deps: HandlerDependencies): () => v
     hibernationService.updateConfig(config);
     return hibernationService.getConfig();
   };
-  ipcMain.handle(CHANNELS.HIBERNATION_UPDATE_CONFIG, handleUpdateConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.HIBERNATION_UPDATE_CONFIG));
+  handlers.push(typedHandle(CHANNELS.HIBERNATION_UPDATE_CONFIG, handleUpdateConfig));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/idleTerminals.ts
+++ b/electron/ipc/handlers/idleTerminals.ts
@@ -1,8 +1,8 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { getIdleTerminalNotificationService } from "../../services/IdleTerminalNotificationService.js";
 import type { IdleTerminalNotifyConfig } from "../../../shared/types/ipc/idleTerminals.js";
 import type { HandlerDependencies } from "../types.js";
+import { typedHandle } from "../utils.js";
 
 export function registerIdleTerminalHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -11,11 +11,9 @@ export function registerIdleTerminalHandlers(_deps: HandlerDependencies): () => 
   const handleGetConfig = async (): Promise<IdleTerminalNotifyConfig> => {
     return service.getConfig();
   };
-  ipcMain.handle(CHANNELS.IDLE_TERMINAL_GET_CONFIG, handleGetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.IDLE_TERMINAL_GET_CONFIG));
+  handlers.push(typedHandle(CHANNELS.IDLE_TERMINAL_GET_CONFIG, handleGetConfig));
 
   const handleUpdateConfig = async (
-    _event: Electron.IpcMainInvokeEvent,
     config: Partial<IdleTerminalNotifyConfig>
   ): Promise<IdleTerminalNotifyConfig> => {
     if (typeof config !== "object" || config === null || Array.isArray(config)) {
@@ -38,32 +36,23 @@ export function registerIdleTerminalHandlers(_deps: HandlerDependencies): () => 
     }
     return service.updateConfig(config);
   };
-  ipcMain.handle(CHANNELS.IDLE_TERMINAL_UPDATE_CONFIG, handleUpdateConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.IDLE_TERMINAL_UPDATE_CONFIG));
+  handlers.push(typedHandle(CHANNELS.IDLE_TERMINAL_UPDATE_CONFIG, handleUpdateConfig));
 
-  const handleCloseProject = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: unknown
-  ): Promise<void> => {
+  const handleCloseProject = async (projectId: unknown): Promise<void> => {
     if (typeof projectId !== "string" || projectId.trim() === "") {
       throw new Error("projectId must be a non-empty string");
     }
     await service.closeProject(projectId);
   };
-  ipcMain.handle(CHANNELS.IDLE_TERMINAL_CLOSE_PROJECT, handleCloseProject);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.IDLE_TERMINAL_CLOSE_PROJECT));
+  handlers.push(typedHandle(CHANNELS.IDLE_TERMINAL_CLOSE_PROJECT, handleCloseProject));
 
-  const handleDismissProject = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: unknown
-  ): Promise<void> => {
+  const handleDismissProject = async (projectId: unknown): Promise<void> => {
     if (typeof projectId !== "string" || projectId.trim() === "") {
       throw new Error("projectId must be a non-empty string");
     }
     service.dismissProject(projectId);
   };
-  ipcMain.handle(CHANNELS.IDLE_TERMINAL_DISMISS_PROJECT, handleDismissProject);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.IDLE_TERMINAL_DISMISS_PROJECT));
+  handlers.push(typedHandle(CHANNELS.IDLE_TERMINAL_DISMISS_PROJECT, handleDismissProject));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/keybinding.ts
+++ b/electron/ipc/handlers/keybinding.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog } from "electron";
+import { dialog } from "electron";
 import { promises as fs } from "node:fs";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
@@ -6,7 +6,7 @@ import type { HandlerDependencies } from "../types.js";
 import type { KeyAction } from "../../../shared/types/keymap.js";
 import { exportProfile, importProfile } from "../../utils/keybindingProfileIO.js";
 import type { ImportResult } from "../../utils/keybindingProfileIO.js";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 function getValidatedOverrides(): Record<string, string[]> {
   const raw = store.get("keybindingOverrides.overrides");
@@ -25,111 +25,112 @@ function getValidatedOverrides(): Record<string, string[]> {
 export function registerKeybindingHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleGetOverrides = async () => {
-    return getValidatedOverrides();
-  };
-  ipcMain.handle(CHANNELS.KEYBINDING_GET_OVERRIDES, handleGetOverrides);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_GET_OVERRIDES));
+  handlers.push(
+    typedHandle(CHANNELS.KEYBINDING_GET_OVERRIDES, async () => {
+      return getValidatedOverrides();
+    })
+  );
 
-  const handleSetOverride = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { actionId: KeyAction; combo: string[] }
-  ) => {
-    if (!payload || typeof payload !== "object") {
-      throw new Error("Invalid keybinding override payload");
-    }
+  handlers.push(
+    typedHandle(
+      CHANNELS.KEYBINDING_SET_OVERRIDE,
+      async (payload: { actionId: KeyAction; combo: string[] }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid keybinding override payload");
+        }
 
-    const { actionId, combo } = payload;
+        const { actionId, combo } = payload;
 
-    if (typeof actionId !== "string" || actionId.trim() === "") {
-      throw new Error("Invalid actionId: must be non-empty string");
-    }
+        if (typeof actionId !== "string" || actionId.trim() === "") {
+          throw new Error("Invalid actionId: must be non-empty string");
+        }
 
-    if (!Array.isArray(combo)) {
-      throw new Error("Invalid combo: must be an array");
-    }
+        if (!Array.isArray(combo)) {
+          throw new Error("Invalid combo: must be an array");
+        }
 
-    if (combo.length > 0 && combo.some((c) => typeof c !== "string" || c.trim() === "")) {
-      throw new Error("Invalid combo: array contains non-string or empty values");
-    }
+        if (combo.length > 0 && combo.some((c) => typeof c !== "string" || c.trim() === "")) {
+          throw new Error("Invalid combo: array contains non-string or empty values");
+        }
 
-    const overrides = getValidatedOverrides();
-    overrides[actionId] = combo;
-    store.set("keybindingOverrides.overrides", overrides);
-  };
-  ipcMain.handle(CHANNELS.KEYBINDING_SET_OVERRIDE, handleSetOverride);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_SET_OVERRIDE));
+        const overrides = getValidatedOverrides();
+        overrides[actionId] = combo;
+        store.set("keybindingOverrides.overrides", overrides);
+      }
+    )
+  );
 
-  const handleRemoveOverride = async (_event: Electron.IpcMainInvokeEvent, actionId: KeyAction) => {
-    if (typeof actionId !== "string" || actionId.trim() === "") {
-      throw new Error("Invalid actionId for remove");
-    }
+  handlers.push(
+    typedHandle(CHANNELS.KEYBINDING_REMOVE_OVERRIDE, async (actionId: KeyAction) => {
+      if (typeof actionId !== "string" || actionId.trim() === "") {
+        throw new Error("Invalid actionId for remove");
+      }
 
-    const overrides = getValidatedOverrides();
-    delete overrides[actionId];
-    store.set("keybindingOverrides.overrides", overrides);
-  };
-  ipcMain.handle(CHANNELS.KEYBINDING_REMOVE_OVERRIDE, handleRemoveOverride);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_REMOVE_OVERRIDE));
+      const overrides = getValidatedOverrides();
+      delete overrides[actionId];
+      store.set("keybindingOverrides.overrides", overrides);
+    })
+  );
 
-  const handleResetAll = async () => {
-    store.set("keybindingOverrides.overrides", {});
-  };
-  ipcMain.handle(CHANNELS.KEYBINDING_RESET_ALL, handleResetAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_RESET_ALL));
+  handlers.push(
+    typedHandle(CHANNELS.KEYBINDING_RESET_ALL, async () => {
+      store.set("keybindingOverrides.overrides", {});
+    })
+  );
 
-  const handleExportProfile = async (_event: Electron.IpcMainInvokeEvent): Promise<boolean> => {
-    const overrides = getValidatedOverrides();
-    const json = exportProfile(overrides);
-    const parentWindow = getWindowForWebContents(_event.sender);
-    const saveOpts: Electron.SaveDialogOptions = {
-      title: "Export Keyboard Shortcuts",
-      defaultPath: "daintree-keybindings.json",
-      filters: [{ name: "Keybinding Profile", extensions: ["json"] }],
-    };
+  handlers.push(
+    typedHandleWithContext(CHANNELS.KEYBINDING_EXPORT_PROFILE, async (ctx): Promise<boolean> => {
+      const overrides = getValidatedOverrides();
+      const json = exportProfile(overrides);
+      const parentWindow = ctx.senderWindow;
+      const saveOpts: Electron.SaveDialogOptions = {
+        title: "Export Keyboard Shortcuts",
+        defaultPath: "daintree-keybindings.json",
+        filters: [{ name: "Keybinding Profile", extensions: ["json"] }],
+      };
 
-    const { filePath, canceled } = parentWindow
-      ? await dialog.showSaveDialog(parentWindow, saveOpts)
-      : await dialog.showSaveDialog(saveOpts);
+      const { filePath, canceled } = parentWindow
+        ? await dialog.showSaveDialog(parentWindow, saveOpts)
+        : await dialog.showSaveDialog(saveOpts);
 
-    if (canceled || !filePath) return false;
+      if (canceled || !filePath) return false;
 
-    await fs.writeFile(filePath, json, "utf-8");
-    return true;
-  };
-  ipcMain.handle(CHANNELS.KEYBINDING_EXPORT_PROFILE, handleExportProfile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_EXPORT_PROFILE));
+      await fs.writeFile(filePath, json, "utf-8");
+      return true;
+    })
+  );
 
-  const handleImportProfile = async (
-    _event: Electron.IpcMainInvokeEvent
-  ): Promise<ImportResult> => {
-    const parentWindow = getWindowForWebContents(_event.sender);
-    const openOpts: Electron.OpenDialogOptions = {
-      title: "Import Keyboard Shortcuts",
-      filters: [{ name: "Keybinding Profile", extensions: ["json"] }],
-      properties: ["openFile"],
-    };
-    const { filePaths, canceled } = parentWindow
-      ? await dialog.showOpenDialog(parentWindow, openOpts)
-      : await dialog.showOpenDialog(openOpts);
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.KEYBINDING_IMPORT_PROFILE,
+      async (ctx): Promise<ImportResult> => {
+        const parentWindow = ctx.senderWindow;
+        const openOpts: Electron.OpenDialogOptions = {
+          title: "Import Keyboard Shortcuts",
+          filters: [{ name: "Keybinding Profile", extensions: ["json"] }],
+          properties: ["openFile"],
+        };
+        const { filePaths, canceled } = parentWindow
+          ? await dialog.showOpenDialog(parentWindow, openOpts)
+          : await dialog.showOpenDialog(openOpts);
 
-    if (canceled || filePaths.length === 0) {
-      return { ok: false, overrides: {}, applied: 0, skipped: 0, errors: ["Cancelled"] };
-    }
+        if (canceled || filePaths.length === 0) {
+          return { ok: false, overrides: {}, applied: 0, skipped: 0, errors: ["Cancelled"] };
+        }
 
-    const json = await fs.readFile(filePaths[0], "utf-8");
-    const result = importProfile(json);
+        const json = await fs.readFile(filePaths[0], "utf-8");
+        const result = importProfile(json);
 
-    if (result.ok) {
-      const existing = getValidatedOverrides();
-      const merged = { ...existing, ...result.overrides };
-      store.set("keybindingOverrides.overrides", merged);
-    }
+        if (result.ok) {
+          const existing = getValidatedOverrides();
+          const merged = { ...existing, ...result.overrides };
+          store.set("keybindingOverrides.overrides", merged);
+        }
 
-    return result;
-  };
-  ipcMain.handle(CHANNELS.KEYBINDING_IMPORT_PROFILE, handleImportProfile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.KEYBINDING_IMPORT_PROFILE));
+        return result;
+      }
+    )
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -1,4 +1,4 @@
-import { ipcMain, shell } from "electron";
+import { shell } from "electron";
 import { CHANNELS } from "../channels.js";
 import { logBuffer } from "../../services/LogBuffer.js";
 import {
@@ -12,33 +12,28 @@ import {
   type LogLevel,
 } from "../../utils/logger.js";
 import type { FilterOptions as LogFilterOptions } from "../../services/LogBuffer.js";
+import { typedHandle } from "../utils.js";
 
 export function registerLogsHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleLogsGetAll = async (
-    _event: Electron.IpcMainInvokeEvent,
-    filters?: LogFilterOptions
-  ) => {
+  const handleLogsGetAll = async (filters?: LogFilterOptions) => {
     if (filters) {
       return logBuffer.getFiltered(filters);
     }
     return logBuffer.getAll();
   };
-  ipcMain.handle(CHANNELS.LOGS_GET_ALL, handleLogsGetAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_GET_ALL));
+  handlers.push(typedHandle(CHANNELS.LOGS_GET_ALL, handleLogsGetAll));
 
   const handleLogsGetSources = async () => {
     return logBuffer.getSources();
   };
-  ipcMain.handle(CHANNELS.LOGS_GET_SOURCES, handleLogsGetSources);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_GET_SOURCES));
+  handlers.push(typedHandle(CHANNELS.LOGS_GET_SOURCES, handleLogsGetSources));
 
   const handleLogsClear = async () => {
     logBuffer.clear();
   };
-  ipcMain.handle(CHANNELS.LOGS_CLEAR, handleLogsClear);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_CLEAR));
+  handlers.push(typedHandle(CHANNELS.LOGS_CLEAR, handleLogsClear));
 
   const handleLogsOpenFile = async () => {
     const logFilePath = getLogFilePath();
@@ -71,10 +66,9 @@ export function registerLogsHandlers(): () => void {
       }
     }
   };
-  ipcMain.handle(CHANNELS.LOGS_OPEN_FILE, handleLogsOpenFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_OPEN_FILE));
+  handlers.push(typedHandle(CHANNELS.LOGS_OPEN_FILE, handleLogsOpenFile));
 
-  const handleLogsSetVerbose = async (_event: Electron.IpcMainInvokeEvent, enabled: boolean) => {
+  const handleLogsSetVerbose = async (enabled: boolean) => {
     if (typeof enabled !== "boolean") {
       logError("Invalid verbose logging payload", undefined, { payload: enabled });
       return { success: false };
@@ -83,19 +77,18 @@ export function registerLogsHandlers(): () => void {
     logInfo(`Verbose logging ${enabled ? "enabled" : "disabled"} by user`);
     return { success: true };
   };
-  ipcMain.handle(CHANNELS.LOGS_SET_VERBOSE, handleLogsSetVerbose);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_SET_VERBOSE));
+  handlers.push(typedHandle(CHANNELS.LOGS_SET_VERBOSE, handleLogsSetVerbose));
 
   const handleLogsGetVerbose = async () => {
     return isVerboseLogging();
   };
-  ipcMain.handle(CHANNELS.LOGS_GET_VERBOSE, handleLogsGetVerbose);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_GET_VERBOSE));
+  handlers.push(typedHandle(CHANNELS.LOGS_GET_VERBOSE, handleLogsGetVerbose));
 
-  const handleLogsWrite = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { level: LogLevel; message: string; context?: Record<string, unknown> }
-  ) => {
+  const handleLogsWrite = async (payload: {
+    level: LogLevel;
+    message: string;
+    context?: Record<string, unknown>;
+  }) => {
     const { level, message, context } = payload;
     const contextWithSource = { ...context, source: "Renderer" };
     switch (level) {
@@ -113,8 +106,7 @@ export function registerLogsHandlers(): () => void {
         break;
     }
   };
-  ipcMain.handle(CHANNELS.LOGS_WRITE, handleLogsWrite);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.LOGS_WRITE));
+  handlers.push(typedHandle(CHANNELS.LOGS_WRITE, handleLogsWrite));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -1,46 +1,50 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { mcpServerService } from "../../services/McpServerService.js";
+import { typedHandle } from "../utils.js";
 
 export function registerMcpServerHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.MCP_SERVER_GET_STATUS, () => mcpServerService.getStatus());
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.MCP_SERVER_GET_STATUS));
+  handlers.push(typedHandle(CHANNELS.MCP_SERVER_GET_STATUS, () => mcpServerService.getStatus()));
 
-  ipcMain.handle(CHANNELS.MCP_SERVER_SET_ENABLED, async (_event, enabled: boolean) => {
-    if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean");
-    await mcpServerService.setEnabled(enabled);
-    return mcpServerService.getStatus();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.MCP_SERVER_SET_ENABLED));
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_SET_ENABLED, async (enabled: boolean) => {
+      if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean");
+      await mcpServerService.setEnabled(enabled);
+      return mcpServerService.getStatus();
+    })
+  );
 
-  ipcMain.handle(CHANNELS.MCP_SERVER_SET_PORT, async (_event, port: number | null) => {
-    if (
-      port !== null &&
-      (typeof port !== "number" || port < 1024 || port > 65535 || !Number.isInteger(port))
-    ) {
-      throw new Error("port must be null or an integer between 1024 and 65535");
-    }
-    await mcpServerService.setPort(port);
-    return mcpServerService.getStatus();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.MCP_SERVER_SET_PORT));
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_SET_PORT, async (port: number | null) => {
+      if (
+        port !== null &&
+        (typeof port !== "number" || port < 1024 || port > 65535 || !Number.isInteger(port))
+      ) {
+        throw new Error("port must be null or an integer between 1024 and 65535");
+      }
+      await mcpServerService.setPort(port);
+      return mcpServerService.getStatus();
+    })
+  );
 
-  ipcMain.handle(CHANNELS.MCP_SERVER_SET_API_KEY, async (_event, apiKey: string) => {
-    if (typeof apiKey !== "string") throw new Error("apiKey must be a string");
-    await mcpServerService.setApiKey(apiKey);
-    return mcpServerService.getStatus();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.MCP_SERVER_SET_API_KEY));
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_SET_API_KEY, async (apiKey: string) => {
+      if (typeof apiKey !== "string") throw new Error("apiKey must be a string");
+      await mcpServerService.setApiKey(apiKey);
+      return mcpServerService.getStatus();
+    })
+  );
 
-  ipcMain.handle(CHANNELS.MCP_SERVER_GENERATE_API_KEY, async () => {
-    return await mcpServerService.generateApiKey();
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.MCP_SERVER_GENERATE_API_KEY));
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_GENERATE_API_KEY, async () => {
+      return await mcpServerService.generateApiKey();
+    })
+  );
 
-  ipcMain.handle(CHANNELS.MCP_SERVER_GET_CONFIG_SNIPPET, () => mcpServerService.getConfigSnippet());
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.MCP_SERVER_GET_CONFIG_SNIPPET));
+  handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_GET_CONFIG_SNIPPET, () => mcpServerService.getConfigSnippet())
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/menu.ts
+++ b/electron/ipc/handlers/menu.ts
@@ -1,8 +1,8 @@
-import { Menu, ipcMain } from "electron";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { Menu } from "electron";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import type { MenuItemOption, ShowContextMenuPayload } from "../../../shared/types/menu.js";
+import { typedHandleWithContext } from "../utils.js";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -89,14 +89,11 @@ function sanitizeShowContextMenuPayload(value: unknown): ShowContextMenuPayload 
 }
 
 export function registerMenuHandlers(_deps: HandlerDependencies): () => void {
-  const handleShowContext = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: ShowContextMenuPayload
-  ): Promise<string | null> => {
+  return typedHandleWithContext(CHANNELS.MENU_SHOW_CONTEXT, async (ctx, payload) => {
     const sanitized = sanitizeShowContextMenuPayload(payload);
     if (!sanitized || sanitized.template.length === 0) return null;
 
-    const win = getWindowForWebContents(event.sender);
+    const win = ctx.senderWindow;
     if (!win || win.isDestroyed()) return null;
 
     return new Promise((resolve) => {
@@ -139,8 +136,5 @@ export function registerMenuHandlers(_deps: HandlerDependencies): () => void {
         callback: () => resolveOnce(null),
       });
     });
-  };
-
-  ipcMain.handle(CHANNELS.MENU_SHOW_CONTEXT, handleShowContext);
-  return () => ipcMain.removeHandler(CHANNELS.MENU_SHOW_CONTEXT);
+  });
 }

--- a/electron/ipc/handlers/milestones.ts
+++ b/electron/ipc/handlers/milestones.ts
@@ -1,21 +1,23 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
+import { typedHandle } from "../utils.js";
 
 export function registerMilestonesHandlers(): () => void {
   const cleanups: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.MILESTONES_GET, () => {
-    return store.get("orchestrationMilestones") ?? {};
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.MILESTONES_GET));
+  cleanups.push(
+    typedHandle(CHANNELS.MILESTONES_GET, () => {
+      return store.get("orchestrationMilestones") ?? {};
+    })
+  );
 
-  ipcMain.handle(CHANNELS.MILESTONES_MARK_SHOWN, (_event, milestoneId: unknown) => {
-    if (typeof milestoneId !== "string") return;
-    const current = store.get("orchestrationMilestones") ?? {};
-    store.set("orchestrationMilestones", { ...current, [milestoneId]: true });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.MILESTONES_MARK_SHOWN));
+  cleanups.push(
+    typedHandle(CHANNELS.MILESTONES_MARK_SHOWN, (milestoneId: unknown) => {
+      if (typeof milestoneId !== "string") return;
+      const current = store.get("orchestrationMilestones") ?? {};
+      store.set("orchestrationMilestones", { ...current, [milestoneId]: true });
+    })
+  );
 
   return () => cleanups.forEach((c) => c());
 }

--- a/electron/ipc/handlers/notes.ts
+++ b/electron/ipc/handlers/notes.ts
@@ -1,6 +1,6 @@
-import { app, ipcMain } from "electron";
+import { app } from "electron";
 import { CHANNELS } from "../channels.js";
-import { broadcastToRenderer } from "../utils.js";
+import { broadcastToRenderer, typedHandle } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import { NotesService, NoteConflictError, type NoteMetadata } from "../../services/NotesService.js";
 import { projectStore } from "../../services/ProjectStore.js";
@@ -73,7 +73,6 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
   };
 
   const handleNotesCreate = async (
-    _event: Electron.IpcMainInvokeEvent,
     title: string,
     scope: "worktree" | "project",
     worktreeId?: string
@@ -83,18 +82,15 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
     broadcastUpdate({ notePath: result.path, title, action: "created" });
     return result;
   };
-  ipcMain.handle(CHANNELS.NOTES_CREATE, handleNotesCreate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.NOTES_CREATE));
+  handlers.push(typedHandle(CHANNELS.NOTES_CREATE, handleNotesCreate));
 
-  const handleNotesRead = async (_event: Electron.IpcMainInvokeEvent, notePath: string) => {
+  const handleNotesRead = async (notePath: string) => {
     const service = getNotesService();
     return await service.read(notePath);
   };
-  ipcMain.handle(CHANNELS.NOTES_READ, handleNotesRead);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.NOTES_READ));
+  handlers.push(typedHandle(CHANNELS.NOTES_READ, handleNotesRead));
 
   const handleNotesWrite = async (
-    _event: Electron.IpcMainInvokeEvent,
     notePath: string,
     content: string,
     metadata: unknown,
@@ -114,7 +110,7 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
     } catch (error) {
       if (error instanceof NoteConflictError) {
         return {
-          error: "conflict",
+          error: "conflict" as const,
           message: error.message,
           currentLastModified: error.currentLastModified,
         };
@@ -122,30 +118,26 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.NOTES_WRITE, handleNotesWrite);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.NOTES_WRITE));
+  handlers.push(typedHandle(CHANNELS.NOTES_WRITE, handleNotesWrite));
 
-  const handleNotesList = async (_event: Electron.IpcMainInvokeEvent) => {
+  const handleNotesList = async () => {
     const service = getNotesService();
     return await service.list();
   };
-  ipcMain.handle(CHANNELS.NOTES_LIST, handleNotesList);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.NOTES_LIST));
+  handlers.push(typedHandle(CHANNELS.NOTES_LIST, handleNotesList));
 
-  const handleNotesDelete = async (_event: Electron.IpcMainInvokeEvent, notePath: string) => {
+  const handleNotesDelete = async (notePath: string) => {
     const service = getNotesService();
     await service.delete(notePath);
     broadcastUpdate({ notePath, title: "", action: "deleted" });
   };
-  ipcMain.handle(CHANNELS.NOTES_DELETE, handleNotesDelete);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.NOTES_DELETE));
+  handlers.push(typedHandle(CHANNELS.NOTES_DELETE, handleNotesDelete));
 
-  const handleNotesSearch = async (_event: Electron.IpcMainInvokeEvent, query: string) => {
+  const handleNotesSearch = async (query: string) => {
     const service = getNotesService();
     return await service.search(query);
   };
-  ipcMain.handle(CHANNELS.NOTES_SEARCH, handleNotesSearch);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.NOTES_SEARCH));
+  handlers.push(typedHandle(CHANNELS.NOTES_SEARCH, handleNotesSearch));
 
   return () => {
     handlers.forEach((dispose) => dispose());

--- a/electron/ipc/handlers/notifications.ts
+++ b/electron/ipc/handlers/notifications.ts
@@ -15,10 +15,13 @@ import {
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
 import type { NotificationSettings } from "../../../shared/types/ipc/api.js";
+import { typedHandle } from "../utils.js";
 
 type SoundId = keyof typeof SOUND_FILES;
 
 export function registerNotificationHandlers(_deps: HandlerDependencies): () => void {
+  const cleanups: Array<() => void> = [];
+
   const handleNotificationUpdate = (
     _event: Electron.IpcMainEvent,
     state: NotificationState
@@ -30,10 +33,7 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
     return store.get("notificationSettings");
   };
 
-  const handleSettingsSet = async (
-    _event: Electron.IpcMainInvokeEvent,
-    rawSettings: unknown
-  ): Promise<void> => {
+  const handleSettingsSet = async (rawSettings: unknown): Promise<void> => {
     if (!rawSettings || typeof rawSettings !== "object") return;
 
     const allowed: Partial<NotificationSettings> = {};
@@ -84,10 +84,7 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
     store.set("notificationSettings", { ...current, ...allowed });
   };
 
-  const handlePlaySound = async (
-    _event: Electron.IpcMainInvokeEvent,
-    soundFile: unknown
-  ): Promise<void> => {
+  const handlePlaySound = async (soundFile: unknown): Promise<void> => {
     if (typeof soundFile !== "string" || !ALLOWED_SOUND_FILES.has(soundFile)) return;
     soundService.previewFile(soundFile);
   };
@@ -98,10 +95,7 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
     agentNotificationService.syncWatchedPanels(ids);
   };
 
-  const handlePlayUiEvent = async (
-    _event: Electron.IpcMainInvokeEvent,
-    soundId: unknown
-  ): Promise<void> => {
+  const handlePlayUiEvent = async (soundId: unknown): Promise<void> => {
     if (typeof soundId !== "string") return;
     if (!(soundId in SOUND_FILES)) return;
     if (!store.get("notificationSettings").uiFeedbackSoundEnabled) return;
@@ -153,24 +147,22 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
     return getSoundsDir();
   };
 
+  // Fire-and-forget listeners (ipcMain.on) — no typedHandle equivalent.
   ipcMain.on(CHANNELS.NOTIFICATION_UPDATE, handleNotificationUpdate);
-  ipcMain.handle(CHANNELS.NOTIFICATION_SETTINGS_GET, handleSettingsGet);
-  ipcMain.handle(CHANNELS.NOTIFICATION_SETTINGS_SET, handleSettingsSet);
-  ipcMain.handle(CHANNELS.NOTIFICATION_PLAY_SOUND, handlePlaySound);
-  ipcMain.handle(CHANNELS.SOUND_GET_DIR, handleGetSoundDir);
   ipcMain.on(CHANNELS.NOTIFICATION_SHOW_NATIVE, handleShowNative);
   ipcMain.on(CHANNELS.NOTIFICATION_SHOW_WATCH, handleShowWatch);
   ipcMain.on(CHANNELS.NOTIFICATION_SYNC_WATCHED, handleSyncWatched);
   ipcMain.on(CHANNELS.NOTIFICATION_WAITING_ACKNOWLEDGE, handleWaitingAcknowledge);
   ipcMain.on(CHANNELS.NOTIFICATION_WORKING_PULSE_ACKNOWLEDGE, handleWorkingPulseAcknowledge);
-  ipcMain.handle(CHANNELS.SOUND_PLAY_UI_EVENT, handlePlayUiEvent);
+
+  cleanups.push(typedHandle(CHANNELS.NOTIFICATION_SETTINGS_GET, handleSettingsGet));
+  cleanups.push(typedHandle(CHANNELS.NOTIFICATION_SETTINGS_SET, handleSettingsSet));
+  cleanups.push(typedHandle(CHANNELS.NOTIFICATION_PLAY_SOUND, handlePlaySound));
+  cleanups.push(typedHandle(CHANNELS.SOUND_GET_DIR, handleGetSoundDir));
+  cleanups.push(typedHandle(CHANNELS.SOUND_PLAY_UI_EVENT, handlePlayUiEvent));
 
   return () => {
     ipcMain.removeListener(CHANNELS.NOTIFICATION_UPDATE, handleNotificationUpdate);
-    ipcMain.removeHandler(CHANNELS.NOTIFICATION_SETTINGS_GET);
-    ipcMain.removeHandler(CHANNELS.NOTIFICATION_SETTINGS_SET);
-    ipcMain.removeHandler(CHANNELS.NOTIFICATION_PLAY_SOUND);
-    ipcMain.removeHandler(CHANNELS.SOUND_GET_DIR);
     ipcMain.removeListener(CHANNELS.NOTIFICATION_SHOW_NATIVE, handleShowNative);
     ipcMain.removeListener(CHANNELS.NOTIFICATION_SHOW_WATCH, handleShowWatch);
     ipcMain.removeListener(CHANNELS.NOTIFICATION_SYNC_WATCHED, handleSyncWatched);
@@ -179,6 +171,6 @@ export function registerNotificationHandlers(_deps: HandlerDependencies): () => 
       CHANNELS.NOTIFICATION_WORKING_PULSE_ACKNOWLEDGE,
       handleWorkingPulseAcknowledge
     );
-    ipcMain.removeHandler(CHANNELS.SOUND_PLAY_UI_EVENT);
+    cleanups.forEach((c) => c());
   };
 }

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -1,7 +1,7 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { StoreSchema } from "../../store.js";
+import { typedHandle } from "../utils.js";
 
 type OnboardingState = StoreSchema["onboarding"];
 type ChecklistState = OnboardingState["checklist"];
@@ -100,185 +100,195 @@ function getChecklistState(): ChecklistState {
 export function registerOnboardingHandlers(): () => void {
   const cleanups: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.ONBOARDING_GET, () => getOnboardingState());
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_GET));
+  cleanups.push(typedHandle(CHANNELS.ONBOARDING_GET, () => getOnboardingState()));
 
-  ipcMain.handle(CHANNELS.ONBOARDING_MIGRATE, (_event, payload: unknown) => {
-    // TODO(0.9.0): Remove this temporary Canopy -> Daintree onboarding
-    // localStorage migration after the 0.8.x upgrade window closes.
-    const state = getOnboardingState();
-    if (state.migratedFromLocalStorage) return state;
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_MIGRATE, (payload: unknown) => {
+      // TODO(0.9.0): Remove this temporary Canopy -> Daintree onboarding
+      // localStorage migration after the 0.8.x upgrade window closes.
+      const state = getOnboardingState();
+      if (state.migratedFromLocalStorage) return state;
 
-    const p = (payload ?? {}) as Partial<MigratePayload>;
-    const telemetrySeen = store.get("privacy")?.hasSeenPrompt ?? false;
-    const agentSelectionDismissed = p.agentSelectionDismissed === true;
-    const agentSetupComplete = p.agentSetupComplete === true;
-    const firstRunToastSeen = p.firstRunToastSeen === true;
+      const p = (payload ?? {}) as Partial<MigratePayload>;
+      const telemetrySeen = store.get("privacy")?.hasSeenPrompt ?? false;
+      const agentSelectionDismissed = p.agentSelectionDismissed === true;
+      const agentSetupComplete = p.agentSetupComplete === true;
+      const firstRunToastSeen = p.firstRunToastSeen === true;
 
-    const allPreviouslyComplete = telemetrySeen && agentSelectionDismissed && agentSetupComplete;
+      const allPreviouslyComplete = telemetrySeen && agentSelectionDismissed && agentSetupComplete;
 
-    const updated: OnboardingState = {
-      ...state,
-      completed: allPreviouslyComplete,
-      currentStep: allPreviouslyComplete ? null : state.currentStep,
-      firstRunToastSeen: firstRunToastSeen || state.firstRunToastSeen,
-      // If the legacy Canopy onboarding was fully completed, the #5131 setup
-      // banner should also be considered dismissed — these users have already
-      // made their agent/telemetry decisions.
-      setupBannerDismissed: allPreviouslyComplete || state.setupBannerDismissed,
-      migratedFromLocalStorage: true,
-      checklist: allPreviouslyComplete
-        ? {
-            dismissed: true,
-            celebrationShown: true,
-            items: {
-              openedProject: true,
-              launchedAgent: true,
-              createdWorktree: true,
-              subscribedNewsletter: true,
-            },
-          }
-        : state.checklist,
-    };
-    store.set("onboarding", updated);
-    return updated;
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MIGRATE));
+      const updated: OnboardingState = {
+        ...state,
+        completed: allPreviouslyComplete,
+        currentStep: allPreviouslyComplete ? null : state.currentStep,
+        firstRunToastSeen: firstRunToastSeen || state.firstRunToastSeen,
+        // If the legacy Canopy onboarding was fully completed, the #5131 setup
+        // banner should also be considered dismissed — these users have already
+        // made their agent/telemetry decisions.
+        setupBannerDismissed: allPreviouslyComplete || state.setupBannerDismissed,
+        migratedFromLocalStorage: true,
+        checklist: allPreviouslyComplete
+          ? {
+              dismissed: true,
+              celebrationShown: true,
+              items: {
+                openedProject: true,
+                launchedAgent: true,
+                createdWorktree: true,
+                subscribedNewsletter: true,
+              },
+            }
+          : state.checklist,
+      };
+      store.set("onboarding", updated);
+      return updated;
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_SET_STEP, (_event, arg: unknown) => {
-    const state = getOnboardingState();
-    if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
-      const payload = arg as { step?: unknown; agentSetupIds?: unknown };
-      const step = typeof payload.step === "string" ? payload.step : null;
-      const agentSetupIds = Array.isArray(payload.agentSetupIds)
-        ? (payload.agentSetupIds as string[]).filter((id) => typeof id === "string")
-        : state.agentSetupIds;
-      store.set("onboarding", { ...state, currentStep: step, agentSetupIds });
-    } else {
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_SET_STEP, (arg: unknown) => {
+      const state = getOnboardingState();
+      if (arg !== null && typeof arg === "object" && !Array.isArray(arg)) {
+        const payload = arg as { step?: unknown; agentSetupIds?: unknown };
+        const step = typeof payload.step === "string" ? payload.step : null;
+        const agentSetupIds = Array.isArray(payload.agentSetupIds)
+          ? (payload.agentSetupIds as string[]).filter((id) => typeof id === "string")
+          : state.agentSetupIds;
+        store.set("onboarding", { ...state, currentStep: step, agentSetupIds });
+      } else {
+        store.set("onboarding", {
+          ...state,
+          currentStep: typeof arg === "string" ? arg : null,
+        });
+      }
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_COMPLETE, () => {
+      const state = getOnboardingState();
       store.set("onboarding", {
         ...state,
-        currentStep: typeof arg === "string" ? arg : null,
+        completed: true,
+        currentStep: null,
+        agentSetupIds: [],
       });
-    }
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_SET_STEP));
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_COMPLETE, () => {
-    const state = getOnboardingState();
-    store.set("onboarding", {
-      ...state,
-      completed: true,
-      currentStep: null,
-      agentSetupIds: [],
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_COMPLETE));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_MARK_TOAST_SEEN, () => {
+      const state = getOnboardingState();
+      store.set("onboarding", {
+        ...state,
+        firstRunToastSeen: true,
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_MARK_TOAST_SEEN, () => {
-    const state = getOnboardingState();
-    store.set("onboarding", {
-      ...state,
-      firstRunToastSeen: true,
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MARK_TOAST_SEEN));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_MARK_NEWSLETTER_SEEN, () => {
+      const state = getOnboardingState();
+      store.set("onboarding", {
+        ...state,
+        newsletterPromptSeen: true,
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_MARK_NEWSLETTER_SEEN, () => {
-    const state = getOnboardingState();
-    store.set("onboarding", {
-      ...state,
-      newsletterPromptSeen: true,
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MARK_NEWSLETTER_SEEN));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN, () => {
+      const state = getOnboardingState();
+      store.set("onboarding", {
+        ...state,
+        waitingNudgeSeen: true,
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN, () => {
-    const state = getOnboardingState();
-    store.set("onboarding", {
-      ...state,
-      waitingNudgeSeen: true,
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN));
-
-  ipcMain.handle(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, (_event, payload: unknown) => {
-    const incoming = Array.isArray(payload)
-      ? (payload as unknown[]).filter((id): id is string => typeof id === "string")
-      : [];
-    const state = getOnboardingState();
-    if (incoming.length === 0) return state;
-    const existing = new Set(state.seenAgentIds);
-    let changed = false;
-    for (const id of incoming) {
-      if (!existing.has(id)) {
-        existing.add(id);
-        changed = true;
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, (payload: unknown) => {
+      const incoming = Array.isArray(payload)
+        ? (payload as unknown[]).filter((id): id is string => typeof id === "string")
+        : [];
+      const state = getOnboardingState();
+      if (incoming.length === 0) return state;
+      const existing = new Set(state.seenAgentIds);
+      let changed = false;
+      for (const id of incoming) {
+        if (!existing.has(id)) {
+          existing.add(id);
+          changed = true;
+        }
       }
-    }
-    if (!changed) return state;
-    const updated: OnboardingState = { ...state, seenAgentIds: Array.from(existing) };
-    store.set("onboarding", updated);
-    return updated;
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN));
+      if (!changed) return state;
+      const updated: OnboardingState = { ...state, seenAgentIds: Array.from(existing) };
+      store.set("onboarding", updated);
+      return updated;
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD, () => {
-    const state = getOnboardingState();
-    const updated: OnboardingState = { ...state, welcomeCardDismissed: true };
-    store.set("onboarding", updated);
-    return updated;
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD, () => {
+      const state = getOnboardingState();
+      const updated: OnboardingState = { ...state, welcomeCardDismissed: true };
+      store.set("onboarding", updated);
+      return updated;
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER, () => {
-    const state = getOnboardingState();
-    const updated: OnboardingState = { ...state, setupBannerDismissed: true };
-    store.set("onboarding", updated);
-    return updated;
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER, () => {
+      const state = getOnboardingState();
+      const updated: OnboardingState = { ...state, setupBannerDismissed: true };
+      store.set("onboarding", updated);
+      return updated;
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_CHECKLIST_GET, () => getChecklistState());
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_CHECKLIST_GET));
+  cleanups.push(typedHandle(CHANNELS.ONBOARDING_CHECKLIST_GET, () => getChecklistState()));
 
-  ipcMain.handle(CHANNELS.ONBOARDING_CHECKLIST_DISMISS, () => {
-    const state = getOnboardingState();
-    store.set("onboarding", {
-      ...state,
-      checklist: { ...state.checklist, dismissed: true },
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_CHECKLIST_DISMISS));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_CHECKLIST_DISMISS, () => {
+      const state = getOnboardingState();
+      store.set("onboarding", {
+        ...state,
+        checklist: { ...state.checklist, dismissed: true },
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN, () => {
-    const state = getOnboardingState();
-    store.set("onboarding", {
-      ...state,
-      checklist: { ...state.checklist, celebrationShown: true },
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN, () => {
+      const state = getOnboardingState();
+      store.set("onboarding", {
+        ...state,
+        checklist: { ...state.checklist, celebrationShown: true },
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.ONBOARDING_CHECKLIST_MARK_ITEM, (_event, item: unknown) => {
-    const validItems = [
-      "openedProject",
-      "launchedAgent",
-      "createdWorktree",
-      "subscribedNewsletter",
-    ];
-    if (typeof item !== "string" || !validItems.includes(item)) return;
-    const state = getOnboardingState();
-    const key = item as keyof typeof state.checklist.items;
-    if (state.checklist.items[key]) return;
-    store.set("onboarding", {
-      ...state,
-      checklist: {
-        ...state.checklist,
-        items: { ...state.checklist.items, [key]: true },
-      },
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.ONBOARDING_CHECKLIST_MARK_ITEM));
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_CHECKLIST_MARK_ITEM, (item: unknown) => {
+      const validItems = [
+        "openedProject",
+        "launchedAgent",
+        "createdWorktree",
+        "subscribedNewsletter",
+      ];
+      if (typeof item !== "string" || !validItems.includes(item)) return;
+      const state = getOnboardingState();
+      const key = item as keyof typeof state.checklist.items;
+      if (state.checklist.items[key]) return;
+      store.set("onboarding", {
+        ...state,
+        checklist: {
+          ...state.checklist,
+          items: { ...state.checklist.items, [key]: true },
+        },
+      });
+    })
+  );
 
   return () => cleanups.forEach((c) => c());
 }

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -9,6 +9,7 @@ import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
 import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type { LoadedPluginInfo, PluginIpcHandler } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
+import { typedHandle } from "../utils.js";
 
 let hasValidatedActionIds = false;
 
@@ -30,10 +31,7 @@ export function registerPluginHandlers(): () => void {
     return getPluginMenuItems();
   };
 
-  const handleValidateActionIds = async (
-    _event: Electron.IpcMainInvokeEvent,
-    actionIds: unknown
-  ): Promise<void> => {
+  const handleValidateActionIds = async (actionIds: string[]): Promise<void> => {
     if (hasValidatedActionIds) return;
     if (!Array.isArray(actionIds)) return;
     hasValidatedActionIds = true;
@@ -59,9 +57,12 @@ export function registerPluginHandlers(): () => void {
     }
   };
 
-  ipcMain.handle(CHANNELS.PLUGIN_LIST, handleList);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_LIST));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_LIST, handleList));
 
+  // plugin:invoke intentionally stays on raw ipcMain.handle: its variadic
+  // `...args: unknown[]` signature and senderFrame.url trust check can't be
+  // expressed through IpcInvokeMap without widening types to `unknown[]`,
+  // which would silently defeat the compile-time safety the migration is for.
   ipcMain.handle(
     CHANNELS.PLUGIN_INVOKE,
     async (event, pluginId: string, channel: string, ...args: unknown[]) => {
@@ -74,14 +75,9 @@ export function registerPluginHandlers(): () => void {
   );
   handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));
 
-  ipcMain.handle(CHANNELS.PLUGIN_TOOLBAR_BUTTONS, handleToolbarButtons);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_TOOLBAR_BUTTONS));
-
-  ipcMain.handle(CHANNELS.PLUGIN_MENU_ITEMS, handleMenuItems);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_MENU_ITEMS));
-
-  ipcMain.handle(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, handleValidateActionIds);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_TOOLBAR_BUTTONS, handleToolbarButtons));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_MENU_ITEMS, handleMenuItems));
+  handlers.push(typedHandle(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, handleValidateActionIds));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/portal.ts
+++ b/electron/ipc/handlers/portal.ts
@@ -1,5 +1,5 @@
-import { Menu, ipcMain } from "electron";
-import { getWindowForWebContents, getAppWebContents } from "../../window/webContentsRegistry.js";
+import { Menu } from "electron";
+import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
@@ -11,6 +11,7 @@ import type {
   PortalShowNewTabMenuPayload,
   PortalNewTabMenuAction,
 } from "../../../shared/types/portal.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 export function registerPortalHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -39,10 +40,7 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
     }
   };
 
-  const handlePortalCreate = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: PortalCreatePayload
-  ) => {
+  const handlePortalCreate = async (payload: PortalCreatePayload) => {
     try {
       if (!deps.portalManager) return;
       if (!payload?.tabId || typeof payload.tabId !== "string") {
@@ -57,13 +55,9 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.PORTAL_CREATE, handlePortalCreate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_CREATE));
+  handlers.push(typedHandle(CHANNELS.PORTAL_CREATE, handlePortalCreate));
 
-  const handlePortalShow = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: PortalShowPayload
-  ) => {
+  const handlePortalShow = async (payload: PortalShowPayload) => {
     try {
       if (!deps.portalManager) return;
       if (!payload?.tabId || typeof payload.tabId !== "string") {
@@ -78,17 +72,15 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.PORTAL_SHOW, handlePortalShow);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_SHOW));
+  handlers.push(typedHandle(CHANNELS.PORTAL_SHOW, handlePortalShow));
 
   const handlePortalHide = async () => {
     if (!deps.portalManager) return;
     deps.portalManager.hideAll();
   };
-  ipcMain.handle(CHANNELS.PORTAL_HIDE, handlePortalHide);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_HIDE));
+  handlers.push(typedHandle(CHANNELS.PORTAL_HIDE, handlePortalHide));
 
-  const handlePortalResize = async (_event: Electron.IpcMainInvokeEvent, bounds: PortalBounds) => {
+  const handlePortalResize = async (bounds: PortalBounds) => {
     try {
       if (!deps.portalManager) return;
       if (!isValidBounds(bounds)) {
@@ -100,26 +92,18 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.PORTAL_RESIZE, handlePortalResize);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_RESIZE));
+  handlers.push(typedHandle(CHANNELS.PORTAL_RESIZE, handlePortalResize));
 
-  const handlePortalCloseTab = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: PortalCloseTabPayload
-  ) => {
+  const handlePortalCloseTab = async (payload: PortalCloseTabPayload) => {
     if (!deps.portalManager) return;
     if (!payload || typeof payload !== "object" || typeof payload.tabId !== "string") {
       return;
     }
     await deps.portalManager.closeTab(payload.tabId);
   };
-  ipcMain.handle(CHANNELS.PORTAL_CLOSE_TAB, handlePortalCloseTab);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_CLOSE_TAB));
+  handlers.push(typedHandle(CHANNELS.PORTAL_CLOSE_TAB, handlePortalCloseTab));
 
-  const handlePortalNavigate = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: PortalNavigatePayload
-  ) => {
+  const handlePortalNavigate = async (payload: PortalNavigatePayload) => {
     if (!deps.portalManager) return;
     if (
       !payload ||
@@ -131,118 +115,108 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
     }
     deps.portalManager.navigate(payload.tabId, payload.url);
   };
-  ipcMain.handle(CHANNELS.PORTAL_NAVIGATE, handlePortalNavigate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_NAVIGATE));
+  handlers.push(typedHandle(CHANNELS.PORTAL_NAVIGATE, handlePortalNavigate));
 
-  const handlePortalGoBack = async (
-    _event: Electron.IpcMainInvokeEvent,
-    tabId: string
-  ): Promise<boolean> => {
+  const handlePortalGoBack = async (tabId: string): Promise<boolean> => {
     if (!deps.portalManager) return false;
     if (typeof tabId !== "string") return false;
     return deps.portalManager.goBack(tabId);
   };
-  ipcMain.handle(CHANNELS.PORTAL_GO_BACK, handlePortalGoBack);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_GO_BACK));
+  handlers.push(typedHandle(CHANNELS.PORTAL_GO_BACK, handlePortalGoBack));
 
-  const handlePortalGoForward = async (
-    _event: Electron.IpcMainInvokeEvent,
-    tabId: string
-  ): Promise<boolean> => {
+  const handlePortalGoForward = async (tabId: string): Promise<boolean> => {
     if (!deps.portalManager) return false;
     if (typeof tabId !== "string") return false;
     return deps.portalManager.goForward(tabId);
   };
-  ipcMain.handle(CHANNELS.PORTAL_GO_FORWARD, handlePortalGoForward);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_GO_FORWARD));
+  handlers.push(typedHandle(CHANNELS.PORTAL_GO_FORWARD, handlePortalGoForward));
 
-  const handlePortalReload = async (_event: Electron.IpcMainInvokeEvent, tabId: string) => {
+  const handlePortalReload = async (tabId: string) => {
     if (!deps.portalManager) return;
     if (typeof tabId !== "string") return;
     deps.portalManager.reload(tabId);
   };
-  ipcMain.handle(CHANNELS.PORTAL_RELOAD, handlePortalReload);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_RELOAD));
+  handlers.push(typedHandle(CHANNELS.PORTAL_RELOAD, handlePortalReload));
 
-  const handleShowNewTabMenu = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: PortalShowNewTabMenuPayload
-  ): Promise<void> => {
-    if (!payload || typeof payload !== "object") return;
-    if (!Array.isArray(payload.links)) return;
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.PORTAL_SHOW_NEW_TAB_MENU,
+      async (ctx, payload: PortalShowNewTabMenuPayload): Promise<void> => {
+        if (!payload || typeof payload !== "object") return;
+        if (!Array.isArray(payload.links)) return;
 
-    const x = Number.isFinite(payload.x) ? Math.round(payload.x) : 0;
-    const y = Number.isFinite(payload.y) ? Math.round(payload.y) : 0;
-    const defaultNewTabUrl =
-      payload.defaultNewTabUrl === null ||
-      (typeof payload.defaultNewTabUrl === "string" && payload.defaultNewTabUrl.trim())
-        ? payload.defaultNewTabUrl
-        : null;
+        const x = Number.isFinite(payload.x) ? Math.round(payload.x) : 0;
+        const y = Number.isFinite(payload.y) ? Math.round(payload.y) : 0;
+        const defaultNewTabUrl =
+          payload.defaultNewTabUrl === null ||
+          (typeof payload.defaultNewTabUrl === "string" && payload.defaultNewTabUrl.trim())
+            ? payload.defaultNewTabUrl
+            : null;
 
-    const links = payload.links
-      .filter(
-        (l): l is { title: string; url: string } =>
-          !!l &&
-          typeof l === "object" &&
-          typeof (l as { title?: unknown }).title === "string" &&
-          typeof (l as { url?: unknown }).url === "string" &&
-          (l as { title: string }).title.trim() !== "" &&
-          (l as { url: string }).url.trim() !== ""
-      )
-      .map((l) => ({ title: l.title.trim(), url: l.url.trim() }));
+        const links = payload.links
+          .filter(
+            (l): l is { title: string; url: string } =>
+              !!l &&
+              typeof l === "object" &&
+              typeof (l as { title?: unknown }).title === "string" &&
+              typeof (l as { url?: unknown }).url === "string" &&
+              (l as { title: string }).title.trim() !== "" &&
+              (l as { url: string }).url.trim() !== ""
+          )
+          .map((l) => ({ title: l.title.trim(), url: l.url.trim() }));
 
-    const win = getWindowForWebContents(event.sender);
-    if (!win || win.isDestroyed()) return;
+        const win = ctx.senderWindow;
+        if (!win || win.isDestroyed()) return;
 
-    const sendAction = (action: PortalNewTabMenuAction) => {
-      if (event.sender.isDestroyed()) return;
-      event.sender.send(CHANNELS.PORTAL_NEW_TAB_MENU_ACTION, action);
-    };
+        const sendAction = (action: PortalNewTabMenuAction) => {
+          if (ctx.event.sender.isDestroyed()) return;
+          ctx.event.sender.send(CHANNELS.PORTAL_NEW_TAB_MENU_ACTION, action);
+        };
 
-    const menu = Menu.buildFromTemplate([
-      ...links.map((link) => ({
-        label: link.title,
-        click: () => sendAction({ type: "open-url", url: link.url, title: link.title }),
-      })),
-      ...(links.length > 0 ? [{ type: "separator" as const }] : []),
-      {
-        label: "Launchpad (Pick provider...)",
-        click: () => sendAction({ type: "open-launchpad" }),
-      },
-      { type: "separator" as const },
-      {
-        label: "Default New Tab",
-        submenu: [
-          {
-            label: "Launchpad",
-            type: "radio" as const,
-            checked: defaultNewTabUrl === null,
-            click: () => sendAction({ type: "set-default-new-tab-url", url: null }),
-          },
-          ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+        const menu = Menu.buildFromTemplate([
           ...links.map((link) => ({
             label: link.title,
-            type: "radio" as const,
-            checked: defaultNewTabUrl === link.url,
-            click: () => sendAction({ type: "set-default-new-tab-url", url: link.url }),
+            click: () => sendAction({ type: "open-url", url: link.url, title: link.title }),
           })),
           ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+          {
+            label: "Launchpad (Pick provider...)",
+            click: () => sendAction({ type: "open-launchpad" }),
+          },
+          { type: "separator" as const },
+          {
+            label: "Default New Tab",
+            submenu: [
+              {
+                label: "Launchpad",
+                type: "radio" as const,
+                checked: defaultNewTabUrl === null,
+                click: () => sendAction({ type: "set-default-new-tab-url", url: null }),
+              },
+              ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+              ...links.map((link) => ({
+                label: link.title,
+                type: "radio" as const,
+                checked: defaultNewTabUrl === link.url,
+                click: () => sendAction({ type: "set-default-new-tab-url", url: link.url }),
+              })),
+              ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+              {
+                label: "Manage Portal Settings...",
+                click: () => sendMenuAction(win, "open-settings:portal"),
+              },
+            ],
+          },
           {
             label: "Manage Portal Settings...",
             click: () => sendMenuAction(win, "open-settings:portal"),
           },
-        ],
-      },
-      {
-        label: "Manage Portal Settings...",
-        click: () => sendMenuAction(win, "open-settings:portal"),
-      },
-    ]);
+        ]);
 
-    menu.popup({ window: win, x, y });
-  };
-  ipcMain.handle(CHANNELS.PORTAL_SHOW_NEW_TAB_MENU, handleShowNewTabMenu);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PORTAL_SHOW_NEW_TAB_MENU));
+        menu.popup({ window: win, x, y });
+      }
+    )
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/privacy.ts
+++ b/electron/ipc/handlers/privacy.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app, shell, session } from "electron";
+import { app, shell, session } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import {
@@ -8,68 +8,74 @@ import {
   setTelemetryLevel,
   type TelemetryLevel,
 } from "../../services/TelemetryService.js";
-import { typedBroadcast } from "../utils.js";
-
+import { typedBroadcast, typedHandle } from "../utils.js";
 const VALID_LEVELS: TelemetryLevel[] = ["off", "errors", "full"];
 const VALID_RETENTION = [7, 30, 90, 0] as const;
 
 export function registerPrivacyHandlers(): () => void {
   const cleanups: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.PRIVACY_GET_SETTINGS, () => ({
-    telemetryLevel: getTelemetryLevel(),
-    logRetentionDays: store.get("privacy")?.logRetentionDays ?? 30,
-    dataFolderPath: app.getPath("userData"),
-  }));
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_GET_SETTINGS));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_GET_SETTINGS, () => ({
+      telemetryLevel: getTelemetryLevel(),
+      logRetentionDays: store.get("privacy")?.logRetentionDays ?? 30,
+      dataFolderPath: app.getPath("userData"),
+    }))
+  );
 
-  ipcMain.handle(CHANNELS.PRIVACY_SET_TELEMETRY_LEVEL, async (_event, level: unknown) => {
-    if (typeof level !== "string" || !VALID_LEVELS.includes(level as TelemetryLevel)) return;
-    await setTelemetryLevel(level as TelemetryLevel);
-    typedBroadcast("privacy:telemetry-consent-changed", {
-      level: level as TelemetryLevel,
-      hasSeenPrompt: hasTelemetryPromptBeenShown(),
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_SET_TELEMETRY_LEVEL));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_SET_TELEMETRY_LEVEL, async (level: unknown) => {
+      if (typeof level !== "string" || !VALID_LEVELS.includes(level as TelemetryLevel)) return;
+      await setTelemetryLevel(level as TelemetryLevel);
+      typedBroadcast("privacy:telemetry-consent-changed", {
+        level: level as TelemetryLevel,
+        hasSeenPrompt: hasTelemetryPromptBeenShown(),
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.PRIVACY_SET_LOG_RETENTION, (_event, days: unknown) => {
-    if (
-      typeof days !== "number" ||
-      !VALID_RETENTION.includes(days as (typeof VALID_RETENTION)[number])
-    )
-      return;
-    const privacy = store.get("privacy") ?? {
-      telemetryLevel: "off" as const,
-      hasSeenPrompt: false,
-      logRetentionDays: 30 as const,
-    };
-    store.set("privacy", { ...privacy, logRetentionDays: days as 7 | 30 | 90 | 0 });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_SET_LOG_RETENTION));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_SET_LOG_RETENTION, (days: unknown) => {
+      if (
+        typeof days !== "number" ||
+        !VALID_RETENTION.includes(days as (typeof VALID_RETENTION)[number])
+      )
+        return;
+      const privacy = store.get("privacy") ?? {
+        telemetryLevel: "off" as const,
+        hasSeenPrompt: false,
+        logRetentionDays: 30 as const,
+      };
+      store.set("privacy", { ...privacy, logRetentionDays: days as 7 | 30 | 90 | 0 });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.PRIVACY_OPEN_DATA_FOLDER, () => {
-    shell.showItemInFolder(app.getPath("userData"));
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_OPEN_DATA_FOLDER));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_OPEN_DATA_FOLDER, () => {
+      shell.showItemInFolder(app.getPath("userData"));
+    })
+  );
 
-  ipcMain.handle(CHANNELS.PRIVACY_CLEAR_CACHE, async () => {
-    await session.defaultSession.clearCache();
-    await session.defaultSession.clearCodeCaches({});
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_CLEAR_CACHE));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_CLEAR_CACHE, async () => {
+      await session.defaultSession.clearCache();
+      await session.defaultSession.clearCodeCaches({});
+    })
+  );
 
-  ipcMain.handle(CHANNELS.PRIVACY_RESET_ALL_DATA, async () => {
-    app.relaunch({ args: process.argv.slice(1).concat(["--reset-data"]) });
-    await closeTelemetry();
-    app.exit(0);
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_RESET_ALL_DATA));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_RESET_ALL_DATA, async () => {
+      app.relaunch({ args: process.argv.slice(1).concat(["--reset-data"]) });
+      await closeTelemetry();
+      app.exit(0);
+    })
+  );
 
-  ipcMain.handle(CHANNELS.PRIVACY_GET_DATA_FOLDER_PATH, () => {
-    return app.getPath("userData");
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PRIVACY_GET_DATA_FOLDER_PATH));
+  cleanups.push(
+    typedHandle(CHANNELS.PRIVACY_GET_DATA_FOLDER_PATH, () => {
+      return app.getPath("userData");
+    })
+  );
 
   return () => cleanups.forEach((c) => c());
 }

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -1,9 +1,9 @@
-import { ipcMain, dialog } from "electron";
+import { dialog } from "electron";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { projectStore } from "../../../services/ProjectStore.js";
-import { broadcastToRenderer } from "../../utils.js";
+import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 
@@ -13,29 +13,26 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
   const handleProjectGetAll = async () => {
     return projectStore.getAllProjects();
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_ALL, handleProjectGetAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_ALL));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_ALL, handleProjectGetAll));
 
-  const handleProjectGetCurrent = async (event: Electron.IpcMainInvokeEvent) => {
-    // Multi-view: resolve the project from the sender's view
-    const senderWinForPvm = getWindowForWebContents(event.sender);
+  const handleProjectGetCurrent = async (ctx: import("../../types.js").IpcContext) => {
+    const senderWinForPvm = getWindowForWebContents(ctx.event.sender);
     const pvmCtx = senderWinForPvm
       ? deps.windowRegistry?.getByWindowId(senderWinForPvm.id)
       : undefined;
     const pvm = pvmCtx?.services?.projectViewManager ?? deps.projectViewManager;
     if (pvm) {
-      const viewProjectId = pvm.getProjectIdForWebContents(event.sender.id);
+      const viewProjectId = pvm.getProjectIdForWebContents(ctx.event.sender.id);
       if (viewProjectId) {
         const project = projectStore.getProjectById(viewProjectId);
         if (project) return project;
       }
     }
 
-    // Fallback: global current project
     const currentProject = projectStore.getCurrentProject();
 
     if (currentProject && deps.worktreeService) {
-      const senderWindow = getWindowForWebContents(event.sender);
+      const senderWindow = getWindowForWebContents(ctx.event.sender);
       const windowId = senderWindow?.id ?? deps.mainWindow?.id;
       try {
         if (windowId !== undefined) {
@@ -48,10 +45,9 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
 
     return currentProject;
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_CURRENT, handleProjectGetCurrent);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_CURRENT));
+  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_GET_CURRENT, handleProjectGetCurrent));
 
-  const handleProjectAdd = async (_event: Electron.IpcMainInvokeEvent, projectPath: string) => {
+  const handleProjectAdd = async (projectPath: string) => {
     if (typeof projectPath !== "string" || !projectPath) {
       throw new Error("Invalid project path");
     }
@@ -59,14 +55,12 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       throw new Error("Project path must be absolute");
     }
     const project = await projectStore.addProject(projectPath);
-    // Notify all renderers so the project list stays in sync across views.
     broadcastToRenderer(CHANNELS.PROJECT_UPDATED, project);
     return project;
   };
-  ipcMain.handle(CHANNELS.PROJECT_ADD, handleProjectAdd);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_ADD));
+  handlers.push(typedHandle(CHANNELS.PROJECT_ADD, handleProjectAdd));
 
-  const handleProjectRemove = async (_event: Electron.IpcMainInvokeEvent, projectId: string) => {
+  const handleProjectRemove = async (projectId: string) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -78,24 +72,17 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
 
     await projectStore.removeProject(projectId);
-    // Notify all renderers so the project list stays in sync across views.
     broadcastToRenderer(CHANNELS.PROJECT_REMOVED, projectId);
   };
-  ipcMain.handle(CHANNELS.PROJECT_REMOVE, handleProjectRemove);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_REMOVE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_REMOVE, handleProjectRemove));
 
-  const handleProjectUpdate = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string,
-    updates: Partial<Project>
-  ) => {
+  const handleProjectUpdate = async (projectId: string, updates: Partial<Project>) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
     if (typeof updates !== "object" || updates === null) {
       throw new Error("Invalid updates object");
     }
-    // Strip control-plane and internal scoring fields
     const {
       inRepoSettings: _inRepo,
       frecencyScore: _fs,
@@ -103,9 +90,6 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       ...safeUpdates
     } = updates;
     const updated = projectStore.updateProject(projectId, safeUpdates);
-    // Notify all renderers so other project views (e.g., a newly-created
-    // project view while the onboarding wizard is still running in the
-    // originating welcome view) refresh their cached project data.
     broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
     if (
       updated.inRepoSettings &&
@@ -126,11 +110,10 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
     return updated;
   };
-  ipcMain.handle(CHANNELS.PROJECT_UPDATE, handleProjectUpdate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_UPDATE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_UPDATE, handleProjectUpdate));
 
-  const handleProjectOpenDialog = async (event: Electron.IpcMainInvokeEvent) => {
-    const senderWindow = getWindowForWebContents(event.sender);
+  const handleProjectOpenDialog = async (ctx: import("../../types.js").IpcContext) => {
+    const senderWindow = getWindowForWebContents(ctx.event.sender);
     const dialogOpts = {
       properties: ["openDirectory" as const, "createDirectory" as const],
       title: "Open Git Repository",
@@ -145,14 +128,9 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
 
     return result.filePaths[0];
   };
-  ipcMain.handle(CHANNELS.PROJECT_OPEN_DIALOG, handleProjectOpenDialog);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_OPEN_DIALOG));
+  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_OPEN_DIALOG, handleProjectOpenDialog));
 
-  const handleProjectClose = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string,
-    options?: { killTerminals?: boolean }
-  ) => {
+  const handleProjectClose = async (projectId: string, options?: { killTerminals?: boolean }) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -224,19 +202,15 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       };
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_CLOSE, handleProjectClose);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_CLOSE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_CLOSE, handleProjectClose));
 
-  const handleProjectCheckMissing = async (
-    _event: Electron.IpcMainInvokeEvent
-  ): Promise<string[]> => {
+  const handleProjectCheckMissing = async (): Promise<string[]> => {
     return projectStore.checkMissingProjects();
   };
-  ipcMain.handle(CHANNELS.PROJECT_CHECK_MISSING, handleProjectCheckMissing);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_CHECK_MISSING));
+  handlers.push(typedHandle(CHANNELS.PROJECT_CHECK_MISSING, handleProjectCheckMissing));
 
   const handleProjectLocate = async (
-    _event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     projectId: string
   ): Promise<Project | null> => {
     if (typeof projectId !== "string" || !projectId) {
@@ -247,7 +221,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       throw new Error(`Project not found: ${projectId}`);
     }
 
-    const senderWindow = getWindowForWebContents(_event.sender);
+    const senderWindow = getWindowForWebContents(ctx.event.sender);
     const openOpts: Electron.OpenDialogOptions = {
       title: `Locate "${project.name}"`,
       properties: ["openDirectory"],
@@ -264,8 +238,7 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     const newPath = result.filePaths[0];
     return projectStore.relocateProject(projectId, newPath);
   };
-  ipcMain.handle(CHANNELS.PROJECT_LOCATE, handleProjectLocate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_LOCATE));
+  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_LOCATE, handleProjectLocate));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -1,8 +1,12 @@
-import { ipcMain } from "electron";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
-import { broadcastToRenderer, sendToRenderer } from "../../utils.js";
+import {
+  broadcastToRenderer,
+  sendToRenderer,
+  typedHandle,
+  typedHandleWithContext,
+} from "../../utils.js";
 import { createAuthenticatedGit } from "../../../utils/hardenedGit.js";
 import type {
   CloneRepoOptions,
@@ -16,14 +20,14 @@ export function registerGitCloneHandlers(): () => void {
   let cloneAbortController: AbortController | null = null;
 
   const handleProjectCloneRepo = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     options: CloneRepoOptions
   ): Promise<CloneRepoResult> => {
     if (!options || typeof options !== "object") {
       throw new Error("Invalid options object");
     }
 
-    const senderWindow = getWindowForWebContents(event.sender);
+    const senderWindow = getWindowForWebContents(ctx.event.sender);
 
     const { url, parentPath, folderName, shallowClone } = options;
 
@@ -142,16 +146,14 @@ export function registerGitCloneHandlers(): () => void {
       cloneAbortController = null;
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_CLONE_REPO, handleProjectCloneRepo);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_CLONE_REPO));
+  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_CLONE_REPO, handleProjectCloneRepo));
 
-  const handleProjectCloneCancel = async (_event: Electron.IpcMainInvokeEvent): Promise<void> => {
+  const handleProjectCloneCancel = async (): Promise<void> => {
     if (cloneAbortController) {
       cloneAbortController.abort();
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_CLONE_CANCEL, handleProjectCloneCancel);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_CLONE_CANCEL));
+  handlers.push(typedHandle(CHANNELS.PROJECT_CLONE_CANCEL, handleProjectCloneCancel));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -1,8 +1,12 @@
-import { ipcMain } from "electron";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
-import { broadcastToRenderer, sendToRenderer } from "../../utils.js";
+import {
+  broadcastToRenderer,
+  sendToRenderer,
+  typedHandle,
+  typedHandleWithContext,
+} from "../../utils.js";
 import { createHardenedGit } from "../../../utils/hardenedGit.js";
 import type {
   GitInitOptions,
@@ -13,10 +17,7 @@ import type {
 export function registerGitInitHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleProjectInitGit = async (
-    _event: Electron.IpcMainInvokeEvent,
-    directoryPath: string
-  ): Promise<void> => {
+  const handleProjectInitGit = async (directoryPath: string): Promise<void> => {
     if (typeof directoryPath !== "string" || !directoryPath) {
       throw new Error("Invalid directory path");
     }
@@ -33,18 +34,17 @@ export function registerGitInitHandlers(): () => void {
     const git = createHardenedGit(directoryPath);
     await git.init();
   };
-  ipcMain.handle(CHANNELS.PROJECT_INIT_GIT, handleProjectInitGit);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_INIT_GIT));
+  handlers.push(typedHandle(CHANNELS.PROJECT_INIT_GIT, handleProjectInitGit));
 
   const handleProjectInitGitGuided = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     options: GitInitOptions
   ): Promise<GitInitResult> => {
     if (!options || typeof options !== "object") {
       throw new Error("Invalid options object");
     }
 
-    const senderWindow = getWindowForWebContents(event.sender);
+    const senderWindow = getWindowForWebContents(ctx.event.sender);
 
     const {
       directoryPath,
@@ -166,8 +166,9 @@ export function registerGitInitHandlers(): () => void {
       };
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_INIT_GIT_GUIDED, handleProjectInitGitGuided);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_INIT_GIT_GUIDED));
+  handlers.push(
+    typedHandleWithContext(CHANNELS.PROJECT_INIT_GIT_GUIDED, handleProjectInitGitGuided)
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectCrud/settings.ts
+++ b/electron/ipc/handlers/projectCrud/settings.ts
@@ -3,32 +3,28 @@
  * and folder provisioning for new projects.
  */
 
-import { ipcMain } from "electron";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { runCommandDetector } from "../../../services/RunCommandDetector.js";
+import { typedHandle } from "../../utils.js";
 import type { ProjectSettings } from "../../../types/index.js";
 
 export function registerProjectSettingsHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleProjectGetSettings = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<ProjectSettings> => {
+  const handleProjectGetSettings = async (projectId: string): Promise<ProjectSettings> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
     return projectStore.getProjectSettings(projectId);
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_SETTINGS, handleProjectGetSettings);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_SETTINGS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_SETTINGS, handleProjectGetSettings));
 
-  const handleProjectSaveSettings = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; settings: ProjectSettings }
-  ): Promise<void> => {
+  const handleProjectSaveSettings = async (payload: {
+    projectId: string;
+    settings: ProjectSettings;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -50,13 +46,9 @@ export function registerProjectSettingsHandlers(): () => void {
       clearGitHubCaches();
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_SAVE_SETTINGS, handleProjectSaveSettings);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SAVE_SETTINGS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SAVE_SETTINGS, handleProjectSaveSettings));
 
-  const handleProjectDetectRunners = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ) => {
+  const handleProjectDetectRunners = async (projectId: string) => {
     if (typeof projectId !== "string" || !projectId) {
       console.warn("[IPC] Invalid project ID for detect runners:", projectId);
       return [];
@@ -70,13 +62,12 @@ export function registerProjectSettingsHandlers(): () => void {
 
     return await runCommandDetector.detect(project.path);
   };
-  ipcMain.handle(CHANNELS.PROJECT_DETECT_RUNNERS, handleProjectDetectRunners);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_DETECT_RUNNERS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_DETECT_RUNNERS, handleProjectDetectRunners));
 
-  const handleProjectCreateFolder = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { parentPath: string; folderName: string }
-  ): Promise<string> => {
+  const handleProjectCreateFolder = async (payload: {
+    parentPath: string;
+    folderName: string;
+  }): Promise<string> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -137,8 +128,7 @@ export function registerProjectSettingsHandlers(): () => void {
     }
     return fullPath;
   };
-  ipcMain.handle(CHANNELS.PROJECT_CREATE_FOLDER, handleProjectCreateFolder);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_CREATE_FOLDER));
+  handlers.push(typedHandle(CHANNELS.PROJECT_CREATE_FOLDER, handleProjectCreateFolder));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -1,6 +1,5 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { checkRateLimit } from "../../utils.js";
+import { checkRateLimit, typedHandle } from "../../utils.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { BulkProjectStats } from "../../../../shared/types/ipc/project.js";
 import { ProjectStatsService } from "../../../services/ProjectStatsService.js";
@@ -22,7 +21,7 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
     projectStatsServiceInstance = null;
   });
 
-  const handleProjectGetStats = async (_event: Electron.IpcMainInvokeEvent, projectId: string) => {
+  const handleProjectGetStats = async (projectId: string) => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -41,13 +40,9 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
       processIds: ptyStats.processIds,
     };
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_STATS, handleProjectGetStats);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_STATS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_STATS, handleProjectGetStats));
 
-  const handleProjectGetBulkStats = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectIds: string[]
-  ): Promise<BulkProjectStats> => {
+  const handleProjectGetBulkStats = async (projectIds: string[]): Promise<BulkProjectStats> => {
     checkRateLimit(CHANNELS.PROJECT_GET_BULK_STATS, 10, 10_000);
     if (!Array.isArray(projectIds)) {
       throw new Error("Invalid projectIds: must be an array");
@@ -103,8 +98,7 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
     }
     return result;
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_BULK_STATS, handleProjectGetBulkStats);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_BULK_STATS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_BULK_STATS, handleProjectGetBulkStats));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -1,5 +1,5 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
+import { typedHandleWithContext } from "../../utils.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { distributePortsToView } from "../../../window/portDistribution.js";
 import { projectStore } from "../../../services/ProjectStore.js";
@@ -21,7 +21,7 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   const projectSwitchService = deps.projectSwitchService ?? new ProjectSwitchService(deps);
 
   const handleProjectSwitch = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     projectId: string,
     outgoingState?: ProjectSwitchOutgoingState
   ) => {
@@ -34,27 +34,23 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       throw new Error(`Project not found: ${projectId}`);
     }
 
-    // Pre-apply the renderer's outgoing terminal state to the current project's
-    // persisted state BEFORE the switch runs.
     const previousProjectId = projectStore.getCurrentProjectId();
     await persistOutgoingProjectState(outgoingState, previousProjectId, "project:switch");
 
-    const pvm = resolveProjectViewManager(deps, event);
+    const pvm = resolveProjectViewManager(deps, ctx.event);
     if (pvm) {
-      await activateProjectView(deps, event, pvm, projectId, project, {
+      await activateProjectView(deps, ctx.event, pvm, projectId, project, {
         logPrefix: "[ProjectSwitch]",
       });
       return project;
     }
 
-    // Fallback: legacy single-view switch path
     return await projectSwitchService.switchProject(projectId);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SWITCH, handleProjectSwitch);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SWITCH));
+  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_SWITCH, handleProjectSwitch));
 
   const handleProjectReopen = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     projectId: string,
     outgoingState?: ProjectSwitchOutgoingState
   ) => {
@@ -75,15 +71,14 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       );
     }
 
-    // Pre-apply outgoing terminal state
     const previousProjectId = projectStore.getCurrentProjectId();
     if (previousProjectId !== projectId) {
       await persistOutgoingProjectState(outgoingState, previousProjectId, "project:reopen");
     }
 
-    const pvm = resolveProjectViewManager(deps, event);
+    const pvm = resolveProjectViewManager(deps, ctx.event);
     if (pvm) {
-      await activateProjectView(deps, event, pvm, projectId, project, {
+      await activateProjectView(deps, ctx.event, pvm, projectId, project, {
         logPrefix: "[ProjectReopen]",
         markActive: true,
         resumeWorkspace: true,
@@ -91,14 +86,12 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       return project;
     }
 
-    // Fallback: legacy single-view path
     if (deps.worktreeService) {
       deps.worktreeService.resumeProject(project.path);
     }
     return await projectSwitchService.reopenProject(projectId);
   };
-  ipcMain.handle(CHANNELS.PROJECT_REOPEN, handleProjectReopen);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_REOPEN));
+  handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectInRepoSettings.ts
+++ b/electron/ipc/handlers/projectInRepoSettings.ts
@@ -1,10 +1,10 @@
-import { ipcMain } from "electron";
 import path from "path";
 import fs from "fs/promises";
 import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../types.js";
 import type { Project } from "../../types/index.js";
+import { typedHandle } from "../utils.js";
 
 async function resolveClaudeMdPath(projectId: string): Promise<string> {
   if (typeof projectId !== "string" || !projectId) {
@@ -49,10 +49,7 @@ async function resolveClaudeMdPath(projectId: string): Promise<string> {
 export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleProjectReadClaudeMd = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<string | null> => {
+  const handleProjectReadClaudeMd = async (projectId: string): Promise<string | null> => {
     const claudeMdPath = await resolveClaudeMdPath(projectId);
     try {
       return await fs.readFile(claudeMdPath, "utf-8");
@@ -68,13 +65,12 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_READ_CLAUDE_MD, handleProjectReadClaudeMd);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_READ_CLAUDE_MD));
+  handlers.push(typedHandle(CHANNELS.PROJECT_READ_CLAUDE_MD, handleProjectReadClaudeMd));
 
-  const handleProjectWriteClaudeMd = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; content: string }
-  ): Promise<void> => {
+  const handleProjectWriteClaudeMd = async (payload: {
+    projectId: string;
+    content: string;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -88,13 +84,9 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
     const claudeMdPath = await resolveClaudeMdPath(projectId);
     await fs.writeFile(claudeMdPath, content, "utf-8");
   };
-  ipcMain.handle(CHANNELS.PROJECT_WRITE_CLAUDE_MD, handleProjectWriteClaudeMd);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_WRITE_CLAUDE_MD));
+  handlers.push(typedHandle(CHANNELS.PROJECT_WRITE_CLAUDE_MD, handleProjectWriteClaudeMd));
 
-  const handleProjectEnableInRepoSettings = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<Project> => {
+  const handleProjectEnableInRepoSettings = async (projectId: string): Promise<Project> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -121,13 +113,11 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
       daintreeConfigPresent: true,
     });
   };
-  ipcMain.handle(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS, handleProjectEnableInRepoSettings);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS));
+  handlers.push(
+    typedHandle(CHANNELS.PROJECT_ENABLE_IN_REPO_SETTINGS, handleProjectEnableInRepoSettings)
+  );
 
-  const handleProjectDisableInRepoSettings = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<Project> => {
+  const handleProjectDisableInRepoSettings = async (projectId: string): Promise<Project> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -137,8 +127,9 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
     }
     return projectStore.updateProject(projectId, { inRepoSettings: false });
   };
-  ipcMain.handle(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS, handleProjectDisableInRepoSettings);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS));
+  handlers.push(
+    typedHandle(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS, handleProjectDisableInRepoSettings)
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -1,31 +1,27 @@
-import { ipcMain, dialog } from "electron";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { dialog } from "electron";
 import fs from "fs/promises";
 import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { safeRecipeFilename } from "../../utils/recipeFilename.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalRecipe } from "../../types/index.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleProjectGetRecipes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<TerminalRecipe[]> => {
+  const handleProjectGetRecipes = async (projectId: string): Promise<TerminalRecipe[]> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
     return projectStore.getRecipes(projectId);
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_RECIPES, handleProjectGetRecipes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_RECIPES));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_RECIPES, handleProjectGetRecipes));
 
-  const handleProjectSaveRecipes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; recipes: TerminalRecipe[] }
-  ): Promise<void> => {
+  const handleProjectSaveRecipes = async (payload: {
+    projectId: string;
+    recipes: TerminalRecipe[];
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -38,13 +34,12 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     return projectStore.saveRecipes(projectId, recipes);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SAVE_RECIPES, handleProjectSaveRecipes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SAVE_RECIPES));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SAVE_RECIPES, handleProjectSaveRecipes));
 
-  const handleProjectAddRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; recipe: TerminalRecipe }
-  ): Promise<void> => {
+  const handleProjectAddRecipe = async (payload: {
+    projectId: string;
+    recipe: TerminalRecipe;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -66,17 +61,13 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     return projectStore.addRecipe(projectId, recipe);
   };
-  ipcMain.handle(CHANNELS.PROJECT_ADD_RECIPE, handleProjectAddRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_ADD_RECIPE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_ADD_RECIPE, handleProjectAddRecipe));
 
-  const handleProjectUpdateRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      projectId: string;
-      recipeId: string;
-      updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
-    }
-  ): Promise<void> => {
+  const handleProjectUpdateRecipe = async (payload: {
+    projectId: string;
+    recipeId: string;
+    updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -92,13 +83,12 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     return projectStore.updateRecipe(projectId, recipeId, updates);
   };
-  ipcMain.handle(CHANNELS.PROJECT_UPDATE_RECIPE, handleProjectUpdateRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_UPDATE_RECIPE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_UPDATE_RECIPE, handleProjectUpdateRecipe));
 
-  const handleProjectDeleteRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; recipeId: string }
-  ): Promise<void> => {
+  const handleProjectDeleteRecipe = async (payload: {
+    projectId: string;
+    recipeId: string;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -111,55 +101,49 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     return projectStore.deleteRecipe(projectId, recipeId);
   };
-  ipcMain.handle(CHANNELS.PROJECT_DELETE_RECIPE, handleProjectDeleteRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_DELETE_RECIPE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_DELETE_RECIPE, handleProjectDeleteRecipe));
 
-  const handleRecipeExportFile = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: { name: string; json: string }
-  ): Promise<boolean> => {
-    if (!payload || typeof payload.name !== "string" || typeof payload.json !== "string") {
-      throw new Error("Invalid payload");
-    }
-    const win = getWindowForWebContents(event.sender) ?? undefined;
-    const defaultFilename = safeRecipeFilename(payload.name);
-    const dialogOptions: Electron.SaveDialogOptions = {
-      title: "Export Recipe",
-      defaultPath: defaultFilename,
-      filters: [{ name: "Recipe Files", extensions: ["json"] }],
-    };
-    const { filePath, canceled } = win
-      ? await dialog.showSaveDialog(win, dialogOptions)
-      : await dialog.showSaveDialog(dialogOptions);
-    if (canceled || !filePath) return false;
-    await fs.writeFile(filePath, payload.json, "utf-8");
-    return true;
-  };
-  ipcMain.handle(CHANNELS.RECIPE_EXPORT_FILE, handleRecipeExportFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECIPE_EXPORT_FILE));
+  handlers.push(
+    typedHandleWithContext(
+      CHANNELS.RECIPE_EXPORT_FILE,
+      async (ctx, payload: { name: string; json: string }): Promise<boolean> => {
+        if (!payload || typeof payload.name !== "string" || typeof payload.json !== "string") {
+          throw new Error("Invalid payload");
+        }
+        const win = ctx.senderWindow ?? undefined;
+        const defaultFilename = safeRecipeFilename(payload.name);
+        const dialogOptions: Electron.SaveDialogOptions = {
+          title: "Export Recipe",
+          defaultPath: defaultFilename,
+          filters: [{ name: "Recipe Files", extensions: ["json"] }],
+        };
+        const { filePath, canceled } = win
+          ? await dialog.showSaveDialog(win, dialogOptions)
+          : await dialog.showSaveDialog(dialogOptions);
+        if (canceled || !filePath) return false;
+        await fs.writeFile(filePath, payload.json, "utf-8");
+        return true;
+      }
+    )
+  );
 
-  const handleRecipeImportFile = async (
-    event: Electron.IpcMainInvokeEvent
-  ): Promise<string | null> => {
-    const win = getWindowForWebContents(event.sender) ?? undefined;
-    const dialogOptions: Electron.OpenDialogOptions = {
-      title: "Import Recipe",
-      filters: [{ name: "Recipe Files", extensions: ["json"] }],
-      properties: ["openFile"],
-    };
-    const { filePaths, canceled } = win
-      ? await dialog.showOpenDialog(win, dialogOptions)
-      : await dialog.showOpenDialog(dialogOptions);
-    if (canceled || filePaths.length === 0) return null;
-    return fs.readFile(filePaths[0]!, "utf-8");
-  };
-  ipcMain.handle(CHANNELS.RECIPE_IMPORT_FILE, handleRecipeImportFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECIPE_IMPORT_FILE));
+  handlers.push(
+    typedHandleWithContext(CHANNELS.RECIPE_IMPORT_FILE, async (ctx): Promise<string | null> => {
+      const win = ctx.senderWindow ?? undefined;
+      const dialogOptions: Electron.OpenDialogOptions = {
+        title: "Import Recipe",
+        filters: [{ name: "Recipe Files", extensions: ["json"] }],
+        properties: ["openFile"],
+      };
+      const { filePaths, canceled } = win
+        ? await dialog.showOpenDialog(win, dialogOptions)
+        : await dialog.showOpenDialog(dialogOptions);
+      if (canceled || filePaths.length === 0) return null;
+      return fs.readFile(filePaths[0]!, "utf-8");
+    })
+  );
 
-  const handleProjectGetInRepoRecipes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<TerminalRecipe[]> => {
+  const handleProjectGetInRepoRecipes = async (projectId: string): Promise<TerminalRecipe[]> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
@@ -169,13 +153,12 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     return projectStore.readInRepoRecipes(project.path);
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_INREPO_RECIPES, handleProjectGetInRepoRecipes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_INREPO_RECIPES));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_INREPO_RECIPES, handleProjectGetInRepoRecipes));
 
-  const handleProjectSyncInRepoRecipes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; recipes: TerminalRecipe[] }
-  ): Promise<void> => {
+  const handleProjectSyncInRepoRecipes = async (payload: {
+    projectId: string;
+    recipes: TerminalRecipe[];
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -194,13 +177,13 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       await projectStore.writeInRepoRecipe(project.path, recipe);
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_SYNC_INREPO_RECIPES, handleProjectSyncInRepoRecipes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SYNC_INREPO_RECIPES));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SYNC_INREPO_RECIPES, handleProjectSyncInRepoRecipes));
 
-  const handleProjectUpdateInRepoRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; recipe: TerminalRecipe; previousName?: string }
-  ): Promise<void> => {
+  const handleProjectUpdateInRepoRecipe = async (payload: {
+    projectId: string;
+    recipe: TerminalRecipe;
+    previousName?: string;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -224,13 +207,14 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
       await projectStore.deleteInRepoRecipe(project.path, previousName);
     }
   };
-  ipcMain.handle(CHANNELS.PROJECT_UPDATE_INREPO_RECIPE, handleProjectUpdateInRepoRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_UPDATE_INREPO_RECIPE));
+  handlers.push(
+    typedHandle(CHANNELS.PROJECT_UPDATE_INREPO_RECIPE, handleProjectUpdateInRepoRecipe)
+  );
 
-  const handleProjectDeleteInRepoRecipe = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; recipeName: string }
-  ): Promise<void> => {
+  const handleProjectDeleteInRepoRecipe = async (payload: {
+    projectId: string;
+    recipeName: string;
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -247,8 +231,9 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     }
     await projectStore.deleteInRepoRecipe(project.path, recipeName);
   };
-  ipcMain.handle(CHANNELS.PROJECT_DELETE_INREPO_RECIPE, handleProjectDeleteInRepoRecipe);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_DELETE_INREPO_RECIPE));
+  handlers.push(
+    typedHandle(CHANNELS.PROJECT_DELETE_INREPO_RECIPE, handleProjectDeleteInRepoRecipe)
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/recovery.ts
+++ b/electron/ipc/handlers/recovery.ts
@@ -1,8 +1,8 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { getCrashRecoveryService } from "../../services/CrashRecoveryService.js";
 import { getDevServerUrl } from "../../../shared/config/devServer.js";
+import { typedHandle } from "../utils.js";
 
 function getAppUrl(): string {
   if (process.env.NODE_ENV === "development") {
@@ -14,24 +14,26 @@ function getAppUrl(): string {
 export function registerRecoveryHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.RECOVERY_RELOAD_APP, () => {
-    const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
-    if (win && !win.isDestroyed()) {
-      console.log("[MAIN] Recovery: reloading app");
-      win.loadURL(getAppUrl());
-    }
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_RELOAD_APP));
+  handlers.push(
+    typedHandle(CHANNELS.RECOVERY_RELOAD_APP, () => {
+      const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
+      if (win && !win.isDestroyed()) {
+        console.log("[MAIN] Recovery: reloading app");
+        win.loadURL(getAppUrl());
+      }
+    })
+  );
 
-  ipcMain.handle(CHANNELS.RECOVERY_RESET_AND_RELOAD, () => {
-    const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
-    if (win && !win.isDestroyed()) {
-      console.log("[MAIN] Recovery: resetting state and reloading app");
-      getCrashRecoveryService().resetToFresh();
-      win.loadURL(getAppUrl());
-    }
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_RESET_AND_RELOAD));
+  handlers.push(
+    typedHandle(CHANNELS.RECOVERY_RESET_AND_RELOAD, () => {
+      const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
+      if (win && !win.isDestroyed()) {
+        console.log("[MAIN] Recovery: resetting state and reloading app");
+        getCrashRecoveryService().resetToFresh();
+        win.loadURL(getAppUrl());
+      }
+    })
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/sentry.ts
+++ b/electron/ipc/handlers/sentry.ts
@@ -1,15 +1,16 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { getTelemetryLevel, hasTelemetryPromptBeenShown } from "../../services/TelemetryService.js";
+import { typedHandle } from "../utils.js";
 
 export function registerSentryHandlers(): () => void {
   const cleanups: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.SENTRY_GET_CONSENT_STATE, () => ({
-    level: getTelemetryLevel(),
-    hasSeenPrompt: hasTelemetryPromptBeenShown(),
-  }));
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.SENTRY_GET_CONSENT_STATE));
+  cleanups.push(
+    typedHandle(CHANNELS.SENTRY_GET_CONSENT_STATE, () => ({
+      level: getTelemetryLevel(),
+      hasSeenPrompt: hasTelemetryPromptBeenShown(),
+    }))
+  );
 
   return () => cleanups.forEach((c) => c());
 }

--- a/electron/ipc/handlers/shortcutHints.ts
+++ b/electron/ipc/handlers/shortcutHints.ts
@@ -1,22 +1,24 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
+import { typedHandle } from "../utils.js";
 
 export function registerShortcutHintsHandlers(): () => void {
   const cleanups: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.SHORTCUT_HINTS_GET_COUNTS, () => {
-    return store.get("shortcutHintCounts") ?? {};
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.SHORTCUT_HINTS_GET_COUNTS));
+  cleanups.push(
+    typedHandle(CHANNELS.SHORTCUT_HINTS_GET_COUNTS, () => {
+      return store.get("shortcutHintCounts") ?? {};
+    })
+  );
 
-  ipcMain.handle(CHANNELS.SHORTCUT_HINTS_INCREMENT_COUNT, (_event, actionId: unknown) => {
-    if (typeof actionId !== "string") return;
-    const counts = store.get("shortcutHintCounts") ?? {};
-    counts[actionId] = (counts[actionId] ?? 0) + 1;
-    store.set("shortcutHintCounts", counts);
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.SHORTCUT_HINTS_INCREMENT_COUNT));
+  cleanups.push(
+    typedHandle(CHANNELS.SHORTCUT_HINTS_INCREMENT_COUNT, (actionId: unknown) => {
+      if (typeof actionId !== "string") return;
+      const counts = store.get("shortcutHintCounts") ?? {};
+      counts[actionId] = (counts[actionId] ?? 0) + 1;
+      store.set("shortcutHintCounts", counts);
+    })
+  );
 
   return () => cleanups.forEach((c) => c());
 }

--- a/electron/ipc/handlers/slashCommands.ts
+++ b/electron/ipc/handlers/slashCommands.ts
@@ -1,17 +1,14 @@
-import { ipcMain } from "electron";
 import path from "path";
 import { CHANNELS } from "../channels.js";
 import { SlashCommandListRequestSchema } from "../../schemas/ipc.js";
 import { slashCommandService } from "../../services/SlashCommandService.js";
 import type { SlashCommand } from "../../../shared/types/index.js";
+import { typedHandle } from "../utils.js";
 
 export function registerSlashCommandHandlers(): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleList = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ): Promise<SlashCommand[]> => {
+  const handleList = async (payload: unknown): Promise<SlashCommand[]> => {
     const parsed = SlashCommandListRequestSchema.safeParse(payload);
     if (!parsed.success) {
       console.error("[IPC] Invalid slash-commands:list payload:", parsed.error.format());
@@ -23,8 +20,7 @@ export function registerSlashCommandHandlers(): () => void {
     return slashCommandService.list(agentId, safeProjectPath);
   };
 
-  ipcMain.handle(CHANNELS.SLASH_COMMANDS_LIST, handleList);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SLASH_COMMANDS_LIST));
+  handlers.push(typedHandle(CHANNELS.SLASH_COMMANDS_LIST, handleList));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -1,4 +1,4 @@
-import { ipcMain, shell } from "electron";
+import { shell } from "electron";
 import os from "os";
 import { CHANNELS } from "../channels.js";
 import { openExternalUrl } from "../../utils/openExternal.js";
@@ -9,14 +9,12 @@ import {
   SystemOpenInEditorPayloadSchema,
 } from "../../schemas/index.js";
 import type { HandlerDependencies } from "../types.js";
+import { typedHandle } from "../utils.js";
 
 export function registerSystemShellHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleSystemOpenExternal = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ) => {
+  const handleSystemOpenExternal = async (payload: unknown) => {
     const parseResult = SystemOpenExternalPayloadSchema.safeParse(payload);
     if (!parseResult.success) {
       console.error("[IPC] system:open-external validation failed:", parseResult.error.format());
@@ -33,10 +31,9 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.SYSTEM_OPEN_EXTERNAL, handleSystemOpenExternal);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_OPEN_EXTERNAL));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_OPEN_EXTERNAL, handleSystemOpenExternal));
 
-  const handleSystemOpenPath = async (_event: Electron.IpcMainInvokeEvent, payload: unknown) => {
+  const handleSystemOpenPath = async (payload: unknown) => {
     const parseResult = SystemOpenPathPayloadSchema.safeParse(payload);
     if (!parseResult.success) {
       console.error("[IPC] system:open-path validation failed:", parseResult.error.format());
@@ -61,13 +58,9 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
       throw error;
     }
   };
-  ipcMain.handle(CHANNELS.SYSTEM_OPEN_PATH, handleSystemOpenPath);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_OPEN_PATH));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_OPEN_PATH, handleSystemOpenPath));
 
-  const handleSystemOpenInEditor = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ) => {
+  const handleSystemOpenInEditor = async (payload: unknown) => {
     const parseResult = SystemOpenInEditorPayloadSchema.safeParse(payload);
     if (!parseResult.success) {
       throw new Error(`Invalid payload: ${parseResult.error.message}`);
@@ -88,13 +81,9 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
     const { openFile } = await import("../../services/EditorService.js");
     await openFile(targetPath, line, col, editorConfig);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_OPEN_IN_EDITOR, handleSystemOpenInEditor);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_OPEN_IN_EDITOR));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_OPEN_IN_EDITOR, handleSystemOpenInEditor));
 
-  const handleSystemCheckCommand = async (
-    _event: Electron.IpcMainInvokeEvent,
-    command: string
-  ): Promise<boolean> => {
+  const handleSystemCheckCommand = async (command: string): Promise<boolean> => {
     if (typeof command !== "string" || !command.trim()) {
       return false;
     }
@@ -113,13 +102,9 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
       return false;
     }
   };
-  ipcMain.handle(CHANNELS.SYSTEM_CHECK_COMMAND, handleSystemCheckCommand);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_CHECK_COMMAND));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_CHECK_COMMAND, handleSystemCheckCommand));
 
-  const handleSystemCheckDirectory = async (
-    _event: Electron.IpcMainInvokeEvent,
-    directoryPath: string
-  ): Promise<boolean> => {
+  const handleSystemCheckDirectory = async (directoryPath: string): Promise<boolean> => {
     if (typeof directoryPath !== "string" || !directoryPath.trim()) {
       return false;
     }
@@ -138,20 +123,17 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
       return false;
     }
   };
-  ipcMain.handle(CHANNELS.SYSTEM_CHECK_DIRECTORY, handleSystemCheckDirectory);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_CHECK_DIRECTORY));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_CHECK_DIRECTORY, handleSystemCheckDirectory));
 
   const handleSystemGetHomeDir = async () => {
     return os.homedir();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_HOME_DIR, handleSystemGetHomeDir);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_HOME_DIR));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_HOME_DIR, handleSystemGetHomeDir));
 
   const handleSystemGetTmpDir = async () => {
     return os.tmpdir();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_GET_TMP_DIR, handleSystemGetTmpDir);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_GET_TMP_DIR));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_TMP_DIR, handleSystemGetTmpDir));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/systemSleep.ts
+++ b/electron/ipc/handlers/systemSleep.ts
@@ -1,6 +1,5 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
-import { broadcastToRenderer } from "../utils.js";
+import { broadcastToRenderer, typedHandle } from "../utils.js";
 import {
   getSystemSleepService,
   type SystemSleepMetrics,
@@ -14,26 +13,20 @@ export function registerSystemSleepHandlers(_deps: HandlerDependencies): () => v
   const handleGetMetrics = async (): Promise<SystemSleepMetrics> => {
     return systemSleepService.getMetrics();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_SLEEP_GET_METRICS, handleGetMetrics);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_SLEEP_GET_METRICS));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_SLEEP_GET_METRICS, handleGetMetrics));
 
-  const handleGetAwakeTime = async (
-    _event: Electron.IpcMainInvokeEvent,
-    startTimestamp: number
-  ): Promise<number> => {
+  const handleGetAwakeTime = async (startTimestamp: number): Promise<number> => {
     if (typeof startTimestamp !== "number" || !Number.isFinite(startTimestamp)) {
       throw new Error("startTimestamp must be a finite number");
     }
     return systemSleepService.getAwakeTimeSince(startTimestamp);
   };
-  ipcMain.handle(CHANNELS.SYSTEM_SLEEP_GET_AWAKE_TIME, handleGetAwakeTime);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_SLEEP_GET_AWAKE_TIME));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_SLEEP_GET_AWAKE_TIME, handleGetAwakeTime));
 
   const handleReset = async (): Promise<void> => {
     systemSleepService.reset();
   };
-  ipcMain.handle(CHANNELS.SYSTEM_SLEEP_RESET, handleReset);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.SYSTEM_SLEEP_RESET));
+  handlers.push(typedHandle(CHANNELS.SYSTEM_SLEEP_RESET, handleReset));
 
   const unsubscribeSuspend = systemSleepService.onSuspend(() => {
     broadcastToRenderer(CHANNELS.SYSTEM_SLEEP_ON_SUSPEND);

--- a/electron/ipc/handlers/telemetry.ts
+++ b/electron/ipc/handlers/telemetry.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import {
   isTelemetryEnabled,
@@ -9,44 +8,48 @@ import {
   trackEvent,
 } from "../../services/TelemetryService.js";
 import { ANALYTICS_EVENTS } from "../../../shared/config/telemetry.js";
-import { typedBroadcast } from "../utils.js";
-
+import { typedBroadcast, typedHandle } from "../utils.js";
 const ALLOWED_EVENTS = new Set<string>(ANALYTICS_EVENTS);
 
 export function registerTelemetryHandlers(): () => void {
   const cleanups: Array<() => void> = [];
 
-  ipcMain.handle(CHANNELS.TELEMETRY_GET, () => ({
-    enabled: isTelemetryEnabled(),
-    hasSeenPrompt: hasTelemetryPromptBeenShown(),
-  }));
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.TELEMETRY_GET));
-
-  ipcMain.handle(CHANNELS.TELEMETRY_SET_ENABLED, async (_event, enabled: unknown) => {
-    if (typeof enabled !== "boolean") return;
-    await setTelemetryEnabled(enabled);
-    typedBroadcast("privacy:telemetry-consent-changed", {
-      level: getTelemetryLevel(),
+  cleanups.push(
+    typedHandle(CHANNELS.TELEMETRY_GET, () => ({
+      enabled: isTelemetryEnabled(),
       hasSeenPrompt: hasTelemetryPromptBeenShown(),
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.TELEMETRY_SET_ENABLED));
+    }))
+  );
 
-  ipcMain.handle(CHANNELS.TELEMETRY_MARK_PROMPT_SHOWN, () => {
-    markTelemetryPromptShown();
-    typedBroadcast("privacy:telemetry-consent-changed", {
-      level: getTelemetryLevel(),
-      hasSeenPrompt: true,
-    });
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.TELEMETRY_MARK_PROMPT_SHOWN));
+  cleanups.push(
+    typedHandle(CHANNELS.TELEMETRY_SET_ENABLED, async (enabled: unknown) => {
+      if (typeof enabled !== "boolean") return;
+      await setTelemetryEnabled(enabled);
+      typedBroadcast("privacy:telemetry-consent-changed", {
+        level: getTelemetryLevel(),
+        hasSeenPrompt: hasTelemetryPromptBeenShown(),
+      });
+    })
+  );
 
-  ipcMain.handle(CHANNELS.TELEMETRY_TRACK, (_event, eventName: unknown, properties: unknown) => {
-    if (typeof eventName !== "string" || !ALLOWED_EVENTS.has(eventName)) return;
-    if (typeof properties !== "object" || properties === null || Array.isArray(properties)) return;
-    trackEvent(eventName, properties as Record<string, unknown>);
-  });
-  cleanups.push(() => ipcMain.removeHandler(CHANNELS.TELEMETRY_TRACK));
+  cleanups.push(
+    typedHandle(CHANNELS.TELEMETRY_MARK_PROMPT_SHOWN, () => {
+      markTelemetryPromptShown();
+      typedBroadcast("privacy:telemetry-consent-changed", {
+        level: getTelemetryLevel(),
+        hasSeenPrompt: true,
+      });
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.TELEMETRY_TRACK, (eventName: unknown, properties: unknown) => {
+      if (typeof eventName !== "string" || !ALLOWED_EVENTS.has(eventName)) return;
+      if (typeof properties !== "object" || properties === null || Array.isArray(properties))
+        return;
+      trackEvent(eventName, properties as Record<string, unknown>);
+    })
+  );
 
   return () => cleanups.forEach((c) => c());
 }

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "events";
 
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+  ipcMain: ipcMainMock,
   app: {
     getPath: vi.fn(() => "/tmp/test"),
   },
@@ -32,6 +34,27 @@ vi.mock("../../../../services/pty/terminalShell.js", () => ({
 vi.mock("../../utils.js", () => ({
   waitForRateLimitSlot: vi.fn(async () => {}),
   consumeRestoreQuota: vi.fn(() => false),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../../shared/config/agentRegistry.js", () => ({

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
 vi.mock("electron", () => ({
-  ipcMain: {
-    handle: vi.fn(),
-    removeHandler: vi.fn(),
-  },
+  ipcMain: ipcMainMock,
   app: {
     getPath: vi.fn(() => "/tmp/test"),
   },
@@ -31,6 +33,27 @@ vi.mock("../../../services/pty/terminalShell.js", () => ({
 vi.mock("../../utils.js", () => ({
   waitForRateLimitSlot: vi.fn(),
   consumeRestoreQuota: vi.fn(() => false),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+  typedHandleWithContext: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      (event: { sender?: { id?: number } } | null | undefined, ...args: unknown[]) => {
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: null,
+          projectId: null,
+        };
+        return (handler as (...a: unknown[]) => unknown)(ctx, ...args);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../../shared/config/agentRegistry.js", () => ({

--- a/electron/ipc/handlers/terminal/artifacts.ts
+++ b/electron/ipc/handlers/terminal/artifacts.ts
@@ -2,19 +2,18 @@
  * Artifact handlers - save to file, apply patch.
  */
 
-import { ipcMain, dialog } from "electron";
-import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
+import { dialog } from "electron";
 import os from "os";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
+import { typedHandle, typedHandleWithContext } from "../../utils.js";
 
 export function registerArtifactHandlers(deps: HandlerDependencies): () => void {
   const mainWindow = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
   const handlers: Array<() => void> = [];
 
   const handleArtifactSaveToFile = async (
-    _event: Electron.IpcMainInvokeEvent,
     options: unknown
   ): Promise<{ filePath: string; success: boolean } | null> => {
     try {
@@ -79,11 +78,10 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
       throw new Error(`Failed to save artifact: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.ARTIFACT_SAVE_TO_FILE, handleArtifactSaveToFile);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.ARTIFACT_SAVE_TO_FILE));
+  handlers.push(typedHandle(CHANNELS.ARTIFACT_SAVE_TO_FILE, handleArtifactSaveToFile));
 
   const handleArtifactApplyPatch = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     options: unknown
   ): Promise<{ success: boolean; error?: string; modifiedFiles?: string[] }> => {
     try {
@@ -128,7 +126,7 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
         }
 
         if (deps.worktreeService) {
-          const senderWindowPatch = getWindowForWebContents(event.sender);
+          const senderWindowPatch = ctx.senderWindow;
           const states = await deps.worktreeService.getAllStatesAsync(senderWindowPatch?.id);
           const isValidWorktree = states.some(
             (wt: { path: string }) => path.resolve(wt.path) === resolvedCwd
@@ -182,8 +180,7 @@ export function registerArtifactHandlers(deps: HandlerDependencies): () => void 
       };
     }
   };
-  ipcMain.handle(CHANNELS.ARTIFACT_APPLY_PATCH, handleArtifactApplyPatch);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.ARTIFACT_APPLY_PATCH));
+  handlers.push(typedHandleWithContext(CHANNELS.ARTIFACT_APPLY_PATCH, handleArtifactApplyPatch));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -9,6 +9,7 @@ import type { TerminalResizePayload } from "../../../types/index.js";
 import { TerminalResizePayloadSchema } from "../../../schemas/ipc.js";
 import type { PtyHostActivityTier } from "../../../../shared/types/pty-host.js";
 import { normalizeObservedTitle } from "../../../../shared/utils/isUselessTitle.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerTerminalIOHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -45,11 +46,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
   ipcMain.on(CHANNELS.TERMINAL_SEND_KEY, handleTerminalSendKey);
   handlers.push(() => ipcMain.removeListener(CHANNELS.TERMINAL_SEND_KEY, handleTerminalSendKey));
 
-  const handleTerminalSubmit = async (
-    _event: Electron.IpcMainInvokeEvent,
-    id: string,
-    text: string
-  ) => {
+  const handleTerminalSubmit = async (id: string, text: string) => {
     try {
       if (typeof id !== "string" || typeof text !== "string") {
         throw new Error("Invalid terminal submit parameters");
@@ -60,8 +57,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       throw new Error(`Failed to submit to terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_SUBMIT, handleTerminalSubmit);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_SUBMIT));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_SUBMIT, handleTerminalSubmit));
 
   const handleTerminalResize = (_event: Electron.IpcMainEvent, payload: TerminalResizePayload) => {
     try {
@@ -170,7 +166,6 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
   );
 
   const handleTerminalForceResume = async (
-    _event: Electron.IpcMainInvokeEvent,
     id: string
   ): Promise<{ success: boolean; error?: string }> => {
     try {
@@ -185,8 +180,7 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
       return { success: false, error: errorMessage };
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_FORCE_RESUME, handleTerminalForceResume);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_FORCE_RESUME));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_FORCE_RESUME, handleTerminalForceResume));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -2,11 +2,10 @@
  * Terminal lifecycle handlers - spawn, kill, trash, restore.
  */
 
-import { ipcMain } from "electron";
 import crypto from "crypto";
 import os from "os";
 import { CHANNELS } from "../../channels.js";
-import { waitForRateLimitSlot, consumeRestoreQuota } from "../../utils.js";
+import { waitForRateLimitSlot, consumeRestoreQuota, typedHandle } from "../../utils.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { TerminalSpawnOptions } from "../../../types/index.js";
@@ -26,10 +25,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
   }
   const handlers: Array<() => void> = [];
 
-  const handleTerminalSpawn = async (
-    _event: Electron.IpcMainInvokeEvent,
-    options: TerminalSpawnOptions
-  ): Promise<string> => {
+  const handleTerminalSpawn = async (options: TerminalSpawnOptions): Promise<string> => {
     const parseResult = TerminalSpawnOptionsSchema.safeParse(options);
     if (!parseResult.success) {
       console.error("[IPC] Invalid terminal spawn options:", parseResult.error.format());
@@ -228,10 +224,9 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to spawn terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_SPAWN, handleTerminalSpawn);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_SPAWN));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_SPAWN, handleTerminalSpawn));
 
-  const handleTerminalKill = async (_event: Electron.IpcMainInvokeEvent, id: string) => {
+  const handleTerminalKill = async (id: string) => {
     try {
       if (typeof id !== "string") {
         throw new Error("Invalid terminal ID: must be a string");
@@ -242,22 +237,17 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to kill terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_KILL, handleTerminalKill);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_KILL));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_KILL, handleTerminalKill));
 
-  const handleTerminalGracefulKill = async (
-    _event: Electron.IpcMainInvokeEvent,
-    id: string
-  ): Promise<string | null> => {
+  const handleTerminalGracefulKill = async (id: string): Promise<string | null> => {
     if (typeof id !== "string") {
       throw new Error("Invalid terminal ID: must be a string");
     }
     return ptyClient.gracefulKill(id);
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GRACEFUL_KILL, handleTerminalGracefulKill);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GRACEFUL_KILL));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GRACEFUL_KILL, handleTerminalGracefulKill));
 
-  const handleTerminalTrash = async (_event: Electron.IpcMainInvokeEvent, id: string) => {
+  const handleTerminalTrash = async (id: string) => {
     try {
       if (typeof id !== "string") {
         throw new Error("Invalid terminal ID: must be a string");
@@ -268,13 +258,9 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to trash terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_TRASH, handleTerminalTrash);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_TRASH));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_TRASH, handleTerminalTrash));
 
-  const handleTerminalRestore = async (
-    _event: Electron.IpcMainInvokeEvent,
-    id: string
-  ): Promise<boolean> => {
+  const handleTerminalRestore = async (id: string): Promise<boolean> => {
     try {
       if (typeof id !== "string") {
         throw new Error("Invalid terminal ID: must be a string");
@@ -285,34 +271,24 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error(`Failed to restore terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_RESTORE, handleTerminalRestore);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_RESTORE));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_RESTORE, handleTerminalRestore));
 
   const handleTerminalRestartService = async () => {
     ptyClient.manualRestart();
   };
-  ipcMain.handle(CHANNELS.TERMINAL_RESTART_SERVICE, handleTerminalRestartService);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_RESTART_SERVICE));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_RESTART_SERVICE, handleTerminalRestartService));
 
-  const handleAgentSessionList = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { worktreeId?: string }
-  ) => {
+  const handleAgentSessionList = async (payload: { worktreeId?: string }) => {
     const { app } = await import("electron");
     return listAgentSessions(payload?.worktreeId, app.getPath("userData"));
   };
-  ipcMain.handle(CHANNELS.AGENT_SESSION_LIST, handleAgentSessionList);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_SESSION_LIST));
+  handlers.push(typedHandle(CHANNELS.AGENT_SESSION_LIST, handleAgentSessionList));
 
-  const handleAgentSessionClear = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { worktreeId?: string }
-  ) => {
+  const handleAgentSessionClear = async (payload: { worktreeId?: string }) => {
     const { app } = await import("electron");
     await clearAgentSessions(payload?.worktreeId, app.getPath("userData"));
   };
-  ipcMain.handle(CHANNELS.AGENT_SESSION_CLEAR, handleAgentSessionClear);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.AGENT_SESSION_CLEAR));
+  handlers.push(typedHandle(CHANNELS.AGENT_SESSION_CLEAR, handleAgentSessionClear));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -2,12 +2,12 @@
  * Terminal snapshot handlers - getSerializedState, wake, getInfo.
  */
 
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 import { TerminalReplayHistoryPayloadSchema } from "../../../schemas/index.js";
 import { logDebug, logInfo, logWarn, logError } from "../../../utils/logger.js";
 import { getAgentAvailabilityStore } from "../../../services/AgentAvailabilityStore.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -17,7 +17,6 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
   const handlers: Array<() => void> = [];
 
   const handleTerminalWake = async (
-    _event: Electron.IpcMainInvokeEvent,
     id: string
   ): Promise<{ state: string | null; warnings?: string[] }> => {
     try {
@@ -30,13 +29,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to wake terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_WAKE, handleTerminalWake);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_WAKE));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_WAKE, handleTerminalWake));
 
-  const handleTerminalGetSerializedState = async (
-    _event: Electron.IpcMainInvokeEvent,
-    terminalId: string
-  ): Promise<string | null> => {
+  const handleTerminalGetSerializedState = async (terminalId: string): Promise<string | null> => {
     try {
       if (typeof terminalId !== "string" || !terminalId) {
         throw new Error("Invalid terminal ID: must be a non-empty string");
@@ -55,11 +50,11 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get serialized terminal state: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_SERIALIZED_STATE, handleTerminalGetSerializedState);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_SERIALIZED_STATE));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_GET_SERIALIZED_STATE, handleTerminalGetSerializedState)
+  );
 
   const handleTerminalGetSerializedStates = async (
-    _event: Electron.IpcMainInvokeEvent,
     terminalIds: string[]
   ): Promise<Record<string, string | null>> => {
     if (!Array.isArray(terminalIds)) {
@@ -95,11 +90,11 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
 
     return Object.fromEntries(results);
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_SERIALIZED_STATES, handleTerminalGetSerializedStates);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_SERIALIZED_STATES));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_GET_SERIALIZED_STATES, handleTerminalGetSerializedStates)
+  );
 
   const handleTerminalGetInfo = async (
-    _event: Electron.IpcMainInvokeEvent,
     id: string
   ): Promise<import("../../../../shared/types/ipc.js").TerminalInfoPayload> => {
     try {
@@ -119,8 +114,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get terminal info: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_INFO, handleTerminalGetInfo);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_INFO));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_INFO, handleTerminalGetInfo));
 
   const handleTerminalGetSharedBuffers = async (): Promise<{
     visualBuffers: SharedArrayBuffer[];
@@ -133,8 +127,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       return { visualBuffers: [], signalBuffer: null };
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_SHARED_BUFFERS, handleTerminalGetSharedBuffers);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_SHARED_BUFFERS));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_SHARED_BUFFERS, handleTerminalGetSharedBuffers));
 
   const handleTerminalGetAnalysisBuffer = async (): Promise<SharedArrayBuffer | null> => {
     try {
@@ -144,13 +137,11 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       return null;
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER, handleTerminalGetAnalysisBuffer);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_GET_ANALYSIS_BUFFER, handleTerminalGetAnalysisBuffer)
+  );
 
-  const handleTerminalReplayHistory = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ) => {
+  const handleTerminalReplayHistory = async (payload: unknown) => {
     const parseResult = TerminalReplayHistoryPayloadSchema.safeParse(payload);
     if (!parseResult.success) {
       logError("terminal:replayHistory validation failed", undefined, {
@@ -171,13 +162,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to replay terminal history: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_REPLAY_HISTORY, handleTerminalReplayHistory);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_REPLAY_HISTORY));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_REPLAY_HISTORY, handleTerminalReplayHistory));
 
-  const handleTerminalGetForProject = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ) => {
+  const handleTerminalGetForProject = async (projectId: string) => {
     try {
       if (typeof projectId !== "string" || !projectId) {
         throw new Error("Invalid project ID: must be a non-empty string");
@@ -235,8 +222,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get terminals for project: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_FOR_PROJECT, handleTerminalGetForProject);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_FOR_PROJECT));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_FOR_PROJECT, handleTerminalGetForProject));
 
   const handleTerminalGetAvailable = async () => {
     try {
@@ -272,10 +258,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get available terminals: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_AVAILABLE, handleTerminalGetAvailable);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_AVAILABLE));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_AVAILABLE, handleTerminalGetAvailable));
 
-  const handleTerminalGetByState = async (_event: Electron.IpcMainInvokeEvent, state: string) => {
+  const handleTerminalGetByState = async (state: string) => {
     try {
       if (typeof state !== "string" || !state) {
         throw new Error("Invalid state: must be a non-empty string");
@@ -320,8 +305,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get terminals by state: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_BY_STATE, handleTerminalGetByState);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_BY_STATE));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_BY_STATE, handleTerminalGetByState));
 
   const handleTerminalGetAll = async () => {
     try {
@@ -357,13 +341,9 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to get all terminals: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_GET_ALL, handleTerminalGetAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_GET_ALL));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_GET_ALL, handleTerminalGetAll));
 
-  const handleTerminalReconnect = async (
-    _event: Electron.IpcMainInvokeEvent,
-    terminalId: string
-  ) => {
+  const handleTerminalReconnect = async (terminalId: string) => {
     try {
       if (typeof terminalId !== "string" || !terminalId) {
         throw new Error("Invalid terminal ID: must be a non-empty string");
@@ -408,8 +388,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
       throw new Error(`Failed to reconnect to terminal: ${errorMessage}`);
     }
   };
-  ipcMain.handle(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_RECONNECT));
+  handlers.push(typedHandle(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminalConfig.ts
+++ b/electron/ipc/handlers/terminalConfig.ts
@@ -1,10 +1,10 @@
-import { ipcMain, dialog, BrowserWindow } from "electron";
-import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { dialog, BrowserWindow } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { parseColorSchemeFile } from "../../utils/colorSchemeImporter.js";
 import { effectiveCachedProjectViews } from "../../utils/cachedProjectViews.js";
 import type { HandlerDependencies } from "../types.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 function getTerminalConfigObject(): Record<string, unknown> {
   const config = store.get("terminalConfig");
@@ -17,20 +17,17 @@ function getTerminalConfigObject(): Record<string, unknown> {
 export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleTerminalConfigGet = async () => {
-    const config = getTerminalConfigObject();
-    return {
-      ...config,
-      cachedProjectViews: effectiveCachedProjectViews(config.cachedProjectViews),
-    };
-  };
-  ipcMain.handle(CHANNELS.TERMINAL_CONFIG_GET, handleTerminalConfigGet);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_GET));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_CONFIG_GET, async () => {
+      const config = getTerminalConfigObject();
+      return {
+        ...config,
+        cachedProjectViews: effectiveCachedProjectViews(config.cachedProjectViews),
+      } as import("../../../shared/types/ipc/config.js").TerminalConfig;
+    })
+  );
 
-  const handleTerminalConfigSetScrollback = async (
-    _event: Electron.IpcMainInvokeEvent,
-    scrollbackLines: number
-  ) => {
+  const handleTerminalConfigSetScrollback = async (scrollbackLines: number) => {
     if (!Number.isFinite(scrollbackLines) || !Number.isInteger(scrollbackLines)) {
       const error = `Invalid scrollback value (not a finite integer): ${scrollbackLines}`;
       console.warn(error);
@@ -44,13 +41,11 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, scrollbackLines });
   };
-  ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK, handleTerminalConfigSetScrollback);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_CONFIG_SET_SCROLLBACK, handleTerminalConfigSetScrollback)
+  );
 
-  const handleTerminalConfigSetPerformanceMode = async (
-    _event: Electron.IpcMainInvokeEvent,
-    performanceMode: boolean
-  ) => {
+  const handleTerminalConfigSetPerformanceMode = async (performanceMode: boolean) => {
     if (typeof performanceMode !== "boolean") {
       console.warn("Invalid terminal performanceMode:", performanceMode);
       return;
@@ -58,16 +53,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, performanceMode });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE,
-    handleTerminalConfigSetPerformanceMode
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE,
+      handleTerminalConfigSetPerformanceMode
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_PERFORMANCE_MODE));
 
-  const handleTerminalConfigSetFontSize = async (
-    _event: Electron.IpcMainInvokeEvent,
-    fontSize: number
-  ) => {
+  const handleTerminalConfigSetFontSize = async (fontSize: number) => {
     if (!Number.isFinite(fontSize) || !Number.isInteger(fontSize)) {
       console.warn("Invalid terminal fontSize (not a finite integer):", fontSize);
       return;
@@ -79,13 +72,11 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, fontSize });
   };
-  ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_FONT_SIZE, handleTerminalConfigSetFontSize);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_FONT_SIZE));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_CONFIG_SET_FONT_SIZE, handleTerminalConfigSetFontSize)
+  );
 
-  const handleTerminalConfigSetFontFamily = async (
-    _event: Electron.IpcMainInvokeEvent,
-    fontFamily: string
-  ) => {
+  const handleTerminalConfigSetFontFamily = async (fontFamily: string) => {
     if (typeof fontFamily !== "string" || !fontFamily.trim()) {
       console.warn("Invalid terminal fontFamily:", fontFamily);
       return;
@@ -94,13 +85,11 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, fontFamily: trimmedFontFamily });
   };
-  ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_FONT_FAMILY, handleTerminalConfigSetFontFamily);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_FONT_FAMILY));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_CONFIG_SET_FONT_FAMILY, handleTerminalConfigSetFontFamily)
+  );
 
-  const handleTerminalConfigSetHybridInputEnabled = async (
-    _event: Electron.IpcMainInvokeEvent,
-    enabled: boolean
-  ) => {
+  const handleTerminalConfigSetHybridInputEnabled = async (enabled: boolean) => {
     if (typeof enabled !== "boolean") {
       console.warn("Invalid terminal hybridInputEnabled:", enabled);
       return;
@@ -108,16 +97,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, hybridInputEnabled: enabled });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_HYBRID_INPUT_ENABLED,
-    handleTerminalConfigSetHybridInputEnabled
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_HYBRID_INPUT_ENABLED,
+      handleTerminalConfigSetHybridInputEnabled
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_HYBRID_INPUT_ENABLED));
 
-  const handleTerminalConfigSetHybridInputAutoFocus = async (
-    _event: Electron.IpcMainInvokeEvent,
-    enabled: boolean
-  ) => {
+  const handleTerminalConfigSetHybridInputAutoFocus = async (enabled: boolean) => {
     if (typeof enabled !== "boolean") {
       console.warn("Invalid terminal hybridInputAutoFocus:", enabled);
       return;
@@ -125,16 +112,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, hybridInputAutoFocus: enabled });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_HYBRID_INPUT_AUTO_FOCUS,
-    handleTerminalConfigSetHybridInputAutoFocus
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_HYBRID_INPUT_AUTO_FOCUS,
+      handleTerminalConfigSetHybridInputAutoFocus
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_HYBRID_INPUT_AUTO_FOCUS));
 
-  const handleTerminalConfigSetColorScheme = async (
-    _event: Electron.IpcMainInvokeEvent,
-    schemeId: string
-  ) => {
+  const handleTerminalConfigSetColorScheme = async (schemeId: string) => {
     if (typeof schemeId !== "string" || !schemeId.trim()) {
       console.warn("Invalid terminal colorScheme:", schemeId);
       return;
@@ -142,13 +127,11 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, colorSchemeId: schemeId.trim() });
   };
-  ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_COLOR_SCHEME, handleTerminalConfigSetColorScheme);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_COLOR_SCHEME));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_CONFIG_SET_COLOR_SCHEME, handleTerminalConfigSetColorScheme)
+  );
 
-  const handleTerminalConfigSetCustomSchemes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    schemesJson: string
-  ) => {
+  const handleTerminalConfigSetCustomSchemes = async (schemesJson: string) => {
     if (typeof schemesJson !== "string") {
       console.warn("Invalid custom schemes:", schemesJson);
       return;
@@ -156,13 +139,11 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, customSchemes: schemesJson });
   };
-  ipcMain.handle(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, handleTerminalConfigSetCustomSchemes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES));
+  handlers.push(
+    typedHandle(CHANNELS.TERMINAL_CONFIG_SET_CUSTOM_SCHEMES, handleTerminalConfigSetCustomSchemes)
+  );
 
-  const handleTerminalConfigSetRecentSchemeIds = async (
-    _event: Electron.IpcMainInvokeEvent,
-    ids: unknown
-  ) => {
+  const handleTerminalConfigSetRecentSchemeIds = async (ids: unknown) => {
     if (!Array.isArray(ids)) {
       console.warn("Invalid terminal recentSchemeIds:", ids);
       return;
@@ -174,16 +155,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, recentSchemeIds: sanitized });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS,
-    handleTerminalConfigSetRecentSchemeIds
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS,
+      handleTerminalConfigSetRecentSchemeIds
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_RECENT_SCHEME_IDS));
 
-  const handleTerminalConfigSetScreenReaderMode = async (
-    _event: Electron.IpcMainInvokeEvent,
-    mode: string
-  ) => {
+  const handleTerminalConfigSetScreenReaderMode = async (mode: string) => {
     if (mode !== "auto" && mode !== "on" && mode !== "off") {
       console.warn("Invalid screen reader mode:", mode);
       return;
@@ -191,16 +170,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, screenReaderMode: mode });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_SCREEN_READER_MODE,
-    handleTerminalConfigSetScreenReaderMode
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_SCREEN_READER_MODE,
+      handleTerminalConfigSetScreenReaderMode
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_SCREEN_READER_MODE));
 
-  const handleTerminalConfigSetResourceMonitoring = async (
-    _event: Electron.IpcMainInvokeEvent,
-    enabled: boolean
-  ) => {
+  const handleTerminalConfigSetResourceMonitoring = async (enabled: boolean) => {
     if (typeof enabled !== "boolean") {
       console.warn("Invalid terminal resourceMonitoringEnabled:", enabled);
       return;
@@ -209,16 +186,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     store.set("terminalConfig", { ...currentConfig, resourceMonitoringEnabled: enabled });
     deps?.ptyClient?.setResourceMonitoring(enabled);
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_RESOURCE_MONITORING,
-    handleTerminalConfigSetResourceMonitoring
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_RESOURCE_MONITORING,
+      handleTerminalConfigSetResourceMonitoring
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_RESOURCE_MONITORING));
 
-  const handleTerminalConfigSetMemoryLeakDetection = async (
-    _event: Electron.IpcMainInvokeEvent,
-    enabled: boolean
-  ) => {
+  const handleTerminalConfigSetMemoryLeakDetection = async (enabled: boolean) => {
     if (typeof enabled !== "boolean") {
       console.warn("Invalid terminal memoryLeakDetectionEnabled:", enabled);
       return;
@@ -226,16 +201,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     const currentConfig = getTerminalConfigObject();
     store.set("terminalConfig", { ...currentConfig, memoryLeakDetectionEnabled: enabled });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_MEMORY_LEAK_DETECTION,
-    handleTerminalConfigSetMemoryLeakDetection
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_MEMORY_LEAK_DETECTION,
+      handleTerminalConfigSetMemoryLeakDetection
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_MEMORY_LEAK_DETECTION));
 
-  const handleTerminalConfigSetMemoryLeakAutoRestart = async (
-    _event: Electron.IpcMainInvokeEvent,
-    thresholdMb: number
-  ) => {
+  const handleTerminalConfigSetMemoryLeakAutoRestart = async (thresholdMb: number) => {
     if (!Number.isFinite(thresholdMb) || !Number.isInteger(thresholdMb)) {
       console.warn("Invalid memoryLeakAutoRestartThresholdMb (not a finite integer):", thresholdMb);
       return;
@@ -253,16 +226,14 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
       memoryLeakAutoRestartThresholdMb: thresholdMb,
     });
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_MEMORY_LEAK_AUTO_RESTART,
-    handleTerminalConfigSetMemoryLeakAutoRestart
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_MEMORY_LEAK_AUTO_RESTART,
+      handleTerminalConfigSetMemoryLeakAutoRestart
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_MEMORY_LEAK_AUTO_RESTART));
 
-  const handleTerminalConfigSetCachedProjectViews = async (
-    _event: Electron.IpcMainInvokeEvent,
-    cachedProjectViews: number
-  ) => {
+  const handleTerminalConfigSetCachedProjectViews = async (cachedProjectViews: number) => {
     if (!Number.isFinite(cachedProjectViews) || !Number.isInteger(cachedProjectViews)) {
       const error = `Invalid cachedProjectViews value (not a finite integer): ${cachedProjectViews}`;
       console.warn(error);
@@ -277,37 +248,47 @@ export function registerTerminalConfigHandlers(deps?: HandlerDependencies): () =
     store.set("terminalConfig", { ...currentConfig, cachedProjectViews });
     deps?.projectViewManager?.setCachedViewLimit(cachedProjectViews);
   };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_SET_CACHED_PROJECT_VIEWS,
-    handleTerminalConfigSetCachedProjectViews
+  handlers.push(
+    typedHandle(
+      CHANNELS.TERMINAL_CONFIG_SET_CACHED_PROJECT_VIEWS,
+      handleTerminalConfigSetCachedProjectViews
+    )
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_SET_CACHED_PROJECT_VIEWS));
 
-  const handleTerminalConfigImportColorScheme = async (event: Electron.IpcMainInvokeEvent) => {
-    const win = getWindowForWebContents(event.sender) ?? BrowserWindow.getFocusedWindow();
-    const dialogOptions = {
-      title: "Import Color Scheme",
-      filters: [
-        { name: "Color Schemes", extensions: ["itermcolors", "json"] },
-        { name: "All Files", extensions: ["*"] },
-      ],
-      properties: ["openFile" as const],
-    };
-    const result = win
-      ? await dialog.showOpenDialog(win, dialogOptions)
-      : await dialog.showOpenDialog(dialogOptions);
+  handlers.push(
+    typedHandleWithContext(CHANNELS.TERMINAL_CONFIG_IMPORT_COLOR_SCHEME, async (ctx) => {
+      const win = ctx.senderWindow ?? BrowserWindow.getFocusedWindow();
+      const dialogOptions = {
+        title: "Import Color Scheme",
+        filters: [
+          { name: "Color Schemes", extensions: ["itermcolors", "json"] },
+          { name: "All Files", extensions: ["*"] },
+        ],
+        properties: ["openFile" as const],
+      };
+      const result = win
+        ? await dialog.showOpenDialog(win, dialogOptions)
+        : await dialog.showOpenDialog(dialogOptions);
 
-    if (result.canceled || result.filePaths.length === 0) {
-      return { ok: false, errors: ["Import cancelled"] };
-    }
+      if (result.canceled || result.filePaths.length === 0) {
+        return { ok: false as const, errors: ["Import cancelled"] };
+      }
 
-    return parseColorSchemeFile(result.filePaths[0]);
-  };
-  ipcMain.handle(
-    CHANNELS.TERMINAL_CONFIG_IMPORT_COLOR_SCHEME,
-    handleTerminalConfigImportColorScheme
+      const parsed = await parseColorSchemeFile(result.filePaths[0]);
+      if (!parsed.ok) {
+        return parsed;
+      }
+      return {
+        ok: true as const,
+        scheme: {
+          id: parsed.scheme.id,
+          name: parsed.scheme.name,
+          type: parsed.scheme.type,
+          colors: { ...parsed.scheme.colors } as Record<string, string>,
+        },
+      };
+    })
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.TERMINAL_CONFIG_IMPORT_COLOR_SCHEME));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminalLayout.ts
+++ b/electron/ipc/handlers/terminalLayout.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import {
@@ -8,6 +7,7 @@ import {
 } from "../../schemas/index.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalSnapshot, TabGroup } from "../../types/index.js";
+import { typedHandle } from "../utils.js";
 
 /**
  * Validate and filter terminal snapshots using the Zod schema.
@@ -69,23 +69,19 @@ export function sanitizeDraftInputs(inputs: Record<string, unknown>): Record<str
 export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleProjectGetTerminals = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<TerminalSnapshot[]> => {
+  const handleProjectGetTerminals = async (projectId: string): Promise<TerminalSnapshot[]> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
     const state = await projectStore.getProjectState(projectId);
     return state?.terminals ?? [];
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_TERMINALS, handleProjectGetTerminals);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_TERMINALS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_TERMINALS, handleProjectGetTerminals));
 
-  const handleProjectSetTerminals = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; terminals: TerminalSnapshot[] }
-  ): Promise<void> => {
+  const handleProjectSetTerminals = async (payload: {
+    projectId: string;
+    terminals: TerminalSnapshot[];
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -115,11 +111,9 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
 
     await projectStore.saveProjectState(projectId, newState);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SET_TERMINALS, handleProjectSetTerminals);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SET_TERMINALS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SET_TERMINALS, handleProjectSetTerminals));
 
   const handleProjectGetTerminalSizes = async (
-    _event: Electron.IpcMainInvokeEvent,
     projectId: string
   ): Promise<Record<string, { cols: number; rows: number }>> => {
     if (typeof projectId !== "string" || !projectId) {
@@ -128,13 +122,9 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
     const state = await projectStore.getProjectState(projectId);
     return state?.terminalSizes ?? {};
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_TERMINAL_SIZES, handleProjectGetTerminalSizes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_TERMINAL_SIZES));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_TERMINAL_SIZES, handleProjectGetTerminalSizes));
 
-  const handleProjectSetTerminalSizes = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ): Promise<void> => {
+  const handleProjectSetTerminalSizes = async (payload: unknown): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -172,26 +162,21 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
 
     await projectStore.saveProjectState(projectId, newState);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SET_TERMINAL_SIZES, handleProjectSetTerminalSizes);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SET_TERMINAL_SIZES));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SET_TERMINAL_SIZES, handleProjectSetTerminalSizes));
 
-  const handleProjectGetTabGroups = async (
-    _event: Electron.IpcMainInvokeEvent,
-    projectId: string
-  ): Promise<TabGroup[]> => {
+  const handleProjectGetTabGroups = async (projectId: string): Promise<TabGroup[]> => {
     if (typeof projectId !== "string" || !projectId) {
       throw new Error("Invalid project ID");
     }
     const state = await projectStore.getProjectState(projectId);
     return state?.tabGroups ?? [];
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_TAB_GROUPS, handleProjectGetTabGroups);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_TAB_GROUPS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_TAB_GROUPS, handleProjectGetTabGroups));
 
-  const handleProjectSetTabGroups = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { projectId: string; tabGroups: TabGroup[] }
-  ): Promise<void> => {
+  const handleProjectSetTabGroups = async (payload: {
+    projectId: string;
+    tabGroups: TabGroup[];
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -220,11 +205,9 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
     };
     await projectStore.saveProjectState(projectId, newState);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SET_TAB_GROUPS, handleProjectSetTabGroups);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SET_TAB_GROUPS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SET_TAB_GROUPS, handleProjectSetTabGroups));
 
   const handleProjectGetFocusMode = async (
-    _event: Electron.IpcMainInvokeEvent,
     projectId: string
   ): Promise<{
     focusMode: boolean;
@@ -239,17 +222,13 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
       focusPanelState: state?.focusPanelState,
     };
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_FOCUS_MODE, handleProjectGetFocusMode);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_FOCUS_MODE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_FOCUS_MODE, handleProjectGetFocusMode));
 
-  const handleProjectSetFocusMode = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      projectId: string;
-      focusMode: boolean;
-      focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
-    }
-  ): Promise<void> => {
+  const handleProjectSetFocusMode = async (payload: {
+    projectId: string;
+    focusMode: boolean;
+    focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
+  }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -299,11 +278,9 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
 
     await projectStore.saveProjectState(projectId, newState);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SET_FOCUS_MODE, handleProjectSetFocusMode);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SET_FOCUS_MODE));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SET_FOCUS_MODE, handleProjectSetFocusMode));
 
   const handleProjectGetDraftInputs = async (
-    _event: Electron.IpcMainInvokeEvent,
     projectId: string
   ): Promise<Record<string, string>> => {
     if (typeof projectId !== "string" || !projectId) {
@@ -312,13 +289,9 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
     const state = await projectStore.getProjectState(projectId);
     return state?.draftInputs ?? {};
   };
-  ipcMain.handle(CHANNELS.PROJECT_GET_DRAFT_INPUTS, handleProjectGetDraftInputs);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_GET_DRAFT_INPUTS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_DRAFT_INPUTS, handleProjectGetDraftInputs));
 
-  const handleProjectSetDraftInputs = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ): Promise<void> => {
+  const handleProjectSetDraftInputs = async (payload: unknown): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
     }
@@ -356,8 +329,7 @@ export function registerTerminalLayoutHandlers(_deps: HandlerDependencies): () =
 
     await projectStore.saveProjectState(projectId, newState);
   };
-  ipcMain.handle(CHANNELS.PROJECT_SET_DRAFT_INPUTS, handleProjectSetDraftInputs);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PROJECT_SET_DRAFT_INPUTS));
+  handlers.push(typedHandle(CHANNELS.PROJECT_SET_DRAFT_INPUTS, handleProjectSetDraftInputs));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -8,13 +8,14 @@ import {
   type CorrectionWord,
 } from "../../services/VoiceTranscriptionService.js";
 import { VoiceCorrectionService } from "../../services/VoiceCorrectionService.js";
-import type { HandlerDependencies } from "../types.js";
+import type { HandlerDependencies, IpcContext } from "../types.js";
 import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
 import { CONFIDENCE_TAG_THRESHOLD } from "../../../shared/config/voiceCorrection.js";
 import { logDebug, logWarn } from "../../utils/logger.js";
 import { assembleKeyterms } from "../../services/voiceContextKeyterms.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { voiceFileLinkResolver } from "../../services/VoiceFileLinkResolver.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 let service: VoiceTranscriptionService | null = null;
 let activeEventUnsubscribe: (() => void) | null = null;
@@ -441,15 +442,12 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     return getVoiceSettings();
   };
 
-  const handleSetSettings = async (
-    _event: Electron.IpcMainInvokeEvent,
-    patch: Partial<VoiceInputSettings>
-  ) => {
+  const handleSetSettings = async (patch: Partial<VoiceInputSettings>) => {
     const current = getVoiceSettings();
     store.set("voiceInput", { ...current, ...patch });
   };
 
-  const handleStart = async (event: Electron.IpcMainInvokeEvent) => {
+  const handleStart = async (ctx: IpcContext) => {
     const svc = getService();
     // Snapshot transcription settings at session start (model, language, API key).
     // Correction settings are read live from store per-event so mid-session changes apply.
@@ -573,8 +571,8 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
       unsubscribe();
       service?.stop();
     };
-    event.sender.once("destroyed", onDestroyed);
-    activeDestroyListener = { sender: event.sender, fn: onDestroyed };
+    ctx.event.sender.once("destroyed", onDestroyed);
+    activeDestroyListener = { sender: ctx.event.sender, fn: onDestroyed };
 
     const result = await svc.start(sessionSettings);
     if (!result.ok) {
@@ -583,7 +581,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
         activeEventUnsubscribe = null;
       }
       unsubscribe();
-      event.sender.removeListener("destroyed", onDestroyed);
+      ctx.event.sender.removeListener("destroyed", onDestroyed);
       activeDestroyListener = null;
     }
     return result;
@@ -627,7 +625,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     return { rawText: null, correctionId: null };
   };
 
-  const handleAudioChunk = (_event: Electron.IpcMainInvokeEvent, chunk: ArrayBuffer) => {
+  const handleAudioChunk = (_event: Electron.IpcMainEvent, chunk: ArrayBuffer) => {
     service?.sendAudioChunk(chunk);
   };
 
@@ -643,41 +641,33 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     openMicSettings();
   };
 
-  const handleValidateApiKey = async (_event: Electron.IpcMainInvokeEvent, apiKey: string) => {
+  const handleValidateApiKey = async (apiKey: string) => {
     return validateDeepgramKey(apiKey);
   };
 
-  const handleValidateCorrectionApiKey = async (
-    _event: Electron.IpcMainInvokeEvent,
-    apiKey: string
-  ) => {
+  const handleValidateCorrectionApiKey = async (apiKey: string) => {
     return validateOpenAIKey(apiKey);
   };
 
-  ipcMain.handle(CHANNELS.VOICE_INPUT_GET_SETTINGS, handleGetSettings);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_SET_SETTINGS, handleSetSettings);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_START, handleStart);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_STOP, handleStop);
+  const cleanups: Array<() => void> = [
+    typedHandle(CHANNELS.VOICE_INPUT_GET_SETTINGS, handleGetSettings),
+    typedHandle(CHANNELS.VOICE_INPUT_SET_SETTINGS, handleSetSettings),
+    typedHandleWithContext(CHANNELS.VOICE_INPUT_START, handleStart),
+    typedHandle(CHANNELS.VOICE_INPUT_STOP, handleStop),
+    typedHandle(CHANNELS.VOICE_INPUT_CHECK_MIC_PERMISSION, handleCheckMicPermission),
+    typedHandle(CHANNELS.VOICE_INPUT_REQUEST_MIC_PERMISSION, handleRequestMicPermission),
+    typedHandle(CHANNELS.VOICE_INPUT_OPEN_MIC_SETTINGS, handleOpenMicSettings),
+    typedHandle(CHANNELS.VOICE_INPUT_VALIDATE_API_KEY, handleValidateApiKey),
+    typedHandle(CHANNELS.VOICE_INPUT_VALIDATE_CORRECTION_API_KEY, handleValidateCorrectionApiKey),
+    typedHandle(CHANNELS.VOICE_INPUT_FLUSH_PARAGRAPH, handleFlushParagraph),
+  ];
+
+  // Fire-and-forget audio-chunk stream stays on ipcMain.on.
   ipcMain.on(CHANNELS.VOICE_INPUT_AUDIO_CHUNK, handleAudioChunk);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_CHECK_MIC_PERMISSION, handleCheckMicPermission);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_REQUEST_MIC_PERMISSION, handleRequestMicPermission);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_OPEN_MIC_SETTINGS, handleOpenMicSettings);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_VALIDATE_API_KEY, handleValidateApiKey);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_VALIDATE_CORRECTION_API_KEY, handleValidateCorrectionApiKey);
-  ipcMain.handle(CHANNELS.VOICE_INPUT_FLUSH_PARAGRAPH, handleFlushParagraph);
 
   return () => {
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_GET_SETTINGS);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_SET_SETTINGS);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_START);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_STOP);
+    for (const cleanup of cleanups) cleanup();
     ipcMain.removeListener(CHANNELS.VOICE_INPUT_AUDIO_CHUNK, handleAudioChunk);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_CHECK_MIC_PERMISSION);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_REQUEST_MIC_PERMISSION);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_OPEN_MIC_SETTINGS);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_VALIDATE_API_KEY);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_VALIDATE_CORRECTION_API_KEY);
-    ipcMain.removeHandler(CHANNELS.VOICE_INPUT_FLUSH_PARAGRAPH);
     cleanupActiveSubscription();
     service?.destroy();
     service = null;

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -1,8 +1,8 @@
-import { BrowserWindow, ipcMain, webContents } from "electron";
+import { BrowserWindow, webContents } from "electron";
 import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
 import { getWebviewDialogService } from "../../services/WebviewDialogService.js";
-import { broadcastToRenderer, sendToRenderer } from "../utils.js";
+import { broadcastToRenderer, sendToRenderer, typedHandle } from "../utils.js";
 import { startOAuthLoopback } from "../../services/OAuthLoopbackService.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
@@ -217,7 +217,6 @@ function cleanupSession(wcId: number): void {
 
 export function registerWebviewHandlers(_deps: HandlerDependencies): () => void {
   const handleSetLifecycleState = async (
-    _event: Electron.IpcMainInvokeEvent,
     webContentsId: unknown,
     frozen: unknown
   ): Promise<void> => {
@@ -250,7 +249,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   };
 
   const handleStartConsoleCapture = async (
-    _event: Electron.IpcMainInvokeEvent,
     webContentsId: unknown,
     paneId: unknown
   ): Promise<void> => {
@@ -413,7 +411,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   }
 
   const handleStopConsoleCapture = async (
-    _event: Electron.IpcMainInvokeEvent,
     webContentsId: unknown,
     paneId: unknown
   ): Promise<void> => {
@@ -447,7 +444,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   };
 
   const handleClearConsoleCapture = async (
-    _event: Electron.IpcMainInvokeEvent,
     webContentsId: unknown,
     paneId: unknown
   ): Promise<void> => {
@@ -467,7 +463,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   };
 
   const handleGetConsoleProperties = async (
-    _event: Electron.IpcMainInvokeEvent,
     webContentsId: unknown,
     objectId: unknown
   ): Promise<{ properties: CdpPropertyDescriptor[] }> => {
@@ -519,10 +514,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     }
   };
 
-  const handleRegisterPanel = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ): Promise<void> => {
+  const handleRegisterPanel = async (payload: unknown): Promise<void> => {
     if (
       !payload ||
       typeof payload !== "object" ||
@@ -535,10 +527,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     getWebviewDialogService().registerPanel(webContentsId, panelId);
   };
 
-  const handleDialogResponse = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
-  ): Promise<void> => {
+  const handleDialogResponse = async (payload: unknown): Promise<void> => {
     if (
       !payload ||
       typeof payload !== "object" ||
@@ -556,7 +545,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
   };
 
   const handleOAuthLoopback = async (
-    _event: Electron.IpcMainInvokeEvent,
     authUrl: unknown,
     panelId: unknown,
     webContentsId: unknown,
@@ -792,24 +780,19 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     return { success: true };
   };
 
-  ipcMain.handle(CHANNELS.WEBVIEW_SET_LIFECYCLE_STATE, handleSetLifecycleState);
-  ipcMain.handle(CHANNELS.WEBVIEW_REGISTER_PANEL, handleRegisterPanel);
-  ipcMain.handle(CHANNELS.WEBVIEW_DIALOG_RESPONSE, handleDialogResponse);
-  ipcMain.handle(CHANNELS.WEBVIEW_START_CONSOLE_CAPTURE, handleStartConsoleCapture);
-  ipcMain.handle(CHANNELS.WEBVIEW_STOP_CONSOLE_CAPTURE, handleStopConsoleCapture);
-  ipcMain.handle(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE, handleClearConsoleCapture);
-  ipcMain.handle(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES, handleGetConsoleProperties);
-  ipcMain.handle(CHANNELS.WEBVIEW_OAUTH_LOOPBACK, handleOAuthLoopback);
+  const cleanups: Array<() => void> = [
+    typedHandle(CHANNELS.WEBVIEW_SET_LIFECYCLE_STATE, handleSetLifecycleState),
+    typedHandle(CHANNELS.WEBVIEW_REGISTER_PANEL, handleRegisterPanel),
+    typedHandle(CHANNELS.WEBVIEW_DIALOG_RESPONSE, handleDialogResponse),
+    typedHandle(CHANNELS.WEBVIEW_START_CONSOLE_CAPTURE, handleStartConsoleCapture),
+    typedHandle(CHANNELS.WEBVIEW_STOP_CONSOLE_CAPTURE, handleStopConsoleCapture),
+    typedHandle(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE, handleClearConsoleCapture),
+    typedHandle(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES, handleGetConsoleProperties),
+    typedHandle(CHANNELS.WEBVIEW_OAUTH_LOOPBACK, handleOAuthLoopback),
+  ];
 
   return () => {
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_SET_LIFECYCLE_STATE);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_REGISTER_PANEL);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_DIALOG_RESPONSE);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_START_CONSOLE_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_STOP_CONSOLE_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES);
-    ipcMain.removeHandler(CHANNELS.WEBVIEW_OAUTH_LOOPBACK);
+    for (const cleanup of cleanups) cleanup();
 
     // Clean up all sessions
     for (const wcId of sessions.keys()) {

--- a/electron/ipc/handlers/worktree/branches.ts
+++ b/electron/ipc/handlers/worktree/branches.ts
@@ -1,29 +1,26 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
 import { generateWorktreePath, validatePathPattern } from "../../../../shared/utils/pathPattern.js";
 import { resolveWorktreePattern } from "../../../utils/worktreePattern.js";
 import { taskWorktreeService } from "../../../services/TaskWorktreeService.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleWorktreeListBranches = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { rootPath: string }
-  ) => {
+  const handleWorktreeListBranches = async (payload: { rootPath: string }) => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
     return await deps.worktreeService.listBranches(payload.rootPath);
   };
-  ipcMain.handle(CHANNELS.WORKTREE_LIST_BRANCHES, handleWorktreeListBranches);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_LIST_BRANCHES));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_LIST_BRANCHES, handleWorktreeListBranches));
 
-  const handleWorktreeFetchPRBranch = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { rootPath: string; prNumber: number; headRefName: string }
-  ) => {
+  const handleWorktreeFetchPRBranch = async (payload: {
+    rootPath: string;
+    prNumber: number;
+    headRefName: string;
+  }) => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
@@ -42,25 +39,22 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
       payload.headRefName
     );
   };
-  ipcMain.handle(CHANNELS.WORKTREE_FETCH_PR_BRANCH, handleWorktreeFetchPRBranch);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_FETCH_PR_BRANCH));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_FETCH_PR_BRANCH, handleWorktreeFetchPRBranch));
 
-  const handleWorktreeGetRecentBranches = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { rootPath: string }
-  ) => {
+  const handleWorktreeGetRecentBranches = async (payload: { rootPath: string }) => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
     return await deps.worktreeService.getRecentBranches(payload.rootPath);
   };
-  ipcMain.handle(CHANNELS.WORKTREE_GET_RECENT_BRANCHES, handleWorktreeGetRecentBranches);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_RECENT_BRANCHES));
+  handlers.push(
+    typedHandle(CHANNELS.WORKTREE_GET_RECENT_BRANCHES, handleWorktreeGetRecentBranches)
+  );
 
-  const handleWorktreeGetDefaultPath = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { rootPath: string; branchName: string }
-  ): Promise<string> => {
+  const handleWorktreeGetDefaultPath = async (payload: {
+    rootPath: string;
+    branchName: string;
+  }): Promise<string> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload for worktree:get-default-path");
     }
@@ -82,20 +76,17 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
       throw new Error(`Invalid stored pattern: ${validation.error}`);
     }
 
-    // Generate the initial path
     const initialPath = generateWorktreePath(rootPath, branchName, pattern);
 
-    // Auto-resolve path conflicts by finding an available path
     const gitService = taskWorktreeService.getGitService(rootPath);
     return gitService.findAvailablePath(initialPath);
   };
-  ipcMain.handle(CHANNELS.WORKTREE_GET_DEFAULT_PATH, handleWorktreeGetDefaultPath);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_DEFAULT_PATH));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_GET_DEFAULT_PATH, handleWorktreeGetDefaultPath));
 
-  const handleWorktreeGetAvailableBranch = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { rootPath: string; branchName: string }
-  ): Promise<string> => {
+  const handleWorktreeGetAvailableBranch = async (payload: {
+    rootPath: string;
+    branchName: string;
+  }): Promise<string> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload for worktree:get-available-branch");
     }
@@ -113,8 +104,9 @@ export function registerWorktreeBranchHandlers(deps: HandlerDependencies): () =>
     const gitService = taskWorktreeService.getGitService(rootPath);
     return gitService.findAvailableBranchName(branchName);
   };
-  ipcMain.handle(CHANNELS.WORKTREE_GET_AVAILABLE_BRANCH, handleWorktreeGetAvailableBranch);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_AVAILABLE_BRANCH));
+  handlers.push(
+    typedHandle(CHANNELS.WORKTREE_GET_AVAILABLE_BRANCH, handleWorktreeGetAvailableBranch)
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -1,26 +1,28 @@
-import { ipcMain } from "electron";
-import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
-import type { HandlerDependencies } from "../../types.js";
+import type { HandlerDependencies, IpcContext } from "../../types.js";
 import type { WorktreeSetActivePayload, WorktreeDeletePayload } from "../../../types/index.js";
+import type { WorktreeState } from "../../../../shared/types/worktree.js";
 import { fileSearchService } from "../../../services/FileSearchService.js";
 import { soundService } from "../../../services/SoundService.js";
-import { checkRateLimit, waitForRateLimitSlot } from "../../utils.js";
+import {
+  checkRateLimit,
+  waitForRateLimitSlot,
+  typedHandle,
+  typedHandleWithContext,
+} from "../../utils.js";
 import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
 
 export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  const handleWorktreeGetAll = async (event: Electron.IpcMainInvokeEvent) => {
+  const handleWorktreeGetAll = async (ctx: IpcContext): Promise<WorktreeState[]> => {
     if (!deps.worktreeService) {
       return [];
     }
-    const senderWindow = getWindowForWebContents(event.sender);
-    return await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
+    return (await deps.worktreeService.getAllStatesAsync(ctx.senderWindow?.id)) as WorktreeState[];
   };
-  ipcMain.handle(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_ALL));
+  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_GET_ALL, handleWorktreeGetAll));
 
   const handleWorktreeRefresh = async () => {
     if (!deps.worktreeService) {
@@ -28,30 +30,22 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     }
     await deps.worktreeService.refresh();
   };
-  ipcMain.handle(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_REFRESH));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_REFRESH, handleWorktreeRefresh));
 
-  const handleWorktreeSetActive = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: WorktreeSetActivePayload
-  ) => {
+  const handleWorktreeSetActive = async (ctx: IpcContext, payload: WorktreeSetActivePayload) => {
     if (!deps.worktreeService) {
       return;
     }
-    const senderWindow = getWindowForWebContents(event.sender);
-    const windowId = senderWindow?.id;
-    await deps.worktreeService.setActiveWorktree(payload.worktreeId, windowId, { silent: true });
+    await deps.worktreeService.setActiveWorktree(payload.worktreeId, ctx.senderWindow?.id, {
+      silent: true,
+    });
   };
-  ipcMain.handle(CHANNELS.WORKTREE_SET_ACTIVE, handleWorktreeSetActive);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_SET_ACTIVE));
+  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_SET_ACTIVE, handleWorktreeSetActive));
 
-  const handleWorktreeCreate = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: {
-      rootPath: string;
-      options: { baseBranch: string; newBranch: string; path: string; fromRemote?: boolean };
-    }
-  ): Promise<string> => {
+  const handleWorktreeCreate = async (payload: {
+    rootPath: string;
+    options: { baseBranch: string; newBranch: string; path: string; fromRemote?: boolean };
+  }): Promise<string> => {
     await waitForRateLimitSlot(WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS);
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
@@ -67,13 +61,9 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     }
     return worktreeId;
   };
-  ipcMain.handle(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CREATE));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate));
 
-  const handleWorktreeDelete = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: WorktreeDeletePayload
-  ) => {
+  const handleWorktreeDelete = async (ctx: IpcContext, payload: WorktreeDeletePayload) => {
     checkRateLimit(CHANNELS.WORKTREE_DELETE, 10, 10_000);
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
@@ -90,8 +80,7 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     if (payload.deleteBranch !== undefined && typeof payload.deleteBranch !== "boolean") {
       throw new Error("Invalid deleteBranch parameter");
     }
-    const senderWindow = getWindowForWebContents(event.sender);
-    const states = await deps.worktreeService.getAllStatesAsync(senderWindow?.id);
+    const states = await deps.worktreeService.getAllStatesAsync(ctx.senderWindow?.id);
     const worktree = states.find((wt) => wt.id === payload.worktreeId);
     await deps.worktreeService.deleteWorktree(
       payload.worktreeId,
@@ -115,8 +104,7 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       store.set("worktreeIssueMap", rest);
     }
   };
-  ipcMain.handle(CHANNELS.WORKTREE_DELETE, handleWorktreeDelete);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_DELETE));
+  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_DELETE, handleWorktreeDelete));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/worktree/pull-requests.ts
+++ b/electron/ipc/handlers/worktree/pull-requests.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { store } from "../../../store.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -7,6 +6,7 @@ import type {
   DetachIssuePayload,
   IssueAssociation,
 } from "../../../../shared/types/ipc/worktree.js";
+import { typedHandle } from "../../utils.js";
 
 export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -17,8 +17,7 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     }
     await deps.worktreeService.refreshPullRequests();
   };
-  ipcMain.handle(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_REFRESH));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_PR_REFRESH, handleWorktreePRRefresh));
 
   const handleWorktreePRStatus = async () => {
     if (!deps.worktreeService) {
@@ -26,13 +25,9 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     }
     return await deps.worktreeService.getPRStatus();
   };
-  ipcMain.handle(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_PR_STATUS));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_PR_STATUS, handleWorktreePRStatus));
 
-  const handleWorktreeAttachIssue = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: AttachIssuePayload
-  ): Promise<void> => {
+  const handleWorktreeAttachIssue = async (payload: AttachIssuePayload): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload for worktree:attach-issue");
     }
@@ -65,13 +60,9 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     const currentMap = store.get("worktreeIssueMap") ?? {};
     store.set("worktreeIssueMap", { ...currentMap, [worktreeId]: association });
   };
-  ipcMain.handle(CHANNELS.WORKTREE_ATTACH_ISSUE, handleWorktreeAttachIssue);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_ATTACH_ISSUE));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_ATTACH_ISSUE, handleWorktreeAttachIssue));
 
-  const handleWorktreeDetachIssue = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: DetachIssuePayload
-  ): Promise<void> => {
+  const handleWorktreeDetachIssue = async (payload: DetachIssuePayload): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload for worktree:detach-issue");
     }
@@ -86,11 +77,9 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     const { [worktreeId]: _removed, ...rest } = currentMap;
     store.set("worktreeIssueMap", rest);
   };
-  ipcMain.handle(CHANNELS.WORKTREE_DETACH_ISSUE, handleWorktreeDetachIssue);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_DETACH_ISSUE));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_DETACH_ISSUE, handleWorktreeDetachIssue));
 
   const handleWorktreeGetIssueAssociation = async (
-    _event: Electron.IpcMainInvokeEvent,
     worktreeId: string
   ): Promise<IssueAssociation | null> => {
     if (typeof worktreeId !== "string" || !worktreeId.trim()) {
@@ -100,19 +89,18 @@ export function registerWorktreePullRequestHandlers(deps: HandlerDependencies): 
     const currentMap = store.get("worktreeIssueMap") ?? {};
     return currentMap[worktreeId] ?? null;
   };
-  ipcMain.handle(CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION, handleWorktreeGetIssueAssociation);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION));
+  handlers.push(
+    typedHandle(CHANNELS.WORKTREE_GET_ISSUE_ASSOCIATION, handleWorktreeGetIssueAssociation)
+  );
 
   const handleWorktreeGetAllIssueAssociations = async (): Promise<
     Record<string, IssueAssociation>
   > => {
     return store.get("worktreeIssueMap") ?? {};
   };
-  ipcMain.handle(
-    CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS,
-    handleWorktreeGetAllIssueAssociations
+  handlers.push(
+    typedHandle(CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS, handleWorktreeGetAllIssueAssociations)
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/worktree/task.ts
+++ b/electron/ipc/handlers/worktree/task.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { CHANNELS } from "../../channels.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -11,7 +10,12 @@ import { generateWorktreePath } from "../../../../shared/utils/pathPattern.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import { logDebug, logError } from "../../../utils/logger.js";
 import { fileSearchService } from "../../../services/FileSearchService.js";
-import { checkRateLimit, waitForRateLimitSlot } from "../../utils.js";
+import {
+  checkRateLimit,
+  waitForRateLimitSlot,
+  typedHandle,
+  typedHandleWithContext,
+} from "../../utils.js";
 import { resolveWorktreePattern } from "../../../utils/worktreePattern.js";
 import { taskWorktreeService } from "../../../services/TaskWorktreeService.js";
 import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
@@ -20,7 +24,7 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
   const handlers: Array<() => void> = [];
 
   const handleWorktreeCreateForTask = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     payload: CreateForTaskPayload
   ): Promise<WorktreeState> => {
     await waitForRateLimitSlot(WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS);
@@ -48,7 +52,7 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
     const rootPath = project.path;
 
     // Get all states to find the main worktree and determine base branch
-    const senderWindowCreate = getWindowForWebContents(event.sender);
+    const senderWindowCreate = getWindowForWebContents(ctx.event.sender);
     const states = await deps.worktreeService.getAllStatesAsync(senderWindowCreate?.id);
     const mainWorktree = states.find((wt) => wt.isMainWorktree);
 
@@ -194,13 +198,11 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
       };
     }
   };
-  ipcMain.handle(CHANNELS.WORKTREE_CREATE_FOR_TASK, handleWorktreeCreateForTask);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CREATE_FOR_TASK));
+  handlers.push(
+    typedHandleWithContext(CHANNELS.WORKTREE_CREATE_FOR_TASK, handleWorktreeCreateForTask)
+  );
 
-  const handleWorktreeGetByTaskId = async (
-    _event: Electron.IpcMainInvokeEvent,
-    taskId: string
-  ): Promise<WorktreeState[]> => {
+  const handleWorktreeGetByTaskId = async (taskId: string): Promise<WorktreeState[]> => {
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }
@@ -252,11 +254,10 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
 
     return results;
   };
-  ipcMain.handle(CHANNELS.WORKTREE_GET_BY_TASK_ID, handleWorktreeGetByTaskId);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_GET_BY_TASK_ID));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_GET_BY_TASK_ID, handleWorktreeGetByTaskId));
 
   const handleWorktreeCleanupTask = async (
-    event: Electron.IpcMainInvokeEvent,
+    ctx: import("../../types.js").IpcContext,
     taskId: string,
     options?: CleanupTaskOptions
   ): Promise<void> => {
@@ -296,7 +297,7 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
     const errors: string[] = [];
 
     // Fetch all worktree states once for efficient main-worktree checking
-    const senderWindowCleanup = getWindowForWebContents(event.sender);
+    const senderWindowCleanup = getWindowForWebContents(ctx.event.sender);
     let allStates: Awaited<ReturnType<typeof deps.worktreeService.getAllStatesAsync>> = [];
     try {
       allStates = await deps.worktreeService.getAllStatesAsync(senderWindowCleanup?.id);
@@ -370,8 +371,7 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
       throw new Error(`Failed to cleanup some worktrees: ${errors.join("; ")}`);
     }
   };
-  ipcMain.handle(CHANNELS.WORKTREE_CLEANUP_TASK, handleWorktreeCleanupTask);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CLEANUP_TASK));
+  handlers.push(typedHandleWithContext(CHANNELS.WORKTREE_CLEANUP_TASK, handleWorktreeCleanupTask));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/worktreeConfig.ts
+++ b/electron/ipc/handlers/worktreeConfig.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
@@ -7,6 +6,7 @@ import {
   validatePathPattern,
   DEFAULT_WORKTREE_PATH_PATTERN,
 } from "../../../shared/utils/pathPattern.js";
+import { typedHandle } from "../utils.js";
 
 function getWorktreeConfig(): WorktreeConfig {
   const raw = store.get("worktreeConfig");
@@ -27,13 +27,9 @@ export function registerWorktreeConfigHandlers(_deps: HandlerDependencies): () =
   const handleGetConfig = async (): Promise<WorktreeConfig> => {
     return getWorktreeConfig();
   };
-  ipcMain.handle(CHANNELS.WORKTREE_CONFIG_GET, handleGetConfig);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CONFIG_GET));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_CONFIG_GET, handleGetConfig));
 
-  const handleSetPattern = async (
-    _event: Electron.IpcMainInvokeEvent,
-    payload: { pattern: string }
-  ): Promise<WorktreeConfig> => {
+  const handleSetPattern = async (payload: { pattern: string }): Promise<WorktreeConfig> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid worktree config payload");
     }
@@ -54,8 +50,7 @@ export function registerWorktreeConfigHandlers(_deps: HandlerDependencies): () =
     store.set("worktreeConfig.pathPattern", trimmedPattern);
     return getWorktreeConfig();
   };
-  ipcMain.handle(CHANNELS.WORKTREE_CONFIG_SET_PATTERN, handleSetPattern);
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.WORKTREE_CONFIG_SET_PATTERN));
+  handlers.push(typedHandle(CHANNELS.WORKTREE_CONFIG_SET_PATTERN, handleSetPattern));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -324,11 +324,17 @@ export function typedHandle<K extends keyof IpcInvokeMap>(
   const captureEnabled = isPerformanceCaptureEnabled();
   let requestCounter = 0;
 
-  ipcMain.handle(channel as string, async (_event, ...args) => {
-    if (!captureEnabled) {
-      return await handler(...(args as IpcInvokeMap[K]["args"]));
-    }
+  // Fast path: when perf capture is disabled, skip the async wrapper so
+  // synchronous handlers stay synchronous (preserves existing behavior for
+  // handlers that returned values directly when registered via ipcMain.handle).
+  if (!captureEnabled) {
+    ipcMain.handle(channel as string, (_event, ...args) =>
+      handler(...(args as IpcInvokeMap[K]["args"]))
+    );
+    return () => ipcMain.removeHandler(channel as string);
+  }
 
+  ipcMain.handle(channel as string, async (_event, ...args) => {
     const traceId = `${String(channel)}-${Date.now().toString(36)}-${(++requestCounter).toString(36)}`;
     const startedAt = performance.now();
     markPerformance(PERF_MARKS.IPC_REQUEST_START, {
@@ -375,15 +381,22 @@ export function typedHandleWithContext<K extends keyof IpcInvokeMap>(
   const captureEnabled = isPerformanceCaptureEnabled();
   let requestCounter = 0;
 
+  if (!captureEnabled) {
+    ipcMain.handle(channel as string, (event, ...args) => {
+      const webContentsId = event.sender.id;
+      const senderWindow = getWindowForWebContents(event.sender);
+      const projectId = getProjectViewManager()?.getProjectIdForWebContents(webContentsId) ?? null;
+      const ctx: IpcContext = { event, webContentsId, senderWindow, projectId };
+      return handler(ctx, ...(args as IpcInvokeMap[K]["args"]));
+    });
+    return () => ipcMain.removeHandler(channel as string);
+  }
+
   ipcMain.handle(channel as string, async (event, ...args) => {
     const webContentsId = event.sender.id;
     const senderWindow = getWindowForWebContents(event.sender);
     const projectId = getProjectViewManager()?.getProjectIdForWebContents(webContentsId) ?? null;
     const ctx: IpcContext = { event, webContentsId, senderWindow, projectId };
-
-    if (!captureEnabled) {
-      return await handler(ctx, ...(args as IpcInvokeMap[K]["args"]));
-    }
 
     const traceId = `${String(channel)}-${Date.now().toString(36)}-${(++requestCounter).toString(36)}`;
     const startedAt = performance.now();

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -53,9 +53,13 @@ export function unregisterWebContents(webContents: WebContents): void {
  * then falls back to the registry (works for WebContentsView webContents).
  */
 export function getWindowForWebContents(webContents: WebContents): BrowserWindow | null {
-  // Fast path: native lookup works for BrowserWindow-owned webContents
-  const native = BrowserWindow.fromWebContents(webContents);
-  if (native) return native;
+  // Fast path: native lookup works for BrowserWindow-owned webContents.
+  // Guarded because test environments frequently stub BrowserWindow without
+  // the static fromWebContents helper.
+  if (typeof BrowserWindow.fromWebContents === "function") {
+    const native = BrowserWindow.fromWebContents(webContents);
+    if (native) return native;
+  }
 
   // Fallback: registry lookup for WebContentsView webContents
   const registered = webContentsToWindow.get(webContents.id);

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -152,7 +152,31 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
+  DemoEncodePayload,
+  DemoEncodeProgressEvent,
+  DemoEncodeResult,
+  DemoAnnotatePayload,
+  DemoAnnotateResult,
+  DemoDismissAnnotationPayload,
+  DemoDragPayload,
+  DemoPressKeyPayload,
+  DemoScrollPayload,
+  DemoSpotlightPayload,
+  DemoWaitForIdlePayload,
 } from "./demo.js";
+import type { BulkProjectStats } from "./project.js";
+import type { PrerequisiteSpec, PrerequisiteCheckResult } from "./system.js";
+import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
+import type { AppAgentConfig } from "../appAgent.js";
+import type { AgentSessionRecord } from "./agentSessionHistory.js";
+import type {
+  CommandContext,
+  CommandExecutePayload,
+  CommandGetPayload,
+  CommandManifestEntry,
+  CommandResult,
+  DaintreeCommand,
+} from "../commands.js";
 
 export type ChecklistItemId =
   | "openedProject"
@@ -1806,6 +1830,310 @@ export interface IpcInvokeMap {
   "demo:get-capture-status": {
     args: [];
     result: DemoCaptureStatus;
+  };
+  "demo:encode": {
+    args: [payload: DemoEncodePayload];
+    result: DemoEncodeResult;
+  };
+  "demo:scroll": {
+    args: [payload: DemoScrollPayload];
+    result: void;
+  };
+  "demo:drag": {
+    args: [payload: DemoDragPayload];
+    result: void;
+  };
+  "demo:press-key": {
+    args: [payload: DemoPressKeyPayload];
+    result: void;
+  };
+  "demo:spotlight": {
+    args: [payload: DemoSpotlightPayload];
+    result: void;
+  };
+  "demo:dismiss-spotlight": {
+    args: [];
+    result: void;
+  };
+  "demo:annotate": {
+    args: [payload: DemoAnnotatePayload];
+    result: DemoAnnotateResult;
+  };
+  "demo:dismiss-annotation": {
+    args: [payload: DemoDismissAnnotationPayload];
+    result: void;
+  };
+  "demo:wait-for-idle": {
+    args: [payload: DemoWaitForIdlePayload];
+    result: void;
+  };
+
+  // Agent session history channels
+  "agent-session:list": {
+    args: [payload: { worktreeId?: string }];
+    result: AgentSessionRecord[];
+  };
+  "agent-session:clear": {
+    args: [payload: { worktreeId?: string }];
+    result: void;
+  };
+
+  // App Agent channels
+  "app-agent:get-config": {
+    args: [];
+    result: Omit<AppAgentConfig, "apiKey">;
+  };
+  "app-agent:set-config": {
+    args: [config: Partial<AppAgentConfig>];
+    result: Omit<AppAgentConfig, "apiKey">;
+  };
+  "app-agent:has-api-key": {
+    args: [];
+    result: boolean;
+  };
+  "app-agent:test-api-key": {
+    args: [apiKey: string];
+    result: { valid: boolean; error?: string };
+  };
+  "app-agent:test-model": {
+    args: [model: string];
+    result: { valid: boolean; error?: string };
+  };
+
+  // Additional app theme channels
+  "app-theme:set-accent-color-override": {
+    args: [color: unknown];
+    result: void;
+  };
+  "app-theme:set-recent-scheme-ids": {
+    args: [ids: unknown];
+    result: void;
+  };
+
+  // Command system channels
+  "commands:list": {
+    args: [context?: CommandContext];
+    result: CommandManifestEntry[];
+  };
+  "commands:get": {
+    args: [payload: CommandGetPayload];
+    result: CommandManifestEntry | null;
+  };
+  "commands:execute": {
+    args: [payload: CommandExecutePayload];
+    result: CommandResult;
+  };
+  "commands:get-builder": {
+    args: [commandId: string];
+    result: DaintreeCommand["builder"] | null;
+  };
+
+  // Additional GitHub channels
+  "github:get-issue-by-number": {
+    args: [payload: { cwd: string; issueNumber: number }];
+    result: import("../github.js").GitHubIssue | null;
+  };
+  "github:get-pr-by-number": {
+    args: [payload: { cwd: string; prNumber: number }];
+    result: import("../github.js").GitHubPR | null;
+  };
+  "github:list-remotes": {
+    args: [cwd: string];
+    result: Array<{
+      name: string;
+      fetchUrl: string;
+      parsedRepo: { owner: string; repo: string } | null;
+    }>;
+  };
+
+  // Global env channels
+  "global-env:get": {
+    args: [];
+    result: Record<string, string>;
+  };
+  "global-env:set": {
+    args: [payload: { variables: Record<string, string> }];
+    result: void;
+  };
+
+  // Global recipe channels
+  "global:get-recipes": {
+    args: [];
+    result: TerminalRecipe[];
+  };
+  "global:add-recipe": {
+    args: [payload: { recipe: TerminalRecipe }];
+    result: void;
+  };
+  "global:update-recipe": {
+    args: [
+      payload: {
+        recipeId: string;
+        updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
+      },
+    ];
+    result: void;
+  };
+  "global:delete-recipe": {
+    args: [payload: { recipeId: string }];
+    result: void;
+  };
+
+  // Help channels
+  "help:get-folder-path": {
+    args: [];
+    result: string;
+  };
+  "help:mark-terminal": {
+    args: [terminalId: string];
+    result: void;
+  };
+  "help:unmark-terminal": {
+    args: [terminalId: string];
+    result: void;
+  };
+
+  // Project clone channels
+  "project:clone-repo": {
+    args: [options: CloneRepoOptions];
+    result: CloneRepoResult;
+  };
+  "project:clone-cancel": {
+    args: [];
+    result: void;
+  };
+
+  // Bulk project stats
+  "project:get-bulk-stats": {
+    args: [projectIds: string[]];
+    result: BulkProjectStats;
+  };
+
+  // Draft inputs
+  "project:get-draft-inputs": {
+    args: [projectId: string];
+    result: Record<string, string>;
+  };
+  "project:set-draft-inputs": {
+    args: [payload: { projectId: string; draftInputs: Record<string, string> }];
+    result: void;
+  };
+
+  // In-repo recipe channels
+  "project:get-inrepo-recipes": {
+    args: [projectId: string];
+    result: TerminalRecipe[];
+  };
+  "project:sync-inrepo-recipes": {
+    args: [payload: { projectId: string; recipes: TerminalRecipe[] }];
+    result: void;
+  };
+  "project:update-inrepo-recipe": {
+    args: [payload: { projectId: string; recipe: TerminalRecipe; previousName?: string }];
+    result: void;
+  };
+  "project:delete-inrepo-recipe": {
+    args: [payload: { projectId: string; recipeName: string }];
+    result: void;
+  };
+
+  // Recipe import/export
+  "recipe:export-file": {
+    args: [payload: { name: string; json: string }];
+    result: boolean;
+  };
+  "recipe:import-file": {
+    args: [];
+    result: string | null;
+  };
+
+  // Recovery channels
+  "recovery:reload-app": {
+    args: [];
+    result: void;
+  };
+  "recovery:reset-and-reload": {
+    args: [];
+    result: void;
+  };
+
+  // System prerequisite check channels
+  "system:check-tool": {
+    args: [spec: PrerequisiteSpec];
+    result: PrerequisiteCheckResult;
+  };
+  "system:health-check-specs": {
+    args: [agentIds?: string[]];
+    result: PrerequisiteSpec[];
+  };
+
+  // Additional terminal config channels
+  "terminal-config:set-resource-monitoring": {
+    args: [enabled: boolean];
+    result: void;
+  };
+  "terminal-config:set-memory-leak-detection": {
+    args: [enabled: boolean];
+    result: void;
+  };
+  "terminal-config:set-memory-leak-auto-restart": {
+    args: [thresholdMb: number];
+    result: void;
+  };
+  "terminal-config:set-cached-project-views": {
+    args: [cachedProjectViews: number];
+    result: void;
+  };
+  "terminal-config:set-recent-scheme-ids": {
+    args: [ids: unknown];
+    result: void;
+  };
+
+  // Additional terminal snapshot channels
+  "terminal:get-all": {
+    args: [];
+    result: BackendTerminalInfo[];
+  };
+  "terminal:get-available": {
+    args: [];
+    result: BackendTerminalInfo[];
+  };
+  "terminal:get-by-state": {
+    args: [state: string];
+    result: BackendTerminalInfo[];
+  };
+  "terminal:graceful-kill": {
+    args: [id: string];
+    result: string | null;
+  };
+
+  // Webview lifecycle / dialog / OAuth channels
+  "webview:set-lifecycle-state": {
+    args: [webContentsId: number, frozen: boolean];
+    result: void;
+  };
+  "webview:register-panel": {
+    args: [payload: { webContentsId: number; panelId: string }];
+    result: void;
+  };
+  "webview:dialog-response": {
+    args: [payload: { dialogId: string; confirmed: boolean; response?: string }];
+    result: void;
+  };
+  "webview:oauth-loopback": {
+    args: [
+      authUrl: string,
+      panelId: string,
+      webContentsId: number,
+      sessionStorageSnapshot?: Array<[string, string]>,
+    ];
+    result: { success: boolean; error?: string } | null;
+  };
+
+  // Additional worktree channels
+  "worktree:fetch-pr-branch": {
+    args: [payload: { rootPath: string; prNumber: number; headRefName: string }];
+    result: void;
   };
 }
 

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -152,9 +152,6 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
-  DemoEncodePayload,
-  DemoEncodeProgressEvent,
-  DemoEncodeResult,
   DemoAnnotatePayload,
   DemoAnnotateResult,
   DemoDismissAnnotationPayload,
@@ -1830,10 +1827,6 @@ export interface IpcInvokeMap {
   "demo:get-capture-status": {
     args: [];
     result: DemoCaptureStatus;
-  };
-  "demo:encode": {
-    args: [payload: DemoEncodePayload];
-    result: DemoEncodeResult;
   };
   "demo:scroll": {
     args: [payload: DemoScrollPayload];

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1982,7 +1982,7 @@ export interface IpcInvokeMap {
   // Help channels
   "help:get-folder-path": {
     args: [];
-    result: string;
+    result: string | null;
   };
   "help:mark-terminal": {
     args: [terminalId: string];


### PR DESCRIPTION
## Summary

- Migrated 378 raw `ipcMain.handle(...)` calls across 56 handler files in `electron/ipc/handlers/` plus 3 in `electron/ipc/errorHandlers.ts` to `typedHandle`/`typedHandleWithContext` from `electron/ipc/utils.ts`. Compile-time IPC type safety via `IpcInvokeMap` is now enforced across the board, and the existing perf-tracing infrastructure activates automatically.
- Filled 62 missing `IpcInvokeMap` entries in `shared/types/ipc/maps.ts` covering agent-session, app-agent, commands, demo, github, global, help, project clone/bulk-stats/draft-inputs/in-repo recipes, recipe import/export, recovery, system tool checks, terminal-config, terminal snapshots, webview, and worktree channels.
- `plugin:invoke` intentionally stays on raw `ipcMain.handle` (variadic `...args` plus `senderFrame.url` trust check are incompatible with `IpcInvokeMap` typing). Documented inline, and a new regression guard at `electron/ipc/__tests__/ipcHandleCoverage.test.ts` greps handler sources for `ipcMain.handle(CHANNELS.` and allowlists only `PLUGIN_INVOKE`.

Closes #5223.

## Changes

- `electron/ipc/utils.ts` — `typedHandle`/`typedHandleWithContext` gained a sync fast-path (when perf-capture is off) so synchronous handlers stay synchronous; preserves existing test expectations and runtime behaviour.
- `electron/ipc/handlers/projectCrud.ts` — `handleProjectGetCurrent` preserves its 3-level lookup chain (windowRegistry → PVM → deps.projectViewManager → currentProject); only event accessors swapped for `ctx` equivalents. `ctx.projectId` intentionally not used to avoid silently changing multi-window behaviour.
- `electron/ipc/handlers/voiceInput.ts` — `handleStart` preserves `event.sender.once("destroyed", ...)` semantics via `ctx.event.sender`; cleanup retains `ipcMain.on(VOICE_INPUT_AUDIO_CHUNK, ...)` removal and service singleton teardown.
- 17 fire-and-forget `ipcMain.on` listeners (perf, notifications, terminal input/resize/send-key, etc.) intentionally untouched — no `typedHandle` equivalent.

## Testing

- `npm run typecheck` (renderer + electron + preload) passes.
- `npm run check` passes (typecheck + lint:ratchet at 401 baseline, no regression + prettier clean).
- Full vitest suite passes: 732 test files, 10901 tests, 1 skipped, 2 todo.
- New regression test `electron/ipc/__tests__/ipcHandleCoverage.test.ts` asserts no raw `ipcMain.handle(CHANNELS.)` calls remain except for the `PLUGIN_INVOKE` allowlist.