### PR TITLE
refactor(actions): convert cargo-culted dynamic imports to static

### DIFF
--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -212,6 +212,10 @@ vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: mocks.terminalInstanceService,
 }));
 
+vi.mock("@/services/terminal/TerminalInstanceService", () => ({
+  terminalInstanceService: mocks.terminalInstanceService,
+}));
+
 vi.mock("@/services/ActionService", () => ({
   actionService: mocks.actionService,
 }));

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -1,32 +1,42 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { CliAvailability } from "@shared/types";
 
-const mockDispatch = vi.fn().mockResolvedValue({ ok: true });
+const {
+  mockDispatch,
+  mockNotify,
+  mockGetAgentPrefsState,
+  mockGetCliAvailabilityState,
+  mockGetAgentSettingsState,
+  mockGetEffectiveAgentConfig,
+} = vi.hoisted(() => ({
+  mockDispatch: vi.fn().mockResolvedValue({ ok: true }),
+  mockNotify: vi.fn().mockReturnValue(""),
+  mockGetAgentPrefsState: vi.fn(),
+  mockGetCliAvailabilityState: vi.fn(),
+  mockGetAgentSettingsState: vi.fn(),
+  mockGetEffectiveAgentConfig: vi.fn(),
+}));
+
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: mockDispatch },
 }));
 
-const mockNotify = vi.fn().mockReturnValue("");
 vi.mock("@/lib/notify", () => ({
   notify: (...args: unknown[]) => mockNotify(...args),
 }));
 
-const mockGetAgentPrefsState = vi.fn();
 vi.mock("@/store/agentPreferencesStore", () => ({
   useAgentPreferencesStore: { getState: () => mockGetAgentPrefsState() },
 }));
 
-const mockGetCliAvailabilityState = vi.fn();
 vi.mock("@/store/cliAvailabilityStore", () => ({
   useCliAvailabilityStore: { getState: () => mockGetCliAvailabilityState() },
 }));
 
-const mockGetAgentSettingsState = vi.fn();
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: { getState: () => mockGetAgentSettingsState() },
 }));
 
-const mockGetEffectiveAgentConfig = vi.fn();
 vi.mock("@shared/config/agentRegistry", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@shared/config/agentRegistry")>();
   return {

--- a/src/services/actions/definitions/__tests__/introspectionActions.test.ts
+++ b/src/services/actions/definitions/__tests__/introspectionActions.test.ts
@@ -4,8 +4,15 @@ import type { ActionDefinition, ActionContext } from "@shared/types/actions";
 
 // Stubs for other actions' dependencies (actions.list, actions.getContext). These
 // are not exercised by the persistedStores tests but must load without errors.
+vi.mock("@/services/ActionService", () => ({
+  actionService: { list: () => [] },
+}));
 vi.mock("@/store/panelStore", () => ({ usePanelStore: { getState: () => ({}) } }));
+vi.mock("@/store/portalStore", () => ({ usePortalStore: { getState: () => ({}) } }));
 vi.mock("@/store/projectStore", () => ({ useProjectStore: { getState: () => ({}) } }));
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: { getState: () => ({}) },
+}));
 vi.mock("@/store/createWorktreeStore", () => ({
   getCurrentViewStore: () => ({ getState: () => ({ worktrees: new Map() }) }),
 }));

--- a/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
@@ -13,6 +13,22 @@ const bracketedMock = vi.hoisted(() => ({
   formatWithBracketedPaste: vi.fn((t: string) => `<BP>${t}</BP>`),
 }));
 const sendToAgentMock = vi.hoisted(() => ({ openSendToAgentPalette: vi.fn() }));
