### PR TITLE
feat(project): fast MRU project switching via Cmd+Opt+-/= (#5143)

### DIFF
--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -160,6 +160,8 @@ export type BuiltInKeyAction =
 
   // Project actions
   | "project.switcherPalette"
+  | "project.mruCycleOlder"
+  | "project.mruCycleNewer"
 
   // Help/Settings
   | "help.shortcuts"
@@ -315,6 +317,8 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "action.palette",
   "action.palette.open",
   "project.switcherPalette",
+  "project.mruCycleOlder",
+  "project.mruCycleNewer",
   "help.shortcuts",
   "help.shortcutsAlt",
   "help.launchAgent",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import { useQuickSwitcher } from "./hooks/useQuickSwitcher";
 import { useWorktreePalette } from "./hooks/useWorktreePalette";
 import { useQuickCreatePalette } from "./hooks/useQuickCreatePalette";
 import { useDoubleShift } from "./hooks/useDoubleShift";
+import { useProjectMruSwitcher } from "./hooks/useProjectMruSwitcher";
 import { useMcpBridge } from "./hooks/useMcpBridge";
 import { useFileDropGuard } from "./hooks/useFileDropGuard";
 import { useSoundPlaybackListener } from "./hooks/useSoundPlaybackListener";
@@ -85,6 +86,7 @@ import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnn
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
 import { CreateProjectFolderDialog } from "./components/Project/CreateProjectFolderDialog";
 import { ProjectSwitcherPalette } from "./components/Project/ProjectSwitcherPalette";
+import { ProjectMruSwitcherOverlay } from "./components/Project/ProjectMruSwitcherOverlay";
 import { ActionPalette } from "./components/ActionPalette";
 import { QuickSwitcher } from "./components/QuickSwitcher";
 import { SendToAgentPalette } from "./components/Terminal/SendToAgentPalette";
@@ -208,6 +210,7 @@ function App() {
   const quickSwitcher = useQuickSwitcher();
   const sendToAgentPalette = useSendToAgentPalette();
   useDoubleShift(actionPalette.toggle);
+  const mruSwitcher = useProjectMruSwitcher();
   const currentProject = useProjectStore((state) => state.currentProject);
   const gitInitDialogOpen = useProjectStore((state) => state.gitInitDialogOpen);
   const gitInitDirectoryPath = useProjectStore((state) => state.gitInitDirectoryPath);
@@ -648,6 +651,11 @@ function App() {
           }
         }}
         onClose={panelPalette.close}
+      />
+      <ProjectMruSwitcherOverlay
+        isVisible={mruSwitcher.isVisible}
+        projects={mruSwitcher.projects}
+        selectedIndex={mruSwitcher.selectedIndex}
       />
       <ProjectSwitcherPalette
         isOpen={projectSwitcherPalette.isOpen && projectSwitcherPalette.mode === "modal"}

