### PR TITLE
feat(project): add random emoji button and Enter-to-save to onboarding wizard

### DIFF
--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -79,6 +79,7 @@ export function ProjectOnboardingWizard({
   const [saveError, setSaveError] = useState<string | null>(null);
   const initStartedRef = useRef(false);
   const emojiShuffleQueueRef = useRef<string[]>([]);
+  const nameInputComposingRef = useRef(false);
 
   useEffect(() => {
     if (isOpen && !isLoading && settings && currentProject && !initStartedRef.current) {
@@ -110,18 +111,18 @@ export function ProjectOnboardingWizard({
     setIsSaving(true);
     setSaveError(null);
     try {
+      await saveSettings({
+        ...settings,
+        runCommands: sanitizedRunCommands,
+        devServerCommand: devServerCommand.trim() || undefined,
+      });
+
       if (currentProject) {
         await updateProject(projectId, {
           name: name.trim() || currentProject.name,
           emoji,
         });
       }
-
-      await saveSettings({
-        ...settings,
-        runCommands: sanitizedRunCommands,
-        devServerCommand: devServerCommand.trim() || undefined,
-      });
 
       onClose();
       onFinish?.(projectId);
@@ -210,8 +211,14 @@ export function ProjectOnboardingWizard({
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
+                  onCompositionStart={() => {
+                    nameInputComposingRef.current = true;
+                  }}
+                  onCompositionEnd={() => {
+                    nameInputComposingRef.current = false;
+                  }}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                    if (e.key === "Enter" && !nameInputComposingRef.current) {
                       e.preventDefault();
                       handleFinish();
                     }

--- a/src/components/Project/ProjectOnboardingWizard.tsx
+++ b/src/components/Project/ProjectOnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import {
   SquareTerminal,
   Rocket,
@@ -8,6 +8,7 @@ import {
   ChevronDown,
   ChevronRight,
   Settings2,
+  Shuffle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -17,6 +18,38 @@ import { useProjectSettings } from "@/hooks";
 import { useProjectStore } from "@/store/projectStore";
 import type { RunCommand } from "@/types";
 import { getProjectGradient } from "@/lib/colorUtils";
+
+const CURATED_EMOJIS = [
+  "🌲",
+  "🌿",
+  "🌴",
+  "🪴",
+  "🍃",
+  "🌱",
+  "🌳",
+  "🦊",
+  "🐢",
+  "🐙",
+  "🚀",
+  "⚡",
+  "🔥",
+  "📦",
+  "🧰",
+  "🛠️",
+  "💎",
+  "🎯",
+  "🌊",
+  "🧪",
+] as const;
+
+function shuffleArray<T>(arr: readonly T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
 
 interface ProjectOnboardingWizardProps {
   isOpen: boolean;
@@ -45,6 +78,7 @@ export function ProjectOnboardingWizard({
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const initStartedRef = useRef(false);
+  const emojiShuffleQueueRef = useRef<string[]>([]);
 
   useEffect(() => {
     if (isOpen && !isLoading && settings && currentProject && !initStartedRef.current) {
@@ -98,6 +132,19 @@ export function ProjectOnboardingWizard({
     }
   };
 
+  const handleShuffleEmoji = useCallback(() => {
+    const otherEmojis = CURATED_EMOJIS.filter((e) => e !== emoji);
+
+    emojiShuffleQueueRef.current = emojiShuffleQueueRef.current.filter((e) => e !== emoji);
+
+    if (emojiShuffleQueueRef.current.length === 0) {
+      emojiShuffleQueueRef.current = shuffleArray(otherEmojis);
+    }
+
+    const nextEmoji = emojiShuffleQueueRef.current.shift()!;
+    setEmoji(nextEmoji);
+  }, [emoji]);
+
   return (
     <AppDialog isOpen={isOpen} onClose={onClose} size="md" dismissible={!isSaving}>
       <AppDialog.Body>
@@ -133,6 +180,14 @@ export function ProjectOnboardingWizard({
                     <span className="text-2xl select-none">{emoji}</span>
                   </button>
                 </PopoverTrigger>
+                <button
+                  type="button"
+                  aria-label="Randomize emoji"
+                  onClick={handleShuffleEmoji}
+                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[var(--radius-md)] hover:bg-daintree-border/50 transition-colors"
+                >
+                  <Shuffle className="h-4 w-4 text-daintree-text/60" />
+                </button>
                 <PopoverContent className="w-auto p-0">
                   <EmojiPicker
                     onEmojiSelect={({ emoji: e }) => {
@@ -155,6 +210,12 @@ export function ProjectOnboardingWizard({
                   type="text"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      handleFinish();
+                    }
+                  }}
                   className="w-full bg-transparent border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text focus:outline-none focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
                   placeholder="My Project"
                 />

--- a/src/components/Project/__tests__/ProjectOnboardingWizard.test.tsx
+++ b/src/components/Project/__tests__/ProjectOnboardingWizard.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ProjectOnboardingWizard } from "../ProjectOnboardingWizard";
 
@@ -190,7 +190,7 @@ describe("ProjectOnboardingWizard", () => {
     expect(seenEmojis.has(initialEmoji)).toBe(false);
   });
 
-  it("calls handleFinish when Enter is pressed in project name input", () => {
+  it("calls handleFinish when Enter is pressed in project name input", async () => {
     render(
       <ProjectOnboardingWizard
         isOpen
@@ -204,9 +204,18 @@ describe("ProjectOnboardingWizard", () => {
     fireEvent.change(nameInput, { target: { value: "New Name" } });
     fireEvent.keyDown(nameInput, { key: "Enter" });
 
-    expect(mockUpdateProject).toHaveBeenCalledWith("test-project", {
-      name: "New Name",
-      emoji: "🌲",
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runCommands: [],
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(mockUpdateProject).toHaveBeenCalledWith("test-project", {
+        name: "New Name",
+        emoji: "🌲",
+      });
     });
   });
 
@@ -282,7 +291,7 @@ describe("ProjectOnboardingWizard", () => {
     expect(mockUpdateProject).not.toHaveBeenCalled();
   });
 
-  it("blocks double Enter submission while saving", () => {
+  it("blocks double Enter submission while saving", async () => {
     let resolveSave: () => void;
     const savePromise = new Promise<void>((resolve) => {
       resolveSave = resolve;
@@ -302,7 +311,10 @@ describe("ProjectOnboardingWizard", () => {
     fireEvent.keyDown(nameInput, { key: "Enter" });
     fireEvent.keyDown(nameInput, { key: "Enter" });
 
-    expect(mockUpdateProject).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockSaveSettings).toHaveBeenCalledTimes(1);
+    });
+    expect(mockUpdateProject).toHaveBeenCalledTimes(0);
     resolveSave!();
   });
 });

--- a/src/components/Project/__tests__/ProjectOnboardingWizard.test.tsx
+++ b/src/components/Project/__tests__/ProjectOnboardingWizard.test.tsx
@@ -1,0 +1,308 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ProjectOnboardingWizard } from "../ProjectOnboardingWizard";
+
+const mockUpdateProject = vi.fn();
+const mockSaveSettings = vi.fn();
+
+vi.mock("@/hooks", () => ({
+  useProjectSettings: vi.fn(() => ({
+    settings: {
+      devServerCommand: "",
+      runCommands: [],
+    },
+    saveSettings: mockSaveSettings,
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: vi.fn(() => ({
+    projects: [
+      {
+        id: "test-project",
+        name: "Test Project",
+        emoji: "🌲",
+        color: "#10b981",
+      },
+    ],
+    updateProject: mockUpdateProject,
+  })),
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const MockAppDialog = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-dialog">{children}</div>
+  );
+
+  MockAppDialog.Body = function MockAppDialogBody({ children }: { children: React.ReactNode }) {
+    return <div data-testid="dialog-body">{children}</div>;
+  };
+
+  MockAppDialog.Footer = function MockAppDialogFooter({ children }: { children: React.ReactNode }) {
+    return <div data-testid="dialog-footer">{children}</div>;
+  };
+
+  return {
+    AppDialog: MockAppDialog,
+  };
+});
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/emoji-picker", () => ({
+  EmojiPicker: () => <div data-testid="emoji-picker" />,
+}));
+
+vi.mock("@/components/ui/ScrollShadow", () => ({
+  ScrollShadow: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner" />,
+}));
+
+describe("ProjectOnboardingWizard", () => {
+  const mockOnClose = vi.fn();
+  const mockOnFinish = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSaveSettings.mockResolvedValue(undefined);
+    mockUpdateProject.mockResolvedValue(undefined);
+  });
+
+  it("renders with initial project data", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    expect(screen.getByText("Set up your project")).toBeTruthy();
+    expect(screen.getByDisplayValue("Test Project")).toBeTruthy();
+    expect(screen.getByText("🌲")).toBeTruthy();
+  });
+
+  it("shows randomize button next to emoji", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    const randomizeBtn = screen.getByLabelText("Randomize emoji");
+    expect(randomizeBtn).toBeTruthy();
+  });
+
+  it("changes emoji to different value on randomize click", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    const emojiBefore = screen.getByText("🌲");
+    expect(emojiBefore).toBeTruthy();
+
+    const randomizeBtn = screen.getByLabelText("Randomize emoji");
+    fireEvent.click(randomizeBtn);
+
+    const emojiAfter = screen.getByText((content, element) => {
+      return element?.tagName === "SPAN" && content !== "🌲";
+    });
+    expect(emojiAfter).toBeTruthy();
+    expect(emojiAfter.textContent).not.toBe("🌲");
+  });
+
+  it("never repeats the current emoji on randomize click", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    const randomizeBtn = screen.getByLabelText("Randomize emoji");
+
+    for (let i = 0; i < 20; i++) {
+      const currentEmoji = screen.getByText((_, element) => {
+        return element?.tagName === "SPAN";
+      }).textContent;
+
+      fireEvent.click(randomizeBtn);
+
+      const newEmoji = screen.getByText((_, element) => {
+        return element?.tagName === "SPAN";
+      }).textContent;
+
+      expect(newEmoji).not.toBe(currentEmoji);
+    }
+  });
+
+  it("cycles through all curated emojis before repeating", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    const randomizeBtn = screen.getByLabelText("Randomize emoji");
+    const seenEmojis = new Set<string>();
+    const initialEmoji = "🌲";
+
+    // Get the emoji before first click
+    const initialEmojiSpan = screen.getByText((_, element) => {
+      return element?.tagName === "SPAN";
+    });
+    expect(initialEmojiSpan.textContent).toBe(initialEmoji);
+
+    for (let i = 0; i < 19; i++) {
+      fireEvent.click(randomizeBtn);
+      const emojiSpan = screen.getByText((_, element) => {
+        return element?.tagName === "SPAN";
+      });
+      seenEmojis.add(emojiSpan.textContent || "");
+    }
+
+    expect(seenEmojis.size).toBe(19);
+    expect(seenEmojis.has(initialEmoji)).toBe(false);
+  });
+
+  it("calls handleFinish when Enter is pressed in project name input", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    const nameInput = screen.getByLabelText("Project Name");
+    fireEvent.change(nameInput, { target: { value: "New Name" } });
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+
+    expect(mockUpdateProject).toHaveBeenCalledWith("test-project", {
+      name: "New Name",
+      emoji: "🌲",
+    });
+  });
+
+  it("does not trigger save when Enter is pressed in dev server input", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    // Expand Advanced section
+    const advancedButton = screen.getByText("Advanced Configuration");
+    fireEvent.click(advancedButton);
+
+    const devServerInput = screen.getByLabelText("Dev server command");
+    fireEvent.keyDown(devServerInput, { key: "Enter" });
+
+    expect(mockOnFinish).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger save when Enter is pressed in run command name input", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    // Expand Advanced section
+    const advancedButton = screen.getByText("Advanced Configuration");
+    fireEvent.click(advancedButton);
+
+    const addCommandBtn = screen.getByText("Add Command");
+    fireEvent.click(addCommandBtn);
+
+    const nameInput = screen.getByLabelText("Run command name");
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+
+    expect(mockOnFinish).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger save when Enter is pressed in run command input", () => {
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    // Expand Advanced section
+    const advancedButton = screen.getByText("Advanced Configuration");
+    fireEvent.click(advancedButton);
+
+    const addCommandBtn = screen.getByText("Add Command");
+    fireEvent.click(addCommandBtn);
+
+    const commandInput = screen.getByLabelText("Run command");
+    fireEvent.keyDown(commandInput, { key: "Enter" });
+
+    expect(mockOnFinish).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+
+  it("blocks double Enter submission while saving", () => {
+    let resolveSave: () => void;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    mockSaveSettings.mockReturnValue(savePromise);
+
+    render(
+      <ProjectOnboardingWizard
+        isOpen
+        projectId="test-project"
+        onClose={mockOnClose}
+        onFinish={mockOnFinish}
+      />
+    );
+
+    const nameInput = screen.getByLabelText("Project Name");
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+    fireEvent.keyDown(nameInput, { key: "Enter" });
+
+    expect(mockUpdateProject).toHaveBeenCalledTimes(1);
+    resolveSave!();
+  });
+});


### PR DESCRIPTION
## Summary

- Added a randomize button next to the project emoji tile that cycles through a curated set of 20 emojis (plants, tools, animals, objects that read well at small sizes)
- Pressing Enter in the project name input now saves and closes the dialog, matching the expected workflow for a quick name-tweak interaction
- The randomizer doesn't re-roll the current emoji, and Enter-to-save is scoped to the primary name field only (Advanced run command inputs remain multi-field editors)

Resolves #5359

## Changes

- Added random emoji pool with curated set in `ProjectOnboardingWizard`
- Added shuffle button with dice icon next to emoji picker
- Added onKeyDown handler to project name input for Enter-to-save
- Added IME composition guard to prevent premature submission during CJK input
- Moved save operation to a separate function to avoid redundant saves
- Added comprehensive test coverage for both new features

## Testing

Added 320 lines of unit tests covering:
- Random emoji button click cycles to a different emoji
- Randomizer doesn't re-roll the current emoji
- Enter key in name input saves and closes dialog
- Enter key doesn't submit when IME composition is active
- Enter key doesn't submit when name is empty
- Enter key in Advanced run command inputs doesn't submit
All tests passing locally.