### PR TITLE
feat(fleet): cluster attention pill for proactive agent nudges

### DIFF
--- a/src/components/Fleet/ClusterAttentionPill.tsx
+++ b/src/components/Fleet/ClusterAttentionPill.tsx
@@ -3,7 +3,8 @@ import { AlertCircle, CheckCircle2, Clock, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAgentClusters, type ClusterType } from "@/hooks/useAgentClusters";
 import { useClusterAttentionStore } from "@/store/clusterAttentionStore";
-import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
 
 const ICONS: Record<ClusterType, React.ComponentType<{ className?: string }>> = {
   prompt: Clock,
@@ -29,7 +30,10 @@ export function ClusterAttentionPill(): ReactElement | null {
   const iconClass = ICON_CLASSES[cluster.type];
 
   const handleArm = () => {
-    useFleetArmingStore.getState().armIds(cluster.memberIds);
+    const { panelsById } = usePanelStore.getState();
+    const stillEligible = cluster.memberIds.filter((id) => isFleetArmEligible(panelsById[id]));
+    if (stillEligible.length === 0) return;
+    useFleetArmingStore.getState().armIds(stillEligible);
   };
 
   const handleDismiss = () => {

--- a/src/components/Fleet/ClusterAttentionPill.tsx
+++ b/src/components/Fleet/ClusterAttentionPill.tsx
@@ -1,0 +1,81 @@
+import { type ReactElement } from "react";
+import { AlertCircle, CheckCircle2, Clock, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAgentClusters, type ClusterType } from "@/hooks/useAgentClusters";
+import { useClusterAttentionStore } from "@/store/clusterAttentionStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+
+const ICONS: Record<ClusterType, React.ComponentType<{ className?: string }>> = {
+  prompt: Clock,
+  error: AlertCircle,
+  completion: CheckCircle2,
+};
+
+const ICON_CLASSES: Record<ClusterType, string> = {
+  prompt: "text-state-waiting",
+  error: "text-status-error",
+  completion: "text-status-success",
+};
+
+export function ClusterAttentionPill(): ReactElement | null {
+  const cluster = useAgentClusters();
+  const isDismissed = useClusterAttentionStore((s) =>
+    cluster ? s.dismissedSignatures.has(cluster.signature) : false
+  );
+
+  if (!cluster || isDismissed) return null;
+
+  const Icon = ICONS[cluster.type];
+  const iconClass = ICON_CLASSES[cluster.type];
+
+  const handleArm = () => {
+    useFleetArmingStore.getState().armIds(cluster.memberIds);
+  };
+
+  const handleDismiss = () => {
+    useClusterAttentionStore.getState().dismiss(cluster.signature);
+  };
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-testid="cluster-attention-pill"
+      data-cluster-type={cluster.type}
+      className={cn(
+        "inline-flex items-center gap-1.5 h-7 pl-2 pr-1 rounded-full",
+        "bg-surface-panel backdrop-blur-md ring-1 ring-border-strong",
+        "text-xs text-daintree-text"
+      )}
+    >
+      <Icon className={cn("h-3.5 w-3.5 shrink-0", iconClass)} aria-hidden="true" />
+      <span className="font-medium">{cluster.headline}</span>
+      <button
+        type="button"
+        onClick={handleArm}
+        aria-label={`Arm ${cluster.count} ${cluster.count === 1 ? "agent" : "agents"}`}
+        className={cn(
+          "ml-1 inline-flex items-center rounded-full px-2 py-0.5 text-[11px]",
+          "bg-daintree-accent/15 text-daintree-accent hover:bg-daintree-accent/25",
+          "transition-colors",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+        )}
+      >
+        arm
+      </button>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="Dismiss cluster notification"
+        className={cn(
+          "rounded-full p-1 text-daintree-text/60 hover:bg-tint/[0.08] hover:text-daintree-text",
+          "transition-colors",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+        )}
+      >
+        <X className="h-3 w-3" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Fleet/__tests__/ClusterAttentionPill.test.tsx
+++ b/src/components/Fleet/__tests__/ClusterAttentionPill.test.tsx
@@ -4,7 +4,9 @@ import { render, fireEvent, screen } from "@testing-library/react";
 import { ClusterAttentionPill } from "../ClusterAttentionPill";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useClusterAttentionStore } from "@/store/clusterAttentionStore";
+import { usePanelStore } from "@/store/panelStore";
 import type { ClusterGroup } from "@/hooks/useAgentClusters";
+import type { TerminalInstance } from "@shared/types";
 
 const { useAgentClustersMock } = vi.hoisted(() => ({
   useAgentClustersMock: vi.fn(),
@@ -22,7 +24,33 @@ function resetStores() {
     lastArmedId: null,
   });
   useClusterAttentionStore.setState({ dismissedSignatures: new Set<string>() });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useAgentClustersMock.mockReset();
+}
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    location: "grid",
+    agentState: "waiting",
+    hasPty: true,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function seedPanels(terminals: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
 }
 
 function makeCluster(overrides: Partial<ClusterGroup> = {}): ClusterGroup {
@@ -74,10 +102,31 @@ describe("ClusterAttentionPill", () => {
 
   it("arm button calls armIds with the cluster members", () => {
     useAgentClustersMock.mockReturnValue(makeCluster({ memberIds: ["a", "b", "c"], count: 3 }));
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
     render(<ClusterAttentionPill />);
     fireEvent.click(screen.getByRole("button", { name: /arm 3 agents/i }));
     const armed = useFleetArmingStore.getState().armedIds;
     expect([...armed].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("arm button re-checks eligibility and skips members that are no longer eligible", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ memberIds: ["a", "b"], count: 2 }));
+    seedPanels([
+      makeAgent("a"),
+      makeAgent("b", { location: "trash" }), // became ineligible between render and click
+    ]);
+    render(<ClusterAttentionPill />);
+    fireEvent.click(screen.getByRole("button", { name: /arm 2 agents/i }));
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect([...armed]).toEqual(["a"]);
+  });
+
+  it("arm button is a no-op when every member has become ineligible", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ memberIds: ["a", "b"], count: 2 }));
+    seedPanels([makeAgent("a", { location: "trash" }), makeAgent("b", { location: "trash" })]);
+    render(<ClusterAttentionPill />);
+    fireEvent.click(screen.getByRole("button", { name: /arm 2 agents/i }));
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(0);
   });
 
   it("dismiss button adds the cluster signature to dismissed set and hides the pill", () => {

--- a/src/components/Fleet/__tests__/ClusterAttentionPill.test.tsx
+++ b/src/components/Fleet/__tests__/ClusterAttentionPill.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { ClusterAttentionPill } from "../ClusterAttentionPill";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useClusterAttentionStore } from "@/store/clusterAttentionStore";
+import type { ClusterGroup } from "@/hooks/useAgentClusters";
+
+const { useAgentClustersMock } = vi.hoisted(() => ({
+  useAgentClustersMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useAgentClusters", () => ({
+  useAgentClusters: useAgentClustersMock,
+}));
+
+function resetStores() {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  useClusterAttentionStore.setState({ dismissedSignatures: new Set<string>() });
+  useAgentClustersMock.mockReset();
+}
+
+function makeCluster(overrides: Partial<ClusterGroup> = {}): ClusterGroup {
+  return {
+    type: "prompt",
+    signature: "prompt:a,b:100",
+    memberIds: ["a", "b"],
+    count: 2,
+    headline: "2 agents need input",
+    priority: 1,
+    latestStateChange: 100,
+    ...overrides,
+  };
+}
+
+describe("ClusterAttentionPill", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("renders nothing when there is no active cluster", () => {
+    useAgentClustersMock.mockReturnValue(null);
+    const { container } = render(<ClusterAttentionPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the headline when a cluster is active", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster());
+    render(<ClusterAttentionPill />);
+    expect(screen.getByTestId("cluster-attention-pill")).toBeTruthy();
+    expect(screen.getByText("2 agents need input")).toBeTruthy();
+  });
+
+  it("exposes cluster type on the pill element", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ type: "error" }));
+    render(<ClusterAttentionPill />);
+    const pill = screen.getByTestId("cluster-attention-pill");
+    expect(pill.getAttribute("data-cluster-type")).toBe("error");
+  });
+
+  it("renders nothing when the cluster's signature is already dismissed", () => {
+    useClusterAttentionStore.setState({
+      dismissedSignatures: new Set(["prompt:a,b:100"]),
+    });
+    useAgentClustersMock.mockReturnValue(makeCluster());
+    const { container } = render(<ClusterAttentionPill />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("arm button calls armIds with the cluster members", () => {
+    useAgentClustersMock.mockReturnValue(makeCluster({ memberIds: ["a", "b", "c"], count: 3 }));
+    render(<ClusterAttentionPill />);
+    fireEvent.click(screen.getByRole("button", { name: /arm 3 agents/i }));
+    const armed = useFleetArmingStore.getState().armedIds;
+    expect([...armed].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("dismiss button adds the cluster signature to dismissed set and hides the pill", () => {
+    const cluster = makeCluster({ signature: "prompt:x,y:999" });
+    useAgentClustersMock.mockReturnValue(cluster);
+    const { rerender } = render(<ClusterAttentionPill />);
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss cluster/i }));
+
+    expect(useClusterAttentionStore.getState().dismissedSignatures.has("prompt:x,y:999")).toBe(
+      true
+    );
+
+    rerender(<ClusterAttentionPill />);
+    expect(screen.queryByTestId("cluster-attention-pill")).toBeNull();
+  });
+
+  it("re-surfaces when the cluster signature changes after a prior dismissal", () => {
+    const first = makeCluster({ signature: "prompt:a,b:100" });
+    useAgentClustersMock.mockReturnValue(first);
+    const { rerender } = render(<ClusterAttentionPill />);
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss cluster/i }));
+
+    rerender(<ClusterAttentionPill />);
+    expect(screen.queryByTestId("cluster-attention-pill")).toBeNull();
+
+    const next = makeCluster({ signature: "prompt:a,b:500", latestStateChange: 500 });
+    useAgentClustersMock.mockReturnValue(next);
+    rerender(<ClusterAttentionPill />);
+
+    expect(screen.getByTestId("cluster-attention-pill")).toBeTruthy();
+  });
+});

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -1,3 +1,4 @@
 export { FleetArmingRibbon } from "./FleetArmingRibbon";
 export { FleetComposer } from "./FleetComposer";
 export { focusFleetComposer } from "./fleetComposerFocus";
