### PR TITLE
fix(notes): prevent blank editor when reopening saved note in palette

### DIFF
--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -553,6 +553,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
                           {!editor.hasConflict && <MarkdownToolbar editorViewRef={editorViewRef} />}
                           <div className="flex-1 overflow-hidden text-[13px] [&_.cm-editor]:h-full [&_.cm-scroller]:p-4 [&_.cm-placeholder]:text-daintree-text/30 [&_.cm-placeholder]:italic">
                             <CodeMirror
+                              key={selectedNote?.id ?? "empty"}
                               value={editor.noteContent}
                               height="100%"
                               theme={daintreeTheme}

--- a/src/hooks/__tests__/useNoteEditor.test.ts
+++ b/src/hooks/__tests__/useNoteEditor.test.ts
@@ -373,6 +373,70 @@ describe("useNoteEditor", () => {
     expect(notesClient.write).not.toHaveBeenCalled();
   });
 
+  it("resets content during loading window when switching notes", async () => {
+    const noteA = makeNote({ id: "a", path: "/notes/a.md" });
+    const noteB = makeNote({ id: "b", path: "/notes/b.md" });
+
+    vi.mocked(notesClient.read).mockResolvedValueOnce(
+      makeContent({
+        metadata: { id: "a", title: "A", scope: "project", createdAt: 1000 },
+        content: "A body",
+        path: "/notes/a.md",
+        lastModified: 5000,
+      })
+    );
+
+    let resolveB: (v: NoteContent) => void = () => {};
+    vi.mocked(notesClient.read).mockImplementationOnce(
+      () =>
+        new Promise<NoteContent>((r) => {
+          resolveB = r;
+        })
+    );
+
+    const { result, rerender } = renderHook(
+      ({ selectedNote }: { selectedNote: NoteListItem | null }) =>
+        useNoteEditor({
+          selectedNote,
+          refresh: vi.fn(),
+          setLastSelectedNoteId: vi.fn(),
+        }),
+      { initialProps: { selectedNote: noteA } }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.noteContent).toBe("A body");
+    expect(result.current.noteLastModified).toBe(5000);
+
+    // Switch to note B — the async read for B is pending
+    rerender({ selectedNote: noteB });
+
+    // During the loading window, state must not expose stale note A content
+    expect(result.current.noteContent).toBe("");
+    expect(result.current.noteMetadata).toBeNull();
+    expect(result.current.noteLastModified).toBeNull();
+    expect(result.current.isLoadingContent).toBe(true);
+
+    await act(async () => {
+      resolveB(
+        makeContent({
+          metadata: { id: "b", title: "B", scope: "project", createdAt: 1500 },
+          content: "B body",
+          path: "/notes/b.md",
+          lastModified: 8000,
+        })
+      );
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.noteContent).toBe("B body");
+    expect(result.current.noteLastModified).toBe(8000);
+    expect(result.current.isLoadingContent).toBe(false);
+  });
+
   it("cancels pending save when adding a tag", async () => {
     const { result } = renderHook(() => useNoteEditor(defaultProps()));
 

--- a/src/hooks/useNoteEditor.ts
+++ b/src/hooks/useNoteEditor.ts
@@ -91,6 +91,9 @@ export function useNoteEditor({
       return;
     }
 
+    setNoteContent("");
+    setNoteMetadata(null);
+    setNoteLastModified(null);
     setIsLoadingContent(true);
     setHasConflict(false);
 


### PR DESCRIPTION
## Summary

- After saving a note, closing, and reopening it in the Notes palette modal, the CodeMirror editor pane showed blank while the preview rendered correctly. Root cause was a race between synchronous `setSelectedNote` and async `notesClient.read` — the editor mounted before content resolved, and `@uiw/react-codemirror`'s reactive value sync can silently fail in React 19 concurrent mode on the zero-to-content transition.
- Added `key={selectedNote?.id ?? "empty"}` to the `<CodeMirror>` component in `NotesPalette.tsx` so it remounts per note, guaranteeing a fresh editor instance with the correct initial value.
- Synchronously reset `noteContent`, `noteMetadata`, and `noteLastModified` at the top of the load effect in `useNoteEditor.ts` before the async read, preventing stale content from leaking through the loading window.

Resolves #5358

## Changes

- `src/components/Notes/NotesPalette.tsx` — `key` prop on `<CodeMirror>` forces remount per note
- `src/hooks/useNoteEditor.ts` — synchronous state reset before async note read
- `src/hooks/__tests__/useNoteEditor.test.ts` — regression test asserting content/metadata/lastModified are cleared during the loading window when switching notes (uses a deferred promise for note B's read)

## Testing

17/17 tests pass in `useNoteEditor.test.ts`. `npm run check` clean (typecheck, lint, format, channel drift, no debug artifacts).