### PR TITLE
test(panels): enforce serializer/deserializer field-coverage parity (#5200)

### DIFF
--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -1,0 +1,279 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
+import type {
+  BuiltInPanelKind,
+  PanelExitBehavior,
+  PanelInstance,
+  TerminalInstance,
+} from "@shared/types/panel";
+import type { BrowserHistory } from "@shared/types/browser";
+import { getDeserializer } from "@/config/panelKindSerialisers";
+import type { SavedTerminalData } from "@/utils/stateHydration/statePatcher";
+import { initBuiltInPanelKinds } from "../registry";
+
+// Field-coverage meta-test. Every persisted field listed below must be
+// referenced by both the serializer and the deserializer, so a rename or
+// removal on one side surfaces as a loud test failure rather than silent
+// data loss on restore.
+//
+// The per-kind arrays are a ratchet, not exhaustive: newly added persisted
+// fields must be appended here by hand. The `satisfies readonly (keyof …)[]`
+// binding catches renames and key removals at TypeScript compile time.
+//
+// Asymmetries:
+//  - terminal/agent have no getDeserializer() entry — they restore through
+//    buildArgsForRespawn / buildArgsForBackendTerminal using backend PTY state.
+//    Serializer coverage only.
+//  - dev-preview `cwd` and `exitBehavior` are injected by
+//    buildArgsForNonPtyRecreation's base args, not the registry deserializer.
+//    Excluded from the deserializer-side check for that kind.
+
+type PtyData = Extract<PanelInstance, { kind: "terminal" | "agent" }>;
+type BrowserData = Extract<PanelInstance, { kind: "browser" }>;
+type NotesData = Extract<PanelInstance, { kind: "notes" }>;
+type DevPreviewData = Extract<PanelInstance, { kind: "dev-preview" }>;
+
+const PERSISTED_PTY_FIELDS = [
+  "type",
+  "agentId",
+  "cwd",
+  "command",
+  "exitBehavior",
+  "agentSessionId",
+  "agentLaunchFlags",
+  "agentModelId",
+  "agentState",
+  "lastStateChange",
+] as const satisfies readonly (keyof PtyData)[];
+
+const PERSISTED_BROWSER_FIELDS = [
+  "browserUrl",
+  "browserHistory",
+  "browserZoom",
+  "browserConsoleOpen",
+] as const satisfies readonly (keyof BrowserData)[];
+
+const PERSISTED_NOTES_FIELDS = [
+  "notePath",
+  "noteId",
+  "scope",
+  "createdAt",
+] as const satisfies readonly (keyof NotesData)[];
+
+const PERSISTED_DEV_PREVIEW_FIELDS = [
+  "cwd",
+  "devCommand",
+  "browserUrl",
+  "browserHistory",
+  "browserZoom",
+  "devPreviewConsoleOpen",
+  "exitBehavior",
+] as const satisfies readonly (keyof DevPreviewData)[];
+
+const BUILT_IN_KINDS = [
+  "terminal",
+  "agent",
+  "browser",
+  "notes",
+  "dev-preview",
+] as const satisfies readonly BuiltInPanelKind[];
+
+const browserHistoryFixture: BrowserHistory = {
+  past: ["https://prev.example"],
+  present: "https://example.com",
+  future: [],
+};
+
+function baseFields(
+  kind: PanelInstance["kind"]
+): Pick<TerminalInstance, "id" | "title" | "location" | "kind"> {
+  return { id: `panel-${kind}`, title: "Panel", location: "grid", kind };
+}
+
+// Fully-populated fixtures — every persisted field set to a truthy, non-empty,
+// non-null value so every conditional spread in the serializers emits its key.
+
+const terminalFixture: TerminalInstance = {
+  ...baseFields("terminal"),
+  type: "terminal",
+  agentId: "claude",
+  cwd: "/home/project",
+  command: "npm start",
+  exitBehavior: "keep" satisfies PanelExitBehavior,
+  agentSessionId: "session-abc",
+  agentLaunchFlags: ["--resume"],
+  agentModelId: "claude-3-5-sonnet",
+  agentState: "idle",
+  lastStateChange: 1_700_000_000_000,
+};
+
+const agentFixture: TerminalInstance = {
+  ...terminalFixture,
+  ...baseFields("agent"),
+};
+
+const browserFixture: TerminalInstance = {
+  ...baseFields("browser"),
+  browserUrl: "https://example.com",
+  browserHistory: browserHistoryFixture,
+  browserZoom: 1.5,
+  // `false` is deliberate — the browser serializer uses `!== undefined`, so
+  // falsy-but-defined values must still emit the key.
+  browserConsoleOpen: false,
+};
+
+const notesFixture: TerminalInstance = {
+  ...baseFields("notes"),
+  notePath: "notes/test.md",
+  noteId: "note-123",
+  scope: "worktree",
+  createdAt: 1_700_000_000_000,
+};
+
+const devPreviewFixture: TerminalInstance = {
+  ...baseFields("dev-preview"),
+  type: "terminal",
+  cwd: "/home/project",
+  devCommand: "npm run dev",
+  browserUrl: "http://localhost:3000",
+  browserHistory: browserHistoryFixture,
+  browserZoom: 1,
+  devPreviewConsoleOpen: false,
+  exitBehavior: "keep",
+};
+
+const savedBrowser: SavedTerminalData = {
+  id: "panel-browser",
+  kind: "browser",
+  browserUrl: "https://example.com",
+  browserHistory: browserHistoryFixture,
+  browserZoom: 1.5,
+  browserConsoleOpen: false,
+};
+
+const savedNotes: SavedTerminalData = {
+  id: "panel-notes",
+  kind: "notes",
+  notePath: "notes/test.md",
+  noteId: "note-123",
+  scope: "worktree",
+  createdAt: 1_700_000_000_000,
+};
+
+const savedDevPreview: SavedTerminalData = {
+  id: "panel-dev-preview",
+  kind: "dev-preview",
+  devCommand: "npm run dev",
+  browserUrl: "http://localhost:3000",
+  browserHistory: browserHistoryFixture,
+  browserZoom: 1,
+  devPreviewConsoleOpen: false,
+  exitBehavior: "keep",
+  createdAt: 1_700_000_000_000,
+};
+
+function assertCovers(
+  label: string,
+  output: Record<string, unknown>,
+  expectedFields: readonly string[],
+  renames: Record<string, string> = {},
+  excluded: readonly string[] = []
+): void {
+  const keys = Object.keys(output);
+  for (const field of expectedFields) {
+    if (excluded.includes(field)) continue;
+    const outputKey = renames[field] ?? field;
+    expect(
+      keys,
+      `${label} missing persisted field "${field}"` +
+        (outputKey === field ? "" : ` (output key "${outputKey}")`) +
+        `; keys=${keys.join(",")}`
+    ).toContain(outputKey);
+  }
+}
+
+beforeAll(() => {
+  initBuiltInPanelKinds();
+});
+
+describe("panel serializer field coverage", () => {
+  it("every built-in kind registers a serializer", () => {
+    for (const kind of BUILT_IN_KINDS) {
+      const config = getPanelKindConfig(kind);
+      expect(config?.serialize, `kind "${kind}" missing serialize`).toBeTypeOf("function");
+    }
+  });
+
+  it("terminal serializer covers every persisted PTY field", () => {
+    const output = getPanelKindConfig("terminal")!.serialize!(terminalFixture) as Record<
+      string,
+      unknown
+    >;
+    assertCovers("terminal serializer", output, PERSISTED_PTY_FIELDS);
+  });
+
+  it("agent serializer covers every persisted PTY field", () => {
+    const output = getPanelKindConfig("agent")!.serialize!(agentFixture) as Record<string, unknown>;
+    assertCovers("agent serializer", output, PERSISTED_PTY_FIELDS);
+  });
+
+  it("browser serializer covers every persisted browser field", () => {
+    const output = getPanelKindConfig("browser")!.serialize!(browserFixture) as Record<
+      string,
+      unknown
+    >;
+    assertCovers("browser serializer", output, PERSISTED_BROWSER_FIELDS);
+  });
+
+  it("notes serializer covers every persisted notes field", () => {
+    const output = getPanelKindConfig("notes")!.serialize!(notesFixture) as Record<string, unknown>;
+    assertCovers("notes serializer", output, PERSISTED_NOTES_FIELDS);
+  });
+
+  it("dev-preview serializer covers every persisted dev-preview field (devCommand → command)", () => {
+    const output = getPanelKindConfig("dev-preview")!.serialize!(devPreviewFixture) as Record<
+      string,
+      unknown
+    >;
+    assertCovers("dev-preview serializer", output, PERSISTED_DEV_PREVIEW_FIELDS, {
+      devCommand: "command",
+    });
+  });
+});
+
+describe("panel deserializer field coverage", () => {
+  it("browser deserializer covers every persisted browser field", () => {
+    const deserializer = getDeserializer("browser");
+    expect(deserializer, "browser deserializer must be registered").toBeDefined();
+    const output = deserializer!(savedBrowser) as Record<string, unknown>;
+    assertCovers("browser deserializer", output, PERSISTED_BROWSER_FIELDS);
+  });
+
+  it("notes deserializer covers every persisted notes field", () => {
+    const deserializer = getDeserializer("notes");
+    expect(deserializer, "notes deserializer must be registered").toBeDefined();
+    const output = deserializer!(savedNotes) as Record<string, unknown>;
+    assertCovers("notes deserializer", output, PERSISTED_NOTES_FIELDS);
+  });
+
+  it("dev-preview deserializer covers every persisted dev-preview field (cwd + exitBehavior via base args)", () => {
+    const deserializer = getDeserializer("dev-preview");
+    expect(deserializer, "dev-preview deserializer must be registered").toBeDefined();
+    const output = deserializer!(savedDevPreview) as Record<string, unknown>;
+    // `cwd` and `exitBehavior` are injected by buildArgsForNonPtyRecreation's
+    // base args, not the dev-preview deserializer, so they are excluded here.
+    assertCovers("dev-preview deserializer", output, PERSISTED_DEV_PREVIEW_FIELDS, {}, [
+      "cwd",
+      "exitBehavior",
+    ]);
+  });
+
+  it("terminal and agent have no deserializer registry entry", () => {
+    // PTY kinds restore through buildArgsForRespawn / buildArgsForBackendTerminal
+    // using BackendTerminalData, not the getDeserializer() registry. Pinning
+    // this asymmetry so an accidental registry entry forces a deliberate
+    // decision about the new restore path.
+    expect(getDeserializer("terminal")).toBeUndefined();
+    expect(getDeserializer("agent")).toBeUndefined();
+  });
+});

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -78,6 +78,14 @@ const BUILT_IN_KINDS = [
   "dev-preview",
 ] as const satisfies readonly BuiltInPanelKind[];
 
+// Compile-time exhaustiveness pin: if a new BuiltInPanelKind is added and not
+// listed above, this assignment fails with a message naming the missing kind.
+type _MissingBuiltInKinds = Exclude<BuiltInPanelKind, (typeof BUILT_IN_KINDS)[number]>;
+const _builtInKindsExhaustive: [_MissingBuiltInKinds] extends [never]
+  ? true
+  : _MissingBuiltInKinds = true;
+void _builtInKindsExhaustive;
+
 const browserHistoryFixture: BrowserHistory = {
   past: ["https://prev.example"],
   present: "https://example.com",
@@ -189,6 +197,13 @@ function assertCovers(
         (outputKey === field ? "" : ` (output key "${outputKey}")`) +
         `; keys=${keys.join(",")}`
     ).toContain(outputKey);
+    // Reject stub implementations that emit the key with an `undefined` value.
+    // All fixtures below supply defined, non-undefined values for every field,
+    // so a real serializer/deserializer must propagate them.
+    expect(
+      output[outputKey],
+      `${label} persisted field "${field}" was present but undefined — stub implementation?`
+    ).not.toBeUndefined();
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `src/panels/__tests__/registry.fieldcoverage.test.ts` — a meta-test that asserts every persisted field in each built-in panel kind is referenced by both its serializer and deserializer. Catches the case where a field is renamed or removed on only one side, which the existing round-trip tests miss.
- `satisfies readonly (keyof …)[]` bindings on the per-kind arrays give compile-time drift detection. Runtime `Object.keys()` checks assert implementation coverage. Two known asymmetries are documented inline: terminal/agent restore via backend PTY state (no registry deserializer), and dev-preview `cwd`/`exitBehavior` coming from `buildArgsForNonPtyRecreation` base args.
- Ratchet tightenings on top: compile-time exhaustiveness check for `BuiltInPanelKind` (new built-in kinds force an update to `BUILT_IN_KINDS`), and rejection of stub serializers/deserializers that emit a key with `undefined`.

Resolves #5200.

## Changes

- `src/panels/__tests__/registry.fieldcoverage.test.ts` (new, 294 lines) — full field-coverage meta-test with documented asymmetry notes and ratchet checks

## Testing

New test file covers all five built-in panel kinds. Ran `npx vitest run src/panels/__tests__/registry.fieldcoverage.test.ts` and all assertions pass.