### PR TITLE
feat(fleet): broadcast text composer for armed agent terminals

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -293,6 +293,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Fleet/FleetComposer.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
   "src/components/GitHub/BulkActionBar.tsx": {
     "success": 1,
     "skip": 0,

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -288,7 +288,8 @@ export type BuiltInActionId =
   | "fleet.interrupt"
   | "fleet.restart"
   | "fleet.kill"
-  | "fleet.trash";
+  | "fleet.trash"
+  | "terminal.focusFleetComposer";
 
 export type ActionId = BuiltInActionId | (string & {});
 

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -118,6 +118,7 @@ export type BuiltInKeyAction =
   | "terminal.bulkCommand"
   | "terminal.armDefault"
   | "terminal.disarmAll"
+  | "terminal.focusFleetComposer"
 
   // Fleet quick-actions (scoped to "fleet ribbon visible" at dispatch time)
   | "fleet.accept"
@@ -305,6 +306,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "fleet.restart",
   "fleet.kill",
   "fleet.trash",
+  "terminal.focusFleetComposer",
   "agent.palette",
   ...BUILT_IN_AGENT_KEY_ACTIONS,
   "agent.terminal",

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -12,6 +12,7 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
+import { FleetComposer } from "./FleetComposer";
 
 interface PresetOption {
   value: FleetArmStatePreset;
@@ -276,73 +277,77 @@ export function FleetArmingRibbon(): ReactElement | null {
   };
 
   return (
-    <div
-      role="status"
-      aria-live="off"
-      className="flex items-center gap-3 border-b border-daintree-accent/40 bg-daintree-accent/10 px-3 py-1.5 text-[12px] text-daintree-text"
-      data-testid="fleet-arming-ribbon"
-    >
-      <span className="font-medium text-daintree-accent">
-        {armedCount} {armedCount === 1 ? "agent" : "agents"} armed
-      </span>
-      <div className="flex items-center gap-1" role="toolbar" aria-label="Arm by state">
-        {PRESETS.map((preset) => (
-          <button
-            key={preset.value}
-            type="button"
-            onClick={(e) => {
-              armByState(preset.value, "current", e.shiftKey);
-            }}
-            className={cn(
-              "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] transition-colors",
-              "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
-            )}
-            aria-label={`Arm ${preset.label.toLowerCase()} agents (shift to extend)`}
-          >
-            {preset.label}
-          </button>
-        ))}
-      </div>
-      <div className="flex items-center gap-1" role="toolbar" aria-label="Fleet quick actions">
-        {QUICK_ACTIONS.map((action) => {
-          const eligible = isEligible(action.id);
-          const chord = action.chordOverride ?? keybindingService.getDisplayCombo(action.id) ?? "";
-          return (
+    <div data-testid="fleet-arming-ribbon-group">
+      <div
+        role="status"
+        aria-live="off"
+        className="flex items-center gap-3 border-b border-daintree-accent/40 bg-daintree-accent/10 px-3 py-1.5 text-[12px] text-daintree-text"
+        data-testid="fleet-arming-ribbon"
+      >
+        <span className="font-medium text-daintree-accent">
+          {armedCount} {armedCount === 1 ? "agent" : "agents"} armed
+        </span>
+        <div className="flex items-center gap-1" role="toolbar" aria-label="Arm by state">
+          {PRESETS.map((preset) => (
             <button
-              key={action.id}
+              key={preset.value}
               type="button"
-              disabled={!eligible}
-              onClick={() => {
-                void actionService.dispatch(action.id, undefined, { source: "user" });
+              onClick={(e) => {
+                armByState(preset.value, "current", e.shiftKey);
               }}
               className={cn(
-                "inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] transition-colors",
-                eligible
-                  ? "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
-                  : "cursor-not-allowed bg-tint/[0.04] text-daintree-text/30"
+                "inline-flex items-center rounded-full px-2 py-0.5 text-[11px] transition-colors",
+                "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
               )}
-              aria-label={`${action.label} armed agents (${chord})`}
-              data-testid={`fleet-quick-${action.id.replace("fleet.", "")}`}
+              aria-label={`Arm ${preset.label.toLowerCase()} agents (shift to extend)`}
             >
-              <span>{action.label}</span>
-              {chord ? (
-                <kbd className="rounded border border-daintree-text/20 bg-tint/[0.06] px-1 font-mono text-[10px] leading-tight">
-                  {chord}
-                </kbd>
-              ) : null}
+              {preset.label}
             </button>
-          );
-        })}
+          ))}
+        </div>
+        <div className="flex items-center gap-1" role="toolbar" aria-label="Fleet quick actions">
+          {QUICK_ACTIONS.map((action) => {
+            const eligible = isEligible(action.id);
+            const chord =
+              action.chordOverride ?? keybindingService.getDisplayCombo(action.id) ?? "";
+            return (
+              <button
+                key={action.id}
+                type="button"
+                disabled={!eligible}
+                onClick={() => {
+                  void actionService.dispatch(action.id, undefined, { source: "user" });
+                }}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] transition-colors",
+                  eligible
+                    ? "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
+                    : "cursor-not-allowed bg-tint/[0.04] text-daintree-text/30"
+                )}
+                aria-label={`${action.label} armed agents (${chord})`}
+                data-testid={`fleet-quick-${action.id.replace("fleet.", "")}`}
+              >
+                <span>{action.label}</span>
+                {chord ? (
+                  <kbd className="rounded border border-daintree-text/20 bg-tint/[0.06] px-1 font-mono text-[10px] leading-tight">
+                    {chord}
+                  </kbd>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        <span className="ml-auto text-[11px] text-daintree-text/50">{hint}</span>
+        <button
+          type="button"
+          onClick={clear}
+          aria-label="Disarm all"
+          className="rounded p-1 text-daintree-text/60 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
       </div>
-      <span className="ml-auto text-[11px] text-daintree-text/50">{hint}</span>
-      <button
-        type="button"
-        onClick={clear}
-        aria-label="Disarm all"
-        className="rounded p-1 text-daintree-text/60 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
+      <FleetComposer />
     </div>
   );
 }

--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -1,0 +1,301 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactElement,
+} from "react";
+import { useShallow } from "zustand/react/shallow";
+import { cn } from "@/lib/utils";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import { useCommandHistoryStore } from "@/store/commandHistoryStore";
+import { useNotificationStore } from "@/store/notificationStore";
+import { replaceRecipeVariables } from "@/utils/recipeVariables";
+import { terminalClient } from "@/clients";
+import {
+  FLEET_BROADCAST_HISTORY_KEY,
+  buildFleetBroadcastRecipeContext,
+  getFleetBroadcastWarnings,
+  needsFleetBroadcastConfirmation,
+  resolveFleetBroadcastTargetIds,
+} from "./fleetBroadcast";
+import { registerFleetComposerFocusHandler } from "./fleetComposerFocus";
+
+interface WarningReason {
+  key: "destructive" | "overByteLimit" | "multiline";
+  label: string;
+}
+
+function describeWarnings(text: string): WarningReason[] {
+  const w = getFleetBroadcastWarnings(text);
+  const reasons: WarningReason[] = [];
+  if (w.destructive) reasons.push({ key: "destructive", label: "destructive command detected" });
+  if (w.overByteLimit) reasons.push({ key: "overByteLimit", label: "payload exceeds 512 bytes" });
+  if (w.multiline) reasons.push({ key: "multiline", label: "multi-line payload" });
+  return reasons;
+}
+
+export function FleetComposer(): ReactElement | null {
+  const armedCount = useFleetArmingStore((s) => s.armedIds.size);
+  const { draft, setDraft, clearDraft } = useFleetComposerStore(
+    useShallow((s) => ({ draft: s.draft, setDraft: s.setDraft, clearDraft: s.clearDraft }))
+  );
+
+  const historyEntries = useCommandHistoryStore(
+    useShallow((s) => s.getProjectHistory(FLEET_BROADCAST_HISTORY_KEY))
+  );
+
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
+  const historySnapshotRef = useRef<string>("");
+
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [historyIndex, setHistoryIndex] = useState(-1);
+
+  // Clear draft and any pending confirm state when the fleet is fully disarmed.
+  // One effect keyed on armedCount — not separate effects sharing a flag (lesson #4958).
+  useEffect(() => {
+    if (armedCount === 0) {
+      clearDraft();
+      setIsConfirming(false);
+      setHistoryIndex(-1);
+      historySnapshotRef.current = "";
+    }
+  }, [armedCount, clearDraft]);
+
+  // Register focus handler so terminal.focusFleetComposer can reach us.
+  useEffect(() => {
+    const unregister = registerFleetComposerFocusHandler(() => {
+      textareaRef.current?.focus();
+    });
+    return () => {
+      unregister();
+    };
+  }, []);
+
+  // When the confirmation strip opens, move focus to Cancel (the safe default).
+  useEffect(() => {
+    if (isConfirming) {
+      cancelButtonRef.current?.focus();
+    }
+  }, [isConfirming]);
+
+  const warningReasons = useMemo(() => describeWarnings(draft), [draft]);
+
+  const handleSubmit = useCallback(
+    async (options: { force?: boolean } = {}) => {
+      const { force = false } = options;
+      const currentDraft = useFleetComposerStore.getState().draft;
+      if (currentDraft.trim() === "" || isSubmitting) return;
+
+      if (!force && needsFleetBroadcastConfirmation(currentDraft)) {
+        setIsConfirming(true);
+        return;
+      }
+
+      setIsConfirming(false);
+      setIsSubmitting(true);
+
+      try {
+        // Read arming + panel state at submit time — not closed-over render values.
+        const targetIds = resolveFleetBroadcastTargetIds();
+        if (targetIds.length === 0) {
+          // No live targets — preserve draft so the user can re-arm and retry.
+          useNotificationStore.getState().addNotification({
+            type: "warning",
+            priority: "low",
+            message: "No armed agents available to send to",
+          });
+          return;
+        }
+
+        const submissions: Promise<void>[] = [];
+        for (const terminalId of targetIds) {
+          const ctx = buildFleetBroadcastRecipeContext(terminalId);
+          if (!ctx) continue;
+          const resolved = replaceRecipeVariables(currentDraft, ctx);
+          submissions.push(terminalClient.submit(terminalId, resolved));
+        }
+
+        if (submissions.length === 0) {
+          useNotificationStore.getState().addNotification({
+            type: "warning",
+            priority: "low",
+            message: "Could not resolve context for any armed agent",
+          });
+          return;
+        }
+
+        const results = await Promise.allSettled(submissions);
+        const successCount = results.filter((r) => r.status === "fulfilled").length;
+        const failureCount = results.length - successCount;
+
+        useNotificationStore.getState().addNotification({
+          type: successCount > 0 ? "success" : "warning",
+          priority: "low",
+          message:
+            failureCount > 0
+              ? `Sent to ${successCount} agent${successCount === 1 ? "" : "s"} (${failureCount} failed)`
+              : `Sent to ${successCount} agent${successCount === 1 ? "" : "s"}`,
+        });
+
+        if (successCount > 0) {
+          useCommandHistoryStore.getState().recordPrompt(FLEET_BROADCAST_HISTORY_KEY, currentDraft);
+          clearDraft();
+          setHistoryIndex(-1);
+          historySnapshotRef.current = "";
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [clearDraft, isSubmitting]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // IME guard — do not submit while composing (CJK, dead keys).
+      if (e.nativeEvent.isComposing) return;
+
+      if (e.key === "Escape") {
+        if (draft.length > 0) {
+          e.preventDefault();
+          e.stopPropagation();
+          clearDraft();
+          setHistoryIndex(-1);
+          historySnapshotRef.current = "";
+        }
+        // Empty draft: allow the event to bubble so the ribbon's useEscapeStack disarms.
+        return;
+      }
+
+      if (e.key === "Enter") {
+        if (e.shiftKey) return; // newline passthrough
+        e.preventDefault();
+        const force = e.metaKey || e.ctrlKey;
+        void handleSubmit({ force });
+        return;
+      }
+
+      if (e.key === "ArrowUp") {
+        if (historyEntries.length === 0) return;
+        const target = e.currentTarget;
+        // Allow traversal freely once in history mode; otherwise only trigger
+        // when the caret is at the start so regular editing isn't hijacked.
+        if (historyIndex === -1 && (target.selectionStart !== 0 || target.selectionEnd !== 0))
+          return;
+        e.preventDefault();
+        if (historyIndex === -1) {
+          historySnapshotRef.current = draft;
+        }
+        const next = Math.min(historyIndex + 1, historyEntries.length - 1);
+        setHistoryIndex(next);
+        setDraft(historyEntries[next].prompt);
+        return;
+      }
+
+      if (e.key === "ArrowDown") {
+        if (historyIndex < 0) return;
+        e.preventDefault();
+        const next = historyIndex - 1;
+        setHistoryIndex(next);
+        if (next < 0) {
+          setDraft(historySnapshotRef.current);
+          historySnapshotRef.current = "";
+        } else {
+          setDraft(historyEntries[next].prompt);
+        }
+      }
+    },
+    [clearDraft, draft, handleSubmit, historyEntries, historyIndex, setDraft]
+  );
+
+  if (armedCount === 0) return null;
+
+  const sendLabel = isSubmitting ? "Sending…" : "Send";
+  const placeholderBase =
+    armedCount === 1
+      ? "Broadcast to 1 armed agent (Enter to send)"
+      : `Broadcast to ${armedCount} armed agents (Enter to send)`;
+
+  return (
+    <div
+      className="flex flex-col gap-1 border-b border-daintree-accent/40 bg-daintree-accent/5 px-3 py-1.5"
+      data-testid="fleet-composer"
+    >
+      <div className="flex items-start gap-2">
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (historyIndex !== -1) {
+              setHistoryIndex(-1);
+              historySnapshotRef.current = "";
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholderBase}
+          rows={1}
+          inert={isConfirming ? true : undefined}
+          aria-label="Broadcast to armed agents"
+          data-testid="fleet-composer-textarea"
+          className={cn(
+            "flex-1 resize-none rounded-[var(--radius-md)] border border-daintree-border bg-daintree-sidebar px-2 py-1 text-[12px] text-daintree-text",
+            "placeholder:italic placeholder:text-daintree-text/40",
+            "focus:border-daintree-accent focus:outline-none focus:ring-1 focus:ring-daintree-accent/30",
+            "min-h-[28px] max-h-[140px] overflow-y-auto"
+          )}
+        />
+        <button
+          type="button"
+          onClick={() => void handleSubmit({ force: false })}
+          disabled={draft.trim().length === 0 || isSubmitting}
+          data-testid="fleet-composer-send"
+          className="shrink-0 rounded-[var(--radius-md)] bg-daintree-accent px-2.5 py-1 text-[11px] text-text-inverse transition-colors hover:bg-daintree-accent/90 disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label="Send broadcast"
+        >
+          {sendLabel}
+        </button>
+      </div>
+      {isConfirming && (
+        <div
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-testid="fleet-composer-confirm"
+          className="flex items-center gap-2 rounded-[var(--radius-md)] border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200"
+        >
+          <span className="flex-1">
+            Send to {armedCount} agent{armedCount === 1 ? "" : "s"} —{" "}
+            {warningReasons.map((r) => r.label).join(", ")}?
+          </span>
+          <button
+            type="button"
+            ref={cancelButtonRef}
+            onClick={() => {
+              setIsConfirming(false);
+              textareaRef.current?.focus();
+            }}
+            data-testid="fleet-composer-confirm-cancel"
+            className="rounded-[var(--radius-md)] px-2 py-0.5 text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit({ force: true })}
+            data-testid="fleet-composer-confirm-send"
+            className="rounded-[var(--radius-md)] bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30"
+          >
+            Send anyway
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -15,6 +15,7 @@ import { useCommandHistoryStore } from "@/store/commandHistoryStore";
 import { useNotificationStore } from "@/store/notificationStore";
 import { replaceRecipeVariables } from "@/utils/recipeVariables";
 import { terminalClient } from "@/clients";
+import { logWarn } from "@/utils/logger";
 import {
   FLEET_BROADCAST_HISTORY_KEY,
   buildFleetBroadcastRecipeContext,
@@ -51,21 +52,14 @@ export function FleetComposer(): ReactElement | null {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const cancelButtonRef = useRef<HTMLButtonElement | null>(null);
   const historySnapshotRef = useRef<string>("");
+  // Synchronous re-entrancy guard — `isSubmitting` React state updates are
+  // batched, so the ref is what actually blocks a double-click between
+  // render passes (lesson #5087: stale closure in async callback).
+  const submittingRef = useRef<boolean>(false);
 
   const [isConfirming, setIsConfirming] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [historyIndex, setHistoryIndex] = useState(-1);
-
-  // Clear draft and any pending confirm state when the fleet is fully disarmed.
-  // One effect keyed on armedCount — not separate effects sharing a flag (lesson #4958).
-  useEffect(() => {
-    if (armedCount === 0) {
-      clearDraft();
-      setIsConfirming(false);
-      setHistoryIndex(-1);
-      historySnapshotRef.current = "";
-    }
-  }, [armedCount, clearDraft]);
 
   // Register focus handler so terminal.focusFleetComposer can reach us.
   useEffect(() => {
@@ -89,14 +83,17 @@ export function FleetComposer(): ReactElement | null {
   const handleSubmit = useCallback(
     async (options: { force?: boolean } = {}) => {
       const { force = false } = options;
+      if (submittingRef.current) return;
+
       const currentDraft = useFleetComposerStore.getState().draft;
-      if (currentDraft.trim() === "" || isSubmitting) return;
+      if (currentDraft.trim() === "") return;
 
       if (!force && needsFleetBroadcastConfirmation(currentDraft)) {
         setIsConfirming(true);
         return;
       }
 
+      submittingRef.current = true;
       setIsConfirming(false);
       setIsSubmitting(true);
 
@@ -115,24 +112,24 @@ export function FleetComposer(): ReactElement | null {
 
         const submissions: Promise<void>[] = [];
         for (const terminalId of targetIds) {
-          const ctx = buildFleetBroadcastRecipeContext(terminalId);
-          if (!ctx) continue;
+          const ctx = buildFleetBroadcastRecipeContext(terminalId) ?? {};
           const resolved = replaceRecipeVariables(currentDraft, ctx);
           submissions.push(terminalClient.submit(terminalId, resolved));
-        }
-
-        if (submissions.length === 0) {
-          useNotificationStore.getState().addNotification({
-            type: "warning",
-            priority: "low",
-            message: "Could not resolve context for any armed agent",
-          });
-          return;
         }
 
         const results = await Promise.allSettled(submissions);
         const successCount = results.filter((r) => r.status === "fulfilled").length;
         const failureCount = results.length - successCount;
+
+        if (failureCount > 0) {
+          const reasons = results
+            .map((r) => (r.status === "rejected" ? String(r.reason) : null))
+            .filter((r): r is string => r !== null);
+          logWarn("[FleetComposer] broadcast submit had rejections", {
+            failureCount,
+            reasons,
+          });
+        }
 
         useNotificationStore.getState().addNotification({
           type: successCount > 0 ? "success" : "warning",
@@ -145,15 +142,20 @@ export function FleetComposer(): ReactElement | null {
 
         if (successCount > 0) {
           useCommandHistoryStore.getState().recordPrompt(FLEET_BROADCAST_HISTORY_KEY, currentDraft);
-          clearDraft();
+          // Only clear if the user hasn't started typing a new draft since we
+          // captured `currentDraft`. Otherwise we'd nuke in-flight typing.
+          if (useFleetComposerStore.getState().draft === currentDraft) {
+            clearDraft();
+          }
           setHistoryIndex(-1);
           historySnapshotRef.current = "";
         }
       } finally {
+        submittingRef.current = false;
         setIsSubmitting(false);
       }
     },
-    [clearDraft, isSubmitting]
+    [clearDraft]
   );
 
   const handleKeyDown = useCallback(
@@ -214,6 +216,15 @@ export function FleetComposer(): ReactElement | null {
     [clearDraft, draft, handleSubmit, historyEntries, historyIndex, setDraft]
   );
 
+  const handleConfirmStripKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsConfirming(false);
+      textareaRef.current?.focus();
+    }
+  }, []);
+
   if (armedCount === 0) return null;
 
   const sendLabel = isSubmitting ? "Sending…" : "Send";
@@ -268,6 +279,7 @@ export function FleetComposer(): ReactElement | null {
           aria-live="polite"
           aria-atomic="true"
           data-testid="fleet-composer-confirm"
+          onKeyDown={handleConfirmStripKeyDown}
           className="flex items-center gap-2 rounded-[var(--radius-md)] border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[11px] text-amber-200"
         >
           <span className="flex-1">
@@ -288,9 +300,10 @@ export function FleetComposer(): ReactElement | null {
           </button>
           <button
             type="button"
+            disabled={isSubmitting}
             onClick={() => void handleSubmit({ force: true })}
             data-testid="fleet-composer-confirm-send"
-            className="rounded-[var(--radius-md)] bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30"
+            className="rounded-[var(--radius-md)] bg-amber-500/20 px-2 py-0.5 text-amber-100 transition-colors hover:bg-amber-500/30 disabled:cursor-not-allowed disabled:opacity-40"
           >
             Send anyway
           </button>

--- a/src/components/Fleet/FleetComposer.tsx
+++ b/src/components/Fleet/FleetComposer.tsx
@@ -196,7 +196,7 @@ export function FleetComposer(): ReactElement | null {
         }
         const next = Math.min(historyIndex + 1, historyEntries.length - 1);
         setHistoryIndex(next);
-        setDraft(historyEntries[next].prompt);
+        setDraft(historyEntries[next]!.prompt);
         return;
       }
 
@@ -209,7 +209,7 @@ export function FleetComposer(): ReactElement | null {
           setDraft(historySnapshotRef.current);
           historySnapshotRef.current = "";
         } else {
-          setDraft(historyEntries[next].prompt);
+          setDraft(historyEntries[next]!.prompt);
         }
       }
     },

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -1,0 +1,436 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, fireEvent, screen, act, waitFor } from "@testing-library/react";
+import { createStore } from "zustand/vanilla";
+import { FleetComposer } from "../FleetComposer";
+import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
+import { useCommandHistoryStore } from "@/store/commandHistoryStore";
+import { useNotificationStore } from "@/store/notificationStore";
+import { setCurrentViewStore } from "@/store/createWorktreeStore";
+import type { WorktreeViewState, WorktreeViewActions } from "@/store/createWorktreeStore";
+import { FLEET_BROADCAST_HISTORY_KEY } from "../fleetBroadcast";
+import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
+
+const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
+
+vi.mock("@/clients", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/clients")>();
+  return {
+    ...actual,
+    terminalClient: {
+      ...actual.terminalClient,
+      submit: (id: string, text: string) => submitMock(id, text),
+    },
+  };
+});
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+    ...(overrides as object),
+  } as TerminalInstance;
+}
+
+function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    path: `/repo/${id}`,
+    name: id,
+    branch: `feature/${id}`,
+    isCurrent: true,
+    issueNumber: 42,
+    prNumber: undefined,
+    ...(overrides as object),
+  } as WorktreeSnapshot;
+}
+
+function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
+  const store = createStore<WorktreeViewState & WorktreeViewActions>(() => ({
+    worktrees,
+    version: 0,
+    isLoading: false,
+    error: null,
+    isInitialized: true,
+    isReconnecting: false,
+    nextVersion: () => 0,
+    applySnapshot: () => {},
+    applyUpdate: () => {},
+    applyRemove: () => {},
+    setLoading: () => {},
+    setError: () => {},
+    setReconnecting: () => {},
+  }));
+  setCurrentViewStore(store);
+}
+
+function resetAll(worktreeId = "wt-1") {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  useFleetComposerStore.setState({ draft: "" });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  useCommandHistoryStore.setState({ history: {} });
+  useNotificationStore.setState({ notifications: [] });
+
+  const worktrees = new Map<string, WorktreeSnapshot>();
+  worktrees.set(
+    worktreeId,
+    makeWorktree(worktreeId, { path: "/repo/wt-1", branch: "feature/x", issueNumber: 42 })
+  );
+  installViewStore(worktrees);
+}
+
+function armTwo() {
+  usePanelStore.setState({
+    panelsById: {
+      t1: makeAgent("t1"),
+      t2: makeAgent("t2"),
+    },
+    panelIds: ["t1", "t2"],
+  });
+  useFleetArmingStore.getState().armIds(["t1", "t2"]);
+}
+
+describe("FleetComposer", () => {
+  beforeEach(() => {
+    submitMock.mockReset();
+    submitMock.mockResolvedValue(undefined);
+    resetAll();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when no agents are armed", () => {
+    const { container } = render(<FleetComposer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not auto-focus the textarea on mount", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea");
+    expect(document.activeElement).not.toBe(textarea);
+  });
+
+  it("submits on plain Enter to all armed targets", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "run tests" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+    expect(submitMock.mock.calls.map(([id]) => id).sort()).toEqual(["t1", "t2"]);
+    expect(submitMock.mock.calls[0][1]).toBe("run tests");
+  });
+
+  it("does not submit while IME is composing", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "中文" } });
+    // React synthetic event exposes nativeEvent.isComposing.
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+
+    expect(submitMock).not.toHaveBeenCalled();
+  });
+
+  it("Shift+Enter does not submit and does not prevent default (newline passes through)", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "line 1" } });
+    const e = fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(e).toBe(true); // default not prevented
+  });
+
+  it("opens confirmation strip for multi-line text and does not send", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "one\ntwo" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(submitMock).not.toHaveBeenCalled();
+    const strip = screen.getByTestId("fleet-composer-confirm");
+    expect(strip).toBeTruthy();
+    expect(strip.getAttribute("role")).toBe("status");
+    expect(strip.getAttribute("aria-live")).toBe("polite");
+    expect(strip.getAttribute("aria-atomic")).toBe("true");
+  });
+
+  it("opens confirmation strip for destructive command", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "rm -rf node_modules" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("fleet-composer-confirm")).toBeTruthy();
+  });
+
+  it("Cmd+Enter bypasses confirmation and force-sends", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "rm -rf node_modules" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+    expect(submitMock.mock.calls[0][1]).toBe("rm -rf node_modules");
+  });
+
+  it("Ctrl+Enter also force-sends (Windows/Linux parity)", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "rm -rf node_modules" } });
+    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("Cancel in confirmation strip returns focus to textarea and does not send", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "line1\nline2" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    const cancel = screen.getByTestId("fleet-composer-confirm-cancel");
+    expect(document.activeElement).toBe(cancel);
+
+    fireEvent.click(cancel);
+    expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull();
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(useFleetComposerStore.getState().draft).toBe("line1\nline2");
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("Send anyway in confirmation strip submits to all armed targets", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "line1\nline2" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    fireEvent.click(screen.getByTestId("fleet-composer-confirm-send"));
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("Escape with non-empty draft clears draft and stops propagation", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "typing" } });
+    const result = fireEvent.keyDown(textarea, { key: "Escape" });
+
+    expect(useFleetComposerStore.getState().draft).toBe("");
+    expect(result).toBe(false); // preventDefault was called
+  });
+
+  it("Escape with empty draft does NOT stop propagation (bubbles to arming)", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    const result = fireEvent.keyDown(textarea, { key: "Escape" });
+    expect(result).toBe(true); // default not prevented — bubbles through
+  });
+
+  it("ArrowUp at caret 0 walks history backward", () => {
+    armTwo();
+    useCommandHistoryStore.setState({
+      history: {
+        [FLEET_BROADCAST_HISTORY_KEY]: [
+          { id: "1", prompt: "newer", agentId: null, addedAt: 2 },
+          { id: "2", prompt: "older", agentId: null, addedAt: 1 },
+        ],
+      },
+    });
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    textarea.setSelectionRange(0, 0);
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(useFleetComposerStore.getState().draft).toBe("newer");
+
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(useFleetComposerStore.getState().draft).toBe("older");
+  });
+
+  it("ArrowDown restores the unsent snapshot when walking past the newest entry", () => {
+    armTwo();
+    useCommandHistoryStore.setState({
+      history: {
+        [FLEET_BROADCAST_HISTORY_KEY]: [{ id: "1", prompt: "earlier", agentId: null, addedAt: 1 }],
+      },
+    });
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "unsent draft" } });
+    textarea.setSelectionRange(0, 0);
+    fireEvent.keyDown(textarea, { key: "ArrowUp" });
+    expect(useFleetComposerStore.getState().draft).toBe("earlier");
+
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    fireEvent.keyDown(textarea, { key: "ArrowDown" });
+    expect(useFleetComposerStore.getState().draft).toBe("unsent draft");
+  });
+
+  it("records history and clears draft after successful send", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "run tests" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(useFleetComposerStore.getState().draft).toBe(""));
+
+    const history = useCommandHistoryStore
+      .getState()
+      .getProjectHistory(FLEET_BROADCAST_HISTORY_KEY);
+    expect(history.map((h) => h.prompt)).toContain("run tests");
+  });
+
+  it("resolves {{branch_name}} variable per-terminal before submit", async () => {
+    usePanelStore.setState({
+      panelsById: {
+        a: makeAgent("a", { worktreeId: "wt-1" }),
+        b: makeAgent("b", { worktreeId: "wt-2" }),
+      },
+      panelIds: ["a", "b"],
+    });
+    const worktrees = new Map<string, WorktreeSnapshot>();
+    worktrees.set("wt-1", makeWorktree("wt-1", { branch: "feature/x", path: "/w/1" }));
+    worktrees.set("wt-2", makeWorktree("wt-2", { branch: "feature/y", path: "/w/2" }));
+    installViewStore(worktrees);
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "checkout {{branch_name}}" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+    const byId = Object.fromEntries(submitMock.mock.calls.map(([id, text]) => [id, text]));
+    expect(byId.a).toBe("checkout feature/x");
+    expect(byId.b).toBe("checkout feature/y");
+  });
+
+  it("drops silently-exited targets at submit time and toasts the actual count", async () => {
+    usePanelStore.setState({
+      panelsById: {
+        a: makeAgent("a"),
+        dead: makeAgent("dead", { location: "trash" }),
+      },
+      panelIds: ["a", "dead"],
+    });
+    useFleetArmingStore.getState().armIds(["a", "dead"]);
+
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+    expect(submitMock.mock.calls[0][0]).toBe("a");
+    await waitFor(() => {
+      const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
+      expect(last).toBe("Sent to 1 agent");
+    });
+  });
+
+  it("does NOT clear draft when no live targets remain at submit", async () => {
+    usePanelStore.setState({
+      panelsById: { dead: makeAgent("dead", { location: "trash" }) },
+      panelIds: ["dead"],
+    });
+    useFleetArmingStore.getState().armIds(["dead"]);
+
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "please keep" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // allow microtasks to flush
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(useFleetComposerStore.getState().draft).toBe("please keep");
+  });
+
+  it("partial failure surfaces the correct toast count", async () => {
+    submitMock.mockReset();
+    submitMock.mockImplementationOnce(() => Promise.resolve());
+    submitMock.mockImplementationOnce(() => Promise.reject(new Error("boom")));
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "x" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
+      expect(last).toBe("Sent to 1 agent (1 failed)");
+    });
+  });
+
+  it("auto-clears draft when armedCount returns to zero", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "typing" } });
+    expect(useFleetComposerStore.getState().draft).toBe("typing");
+
+    act(() => {
+      useFleetArmingStore.getState().clear();
+    });
+    expect(useFleetComposerStore.getState().draft).toBe("");
+  });
+
+  it("disables send button when draft is blank", () => {
+    armTwo();
+    render(<FleetComposer />);
+    const send = screen.getByTestId("fleet-composer-send") as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "hi" } });
+    expect(send.disabled).toBe(false);
+  });
+});

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -139,7 +139,7 @@ describe("FleetComposer", () => {
 
     await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
     expect(submitMock.mock.calls.map(([id]) => id).sort()).toEqual(["t1", "t2"]);
-    expect(submitMock.mock.calls[0][1]).toBe("run tests");
+    expect(submitMock.mock.calls[0]![1]).toBe("run tests");
   });
 
   it("does not submit while IME is composing", () => {
@@ -203,7 +203,7 @@ describe("FleetComposer", () => {
     fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
 
     await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
-    expect(submitMock.mock.calls[0][1]).toBe("rm -rf node_modules");
+    expect(submitMock.mock.calls[0]![1]).toBe("rm -rf node_modules");
   });
 
   it("Ctrl+Enter also force-sends (Windows/Linux parity)", async () => {
@@ -367,7 +367,7 @@ describe("FleetComposer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
-    expect(submitMock.mock.calls[0][0]).toBe("a");
+    expect(submitMock.mock.calls[0]![0]).toBe("a");
     await waitFor(() => {
       const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
       expect(last).toBe("Sent to 1 agent");
@@ -500,7 +500,7 @@ describe("FleetComposer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
-    expect(submitMock.mock.calls[0][1]).toBe("still send me");
+    expect(submitMock.mock.calls[0]![1]).toBe("still send me");
   });
 
   it("leaves unresolved variables empty when worktree context is missing", async () => {
@@ -517,7 +517,7 @@ describe("FleetComposer", () => {
     fireEvent.keyDown(textarea, { key: "Enter" });
 
     await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
-    expect(submitMock.mock.calls[0][1]).toBe("branch is ");
+    expect(submitMock.mock.calls[0]![1]).toBe("branch is ");
   });
 
   it("Escape inside the confirm strip closes it and keeps fleet armed", async () => {

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -433,4 +433,134 @@ describe("FleetComposer", () => {
     fireEvent.change(textarea, { target: { value: "hi" } });
     expect(send.disabled).toBe(false);
   });
+
+  it("all submits reject — toasts 0 success / N failed, draft retained, history not recorded", async () => {
+    submitMock.mockReset();
+    submitMock.mockRejectedValue(new Error("boom"));
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "fail it" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      const last = useNotificationStore.getState().notifications.at(-1)?.message ?? "";
+      expect(last).toBe("Sent to 0 agents (2 failed)");
+    });
+    expect(useFleetComposerStore.getState().draft).toBe("fail it");
+    const history = useCommandHistoryStore
+      .getState()
+      .getProjectHistory(FLEET_BROADCAST_HISTORY_KEY);
+    expect(history.map((h) => h.prompt)).not.toContain("fail it");
+
+    // Send button is usable again after failure.
+    const send = screen.getByTestId("fleet-composer-send") as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
+  });
+
+  it("double-click 'Send anyway' only enqueues one batch (re-entrancy guard)", async () => {
+    const resolvers: Array<() => void> = [];
+    submitMock.mockReset();
+    submitMock.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolvers.push(r);
+        })
+    );
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "multi\nline" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    const confirmSend = await screen.findByTestId("fleet-composer-confirm-send");
+    fireEvent.click(confirmSend);
+    fireEvent.click(confirmSend);
+    fireEvent.click(confirmSend);
+
+    // Exactly 2 submit calls — one per armed terminal — not 6.
+    expect(submitMock).toHaveBeenCalledTimes(2);
+    resolvers.forEach((r) => r());
+    await waitFor(() => expect(useFleetComposerStore.getState().draft).toBe(""));
+  });
+
+  it("delivers even when worktree context cannot be resolved (empty-ctx fallback)", async () => {
+    // Panel references a worktree that is not in the view store.
+    usePanelStore.setState({
+      panelsById: { lonely: makeAgent("lonely", { worktreeId: "wt-ghost" }) },
+      panelIds: ["lonely"],
+    });
+    installViewStore(new Map());
+    useFleetArmingStore.getState().armIds(["lonely"]);
+
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "still send me" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+    expect(submitMock.mock.calls[0][1]).toBe("still send me");
+  });
+
+  it("leaves unresolved variables empty when worktree context is missing", async () => {
+    usePanelStore.setState({
+      panelsById: { lonely: makeAgent("lonely", { worktreeId: "wt-ghost" }) },
+      panelIds: ["lonely"],
+    });
+    installViewStore(new Map());
+    useFleetArmingStore.getState().armIds(["lonely"]);
+
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "branch is {{branch_name}}" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+    expect(submitMock.mock.calls[0][1]).toBe("branch is ");
+  });
+
+  it("Escape inside the confirm strip closes it and keeps fleet armed", async () => {
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "rm -rf x" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    const strip = await screen.findByTestId("fleet-composer-confirm");
+    // The strip receives focus on Cancel by default — press Escape on it.
+    fireEvent.keyDown(strip, { key: "Escape" });
+
+    expect(screen.queryByTestId("fleet-composer-confirm")).toBeNull();
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(2);
+  });
+
+  it("preserves in-flight new typing — does not clear a replacement draft", async () => {
+    const resolvers: Array<() => void> = [];
+    submitMock.mockReset();
+    submitMock.mockImplementation(
+      () =>
+        new Promise<void>((r) => {
+          resolvers.push(r);
+        })
+    );
+    armTwo();
+    render(<FleetComposer />);
+    const textarea = screen.getByTestId("fleet-composer-textarea") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "first" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(2));
+
+    // User starts typing a new draft while the first batch is still in flight.
+    useFleetComposerStore.getState().setDraft("second");
+
+    resolvers.forEach((r) => r());
+    await waitFor(() =>
+      expect(
+        useCommandHistoryStore.getState().getProjectHistory(FLEET_BROADCAST_HISTORY_KEY).length
+      ).toBe(1)
+    );
+    expect(useFleetComposerStore.getState().draft).toBe("second");
+  });
 });

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { createStore } from "zustand/vanilla";
+import {
+  FLEET_BROADCAST_HISTORY_KEY,
+  FLEET_CONFIRM_BYTE_THRESHOLD,
+  FLEET_DESTRUCTIVE_RE,
+  buildFleetBroadcastRecipeContext,
+  getFleetBroadcastByteLength,
+  getFleetBroadcastWarnings,
+  needsFleetBroadcastConfirmation,
+  resolveFleetBroadcastTargetIds,
+} from "../fleetBroadcast";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
+import { setCurrentViewStore } from "@/store/createWorktreeStore";
+import type { WorktreeViewState, WorktreeViewActions } from "@/store/createWorktreeStore";
+import type { TerminalInstance, WorktreeSnapshot } from "@shared/types";
+
+function resetStores() {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+}
+
+function seedPanels(terminals: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const t of terminals) {
+    panelsById[t.id] = t;
+    panelIds.push(t.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
+}
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+    ...(overrides as object),
+  } as TerminalInstance;
+}
+
+function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    path: `/tmp/${id}`,
+    name: id,
+    branch: `feature/${id}`,
+    isCurrent: false,
+    issueNumber: 42,
+    prNumber: 101,
+    ...(overrides as object),
+  } as WorktreeSnapshot;
+}
+
+function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
+  const store = createStore<WorktreeViewState & WorktreeViewActions>(() => ({
+    worktrees,
+    version: 0,
+    isLoading: false,
+    error: null,
+    isInitialized: true,
+    isReconnecting: false,
+    nextVersion: () => 0,
+    applySnapshot: () => {},
+    applyUpdate: () => {},
+    applyRemove: () => {},
+    setLoading: () => {},
+    setError: () => {},
+    setReconnecting: () => {},
+  }));
+  setCurrentViewStore(store);
+}
+
+describe("fleetBroadcast constants", () => {
+  it("history key is stable", () => {
+    expect(FLEET_BROADCAST_HISTORY_KEY).toBe("fleet-broadcast");
+  });
+  it("confirmation threshold matches spec (512 bytes)", () => {
+    expect(FLEET_CONFIRM_BYTE_THRESHOLD).toBe(512);
+  });
+});
+
+describe("FLEET_DESTRUCTIVE_RE", () => {
+  const positives = [
+    "rm -rf /tmp/foo",
+    "rm -r ./build",
+    "rm -f something",
+    "sudo apt install",
+    "drop table users",
+    "DROP TABLE USERS",
+    "truncate table sessions",
+    "chmod -R 777 /",
+    "mkfs.ext4 /dev/sda1",
+    "dd if=/dev/zero of=/dev/sda",
+    ":(){ :|:& };:",
+  ];
+  for (const cmd of positives) {
+    it(`flags: ${cmd}`, () => {
+      expect(FLEET_DESTRUCTIVE_RE.test(cmd)).toBe(true);
+    });
+  }
+
+  const negatives = [
+    "echo hello",
+    "git status",
+    "npm test",
+    "ls -la",
+    "echo 'drop it'",
+    "please rm the unused code",
+  ];
+  for (const cmd of negatives) {
+    it(`does not flag: ${cmd}`, () => {
+      expect(FLEET_DESTRUCTIVE_RE.test(cmd)).toBe(false);
+    });
+  }
+});
+
+describe("getFleetBroadcastByteLength", () => {
+  it("counts ASCII bytes", () => {
+    expect(getFleetBroadcastByteLength("hello")).toBe(5);
+  });
+  it("counts multi-byte UTF-8 characters (emoji = 4 bytes)", () => {
+    expect(getFleetBroadcastByteLength("✓")).toBe(3);
+    expect(getFleetBroadcastByteLength("🚀")).toBe(4);
+  });
+});
+
+describe("getFleetBroadcastWarnings", () => {
+  it("detects multi-line payloads", () => {
+    expect(getFleetBroadcastWarnings("one\ntwo").multiline).toBe(true);
+    expect(getFleetBroadcastWarnings("one two").multiline).toBe(false);
+  });
+
+  it("detects byte-length overflow", () => {
+    const small = "a".repeat(FLEET_CONFIRM_BYTE_THRESHOLD);
+    const large = "a".repeat(FLEET_CONFIRM_BYTE_THRESHOLD + 1);
+    expect(getFleetBroadcastWarnings(small).overByteLimit).toBe(false);
+    expect(getFleetBroadcastWarnings(large).overByteLimit).toBe(true);
+  });
+
+  it("detects destructive commands", () => {
+    expect(getFleetBroadcastWarnings("rm -rf node_modules").destructive).toBe(true);
+    expect(getFleetBroadcastWarnings("echo 'hi'").destructive).toBe(false);
+  });
+});
+
+describe("needsFleetBroadcastConfirmation", () => {
+  it("returns true when any warning fires", () => {
+    expect(needsFleetBroadcastConfirmation("multi\nline")).toBe(true);
+    expect(needsFleetBroadcastConfirmation("rm -rf .")).toBe(true);
+    expect(needsFleetBroadcastConfirmation("x".repeat(700))).toBe(true);
+  });
+  it("returns false for short, single-line, safe text", () => {
+    expect(needsFleetBroadcastConfirmation("run the test")).toBe(false);
+  });
+});
+
+describe("resolveFleetBroadcastTargetIds", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("returns empty array when nothing is armed", () => {
+    expect(resolveFleetBroadcastTargetIds()).toEqual([]);
+  });
+
+  it("drops trashed/background/non-pty terminals silently", () => {
+    seedPanels([
+      makeAgent("ok"),
+      makeAgent("trashed", { location: "trash" }),
+      makeAgent("bg", { location: "background" }),
+      makeAgent("noPty", { hasPty: false }),
+    ]);
+    useFleetArmingStore.getState().armIds(["ok", "trashed", "bg", "noPty"]);
+    expect(resolveFleetBroadcastTargetIds()).toEqual(["ok"]);
+  });
+
+  it("preserves armOrder ordering", () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    useFleetArmingStore.getState().armIds(["c", "a", "b"]);
+    expect(resolveFleetBroadcastTargetIds()).toEqual(["c", "a", "b"]);
+  });
+
+  it("drops ids that no longer exist in panel store", () => {
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a", "ghost"]);
+    expect(resolveFleetBroadcastTargetIds()).toEqual(["a"]);
+  });
+});
+
+describe("buildFleetBroadcastRecipeContext", () => {
+  beforeEach(() => {
+    resetStores();
+    const worktrees = new Map<string, WorktreeSnapshot>();
+    worktrees.set(
+      "wt-1",
+      makeWorktree("wt-1", {
+        path: "/repo/wt-1",
+        branch: "feature/x",
+        issueNumber: 7,
+        prNumber: 9,
+      })
+    );
+    installViewStore(worktrees);
+  });
+
+  it("resolves the context fields from the worktree store", () => {
+    seedPanels([makeAgent("t1", { worktreeId: "wt-1" })]);
+    const ctx = buildFleetBroadcastRecipeContext("t1");
+    expect(ctx).toEqual({
+      issueNumber: 7,
+      prNumber: 9,
+      worktreePath: "/repo/wt-1",
+      branchName: "feature/x",
+    });
+  });
+
+  it("returns null for unknown terminal id", () => {
+    expect(buildFleetBroadcastRecipeContext("missing")).toBeNull();
+  });
+
+  it("returns null when panel has no worktreeId", () => {
+    seedPanels([makeAgent("orphan", { worktreeId: undefined as unknown as string })]);
+    expect(buildFleetBroadcastRecipeContext("orphan")).toBeNull();
+  });
+
+  it("returns null when worktree missing from view store", () => {
+    seedPanels([makeAgent("t2", { worktreeId: "wt-missing" })]);
+    expect(buildFleetBroadcastRecipeContext("t2")).toBeNull();
+  });
+
+  it("falls back to worktree.name when branch is unset", () => {
+    const worktrees = new Map<string, WorktreeSnapshot>();
+    worktrees.set("wt-x", makeWorktree("wt-x", { branch: undefined, name: "fallback-name" }));
+    installViewStore(worktrees);
+    seedPanels([makeAgent("t3", { worktreeId: "wt-x" })]);
+    expect(buildFleetBroadcastRecipeContext("t3")?.branchName).toBe("fallback-name");
+  });
+});

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -100,6 +100,10 @@ describe("FLEET_DESTRUCTIVE_RE", () => {
     "rm -rf /tmp/foo",
     "rm -r ./build",
     "rm -f something",
+    "rm -rfv node_modules",
+    "rm -Rf /tmp/foo",
+    "git clean -fd",
+    "git clean -fdx",
     "sudo apt install",
     "drop table users",
     "DROP TABLE USERS",
@@ -151,6 +155,18 @@ describe("getFleetBroadcastWarnings", () => {
     const large = "a".repeat(FLEET_CONFIRM_BYTE_THRESHOLD + 1);
     expect(getFleetBroadcastWarnings(small).overByteLimit).toBe(false);
     expect(getFleetBroadcastWarnings(large).overByteLimit).toBe(true);
+  });
+
+  it("counts UTF-8 bytes — 509 ASCII + rocket (4 bytes) crosses to 513", () => {
+    const borderline = "a".repeat(FLEET_CONFIRM_BYTE_THRESHOLD - 3) + "🚀";
+    expect(getFleetBroadcastByteLength(borderline)).toBe(FLEET_CONFIRM_BYTE_THRESHOLD + 1);
+    expect(getFleetBroadcastWarnings(borderline).overByteLimit).toBe(true);
+  });
+
+  it("treats exactly 512 UTF-8 bytes as within limit", () => {
+    const exact = "a".repeat(FLEET_CONFIRM_BYTE_THRESHOLD - 4) + "🚀";
+    expect(getFleetBroadcastByteLength(exact)).toBe(FLEET_CONFIRM_BYTE_THRESHOLD);
+    expect(getFleetBroadcastWarnings(exact).overByteLimit).toBe(false);
   });
 
   it("detects destructive commands", () => {

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -1,0 +1,86 @@
+import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
+import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import type { RecipeContext } from "@/utils/recipeVariables";
+
+export const FLEET_BROADCAST_HISTORY_KEY = "fleet-broadcast" as const;
+
+/**
+ * Bytes in UTF-8 rather than JS string length — keeps accounting honest for
+ * multi-byte characters when we compare against the backend's paste buffer.
+ */
+export const FLEET_CONFIRM_BYTE_THRESHOLD = 512;
+
+/**
+ * Conservative — flags commands that are usually destructive outside a sandbox.
+ * Intentionally does NOT try to be a shell parser. False positives are fine
+ * (an extra confirm). False negatives are the real cost.
+ */
+export const FLEET_DESTRUCTIVE_RE =
+  /(\brm\s+(?:-[rRf]{1,3}\s|-[rRf]{1,3}[^\s]*\s|--recursive\s|--force\s))|(^|\s)sudo\s|(\bdrop\s+(?:table|database|schema)\b)|(\btruncate\s+table\b)|(\bchmod\s+-R\s+)|(\bmkfs\b)|(\bdd\s+if=)|(\bforkbomb\b)|(:\(\)\s*\{)/i;
+
+export interface FleetBroadcastWarnings {
+  multiline: boolean;
+  overByteLimit: boolean;
+  destructive: boolean;
+}
+
+export function getFleetBroadcastByteLength(text: string): number {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(text).length;
+  }
+  // Fallback approximation — only hit in non-browser runtimes.
+  return text.length;
+}
+
+export function getFleetBroadcastWarnings(text: string): FleetBroadcastWarnings {
+  return {
+    multiline: text.includes("\n"),
+    overByteLimit: getFleetBroadcastByteLength(text) > FLEET_CONFIRM_BYTE_THRESHOLD,
+    destructive: FLEET_DESTRUCTIVE_RE.test(text),
+  };
+}
+
+export function needsFleetBroadcastConfirmation(text: string): boolean {
+  const w = getFleetBroadcastWarnings(text);
+  return w.multiline || w.overByteLimit || w.destructive;
+}
+
+/**
+ * Re-evaluate arming set against live panel state so we never submit to a
+ * trashed, backgrounded, or exited terminal that was armed earlier.
+ * Preserves the `armOrder` ordering from fleetArmingStore.
+ */
+export function resolveFleetBroadcastTargetIds(): string[] {
+  const { armOrder, armedIds } = useFleetArmingStore.getState();
+  if (armedIds.size === 0) return [];
+  const { panelsById } = usePanelStore.getState();
+  const out: string[] = [];
+  for (const id of armOrder) {
+    if (!armedIds.has(id)) continue;
+    const panel = panelsById[id];
+    if (isFleetArmEligible(panel)) out.push(id);
+  }
+  return out;
+}
+
+export function buildFleetBroadcastRecipeContext(terminalId: string): RecipeContext | null {
+  const panel = usePanelStore.getState().panelsById[terminalId];
+  if (!panel) return null;
+  const worktreeId = panel.worktreeId;
+  if (!worktreeId) return null;
+  let worktree;
+  try {
+    worktree = getCurrentViewStore().getState().worktrees.get(worktreeId);
+  } catch {
+    // WorktreeViewStore not initialized — renderer not fully mounted.
+    return null;
+  }
+  if (!worktree) return null;
+  return {
+    issueNumber: worktree.issueNumber,
+    prNumber: worktree.prNumber,
+    worktreePath: worktree.path,
+    branchName: worktree.branch ?? worktree.name,
+  };
+}

--- a/src/components/Fleet/fleetBroadcast.ts
+++ b/src/components/Fleet/fleetBroadcast.ts
@@ -17,7 +17,7 @@ export const FLEET_CONFIRM_BYTE_THRESHOLD = 512;
  * (an extra confirm). False negatives are the real cost.
  */
 export const FLEET_DESTRUCTIVE_RE =
-  /(\brm\s+(?:-[rRf]{1,3}\s|-[rRf]{1,3}[^\s]*\s|--recursive\s|--force\s))|(^|\s)sudo\s|(\bdrop\s+(?:table|database|schema)\b)|(\btruncate\s+table\b)|(\bchmod\s+-R\s+)|(\bmkfs\b)|(\bdd\s+if=)|(\bforkbomb\b)|(:\(\)\s*\{)/i;
+  /(\brm\s+(?:-[rRfv]{1,4}\s|-[rRfv]{1,4}[^\s]*\s|--recursive\s|--force\s))|(^|\s)sudo\s|(\bgit\s+clean\s+-[a-z]*f[a-z]*\b)|(\bdrop\s+(?:table|database|schema)\b)|(\btruncate\s+table\b)|(\bchmod\s+-R\s+)|(\bmkfs\b)|(\bdd\s+if=)|(\bforkbomb\b)|(:\(\)\s*\{)/i;
 
 export interface FleetBroadcastWarnings {
   multiline: boolean;

--- a/src/components/Fleet/fleetComposerFocus.ts
+++ b/src/components/Fleet/fleetComposerFocus.ts
@@ -1,0 +1,16 @@
+type FocusHandler = () => void;
+
+let handler: FocusHandler | null = null;
+
+export function registerFleetComposerFocusHandler(fn: FocusHandler): () => void {
+  handler = fn;
+  return () => {
+    if (handler === fn) {
+      handler = null;
+    }
+  };
+}
+
+export function focusFleetComposer(): void {
+  handler?.();
+}

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -1,1 +1,3 @@
 export { FleetArmingRibbon } from "./FleetArmingRibbon";
+export { FleetComposer } from "./FleetComposer";
+export { focusFleetComposer } from "./fleetComposerFocus";

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -286,4 +286,18 @@ export function registerTerminalInputActions(
       useFleetArmingStore.getState().armAll("current");
     },
   }));
+
+  actions.set("terminal.focusFleetComposer", () => ({
+    id: "terminal.focusFleetComposer",
+    title: "Focus Fleet Broadcast",
+    description: "Focus the fleet broadcast composer for armed agents",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const { focusFleetComposer } = await import("@/components/Fleet/fleetComposerFocus");
+      focusFleetComposer();
+    },
+  }));
 }

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -390,6 +390,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Fleet",
   },
   {
+    actionId: "terminal.focusFleetComposer",
+    combo: "Cmd+Shift+F",
+    scope: "global",
+    priority: 0,
+    description: "Focus the fleet broadcast composer",
+    category: "Terminal",
+  },
+  {
     actionId: "terminal.bulkCommand",
     combo: "Cmd+Alt+Shift+B",
     scope: "global",

--- a/src/store/__tests__/fleetComposerStore.test.ts
+++ b/src/store/__tests__/fleetComposerStore.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useFleetComposerStore } from "../fleetComposerStore";
+import { useFleetArmingStore } from "../fleetArmingStore";
+
+function resetStore() {
+  useFleetComposerStore.setState({ draft: "" });
+}
+
+describe("fleetComposerStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("starts with an empty draft", () => {
+    expect(useFleetComposerStore.getState().draft).toBe("");
+  });
+
+  it("setDraft updates the draft", () => {
+    useFleetComposerStore.getState().setDraft("hello fleet");
+    expect(useFleetComposerStore.getState().draft).toBe("hello fleet");
+  });
+
+  it("clearDraft resets the draft to empty", () => {
+    useFleetComposerStore.getState().setDraft("something");
+    useFleetComposerStore.getState().clearDraft();
+    expect(useFleetComposerStore.getState().draft).toBe("");
+  });
+
+  it("is independent from fleetArmingStore", () => {
+    useFleetComposerStore.getState().setDraft("typing");
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    // Draft survives arming changes
+    expect(useFleetComposerStore.getState().draft).toBe("typing");
+    // Arming persists regardless of composer draft changes
+    useFleetComposerStore.getState().clearDraft();
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(2);
+    useFleetArmingStore.getState().clear();
+  });
+});

