### PR TITLE
fix(actions): throw on duplicate registration and fix palette shortcut hint

### DIFF
--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -39,7 +39,7 @@ const SHORTCUT_TIPS: { label: string; actionId: string }[] = [
   { label: "New Panel", actionId: "panel.palette" },
   { label: "Quick Switcher", actionId: "nav.quickSwitcher" },
   { label: "New Terminal", actionId: "terminal.new" },
-  { label: "Command Palette", actionId: "action.palette" },
+  { label: "Command Palette", actionId: "action.palette.open" },
   { label: "Keyboard Shortcuts", actionId: "help.shortcuts" },
   { label: "Settings", actionId: "app.settings" },
 ];

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -18,7 +18,7 @@ const { getDisplayComboMock } = vi.hoisted(() => ({
       "panel.palette": "⌘N",
       "nav.quickSwitcher": "⌘P",
       "terminal.new": "⌘⌥T",
-      "action.palette": "⌘K",
+      "action.palette.open": "⌘K",
       "help.shortcuts": "⌘/",
       "app.settings": "⌘,",
     };

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -46,7 +46,7 @@ export class ActionService {
 
   register<Args = unknown, Result = unknown>(definition: ActionDefinition<Args, Result>): void {
     if (this.registry.has(definition.id)) {
-      logWarn(`Action "${definition.id}" already registered. Overwriting.`);
+      throw new Error(`Action "${definition.id}" is already registered.`);
     }
     this.registry.set(definition.id, definition as ActionDefinition<unknown, unknown>);
   }

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -58,9 +58,7 @@ describe("ActionService", () => {
       expect(manifest[0]!.id).toBe("actions.list");
     });
 
-    it("should warn when registering duplicate action", () => {
-      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-
+    it("should throw when registering duplicate action", () => {
       const action: ActionDefinition = {
         id: "actions.list" as ActionId,
         title: "Test Action",
@@ -73,14 +71,10 @@ describe("ActionService", () => {
       };
 
       service.register(action);
-      service.register(action);
 
-      expect(consoleWarn).toHaveBeenCalledWith(
-        '[WARN] Action "actions.list" already registered. Overwriting.',
-        ""
+      expect(() => service.register(action)).toThrow(
+        'Action "actions.list" is already registered.'
       );
-
-      consoleWarn.mockRestore();
     });
   });
 

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -58,23 +58,38 @@ describe("ActionService", () => {
       expect(manifest[0]!.id).toBe("actions.list");
     });
 
-    it("should throw when registering duplicate action", () => {
-      const action: ActionDefinition = {
+    it("should throw when registering duplicate action and preserve the original registration", async () => {
+      const originalRun = vi.fn().mockResolvedValue("original");
+      const original: ActionDefinition = {
         id: "actions.list" as ActionId,
-        title: "Test Action",
-        description: "A test action",
+        title: "Original Action",
+        description: "Original",
         category: "test",
         kind: "command",
         danger: "safe",
         scope: "renderer",
-        run: vi.fn().mockResolvedValue(undefined),
+        run: originalRun,
       };
 
-      service.register(action);
+      const duplicateRun = vi.fn().mockResolvedValue("duplicate");
+      const duplicate: ActionDefinition = {
+        ...original,
+        title: "Duplicate Action",
+        run: duplicateRun,
+      };
 
-      expect(() => service.register(action)).toThrow(
-        'Action "actions.list" is already registered.'
+      service.register(original);
+
+      expect(() => service.register(duplicate)).toThrow(
+        /^Action "actions\.list" is already registered\.$/
       );
+
+      const result = await service.dispatch("actions.list" as ActionId);
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.result).toBe("original");
+      expect(originalRun).toHaveBeenCalledTimes(1);
+      expect(duplicateRun).not.toHaveBeenCalled();
+      expect(service.get("actions.list" as ActionId)?.title).toBe("Original Action");
     });
   });
 


### PR DESCRIPTION
## Summary

- `ActionService.register()` now throws on duplicate IDs instead of silently overwriting. The only production caller (`useActionRegistry`) already guards against React 19 StrictMode double-invocation via `registeredRef.current`, so this is safe to tighten.
- Fixed a broken shortcut hint on the Welcome screen: `"action.palette"` was used where `"action.palette.open"` is the actual registered action bound to Cmd+Shift+P.

Resolves #5245

## Audit findings

The issue framed this as a 56-entry gap via `string & {}` escape hatch. The audit found zero such escapes — all 361 `actions.set()` registrations use typed IDs. The apparent gap came from conflating `BuiltInKeyAction` (148 entries, includes keybinding-only IDs) with `BuiltInActionId` (270 entries, registered actions).

The 17 `BuiltInKeyAction`-only IDs (`nav.*`, `ui.escape`, `file.*`, `git.toggle`, `action.palette`) are component-local keybindings handled by `useKeybinding` hooks, not the action registry. That's correct by design — the same two-tier architecture VS Code uses. No changes needed there.

## Changes

- `src/services/ActionService.ts` — throw instead of logWarn on duplicate registration
- `src/services/__tests__/ActionService.test.ts` — duplicate-throw test with regex-anchored message and registry integrity check
- `src/components/Project/WelcomeScreen.tsx` — `action.palette` → `action.palette.open`
- `src/components/Project/__tests__/WelcomeScreen.test.tsx` — matching mock key update

## Testing

122 tests passing locally across ActionService.test.ts, ActionService.adversarial.test.ts, ActionService.e2eGate.test.ts, navigationActions.adversarial.test.ts, actionDefinitions.adversarial.test.ts, WelcomeScreen.test.tsx, and useMenuActions.test.tsx. Typecheck, lint (401 baseline warnings, 0 new), format, and channel drift checks all clean.