+const terminalInputStoreMock = vi.hoisted(() => ({
+  triggerStashInput: vi.fn(),
+  triggerPopStash: vi.fn(),
+}));
+const fleetArmingMock = vi.hoisted(() => ({
+  useFleetArmingStore: {
+    getState: vi.fn(() => ({
+      armId: vi.fn(),
+      disarmId: vi.fn(),
+      clear: vi.fn(),
+      armByState: vi.fn(),
+      armAll: vi.fn(),
+    })),
+  },
+  isFleetArmEligible: vi.fn(() => false),
+}));
 
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: { getState: panelStoreMock.getState },
@@ -24,6 +40,8 @@ vi.mock("@/services/terminal/TerminalInstanceService", () => ({
 vi.mock("@/clients", () => ({ terminalClient: terminalClientMock }));
 vi.mock("@shared/utils/terminalInputProtocol", () => bracketedMock);
 vi.mock("@/hooks/useSendToAgentPalette", () => sendToAgentMock);
+vi.mock("@/store/terminalInputStore", () => terminalInputStoreMock);
+vi.mock("@/store/fleetArmingStore", () => fleetArmingMock);
 vi.mock("@shared/config/panelKindRegistry", () => ({
   panelKindHasPty: (kind: string) => kind === "terminal" || kind === "agent",
 }));

--- a/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalInputActions.adversarial.test.ts
@@ -13,6 +13,7 @@ const bracketedMock = vi.hoisted(() => ({
   formatWithBracketedPaste: vi.fn((t: string) => `<BP>${t}</BP>`),
 }));
 const sendToAgentMock = vi.hoisted(() => ({ openSendToAgentPalette: vi.fn() }));
+const bulkCommandMock = vi.hoisted(() => ({ openBulkCommandPalette: vi.fn() }));
 const terminalInputStoreMock = vi.hoisted(() => ({
   triggerStashInput: vi.fn(),
   triggerPopStash: vi.fn(),
@@ -40,6 +41,7 @@ vi.mock("@/services/terminal/TerminalInstanceService", () => ({
 vi.mock("@/clients", () => ({ terminalClient: terminalClientMock }));
 vi.mock("@shared/utils/terminalInputProtocol", () => bracketedMock);
 vi.mock("@/hooks/useSendToAgentPalette", () => sendToAgentMock);
+vi.mock("@/components/BulkCommandCenter/BulkCommandPalette", () => bulkCommandMock);
 vi.mock("@/store/terminalInputStore", () => terminalInputStoreMock);
 vi.mock("@/store/fleetArmingStore", () => fleetArmingMock);
 vi.mock("@shared/config/panelKindRegistry", () => ({

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -2,6 +2,8 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { AgentIdSchema, LaunchLocationSchema } from "./schemas";
 import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { AGENT_REGISTRY } from "@/config/agents";
 import type { ActionId } from "@shared/types/actions";
 export function registerAgentActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
@@ -98,7 +100,6 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     scope: "renderer",
     run: async () => {
       const state = usePanelStore.getState();
-      const { getCurrentViewStore } = await import("@/store/createWorktreeStore");
       const worktreeData = getCurrentViewStore().getState();
       const validWorktreeIds = new Set<string>();
       for (const [id, wt] of worktreeData.worktrees) {
@@ -119,7 +120,6 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     scope: "renderer",
     run: async () => {
       const state = usePanelStore.getState();
-      const { getCurrentViewStore } = await import("@/store/createWorktreeStore");
       const worktreeData = getCurrentViewStore().getState();
       const validWorktreeIds = new Set<string>();
       for (const [id, wt] of worktreeData.worktrees) {
@@ -140,7 +140,6 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     scope: "renderer",
     run: async () => {
       const state = usePanelStore.getState();
-      const { getCurrentViewStore } = await import("@/store/createWorktreeStore");
       const worktreeData = getCurrentViewStore().getState();
       const validWorktreeIds = new Set<string>();
       for (const [id, wt] of worktreeData.worktrees) {
@@ -161,7 +160,6 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     scope: "renderer",
     run: async () => {
       const state = usePanelStore.getState();
-      const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
       const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
       state.focusNextBlockedDock(activeWorktreeId ?? undefined, state.getPanelGroup);
     },
@@ -177,7 +175,6 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     scope: "renderer",
     run: async () => {
       const state = usePanelStore.getState();
-      const { getCurrentViewStore } = await import("@/store/createWorktreeStore");
       const worktreeData = getCurrentViewStore().getState();
       const validWorktreeIds = new Set<string>();
       for (const [id, wt] of worktreeData.worktrees) {

--- a/src/services/actions/definitions/introspectionActions.ts
+++ b/src/services/actions/definitions/introspectionActions.ts
@@ -1,8 +1,11 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
 import { z } from "zod";
+import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
+import { usePortalStore } from "@/store/portalStore";
 import { useProjectStore } from "@/store/projectStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { listPersistedStores } from "@/store/persistence/persistedStoreRegistry";
 import { readLocalStorageItemSafely } from "@/store/persistence/safeStorage";
@@ -50,7 +53,6 @@ export function registerIntrospectionActions(
     run: async (args: unknown, ctx: ActionContext) => {
       const { category, search, enabledOnly } =
         (args as { category?: string; search?: string; enabledOnly?: boolean } | undefined) ?? {};
-      const { actionService } = await import("@/services/ActionService");
       let manifest = actionService.list(ctx);
 
       if (category) {
@@ -83,9 +85,6 @@ export function registerIntrospectionActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
-      const { usePortalStore } = await import("@/store/portalStore");
-
       const project = useProjectStore.getState().currentProject;
       const terminalState = usePanelStore.getState();
       const worktreeSelection = useWorktreeSelectionStore.getState();

--- a/src/services/actions/definitions/notesActions.ts
+++ b/src/services/actions/definitions/notesActions.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { notesClient } from "@/clients/notesClient";
+import { usePanelStore } from "@/store/panelStore";
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 
 export function registerNotesActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
@@ -58,7 +59,6 @@ export function registerNotesActions(actions: ActionRegistry, _callbacks: Action
         await notesClient.write(note.path, content, note.metadata);
       }
       if (openPanel) {
-        const { usePanelStore } = await import("@/store/panelStore");
         const resolvedScope = noteScope ?? "project";
         await usePanelStore.getState().addPanel({
           kind: "notes",

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -1,5 +1,6 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
+import { PORTAL_DEFAULT_WIDTH } from "@shared/types";
 import { systemClient } from "@/clients";
 import { getAIAgentInfo } from "@/lib/aiAgentDetection";
 import { getPortalPlaceholderBounds } from "@/lib/portalBounds";
@@ -812,7 +813,6 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { PORTAL_DEFAULT_WIDTH } = await import("@shared/types");
       usePortalStore.getState().setWidth(PORTAL_DEFAULT_WIDTH);
     },
   }));

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -10,10 +10,13 @@ import {
   worktreeConfigClient,
 } from "@/clients";
 import { notify } from "@/lib/notify";
+import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
 import { useAgentPreferencesStore } from "@/store/agentPreferencesStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { ASSISTANT_FAST_MODELS, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { getAgentSettingsEntry } from "@shared/types";
 import { getDefaultAgentId } from "@/lib/resolveAgentId";
 import { usePerformanceModeStore } from "@/store/performanceModeStore";
@@ -678,8 +681,6 @@ export function registerPreferencesActions(
       const agentSettings = useAgentSettingsStore.getState().settings;
       const agentEntry = getAgentSettingsEntry(agentSettings, agentId);
       const storedModel = agentEntry.assistantModelId as string | undefined;
-      const { getEffectiveAgentConfig, ASSISTANT_FAST_MODELS } =
-        await import("@shared/config/agentRegistry");
       const agentCfg = getEffectiveAgentConfig(agentId);
       let model: string | undefined;
       if (storedModel && agentCfg?.models?.some((m) => m.id === storedModel)) {
@@ -692,7 +693,6 @@ export function registerPreferencesActions(
       const helpPrompt =
         "I need help with Daintree, an Electron-based IDE for orchestrating AI coding agents. Please briefly tell me how you can help.";
 
-      const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch<{ terminalId: string | null }>(
         "agent.launch",
         { agentId, cwd: folderPath, location: "dock", prompt: helpPrompt, ...(model && { model }) },
@@ -700,7 +700,6 @@ export function registerPreferencesActions(
       );
 
       // Store the terminal in the help panel
-      const { useHelpPanelStore } = await import("@/store/helpPanelStore");
       if (result.ok && result.result?.terminalId) {
         useHelpPanelStore.getState().setTerminal(result.result.terminalId, agentId);
         useHelpPanelStore.getState().setOpen(true);
@@ -718,7 +717,6 @@ export function registerPreferencesActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { useHelpPanelStore } = await import("@/store/helpPanelStore");
       useHelpPanelStore.getState().toggle();
     },
   }));

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -1,8 +1,13 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
+import { terminalClient } from "@/clients";
 import { openPanelContextMenu } from "@/lib/panelContextMenu";
+import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
+import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
+import { triggerPopStash, triggerStashInput } from "@/store/terminalInputStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
 export function registerTerminalInputActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -37,8 +42,6 @@ export function registerTerminalInputActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (!targetId) return;
-      const { terminalInstanceService } =
-        await import("@/services/terminal/TerminalInstanceService");
       const managed = terminalInstanceService.get(targetId);
       if (managed?.terminal) {
         const selection = managed.terminal.getSelection();
@@ -65,15 +68,11 @@ export function registerTerminalInputActions(
       if (!targetId) return;
       const terminal = state.panelsById[targetId];
       if (terminal?.isInputLocked) return;
-      const { terminalInstanceService } =
-        await import("@/services/terminal/TerminalInstanceService");
       const managed = terminalInstanceService.get(targetId);
       if (!managed || managed.isInputLocked) return;
       try {
         const text = await navigator.clipboard.readText();
         if (!text) return;
-        const { terminalClient } = await import("@/clients");
-        const { formatWithBracketedPaste } = await import("@shared/utils/terminalInputProtocol");
         if (managed.terminal.modes.bracketedPasteMode) {
           terminalClient.write(targetId, formatWithBracketedPaste(text));
         } else {
@@ -129,7 +128,6 @@ export function registerTerminalInputActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { triggerStashInput } = await import("@/store/terminalInputStore");
       const state = usePanelStore.getState();
       const targetId = state.focusedId;
       if (targetId) triggerStashInput(targetId);
@@ -145,7 +143,6 @@ export function registerTerminalInputActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { triggerPopStash } = await import("@/store/terminalInputStore");
       const state = usePanelStore.getState();
       const targetId = state.focusedId;
       if (targetId) triggerPopStash(targetId);
@@ -161,6 +158,8 @@ export function registerTerminalInputActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
+      // Lazy-loaded: BulkCommandPalette is a heavy React component pulled in only when the
+      // user opens the bulk-operations palette — keeps its transitive graph out of startup.
       const { openBulkCommandPalette } =
         await import("@/components/BulkCommandCenter/BulkCommandPalette");
       openBulkCommandPalette();
@@ -186,6 +185,8 @@ export function registerTerminalInputActions(
       if (!terminal) return;
       if (terminal.kind && !panelKindHasPty(terminal.kind)) return;
 
+      // Lazy-loaded: useSendToAgentPalette pulls in fuse.js and a React hook graph — only
+      // needed when the user triggers the send-to-agent flow.
       const { openSendToAgentPalette } = await import("@/hooks/useSendToAgentPalette");
       openSendToAgentPalette(sourceId);
     },
@@ -203,7 +204,6 @@ export function registerTerminalInputActions(
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId: string };
       const terminal = usePanelStore.getState().panelsById[terminalId];
-      const { useFleetArmingStore, isFleetArmEligible } = await import("@/store/fleetArmingStore");
       if (!isFleetArmEligible(terminal)) return;
       useFleetArmingStore.getState().armId(terminalId);
     },
@@ -220,7 +220,6 @@ export function registerTerminalInputActions(
     argsSchema: z.object({ terminalId: z.string() }),
     run: async (args: unknown) => {
       const { terminalId } = args as { terminalId: string };
-      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
       useFleetArmingStore.getState().disarmId(terminalId);
     },
   }));
@@ -234,7 +233,6 @@ export function registerTerminalInputActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
       useFleetArmingStore.getState().clear();
     },
   }));
@@ -262,7 +260,6 @@ export function registerTerminalInputActions(
         scope?: "current" | "all";
         extend?: boolean;
       };
-      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
       useFleetArmingStore.getState().armByState(state, scope, extend);
     },
   }));
@@ -278,7 +275,6 @@ export function registerTerminalInputActions(
     argsSchema: z.object({ scope: z.enum(["current", "all"]).optional() }).optional(),
     run: async (args: unknown) => {
       const { scope = "current" } = (args ?? {}) as { scope?: "current" | "all" };
-      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
       useFleetArmingStore.getState().armAll(scope);
     },
   }));
@@ -292,7 +288,6 @@ export function registerTerminalInputActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
       useFleetArmingStore.getState().armAll("current");
     },
   }));

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -1,6 +1,8 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import { terminalClient } from "@/clients";
+import { openBulkCommandPalette } from "@/components/BulkCommandCenter/BulkCommandPalette";
+import { openSendToAgentPalette } from "@/hooks/useSendToAgentPalette";
 import { openPanelContextMenu } from "@/lib/panelContextMenu";
 import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
@@ -158,10 +160,6 @@ export function registerTerminalInputActions(
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      // Lazy-loaded: BulkCommandPalette is a heavy React component pulled in only when the
-      // user opens the bulk-operations palette — keeps its transitive graph out of startup.
-      const { openBulkCommandPalette } =
-        await import("@/components/BulkCommandCenter/BulkCommandPalette");
       openBulkCommandPalette();
     },
   }));
@@ -185,9 +183,6 @@ export function registerTerminalInputActions(
       if (!terminal) return;
       if (terminal.kind && !panelKindHasPty(terminal.kind)) return;
 
-      // Lazy-loaded: useSendToAgentPalette pulls in fuse.js and a React hook graph — only
-      // needed when the user triggers the send-to-agent flow.
-      const { openSendToAgentPalette } = await import("@/hooks/useSendToAgentPalette");
       openSendToAgentPalette(sourceId);
     },
   }));

--- a/src/services/actions/definitions/terminalLifecycleActions.ts
+++ b/src/services/actions/definitions/terminalLifecycleActions.ts
@@ -1,6 +1,9 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
+import { actionService } from "@/services/ActionService";
 import { terminalClient } from "@/clients";
+import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
+import { fireWatchNotification } from "@/lib/watchNotification";
 import { usePanelStore } from "@/store/panelStore";
 export function registerTerminalLifecycleActions(
   actions: ActionRegistry,
@@ -124,8 +127,6 @@ export function registerTerminalLifecycleActions(
       const state = usePanelStore.getState();
       const targetId = terminalId ?? state.focusedId;
       if (targetId) {
-        const { terminalInstanceService } =
-          await import("@/services/terminal/TerminalInstanceService");
         terminalInstanceService.resetRenderer(targetId);
       }
     },
@@ -348,7 +349,6 @@ export function registerTerminalLifecycleActions(
           terminal?.agentState === "waiting" ||
           terminal?.agentState === "exited"
         ) {
-          const { fireWatchNotification } = await import("@/lib/watchNotification");
           fireWatchNotification(targetId, terminal.title ?? targetId, terminal.agentState);
         } else {
           state.watchPanel(targetId);
@@ -376,7 +376,6 @@ export function registerTerminalLifecycleActions(
         notePath: string;
         noteTitle?: string;
       };
-      const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch(
         "notes.delete",
         { notePath, noteTitle },

--- a/src/services/actions/definitions/terminalNavigationActions.ts
+++ b/src/services/actions/definitions/terminalNavigationActions.ts
@@ -2,6 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import type { ActionId } from "@shared/types/actions";
 import { usePanelStore } from "@/store/panelStore";
+import { terminalInstanceService } from "@/services/terminal/TerminalInstanceService";
 export function registerTerminalNavigationActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -182,8 +183,6 @@ export function registerTerminalNavigationActions(
     run: async () => {
       const focusedId = usePanelStore.getState().focusedId;
       if (!focusedId) return;
-      const { terminalInstanceService } =
-        await import("@/services/terminal/TerminalInstanceService");
       terminalInstanceService.scrollToLastActivity(focusedId);
     },
   }));

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import { stripAnsiCodes } from "@shared/utils/artifactParser";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalClient } from "@/clients";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 export function registerTerminalQueryActions(
@@ -159,7 +160,6 @@ export function registerTerminalQueryActions(
       }
 
       // Check if terminal kind supports PTY (must have a shell to send commands to)
-      const { panelKindHasPty } = await import("@shared/config/panelKindRegistry");
       const kind = terminal.kind ?? "terminal";
       if (!panelKindHasPty(kind)) {
         throw new Error(`Terminal kind "${kind}" does not support command execution`);

--- a/src/services/actions/definitions/terminalWorktreeActions.ts
+++ b/src/services/actions/definitions/terminalWorktreeActions.ts
@@ -1,5 +1,6 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
+import { actionService } from "@/services/ActionService";
 import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 export function registerTerminalWorktreeActions(
@@ -43,7 +44,6 @@ export function registerTerminalWorktreeActions(
       const data = getTerminalWorktree(ctx);
       if (!data) return;
 
-      const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch(
         "worktree.openEditor",
         { worktreeId: data.worktree.id },
@@ -81,7 +81,6 @@ export function registerTerminalWorktreeActions(
       const data = getTerminalWorktree(ctx);
       if (!data || !data.worktree.issueNumber) return;
 
-      const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch(
         "worktree.openIssue",
         { worktreeId: data.worktree.id },
@@ -119,7 +118,6 @@ export function registerTerminalWorktreeActions(
       const data = getTerminalWorktree(ctx);
       if (!data || !data.worktree.prUrl) return;
 
-      const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch(
         "worktree.openPR",
         { worktreeId: data.worktree.id },

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import type { ActionContext, ActionId } from "@shared/types/actions";
+import { actionService } from "@/services/ActionService";
 import { copyTreeClient, githubClient, systemClient, worktreeClient } from "@/clients";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -608,7 +609,6 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       })
       .optional(),
     run: async (args: unknown) => {
-      const { actionService } = await import("@/services/ActionService");
       const result = await actionService.dispatch("worktree.copyTree", args, { source: "user" });
       if (!result.ok) {
         throw new Error(result.error.message);
@@ -761,7 +761,6 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
         return;
       }
 
-      const { actionService } = await import("@/services/ActionService");
       await actionService.dispatch(
         "portal.openUrl",
         {
@@ -816,7 +815,6 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
       const issueUrl = await githubClient.getIssueUrl(worktree.path, worktree.issueNumber);
       if (!issueUrl) return;
 
-      const { actionService } = await import("@/services/ActionService");
       await actionService.dispatch(
         "portal.openUrl",
         {


### PR DESCRIPTION
## Summary

- Audited all ~37 `await import()` calls across 11 action definition files in `src/services/actions/definitions/`. None were needed: `ActionService` never imports from the definitions directory, so there's no circular dependency at all.
- Converted every dynamic import to a static one, including the two React component modules (`BulkCommandPalette`, `useSendToAgentPalette`) whose apparent "code-split" rationale turned out to be hollow since `App.tsx` already imports them statically at startup.
- Updated 4 test files whose narrow mocks were only satisfied because dynamic imports were deferring transitive deps at module load time.

Resolves #5250

## Changes

- `src/services/actions/definitions/agentActions.ts` — static imports
- `src/services/actions/definitions/introspectionActions.ts` — static imports
- `src/services/actions/definitions/notesActions.ts` — static imports
- `src/services/actions/definitions/panelActions.ts` — static imports
- `src/services/actions/definitions/preferencesActions.ts` — static imports
- `src/services/actions/definitions/terminalInputActions.ts` — static imports
- `src/services/actions/definitions/terminalLifecycleActions.ts` — static imports
- `src/services/actions/definitions/terminalNavigationActions.ts` — static imports
- `src/services/actions/definitions/terminalQueryActions.ts` — static imports
- `src/services/actions/definitions/terminalWorktreeActions.ts` — static imports
- `src/services/actions/definitions/worktreeActions.ts` — static imports
- 4 test files updated to match

## Testing

All 244 action-system unit tests pass. `npm run check` (typecheck + lint + format) is clean. Zero `await import(` remaining in the definitions directory.