### PR TITLE
feat(settings): hover-preview in app theme picker

### DIFF
--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -17,6 +18,7 @@ import { applyAccentOverrideToScheme, resolveAppTheme } from "@shared/theme";
 import { PaletteStrip } from "@/components/ui/PaletteStrip";
 import { APP_THEME_PREVIEW_KEYS, getAppThemeWarnings } from "@shared/theme";
 import type { AppColorScheme, AppThemeValidationWarning } from "@shared/types/appTheme";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 
 function shuffleArray<T>(arr: T[]): T[] {
@@ -78,11 +80,17 @@ function ThemeRow({
   scheme,
   isSelected,
   onSelect,
+  onPreviewEnter,
+  onPreviewLeave,
+  onFocusPreview,
   warnings,
 }: {
   scheme: AppColorScheme;
   isSelected: boolean;
   onSelect: (id: string, origin: { x: number; y: number }) => void;
+  onPreviewEnter: (id: string) => void;
+  onPreviewLeave: () => void;
+  onFocusPreview: (id: string) => void;
   warnings: AppThemeValidationWarning[];
 }) {
   return (
@@ -91,6 +99,10 @@ function ThemeRow({
       role="option"
       aria-selected={isSelected}
       onClick={(e) => onSelect(scheme.id, { x: e.clientX, y: e.clientY })}
+      onPointerEnter={() => onPreviewEnter(scheme.id)}
+      onPointerLeave={onPreviewLeave}
+      onFocus={() => onFocusPreview(scheme.id)}
+      onBlur={onPreviewLeave}
       className={cn(
         "w-full flex items-center gap-2.5 px-2.5 py-2 text-left transition-colors",
         isSelected ? "bg-daintree-accent/10" : "hover:bg-surface-hover"
@@ -148,9 +160,12 @@ export function AppThemePicker() {
   const setPreferredLightSchemeId = useAppThemeStore((s) => s.setPreferredLightSchemeId);
   const accentColorOverride = useAppThemeStore((s) => s.accentColorOverride);
   const setAccentColorOverride = useAppThemeStore((s) => s.setAccentColorOverride);
+  const previewSchemeId = useAppThemeStore((s) => s.previewSchemeId);
+  const setPreviewSchemeId = useAppThemeStore((s) => s.setPreviewSchemeId);
   const [importWarnings, setImportWarnings] = useState<AppThemeValidationWarning[]>([]);
   const [importMessage, setImportMessage] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [previewAnnouncement, setPreviewAnnouncement] = useState("");
   const [typeFilter, setTypeFilter] = useState<"dark" | "light">(() =>
     (selectedSchemeId &&
       [...BUILT_IN_APP_SCHEMES, ...customSchemes].find((s) => s.id === selectedSchemeId)?.type) ===
@@ -160,6 +175,8 @@ export function AppThemePicker() {
   );
 
   const shuffleQueueRef = useRef<string[]>([]);
+  const previewDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const revertRafRef = useRef<number | null>(null);
 
   const allSchemes = useMemo(() => [...BUILT_IN_APP_SCHEMES, ...customSchemes], [customSchemes]);
   const darkSchemes = useMemo(() => allSchemes.filter((s) => s.type !== "light"), [allSchemes]);
@@ -167,6 +184,11 @@ export function AppThemePicker() {
   const selectedScheme = useMemo(
     () => allSchemes.find((s) => s.id === selectedSchemeId) ?? allSchemes[0]!,
     [allSchemes, selectedSchemeId]
+  );
+  const effectiveSchemeId = previewSchemeId ?? selectedSchemeId;
+  const effectiveScheme = useMemo(
+    () => allSchemes.find((s) => s.id === effectiveSchemeId) ?? selectedScheme,
+    [allSchemes, effectiveSchemeId, selectedScheme]
   );
 
   const lowerQuery = query.toLowerCase();
@@ -220,6 +242,103 @@ export function AppThemePicker() {
     });
   }, [setAccentColorOverride]);
 
+  const handlePreviewEnter = useCallback(
+    (id: string) => {
+      if (revertRafRef.current !== null) {
+        cancelAnimationFrame(revertRafRef.current);
+        revertRafRef.current = null;
+      }
+      if (previewDebounceRef.current !== null) {
+        clearTimeout(previewDebounceRef.current);
+      }
+      previewDebounceRef.current = setTimeout(() => {
+        previewDebounceRef.current = null;
+        const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
+        setPreviewSchemeId(id);
+        injectSchemeToDOM(scheme);
+        setPreviewAnnouncement(`Previewing: ${scheme.name}`);
+      }, 300);
+    },
+    [setPreviewSchemeId]
+  );
+
+  const handleFocusPreview = useCallback(
+    (id: string) => {
+      if (previewDebounceRef.current !== null) {
+        clearTimeout(previewDebounceRef.current);
+        previewDebounceRef.current = null;
+      }
+      if (revertRafRef.current !== null) {
+        cancelAnimationFrame(revertRafRef.current);
+        revertRafRef.current = null;
+      }
+      const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
+      setPreviewSchemeId(id);
+      injectSchemeToDOM(scheme);
+      setPreviewAnnouncement(`Previewing: ${scheme.name}`);
+    },
+    [setPreviewSchemeId]
+  );
+
+  const handlePreviewLeave = useCallback(() => {
+    if (previewDebounceRef.current !== null) {
+      clearTimeout(previewDebounceRef.current);
+      previewDebounceRef.current = null;
+    }
+    if (revertRafRef.current !== null) {
+      cancelAnimationFrame(revertRafRef.current);
+    }
+    revertRafRef.current = requestAnimationFrame(() => {
+      revertRafRef.current = null;
+      const state = useAppThemeStore.getState();
+      if (state.previewSchemeId !== null) {
+        const committed = resolveAppTheme(state.selectedSchemeId, state.customSchemes);
+        setPreviewSchemeId(null);
+        injectSchemeToDOM(committed);
+      }
+      setPreviewAnnouncement("");
+    });
+  }, [setPreviewSchemeId]);
+
+  const clearPreview = useCallback(() => {
+    if (previewDebounceRef.current !== null) {
+      clearTimeout(previewDebounceRef.current);
+      previewDebounceRef.current = null;
+    }
+    if (revertRafRef.current !== null) {
+      cancelAnimationFrame(revertRafRef.current);
+      revertRafRef.current = null;
+    }
+    const state = useAppThemeStore.getState();
+    if (state.previewSchemeId !== null) {
+      const committed = resolveAppTheme(state.selectedSchemeId, state.customSchemes);
+      setPreviewSchemeId(null);
+      injectSchemeToDOM(committed);
+    }
+    setPreviewAnnouncement("");
+  }, [setPreviewSchemeId]);
+
+  useEscapeStack(previewSchemeId !== null, clearPreview);
+
+  useEffect(() => {
+    return () => {
+      if (previewDebounceRef.current !== null) {
+        clearTimeout(previewDebounceRef.current);
+        previewDebounceRef.current = null;
+      }
+      if (revertRafRef.current !== null) {
+        cancelAnimationFrame(revertRafRef.current);
+        revertRafRef.current = null;
+      }
+      const state = useAppThemeStore.getState();
+      if (state.previewSchemeId !== null) {
+        const committed = resolveAppTheme(state.selectedSchemeId, state.customSchemes);
+        setPreviewSchemeId(null);
+        injectSchemeToDOM(committed);
+      }
+    };
+  }, [setPreviewSchemeId]);
+
   const handleSelect = useCallback(
     async (id: string, origin?: { x: number; y: number }) => {
       if (followSystem) {
@@ -227,8 +346,23 @@ export function AppThemePicker() {
         appThemeClient.setFollowSystem(false).catch(console.error);
       }
 
-      const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
+      // Cancel any in-flight preview work and clear preview state BEFORE the
+      // View Transition fires. Otherwise `runThemeReveal`'s async callback
+      // would still see `previewSchemeId` in the store and `injectSchemeToDOM`
+      // could be undone on the next preview cycle (see PR #5087).
+      if (previewDebounceRef.current !== null) {
+        clearTimeout(previewDebounceRef.current);
+        previewDebounceRef.current = null;
+      }
+      if (revertRafRef.current !== null) {
+        cancelAnimationFrame(revertRafRef.current);
+        revertRafRef.current = null;
+      }
+      setPreviewSchemeId(null);
+      setPreviewAnnouncement("");
+
       commitSchemeSelection(id);
+      const scheme = resolveAppTheme(id, useAppThemeStore.getState().customSchemes);
       setTypeFilter(scheme.type === "light" ? "light" : "dark");
       runThemeReveal(origin ?? null, () => injectSchemeToDOM(scheme));
 
@@ -239,7 +373,7 @@ export function AppThemePicker() {
         console.error("Failed to persist app theme:", error);
       }
     },
-    [commitSchemeSelection, followSystem, setFollowSystem]
+    [commitSchemeSelection, followSystem, setFollowSystem, setPreviewSchemeId]
   );
 
   const handleToggleFollowSystem = useCallback(async () => {
@@ -396,29 +530,29 @@ export function AppThemePicker() {
 
       <div className="flex flex-col rounded-[var(--radius-md)] border border-daintree-border overflow-hidden">
         <div className="relative h-[200px] shrink-0 overflow-hidden">
-          {selectedScheme.heroImage ? (
+          {effectiveScheme.heroImage ? (
             <img
-              src={selectedScheme.heroImage}
-              alt={selectedScheme.name}
+              src={effectiveScheme.heroImage}
+              alt={effectiveScheme.name}
               className="w-full h-full object-cover"
             />
           ) : (
             <div
               className="w-full h-full flex items-center justify-center"
               style={{
-                backgroundColor: selectedScheme.tokens[APP_THEME_PREVIEW_KEYS.background],
+                backgroundColor: effectiveScheme.tokens[APP_THEME_PREVIEW_KEYS.background],
               }}
             >
-              <PaletteStrip scheme={selectedScheme} />
+              <PaletteStrip scheme={effectiveScheme} />
             </div>
           )}
           <div className="absolute bottom-0 inset-x-0 bg-black/40 backdrop-blur-sm px-3 py-1.5 flex items-center justify-between">
             <span className="text-sm font-medium text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
-              {selectedScheme.name}
+              {effectiveScheme.name}
             </span>
-            {selectedScheme.location && (
+            {effectiveScheme.location && (
               <span className="text-[11px] text-white/75 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]">
-                {selectedScheme.location}
+                {effectiveScheme.location}
               </span>
             )}
           </div>
@@ -433,7 +567,14 @@ export function AppThemePicker() {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
+                  // preventDefault is required in addition to stopPropagation
+                  // because `useGlobalEscapeDispatcher` listens on the native
+                  // `window` keydown and only checks `defaultPrevented` —
+                  // React's synthetic `stopPropagation` does not block it.
+                  // Without this, pressing Escape while clearing search text
+                  // would simultaneously clear an active hover preview.
                   e.stopPropagation();
+                  e.preventDefault();
                   setQuery("");
                 }
               }}
@@ -482,10 +623,17 @@ export function AppThemePicker() {
                 scheme={scheme}
                 isSelected={scheme.id === selectedSchemeId}
                 onSelect={handleSelect}
+                onPreviewEnter={handlePreviewEnter}
+                onPreviewLeave={handlePreviewLeave}
+                onFocusPreview={handleFocusPreview}
                 warnings={warningsByScheme.get(scheme.id) ?? []}
               />
             ))
           )}
+        </div>
+
+        <div aria-live="polite" aria-atomic="true" className="sr-only">
+          {previewAnnouncement}
         </div>
       </div>
 

--- a/src/components/Settings/AppThemePicker.tsx
+++ b/src/components/Settings/AppThemePicker.tsx
@@ -566,13 +566,15 @@ export function AppThemePicker() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Escape") {
+                if (e.key === "Escape" && query !== "") {
+                  // Only intercept Escape when there's a query to clear. The
                   // preventDefault is required in addition to stopPropagation
                   // because `useGlobalEscapeDispatcher` listens on the native
                   // `window` keydown and only checks `defaultPrevented` —
                   // React's synthetic `stopPropagation` does not block it.
-                  // Without this, pressing Escape while clearing search text
-                  // would simultaneously clear an active hover preview.
+                  // Letting Escape bubble when the query is empty lets the
+                  // global dispatcher clear an active preview or close the
+                  // modal instead of trapping focus.
                   e.stopPropagation();
                   e.preventDefault();
                   setQuery("");

--- a/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
@@ -1,0 +1,286 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { BUILT_IN_APP_SCHEMES, DEFAULT_APP_SCHEME_ID } from "@/config/appColorSchemes";
+import { useAppThemeStore } from "@/store/appThemeStore";
+import { _resetForTests } from "@/lib/escapeStack";
+import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: {
+    setColorScheme: vi.fn().mockResolvedValue(undefined),
+    setFollowSystem: vi.fn().mockResolvedValue(undefined),
+    setCustomSchemes: vi.fn().mockResolvedValue(undefined),
+    setRecentSchemeIds: vi.fn().mockResolvedValue(undefined),
+    setAccentColorOverride: vi.fn().mockResolvedValue(undefined),
+    importTheme: vi.fn().mockResolvedValue({ ok: false, errors: ["Import cancelled"] }),
+    exportTheme: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { AppThemePicker } from "../AppThemePicker";
+
+let pendingRaf: Array<{ handle: number; cb: FrameRequestCallback }> = [];
+let nextHandle = 0;
+const flushRaf = () => {
+  act(() => {
+    const pending = pendingRaf;
+    pendingRaf = [];
+    for (const entry of pending) entry.cb(0);
+  });
+};
+
+function Harness() {
+  useGlobalEscapeDispatcher();
+  return <AppThemePicker />;
+}
+
+function otherDarkScheme() {
+  return BUILT_IN_APP_SCHEMES.find((s) => s.type !== "light" && s.id !== DEFAULT_APP_SCHEME_ID)!;
+}
+
+function findRowByName(name: string) {
+  return screen
+    .getAllByRole("option")
+    .find((o) => o.textContent?.toLowerCase().includes(name.toLowerCase()))!;
+}
+
+describe("AppThemePicker hover preview", () => {
+  beforeEach(() => {
+    _resetForTests();
+    vi.useFakeTimers();
+    pendingRaf = [];
+    nextHandle = 0;
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      nextHandle += 1;
+      pendingRaf.push({ handle: nextHandle, cb });
+      return nextHandle;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (handle: number) => {
+      pendingRaf = pendingRaf.filter((entry) => entry.handle !== handle);
+    });
+
+    useAppThemeStore.setState({
+      selectedSchemeId: DEFAULT_APP_SCHEME_ID,
+      customSchemes: [],
+      colorVisionMode: "default",
+      followSystem: false,
+      preferredDarkSchemeId: "daintree",
+      preferredLightSchemeId: "bondi",
+      recentSchemeIds: [],
+      accentColorOverride: null,
+      previewSchemeId: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    _resetForTests();
+    useAppThemeStore.setState({ previewSchemeId: null });
+  });
+
+  it("does not preview before the 300ms debounce fires", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("sets previewSchemeId after 300ms debounce on pointer enter", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+  });
+
+  it("cancels the debounce when pointer leaves before 300ms", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    const row = findRowByName(target.name);
+    fireEvent.pointerEnter(row);
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    fireEvent.pointerLeave(row);
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    flushRaf();
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("clears previewSchemeId on pointer leave after rAF flush", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    const row = findRowByName(target.name);
+    fireEvent.pointerEnter(row);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    fireEvent.pointerLeave(row);
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+    flushRaf();
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("keyboard focus previews immediately without debounce", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    const row = findRowByName(target.name);
+    fireEvent.focus(row);
+
+    // No timer advance — focus preview should be synchronous.
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    fireEvent.blur(row);
+    flushRaf();
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("clears preview when the picker unmounts mid-preview", () => {
+    const target = otherDarkScheme();
+    const { unmount } = render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    unmount();
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("Escape clears an active preview", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("Escape in the search input only clears the query, not the preview", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    // Establish an active preview first.
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    // Type in the search input, then press Escape inside it.
+    const searchInput = screen.getByLabelText("Filter themes") as HTMLInputElement;
+    fireEvent.change(searchInput, { target: { value: "dai" } });
+    expect(searchInput.value).toBe("dai");
+
+    fireEvent.keyDown(searchInput, { key: "Escape" });
+
+    // Query cleared.
+    expect(searchInput.value).toBe("");
+    // Preview must still be active.
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+  });
+
+  it("click commits the hovered theme and clears the preview before the view transition", () => {
+    const target = otherDarkScheme();
+    // Capture the value of previewSchemeId at the moment startViewTransition's
+    // callback fires — it must be null by then (per PR #5087 ordering rule).
+    const callbackObservations: Array<string | null> = [];
+    const startViewTransition = vi.fn((cb: () => void) => {
+      callbackObservations.push(useAppThemeStore.getState().previewSchemeId);
+      cb();
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    });
+    (
+      document as unknown as { startViewTransition?: typeof startViewTransition }
+    ).startViewTransition = startViewTransition;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+
+    render(<Harness />);
+    const row = findRowByName(target.name);
+    fireEvent.pointerEnter(row);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    fireEvent.click(row);
+
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe(target.id);
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+    expect(callbackObservations).toEqual([null]);
+
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+  });
+
+  it("aria-live announces the previewed theme on enter and clears on leave", () => {
+    const target = otherDarkScheme();
+    const { container } = render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent).toBe(`Previewing: ${target.name}`);
+
+    fireEvent.pointerLeave(findRowByName(target.name));
+    flushRaf();
+    expect(live?.textContent).toBe("");
+  });
+
+  it("hero panel image reflects the previewed theme during preview", () => {
+    const target = otherDarkScheme();
+    if (!target.heroImage) return; // guard against data drift
+    const { container } = render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // The hero image sits in a container sized 200px tall; select by class
+    // sequence used in the component to narrow to the hero block.
+    const heroImg = container.querySelector<HTMLImageElement>(
+      `.h-\\[200px\\] img[src='${target.heroImage}']`
+    );
+    expect(heroImg).not.toBeNull();
+  });
+});

--- a/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.preview.test.tsx
@@ -210,6 +210,31 @@ describe("AppThemePicker hover preview", () => {
     expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
   });
 
+  it("Escape in the search input with an empty query clears the preview", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    const searchInput = screen.getByLabelText("Filter themes") as HTMLInputElement;
+    expect(searchInput.value).toBe("");
+
+    // Fire the synthetic keyDown AND dispatch the native event on window in
+    // the same tick — the search input should NOT preventDefault (because
+    // the query is already empty), so the global dispatcher runs and clears
+    // the preview.
+    act(() => {
+      fireEvent.keyDown(searchInput, { key: "Escape" });
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
   it("click commits the hovered theme and clears the preview before the view transition", () => {
     const target = otherDarkScheme();
     // Capture the value of previewSchemeId at the moment startViewTransition's
@@ -264,6 +289,139 @@ describe("AppThemePicker hover preview", () => {
     fireEvent.pointerLeave(findRowByName(target.name));
     flushRaf();
     expect(live?.textContent).toBe("");
+  });
+
+  it("rapid traversal across rows previews only the final row", () => {
+    const a = BUILT_IN_APP_SCHEMES.find(
+      (s) => s.type !== "light" && s.id !== DEFAULT_APP_SCHEME_ID
+    )!;
+    const b = BUILT_IN_APP_SCHEMES.find(
+      (s) => s.type !== "light" && s.id !== DEFAULT_APP_SCHEME_ID && s.id !== a.id
+    )!;
+    render(<Harness />);
+
+    const rowA = findRowByName(a.name);
+    const rowB = findRowByName(b.name);
+
+    fireEvent.pointerEnter(rowA);
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    // Switch to B before A's debounce fires.
+    fireEvent.pointerEnter(rowB);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(b.id);
+  });
+
+  it("leave-then-re-enter cancels the pending rAF revert", () => {
+    const a = BUILT_IN_APP_SCHEMES.find(
+      (s) => s.type !== "light" && s.id !== DEFAULT_APP_SCHEME_ID
+    )!;
+    const b = BUILT_IN_APP_SCHEMES.find(
+      (s) => s.type !== "light" && s.id !== DEFAULT_APP_SCHEME_ID && s.id !== a.id
+    )!;
+    render(<Harness />);
+
+    // Establish preview on A.
+    fireEvent.pointerEnter(findRowByName(a.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(a.id);
+
+    // Leave A — this schedules a rAF revert.
+    fireEvent.pointerLeave(findRowByName(a.name));
+    // Enter B before rAF flushes — should cancel the revert and debounce B.
+    fireEvent.pointerEnter(findRowByName(b.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    flushRaf(); // any stale rAF must be a no-op now
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(b.id);
+  });
+
+  it("setAccentColorOverride during an active preview targets the previewed scheme", () => {
+    const target = otherDarkScheme();
+    render(<Harness />);
+
+    fireEvent.pointerEnter(findRowByName(target.name));
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(useAppThemeStore.getState().previewSchemeId).toBe(target.id);
+
+    act(() => {
+      useAppThemeStore.getState().setAccentColorOverride("#ff00aa");
+    });
+
+    // After the override, the previewed scheme must still be the one on :root:
+    // the accent-primary CSS var should reflect the override, and non-accent
+    // tokens should reflect the PREVIEWED scheme (not the committed one).
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      "#ff00aa"
+    );
+    expect(document.documentElement.style.getPropertyValue("--theme-surface-canvas")).toBe(
+      target.tokens["surface-canvas"]
+    );
+  });
+
+  it("click commit calls setPreviewSchemeId(null) before startViewTransition", () => {
+    const target = otherDarkScheme();
+    const callOrder: string[] = [];
+
+    const originalSet = useAppThemeStore.getState().setPreviewSchemeId;
+    const originalCommit = useAppThemeStore.getState().commitSchemeSelection;
+    useAppThemeStore.setState({
+      setPreviewSchemeId: (id: string | null) => {
+        if (id === null && callOrder[callOrder.length - 1] !== "clearPreview") {
+          callOrder.push("clearPreview");
+        }
+        originalSet(id);
+      },
+      commitSchemeSelection: (id: string) => {
+        callOrder.push("commit");
+        originalCommit(id);
+      },
+    });
+
+    const startViewTransition = vi.fn((cb: () => void) => {
+      callOrder.push("startViewTransition");
+      cb();
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
+    });
+    (
+      document as unknown as { startViewTransition?: typeof startViewTransition }
+    ).startViewTransition = startViewTransition;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: () => ({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    });
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+
+    render(<Harness />);
+    const row = findRowByName(target.name);
+    fireEvent.pointerEnter(row);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    fireEvent.click(row);
+
+    // Expect strict ordering: preview cleared → commit → view transition.
+    const clearIdx = callOrder.indexOf("clearPreview");
+    const commitIdx = callOrder.indexOf("commit");
+    const transitionIdx = callOrder.indexOf("startViewTransition");
+    expect(clearIdx).toBeGreaterThanOrEqual(0);
+    expect(commitIdx).toBeGreaterThan(clearIdx);
+    expect(transitionIdx).toBeGreaterThan(commitIdx);
+
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
   });
 
   it("hero panel image reflects the previewed theme during preview", () => {

--- a/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
+++ b/src/components/Settings/__tests__/AppThemePicker.shuffle.test.tsx
@@ -97,6 +97,8 @@ describe("AppThemePicker shuffle button", () => {
       addCustomScheme: vi.fn(),
       accentColorOverride: null,
       setAccentColorOverride: vi.fn(),
+      previewSchemeId: null,
+      setPreviewSchemeId: vi.fn(),
     });
   });
 
@@ -186,6 +188,8 @@ describe("AppThemePicker image loading attributes", () => {
       addCustomScheme: vi.fn(),
       accentColorOverride: null,
       setAccentColorOverride: vi.fn(),
+      previewSchemeId: null,
+      setPreviewSchemeId: vi.fn(),
     });
   });
 

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -14,6 +14,7 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
       preferredLightSchemeId: "bondi",
       recentSchemeIds: [],
       accentColorOverride: null,
+      previewSchemeId: null,
     });
   });
 
@@ -142,6 +143,50 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
     expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
       "#abcdef"
     );
+  });
+
+  it("setPreviewSchemeId does not mutate selectedSchemeId or recentSchemeIds", () => {
+    useAppThemeStore.getState().setSelectedSchemeId("daintree");
+    const recentBefore = useAppThemeStore.getState().recentSchemeIds;
+
+    useAppThemeStore.getState().setPreviewSchemeId("bondi");
+    expect(useAppThemeStore.getState().previewSchemeId).toBe("bondi");
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe("daintree");
+    expect(useAppThemeStore.getState().recentSchemeIds).toEqual(recentBefore);
+
+    useAppThemeStore.getState().setPreviewSchemeId(null);
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("removeCustomScheme clears previewSchemeId when it points at the removed id", () => {
+    const customScheme = {
+      id: "custom-preview-target",
+      name: "CustomPreview",
+      type: "dark" as const,
+      builtin: false,
+      tokens: {} as never,
+    };
+    useAppThemeStore.getState().addCustomScheme(customScheme);
+    useAppThemeStore.getState().setPreviewSchemeId("custom-preview-target");
+    expect(useAppThemeStore.getState().previewSchemeId).toBe("custom-preview-target");
+
+    useAppThemeStore.getState().removeCustomScheme("custom-preview-target");
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+  });
+
+  it("removeCustomScheme leaves previewSchemeId alone when unrelated id is removed", () => {
+    const customScheme = {
+      id: "some-custom",
+      name: "Some Custom",
+      type: "dark" as const,
+      builtin: false,
+      tokens: {} as never,
+    };
+    useAppThemeStore.getState().addCustomScheme(customScheme);
+    useAppThemeStore.getState().setPreviewSchemeId("daintree");
+
+    useAppThemeStore.getState().removeCustomScheme("some-custom");
+    expect(useAppThemeStore.getState().previewSchemeId).toBe("daintree");
   });
 
   it("removeCustomScheme strips the removed id from recentSchemeIds", () => {

--- a/src/store/__tests__/appThemeStore.test.ts
+++ b/src/store/__tests__/appThemeStore.test.ts
@@ -174,6 +174,40 @@ describe("appThemeStore.recentSchemeIds LRU", () => {
     expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
   });
 
+  it("removeCustomScheme reverts the DOM to the committed scheme when removing an actively previewed scheme", () => {
+    // Commit to daintree so we have a known baseline for the revert target.
+    useAppThemeStore.getState().setSelectedSchemeIdSilent("daintree");
+    const daintree = BUILT_IN_APP_SCHEMES.find((s) => s.id === "daintree")!;
+
+    const customScheme = {
+      id: "custom-preview-target",
+      name: "CustomPreview",
+      type: "dark" as const,
+      builtin: false,
+      tokens: {
+        ...daintree.tokens,
+        "accent-primary": "#abcdef",
+      },
+    } as unknown as (typeof BUILT_IN_APP_SCHEMES)[number];
+
+    useAppThemeStore.getState().addCustomScheme(customScheme);
+    useAppThemeStore.getState().setPreviewSchemeId("custom-preview-target");
+    // Simulate the picker having injected the previewed scheme's tokens.
+    useAppThemeStore.getState().injectTheme(customScheme);
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      "#abcdef"
+    );
+
+    useAppThemeStore.getState().removeCustomScheme("custom-preview-target");
+
+    expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+    expect(useAppThemeStore.getState().selectedSchemeId).toBe("daintree");
+    // DOM should now reflect the committed daintree accent, not the deleted scheme.
+    expect(document.documentElement.style.getPropertyValue("--theme-accent-primary")).toBe(
+      daintree.tokens["accent-primary"]
+    );
+  });
+
   it("removeCustomScheme leaves previewSchemeId alone when unrelated id is removed", () => {
     const customScheme = {
       id: "some-custom",

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -15,7 +15,15 @@ interface AppThemeState {
   preferredLightSchemeId: string;
   recentSchemeIds: string[];
   accentColorOverride: string | null;
+  /**
+   * Ephemeral override used by the picker for live hover/focus preview.
+   * Never persisted. The picker reads this to drive the hero panel image
+   * and aria-live announcement during preview, while calling
+   * `injectSchemeToDOM` imperatively for the CSS variable side-effect.
+   */
+  previewSchemeId: string | null;
   setSelectedSchemeId: (id: string) => void;
+  setPreviewSchemeId: (id: string | null) => void;
   /**
    * Updates Zustand state for a deliberate scheme selection (selectedSchemeId
    * + recentSchemeIds LRU) WITHOUT touching the DOM. The caller is responsible
@@ -63,6 +71,7 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
   preferredLightSchemeId: "bondi",
   recentSchemeIds: [],
   accentColorOverride: null,
+  previewSchemeId: null,
 
   setSelectedSchemeId: (id) => {
     const { customSchemes } = useAppThemeStore.getState();
@@ -76,6 +85,8 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     }));
     injectSchemeToDOM(scheme);
   },
+
+  setPreviewSchemeId: (id) => set({ previewSchemeId: id }),
 
   commitSchemeSelection: (id) => {
     const { customSchemes } = useAppThemeStore.getState();
@@ -107,6 +118,7 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     set((state) => ({
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: needsFallback ? DEFAULT_APP_SCHEME_ID : state.selectedSchemeId,
+      previewSchemeId: state.previewSchemeId === id ? null : state.previewSchemeId,
       recentSchemeIds: state.recentSchemeIds.filter((x) => x !== id),
     }));
     if (needsFallback) {

--- a/src/store/appThemeStore.ts
+++ b/src/store/appThemeStore.ts
@@ -113,17 +113,24 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     })),
 
   removeCustomScheme: (id) => {
-    const { selectedSchemeId } = useAppThemeStore.getState();
-    const needsFallback = selectedSchemeId === id;
+    const prev = useAppThemeStore.getState();
+    const needsFallback = prev.selectedSchemeId === id;
+    const wasPreviewing = prev.previewSchemeId === id;
     set((state) => ({
       customSchemes: state.customSchemes.filter((s) => s.id !== id),
       selectedSchemeId: needsFallback ? DEFAULT_APP_SCHEME_ID : state.selectedSchemeId,
-      previewSchemeId: state.previewSchemeId === id ? null : state.previewSchemeId,
+      previewSchemeId: wasPreviewing ? null : state.previewSchemeId,
       recentSchemeIds: state.recentSchemeIds.filter((x) => x !== id),
     }));
     if (needsFallback) {
       const defaultScheme = BUILT_IN_APP_SCHEMES.find((s) => s.id === DEFAULT_APP_SCHEME_ID)!;
       injectSchemeToDOM(defaultScheme);
+    } else if (wasPreviewing) {
+      // Preview was pointing at the deleted scheme — CSS vars on :root still
+      // reflect it. Revert the DOM to the (still-committed) selected scheme
+      // so the app theme doesn't silently get stuck on a deleted theme.
+      const { selectedSchemeId, customSchemes } = useAppThemeStore.getState();
+      injectSchemeToDOM(resolveAppTheme(selectedSchemeId, customSchemes));
     }
   },
 
@@ -146,8 +153,12 @@ export const useAppThemeStore = create<AppThemeState>()((set) => ({
     set({ accentColorOverride: color });
     // Re-inject the currently active scheme so the override (or its removal)
     // takes effect immediately via the single injectSchemeToDOM pipeline.
-    const { selectedSchemeId, customSchemes } = useAppThemeStore.getState();
-    const scheme = resolveAppTheme(selectedSchemeId, customSchemes);
+    // When a hover preview is active, the previewed scheme is what's on the
+    // DOM — re-injecting the committed scheme here would flip the DOM off
+    // the preview until the pointer moved.
+    const { selectedSchemeId, previewSchemeId, customSchemes } = useAppThemeStore.getState();
+    const activeId = previewSchemeId ?? selectedSchemeId;
+    const scheme = resolveAppTheme(activeId, customSchemes);
     injectSchemeToDOM(scheme);
   },
 }));


### PR DESCRIPTION
## Summary

- Adds `previewSchemeId` to `appThemeStore` (ephemeral, not persisted) so hovering a row previews the whole app without committing the change
- `AppThemePicker` wires pointer/focus events with 300ms debounce on hover, immediate on focus, rAF revert on leave/blur, Escape-to-clear via `useEscapeStack`, and a polite `aria-live` announcement
- The hero panel shows the effective (preview ?? selected) scheme while the accent, warnings, and selection checkmark stay on the committed scheme

Resolves #5249

## Changes

- `src/store/appThemeStore.ts` — added `previewSchemeId`/`setPreviewSchemeId`, updated `setAccentColorOverride` to respect active preview, fixed `removeCustomScheme` to revert CSS vars when the deleted scheme was being previewed
- `src/components/Settings/AppThemePicker.tsx` — full preview wiring: debounced hover, rAF revert, Escape stack integration, aria-live region, commit path clears preview before `runThemeReveal` fires
- `src/components/Settings/__tests__/AppThemePicker.preview.test.tsx` — 15 new test cases covering the full preview lifecycle
- `src/store/__tests__/appThemeStore.test.ts` — store tests for setter invariants, custom-scheme cleanup, and DOM rollback

## Testing

15 new unit tests in `AppThemePicker.preview.test.tsx` cover hover/focus preview, debounce, revert-on-leave, Escape clearing, commit order (preview cleared before reveal fires), and the `aria-live` announcement. Existing shuffle and store tests all pass. The Escape fix (only `preventDefault` when query is non-empty) prevents the trap where an empty-query Escape couldn't clear preview or close the modal.