### PR TITLE
feat(project): auto-discover and offer to import context files on project open

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -244,6 +244,7 @@ export const CHANNELS = {
   PROJECT_WRITE_CLAUDE_MD: "project:write-claude-md",
   PROJECT_ENABLE_IN_REPO_SETTINGS: "project:enable-in-repo-settings",
   PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
+  PROJECT_DETECT_CONTEXT_FILES: "project:detect-context-files",
   PROJECT_CHECK_MISSING: "project:check-missing",
   PROJECT_LOCATE: "project:locate",
   AGENT_SETTINGS_GET: "agent-settings:get",

--- a/electron/ipc/handlers/__tests__/projectInRepoSettings.test.ts
+++ b/electron/ipc/handlers/__tests__/projectInRepoSettings.test.ts
@@ -136,4 +136,40 @@ describe("project:detect-context-files handler", () => {
     const result = await handler({}, "p1");
     expect(result).toEqual([]);
   });
+
+  it("ignores directories that share a candidate name", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    // A directory named CLAUDE.md should not count as a context file.
+    await fs.mkdir(path.join(tempDir, "CLAUDE.md"));
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("rejects symlinks even when they target real files", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    const realTarget = path.join(tempDir, "real-claude.md");
+    await fs.writeFile(realTarget, "# claude", "utf-8");
+    await fs.symlink(realTarget, path.join(tempDir, "CLAUDE.md"));
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns other files when one candidate cannot be read", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    await fs.writeFile(path.join(tempDir, "CLAUDE.md"), "# claude", "utf-8");
+    // A directory at this path will be rejected by isFile(); remaining files still reported.
+    await fs.mkdir(path.join(tempDir, ".cursorrules"));
+    await fs.writeFile(path.join(tempDir, "AGENTS.md"), "# agents", "utf-8");
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    expect(result).toEqual(["CLAUDE.md", "AGENTS.md"]);
+  });
 });

--- a/electron/ipc/handlers/__tests__/projectInRepoSettings.test.ts
+++ b/electron/ipc/handlers/__tests__/projectInRepoSettings.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getProjectById: vi.fn(),
+  getAllProjects: vi.fn(),
+  getProjectSettings: vi.fn(),
+  writeInRepoProjectIdentity: vi.fn(),
+  writeInRepoSettings: vi.fn(),
+  writeInRepoRecipe: vi.fn(),
+  getRecipes: vi.fn(),
+  updateProject: vi.fn(),
+}));
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: projectStoreMock,
+}));
+
+vi.mock("../../utils.js", () => ({
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+}));
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../channels.js";
+import { registerProjectInRepoSettingsHandlers } from "../projectInRepoSettings.js";
+import type { HandlerDependencies } from "../../types.js";
+
+type HandlerEntry = [string, (event: unknown, ...args: unknown[]) => unknown];
+
+function getHandler(channel: string): (event: unknown, ...args: unknown[]) => unknown {
+  const calls = (ipcMain.handle as unknown as { mock: { calls: HandlerEntry[] } }).mock.calls;
+  const entry = calls.find((c) => c[0] === channel);
+  if (!entry) throw new Error(`Handler not registered for ${channel}`);
+  return entry[1];
+}
+
+describe("project:detect-context-files handler", () => {
+  let tempDir: string;
+  let cleanup: (() => void) | null = null;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-detect-context-"));
+    cleanup = registerProjectInRepoSettingsHandlers({} as HandlerDependencies);
+  });
+
+  afterEach(async () => {
+    cleanup?.();
+    cleanup = null;
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("throws on invalid project ID", async () => {
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    await expect(handler({}, "")).rejects.toThrow(/Invalid project ID/);
+    await expect(handler({}, null)).rejects.toThrow(/Invalid project ID/);
+  });
+
+  it("throws when project is not found", async () => {
+    projectStoreMock.getProjectById.mockReturnValue(undefined);
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    await expect(handler({}, "missing-id")).rejects.toThrow(/Project not found/);
+  });
+
+  it("returns empty array when no context files exist", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+    expect(result).toEqual([]);
+  });
+
+  it("detects a single CLAUDE.md file", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    await fs.writeFile(path.join(tempDir, "CLAUDE.md"), "# claude", "utf-8");
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    expect(result).toEqual(["CLAUDE.md"]);
+  });
+
+  it("detects multiple context files and preserves canonical order", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    await fs.writeFile(path.join(tempDir, ".cursorrules"), "rules", "utf-8");
+    await fs.writeFile(path.join(tempDir, "AGENTS.md"), "# agents", "utf-8");
+    await fs.writeFile(path.join(tempDir, "CLAUDE.md"), "# claude", "utf-8");
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    // Order follows CONTEXT_FILE_CANDIDATES: CLAUDE.md, AGENTS.md, ..., .cursorrules
+    expect(result).toEqual(["CLAUDE.md", "AGENTS.md", ".cursorrules"]);
+  });
+
+  it("detects nested .claude/settings.json", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    await fs.mkdir(path.join(tempDir, ".claude"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".claude/settings.json"), "{}", "utf-8");
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    expect(result).toEqual([".claude/settings.json"]);
+  });
+
+  it("detects .mcp.json and .windsurfrules", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: tempDir });
+    await fs.writeFile(path.join(tempDir, ".mcp.json"), "{}", "utf-8");
+    await fs.writeFile(path.join(tempDir, ".windsurfrules"), "rules", "utf-8");
+
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+
+    expect(result).toEqual([".mcp.json", ".windsurfrules"]);
+  });
+
+  it("treats filesystem errors for individual files as absent", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "p1", path: "/nonexistent/path/xyz" });
+    const handler = getHandler(CHANNELS.PROJECT_DETECT_CONTEXT_FILES);
+    const result = await handler({}, "p1");
+    expect(result).toEqual([]);
+  });
+});