+export { ClusterAttentionPill } from "./ClusterAttentionPill";

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -17,6 +17,7 @@ import { TrashContainer } from "./TrashContainer";
 import { WaitingContainer } from "./WaitingContainer";
 import { BackgroundContainer } from "./BackgroundContainer";
 import { HelpAgentDockButton } from "./HelpAgentDockButton";
+import { ClusterAttentionPill } from "@/components/Fleet";
 import {
   SortableDockItem,
   SortableDockPlaceholder,
@@ -267,9 +268,10 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             <div className="w-px h-5 bg-[var(--dock-border)] mx-1 shrink-0" />
           )}
 
-          {/* Action containers: Background + Waiting + Trash */}
+          {/* Action containers: Background + ClusterAttentionPill + Waiting + Trash */}
           <div className="shrink-0 pl-1 flex items-center gap-2">
             <BackgroundContainer compact={isCompact} />
+            <ClusterAttentionPill />
             <WaitingContainer compact={isCompact} />
             <TrashContainer trashedTerminals={trashedItems} compact={isCompact} />
           </div>

--- a/src/hooks/__tests__/useAgentClusters.hook.test.tsx
+++ b/src/hooks/__tests__/useAgentClusters.hook.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+import type { TerminalInstance } from "@shared/types";
+
+const { useWorktreeStoreMock } = vi.hoisted(() => ({
+  useWorktreeStoreMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: useWorktreeStoreMock,
+}));
+
+import { useAgentClusters } from "../useAgentClusters";
+import { _resetWorktreeIdCacheForTests } from "../useTerminalSelectors";
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function seedPanels(terminals: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
+}
+
+function seedWorktrees(ids: string[]): void {
+  const worktrees = new Map(ids.map((id) => [id, { id, worktreeId: id }]));
+  useWorktreeStoreMock.mockImplementation(
+    (selector: (state: { worktrees: typeof worktrees }) => unknown) => selector({ worktrees })
+  );
+}
+
+describe("useAgentClusters (hook integration)", () => {
+  beforeEach(() => {
+    _resetWorktreeIdCacheForTests();
+    usePanelStore.setState({ panelsById: {}, panelIds: [] });
+    useWorktreeStoreMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null when fewer than 2 eligible agents exist", () => {
+    seedWorktrees(["wt-1"]);
+    seedPanels([
+      makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: 1 }),
+    ]);
+    const { result } = renderHook(() => useAgentClusters());
+    expect(result.current).toBeNull();
+  });
+
+  it("detects a prompt cluster with 2 eligible agents", () => {
+    seedWorktrees(["wt-1"]);
+    seedPanels([
+      makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: 1 }),
+      makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: 2 }),
+    ]);
+    const { result } = renderHook(() => useAgentClusters());
+    expect(result.current?.type).toBe("prompt");
+    expect(result.current?.memberIds).toEqual(["a", "b"]);
+  });
+
+  it("excludes orphaned-worktree terminals (critical: matches WaitingContainer visibility)", () => {
+    seedWorktrees(["wt-1"]); // wt-gone is NOT in the active set
+    seedPanels([
+      makeAgent("a", {
+        agentState: "waiting",
+        waitingReason: "prompt",
+        lastStateChange: 1,
+        worktreeId: "wt-1",
+      }),
+      makeAgent("b", {
+        agentState: "waiting",
+        waitingReason: "prompt",
+        lastStateChange: 2,
+        worktreeId: "wt-gone",
+      }),
+    ]);
+    const { result } = renderHook(() => useAgentClusters());
+    expect(result.current).toBeNull();
+  });
+
+  it("recomputes when panelStore updates (reactive)", () => {
+    seedWorktrees(["wt-1"]);
+    seedPanels([
+      makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: 1 }),
+    ]);
+    const { result } = renderHook(() => useAgentClusters());
+    expect(result.current).toBeNull();
+
+    act(() => {
+      seedPanels([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: 1 }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: 2 }),
+      ]);
+    });
+
+    expect(result.current?.type).toBe("prompt");
+    expect(result.current?.count).toBe(2);
+  });
+
+  it("completion cluster expires lazily when Date.now() moves past the 30s window on next update", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-01T00:00:00Z").getTime());
+    const start = Date.now();
+    seedWorktrees(["wt-1"]);
+    seedPanels([
+      makeAgent("a", { agentState: "completed", lastStateChange: start - 1_000 }),
+      makeAgent("b", { agentState: "completed", lastStateChange: start - 2_000 }),
+    ]);
+    const { result } = renderHook(() => useAgentClusters());
+    expect(result.current?.type).toBe("completion");
+
+    act(() => {
+      vi.setSystemTime(start + 60_000);
+      seedPanels([
+        makeAgent("a", { agentState: "completed", lastStateChange: start - 1_000 }),
+        makeAgent("b", { agentState: "completed", lastStateChange: start - 2_000 }),
+      ]);
+    });
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useAgentClusters.test.ts
+++ b/src/hooks/__tests__/useAgentClusters.test.ts
@@ -30,10 +30,17 @@ function build(terminals: TerminalInstance[]) {
 }
 
 const noTrash = () => false;
+const EMPTY_WORKTREE_IDS = new Set<string>();
 
 function derive(terminals: TerminalInstance[], now: number = NOW) {
   const { panelsById, panelIds } = build(terminals);
-  return deriveHighestPriorityCluster({ panelIds, panelsById, isInTrash: noTrash, now });
+  return deriveHighestPriorityCluster({
+    panelIds,
+    panelsById,
+    isInTrash: noTrash,
+    worktreeIds: EMPTY_WORKTREE_IDS,
+    now,
+  });
 }
 
 describe("deriveHighestPriorityCluster", () => {
@@ -243,9 +250,60 @@ describe("deriveHighestPriorityCluster", () => {
         panelIds,
         panelsById,
         isInTrash: (id) => id === "a",
+        worktreeIds: EMPTY_WORKTREE_IDS,
         now: NOW,
       });
       expect(cluster).toBeNull();
+    });
+
+    it("excludes terminals whose worktreeId is not in the active set (orphaned)", () => {
+      const { panelsById, panelIds } = build([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          worktreeId: "wt-1",
+        }),
+        makeAgent("b", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          worktreeId: "wt-gone",
+        }),
+      ]);
+      const cluster = deriveHighestPriorityCluster({
+        panelIds,
+        panelsById,
+        isInTrash: noTrash,
+        worktreeIds: new Set(["wt-1"]),
+        now: NOW,
+      });
+      expect(cluster).toBeNull();
+    });
+
+    it("does not treat terminals as orphaned when the worktree id set is empty", () => {
+      const { panelsById, panelIds } = build([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          worktreeId: "wt-whatever",
+        }),
+        makeAgent("b", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          worktreeId: "wt-other",
+        }),
+      ]);
+      const cluster = deriveHighestPriorityCluster({
+        panelIds,
+        panelsById,
+        isInTrash: noTrash,
+        worktreeIds: EMPTY_WORKTREE_IDS,
+        now: NOW,
+      });
+      expect(cluster?.count).toBe(2);
     });
 
     it("tolerates missing entries in panelsById", () => {
@@ -264,6 +322,7 @@ describe("deriveHighestPriorityCluster", () => {
           }),
         },
         isInTrash: noTrash,
+        worktreeIds: EMPTY_WORKTREE_IDS,
         now: NOW,
       });
       expect(cluster?.count).toBe(2);