--- a/src/components/Project/ProjectMruSwitcherOverlay.tsx
+++ b/src/components/Project/ProjectMruSwitcherOverlay.tsx
@@ -1,0 +1,80 @@
+import { memo } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+import { getProjectGradient } from "@/lib/colorUtils";
+import type { Project } from "@shared/types";
+
+export interface ProjectMruSwitcherOverlayProps {
+  isVisible: boolean;
+  projects: Project[];
+  selectedIndex: number;
+}
+
+const MAX_VISIBLE_ROWS = 9;
+
+function ProjectMruSwitcherOverlayInner({
+  isVisible,
+  projects,
+  selectedIndex,
+}: ProjectMruSwitcherOverlayProps): React.ReactElement | null {
+  if (!isVisible || projects.length < 2 || typeof document === "undefined") {
+    return null;
+  }
+
+  const startIndex = Math.max(0, Math.min(selectedIndex - 1, projects.length - MAX_VISIBLE_ROWS));
+  const visible = projects.slice(startIndex, startIndex + MAX_VISIBLE_ROWS);
+
+  const content = (
+    <div
+      className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center"
+      role="presentation"
+      aria-hidden="true"
+      tabIndex={-1}
+    >
+      <div
+        className="pointer-events-none min-w-[320px] max-w-[420px] rounded-lg border border-palette-border bg-palette-bg/95 p-2 shadow-xl backdrop-blur-md"
+        tabIndex={-1}
+      >
+        <div className="px-2 pb-1 pt-1 text-[11px] font-medium uppercase tracking-wide text-palette-muted">
+          Recent projects
+        </div>
+        <ul className="flex flex-col gap-0.5">
+          {visible.map((project, index) => {
+            const absoluteIndex = startIndex + index;
+            const isSelected = absoluteIndex === selectedIndex;
+            const isCurrent = absoluteIndex === 0;
+            return (
+              <li
+                key={project.id}
+                className={cn(
+                  "flex items-center gap-2 rounded px-2 py-1.5 text-sm",
+                  isSelected
+                    ? "bg-palette-accent/15 ring-1 ring-inset ring-palette-accent text-palette-fg"
+                    : "text-palette-fg/80"
+                )}
+              >
+                <span
+                  className="flex h-6 w-6 items-center justify-center rounded text-sm"
+                  style={{ background: getProjectGradient(project.color) }}
+                >
+                  {project.emoji || "🌲"}
+                </span>
+                <span className="flex-1 truncate">{project.name}</span>
+                {isCurrent && (
+                  <span className="text-[10px] uppercase tracking-wide text-palette-muted">
+                    current
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+
+  return createPortal(content, document.body);
+}
+
+export const ProjectMruSwitcherOverlay = memo(ProjectMruSwitcherOverlayInner);

--- a/src/components/Project/ProjectMruSwitcherOverlay.tsx
+++ b/src/components/Project/ProjectMruSwitcherOverlay.tsx
@@ -33,10 +33,10 @@ function ProjectMruSwitcherOverlayInner({
       tabIndex={-1}
     >
       <div
-        className="pointer-events-none min-w-[320px] max-w-[420px] rounded-lg border border-palette-border bg-palette-bg/95 p-2 shadow-xl backdrop-blur-md"
+        className="pointer-events-none min-w-[320px] max-w-[420px] rounded-[var(--radius-xl)] border border-[var(--border-overlay)] bg-daintree-bg/95 p-2 shadow-modal backdrop-blur-md"
         tabIndex={-1}
       >
-        <div className="px-2 pb-1 pt-1 text-[11px] font-medium uppercase tracking-wide text-palette-muted">
+        <div className="px-2 pb-1 pt-1 text-[11px] font-medium uppercase tracking-wide text-daintree-text/50">
           Recent projects
         </div>
         <ul className="flex flex-col gap-0.5">
@@ -48,10 +48,10 @@ function ProjectMruSwitcherOverlayInner({
               <li
                 key={project.id}
                 className={cn(
-                  "flex items-center gap-2 rounded px-2 py-1.5 text-sm",
+                  "flex items-center gap-2 rounded-[var(--radius-md)] px-2 py-1.5 text-sm",
                   isSelected
-                    ? "bg-palette-accent/15 ring-1 ring-inset ring-palette-accent text-palette-fg"
-                    : "text-palette-fg/80"
+                    ? "bg-overlay-soft ring-1 ring-inset ring-daintree-accent text-daintree-text"
+                    : "text-daintree-text/80"
                 )}
               >
                 <span
@@ -62,7 +62,7 @@ function ProjectMruSwitcherOverlayInner({
                 </span>
                 <span className="flex-1 truncate">{project.name}</span>
                 {isCurrent && (
-                  <span className="text-[10px] uppercase tracking-wide text-palette-muted">
+                  <span className="text-[10px] uppercase tracking-wide text-daintree-text/40">
                     current
                   </span>
                 )}

--- a/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
+++ b/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
@@ -1,0 +1,465 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { switchProjectMock, reopenProjectMock, notifyMock, projectState, useProjectStoreMock } =
+  vi.hoisted(() => {
+    const switchProjectMock = vi.fn().mockResolvedValue(undefined);
+    const reopenProjectMock = vi.fn().mockResolvedValue(undefined);
+    const notifyMock = vi.fn().mockReturnValue("");
+
+    const projectState = {
+      projects: [
+        { id: "p-current", path: "/p-current", name: "Current", emoji: "🌲", lastOpened: 500 },
+        { id: "p-recent", path: "/p-recent", name: "Recent", emoji: "🍎", lastOpened: 400 },
+        { id: "p-older", path: "/p-older", name: "Older", emoji: "🥕", lastOpened: 300 },
+        { id: "p-oldest", path: "/p-oldest", name: "Oldest", emoji: "🌵", lastOpened: 200 },
+      ] as Array<{
+        id: string;
+        path: string;
+        name: string;
+        emoji: string;
+        lastOpened: number;
+        status?: "active" | "background" | "closed" | "missing";
+      }>,
+      currentProject: { id: "p-current" } as { id: string } | null,
+      switchProject: switchProjectMock,
+      reopenProject: reopenProjectMock,
+    };
+
+    const useProjectStoreMock = Object.assign(
+      vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
+      { getState: () => projectState }
+    );
+
+    return {
+      switchProjectMock,
+      reopenProjectMock,
+      notifyMock,
+      projectState,
+      useProjectStoreMock,
+    };
+  });
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: useProjectStoreMock,
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+import { _resetForTests as resetEscapeStack, dispatchEscape } from "@/lib/escapeStack";
+import { useProjectMruSwitcher } from "../useProjectMruSwitcher";
+
+function keyDown(
+  code: "Minus" | "Equal",
+  opts: { repeat?: boolean; isComposing?: boolean; target?: Element | null } = {}
+) {
+  const key = code === "Minus" ? "–" : "≠";
+  const event = new KeyboardEvent("keydown", {
+    key,
+    code,
+    metaKey: true,
+    altKey: true,
+    repeat: opts.repeat ?? false,
+    isComposing: opts.isComposing ?? false,
+    bubbles: true,
+    cancelable: true,
+  });
+  if (opts.target) {
+    Object.defineProperty(event, "target", { value: opts.target, writable: false });
+  }
+  window.dispatchEvent(event);
+  return event;
+}
+
+function keyUp(key: "Meta" | "Alt") {
+  const event = new KeyboardEvent("keyup", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("useProjectMruSwitcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    resetEscapeStack();
+    projectState.currentProject = { id: "p-current" };
+    projectState.projects = [
+      { id: "p-current", path: "/p-current", name: "Current", emoji: "🌲", lastOpened: 500 },
+      { id: "p-recent", path: "/p-recent", name: "Recent", emoji: "🍎", lastOpened: 400 },
+      { id: "p-older", path: "/p-older", name: "Older", emoji: "🥕", lastOpened: 300 },
+      { id: "p-oldest", path: "/p-oldest", name: "Oldest", emoji: "🌵", lastOpened: 200 },
+    ];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tap Cmd+Alt+- switches to most recent other project without showing overlay", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).toHaveBeenCalledWith("p-recent");
+    expect(reopenProjectMock).not.toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("tap Cmd+Alt+= also switches to the same most recent other project", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Equal");
+    });
+    act(() => {
+      keyUp("Alt");
+    });
+
+    expect(switchProjectMock).toHaveBeenCalledWith("p-recent");
+  });
+
+  it("single-project state is a no-op", () => {
+    projectState.projects = [
+      { id: "p-current", path: "/p-current", name: "Current", emoji: "🌲", lastOpened: 500 },
+    ];
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalled();
+    expect(reopenProjectMock).not.toHaveBeenCalled();
+  });
+
+  it("IME composition keydown is ignored", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus", { isComposing: true });
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalled();
+  });
+
+  it("Sticky Keys: modifier release without any trigger keydown does not commit", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalled();
+  });
+
+  it("holding past threshold shows overlay with selectedIndex 1", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    act(() => {
+      vi.advanceTimersByTime(130);
+    });
+
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.selectedIndex).toBe(1);
+    expect(result.current.projects.map((p) => p.id)).toEqual([
+      "p-current",
+      "p-recent",
+      "p-older",
+      "p-oldest",
+    ]);
+  });
+
+  it("hold + Minus advances older through MRU", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+    act(() => {
+      keyDown("Minus", { repeat: true });
+    });
+
+    expect(result.current.selectedIndex).toBe(2);
+  });
+
+  it("hold + Equal from index 1 wraps to last index", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+    act(() => {
+      keyDown("Equal", { repeat: true });
+    });
+
+    expect(result.current.selectedIndex).toBe(3);
+  });
+
+  it("hold + Minus at last wraps back to 1", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+    act(() => {
+      keyDown("Minus", { repeat: true });
+      keyDown("Minus", { repeat: true });
+      keyDown("Minus", { repeat: true });
+    });
+
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("releasing modifier during hold commits highlighted project", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+    act(() => {
+      keyDown("Minus", { repeat: true });
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).toHaveBeenCalledWith("p-older");
+  });
+
+  it("Escape during hold cancels without committing", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+    expect(result.current.isVisible).toBe(true);
+
+    act(() => {
+      dispatchEscape();
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    act(() => {
+      keyUp("Meta");
+    });
+    expect(switchProjectMock).not.toHaveBeenCalled();
+  });
+
+  it("window blur during hold cancels without committing", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    act(() => {
+      keyUp("Meta");
+    });
+    expect(switchProjectMock).not.toHaveBeenCalled();
+  });
+
+  it("document hidden during hold cancels", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+
+    Object.defineProperty(document, "hidden", { value: true, configurable: true });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current.isVisible).toBe(false);
+    Object.defineProperty(document, "hidden", { value: false, configurable: true });
+  });
+
+  it("e.repeat advances without restarting the hold timer", () => {
+    const { result } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    // Before threshold, repeat events advance the index but do NOT restart timer
+    act(() => {
+      vi.advanceTimersByTime(80);
+      keyDown("Minus", { repeat: true });
+      vi.advanceTimersByTime(60);
+    });
+
+    // 80 + 60 = 140 > 120 threshold, so overlay should be visible
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.selectedIndex).toBe(2);
+  });
+
+  it("commits background project via reopenProject", () => {
+    projectState.projects = [
+      { id: "p-current", path: "/p-current", name: "Current", emoji: "🌲", lastOpened: 500 },
+      {
+        id: "p-bg",
+        path: "/p-bg",
+        name: "BG",
+        emoji: "🍃",
+        lastOpened: 400,
+        status: "background",
+      },
+    ];
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(reopenProjectMock).toHaveBeenCalledWith("p-bg");
+    expect(switchProjectMock).not.toHaveBeenCalled();
+  });
+
+  it("no-op when target is an editable input", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      keyDown("Minus", { target: input });
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("still fires inside an .xterm container (terminal panel must work)", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    const term = document.createElement("div");
+    term.className = "xterm";
+    document.body.appendChild(term);
+    act(() => {
+      keyDown("Minus", { target: term });
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).toHaveBeenCalledWith("p-recent");
+    term.remove();
+  });
+
+  it("switchProject rejection surfaces via notify", async () => {
+    const err = new Error("boom");
+    switchProjectMock.mockRejectedValueOnce(err);
+
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    await vi.waitFor(() => {
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", message: "boom" })
+      );
+    });
+  });
+
+  it("unmount mid-hold clears timer and does not commit", () => {
+    const { result, unmount } = renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+    });
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalled();
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("calls preventDefault and stopPropagation on handled keydowns", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    const event = new KeyboardEvent("keydown", {
+      key: "–",
+      code: "Minus",
+      metaKey: true,
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const pd = vi.spyOn(event, "preventDefault");
+    const sp = vi.spyOn(event, "stopPropagation");
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(pd).toHaveBeenCalled();
+    expect(sp).toHaveBeenCalled();
+  });
+
+  it("ignores keydowns when modifiers are absent", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    const event = new KeyboardEvent("keydown", {
+      key: "-",
+      code: "Minus",
+      metaKey: false,
+      altKey: false,
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
+++ b/src/hooks/__tests__/useProjectMruSwitcher.test.tsx
@@ -442,6 +442,64 @@ describe("useProjectMruSwitcher", () => {
     expect(sp).toHaveBeenCalled();
   });
 
+  it("fires inside xterm helper textarea (common terminal focus state)", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    const term = document.createElement("div");
+    term.className = "xterm";
+    const helper = document.createElement("textarea");
+    helper.className = "xterm-helper-textarea";
+    term.appendChild(helper);
+    document.body.appendChild(term);
+
+    act(() => {
+      keyDown("Minus", { target: helper });
+    });
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).toHaveBeenCalledWith("p-recent");
+    term.remove();
+  });
+
+  it("calls stopImmediatePropagation to block sibling capture listeners", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    const event = new KeyboardEvent("keydown", {
+      key: "–",
+      code: "Minus",
+      metaKey: true,
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const sip = vi.spyOn(event, "stopImmediatePropagation");
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(sip).toHaveBeenCalled();
+  });
+
+  it("revalidates target against live store at commit time", () => {
+    renderHook(() => useProjectMruSwitcher());
+
+    act(() => {
+      keyDown("Minus");
+      vi.advanceTimersByTime(130);
+    });
+    // Mutate the store: remove the selected target (p-recent at index 1)
+    projectState.projects = projectState.projects.filter((p) => p.id !== "p-recent");
+
+    act(() => {
+      keyUp("Meta");
+    });
+
+    expect(switchProjectMock).not.toHaveBeenCalledWith("p-recent");
+  });
+
   it("ignores keydowns when modifiers are absent", () => {
     renderHook(() => useProjectMruSwitcher());
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -83,6 +83,9 @@ export type { ActionPaletteItem, UseActionPaletteReturn } from "./useActionPalet
 
 export { useDoubleShift } from "./useDoubleShift";
 
+export { useProjectMruSwitcher } from "./useProjectMruSwitcher";
+export type { UseProjectMruSwitcherReturn } from "./useProjectMruSwitcher";
+
 export { useMainProcessToastListener } from "./useMainProcessToastListener";
 
 export { useAnimatedPresence } from "./useAnimatedPresence";

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -70,7 +70,9 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
       holdTimerRef.current = null;
     }
     sessionRef.current = createIdleSession();
-    setOverlay((prev) => (prev.visible ? { visible: false, selectedIndex: 1, projects: [] } : prev));
+    setOverlay((prev) =>
+      prev.visible ? { visible: false, selectedIndex: 1, projects: [] } : prev
+    );
   }, []);
 
   const commitSelection = useCallback((session: SessionState) => {
@@ -80,8 +82,7 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
     const liveTarget = state.projects.find((p) => p.id === snapshotTarget.id);
     if (!liveTarget) return;
     if (state.currentProject?.id === liveTarget.id) return;
-    const switchFn =
-      liveTarget.status === "background" ? state.reopenProject : state.switchProject;
+    const switchFn = liveTarget.status === "background" ? state.reopenProject : state.switchProject;
     Promise.resolve(switchFn(liveTarget.id)).catch((error) => {
       notify({
         type: "error",

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -35,6 +35,7 @@ function createIdleSession(): SessionState {
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
+  if (target.closest(".xterm") !== null) return false;
   if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return true;
   if (target.isContentEditable) return true;
   return false;
@@ -73,13 +74,15 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
   }, []);
 
   const commitSelection = useCallback((session: SessionState) => {
-    const target = session.projects[session.selectedIndex];
-    if (!target) return;
+    const snapshotTarget = session.projects[session.selectedIndex];
+    if (!snapshotTarget) return;
     const state = useProjectStore.getState();
-    if (state.currentProject?.id === target.id) return;
+    const liveTarget = state.projects.find((p) => p.id === snapshotTarget.id);
+    if (!liveTarget) return;
+    if (state.currentProject?.id === liveTarget.id) return;
     const switchFn =
-      target.status === "background" ? state.reopenProject : state.switchProject;
-    Promise.resolve(switchFn(target.id)).catch((error) => {
+      liveTarget.status === "background" ? state.reopenProject : state.switchProject;
+    Promise.resolve(switchFn(liveTarget.id)).catch((error) => {
       notify({
         type: "error",
         title: "Failed to switch project",
@@ -118,6 +121,7 @@ export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
 
       event.preventDefault();
       event.stopPropagation();
+      event.stopImmediatePropagation();
 
       const state = useProjectStore.getState();
       const currentId = state.currentProject?.id ?? null;

--- a/src/hooks/useProjectMruSwitcher.ts
+++ b/src/hooks/useProjectMruSwitcher.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { advanceMruIndex, getMruProjects } from "@/lib/projectMru";
+import { notify } from "@/lib/notify";
+import { useProjectStore } from "@/store/projectStore";
+import type { Project } from "@shared/types";
+
+import { useEscapeStack } from "./useEscapeStack";
+
+const HOLD_THRESHOLD_MS = 120;
+
+export interface UseProjectMruSwitcherReturn {
+  isVisible: boolean;
+  projects: Project[];
+  selectedIndex: number;
+}
+
+interface SessionState {
+  active: boolean;
+  holding: boolean;
+  hasTriggerKey: boolean;
+  selectedIndex: number;
+  projects: Project[];
+}
+
+function createIdleSession(): SessionState {
+  return {
+    active: false,
+    holding: false,
+    hasTriggerKey: false,
+    selectedIndex: 1,
+    projects: [],
+  };
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+/**
+ * Hold-scrub MRU project switcher.
+ *
+ * Tap Cmd+Alt+- (or Cmd+Alt+=): switch to the most recent other project.
+ * Hold Cmd+Alt+-/= for >120ms: show an overlay that scrubs through the MRU
+ * list with each additional '-' (older) or '=' (newer) keypress. Release
+ * Cmd/Alt to commit; Escape or window blur to cancel.
+ *
+ * Uses capture-phase window listeners so the event fires before xterm's
+ * custom key handler and before `KeybindingService` dispatches the matching
+ * action. Call `stopPropagation` + `preventDefault` on handled events to
+ * prevent double-dispatch.
+ */
+export function useProjectMruSwitcher(): UseProjectMruSwitcherReturn {
+  const [overlay, setOverlay] = useState<{
+    visible: boolean;
+    selectedIndex: number;
+    projects: Project[];
+  }>({ visible: false, selectedIndex: 1, projects: [] });
+
+  const sessionRef = useRef<SessionState>(createIdleSession());
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const cancelSession = useCallback(() => {
+    if (holdTimerRef.current !== null) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    sessionRef.current = createIdleSession();
+    setOverlay((prev) => (prev.visible ? { visible: false, selectedIndex: 1, projects: [] } : prev));
+  }, []);
+
+  const commitSelection = useCallback((session: SessionState) => {
+    const target = session.projects[session.selectedIndex];
+    if (!target) return;
+    const state = useProjectStore.getState();
+    if (state.currentProject?.id === target.id) return;
+    const switchFn =
+      target.status === "background" ? state.reopenProject : state.switchProject;
+    Promise.resolve(switchFn(target.id)).catch((error) => {
+      notify({
+        type: "error",
+        title: "Failed to switch project",
+        message: error instanceof Error ? error.message : "Unknown error",
+        duration: 5000,
+      });
+    });
+  }, []);
+
+  useEscapeStack(overlay.visible, cancelSession);
+
+  useEffect(() => {
+    const startHoldTimer = () => {
+      if (holdTimerRef.current !== null) return;
+      holdTimerRef.current = setTimeout(() => {
+        holdTimerRef.current = null;
+        const session = sessionRef.current;
+        if (!session.active) return;
+        session.holding = true;
+        setOverlay({
+          visible: true,
+          selectedIndex: session.selectedIndex,
+          projects: session.projects,
+        });
+      }, HOLD_THRESHOLD_MS);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing) return;
+      if (!event.metaKey || !event.altKey) return;
+      const isOlder = event.code === "Minus";
+      const isNewer = event.code === "Equal";
+      if (!isOlder && !isNewer) return;
+
+      if (isEditableTarget(event.target)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const state = useProjectStore.getState();
+      const currentId = state.currentProject?.id ?? null;
+      if (!currentId) return;
+      const sortedAll = getMruProjects(state.projects);
+      const current = sortedAll.find((p) => p.id === currentId);
+      if (!current) return;
+      const sorted = [current, ...sortedAll.filter((p) => p.id !== currentId)];
+
+      if (sorted.length < 2) return;
+
+      const session = sessionRef.current;
+      if (!session.active) {
+        sessionRef.current = {
+          active: true,
+          holding: false,
+          hasTriggerKey: true,
+          selectedIndex: 1,
+          projects: sorted,
+        };
+        startHoldTimer();
+        return;
+      }
+
+      session.hasTriggerKey = true;
+      session.projects = sorted;
+      const newIndex = advanceMruIndex(
+        session.selectedIndex,
+        isOlder ? "older" : "newer",
+        sorted.length
+      );
+      session.selectedIndex = newIndex;
+      if (session.holding) {
+        setOverlay({
+          visible: true,
+          selectedIndex: newIndex,
+          projects: sorted,
+        });
+      }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key !== "Meta" && event.key !== "Alt") return;
+      const session = sessionRef.current;
+      if (!session.active) return;
+
+      if (session.hasTriggerKey) {
+        commitSelection(session);
+      }
+      cancelSession();
+    };
+
+    const handleBlur = () => {
+      cancelSession();
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) cancelSession();
+    };
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    window.addEventListener("keyup", handleKeyUp, { capture: true });
+    window.addEventListener("blur", handleBlur);
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+      window.removeEventListener("keyup", handleKeyUp, { capture: true });
+      window.removeEventListener("blur", handleBlur);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      if (holdTimerRef.current !== null) {
+        clearTimeout(holdTimerRef.current);
+        holdTimerRef.current = null;
+      }
+    };
+  }, [cancelSession, commitSelection]);
+
+  return {
+    isVisible: overlay.visible,
+    projects: overlay.projects,
+    selectedIndex: overlay.selectedIndex,
+  };
+}

--- a/src/lib/__tests__/projectMru.test.ts
+++ b/src/lib/__tests__/projectMru.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { advanceMruIndex, getMruProjects } from "../projectMru";
+import type { Project } from "@shared/types";
+
+function make(id: string, lastOpened: number, name = id): Project {
+  return { id, path: `/repo/${id}`, name, emoji: "🌲", lastOpened };
+}
+
+describe("getMruProjects", () => {
+  it("returns empty array for empty input", () => {
+    expect(getMruProjects([])).toEqual([]);
+  });
+
+  it("sorts by lastOpened descending", () => {
+    const projects = [make("a", 100), make("b", 300), make("c", 200)];
+    const sorted = getMruProjects(projects);
+    expect(sorted.map((p) => p.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("breaks ties by name ascending", () => {
+    const projects = [make("a", 100, "Zebra"), make("b", 100, "Alpha"), make("c", 100, "Mango")];
+    const sorted = getMruProjects(projects);
+    expect(sorted.map((p) => p.name)).toEqual(["Alpha", "Mango", "Zebra"]);
+  });
+
+  it("treats missing lastOpened as 0", () => {
+    const projects: Project[] = [
+      { id: "a", path: "/a", name: "A", emoji: "🌲" },
+      make("b", 50),
+    ];
+    const sorted = getMruProjects(projects);
+    expect(sorted.map((p) => p.id)).toEqual(["b", "a"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const projects = [make("a", 100), make("b", 300)];
+    const snapshot = projects.map((p) => p.id);
+    getMruProjects(projects);
+    expect(projects.map((p) => p.id)).toEqual(snapshot);
+  });
+});
+
+describe("advanceMruIndex", () => {
+  it("returns currentIndex when length < 2", () => {
+    expect(advanceMruIndex(1, "older", 1)).toBe(1);
+    expect(advanceMruIndex(1, "newer", 0)).toBe(1);
+  });
+
+  it("advances older from 1 to 2", () => {
+    expect(advanceMruIndex(1, "older", 5)).toBe(2);
+  });
+
+  it("wraps older from last index back to 1", () => {
+    expect(advanceMruIndex(4, "older", 5)).toBe(1);
+  });
+
+  it("advances newer from last toward 1", () => {
+    expect(advanceMruIndex(4, "newer", 5)).toBe(3);
+  });
+
+  it("wraps newer from 1 to last index (skipping 0)", () => {
+    expect(advanceMruIndex(1, "newer", 5)).toBe(4);
+  });
+
+  it("with length 2, older/newer cycle only between indices 1 and 1", () => {
+    expect(advanceMruIndex(1, "older", 2)).toBe(1);
+    expect(advanceMruIndex(1, "newer", 2)).toBe(1);
+  });
+
+  it("clamps sub-1 index back to 1 on older", () => {
+    expect(advanceMruIndex(0, "older", 5)).toBe(1);
+  });
+});

--- a/src/lib/__tests__/projectMru.test.ts
+++ b/src/lib/__tests__/projectMru.test.ts
@@ -26,7 +26,7 @@ describe("getMruProjects", () => {
 
   it("treats missing lastOpened as 0", () => {
     const projects: Project[] = [
-      { id: "a", path: "/a", name: "A", emoji: "🌲" },
+      { id: "a", path: "/a", name: "A", emoji: "🌲" } as unknown as Project,
       make("b", 50),
     ];
     const sorted = getMruProjects(projects);
@@ -70,5 +70,13 @@ describe("advanceMruIndex", () => {
 
   it("clamps sub-1 index back to 1 on older", () => {
     expect(advanceMruIndex(0, "older", 5)).toBe(1);
+  });
+
+  it("clamps above-range index on newer (list shrank mid-session)", () => {
+    expect(advanceMruIndex(3, "newer", 2)).toBe(1);
+  });
+
+  it("wraps above-range index on older (list shrank mid-session)", () => {
+    expect(advanceMruIndex(5, "older", 3)).toBe(1);
   });
 });

--- a/src/lib/projectMru.ts
+++ b/src/lib/projectMru.ts
@@ -1,0 +1,37 @@
+import type { Project } from "@shared/types";
+
+/**
+ * Return projects sorted by MRU order (most-recently-opened first), stable by name.
+ * Matches the sort used by the project switcher palette.
+ */
+export function getMruProjects(projects: readonly Project[]): Project[] {
+  return [...projects].sort((a, b) => {
+    const aLast = a.lastOpened ?? 0;
+    const bLast = b.lastOpened ?? 0;
+    if (aLast !== bLast) return bLast - aLast;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/**
+ * Advance the highlighted MRU index during a hold-scrub session.
+ *
+ * Index 0 is the current project and must never be selected. Valid indices are
+ * 1..length-1 and the cycle wraps from the last back to 1 (older) or from 1
+ * back to the last (newer).
+ */
+export function advanceMruIndex(
+  currentIndex: number,
+  direction: "older" | "newer",
+  length: number
+): number {
+  if (length < 2) return currentIndex;
+  const lastIndex = length - 1;
+  if (direction === "older") {
+    if (currentIndex >= lastIndex) return 1;
+    const next = currentIndex + 1;
+    return next < 1 ? 1 : next;
+  }
+  if (currentIndex <= 1) return lastIndex;
+  return currentIndex - 1;
+}

--- a/src/lib/projectMru.ts
+++ b/src/lib/projectMru.ts
@@ -33,5 +33,6 @@ export function advanceMruIndex(
     return next < 1 ? 1 : next;
   }
   if (currentIndex <= 1) return lastIndex;
+  if (currentIndex > lastIndex) return lastIndex;
   return currentIndex - 1;
 }

--- a/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.project-system-preferences.adversarial.test.ts
@@ -316,6 +316,8 @@ describe("project action hardening", () => {
 
     expectRegistryToMatchIds(actions, [
       "project.switcherPalette",
+      "project.mruCycleOlder",
+      "project.mruCycleNewer",
       "project.add",
       "project.openDialog",
       "project.switch",

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -12,8 +12,7 @@ async function runMruFallbackSwitch(direction: "older" | "newer"): Promise<void>
   const otherProjects = sorted.filter((p) => p.id !== currentId);
   if (otherProjects.length === 0) return;
 
-  const target =
-    direction === "older" ? otherProjects[0] : otherProjects[otherProjects.length - 1];
+  const target = direction === "older" ? otherProjects[0] : otherProjects[otherProjects.length - 1];
   if (!target) return;
 
   try {

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -2,6 +2,32 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
+import { getMruProjects } from "@/lib/projectMru";
+import { notify } from "@/lib/notify";
+
+async function runMruFallbackSwitch(): Promise<void> {
+  const state = useProjectStore.getState();
+  const currentId = state.currentProject?.id ?? null;
+  const sorted = getMruProjects(state.projects);
+  const otherProjects = sorted.filter((p) => p.id !== currentId);
+  const target = otherProjects[0];
+  if (!target) return;
+
+  try {
+    if (target.status === "background") {
+      await state.reopenProject(target.id);
+    } else {
+      await state.switchProject(target.id);
+    }
+  } catch (error) {
+    notify({
+      type: "error",
+      title: "Failed to switch project",
+      message: error instanceof Error ? error.message : "Unknown error",
+      duration: 5000,
+    });
+  }
+}
 
 export function registerProjectActions(actions: ActionRegistry, callbacks: ActionCallbacks): void {
   actions.set("project.switcherPalette", () => ({
@@ -15,6 +41,28 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     run: async () => {
       callbacks.onOpenProjectSwitcherPalette();
     },
+  }));
+
+  actions.set("project.mruCycleOlder", () => ({
+    id: "project.mruCycleOlder",
+    title: "Switch to Previous Project (Older)",
+    description: "Switch to the most recent other project; hold to scrub older",
+    category: "project",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: runMruFallbackSwitch,
+  }));
+
+  actions.set("project.mruCycleNewer", () => ({
+    id: "project.mruCycleNewer",
+    title: "Switch to Previous Project (Newer)",
+    description: "Switch to the most recent other project; hold to scrub newer",
+    category: "project",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: runMruFallbackSwitch,
   }));
 
   actions.set("project.add", () => ({

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -5,12 +5,15 @@ import { useProjectStore } from "@/store/projectStore";
 import { getMruProjects } from "@/lib/projectMru";
 import { notify } from "@/lib/notify";
 
-async function runMruFallbackSwitch(): Promise<void> {
+async function runMruFallbackSwitch(direction: "older" | "newer"): Promise<void> {
   const state = useProjectStore.getState();
   const currentId = state.currentProject?.id ?? null;
   const sorted = getMruProjects(state.projects);
   const otherProjects = sorted.filter((p) => p.id !== currentId);
-  const target = otherProjects[0];
+  if (otherProjects.length === 0) return;
+
+  const target =
+    direction === "older" ? otherProjects[0] : otherProjects[otherProjects.length - 1];
   if (!target) return;
 
   try {
@@ -51,18 +54,18 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    run: runMruFallbackSwitch,
+    run: () => runMruFallbackSwitch("older"),
   }));
 
   actions.set("project.mruCycleNewer", () => ({
     id: "project.mruCycleNewer",
-    title: "Switch to Previous Project (Newer)",
-    description: "Switch to the most recent other project; hold to scrub newer",
+    title: "Switch to Oldest Project (Newer)",
+    description: "Switch to the oldest other project; hold to scrub newer",
     category: "project",
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    run: runMruFallbackSwitch,
+    run: () => runMruFallbackSwitch("newer"),
   }));
 
   actions.set("project.add", () => ({

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -656,6 +656,22 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Project",
   },
   {
+    actionId: "project.mruCycleOlder",
+    combo: "Cmd+Alt+-",
+    scope: "global",
+    priority: 10,
+    description: "Switch to previous project (hold to scrub older)",
+    category: "Project",
+  },
+  {
+    actionId: "project.mruCycleNewer",
+    combo: "Cmd+Alt+=",
+    scope: "global",
+    priority: 10,
+    description: "Switch to previous project (hold to scrub newer)",
+    category: "Project",
+  },
+  {
     actionId: "notes.openPalette",
     combo: "Cmd+Shift+N",
     scope: "global",


### PR DESCRIPTION
## Summary

- Adds `Cmd+Opt+-` and `Cmd+Opt+=` as a hold-scrub MRU project switcher, giving a fast path for bouncing between recent projects without opening the palette
- Quick tap (under 120ms) does an instant switch to the previous project with no overlay; holding the modifiers brings up a lightweight overlay for scrubbing further through the list
- On release of `Cmd+Opt`, the highlighted project is committed; Escape cancels without switching

Resolves #5143

## Changes

- `src/lib/projectMru.ts` — MRU sort helpers (reuses `lastOpened` from `projectStore`)
- `src/hooks/useProjectMruSwitcher.ts` — core hook: tap-vs-hold detection, modifier tracking, key repeat scrubbing, blur/escape cancellation
- `src/components/Project/ProjectMruSwitcherOverlay.tsx` — minimal overlay shown during hold, lists MRU projects with the active selection highlighted
- `shared/types/keymap.ts` — two new `KeyAction` entries (`project.mruOlder`, `project.mruNewer`)
- `src/services/defaultKeybindings.ts` — bindings for both new actions
- `src/services/actions/definitions/projectActions.ts` — action definitions wired into `ActionService`
- `src/App.tsx` — mounts the hook and overlay

## Testing

Unit tests cover the MRU sort logic (`src/lib/__tests__/projectMru.test.ts`) and the full hook behaviour (`src/hooks/__tests__/useProjectMruSwitcher.test.tsx`): tap-vs-hold threshold, index wrapping in both directions, repeat-keydown scrubbing, Escape cancel, window blur reset, single-project no-op, and the `isComposing` IME guard. All 605 tests pass.