### PR TITLE
perf(pty): bound pendingKillCount to prevent unbounded growth after host crashes

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1107,25 +1107,24 @@ export class PtyClient extends EventEmitter {
     // Only track pendingKillCount for ids we've seen locally. An "exit"
     // decrement only arrives for terminals the host actually owned, so
     // tracking kills for unknown ids would leak cap slots permanently.
+    //
+    // Cap is SOFT: the primary defense against unbounded growth is the
+    // clear-on-respawn in respawnPending(). Skipping tracking at cap would
+    // allow a late "exit" for this id to hit the exit handler's else branch
+    // and incorrectly delete a re-spawned entry for the same id (supported
+    // by the hydration flow via `requestedId`). So at cap we log a warning
+    // for observability but still track.
     if (wasKnown) {
       const current = this.pendingKillCount.get(id);
-      if (current !== undefined) {
-        // Existing entry — incrementing doesn't grow the map, always allow.
-        this.pendingKillCount.set(id, current + 1);
-      } else if (this.pendingKillCount.size < this.MAX_PENDING_KILLS) {
-        this.pendingKillCount.set(id, 1);
-      } else {
-        // At cap with a new id: skip tracking. The kill IPC still goes out so
-        // the host-side terminal is killed; we accept that exit attribution
-        // for this id may fall through to the "normal exit" branch of the
-        // exit handler. Prevents silent PTY leaks under repeated crashes.
+      if (current === undefined && this.pendingKillCount.size >= this.MAX_PENDING_KILLS) {
         logWarn(
-          `[PtyClient] kill untracked — pendingKillCount at cap (${this.MAX_PENDING_KILLS}), id=${id}`
+          `[PtyClient] pendingKillCount exceeds soft cap (${this.MAX_PENDING_KILLS}), id=${id}`
         );
       }
+      this.pendingKillCount.set(id, (current ?? 0) + 1);
     }
-    // Always send the kill IPC. PtyManager.kill() guards on registry.get(id),
-    // so unknown ids are a safe no-op on the host side.
+    // Always send the kill IPC. The host-side handler kills the terminal if
+    // it exists and removes any persisted session state for the id.
     this.send({ type: "kill", id, reason });
   }
 

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1100,16 +1100,32 @@ export class PtyClient extends EventEmitter {
 
   kill(id: string, reason?: string): void {
     getTrashedPidTracker().removeTrashed(id);
+    const wasKnown = this.pendingSpawns.has(id);
     this.pendingSpawns.delete(id);
     this.ipcDataMirrorIds.delete(id);
 
-    if (!this.pendingKillCount.has(id) && this.pendingKillCount.size >= this.MAX_PENDING_KILLS) {
-      logWarn(
-        `[PtyClient] kill skipped — pendingKillCount at cap (${this.MAX_PENDING_KILLS}), id=${id}`
-      );
-      return;
+    // Only track pendingKillCount for ids we've seen locally. An "exit"
+    // decrement only arrives for terminals the host actually owned, so
+    // tracking kills for unknown ids would leak cap slots permanently.
+    if (wasKnown) {
+      const current = this.pendingKillCount.get(id);
+      if (current !== undefined) {
+        // Existing entry — incrementing doesn't grow the map, always allow.
+        this.pendingKillCount.set(id, current + 1);
+      } else if (this.pendingKillCount.size < this.MAX_PENDING_KILLS) {
+        this.pendingKillCount.set(id, 1);
+      } else {
+        // At cap with a new id: skip tracking. The kill IPC still goes out so
+        // the host-side terminal is killed; we accept that exit attribution
+        // for this id may fall through to the "normal exit" branch of the
+        // exit handler. Prevents silent PTY leaks under repeated crashes.
+        logWarn(
+          `[PtyClient] kill untracked — pendingKillCount at cap (${this.MAX_PENDING_KILLS}), id=${id}`
+        );
+      }
     }
-    this.pendingKillCount.set(id, (this.pendingKillCount.get(id) ?? 0) + 1);
+    // Always send the kill IPC. PtyManager.kill() guards on registry.get(id),
+    // so unknown ids are a safe no-op on the host side.
     this.send({ type: "kill", id, reason });
   }
 

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -218,6 +218,14 @@ export class PtyClient extends EventEmitter {
    */
   private readonly MAX_PENDING_SPAWNS = 250;
 
+  /**
+   * Cap on pendingKillCount to prevent unbounded growth after repeated host
+   * crashes. Entries are decremented via "exit" events; if the host crashes
+   * before emitting them, entries persist. 2x MAX_PENDING_SPAWNS since kills
+   * are fire-and-forget IPC messages with no replay cost.
+   */
+  private readonly MAX_PENDING_KILLS = 500;
+
   /** RTT observability: timestamp of the in-flight health-check ping, or null if none. */
   private lastPingTime: number | null = null;
   private rttSamples: number[] = [];
@@ -829,6 +837,13 @@ export class PtyClient extends EventEmitter {
   }
 
   private respawnPending(): void {
+    // Kills sent to the crashed host will never receive "exit" events, so
+    // pendingKillCount entries from that session are permanently stale.
+    // Unlike pendingSpawns (replayed below to recreate terminals on the new
+    // host), pendingKillCount is cleared — the terminals those kills targeted
+    // died with the host process.
+    this.pendingKillCount.clear();
+
     // Notify that ports need refresh after host restart
     if (this.onPortRefresh) {
       for (const port of this.pendingMessagePorts.values()) {
@@ -1085,9 +1100,16 @@ export class PtyClient extends EventEmitter {
 
   kill(id: string, reason?: string): void {
     getTrashedPidTracker().removeTrashed(id);
-    this.pendingKillCount.set(id, (this.pendingKillCount.get(id) ?? 0) + 1);
     this.pendingSpawns.delete(id);
     this.ipcDataMirrorIds.delete(id);
+
+    if (!this.pendingKillCount.has(id) && this.pendingKillCount.size >= this.MAX_PENDING_KILLS) {
+      logWarn(
+        `[PtyClient] kill skipped — pendingKillCount at cap (${this.MAX_PENDING_KILLS}), id=${id}`
+      );
+      return;
+    }
+    this.pendingKillCount.set(id, (this.pendingKillCount.get(id) ?? 0) + 1);
     this.send({ type: "kill", id, reason });
   }
 

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -912,7 +912,7 @@ describe("PtyClient adversarial", () => {
     }
   }
 
-  it("PENDING_KILLS_UNTRACKED_AT_CAP_BUT_IPC_STILL_SENT", async () => {
+  it("NEW_ID_AT_CAP_WARNS_BUT_TRACKS_AND_SENDS_IPC", async () => {
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const { logWarn } = await import("../../utils/logger.js");
@@ -925,11 +925,12 @@ describe("PtyClient adversarial", () => {
     client.spawn("t-overflow", baseSpawnOptions());
     client.kill("t-overflow");
 
-    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
-    expect(privateAccess.pendingKillCount.has("t-overflow")).toBe(false);
-    // IPC must still be dispatched so the host-side PTY is actually killed.
+    // Cap is soft — tracking the known id is required to prevent a late
+    // "exit" from deleting a re-spawned entry with the same id.
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS + 1);
+    expect(privateAccess.pendingKillCount.get("t-overflow")).toBe(1);
     expect(countKillMessages(mockChild, "t-overflow")).toBe(1);
-    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("pendingKillCount at cap"));
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("exceeds soft cap"));
   });
 
   it("KILL_EXISTING_ID_INCREMENTS_AT_CAP", async () => {
@@ -943,7 +944,8 @@ describe("PtyClient adversarial", () => {
     mockChild.postMessage.mockClear();
 
     // Already-tracked id: re-spawn so the next kill sees it as known,
-    // then kill again. Size stays at cap; count bumps to 2.
+    // then kill again. Size stays at cap; count bumps to 2. No warn because
+    // the entry existed (no soft-cap crossing).
     client.spawn("k-0", baseSpawnOptions());
     client.kill("k-0");
 
@@ -964,7 +966,8 @@ describe("PtyClient adversarial", () => {
     }
 
     // Unknown ids were never spawned, so they must not occupy cap slots —
-    // otherwise stray kills would permanently starve legitimate kills.
+    // otherwise stray kills would inflate the soft cap without any host-side
+    // terminal actually owning the slot.
     expect(privateAccess.pendingKillCount.size).toBe(0);
     expect(logWarn).not.toHaveBeenCalled();
     // IPC still sent for each — PtyManager.kill() no-ops for unknown ids.
@@ -975,25 +978,20 @@ describe("PtyClient adversarial", () => {
     expect(privateAccess.pendingKillCount.get("t-real")).toBe(1);
   });
 
-  it("EXIT_DECREMENT_FREES_CAPACITY_FOR_NEW_ID", async () => {
+  it("EXIT_DECREMENTS_AND_REMOVES_ENTRY", async () => {
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
-    const { logWarn } = await import("../../utils/logger.js");
 
-    fillKnownPendingKills(client, MAX_PENDING_KILLS);
-    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    client.spawn("k-0", baseSpawnOptions());
+    client.kill("k-0");
+    client.spawn("k-0", baseSpawnOptions());
+    client.kill("k-0");
+    expect(privateAccess.pendingKillCount.get("k-0")).toBe(2);
 
-    // Exit for k-0 decrements (and deletes) its entry.
     mockChild.emit("message", { type: "exit", id: "k-0", exitCode: 0 });
-    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS - 1);
-    (logWarn as Mock).mockClear();
-
-    client.spawn("t-new", baseSpawnOptions());
-    client.kill("t-new");
-
-    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
-    expect(privateAccess.pendingKillCount.get("t-new")).toBe(1);
-    expect(logWarn).not.toHaveBeenCalled();
+    expect(privateAccess.pendingKillCount.get("k-0")).toBe(1);
+    mockChild.emit("message", { type: "exit", id: "k-0", exitCode: 0 });
+    expect(privateAccess.pendingKillCount.has("k-0")).toBe(false);
   });
 
   it("KILL_COUNT_CLEARED_ON_HOST_CRASH", () => {
@@ -1015,7 +1013,7 @@ describe("PtyClient adversarial", () => {
     client.dispose();
   });
 
-  it("BOOKKEEPING_RUNS_AND_IPC_SENT_WHEN_KILL_UNTRACKED_AT_CAP", async () => {
+  it("BOOKKEEPING_RUNS_AND_IPC_SENT_WHEN_CAP_EXCEEDED", async () => {
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const { logWarn } = await import("../../utils/logger.js");
@@ -1032,12 +1030,36 @@ describe("PtyClient adversarial", () => {
 
     client.kill("t-victim");
 
-    // Full bookkeeping must have run despite the cap.
+    // Full bookkeeping must have run, and the victim must be tracked so a
+    // late "exit" doesn't fall into the wrong branch of the exit handler.
     expect(client.hasTerminal("t-victim")).toBe(false);
     expect(privateAccess.ipcDataMirrorIds.has("t-victim")).toBe(false);
-    expect(privateAccess.pendingKillCount.has("t-victim")).toBe(false);
-    // IPC must still be dispatched — otherwise the host-side PTY leaks.
+    expect(privateAccess.pendingKillCount.get("t-victim")).toBe(1);
     expect(countKillMessages(mockChild, "t-victim")).toBe(1);
-    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("pendingKillCount at cap"));
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("exceeds soft cap"));
+  });
+
+  it("LATE_EXIT_DOES_NOT_DELETE_NEWLY_RESPAWNED_ID_AT_CAP", () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+
+    // Fill to soft cap so the next new-id kill crosses it.
+    fillKnownPendingKills(client, MAX_PENDING_KILLS);
+
+    client.spawn("t-same", baseSpawnOptions());
+    client.kill("t-same");
+    expect(privateAccess.pendingKillCount.get("t-same")).toBe(1);
+
+    // Re-spawn the same id (hydration path: requestedId: saved.id).
+    client.spawn("t-same", baseSpawnOptions());
+    expect(client.hasTerminal("t-same")).toBe(true);
+
+    // Now the late "exit" for the old terminal arrives. The exit handler
+    // must take the killCount > 0 branch and NOT delete pendingSpawns —
+    // otherwise the newly respawned terminal would be silently dropped.
+    mockChild.emit("message", { type: "exit", id: "t-same", exitCode: 0 });
+
+    expect(client.hasTerminal("t-same")).toBe(true);
+    expect(privateAccess.pendingKillCount.has("t-same")).toBe(false);
   });
 });

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -56,6 +56,7 @@ interface PtyClientPrivateAccess {
   child: MockUtilityProcess | null;
   pendingMessagePorts: Map<number, MockMessagePortMain>;
   pendingKillCount: Map<string, number>;
+  ipcDataMirrorIds: Set<string>;
 }
 
 function createMockChild(): MockUtilityProcess {
@@ -896,56 +897,103 @@ describe("PtyClient adversarial", () => {
 
   const MAX_PENDING_KILLS = 500;
 
-  function countKillMessages(child: MockUtilityProcess): number {
-    return child.postMessage.mock.calls.filter(
-      (call: unknown[]) => (call[0] as { type?: string })?.type === "kill"
-    ).length;
+  function countKillMessages(child: MockUtilityProcess, id?: string): number {
+    return child.postMessage.mock.calls.filter((call: unknown[]) => {
+      const msg = call[0] as { type?: string; id?: string };
+      if (msg?.type !== "kill") return false;
+      return id === undefined || msg.id === id;
+    }).length;
   }
 
-  it("PENDING_KILLS_REJECTED_AT_CAP", async () => {
+  function fillKnownPendingKills(client: import("../PtyClient.js").PtyClient, count: number): void {
+    for (let i = 0; i < count; i++) {
+      client.spawn(`k-${i}`, baseSpawnOptions());
+      client.kill(`k-${i}`);
+    }
+  }
+
+  it("PENDING_KILLS_UNTRACKED_AT_CAP_BUT_IPC_STILL_SENT", async () => {
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const { logWarn } = await import("../../utils/logger.js");
 
-    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
-      client.kill(`t-${i}`);
-    }
+    fillKnownPendingKills(client, MAX_PENDING_KILLS);
     expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
-    expect(countKillMessages(mockChild)).toBe(MAX_PENDING_KILLS);
     (logWarn as Mock).mockClear();
     mockChild.postMessage.mockClear();
 
+    client.spawn("t-overflow", baseSpawnOptions());
     client.kill("t-overflow");
 
     expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
     expect(privateAccess.pendingKillCount.has("t-overflow")).toBe(false);
-    expect(countKillMessages(mockChild)).toBe(0);
+    // IPC must still be dispatched so the host-side PTY is actually killed.
+    expect(countKillMessages(mockChild, "t-overflow")).toBe(1);
     expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("pendingKillCount at cap"));
   });
 
-  it("KILL_EXISTING_ID_ALLOWED_AT_CAP", async () => {
+  it("KILL_EXISTING_ID_INCREMENTS_AT_CAP", async () => {
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const { logWarn } = await import("../../utils/logger.js");
 
-    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
-      client.kill(`t-${i}`);
-    }
+    fillKnownPendingKills(client, MAX_PENDING_KILLS);
     expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
     (logWarn as Mock).mockClear();
     mockChild.postMessage.mockClear();
 
-    client.kill("t-0");
+    // Already-tracked id: re-spawn so the next kill sees it as known,
+    // then kill again. Size stays at cap; count bumps to 2.
+    client.spawn("k-0", baseSpawnOptions());
+    client.kill("k-0");
 
     expect(logWarn).not.toHaveBeenCalled();
     expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
-    expect(privateAccess.pendingKillCount.get("t-0")).toBe(2);
-    const killCalls = mockChild.postMessage.mock.calls.filter(
-      (call: unknown[]) =>
-        (call[0] as { type?: string })?.type === "kill" &&
-        (call[0] as { id?: string })?.id === "t-0"
-    );
-    expect(killCalls).toHaveLength(1);
+    expect(privateAccess.pendingKillCount.get("k-0")).toBe(2);
+    expect(countKillMessages(mockChild, "k-0")).toBe(1);
+  });
+
+  it("KILL_BOGUS_ID_DOES_NOT_CONSUME_CAP_SLOT", async () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+    const { logWarn } = await import("../../utils/logger.js");
+    mockChild.postMessage.mockClear();
+
+    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
+      client.kill(`unknown-${i}`);
+    }
+
+    // Unknown ids were never spawned, so they must not occupy cap slots —
+    // otherwise stray kills would permanently starve legitimate kills.
+    expect(privateAccess.pendingKillCount.size).toBe(0);
+    expect(logWarn).not.toHaveBeenCalled();
+    // IPC still sent for each — PtyManager.kill() no-ops for unknown ids.
+    expect(countKillMessages(mockChild)).toBe(MAX_PENDING_KILLS);
+
+    client.spawn("t-real", baseSpawnOptions());
+    client.kill("t-real");
+    expect(privateAccess.pendingKillCount.get("t-real")).toBe(1);
+  });
+
+  it("EXIT_DECREMENT_FREES_CAPACITY_FOR_NEW_ID", async () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+    const { logWarn } = await import("../../utils/logger.js");
+
+    fillKnownPendingKills(client, MAX_PENDING_KILLS);
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+
+    // Exit for k-0 decrements (and deletes) its entry.
+    mockChild.emit("message", { type: "exit", id: "k-0", exitCode: 0 });
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS - 1);
+    (logWarn as Mock).mockClear();
+
+    client.spawn("t-new", baseSpawnOptions());
+    client.kill("t-new");
+
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    expect(privateAccess.pendingKillCount.get("t-new")).toBe(1);
+    expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("KILL_COUNT_CLEARED_ON_HOST_CRASH", () => {
@@ -953,9 +1001,7 @@ describe("PtyClient adversarial", () => {
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const restartedChild = createMockChild();
 
-    client.kill("t-0");
-    client.kill("t-1");
-    client.kill("t-2");
+    fillKnownPendingKills(client, 3);
     expect(privateAccess.pendingKillCount.size).toBe(3);
 
     shared.forkMock.mockReturnValue(restartedChild);
@@ -969,24 +1015,29 @@ describe("PtyClient adversarial", () => {
     client.dispose();
   });
 
-  it("BOOKKEEPING_RUNS_ON_REJECTED_KILL", async () => {
+  it("BOOKKEEPING_RUNS_AND_IPC_SENT_WHEN_KILL_UNTRACKED_AT_CAP", async () => {
     const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
     const { logWarn } = await import("../../utils/logger.js");
 
     client.spawn("t-victim", baseSpawnOptions());
+    client.setIpcDataMirror("t-victim", true);
     expect(client.hasTerminal("t-victim")).toBe(true);
+    expect(privateAccess.ipcDataMirrorIds.has("t-victim")).toBe(true);
 
-    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
-      client.kill(`fill-${i}`);
-    }
+    fillKnownPendingKills(client, MAX_PENDING_KILLS);
     expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
     (logWarn as Mock).mockClear();
+    mockChild.postMessage.mockClear();
 
     client.kill("t-victim");
 
+    // Full bookkeeping must have run despite the cap.
     expect(client.hasTerminal("t-victim")).toBe(false);
+    expect(privateAccess.ipcDataMirrorIds.has("t-victim")).toBe(false);
     expect(privateAccess.pendingKillCount.has("t-victim")).toBe(false);
+    // IPC must still be dispatched — otherwise the host-side PTY leaks.
+    expect(countKillMessages(mockChild, "t-victim")).toBe(1);
     expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("pendingKillCount at cap"));
   });
 });

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -893,4 +893,100 @@ describe("PtyClient adversarial", () => {
       result: { success: true, id: "t-overflow" },
     });
   });
+
+  const MAX_PENDING_KILLS = 500;
+
+  function countKillMessages(child: MockUtilityProcess): number {
+    return child.postMessage.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { type?: string })?.type === "kill"
+    ).length;
+  }
+
+  it("PENDING_KILLS_REJECTED_AT_CAP", async () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+    const { logWarn } = await import("../../utils/logger.js");
+
+    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
+      client.kill(`t-${i}`);
+    }
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    expect(countKillMessages(mockChild)).toBe(MAX_PENDING_KILLS);
+    (logWarn as Mock).mockClear();
+    mockChild.postMessage.mockClear();
+
+    client.kill("t-overflow");
+
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    expect(privateAccess.pendingKillCount.has("t-overflow")).toBe(false);
+    expect(countKillMessages(mockChild)).toBe(0);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("pendingKillCount at cap"));
+  });
+
+  it("KILL_EXISTING_ID_ALLOWED_AT_CAP", async () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+    const { logWarn } = await import("../../utils/logger.js");
+
+    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
+      client.kill(`t-${i}`);
+    }
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    (logWarn as Mock).mockClear();
+    mockChild.postMessage.mockClear();
+
+    client.kill("t-0");
+
+    expect(logWarn).not.toHaveBeenCalled();
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    expect(privateAccess.pendingKillCount.get("t-0")).toBe(2);
+    const killCalls = mockChild.postMessage.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[0] as { type?: string })?.type === "kill" &&
+        (call[0] as { id?: string })?.id === "t-0"
+    );
+    expect(killCalls).toHaveLength(1);
+  });
+
+  it("KILL_COUNT_CLEARED_ON_HOST_CRASH", () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+    const restartedChild = createMockChild();
+
+    client.kill("t-0");
+    client.kill("t-1");
+    client.kill("t-2");
+    expect(privateAccess.pendingKillCount.size).toBe(3);
+
+    shared.forkMock.mockReturnValue(restartedChild);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(2000);
+    restartedChild.emit("message", { type: "ready" });
+
+    expect(privateAccess.pendingKillCount.size).toBe(0);
+    expect(countKillMessages(restartedChild)).toBe(0);
+
+    client.dispose();
+  });
+
+  it("BOOKKEEPING_RUNS_ON_REJECTED_KILL", async () => {
+    const client = createReadyClient();
+    const privateAccess = client as unknown as PtyClientPrivateAccess;
+    const { logWarn } = await import("../../utils/logger.js");
+
+    client.spawn("t-victim", baseSpawnOptions());
+    expect(client.hasTerminal("t-victim")).toBe(true);
+
+    for (let i = 0; i < MAX_PENDING_KILLS; i++) {
+      client.kill(`fill-${i}`);
+    }
+    expect(privateAccess.pendingKillCount.size).toBe(MAX_PENDING_KILLS);
+    (logWarn as Mock).mockClear();
+
+    client.kill("t-victim");
+
+    expect(client.hasTerminal("t-victim")).toBe(false);
+    expect(privateAccess.pendingKillCount.has("t-victim")).toBe(false);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("pendingKillCount at cap"));
+  });
 });


### PR DESCRIPTION
## Summary

- `PtyClient.pendingKillCount` could grow without bound across repeated PTY host crashes because killed IDs never received their `exit` event, so the map entries were never cleared.
- Added a soft cap of 500 (`MAX_PENDING_KILLS`) with a warning log when reached. Clear-on-respawn is the primary defence. The cap is a backstop for the unbounded-growth failure mode.
- Kill IPC is always dispatched regardless of cap state (it's idempotent for unknown IDs). Unknown IDs don't consume cap slots. Known IDs at the cap are still tracked to avoid a late-exit/re-spawn race where a stale exit event deletes a freshly spawned process.

Resolves #5319

## Changes

- `electron/services/PtyClient.ts`: added `MAX_PENDING_KILLS = 500`, soft-cap guard in `kill()`, and `pendingKillCount.clear()` on host respawn
- `electron/services/__tests__/PtyClient.adversarial.test.ts`: 7 new adversarial tests covering cap enforcement, existing-id increment at cap, bogus-id bypass, exit decrement, crash-clear, full bookkeeping, and the late-exit/re-spawn race

## Testing

All 7 adversarial tests pass. The implementation mirrors the `pendingSpawns` cap pattern from #5206.