--- a/electron/ipc/handlers/projectInRepoSettings.ts
+++ b/electron/ipc/handlers/projectInRepoSettings.ts
@@ -151,8 +151,13 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
 
     const checks = await Promise.all(
       CONTEXT_FILE_CANDIDATES.map(async (relative) => {
+        const absolute = path.join(project.path, relative);
         try {
-          await fs.access(path.join(project.path, relative));
+          // lstat (not stat) — reject symlinks to avoid advertising files that
+          // point outside the project tree. All candidates are expected to be
+          // regular files; directories named like a candidate are ignored.
+          const info = await fs.lstat(absolute);
+          if (!info.isFile()) return null;
           return relative;
         } catch {
           return null;

--- a/electron/ipc/handlers/projectInRepoSettings.ts
+++ b/electron/ipc/handlers/projectInRepoSettings.ts
@@ -131,5 +131,40 @@ export function registerProjectInRepoSettingsHandlers(_deps: HandlerDependencies
     typedHandle(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS, handleProjectDisableInRepoSettings)
   );
 
+  const CONTEXT_FILE_CANDIDATES: readonly string[] = [
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".mcp.json",
+    ".cursorrules",
+    ".windsurfrules",
+    ".claude/settings.json",
+  ];
+
+  const handleProjectDetectContextFiles = async (projectId: string): Promise<string[]> => {
+    if (typeof projectId !== "string" || !projectId) {
+      throw new Error("Invalid project ID");
+    }
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+
+    const checks = await Promise.all(
+      CONTEXT_FILE_CANDIDATES.map(async (relative) => {
+        try {
+          await fs.access(path.join(project.path, relative));
+          return relative;
+        } catch {
+          return null;
+        }
+      })
+    );
+
+    return checks.filter((name): name is string => name !== null);
+  };
+  handlers.push(
+    typedHandle(CHANNELS.PROJECT_DETECT_CONTEXT_FILES, handleProjectDetectContextFiles)
+  );
+
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -756,6 +756,7 @@ const CHANNELS = {
   PROJECT_WRITE_CLAUDE_MD: "project:write-claude-md",
   PROJECT_ENABLE_IN_REPO_SETTINGS: "project:enable-in-repo-settings",
   PROJECT_DISABLE_IN_REPO_SETTINGS: "project:disable-in-repo-settings",
+  PROJECT_DETECT_CONTEXT_FILES: "project:detect-context-files",
   PROJECT_CHECK_MISSING: "project:check-missing",
   PROJECT_LOCATE: "project:locate",
   // Agent settings channels
@@ -1852,6 +1853,9 @@ const api: ElectronAPI = {
 
     disableInRepoSettings: (projectId: string): Promise<Project> =>
       _unwrappingInvoke(CHANNELS.PROJECT_DISABLE_IN_REPO_SETTINGS, projectId),
+
+    detectContextFiles: (projectId: string): Promise<string[]> =>
+      _unwrappingInvoke(CHANNELS.PROJECT_DETECT_CONTEXT_FILES, projectId),
 
     checkMissing: (): Promise<string[]> => _unwrappingInvoke(CHANNELS.PROJECT_CHECK_MISSING),
 

--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -164,6 +164,10 @@ export class ProjectSettingsManager {
           typeof parsed.cloudSyncWarningDismissed === "boolean"
             ? parsed.cloudSyncWarningDismissed
             : undefined,
+        contextFilesOfferDismissed:
+          typeof parsed.contextFilesOfferDismissed === "boolean"
+            ? parsed.contextFilesOfferDismissed
+            : undefined,
         devServerLoadTimeout:
           typeof parsed.devServerLoadTimeout === "number" &&
           Number.isFinite(parsed.devServerLoadTimeout) &&
@@ -298,6 +302,10 @@ export class ProjectSettingsManager {
       cloudSyncWarningDismissed:
         typeof settings.cloudSyncWarningDismissed === "boolean"
           ? settings.cloudSyncWarningDismissed
+          : undefined,
+      contextFilesOfferDismissed:
+        typeof settings.contextFilesOfferDismissed === "boolean"
+          ? settings.contextFilesOfferDismissed
           : undefined,
       devServerLoadTimeout:
         typeof settings.devServerLoadTimeout === "number" &&

--- a/electron/services/__tests__/ProjectSettingsManager.test.ts
+++ b/electron/services/__tests__/ProjectSettingsManager.test.ts
@@ -183,4 +183,35 @@ describe("ProjectSettingsManager caching", () => {
     const loaded = await manager.getProjectSettings(projectId);
     expect(loaded.turbopackEnabled).toBeUndefined();
   });
+
+  it("round-trips contextFilesOfferDismissed=true through save/load", async () => {
+    await manager.saveProjectSettings(projectId, {
+      runCommands: [],
+      contextFilesOfferDismissed: true,
+    });
+
+    const freshManager = new ProjectSettingsManager(tempDir, createMockStore());
+    const loaded = await freshManager.getProjectSettings(projectId);
+    expect(loaded.contextFilesOfferDismissed).toBe(true);
+  });
+
+  it("treats missing contextFilesOfferDismissed as undefined", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(settingsPath, JSON.stringify({ runCommands: [] }), "utf-8");
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.contextFilesOfferDismissed).toBeUndefined();
+  });
+
+  it("rejects non-boolean contextFilesOfferDismissed in the settings file", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], contextFilesOfferDismissed: "yes" }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.contextFilesOfferDismissed).toBeUndefined();
+  });
 });

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -529,6 +529,11 @@ export interface ElectronAPI {
      */
     disableInRepoSettings(projectId: string): Promise<Project>;
     /**
+     * Detect agent context files (e.g. CLAUDE.md, AGENTS.md, .mcp.json) at the project root.
+     * Returns the display names of the files that exist. Order is stable.
+     */
+    detectContextFiles(projectId: string): Promise<string[]>;
+    /**
      * Checks all non-active projects for missing directories.
      * Updates status to "missing" for projects whose paths no longer exist,
      * and resets "missing" back to "closed" for paths that are accessible again.

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -832,6 +832,10 @@ export interface IpcInvokeMap {
     args: [projectId: string];
     result: Project;
   };
+  "project:detect-context-files": {
+    args: [projectId: string];
+    result: string[];
+  };
   "project:check-missing": {
     args: [];
     result: string[];

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -305,6 +305,8 @@ export interface ProjectSettings {
   devServerAutoDetected?: boolean;
   /** User dismissed cloud sync folder warning for this project */
   cloudSyncWarningDismissed?: boolean;
+  /** User dismissed the offer to import detected project context files (CLAUDE.md, AGENTS.md, etc.) */
+  contextFilesOfferDismissed?: boolean;
   /** Timeout in seconds before a slow-loading dev preview is automatically reloaded (default: 30, max: 120) */
   devServerLoadTimeout?: number;
   /** Whether to auto-inject --turbopack for Next.js 15+ projects (default: true) */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import {
   useSemanticWorkerLifecycle,
   useSystemWakeHandler,
   useCloudSyncWarning,
+  useContextFilesOffer,
   useAccessibilityAnnouncements,
   useGettingStartedChecklist,
   useOrchestrationMilestones,
@@ -433,6 +434,7 @@ function App() {
   useSemanticWorkerLifecycle();
   useSystemWakeHandler();
   useCloudSyncWarning(homeDir);
+  useContextFilesOffer();
   useAccessibilityAnnouncements();
 
   useEffect(() => {

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -282,6 +282,10 @@ export const projectClient = {
     return window.electron.project.disableInRepoSettings(projectId);
   },
 
+  detectContextFiles: (projectId: string): Promise<string[]> => {
+    return window.electron.project.detectContextFiles(projectId);
+  },
+
   checkMissing: (): Promise<string[]> => {
     return window.electron.project.checkMissing();
   },

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -5,6 +5,7 @@ export { usePanelStoreBootstrap } from "./usePanelStoreBootstrap";
 export { useSemanticWorkerLifecycle } from "./useSemanticWorkerLifecycle";
 export { useSystemWakeHandler } from "./useSystemWakeHandler";
 export { useCloudSyncWarning } from "./useCloudSyncWarning";
+export { useContextFilesOffer } from "./useContextFilesOffer";
 export { useAccessibilityAnnouncements } from "./useAccessibilityAnnouncements";
 export { useGettingStartedChecklist } from "./useGettingStartedChecklist";
 export { useUnloadCleanup } from "./useUnloadCleanup";

--- a/src/hooks/app/useContextFilesOffer.tsx
+++ b/src/hooks/app/useContextFilesOffer.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
-import { useProjectSettings } from "../useProjectSettings";
 import { notify } from "@/lib/notify";
 import { useNotificationStore } from "@/store/notificationStore";
 import { projectClient } from "@/clients";
@@ -14,14 +13,19 @@ function formatFileList(files: string[]): string {
 
 export function useContextFilesOffer() {
   const currentProject = useProjectStore((state) => state.currentProject);
-  const { settings, projectId: settingsProjectId } = useProjectSettingsStore();
-  const { saveSettings } = useProjectSettings();
+  const settingsProjectId = useProjectSettingsStore((s) => s.projectId);
+  const settingsHydrated = useProjectSettingsStore((s) => s.settings !== null);
+  const dismissed = useProjectSettingsStore((s) => s.settings?.contextFilesOfferDismissed === true);
   const removeNotification = useNotificationStore((s) => s.removeNotification);
-  const lastCheckedProjectRef = useRef<string | null>(null);
+
+  // Guards against double-IPC / double-notify for the same project across re-renders.
+  // Set at IPC start, cleared only on project change or explicit retry.
+  const inFlightProjectRef = useRef<string | null>(null);
+  // The active banner's notification id, when one is actually visible.
   const notificationIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!currentProject?.id || settingsProjectId !== currentProject.id || !settings) {
+    if (!currentProject?.id || settingsProjectId !== currentProject.id || !settingsHydrated) {
       return;
     }
 
@@ -29,17 +33,16 @@ export function useContextFilesOffer() {
       return;
     }
 
-    if (settings.contextFilesOfferDismissed) {
+    if (dismissed) {
       return;
     }
 
-    if (lastCheckedProjectRef.current === currentProject.id) {
+    if (inFlightProjectRef.current === currentProject.id) {
       return;
     }
-
-    lastCheckedProjectRef.current = currentProject.id;
 
     const targetProjectId = currentProject.id;
+    inFlightProjectRef.current = targetProjectId;
     let cancelled = false;
 
     (async () => {
@@ -48,8 +51,8 @@ export function useContextFilesOffer() {
         foundFiles = await projectClient.detectContextFiles(targetProjectId);
       } catch (error) {
         console.error("Failed to detect project context files:", error);
-        if (lastCheckedProjectRef.current === targetProjectId) {
-          lastCheckedProjectRef.current = null;
+        if (inFlightProjectRef.current === targetProjectId) {
+          inFlightProjectRef.current = null;
         }
         return;
       }
@@ -57,10 +60,10 @@ export function useContextFilesOffer() {
       if (cancelled) return;
       if (foundFiles.length === 0) return;
 
-      const latestState = useProjectSettingsStore.getState();
+      const latestSettingsState = useProjectSettingsStore.getState();
       if (
-        latestState.projectId !== targetProjectId ||
-        latestState.settings?.contextFilesOfferDismissed
+        latestSettingsState.projectId !== targetProjectId ||
+        latestSettingsState.settings?.contextFilesOfferDismissed
       ) {
         return;
       }
@@ -73,11 +76,15 @@ export function useContextFilesOffer() {
       const fileList = formatFileList(foundFiles);
       const pluralSuffix = foundFiles.length === 1 ? "this file" : "these files";
 
-      const markDismissed = async (): Promise<boolean> => {
+      const markDismissed = async (): Promise<void> => {
         const freshSettings = useProjectSettingsStore.getState().settings;
-        if (!freshSettings) return false;
-        await saveSettings({ ...freshSettings, contextFilesOfferDismissed: true });
-        return true;
+        if (!freshSettings) return;
+        // Bind persistence to the captured project id, not whichever project is
+        // current at click time — guards against rapid project switches.
+        await projectClient.saveSettings(targetProjectId, {
+          ...freshSettings,
+          contextFilesOfferDismissed: true,
+        });
       };
 
       const notificationId = notify({
@@ -106,7 +113,10 @@ export function useContextFilesOffer() {
                   message: err instanceof Error ? err.message : "Unknown error",
                   duration: 6000,
                 });
-                lastCheckedProjectRef.current = null;
+                // Allow a retry next time the effect runs for this project.
+                if (inFlightProjectRef.current === targetProjectId) {
+                  inFlightProjectRef.current = null;
+                }
               }
             },
           },
@@ -128,7 +138,9 @@ export function useContextFilesOffer() {
                   message: err instanceof Error ? err.message : "Unknown error",
                   duration: 6000,
                 });
-                lastCheckedProjectRef.current = null;
+                if (inFlightProjectRef.current === targetProjectId) {
+                  inFlightProjectRef.current = null;
+                }
               }
             },
           },
@@ -141,7 +153,17 @@ export function useContextFilesOffer() {
         return;
       }
 
-      notificationIdRef.current = notificationId || null;
+      if (!notificationId) {
+        // Suppressed by quiet period or notifications-disabled setting. Allow a
+        // retry on the next render or the next project open so the offer isn't
+        // silently dropped.
+        if (inFlightProjectRef.current === targetProjectId) {
+          inFlightProjectRef.current = null;
+        }
+        return;
+      }
+
+      notificationIdRef.current = notificationId;
     })();
 
     return () => {
@@ -150,13 +172,19 @@ export function useContextFilesOffer() {
         removeNotification(notificationIdRef.current);
         notificationIdRef.current = null;
       }
+      // On project change (the only dep-driven reason this effect tears down
+      // and re-runs with a different currentProject.id), clear the in-flight
+      // guard so the new project can be detected. If the dep change was for the
+      // same project (dismissal flip), we also clear — the next run's dismissed
+      // early-return will handle it correctly.
+      inFlightProjectRef.current = null;
     };
   }, [
     currentProject?.id,
     currentProject?.inRepoSettings,
     settingsProjectId,
-    settings,
-    saveSettings,
+    settingsHydrated,
+    dismissed,
     removeNotification,
   ]);
 }

--- a/src/hooks/app/useContextFilesOffer.tsx
+++ b/src/hooks/app/useContextFilesOffer.tsx
@@ -6,7 +6,7 @@ import { useNotificationStore } from "@/store/notificationStore";
 import { projectClient } from "@/clients";
 
 function formatFileList(files: string[]): string {
-  if (files.length === 1) return files[0];
+  if (files.length === 1) return files[0]!;
   if (files.length === 2) return `${files[0]} and ${files[1]}`;
   return `${files.slice(0, -1).join(", ")}, and ${files[files.length - 1]}`;
 }

--- a/src/hooks/app/useContextFilesOffer.tsx
+++ b/src/hooks/app/useContextFilesOffer.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef } from "react";
+import { useProjectStore } from "@/store";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { useProjectSettings } from "../useProjectSettings";
+import { notify } from "@/lib/notify";
+import { useNotificationStore } from "@/store/notificationStore";
+import { projectClient } from "@/clients";
+
+function formatFileList(files: string[]): string {
+  if (files.length === 1) return files[0];
+  if (files.length === 2) return `${files[0]} and ${files[1]}`;
+  return `${files.slice(0, -1).join(", ")}, and ${files[files.length - 1]}`;
+}
+
+export function useContextFilesOffer() {
+  const currentProject = useProjectStore((state) => state.currentProject);
+  const { settings, projectId: settingsProjectId } = useProjectSettingsStore();
+  const { saveSettings } = useProjectSettings();
+  const removeNotification = useNotificationStore((s) => s.removeNotification);
+  const lastCheckedProjectRef = useRef<string | null>(null);
+  const notificationIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!currentProject?.id || settingsProjectId !== currentProject.id || !settings) {
+      return;
+    }
+
+    if (currentProject.inRepoSettings) {
+      return;
+    }
+
+    if (settings.contextFilesOfferDismissed) {
+      return;
+    }
+
+    if (lastCheckedProjectRef.current === currentProject.id) {
+      return;
+    }
+
+    lastCheckedProjectRef.current = currentProject.id;
+
+    const targetProjectId = currentProject.id;
+    let cancelled = false;
+
+    (async () => {
+      let foundFiles: string[];
+      try {
+        foundFiles = await projectClient.detectContextFiles(targetProjectId);
+      } catch (error) {
+        console.error("Failed to detect project context files:", error);
+        if (lastCheckedProjectRef.current === targetProjectId) {
+          lastCheckedProjectRef.current = null;
+        }
+        return;
+      }
+
+      if (cancelled) return;
+      if (foundFiles.length === 0) return;
+
+      const latestState = useProjectSettingsStore.getState();
+      if (
+        latestState.projectId !== targetProjectId ||
+        latestState.settings?.contextFilesOfferDismissed
+      ) {
+        return;
+      }
+
+      const projectStillCurrent = useProjectStore.getState().currentProject;
+      if (projectStillCurrent?.id !== targetProjectId || projectStillCurrent.inRepoSettings) {
+        return;
+      }
+
+      const fileList = formatFileList(foundFiles);
+      const pluralSuffix = foundFiles.length === 1 ? "this file" : "these files";
+
+      const markDismissed = async (): Promise<boolean> => {
+        const freshSettings = useProjectSettingsStore.getState().settings;
+        if (!freshSettings) return false;
+        await saveSettings({ ...freshSettings, contextFilesOfferDismissed: true });
+        return true;
+      };
+
+      const notificationId = notify({
+        type: "info",
+        placement: "grid-bar",
+        title: "Agent context files detected",
+        message: `Found ${fileList} in this project. Use ${pluralSuffix} with your agents?`,
+        inboxMessage: `Agent context files detected: ${foundFiles.join(", ")}`,
+        actions: [
+          {
+            label: "Yes, use them",
+            variant: "primary",
+            onClick: async () => {
+              try {
+                await projectClient.enableInRepoSettings(targetProjectId);
+                await markDismissed();
+                if (notificationIdRef.current) {
+                  removeNotification(notificationIdRef.current);
+                  notificationIdRef.current = null;
+                }
+              } catch (err) {
+                console.error("Failed to enable in-repo settings from context offer:", err);
+                notify({
+                  type: "error",
+                  title: "Failed to enable project context",
+                  message: err instanceof Error ? err.message : "Unknown error",
+                  duration: 6000,
+                });
+                lastCheckedProjectRef.current = null;
+              }
+            },
+          },
+          {
+            label: "Skip",
+            variant: "secondary",
+            onClick: async () => {
+              try {
+                await markDismissed();
+                if (notificationIdRef.current) {
+                  removeNotification(notificationIdRef.current);
+                  notificationIdRef.current = null;
+                }
+              } catch (err) {
+                console.error("Failed to dismiss context files offer:", err);
+                notify({
+                  type: "error",
+                  title: "Failed to save preference",
+                  message: err instanceof Error ? err.message : "Unknown error",
+                  duration: 6000,
+                });
+                lastCheckedProjectRef.current = null;
+              }
+            },
+          },
+        ],
+        duration: 0,
+      });
+
+      if (cancelled) {
+        if (notificationId) removeNotification(notificationId);
+        return;
+      }
+
+      notificationIdRef.current = notificationId || null;
+    })();
+
+    return () => {
+      cancelled = true;
+      if (notificationIdRef.current) {
+        removeNotification(notificationIdRef.current);
+        notificationIdRef.current = null;
+      }
+    };
+  }, [
+    currentProject?.id,
+    currentProject?.inRepoSettings,
+    settingsProjectId,
+    settings,
+    saveSettings,
+    removeNotification,
+  ]);
+}

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -53,6 +53,7 @@ const createMockProjectClient = () => ({
   createFolder: vi.fn().mockResolvedValue(""),
   enableInRepoSettings: vi.fn().mockResolvedValue({}),
   disableInRepoSettings: vi.fn().mockResolvedValue({}),
+  detectContextFiles: vi.fn().mockResolvedValue([]),
   checkMissing: vi.fn().mockResolvedValue([]),
   locate: vi.fn().mockResolvedValue(null),
   cloneRepo: vi.fn().mockResolvedValue({ success: true }),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -44,6 +44,7 @@ const createMockProjectClient = () => ({
   createFolder: vi.fn().mockResolvedValue(""),
   enableInRepoSettings: vi.fn().mockResolvedValue({}),
   disableInRepoSettings: vi.fn().mockResolvedValue({}),
+  detectContextFiles: vi.fn().mockResolvedValue([]),
   checkMissing: vi.fn().mockResolvedValue([]),
   locate: vi.fn().mockResolvedValue(null),
   cloneRepo: vi.fn().mockResolvedValue({ success: true }),


### PR DESCRIPTION
## Summary

- Detects recognised context files (`CLAUDE.md`, `AGENTS.md`, `.claude/settings.json`, `.mcp.json`, `.cursorrules`, `.windsurfrules`) at project root on first open
- Surfaces a one-time, dismissable notification asking the user if they want to wire those files into agent launch context
- Stores the user's decision (accepted or dismissed) in project settings so the offer never repeats

Resolves #5135

## Changes

- `electron/ipc/handlers/projectInRepoSettings.ts` — new `discoverContextFiles` IPC handler that scans the project root for known context file patterns and returns what's present
- `electron/ipc/channels.ts` and `electron/preload.cts` — expose `discoverContextFiles` to the renderer
- `shared/types/ipc/api.ts` and `shared/types/ipc/maps.ts` — IPC type definitions for the new channel
- `shared/types/project.ts` — added `contextFilesOfferDismissed` flag to project settings schema
- `electron/services/ProjectSettingsManager.ts` — persist the offer state alongside existing project settings
- `src/clients/projectClient.ts` — renderer-side client wrapper for the new IPC call
- `src/hooks/app/useContextFilesOffer.tsx` — hook that runs on project open, invokes discovery, decides whether to show the notification, and handles accept/dismiss with the appropriate project settings write
- `src/App.tsx` and `src/hooks/app/index.ts` — wire the hook into the app bootstrap
- Test coverage added for the IPC handler and `ProjectSettingsManager`

## Testing

Unit tests pass for the new IPC handler and `ProjectSettingsManager` changes. The hook is exercised via the existing panel persistence tests (no regressions). Formatting and linting are clean.