--- a/src/store/fleetComposerStore.ts
+++ b/src/store/fleetComposerStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+
+interface FleetComposerState {
+  draft: string;
+  setDraft: (draft: string) => void;
+  clearDraft: () => void;
+}
+
+export const useFleetComposerStore = create<FleetComposerState>()((set) => ({
+  draft: "",
+  setDraft: (draft) => set({ draft }),
+  clearDraft: () => set({ draft: "" }),
+}));

--- a/src/store/fleetComposerStore.ts
+++ b/src/store/fleetComposerStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useFleetArmingStore } from "./fleetArmingStore";
 
 interface FleetComposerState {
   draft: string;
@@ -11,3 +12,50 @@ export const useFleetComposerStore = create<FleetComposerState>()((set) => ({
   setDraft: (draft) => set({ draft }),
   clearDraft: () => set({ draft: "" }),
 }));
+
+/**
+ * Clear the composer draft whenever the fleet is fully disarmed. The
+ * FleetComposer component is unmounted by the ribbon when armedCount → 0,
+ * so this cleanup cannot live inside the component — a typed draft would
+ * otherwise survive across arm/disarm cycles as a stale singleton.
+ *
+ * HMR/test re-imports stack subscribers on every module reload. We store
+ * registration state on globalThis so subsequent instances reuse the
+ * existing subscription but drive the current store — mirroring the
+ * pattern in fleetArmingStore.ts / projectStore.ts.
+ */
+interface FleetComposerSubscriptionState {
+  registered: boolean;
+  lastCount: number;
+}
+
+const FLEET_COMPOSER_SUBSCRIPTION_KEY = "__daintreeFleetComposerSubscription";
+
+function getFleetComposerSubscriptionState(): FleetComposerSubscriptionState {
+  const target = globalThis as typeof globalThis & {
+    [FLEET_COMPOSER_SUBSCRIPTION_KEY]?: FleetComposerSubscriptionState;
+  };
+  const existing = target[FLEET_COMPOSER_SUBSCRIPTION_KEY];
+  if (existing) return existing;
+  const created: FleetComposerSubscriptionState = {
+    registered: false,
+    lastCount: useFleetArmingStore.getState().armedIds.size,
+  };
+  target[FLEET_COMPOSER_SUBSCRIPTION_KEY] = created;
+  return created;
+}
+
+if (typeof useFleetArmingStore.subscribe === "function") {
+  const subState = getFleetComposerSubscriptionState();
+  if (!subState.registered) {
+    subState.registered = true;
+    useFleetArmingStore.subscribe((state) => {
+      const nextCount = state.armedIds.size;
+      const prevCount = subState.lastCount;
+      subState.lastCount = nextCount;
+      if (prevCount > 0 && nextCount === 0) {
+        useFleetComposerStore.getState().clearDraft();
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a non-modal broadcast composer embedded in `FleetArmingRibbon` that fans typed text out to every armed agent terminal atomically via `terminalClient.submit()`
- Wraps unsafe payloads (multi-line, >512 bytes, or destructive-command regex match) in an inline confirmation strip before sending
- Up-arrow recalls broadcast history; `Cmd+Shift+F` focuses the composer via a new `terminal.focusFleetComposer` action

Resolves #5299

## Changes

- `src/store/fleetComposerStore.ts` — isolated draft store with auto-clear when fleet is fully disarmed
- `src/components/Fleet/fleetBroadcast.ts` — pure helpers: safety heuristics, target resolution, per-terminal recipe context
- `src/components/Fleet/fleetComposerFocus.ts` — singleton focus registry
- `src/components/Fleet/FleetComposer.tsx` — composer component with textarea, send button, inline confirm strip, and keyboard handlers
- `shared/types/actions.ts` + `shared/types/keymap.ts` — new `terminal.focusFleetComposer` action and key action
- `src/services/actions/definitions/terminalInputActions.ts` + `src/services/defaultKeybindings.ts` — registered action and bound `Cmd+Shift+F`
- Full unit test coverage across store, helpers, and component (875 lines of tests across three test files)

## Testing

Unit tests pass for the store, broadcast helpers, and component. Typecheck and lint clean. The fan-out logic routes through the existing `terminalClient.submit()` path so bracketed paste negotiation is handled per-PTY by the backend as before.