### PR TITLE
feat(hydration): surface quarantined project state via recovery notification

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -33,9 +33,12 @@ export function registerAppStateHandlers(): () => void {
     let focusPanelStateToUse = globalAppState.focusPanelState;
     // Active worktree state to include in response
     let activeWorktreeIdToUse = globalAppState.activeWorktreeId;
+    let projectStateQuarantinedPath: string | undefined;
 
     if (projectId) {
-      const projectState = await projectStore.getProjectState(projectId);
+      const { state: projectState, quarantinedPath } =
+        await projectStore.getProjectStateWithRecovery(projectId);
+      projectStateQuarantinedPath = quarantinedPath;
       // Per-project state exists (even if empty) - use it as authoritative
       if (projectState?.terminals !== undefined) {
         // Use per-project terminals, excluding trashed and normalizing location
@@ -239,6 +242,9 @@ export function registerAppStateHandlers(): () => void {
       gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
       safeMode: inSafeMode,
       settingsRecovery: consumePendingSettingsRecovery(),
+      projectStateRecovery: projectStateQuarantinedPath
+        ? { quarantinedPath: projectStateQuarantinedPath }
+        : null,
     };
   };
   handlers.push(typedHandle(CHANNELS.APP_HYDRATE, handleAppHydrate));

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -28,7 +28,8 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
   let focusPanelStateToUse = globalAppState.focusPanelState;
   let activeWorktreeIdToUse = globalAppState.activeWorktreeId;
 
-  const projectState = await projectStore.getProjectState(projectId);
+  const { state: projectState, quarantinedPath: projectStateQuarantinedPath } =
+    await projectStore.getProjectStateWithRecovery(projectId);
 
   if (projectState?.terminals !== undefined) {
     const validatedTerminals = filterValidTerminalEntries(
@@ -85,5 +86,8 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
     safeMode: inSafeMode,
     settingsRecovery: null,
+    projectStateRecovery: projectStateQuarantinedPath
+      ? { quarantinedPath: projectStateQuarantinedPath }
+      : null,
   };
 }

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -14,8 +14,14 @@ interface ProjectStateCacheEntry {
   value: ProjectState | null;
 }
 
+export interface ProjectStateReadResult {
+  state: ProjectState | null;
+  quarantinedPath?: string;
+}
+
 export class ProjectStateManager {
   private projectStateCache = new Map<string, ProjectStateCacheEntry>();
+  private pendingQuarantines = new Map<string, string>();
 
   constructor(private projectsConfigDir: string) {}
 
@@ -177,6 +183,7 @@ export class ProjectStateManager {
         const quarantinePath = `${filePath}.corrupted`;
         markPerformance(PERF_MARKS.PROJECT_STATE_QUARANTINE, { projectId });
         await resilientRename(filePath, quarantinePath);
+        this.pendingQuarantines.set(projectId, quarantinePath);
         console.warn(`[ProjectStateManager] Corrupted state file moved to ${quarantinePath}`);
       } catch {
         // Ignore
@@ -184,6 +191,16 @@ export class ProjectStateManager {
       this.setProjectStateCache(projectId, null);
       return null;
     }
+  }
+
+  async getProjectStateWithRecovery(projectId: string): Promise<ProjectStateReadResult> {
+    const state = await this.getProjectState(projectId);
+    const quarantinedPath = this.pendingQuarantines.get(projectId);
+    if (quarantinedPath !== undefined) {
+      this.pendingQuarantines.delete(projectId);
+      return { state, quarantinedPath };
+    }
+    return { state };
   }
 
   async clearProjectState(projectId: string): Promise<void> {

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -23,7 +23,7 @@ import {
 import { eq, desc } from "drizzle-orm";
 import { generateProjectId, getProjectStateDir } from "./projectStorePaths.js";
 import { ProjectSettingsManager } from "./ProjectSettingsManager.js";
-import { ProjectStateManager } from "./ProjectStateManager.js";
+import { ProjectStateManager, type ProjectStateReadResult } from "./ProjectStateManager.js";
 import { ProjectFileStore } from "./ProjectFileStore.js";
 import { GlobalFileStore } from "./GlobalFileStore.js";
 import { ProjectIdentityFiles } from "./ProjectIdentityFiles.js";
@@ -549,6 +549,10 @@ export class ProjectStore {
 
   async getProjectState(projectId: string): Promise<ProjectState | null> {
     return this.stateManager.getProjectState(projectId);
+  }
+
+  async getProjectStateWithRecovery(projectId: string): Promise<ProjectStateReadResult> {
+    return this.stateManager.getProjectStateWithRecovery(projectId);
   }
 
   async clearProjectState(projectId: string): Promise<void> {

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -255,11 +255,11 @@ describe("AppHydrationService adversarial", () => {
     };
     let resolveProjectState!: (value: {
       state: ProjectStateFixture;
-      quarantinedPath?: string;
+      quarantinedPath: string | undefined;
     }) => void;
     const pendingProjectState = new Promise<{
       state: ProjectStateFixture;
-      quarantinedPath?: string;
+      quarantinedPath: string | undefined;
     }>((resolve) => {
       resolveProjectState = resolve;
     });
@@ -284,6 +284,7 @@ describe("AppHydrationService adversarial", () => {
         focusMode: false,
         activeWorktreeId: "wt-project",
       },
+      quarantinedPath: undefined,
     });
 
     const [first, second] = (await Promise.all([firstPromise, secondPromise])) as [

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -29,6 +29,7 @@ const mockState = vi.hoisted(() => ({
         focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
       }
     | undefined,
+  projectStateQuarantinedPath: undefined as string | undefined,
   safeMode: false,
   gpuStatus: { webgl2: "enabled" },
   gpuWebGLHardware: true,
@@ -39,6 +40,12 @@ const getProjectByIdMock = vi.hoisted(() =>
   vi.fn((projectId: string) => (projectId === mockState.project?.id ? mockState.project : null))
 );
 const getProjectStateMock = vi.hoisted(() => vi.fn(async () => mockState.projectState));
+const getProjectStateWithRecoveryMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    state: mockState.projectState,
+    quarantinedPath: mockState.projectStateQuarantinedPath,
+  }))
+);
 const storeGetMock = vi.hoisted(() =>
   vi.fn((key: string) => {
     if (key === "appState") return mockState.appState;
@@ -69,6 +76,7 @@ vi.mock("../ProjectStore.js", () => ({
   projectStore: {
     getProjectById: getProjectByIdMock,
     getProjectState: getProjectStateMock,
+    getProjectStateWithRecovery: getProjectStateWithRecoveryMock,
   },
 }));
 
@@ -109,6 +117,7 @@ describe("AppHydrationService adversarial", () => {
     mockState.agentSettings = { defaultAgent: "codex" };
     mockState.project = { id: "project-1", name: "Project One", path: "/project/one" };
     mockState.projectState = undefined;
+    mockState.projectStateQuarantinedPath = undefined;
     mockState.safeMode = false;
     mockState.gpuStatus = { webgl2: "enabled" };
     mockState.gpuWebGLHardware = true;
@@ -234,31 +243,74 @@ describe("AppHydrationService adversarial", () => {
     expect(result.appState.activeWorktreeId).toBe("wt-global");
     expect(result.appState.focusMode).toBe(true);
     expect(result.settingsRecovery).toBeNull();
+    expect(result.projectStateRecovery).toBeNull();
   });
 
   it("CONCURRENT_CALLS_READ_ONLY", async () => {
-    let resolveProjectState!: (value: {
+    type ProjectStateFixture = {
       terminals?: unknown[];
       activeWorktreeId?: string;
       focusMode?: boolean;
       focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
+    };
+    let resolveProjectState!: (value: {
+      state: ProjectStateFixture;
+      quarantinedPath?: string;
     }) => void;
     const pendingProjectState = new Promise<{
-      terminals?: unknown[];
-      activeWorktreeId?: string;
-      focusMode?: boolean;
-      focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
+      state: ProjectStateFixture;
+      quarantinedPath?: string;
     }>((resolve) => {
       resolveProjectState = resolve;
     });
-    getProjectStateMock.mockReturnValueOnce(pendingProjectState);
-    getProjectStateMock.mockReturnValueOnce(pendingProjectState);
+    getProjectStateWithRecoveryMock.mockReturnValueOnce(pendingProjectState);
+    getProjectStateWithRecoveryMock.mockReturnValueOnce(pendingProjectState);
 
     const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
     const firstPromise = buildSwitchHydrateResult("project-1");
     const secondPromise = buildSwitchHydrateResult("project-1");
 
     resolveProjectState({
+      state: {
+        terminals: [
+          {
+            id: "project-terminal",
+            type: "terminal",
+            title: "Project Terminal",
+            cwd: "/project",
+            location: "grid",
+          },
+        ],
+        focusMode: false,
+        activeWorktreeId: "wt-project",
+      },
+    });
+
+    const [first, second] = (await Promise.all([firstPromise, secondPromise])) as [
+      HydrateResult,
+      HydrateResult,
+    ];
+
+    expect(first).toEqual(second);
+    expect(getProjectStateWithRecoveryMock).toHaveBeenCalledTimes(2);
+    expect(storeGetMock).not.toHaveBeenCalledWith("pendingSettingsRecovery");
+  });
+
+  it("PROJECT_STATE_RECOVERY_PROPAGATED", async () => {
+    mockState.projectState = undefined;
+    mockState.projectStateQuarantinedPath = "/projects/abc/state.json.corrupted";
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.projectStateRecovery).toEqual({
+      quarantinedPath: "/projects/abc/state.json.corrupted",
+    });
+    expect(result.appState.terminals).toEqual([]);
+  });
+
+  it("PROJECT_STATE_RECOVERY_NULL_WHEN_CLEAN", async () => {
+    mockState.projectState = {
       terminals: [
         {
           id: "project-terminal",
@@ -268,18 +320,13 @@ describe("AppHydrationService adversarial", () => {
           location: "grid",
         },
       ],
-      focusMode: false,
-      activeWorktreeId: "wt-project",
-    });
+    };
+    mockState.projectStateQuarantinedPath = undefined;
 
-    const [first, second] = (await Promise.all([firstPromise, secondPromise])) as [
-      HydrateResult,
-      HydrateResult,
-    ];
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
 
-    expect(first).toEqual(second);
-    expect(getProjectStateMock).toHaveBeenCalledTimes(2);
-    expect(storeGetMock).not.toHaveBeenCalledWith("pendingSettingsRecovery");
+    expect(result.projectStateRecovery).toBeNull();
   });
 
   it("UNKNOWN_PROJECT_ID_STILL_VALID", async () => {

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -184,3 +184,68 @@ describe("ProjectStateManager telemetry", () => {
     });
   });
 });
+
+describe("ProjectStateManager quarantine recovery", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-state-recovery-"));
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/recovery-project");
+    await fs.mkdir(path.join(tempDir, projectId), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("surfaces the quarantined path when state JSON is invalid", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).toBeNull();
+    expect(result.quarantinedPath).toBe(`${filePath}.corrupted`);
+    await expect(fs.access(`${filePath}.corrupted`)).resolves.toBeUndefined();
+  });
+
+  it("drains the quarantine signal after one read — subsequent reads return no path", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+
+    const first = await manager.getProjectStateWithRecovery(projectId);
+    expect(first.quarantinedPath).toBe(`${filePath}.corrupted`);
+
+    const second = await manager.getProjectStateWithRecovery(projectId);
+    expect(second.state).toBeNull();
+    expect(second.quarantinedPath).toBeUndefined();
+  });
+
+  it("returns no quarantinedPath when state is valid", async () => {
+    await manager.saveProjectState(projectId, makeState());
+
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).not.toBeNull();
+    expect(result.quarantinedPath).toBeUndefined();
+  });
+
+  it("surfaces the quarantine when a preceding getProjectState() triggered it", async () => {
+    const filePath = stateFilePath(tempDir, projectId)!;
+    await fs.writeFile(filePath, "{ not valid json", "utf-8");
+
+    // windowServices.ts-style caller reads state via the plain method — this
+    // triggers quarantine but discards the recovery signal.
+    const firstState = await manager.getProjectState(projectId);
+    expect(firstState).toBeNull();
+
+    // Hydration path later reads via the recovery-aware method and should
+    // still receive the quarantined path.
+    const result = await manager.getProjectStateWithRecovery(projectId);
+    expect(result.state).toBeNull();
+    expect(result.quarantinedPath).toBe(`${filePath}.corrupted`);
+  });
+});

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -73,6 +73,7 @@ const buildSwitchHydrateResultMock = vi.hoisted(() =>
     gpuHardwareAccelerationDisabled: false,
     safeMode: false,
     settingsRecovery: null,
+    projectStateRecovery: null,
   }))
 );
 

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -87,6 +87,11 @@ export type SettingsRecovery =
   | { kind: "restored-from-backup"; quarantinedPath?: string }
   | { kind: "reset-to-defaults"; quarantinedPath?: string };
 
+/** Describes a per-project state file that was quarantined due to corruption */
+export interface ProjectStateRecovery {
+  quarantinedPath: string;
+}
+
 /** Result from app hydration */
 export interface HydrateResult {
   appState: AppState;
@@ -97,4 +102,5 @@ export interface HydrateResult {
   gpuHardwareAccelerationDisabled: boolean;
   safeMode: boolean;
   settingsRecovery?: SettingsRecovery | null;
+  projectStateRecovery?: ProjectStateRecovery | null;
 }

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -2140,8 +2140,8 @@ describe("hydrateAppState", () => {
           duration: 0,
         })
       );
-      expect(notifyMock.mock.calls[0][0].message).toContain("/path/to/state.json.corrupted");
-      expect(notifyMock.mock.calls[0][0].message).toContain("has been reset");
+      expect(notifyMock.mock.calls[0]![0].message).toContain("/path/to/state.json.corrupted");
+      expect(notifyMock.mock.calls[0]![0].message).toContain("has been reset");
     });
 
     it("does not show notification when projectStateRecovery is null", async () => {

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -2112,6 +2112,104 @@ describe("hydrateAppState", () => {
     });
   });
 
+  describe("project state recovery notifications", () => {
+    it("shows persistent warning toast when project state was quarantined", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        projectStateRecovery: {
+          quarantinedPath: "/path/to/state.json.corrupted",
+        },
+      });
+
+      await hydrateAppState({
+        addPanel: vi.fn().mockResolvedValue("terminal-id"),
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+      });
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "warning",
+          title: "Project State Corrupted",
+          priority: "high",
+          duration: 0,
+        })
+      );
+      expect(notifyMock.mock.calls[0][0].message).toContain("/path/to/state.json.corrupted");
+      expect(notifyMock.mock.calls[0][0].message).toContain("has been reset");
+    });
+
+    it("does not show notification when projectStateRecovery is null", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        projectStateRecovery: null,
+      });
+
+      await hydrateAppState({
+        addPanel: vi.fn().mockResolvedValue("terminal-id"),
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+      });
+
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("does not show notification when projectStateRecovery is omitted", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+      });
+
+      await hydrateAppState({
+        addPanel: vi.fn().mockResolvedValue("terminal-id"),
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+      });
+
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("shows both settings and project state notifications when both recoveries occur", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        settingsRecovery: {
+          kind: "reset-to-defaults",
+          quarantinedPath: "/path/to/config.json.corrupted",
+        },
+        projectStateRecovery: {
+          quarantinedPath: "/path/to/state.json.corrupted",
+        },
+      });
+
+      await hydrateAppState({
+        addPanel: vi.fn().mockResolvedValue("terminal-id"),
+        setActiveWorktree: vi.fn(),
+        loadRecipes: vi.fn().mockResolvedValue(undefined),
+        openDiagnosticsDock: vi.fn(),
+      });
+
+      expect(notifyMock).toHaveBeenCalledTimes(2);
+      const titles = notifyMock.mock.calls.map((call) => call[0].title);
+      expect(titles).toContain("Settings Reset to Defaults");
+      expect(titles).toContain("Project State Corrupted");
+    });
+  });
+
   describe("orphan filter for default terminals", () => {
     it("filters out default-N orphan when no saved panels exist (brand-new project)", async () => {
       appClientMock.hydrate.mockResolvedValue({

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -279,6 +279,17 @@ export async function hydrateAppState(
       }
     }
 
+    if (hydrateResult.projectStateRecovery) {
+      const { quarantinedPath } = hydrateResult.projectStateRecovery;
+      notify({
+        type: "warning",
+        title: "Project State Corrupted",
+        message: `Your project state was corrupted and has been reset. The corrupt file is preserved at: ${quarantinedPath}`,
+        priority: "high",
+        duration: 0,
+      });
+    }
+
     normalizeAndApplyScrollback(terminalConfig, logHydrationInfo);
 
     if (!appState) {


### PR DESCRIPTION
## Summary

- When `ProjectStateManager` encountered a JSON parse failure it renamed the file to `*.corrupted` and returned null, silently wiping the user's layout, panels, and tab groups with no indication anything went wrong.
- This mirrors the existing `settingsRecovery` pattern: a `pendingQuarantines` map on `ProjectStateManager` is populated on quarantine and drained by a new `getProjectStateWithRecovery()` method, surfaced through a `HydrateResult.projectStateRecovery` field, and rendered as a persistent warning toast in `hydrateAppState`.
- Both the `APP_HYDRATE` handler and `buildSwitchHydrateResult` consume the recovery signal so it fires whether the user opens a project fresh or switches to one mid-session.

Resolves #5190

## Changes

- `ProjectStateManager` — added `pendingQuarantines` map and `getProjectStateWithRecovery()` to pair the existing quarantine logic with a signalling mechanism
- `AppHydrationService` — both hydration paths now call `getProjectStateWithRecovery()` and populate the new `projectStateRecovery` field
- `shared/types/ipc/app.ts` — added optional `projectStateRecovery: { quarantinedPath: string }` to `HydrateResult`
- `src/utils/stateHydration/index.ts` — renderer side reads the field and calls `notify()` with a warning toast (persistent, includes the quarantined path)
- Full test coverage added for the new signalling path and the renderer notification logic

## Testing

Ran the full unit test suite — all passing. Covered the new path with dedicated tests in `ProjectStateManager.test.ts`, `AppHydrationService.adversarial.test.ts`, and `stateHydration.test.ts`.