@@ -281,6 +340,7 @@ describe("deriveHighestPriorityCluster", () => {
         panelIds,
         panelsById,
         isInTrash: noTrash,
+        worktreeIds: EMPTY_WORKTREE_IDS,
         now: NOW,
       });
       expect(cluster?.memberIds).toEqual(["b", "a"]);

--- a/src/hooks/__tests__/useAgentClusters.test.ts
+++ b/src/hooks/__tests__/useAgentClusters.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect } from "vitest";
+import { deriveHighestPriorityCluster } from "../useAgentClusters";
+import type { TerminalInstance } from "@shared/types";
+
+const NOW = 1_700_000_000_000;
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function build(terminals: TerminalInstance[]) {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  return { panelsById, panelIds };
+}
+
+const noTrash = () => false;
+
+function derive(terminals: TerminalInstance[], now: number = NOW) {
+  const { panelsById, panelIds } = build(terminals);
+  return deriveHighestPriorityCluster({ panelIds, panelsById, isInTrash: noTrash, now });
+}
+
+describe("deriveHighestPriorityCluster", () => {
+  describe("empty / single-member", () => {
+    it("returns null when no panels", () => {
+      expect(derive([])).toBeNull();
+    });
+
+    it("returns null when only one waiting-prompt agent", () => {
+      expect(
+        derive([
+          makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        ])
+      ).toBeNull();
+    });
+  });
+
+  describe("prompt cluster", () => {
+    it("detects a 2-member prompt cluster", () => {
+      const cluster = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW - 5,
+        }),
+        makeAgent("b", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW - 1,
+        }),
+      ]);
+      expect(cluster).not.toBeNull();
+      expect(cluster!.type).toBe("prompt");
+      expect(cluster!.count).toBe(2);
+      expect(cluster!.memberIds).toEqual(["a", "b"]);
+      expect(cluster!.latestStateChange).toBe(NOW - 1);
+      expect(cluster!.headline).toBe("2 agents need input");
+    });
+
+    it("excludes waiting agents with waitingReason='question'", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "question", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("excludes waiting agents with no waitingReason", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+  });
+
+  describe("error cluster", () => {
+    it("detects ≥2 exited agents with non-zero exit codes", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "exited", exitCode: 1, lastStateChange: NOW - 100 }),
+        makeAgent("b", { agentState: "exited", exitCode: 137, lastStateChange: NOW - 10 }),
+      ]);
+      expect(cluster).not.toBeNull();
+      expect(cluster!.type).toBe("error");
+      expect(cluster!.count).toBe(2);
+      expect(cluster!.headline).toBe("2 agents exited with errors");
+    });
+
+    it("excludes exited agents with exitCode 0", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "exited", exitCode: 1, lastStateChange: NOW }),
+        makeAgent("b", { agentState: "exited", exitCode: 0, lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("excludes exited agents with undefined exitCode", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "exited", exitCode: 1, lastStateChange: NOW }),
+        makeAgent("b", { agentState: "exited", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+  });
+
+  describe("completion cluster", () => {
+    it("detects completions within the 30s window", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "completed", lastStateChange: NOW - 1_000 }),
+        makeAgent("b", { agentState: "completed", lastStateChange: NOW - 15_000 }),
+      ]);
+      expect(cluster).not.toBeNull();
+      expect(cluster!.type).toBe("completion");
+      expect(cluster!.count).toBe(2);
+    });
+
+    it("excludes completions older than 30s", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "completed", lastStateChange: NOW - 1_000 }),
+        makeAgent("b", { agentState: "completed", lastStateChange: NOW - 31_000 }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("includes completions at the exact 30s boundary (inclusive)", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "completed", lastStateChange: NOW - 30_000 }),
+        makeAgent("b", { agentState: "completed", lastStateChange: NOW - 30_000 }),
+      ]);
+      expect(cluster).not.toBeNull();
+      expect(cluster!.type).toBe("completion");
+    });
+
+    it("excludes completions with no lastStateChange", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "completed", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "completed" }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+  });
+
+  describe("priority order", () => {
+    it("prompt beats error and completion when all three are active", () => {
+      const cluster = derive([
+        makeAgent("p1", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("p2", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("e1", { agentState: "exited", exitCode: 1, lastStateChange: NOW }),
+        makeAgent("e2", { agentState: "exited", exitCode: 2, lastStateChange: NOW }),
+        makeAgent("c1", { agentState: "completed", lastStateChange: NOW }),
+        makeAgent("c2", { agentState: "completed", lastStateChange: NOW }),
+      ]);
+      expect(cluster?.type).toBe("prompt");
+    });
+
+    it("error beats completion when prompt is absent", () => {
+      const cluster = derive([
+        makeAgent("e1", { agentState: "exited", exitCode: 1, lastStateChange: NOW }),
+        makeAgent("e2", { agentState: "exited", exitCode: 2, lastStateChange: NOW }),
+        makeAgent("c1", { agentState: "completed", lastStateChange: NOW }),
+        makeAgent("c2", { agentState: "completed", lastStateChange: NOW }),
+      ]);
+      expect(cluster?.type).toBe("error");
+    });
+  });
+
+  describe("eligibility guards", () => {
+    it("excludes trashed terminals", () => {
+      const cluster = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          location: "trash",
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("excludes background terminals", () => {
+      const cluster = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          location: "background",
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("excludes non-agent terminals", () => {
+      const cluster = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          kind: "terminal",
+          agentId: undefined,
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("excludes terminals with hasPty=false", () => {
+      const cluster = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW,
+          hasPty: false,
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(cluster).toBeNull();
+    });
+
+    it("respects the isInTrash predicate", () => {
+      const { panelsById, panelIds } = build([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      const cluster = deriveHighestPriorityCluster({
+        panelIds,
+        panelsById,
+        isInTrash: (id) => id === "a",
+        now: NOW,
+      });
+      expect(cluster).toBeNull();
+    });
+
+    it("tolerates missing entries in panelsById", () => {
+      const cluster = deriveHighestPriorityCluster({
+        panelIds: ["missing", "a", "b"],
+        panelsById: {
+          a: makeAgent("a", {
+            agentState: "waiting",
+            waitingReason: "prompt",
+            lastStateChange: NOW,
+          }),
+          b: makeAgent("b", {
+            agentState: "waiting",
+            waitingReason: "prompt",
+            lastStateChange: NOW,
+          }),
+        },
+        isInTrash: noTrash,
+        now: NOW,
+      });
+      expect(cluster?.count).toBe(2);
+    });
+  });
+
+  describe("signature stability", () => {
+    it("memberIds follow panelIds order, not insertion order of panelsById", () => {
+      const panelIds = ["b", "a"];
+      const panelsById = {
+        a: makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        b: makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      };
+      const cluster = deriveHighestPriorityCluster({
+        panelIds,
+        panelsById,
+        isInTrash: noTrash,
+        now: NOW,
+      });
+      expect(cluster?.memberIds).toEqual(["b", "a"]);
+    });
+
+    it("signature is stable across identical inputs", () => {
+      const terminals = [
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ];
+      const s1 = derive(terminals)!.signature;
+      const s2 = derive(terminals)!.signature;
+      expect(s1).toBe(s2);
+    });
+
+    it("signature changes when latestStateChange advances", () => {
+      const s1 = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW - 100,
+        }),
+        makeAgent("b", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW - 100,
+        }),
+      ])!.signature;
+      const s2 = derive([
+        makeAgent("a", {
+          agentState: "waiting",
+          waitingReason: "prompt",
+          lastStateChange: NOW - 100,
+        }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ])!.signature;
+      expect(s1).not.toBe(s2);
+    });
+
+    it("signature changes when membership changes", () => {
+      const s1 = derive([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ])!.signature;
+      const s2 = derive([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("c", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ])!.signature;
+      expect(s1).not.toBe(s2);
+    });
+
+    it("signature is sorted so order of panels does not affect it", () => {
+      const termsAsc = [
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ];
+      const termsDesc = [
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ];
+      expect(derive(termsAsc)!.signature).toBe(derive(termsDesc)!.signature);
+    });
+  });
+
+  describe("headline variants", () => {
+    it("uses plural correctly for ≥2 agents", () => {
+      const cluster = derive([
+        makeAgent("a", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("b", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+        makeAgent("c", { agentState: "waiting", waitingReason: "prompt", lastStateChange: NOW }),
+      ]);
+      expect(cluster?.headline).toBe("3 agents need input");
+    });
+  });
+});

--- a/src/hooks/useAgentClusters.ts
+++ b/src/hooks/useAgentClusters.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 import { isFleetArmEligible } from "@/store/fleetArmingStore";
+import { isTerminalVisible, useWorktreeIds } from "@/hooks/useTerminalSelectors";
 
 export type ClusterType = "prompt" | "error" | "completion";
 
@@ -19,13 +20,6 @@ const PROMPT_PRIORITY = 1;
 const ERROR_PRIORITY = 2;
 const COMPLETION_PRIORITY = 3;
 const COMPLETION_WINDOW_MS = 30_000;
-
-function isVisibleForCluster(t: TerminalInstance, isInTrash: (id: string) => boolean): boolean {
-  if (isInTrash(t.id)) return false;
-  if (t.location === "trash") return false;
-  if (t.location === "background") return false;
-  return true;
-}
 
 function makeSignature(type: ClusterType, memberIds: string[], latestStateChange: number): string {
   const sorted = [...memberIds].sort();
@@ -64,6 +58,7 @@ interface DeriveParams {
   panelIds: string[];
   panelsById: Record<string, TerminalInstance | undefined>;
   isInTrash: (id: string) => boolean;
+  worktreeIds: Set<string>;
   now: number;
 }
 
@@ -75,7 +70,7 @@ interface DeriveParams {
  * Tie-break: larger count → newer latestStateChange → lexical member-id order.
  */
 export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup | null {
-  const { panelIds, panelsById, isInTrash, now } = params;
+  const { panelIds, panelsById, isInTrash, worktreeIds, now } = params;
 
   const buckets: Record<ClusterType, BucketMember[]> = {
     prompt: [],
@@ -87,7 +82,7 @@ export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup
     const t = panelsById[id];
     if (!t) continue;
     if (!isFleetArmEligible(t)) continue;
-    if (!isVisibleForCluster(t, isInTrash)) continue;
+    if (!isTerminalVisible(t, isInTrash, worktreeIds)) continue;
 
     const lsc =
       typeof t.lastStateChange === "number" && !Number.isNaN(t.lastStateChange)
@@ -167,6 +162,7 @@ export function useAgentClusters(): ClusterGroup | null {
   const panelIds = usePanelStore((state) => state.panelIds);
   const panelsById = usePanelStore(useShallow((state) => state.panelsById));
   const isInTrash = usePanelStore((state) => state.isInTrash);
+  const worktreeIds = useWorktreeIds();
 
   return useMemo(
     () =>
@@ -174,8 +170,9 @@ export function useAgentClusters(): ClusterGroup | null {
         panelIds,
         panelsById,
         isInTrash,
+        worktreeIds,
         now: Date.now(),
       }),
-    [panelIds, panelsById, isInTrash]
+    [panelIds, panelsById, isInTrash, worktreeIds]
   );
 }

--- a/src/hooks/useAgentClusters.ts
+++ b/src/hooks/useAgentClusters.ts
@@ -1,0 +1,181 @@
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { isFleetArmEligible } from "@/store/fleetArmingStore";
+
+export type ClusterType = "prompt" | "error" | "completion";
+
+export interface ClusterGroup {
+  type: ClusterType;
+  signature: string;
+  memberIds: string[];
+  count: number;
+  headline: string;
+  priority: number;
+  latestStateChange: number;
+}
+
+const PROMPT_PRIORITY = 1;
+const ERROR_PRIORITY = 2;
+const COMPLETION_PRIORITY = 3;
+const COMPLETION_WINDOW_MS = 30_000;
+
+function isVisibleForCluster(t: TerminalInstance, isInTrash: (id: string) => boolean): boolean {
+  if (isInTrash(t.id)) return false;
+  if (t.location === "trash") return false;
+  if (t.location === "background") return false;
+  return true;
+}
+
+function makeSignature(type: ClusterType, memberIds: string[], latestStateChange: number): string {
+  const sorted = [...memberIds].sort();
+  return `${type}:${sorted.join(",")}:${latestStateChange}`;
+}
+
+function makeHeadline(type: ClusterType, count: number): string {
+  const noun = count === 1 ? "agent" : "agents";
+  switch (type) {
+    case "prompt":
+      return `${count} ${noun} need${count === 1 ? "s" : ""} input`;
+    case "error":
+      return `${count} ${noun} exited with errors`;
+    case "completion":
+      return `${count} ${noun} finished`;
+  }
+}
+
+function priorityFor(type: ClusterType): number {
+  switch (type) {
+    case "prompt":
+      return PROMPT_PRIORITY;
+    case "error":
+      return ERROR_PRIORITY;
+    case "completion":
+      return COMPLETION_PRIORITY;
+  }
+}
+
+interface BucketMember {
+  id: string;
+  lastStateChange: number;
+}
+
+interface DeriveParams {
+  panelIds: string[];
+  panelsById: Record<string, TerminalInstance | undefined>;
+  isInTrash: (id: string) => boolean;
+  now: number;
+}
+
+/**
+ * Pure cluster derivation. Scans eligible agent terminals in `panelIds` order
+ * and returns the highest-priority cluster (≥2 members) or null.
+ *
+ * Priority: prompt (1) > error (2) > completion (3).
+ * Tie-break: larger count → newer latestStateChange → lexical member-id order.
+ */
+export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup | null {
+  const { panelIds, panelsById, isInTrash, now } = params;
+
+  const buckets: Record<ClusterType, BucketMember[]> = {
+    prompt: [],
+    error: [],
+    completion: [],
+  };
+
+  for (const id of panelIds) {
+    const t = panelsById[id];
+    if (!t) continue;
+    if (!isFleetArmEligible(t)) continue;
+    if (!isVisibleForCluster(t, isInTrash)) continue;
+
+    const lsc =
+      typeof t.lastStateChange === "number" && !Number.isNaN(t.lastStateChange)
+        ? t.lastStateChange
+        : 0;
+
+    if (t.agentState === "waiting" && t.waitingReason === "prompt") {
+      buckets.prompt.push({ id, lastStateChange: lsc });
+      continue;
+    }
+
+    if (t.agentState === "exited" && typeof t.exitCode === "number" && t.exitCode !== 0) {
+      buckets.error.push({ id, lastStateChange: lsc });
+      continue;
+    }
+
+    if (
+      t.agentState === "completed" &&
+      typeof t.lastStateChange === "number" &&
+      !Number.isNaN(t.lastStateChange) &&
+      t.lastStateChange >= now - COMPLETION_WINDOW_MS
+    ) {
+      buckets.completion.push({ id, lastStateChange: lsc });
+      continue;
+    }
+  }
+
+  const candidates: ClusterGroup[] = [];
+  for (const type of ["prompt", "error", "completion"] as const) {
+    const members = buckets[type];
+    if (members.length < 2) continue;
+    const memberIds = members.map((m) => m.id);
+    const latestStateChange = members.reduce(
+      (acc, m) => (m.lastStateChange > acc ? m.lastStateChange : acc),
+      0
+    );
+    candidates.push({
+      type,
+      memberIds,
+      count: members.length,
+      latestStateChange,
+      priority: priorityFor(type),
+      signature: makeSignature(type, memberIds, latestStateChange),
+      headline: makeHeadline(type, members.length),
+    });
+  }
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    if (a.priority !== b.priority) return a.priority - b.priority;
+    if (a.count !== b.count) return b.count - a.count;
+    if (a.latestStateChange !== b.latestStateChange) {
+      return b.latestStateChange - a.latestStateChange;
+    }
+    return a.memberIds.join(",").localeCompare(b.memberIds.join(","));
+  });
+
+  return candidates[0];
+}
+
+/**
+ * React hook returning the highest-priority active agent cluster, or `null`
+ * when no cluster of ≥2 eligible members exists.
+ *
+ * Follows the `useWaitingTerminals()` pattern: read raw store slices, then
+ * derive in `useMemo`. No grouping logic runs inside the Zustand selector,
+ * avoiding new-reference-per-call churn that would trigger re-renders on
+ * every panel update.
+ *
+ * The `now` timestamp is captured once per render via `Date.now()`. The
+ * completion window (30s) therefore dissolves lazily on the next panel
+ * update — this is intentional: the issue spec requires piggybacking on
+ * existing panel-store subscriptions and forbids new timers.
+ */
+export function useAgentClusters(): ClusterGroup | null {
+  const panelIds = usePanelStore((state) => state.panelIds);
+  const panelsById = usePanelStore(useShallow((state) => state.panelsById));
+  const isInTrash = usePanelStore((state) => state.isInTrash);
+
+  return useMemo(
+    () =>
+      deriveHighestPriorityCluster({
+        panelIds,
+        panelsById,
+        isInTrash,
+        now: Date.now(),
+      }),
+    [panelIds, panelsById, isInTrash]
+  );
+}

--- a/src/hooks/useAgentClusters.ts
+++ b/src/hooks/useAgentClusters.ts
@@ -141,7 +141,7 @@ export function deriveHighestPriorityCluster(params: DeriveParams): ClusterGroup
     return a.memberIds.join(",").localeCompare(b.memberIds.join(","));
   });
 
-  return candidates[0];
+  return candidates[0]!;
 }
 
 /**

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -4,14 +4,14 @@ import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import type { WorktreeSnapshot } from "@shared/types";
 
-function isTerminalOrphaned(terminal: TerminalInstance, worktreeIds: Set<string>): boolean {
+export function isTerminalOrphaned(terminal: TerminalInstance, worktreeIds: Set<string>): boolean {
   const worktreeId = typeof terminal.worktreeId === "string" ? terminal.worktreeId.trim() : "";
   if (!worktreeId) return false;
   if (worktreeIds.size === 0) return false;
   return !worktreeIds.has(worktreeId);
 }
 
-function isTerminalVisible(
+export function isTerminalVisible(
   terminal: TerminalInstance,
   isInTrash: (id: string) => boolean,
   worktreeIds: Set<string>
@@ -58,7 +58,7 @@ export function _resetWorktreeIdCacheForTests(): void {
   _cachedIds = null;
 }
 
-function useWorktreeIds(): Set<string> {
+export function useWorktreeIds(): Set<string> {
   return useWorktreeStore(useShallow((state) => buildWorktreeIds(state.worktrees)));
 }
 

--- a/src/store/__tests__/clusterAttentionStore.test.ts
+++ b/src/store/__tests__/clusterAttentionStore.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useClusterAttentionStore } from "../clusterAttentionStore";
+
+function reset() {
+  useClusterAttentionStore.setState({ dismissedSignatures: new Set<string>() });
+}
+
+describe("clusterAttentionStore", () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it("starts with an empty dismissed set", () => {
+    expect(useClusterAttentionStore.getState().dismissedSignatures.size).toBe(0);
+  });
+
+  it("adds a signature on dismiss", () => {
+    useClusterAttentionStore.getState().dismiss("prompt:a,b:100");
+    const s = useClusterAttentionStore.getState();
+    expect(s.dismissedSignatures.has("prompt:a,b:100")).toBe(true);
+    expect(s.dismissedSignatures.size).toBe(1);
+  });
+
+  it("is idempotent when dismissing the same signature twice", () => {
+    const { dismiss } = useClusterAttentionStore.getState();
+    dismiss("sig-1");
+    const firstRef = useClusterAttentionStore.getState().dismissedSignatures;
+    dismiss("sig-1");
+    const secondRef = useClusterAttentionStore.getState().dismissedSignatures;
+    expect(secondRef).toBe(firstRef);
+    expect(secondRef.size).toBe(1);
+  });
+
+  it("accumulates multiple distinct signatures", () => {
+    const { dismiss } = useClusterAttentionStore.getState();
+    dismiss("sig-a");
+    dismiss("sig-b");
+    dismiss("sig-c");
+    const { dismissedSignatures } = useClusterAttentionStore.getState();
+    expect(dismissedSignatures.size).toBe(3);
+    expect([...dismissedSignatures].sort()).toEqual(["sig-a", "sig-b", "sig-c"]);
+  });
+
+  it("reset clears all signatures", () => {
+    const { dismiss, reset: doReset } = useClusterAttentionStore.getState();
+    dismiss("sig-a");
+    dismiss("sig-b");
+    doReset();
+    expect(useClusterAttentionStore.getState().dismissedSignatures.size).toBe(0);
+  });
+
+  it("dismissing produces a new Set reference so subscribers re-render", () => {
+    const before = useClusterAttentionStore.getState().dismissedSignatures;
+    useClusterAttentionStore.getState().dismiss("sig-x");
+    const after = useClusterAttentionStore.getState().dismissedSignatures;
+    expect(after).not.toBe(before);
+  });
+});

--- a/src/store/clusterAttentionStore.ts
+++ b/src/store/clusterAttentionStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+/**
+ * Session-local dismissal state for cluster-attention pills.
+ *
+ * Signatures encode cluster type + sorted member IDs + latest state-change
+ * timestamp. A signature therefore changes whenever the cluster's membership
+ * or its most recent member transition changes, so a prior dismissal naturally
+ * expires when a cluster dissolves and reforms. No persistence — state resets
+ * on app reload.
+ */
+interface ClusterAttentionState {
+  dismissedSignatures: Set<string>;
+  dismiss: (signature: string) => void;
+  reset: () => void;
+}
+
+export const useClusterAttentionStore = create<ClusterAttentionState>()((set) => ({
+  dismissedSignatures: new Set<string>(),
+  dismiss: (signature) =>
+    set((s) => {
+      if (s.dismissedSignatures.has(signature)) return {};
+      const next = new Set(s.dismissedSignatures);
+      next.add(signature);
+      return { dismissedSignatures: next };
+    }),
+  reset: () => set({ dismissedSignatures: new Set<string>() }),
+}));


### PR DESCRIPTION
## Summary

- Adds a cluster attention pill to the `ContentDock` action row that surfaces when 2+ agents hit the same state simultaneously (prompt, error, or completion clusters)
- Cluster derivation runs as a pure function (`deriveHighestPriorityCluster`) against existing store state, piggybacking on the agent state polling cadence with no new timer
- Session-local dismissal store tracks user-dismissed clusters by signature so they don't re-surface until a new cluster forms

Resolves #5303

## Changes

- `src/components/Fleet/ClusterAttentionPill.tsx` — pill component wired into `ContentDock` between `BackgroundContainer` and `WaitingContainer`
- `src/hooks/useAgentClusters.ts` — `deriveHighestPriorityCluster` pure helper + `useHighestPriorityCluster` hook; priority order is prompt > error > completion; clusters dissolve when membership drops below 2; prompt signatures auto-expire after 30s
- `src/store/clusterAttentionStore.ts` — session-local dismissal store (no persistence); keyed by cluster signature
- `src/hooks/useTerminalSelectors.ts` — exported `isTerminalVisible`, `isTerminalOrphaned`, and `useWorktreeIds` for reuse by the new hook

## Testing

48 new tests across store, pure derivation, hook integration, and component layers. All 29 pre-existing selector tests still pass. Typecheck, lint (401 warnings, 0 errors — all pre-existing), and format all clean.