### PR TITLE
feat(fleet): issue #5301 — fleet quick-actions (accept, reject, interrupt, restart, kill, trash)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -56,6 +56,7 @@ export const CHANNELS = {
   TERMINAL_BACKEND_CRASHED: "terminal:backend-crashed",
   TERMINAL_BACKEND_READY: "terminal:backend-ready",
   TERMINAL_SEND_KEY: "terminal:send-key",
+  TERMINAL_BATCH_DOUBLE_ESCAPE: "terminal:batch-double-escape",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
   TERMINAL_UPDATE_OBSERVED_TITLE: "terminal:update-observed-title",
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -46,6 +46,24 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
   ipcMain.on(CHANNELS.TERMINAL_SEND_KEY, handleTerminalSendKey);
   handlers.push(() => ipcMain.removeListener(CHANNELS.TERMINAL_SEND_KEY, handleTerminalSendKey));
 
+  const handleTerminalBatchDoubleEscape = (_event: Electron.IpcMainEvent, ids: unknown) => {
+    try {
+      if (!Array.isArray(ids)) {
+        console.error("Invalid terminal batchDoubleEscape parameters: expected string[]");
+        return;
+      }
+      const validIds = ids.filter((id): id is string => typeof id === "string" && id.length > 0);
+      if (validIds.length === 0) return;
+      ptyClient.batchDoubleEscape(validIds);
+    } catch (error) {
+      console.error("Error sending batch double escape to terminals:", error);
+    }
+  };
+  ipcMain.on(CHANNELS.TERMINAL_BATCH_DOUBLE_ESCAPE, handleTerminalBatchDoubleEscape);
+  handlers.push(() =>
+    ipcMain.removeListener(CHANNELS.TERMINAL_BATCH_DOUBLE_ESCAPE, handleTerminalBatchDoubleEscape)
+  );
+
   const handleTerminalSubmit = async (id: string, text: string) => {
     try {
       if (typeof id !== "string" || typeof text !== "string") {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -540,6 +540,7 @@ const CHANNELS = {
   TERMINAL_BACKEND_CRASHED: "terminal:backend-crashed",
   TERMINAL_BACKEND_READY: "terminal:backend-ready",
   TERMINAL_SEND_KEY: "terminal:send-key",
+  TERMINAL_BATCH_DOUBLE_ESCAPE: "terminal:batch-double-escape",
   TERMINAL_AGENT_TITLE_STATE: "terminal:agent-title-state",
   TERMINAL_UPDATE_OBSERVED_TITLE: "terminal:update-observed-title",
   TERMINAL_REDUCE_SCROLLBACK: "terminal:reduce-scrollback",
@@ -1343,6 +1344,9 @@ const api: ElectronAPI = {
     },
 
     sendKey: (id: string, key: string) => ipcRenderer.send(CHANNELS.TERMINAL_SEND_KEY, id, key),
+
+    batchDoubleEscape: (ids: string[]) =>
+      ipcRenderer.send(CHANNELS.TERMINAL_BATCH_DOUBLE_ESCAPE, ids),
 
     reportTitleState: (id: string, state: "working" | "waiting") =>
       ipcRenderer.send(CHANNELS.TERMINAL_AGENT_TITLE_STATE, { id, state }),

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -905,6 +905,28 @@ port.on("message", async (rawMsg: any) => {
         ptyManager.submit(msg.id, msg.text);
         break;
 
+      case "batch-double-escape": {
+        // Fan out an ESC, 50ms per-PTY gap, then a second ESC. Scheduling the
+        // gap inside the utility-process event loop is load-bearing — doing
+        // it in the renderer or Main process lets IPC batching collapse the
+        // two writes into a single Meta-Escape on the receiving terminal.
+        const ESC = "\u001b";
+        const INTER_ESC_DELAY_MS = 50;
+        const ids: string[] = Array.isArray(msg.ids) ? msg.ids : [];
+        for (const id of ids) {
+          if (typeof id !== "string" || !id) continue;
+          const terminal = ptyManager.getTerminal(id);
+          if (!terminal || terminal.wasKilled || terminal.isExited) continue;
+          ptyManager.write(id, ESC);
+          setTimeout(() => {
+            const t = ptyManager.getTerminal(id);
+            if (!t || t.wasKilled || t.isExited) return;
+            ptyManager.write(id, ESC);
+          }, INTER_ESC_DELAY_MS);
+        }
+        break;
+      }
+
       case "resize":
         ptyManager.resize(msg.id, msg.cols, msg.rows);
         break;

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1094,6 +1094,19 @@ export class PtyClient extends EventEmitter {
     this.write(id, sequence);
   }
 
+  /**
+   * Fan out a double-Escape to each terminal. The per-PTY inter-escape
+   * delay is scheduled inside the PTY host utility process so the 50ms
+   * gap survives main-process IPC jitter (which can otherwise collapse two
+   * sub-10ms writes into a single Meta-Escape).
+   */
+  batchDoubleEscape(ids: string[]): void {
+    if (!Array.isArray(ids) || ids.length === 0) return;
+    const validIds = ids.filter((id) => typeof id === "string" && id.length > 0);
+    if (validIds.length === 0) return;
+    this.send({ type: "batch-double-escape", ids: validIds });
+  }
+
   resize(id: string, cols: number, rows: number): void {
     this.send({ type: "resize", id, cols, rows });
   }

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -282,7 +282,13 @@ export type BuiltInActionId =
   | "terminal.disarmAll"
   | "terminal.armByState"
   | "terminal.armAll"
-  | "terminal.armDefault";
+  | "terminal.armDefault"
+  | "fleet.accept"
+  | "fleet.reject"
+  | "fleet.interrupt"
+  | "fleet.restart"
+  | "fleet.kill"
+  | "fleet.trash";
 
 export type ActionId = BuiltInActionId | (string & {});
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -258,6 +258,7 @@ export interface ElectronAPI {
     ): () => void;
     onBackendReady(callback: () => void): () => void;
     sendKey(id: string, key: string): void;
+    batchDoubleEscape(ids: string[]): void;
     reportTitleState(id: string, state: "working" | "waiting"): void;
     updateObservedTitle(id: string, title: string): void;
     onSpawnResult(callback: (id: string, result: SpawnResult) => void): () => void;

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -119,6 +119,14 @@ export type BuiltInKeyAction =
   | "terminal.armDefault"
   | "terminal.disarmAll"
 
+  // Fleet quick-actions (scoped to "fleet ribbon visible" at dispatch time)
+  | "fleet.accept"
+  | "fleet.reject"
+  | "fleet.interrupt"
+  | "fleet.restart"
+  | "fleet.kill"
+  | "fleet.trash"
+
   // Agent spawning
   | "agent.palette"
   | AgentKeyAction
@@ -291,6 +299,12 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "terminal.bulkCommand",
   "terminal.armDefault",
   "terminal.disarmAll",
+  "fleet.accept",
+  "fleet.reject",
+  "fleet.interrupt",
+  "fleet.restart",
+  "fleet.kill",
+  "fleet.trash",
   "agent.palette",
   ...BUILT_IN_AGENT_KEY_ACTIONS,
   "agent.terminal",

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -47,6 +47,7 @@ export type PtyHostRequest =
   | { type: "resize"; id: string; cols: number; rows: number }
   | { type: "write"; id: string; data: string; traceId?: string }
   | { type: "submit"; id: string; text: string }
+  | { type: "batch-double-escape"; ids: string[] }
   | { type: "kill"; id: string; reason?: string }
   | { type: "trash"; id: string }
   | { type: "restore"; id: string }

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -170,6 +170,17 @@ export const terminalClient = {
     window.electron.terminal.sendKey(id, key);
   },
 
+  /**
+   * Send a double-Escape to each terminal in the batch, with a per-PTY delay
+   * scheduled inside the PTY host utility process. Used by fleet.interrupt to
+   * drop each armed agent out of sub-menus/dialogs without the sub-10ms
+   * timing collapse that renderer-side setTimeout exhibits under IPC jitter.
+   */
+  batchDoubleEscape: (ids: string[]): void => {
+    if (ids.length === 0) return;
+    window.electron.terminal.batchDoubleEscape(ids);
+  },
+
   resize: (id: string, cols: number, rows: number): void => {
     if (messagePort) {
       try {

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -73,7 +73,7 @@ interface QuickAction {
 const QUICK_ACTIONS: QuickAction[] = [
   { id: "fleet.accept", label: "Accept" },
   { id: "fleet.reject", label: "Reject" },
-  { id: "fleet.interrupt", label: "Interrupt", chordOverride: "⎋⎋" },
+  { id: "fleet.interrupt", label: "Interrupt", chordOverride: "⌘⎋⎋" },
   { id: "fleet.restart", label: "Restart" },
   { id: "fleet.kill", label: "Kill" },
   { id: "fleet.trash", label: "Trash" },
@@ -85,6 +85,8 @@ function buildConfirmMessage(
   sessionLoss: number
 ): string {
   switch (kind) {
+    case "reject":
+      return `Reject ${count} ${count === 1 ? "prompt" : "prompts"}?`;
     case "interrupt":
       return `Interrupt ${count} ${count === 1 ? "agent" : "agents"}?`;
     case "restart": {
@@ -144,7 +146,11 @@ export function FleetArmingRibbon(): ReactElement | null {
     if (pending === null) return;
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
-      const target = e.target as HTMLElement | null;
+      const rawTarget = e.target;
+      const target =
+        rawTarget && typeof (rawTarget as HTMLElement).closest === "function"
+          ? (rawTarget as HTMLElement)
+          : null;
       if (
         target &&
         (target.tagName === "INPUT" ||
@@ -157,24 +163,27 @@ export function FleetArmingRibbon(): ReactElement | null {
       e.preventDefault();
       e.stopPropagation();
       const actionId: QuickActionId =
-        pending.kind === "interrupt"
-          ? "fleet.interrupt"
-          : pending.kind === "restart"
-            ? "fleet.restart"
-            : pending.kind === "kill"
-              ? "fleet.kill"
-              : "fleet.trash";
+        pending.kind === "reject"
+          ? "fleet.reject"
+          : pending.kind === "interrupt"
+            ? "fleet.interrupt"
+            : pending.kind === "restart"
+              ? "fleet.restart"
+              : pending.kind === "kill"
+                ? "fleet.kill"
+                : "fleet.trash";
       void actionService.dispatch(actionId, { confirmed: true }, { source: "keybinding" });
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
   }, [pending]);
 
-  // Esc-Esc double-tap → fleet.interrupt. Using a chord binding would
-  // intercept the single Escape too and break the escape-stack LIFO that
-  // powers overlay dismissal elsewhere. This listener watches for two
-  // Escapes within DOUBLE_ESC_WINDOW_MS and only stops propagation on the
-  // second one — the first still flows through the escape stack.
+  // Cmd+Esc Esc double-tap → fleet.interrupt. The Cmd modifier is what
+  // separates this from the plain-Escape escape-stack LIFO used elsewhere
+  // in the app: bare Escape continues to dismiss confirmations / disarm
+  // the fleet without poisoning the double-tap timer. (An earlier
+  // bare-Escape version had a race where cancelling a confirmation with
+  // Escape then pressing Escape again to disarm fired fleet.interrupt.)
   const lastEscapeMsRef = useRef<number>(0);
   useEffect(() => {
     if (armedCount === 0) {
@@ -183,7 +192,14 @@ export function FleetArmingRibbon(): ReactElement | null {
     }
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      const target = e.target as HTMLElement | null;
+      // Cmd on macOS, Ctrl on other platforms — keybindingService
+      // normalizes the two, but for a raw listener we accept either.
+      if (!e.metaKey && !e.ctrlKey) return;
+      const rawTarget = e.target;
+      const target =
+        rawTarget && typeof (rawTarget as HTMLElement).closest === "function"
+          ? (rawTarget as HTMLElement)
+          : null;
       if (
         target &&
         (target.tagName === "INPUT" ||
@@ -207,7 +223,7 @@ export function FleetArmingRibbon(): ReactElement | null {
   }, [armedCount]);
 
   const hint = useMemo(() => {
-    return "Esc to disarm · Esc Esc to interrupt · Shift-click to extend";
+    return "Esc to disarm · ⌘Esc Esc to interrupt · Shift-click to extend";
   }, []);
 
   if (armedCount === 0) return null;

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useMemo, useRef, type ReactElement } from "react";
 import { X } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { useEscapeStack } from "@/hooks";
 import { useFleetArmingStore, type FleetArmStatePreset } from "@/store/fleetArmingStore";
+import {
+  useFleetPendingActionStore,
+  type FleetPendingActionKind,
+} from "@/store/fleetPendingActionStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { usePanelStore } from "@/store/panelStore";
+import { actionService } from "@/services/ActionService";
+import { keybindingService } from "@/services/KeybindingService";
 
 interface PresetOption {
   value: FleetArmStatePreset;
@@ -16,12 +24,106 @@ const PRESETS: PresetOption[] = [
   { value: "finished", label: "Finished" },
 ];
 
+interface ArmedCounts {
+  live: number;
+  waiting: number;
+  workingOrRunning: number;
+  sessionLoss: number;
+}
+
+const DOUBLE_ESC_WINDOW_MS = 350;
+
+function useArmedCounts(): ArmedCounts {
+  return usePanelStore(
+    useShallow((state) => {
+      const armedIds = useFleetArmingStore.getState().armedIds;
+      let live = 0;
+      let waiting = 0;
+      let workingOrRunning = 0;
+      let sessionLoss = 0;
+      for (const id of armedIds) {
+        const t = state.panelsById[id];
+        if (!t) continue;
+        if (t.location === "trash" || t.location === "background") continue;
+        if (t.hasPty === false) continue;
+        live++;
+        if (t.agentState === "waiting") waiting++;
+        if (t.agentState === "working" || t.agentState === "running") workingOrRunning++;
+        if (t.agentSessionId) sessionLoss++;
+      }
+      return { live, waiting, workingOrRunning, sessionLoss };
+    })
+  );
+}
+
+type QuickActionId =
+  | "fleet.accept"
+  | "fleet.reject"
+  | "fleet.interrupt"
+  | "fleet.restart"
+  | "fleet.kill"
+  | "fleet.trash";
+
+interface QuickAction {
+  id: QuickActionId;
+  label: string;
+  chordOverride?: string;
+}
+
+const QUICK_ACTIONS: QuickAction[] = [
+  { id: "fleet.accept", label: "Accept" },
+  { id: "fleet.reject", label: "Reject" },
+  { id: "fleet.interrupt", label: "Interrupt", chordOverride: "⎋⎋" },
+  { id: "fleet.restart", label: "Restart" },
+  { id: "fleet.kill", label: "Kill" },
+  { id: "fleet.trash", label: "Trash" },
+];
+
+function buildConfirmMessage(
+  kind: FleetPendingActionKind,
+  count: number,
+  sessionLoss: number
+): string {
+  switch (kind) {
+    case "interrupt":
+      return `Interrupt ${count} ${count === 1 ? "agent" : "agents"}?`;
+    case "restart": {
+      const base = `Restart ${count} ${count === 1 ? "agent" : "agents"}?`;
+      if (sessionLoss > 0) {
+        const noun = sessionLoss === 1 ? "agent will lose its" : "agents will lose their";
+        return `${base} ${sessionLoss} ${noun} session.`;
+      }
+      return base;
+    }
+    case "kill":
+      return `Kill ${count} ${count === 1 ? "terminal" : "terminals"}?`;
+    case "trash":
+      return `Trash ${count} ${count === 1 ? "worktree" : "worktrees"}?`;
+  }
+}
+
 export function FleetArmingRibbon(): ReactElement | null {
   const armedCount = useFleetArmingStore((s) => s.armedIds.size);
   const clear = useFleetArmingStore((s) => s.clear);
   const armByState = useFleetArmingStore((s) => s.armByState);
+  const counts = useArmedCounts();
+  const pending = useFleetPendingActionStore((s) => s.pending);
+  const clearPending = useFleetPendingActionStore((s) => s.clear);
 
-  useEscapeStack(armedCount > 0, clear);
+  // Escape stack: confirmation cancel sits above the fleet-disarm entry, so
+  // the first Escape while confirming clears the pending action and a
+  // second Escape disarms the fleet.
+  useEscapeStack(pending !== null, clearPending);
+  useEscapeStack(armedCount > 0 && pending === null, clear);
+
+  // If the armed set drains while a confirmation is pending (e.g., all
+  // armed agents exit), collapse the confirmation so it can't execute
+  // against zero targets.
+  useEffect(() => {
+    if (armedCount === 0 && pending !== null) {
+      clearPending();
+    }
+  }, [armedCount, pending, clearPending]);
 
   const lastAnnouncedCount = useRef<number>(0);
   useEffect(() => {
@@ -35,11 +137,127 @@ export function FleetArmingRibbon(): ReactElement | null {
     lastAnnouncedCount.current = armedCount;
   }, [armedCount]);
 
+  // Enter confirms a pending destructive action. Bound locally so that
+  // `fleet.*` actions can be re-dispatched with `{ confirmed: true }` to
+  // bypass the threshold check on the second pass.
+  useEffect(() => {
+    if (pending === null) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Enter") return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable ||
+          target.closest(".xterm") !== null)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      const actionId: QuickActionId =
+        pending.kind === "interrupt"
+          ? "fleet.interrupt"
+          : pending.kind === "restart"
+            ? "fleet.restart"
+            : pending.kind === "kill"
+              ? "fleet.kill"
+              : "fleet.trash";
+      void actionService.dispatch(actionId, { confirmed: true }, { source: "keybinding" });
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [pending]);
+
+  // Esc-Esc double-tap → fleet.interrupt. Using a chord binding would
+  // intercept the single Escape too and break the escape-stack LIFO that
+  // powers overlay dismissal elsewhere. This listener watches for two
+  // Escapes within DOUBLE_ESC_WINDOW_MS and only stops propagation on the
+  // second one — the first still flows through the escape stack.
+  const lastEscapeMsRef = useRef<number>(0);
+  useEffect(() => {
+    if (armedCount === 0) {
+      lastEscapeMsRef.current = 0;
+      return;
+    }
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable ||
+          target.closest(".xterm") !== null)
+      ) {
+        return;
+      }
+      const now = Date.now();
+      const prev = lastEscapeMsRef.current;
+      lastEscapeMsRef.current = now;
+      if (prev === 0 || now - prev > DOUBLE_ESC_WINDOW_MS) return;
+      lastEscapeMsRef.current = 0;
+      e.stopPropagation();
+      e.preventDefault();
+      void actionService.dispatch("fleet.interrupt", undefined, { source: "keybinding" });
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [armedCount]);
+
   const hint = useMemo(() => {
-    return "Esc to disarm · Shift-click to extend · Cmd-click to toggle";
+    return "Esc to disarm · Esc Esc to interrupt · Shift-click to extend";
   }, []);
 
   if (armedCount === 0) return null;
+
+  if (pending !== null) {
+    const message = buildConfirmMessage(
+      pending.kind,
+      pending.targetCount,
+      pending.sessionLossCount
+    );
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="flex items-center gap-3 border-b border-daintree-accent/40 bg-daintree-accent/10 px-3 py-1.5 text-[12px] text-daintree-text"
+        data-testid="fleet-arming-ribbon"
+        data-pending-action={pending.kind}
+      >
+        <span className="font-medium text-daintree-accent">{message}</span>
+        <div className="ml-auto flex items-center gap-2 text-[11px] text-daintree-text/70">
+          <span>
+            <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
+              Enter
+            </kbd>{" "}
+            to confirm
+          </span>
+          <span>
+            <kbd className="rounded border border-daintree-text/20 bg-tint/[0.08] px-1 py-0.5 font-mono text-[10px]">
+              Esc
+            </kbd>{" "}
+            to cancel
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const isEligible = (id: QuickActionId): boolean => {
+    switch (id) {
+      case "fleet.accept":
+      case "fleet.reject":
+        return counts.waiting > 0;
+      case "fleet.interrupt":
+        return counts.workingOrRunning > 0 || counts.waiting > 0;
+      case "fleet.restart":
+      case "fleet.kill":
+      case "fleet.trash":
+        return counts.live > 0;
+    }
+  };
 
   return (
     <div
@@ -68,6 +286,37 @@ export function FleetArmingRibbon(): ReactElement | null {
             {preset.label}
           </button>
         ))}
+      </div>
+      <div className="flex items-center gap-1" role="toolbar" aria-label="Fleet quick actions">
+        {QUICK_ACTIONS.map((action) => {
+          const eligible = isEligible(action.id);
+          const chord = action.chordOverride ?? keybindingService.getDisplayCombo(action.id) ?? "";
+          return (
+            <button
+              key={action.id}
+              type="button"
+              disabled={!eligible}
+              onClick={() => {
+                void actionService.dispatch(action.id, undefined, { source: "user" });
+              }}
+              className={cn(
+                "inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] transition-colors",
+                eligible
+                  ? "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.14] hover:text-daintree-text"
+                  : "cursor-not-allowed bg-tint/[0.04] text-daintree-text/30"
+              )}
+              aria-label={`${action.label} armed agents (${chord})`}
+              data-testid={`fleet-quick-${action.id.replace("fleet.", "")}`}
+            >
+              <span>{action.label}</span>
+              {chord ? (
+                <kbd className="rounded border border-daintree-text/20 bg-tint/[0.06] px-1 font-mono text-[10px] leading-tight">
+                  {chord}
+                </kbd>
+              ) : null}
+            </button>
+          );
+        })}
       </div>
       <span className="ml-auto text-[11px] text-daintree-text/50">{hint}</span>
       <button

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { render, fireEvent, screen, act } from "@testing-library/react";
 import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -15,6 +16,7 @@ function resetStores() {
     armOrderById: {},
     lastArmedId: null,
   });
+  useFleetPendingActionStore.setState({ pending: null });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
   useAnnouncerStore.setState({ polite: null, assertive: null });
@@ -120,5 +122,44 @@ describe("FleetArmingRibbon", () => {
       useFleetArmingStore.getState().clear();
     });
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Fleet disarmed");
+  });
+
+  it("renders confirmation view when a pending action is set", () => {
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "restart", targetCount: 3, sessionLossCount: 2 },
+    });
+    render(<FleetArmingRibbon />);
+    const ribbon = screen.getByTestId("fleet-arming-ribbon");
+    expect(ribbon.getAttribute("data-pending-action")).toBe("restart");
+    expect(screen.getByText(/Restart 3 agents\?/)).toBeTruthy();
+    expect(screen.getByText(/2 agents will lose their session/)).toBeTruthy();
+  });
+
+  it("collapses pending confirmation when the armed set drains", () => {
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "kill", targetCount: 2, sessionLossCount: 0 },
+    });
+    render(<FleetArmingRibbon />);
+    expect(useFleetPendingActionStore.getState().pending).not.toBeNull();
+    act(() => {
+      useFleetArmingStore.getState().clear();
+    });
+    expect(useFleetPendingActionStore.getState().pending).toBeNull();
+  });
+
+  it("disables quick-action buttons that have no eligible targets", () => {
+    seed([makeAgent("t1", "completed")]);
+    useFleetArmingStore.getState().armIds(["t1"]);
+    render(<FleetArmingRibbon />);
+    // No waiting agents armed → Accept/Reject disabled
+    const accept = screen.getByTestId("fleet-quick-accept") as HTMLButtonElement;
+    expect(accept.disabled).toBe(true);
+    const reject = screen.getByTestId("fleet-quick-reject") as HTMLButtonElement;
+    expect(reject.disabled).toBe(true);
+    // Completed agent is still "live" → Restart/Kill/Trash enabled
+    const kill = screen.getByTestId("fleet-quick-kill") as HTMLButtonElement;
+    expect(kill.disabled).toBe(false);
   });
 });

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, fireEvent, screen, act } from "@testing-library/react";
 import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -161,5 +161,50 @@ describe("FleetArmingRibbon", () => {
     // Completed agent is still "live" → Restart/Kill/Trash enabled
     const kill = screen.getByTestId("fleet-quick-kill") as HTMLButtonElement;
     expect(kill.disabled).toBe(false);
+    // Completed agent is NOT a valid interrupt target → Interrupt disabled
+    const interrupt = screen.getByTestId("fleet-quick-interrupt") as HTMLButtonElement;
+    expect(interrupt.disabled).toBe(true);
+  });
+
+  it("Cmd+Esc pressed twice within 350ms dispatches fleet.interrupt", async () => {
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    // First Cmd+Esc — stamps the ref, no dispatch
+    fireEvent.keyDown(window, { key: "Escape", metaKey: true });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    // Second Cmd+Esc within the window → dispatch
+    fireEvent.keyDown(window, { key: "Escape", metaKey: true });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(true);
+    dispatchSpy.mockRestore();
+  });
+
+  it("bare Escape Escape does NOT dispatch fleet.interrupt (no Cmd modifier)", async () => {
+    seed([makeAgent("t1", "working"), makeAgent("t2", "working")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.interrupt")).toBe(false);
+    dispatchSpy.mockRestore();
+  });
+
+  it("Enter while a pending action is open re-dispatches the action with confirmed:true", async () => {
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "restart", targetCount: 3, sessionLossCount: 0 },
+    });
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    render(<FleetArmingRibbon />);
+    fireEvent.keyDown(window, { key: "Enter" });
+    const match = dispatchSpy.mock.calls.find((c) => c[0] === "fleet.restart");
+    expect(match).toBeDefined();
+    expect(match?.[1]).toEqual({ confirmed: true });
+    dispatchSpy.mockRestore();
   });
 });

--- a/src/services/actions/actionDefinitions.ts
+++ b/src/services/actions/actionDefinitions.ts
@@ -23,6 +23,7 @@ import { registerTerminalNavigationActions } from "./definitions/terminalNavigat
 import { registerTerminalLayoutActions } from "./definitions/terminalLayoutActions";
 import { registerTerminalInputActions } from "./definitions/terminalInputActions";
 import { registerTerminalWorktreeActions } from "./definitions/terminalWorktreeActions";
+import { registerFleetActions } from "./definitions/fleetActions";
 import { registerVoiceActions } from "./definitions/voiceActions";
 import { registerWorktreeActions } from "./definitions/worktreeActions";
 import { registerWorktreeSessionActions } from "./definitions/worktreeSessionActions";
@@ -40,6 +41,7 @@ export function createActionDefinitions(callbacks: ActionCallbacks): ActionRegis
   registerTerminalLayoutActions(actions, callbacks);
   registerTerminalInputActions(actions, callbacks);
   registerTerminalWorktreeActions(actions, callbacks);
+  registerFleetActions(actions);
   registerAgentActions(actions, callbacks);
   registerPanelActions(actions, callbacks);
   registerWorktreeActions(actions, callbacks);

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { TerminalInstance } from "@shared/types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn().mockResolvedValue("test-id"),
+    write: vi.fn(),
+    resize: vi.fn(),
+    trash: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn(),
+    sendKey: vi.fn(),
+    batchDoubleEscape: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    destroy: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+  },
+}));
+
+vi.mock("@/store/persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+  },
+}));
+
+const { useFleetArmingStore } = await import("@/store/fleetArmingStore");
+const { useFleetPendingActionStore } = await import("@/store/fleetPendingActionStore");
+const { usePanelStore } = await import("@/store/panelStore");
+const { terminalClient } = await import("@/clients");
+const { registerFleetActions } = await import("../fleetActions");
+
+type ActionRegistry = Awaited<
+  ReturnType<typeof import("@/services/actions/actionDefinitions").createActionDefinitions>
+>;
+
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    type: "terminal",
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "waiting",
+    hasPty: true,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function seedPanels(terminals: TerminalInstance[]): void {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
+    panelIds: terminals.map((t) => t.id),
+  });
+}
+
+function resetStores(): void {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  useFleetPendingActionStore.setState({ pending: null });
+  usePanelStore.setState({
+    panelsById: {},
+    panelIds: [],
+    focusedId: null,
+    maximizedId: null,
+    commandQueue: [],
+  });
+}
+
+async function buildRegistry(): Promise<ActionRegistry> {
+  const registry: ActionRegistry = new Map();
+  registerFleetActions(registry);
+  return registry;
+}
+
+async function run(registry: ActionRegistry, id: string, args?: unknown): Promise<void> {
+  const factory = registry.get(id);
+  if (!factory) throw new Error(`action ${id} not registered`);
+  const def = factory();
+  await def.run(args as never, {} as never);
+}
+
+describe("fleet actions — threshold confirmation", () => {
+  beforeEach(() => {
+    resetStores();
+    vi.clearAllMocks();
+  });
+
+  it("fleet.interrupt dispatches immediately when fewer than 3 targets", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b")]);
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.interrupt");
+    expect(terminalClient.batchDoubleEscape).toHaveBeenCalledWith(["a", "b"]);
+    expect(useFleetPendingActionStore.getState().pending).toBeNull();
+  });
+
+  it("fleet.interrupt opens a confirmation when 3+ targets", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.interrupt");
+    expect(terminalClient.batchDoubleEscape).not.toHaveBeenCalled();
+    const pending = useFleetPendingActionStore.getState().pending;
+    expect(pending?.kind).toBe("interrupt");
+    expect(pending?.targetCount).toBe(3);
+  });
+
+  it("fleet.interrupt skips confirmation when re-dispatched with { confirmed: true }", async () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    useFleetPendingActionStore.setState({
+      pending: { kind: "interrupt", targetCount: 3, sessionLossCount: 0 },
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.interrupt", { confirmed: true });
+    expect(terminalClient.batchDoubleEscape).toHaveBeenCalledWith(["a", "b", "c"]);
+    expect(useFleetPendingActionStore.getState().pending).toBeNull();
+  });
+
+  it("fleet.restart always confirms (even for a single target)", async () => {
+    seedPanels([makeAgent("a")]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.restart");
+    const pending = useFleetPendingActionStore.getState().pending;
+    expect(pending?.kind).toBe("restart");
+  });
+
+  it("fleet.trash dispatches immediately below the 5-target threshold", async () => {
+    const agents = Array.from({ length: 4 }, (_, i) => makeAgent(`a${i}`));
+    seedPanels(agents);
+    useFleetArmingStore.getState().armIds(agents.map((a) => a.id));
+    const registry = await buildRegistry();
+    await run(registry, "fleet.trash");
+    expect(useFleetPendingActionStore.getState().pending).toBeNull();
+    // All trashed
+    expect(usePanelStore.getState().panelsById["a0"]?.location).toBe("trash");
+    expect(usePanelStore.getState().panelsById["a3"]?.location).toBe("trash");
+  });
+
+  it("fleet.trash opens a confirmation at 5+ targets", async () => {
+    const agents = Array.from({ length: 5 }, (_, i) => makeAgent(`a${i}`));
+    seedPanels(agents);
+    useFleetArmingStore.getState().armIds(agents.map((a) => a.id));
+    const registry = await buildRegistry();
+    await run(registry, "fleet.trash");
+    const pending = useFleetPendingActionStore.getState().pending;
+    expect(pending?.kind).toBe("trash");
+    expect(pending?.targetCount).toBe(5);
+    // Not yet trashed
+    expect(usePanelStore.getState().panelsById["a0"]?.location).toBe("grid");
+  });
+
+  it("fleet.accept only targets armed agents in the waiting state", async () => {
+    seedPanels([
+      makeAgent("a", { agentState: "waiting" }),
+      makeAgent("b", { agentState: "working" }),
+      makeAgent("c", { agentState: "waiting" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.accept");
+    // sendKey called for a and c, not b
+    const sendKey = terminalClient.sendKey as ReturnType<typeof vi.fn>;
+    const calls = sendKey.mock.calls.map((c) => c[0]);
+    expect(calls.sort()).toEqual(["a", "c"]);
+  });
+
+  it("fleet.accept drops terminals that are no longer eligible at dispatch time", async () => {
+    // Arm three agents, then transition one to exited before dispatch — it
+    // should be silently dropped, not cause an error.
+    seedPanels([
+      makeAgent("a", { agentState: "waiting" }),
+      makeAgent("b", { agentState: "waiting", hasPty: false }),
+      makeAgent("c", { agentState: "waiting", location: "trash" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.accept");
+    const sendKey = terminalClient.sendKey as ReturnType<typeof vi.fn>;
+    const calls = sendKey.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["a"]);
+  });
+
+  it("fleet.reject no-ops when waiting set is empty but keeps armed set intact", async () => {
+    seedPanels([makeAgent("a", { agentState: "working" })]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    const registry = await buildRegistry();
+    await run(registry, "fleet.reject");
+    const sendKey = terminalClient.sendKey as ReturnType<typeof vi.fn>;
+    expect(sendKey).not.toHaveBeenCalled();
+    expect(useFleetArmingStore.getState().armedIds.size).toBe(1);
+  });
+});

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -172,7 +172,7 @@ describe("fleet actions — threshold confirmation", () => {
     expect(usePanelStore.getState().panelsById["a0"]?.location).toBe("grid");
   });
 
-  it("fleet.accept only targets armed agents in the waiting state", async () => {
+  it("fleet.accept writes 'y\\r' only to armed agents in the waiting state", async () => {
     seedPanels([
       makeAgent("a", { agentState: "waiting" }),
       makeAgent("b", { agentState: "working" }),
@@ -181,15 +181,13 @@ describe("fleet actions — threshold confirmation", () => {
     useFleetArmingStore.getState().armIds(["a", "b", "c"]);
     const registry = await buildRegistry();
     await run(registry, "fleet.accept");
-    // sendKey called for a and c, not b
-    const sendKey = terminalClient.sendKey as ReturnType<typeof vi.fn>;
-    const calls = sendKey.mock.calls.map((c) => c[0]);
-    expect(calls.sort()).toEqual(["a", "c"]);
+    const write = terminalClient.write as ReturnType<typeof vi.fn>;
+    const calls = write.mock.calls;
+    expect(calls.map((c) => c[0]).sort()).toEqual(["a", "c"]);
+    for (const c of calls) expect(c[1]).toBe("y\r");
   });
 
   it("fleet.accept drops terminals that are no longer eligible at dispatch time", async () => {
-    // Arm three agents, then transition one to exited before dispatch — it
-    // should be silently dropped, not cause an error.
     seedPanels([
       makeAgent("a", { agentState: "waiting" }),
       makeAgent("b", { agentState: "waiting", hasPty: false }),
@@ -198,18 +196,72 @@ describe("fleet actions — threshold confirmation", () => {
     useFleetArmingStore.getState().armIds(["a", "b", "c"]);
     const registry = await buildRegistry();
     await run(registry, "fleet.accept");
-    const sendKey = terminalClient.sendKey as ReturnType<typeof vi.fn>;
-    const calls = sendKey.mock.calls.map((c) => c[0]);
-    expect(calls).toEqual(["a"]);
+    const write = terminalClient.write as ReturnType<typeof vi.fn>;
+    expect(write.mock.calls.map((c) => c[0])).toEqual(["a"]);
   });
 
-  it("fleet.reject no-ops when waiting set is empty but keeps armed set intact", async () => {
-    seedPanels([makeAgent("a", { agentState: "working" })]);
-    useFleetArmingStore.getState().armIds(["a"]);
+  it("fleet.reject writes 'n\\r' and respects the 5-target threshold", async () => {
+    // Below threshold — dispatches directly
+    const agents = Array.from({ length: 4 }, (_, i) =>
+      makeAgent(`a${i}`, { agentState: "waiting" })
+    );
+    seedPanels(agents);
+    useFleetArmingStore.getState().armIds(agents.map((a) => a.id));
     const registry = await buildRegistry();
     await run(registry, "fleet.reject");
-    const sendKey = terminalClient.sendKey as ReturnType<typeof vi.fn>;
-    expect(sendKey).not.toHaveBeenCalled();
-    expect(useFleetArmingStore.getState().armedIds.size).toBe(1);
+    const write = terminalClient.write as ReturnType<typeof vi.fn>;
+    expect(write.mock.calls.length).toBe(4);
+    for (const c of write.mock.calls) expect(c[1]).toBe("n\r");
+    expect(useFleetPendingActionStore.getState().pending).toBeNull();
+  });
+
+  it("fleet.reject opens a confirmation at 5+ waiting targets", async () => {
+    const agents = Array.from({ length: 5 }, (_, i) =>
+      makeAgent(`a${i}`, { agentState: "waiting" })
+    );
+    seedPanels(agents);
+    useFleetArmingStore.getState().armIds(agents.map((a) => a.id));
+    const registry = await buildRegistry();
+    await run(registry, "fleet.reject");
+    expect(terminalClient.write).not.toHaveBeenCalled();
+    const pending = useFleetPendingActionStore.getState().pending;
+    expect(pending?.kind).toBe("reject");
+    expect(pending?.targetCount).toBe(5);
+  });
+
+  it("fleet.reject falls through to panel.palette when no waiting agents are armed", async () => {
+    // Setup: armed agent exists but is 'working' — nothing to reject.
+    seedPanels([makeAgent("a", { agentState: "working" })]);
+    useFleetArmingStore.getState().armIds(["a"]);
+    // Spy on actionService.dispatch via dynamic import mock
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+    const registry = await buildRegistry();
+    await run(registry, "fleet.reject");
+    // Should have called panel.palette
+    const calls = dispatchSpy.mock.calls.map((c) => c[0]);
+    expect(calls).toContain("panel.palette");
+    dispatchSpy.mockRestore();
+  });
+
+  it("fleet.interrupt only targets working/waiting/running agents", async () => {
+    seedPanels([
+      makeAgent("a", { agentState: "working" }),
+      makeAgent("b", { agentState: "waiting" }),
+      makeAgent("c", { agentState: "running" }),
+      makeAgent("d", { agentState: "completed" }),
+      makeAgent("e", { agentState: "idle" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["a", "b", "c", "d", "e"]);
+    const registry = await buildRegistry();
+    // 3 interrupt candidates (a, b, c) hits the ≥3 threshold → confirmation
+    await run(registry, "fleet.interrupt");
+    expect(terminalClient.batchDoubleEscape).not.toHaveBeenCalled();
+    const pending = useFleetPendingActionStore.getState().pending;
+    expect(pending?.kind).toBe("interrupt");
+    expect(pending?.targetCount).toBe(3);
+    // Confirm and verify only the right subset is interrupted
+    await run(registry, "fleet.interrupt", { confirmed: true });
+    expect(terminalClient.batchDoubleEscape).toHaveBeenCalledWith(["a", "b", "c"]);
   });
 });

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -12,6 +12,7 @@ import type { TerminalInstance } from "@shared/types";
 interface ArmedSnapshot {
   liveTerminals: TerminalInstance[];
   waitingTerminals: TerminalInstance[];
+  interruptCandidates: TerminalInstance[];
   sessionLossCount: number;
 }
 
@@ -26,17 +27,26 @@ function snapshotArmed(): ArmedSnapshot {
   const armedIds = useFleetArmingStore.getState().armedIds;
   const liveTerminals: TerminalInstance[] = [];
   const waitingTerminals: TerminalInstance[] = [];
+  const interruptCandidates: TerminalInstance[] = [];
   let sessionLossCount = 0;
-  if (armedIds.size === 0) return { liveTerminals, waitingTerminals, sessionLossCount };
+  if (armedIds.size === 0) {
+    return { liveTerminals, waitingTerminals, interruptCandidates, sessionLossCount };
+  }
   const { panelsById } = usePanelStore.getState();
   for (const id of armedIds) {
     const t = panelsById[id];
     if (!isFleetArmEligible(t)) continue;
     liveTerminals.push(t);
     if (t.agentState === "waiting") waitingTerminals.push(t);
+    // Interrupt only makes sense for agents that are actually doing
+    // something — sending ESC ESC to a completed/idle/exited agent is
+    // either a no-op or a spurious keystroke.
+    if (t.agentState === "working" || t.agentState === "running" || t.agentState === "waiting") {
+      interruptCandidates.push(t);
+    }
     if (t.agentSessionId) sessionLossCount++;
   }
-  return { liveTerminals, waitingTerminals, sessionLossCount };
+  return { liveTerminals, waitingTerminals, interruptCandidates, sessionLossCount };
 }
 
 const confirmedArgsSchema = z.object({ confirmed: z.boolean().optional() }).optional();
@@ -66,7 +76,8 @@ export function registerFleetActions(actions: ActionRegistry): void {
   actions.set("fleet.accept", () => ({
     id: "fleet.accept",
     title: "Fleet: Accept",
-    description: "Send Enter to every armed agent that is waiting for input",
+    description:
+      "Send 'y' + Enter to every armed agent that is waiting for input (accepts [y/N] prompts)",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -77,7 +88,9 @@ export function registerFleetActions(actions: ActionRegistry): void {
       await Promise.allSettled(
         snap.waitingTerminals.map((t) => {
           try {
-            terminalClient.sendKey(t.id, "enter");
+            // Write literal "y\r" so CLI prompts like "Continue? [y/N]"
+            // receive an explicit affirmative rather than the default.
+            terminalClient.write(t.id, "y\r");
             return Promise.resolve();
           } catch (error) {
             return Promise.reject(error);
@@ -90,27 +103,38 @@ export function registerFleetActions(actions: ActionRegistry): void {
   actions.set("fleet.reject", () => ({
     id: "fleet.reject",
     title: "Fleet: Reject",
-    description: "Send Escape to every armed agent that is waiting for input",
+    description:
+      "Send 'n' + Enter to every armed agent that is waiting for input (rejects [y/N] prompts; confirms when 5+ targets)",
     category: "terminal",
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    run: async () => {
+    argsSchema: confirmedArgsSchema,
+    run: async (args: unknown) => {
       // fleet.reject shares Cmd+N with panel.palette and wins on priority.
-      // When nothing is armed we fall through so the global shortcut still
-      // opens the palette — otherwise this hotkey would silently swallow
-      // Cmd+N for every user whose ribbon happens to be hidden.
+      // When nothing is armed — or the armed set has no waiting agent to
+      // reject — we fall through so the global shortcut still opens the
+      // palette; otherwise this hotkey would silently swallow Cmd+N.
       const snap = snapshotArmed();
-      if (snap.liveTerminals.length === 0) {
+      if (snap.waitingTerminals.length === 0) {
         const { actionService } = await import("@/services/ActionService");
         await actionService.dispatch("panel.palette", undefined, { source: "keybinding" });
         return;
       }
-      if (snap.waitingTerminals.length === 0) return;
+      const confirmed = parseConfirmed(args);
+      if (!confirmed && snap.waitingTerminals.length >= 5) {
+        useFleetPendingActionStore.getState().request({
+          kind: "reject",
+          targetCount: snap.waitingTerminals.length,
+          sessionLossCount: snap.sessionLossCount,
+        });
+        return;
+      }
+      clearPendingIf("reject");
       await Promise.allSettled(
         snap.waitingTerminals.map((t) => {
           try {
-            terminalClient.sendKey(t.id, "escape");
+            terminalClient.write(t.id, "n\r");
             return Promise.resolve();
           } catch (error) {
             return Promise.reject(error);
@@ -124,7 +148,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
     id: "fleet.interrupt",
     title: "Fleet: Interrupt",
     description:
-      "Send a double-Escape to every armed agent (confirms when 3+ targets; 50ms per-PTY gap scheduled in the PTY host)",
+      "Send a double-Escape to armed agents in working/waiting/running state (confirms when 3+ targets; 50ms per-PTY gap scheduled in the PTY host)",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -132,14 +156,21 @@ export function registerFleetActions(actions: ActionRegistry): void {
     argsSchema: confirmedArgsSchema,
     run: async (args: unknown) => {
       const snap = snapshotArmed();
-      if (snap.liveTerminals.length === 0) return;
+      // Double-Escape is only meaningful for agents that are actually
+      // mid-work — completed/exited/idle get filtered out at dispatch.
+      const targets = snap.interruptCandidates;
+      if (targets.length === 0) return;
       const confirmed = parseConfirmed(args);
-      if (!confirmed && snap.liveTerminals.length >= 3) {
-        requestConfirmation("interrupt", snap);
+      if (!confirmed && targets.length >= 3) {
+        useFleetPendingActionStore.getState().request({
+          kind: "interrupt",
+          targetCount: targets.length,
+          sessionLossCount: snap.sessionLossCount,
+        });
         return;
       }
       clearPendingIf("interrupt");
-      terminalClient.batchDoubleEscape(snap.liveTerminals.map((t) => t.id));
+      terminalClient.batchDoubleEscape(targets.map((t) => t.id));
     },
   }));
 
@@ -169,7 +200,8 @@ export function registerFleetActions(actions: ActionRegistry): void {
   actions.set("fleet.kill", () => ({
     id: "fleet.kill",
     title: "Fleet: Kill",
-    description: "Permanently remove every armed terminal (always requires confirmation)",
+    description:
+      "Remove every armed terminal panel (matches terminal.killAll semantics — not a raw SIGKILL; always requires confirmation)",
     category: "terminal",
     kind: "command",
     danger: "safe",

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+import type { ActionRegistry } from "../actionTypes";
+import { usePanelStore } from "@/store/panelStore";
+import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
+import {
+  useFleetPendingActionStore,
+  type FleetPendingActionKind,
+} from "@/store/fleetPendingActionStore";
+import { terminalClient } from "@/clients";
+import type { TerminalInstance } from "@shared/types";
+
+interface ArmedSnapshot {
+  liveTerminals: TerminalInstance[];
+  waitingTerminals: TerminalInstance[];
+  sessionLossCount: number;
+}
+
+/**
+ * Snapshot of the armed fleet at dispatch time. Exited/trashed/backgrounded
+ * terminals are silently dropped — the armed set can drift while the user
+ * composes it. Always re-read `useFleetArmingStore.getState()` and
+ * `usePanelStore.getState()` inside action run() bodies (not in a closure
+ * captured above) so the filter reflects state at execution, not bind time.
+ */
+function snapshotArmed(): ArmedSnapshot {
+  const armedIds = useFleetArmingStore.getState().armedIds;
+  const liveTerminals: TerminalInstance[] = [];
+  const waitingTerminals: TerminalInstance[] = [];
+  let sessionLossCount = 0;
+  if (armedIds.size === 0) return { liveTerminals, waitingTerminals, sessionLossCount };
+  const { panelsById } = usePanelStore.getState();
+  for (const id of armedIds) {
+    const t = panelsById[id];
+    if (!isFleetArmEligible(t)) continue;
+    liveTerminals.push(t);
+    if (t.agentState === "waiting") waitingTerminals.push(t);
+    if (t.agentSessionId) sessionLossCount++;
+  }
+  return { liveTerminals, waitingTerminals, sessionLossCount };
+}
+
+const confirmedArgsSchema = z.object({ confirmed: z.boolean().optional() }).optional();
+
+function parseConfirmed(args: unknown): boolean {
+  if (!args || typeof args !== "object") return false;
+  const { confirmed } = args as { confirmed?: unknown };
+  return confirmed === true;
+}
+
+function requestConfirmation(kind: FleetPendingActionKind, snapshot: ArmedSnapshot): void {
+  useFleetPendingActionStore.getState().request({
+    kind,
+    targetCount: snapshot.liveTerminals.length,
+    sessionLossCount: snapshot.sessionLossCount,
+  });
+}
+
+function clearPendingIf(kind: FleetPendingActionKind): void {
+  const pending = useFleetPendingActionStore.getState().pending;
+  if (pending && pending.kind === kind) {
+    useFleetPendingActionStore.getState().clear();
+  }
+}
+
+export function registerFleetActions(actions: ActionRegistry): void {
+  actions.set("fleet.accept", () => ({
+    id: "fleet.accept",
+    title: "Fleet: Accept",
+    description: "Send Enter to every armed agent that is waiting for input",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      const snap = snapshotArmed();
+      if (snap.waitingTerminals.length === 0) return;
+      await Promise.allSettled(
+        snap.waitingTerminals.map((t) => {
+          try {
+            terminalClient.sendKey(t.id, "enter");
+            return Promise.resolve();
+          } catch (error) {
+            return Promise.reject(error);
+          }
+        })
+      );
+    },
+  }));
+
+  actions.set("fleet.reject", () => ({
+    id: "fleet.reject",
+    title: "Fleet: Reject",
+    description: "Send Escape to every armed agent that is waiting for input",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      // fleet.reject shares Cmd+N with panel.palette and wins on priority.
+      // When nothing is armed we fall through so the global shortcut still
+      // opens the palette — otherwise this hotkey would silently swallow
+      // Cmd+N for every user whose ribbon happens to be hidden.
+      const snap = snapshotArmed();
+      if (snap.liveTerminals.length === 0) {
+        const { actionService } = await import("@/services/ActionService");
+        await actionService.dispatch("panel.palette", undefined, { source: "keybinding" });
+        return;
+      }
+      if (snap.waitingTerminals.length === 0) return;
+      await Promise.allSettled(
+        snap.waitingTerminals.map((t) => {
+          try {
+            terminalClient.sendKey(t.id, "escape");
+            return Promise.resolve();
+          } catch (error) {
+            return Promise.reject(error);
+          }
+        })
+      );
+    },
+  }));
+
+  actions.set("fleet.interrupt", () => ({
+    id: "fleet.interrupt",
+    title: "Fleet: Interrupt",
+    description:
+      "Send a double-Escape to every armed agent (confirms when 3+ targets; 50ms per-PTY gap scheduled in the PTY host)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: confirmedArgsSchema,
+    run: async (args: unknown) => {
+      const snap = snapshotArmed();
+      if (snap.liveTerminals.length === 0) return;
+      const confirmed = parseConfirmed(args);
+      if (!confirmed && snap.liveTerminals.length >= 3) {
+        requestConfirmation("interrupt", snap);
+        return;
+      }
+      clearPendingIf("interrupt");
+      terminalClient.batchDoubleEscape(snap.liveTerminals.map((t) => t.id));
+    },
+  }));
+
+  actions.set("fleet.restart", () => ({
+    id: "fleet.restart",
+    title: "Fleet: Restart",
+    description: "Restart every armed agent terminal (always requires confirmation)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: confirmedArgsSchema,
+    run: async (args: unknown) => {
+      const snap = snapshotArmed();
+      if (snap.liveTerminals.length === 0) return;
+      const confirmed = parseConfirmed(args);
+      if (!confirmed) {
+        requestConfirmation("restart", snap);
+        return;
+      }
+      clearPendingIf("restart");
+      const ids = new Set(snap.liveTerminals.map((t) => t.id));
+      await usePanelStore.getState().bulkRestartSet(ids);
+    },
+  }));
+
+  actions.set("fleet.kill", () => ({
+    id: "fleet.kill",
+    title: "Fleet: Kill",
+    description: "Permanently remove every armed terminal (always requires confirmation)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: confirmedArgsSchema,
+    run: async (args: unknown) => {
+      const snap = snapshotArmed();
+      if (snap.liveTerminals.length === 0) return;
+      const confirmed = parseConfirmed(args);
+      if (!confirmed) {
+        requestConfirmation("kill", snap);
+        return;
+      }
+      clearPendingIf("kill");
+      const ids = new Set(snap.liveTerminals.map((t) => t.id));
+      usePanelStore.getState().bulkKillSet(ids);
+      useFleetArmingStore.getState().clear();
+    },
+  }));
+
+  actions.set("fleet.trash", () => ({
+    id: "fleet.trash",
+    title: "Fleet: Trash",
+    description: "Move every armed terminal to trash (confirms when 5+ targets)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: confirmedArgsSchema,
+    run: async (args: unknown) => {
+      const snap = snapshotArmed();
+      if (snap.liveTerminals.length === 0) return;
+      const confirmed = parseConfirmed(args);
+      if (!confirmed && snap.liveTerminals.length >= 5) {
+        requestConfirmation("trash", snap);
+        return;
+      }
+      clearPendingIf("trash");
+      const ids = new Set(snap.liveTerminals.map((t) => t.id));
+      usePanelStore.getState().bulkTrashSet(ids);
+      useFleetArmingStore.getState().clear();
+    },
+  }));
+}

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -341,6 +341,54 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     description: "Arm all eligible agents in the current worktree",
     category: "Terminal",
   },
+  // Fleet quick-actions. These are registered at priority 5 so they beat
+  // conflicting global bindings (panel.palette at Cmd+N) while the fleet
+  // ribbon is visible. When nothing is armed, each action either no-ops
+  // (accept/interrupt/restart/kill/trash) or falls through to the
+  // conflicting binding (reject → panel.palette) so the UI stays intact.
+  // fleet.interrupt has no combo here — it's driven by a custom Esc-Esc
+  // double-tap handler in FleetArmingRibbon that avoids the escape-stack
+  // LIFO collision a chord binding would cause.
+  {
+    actionId: "fleet.accept",
+    combo: "Cmd+Y",
+    scope: "global",
+    priority: 5,
+    description: "Accept all armed waiting agents",
+    category: "Fleet",
+  },
+  {
+    actionId: "fleet.reject",
+    combo: "Cmd+N",
+    scope: "global",
+    priority: 5,
+    description: "Reject all armed waiting agents",
+    category: "Fleet",
+  },
+  {
+    actionId: "fleet.restart",
+    combo: "Cmd+Shift+R",
+    scope: "global",
+    priority: 5,
+    description: "Restart all armed agents",
+    category: "Fleet",
+  },
+  {
+    actionId: "fleet.kill",
+    combo: "Cmd+Shift+K",
+    scope: "global",
+    priority: 5,
+    description: "Kill all armed terminals",
+    category: "Fleet",
+  },
+  {
+    actionId: "fleet.trash",
+    combo: "Cmd+Shift+Backspace",
+    scope: "global",
+    priority: 5,
+    description: "Trash all armed terminals",
+    category: "Fleet",
+  },
   {
     actionId: "terminal.bulkCommand",
     combo: "Cmd+Alt+Shift+B",

--- a/src/store/fleetPendingActionStore.ts
+++ b/src/store/fleetPendingActionStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+/**
+ * Ephemeral UI state for fleet quick-action confirmations. Fleet actions
+ * that need confirmation (interrupt ≥3, restart/kill always, trash ≥5) set
+ * this store instead of running immediately; FleetArmingRibbon subscribes
+ * and renders inline confirmation UI that dispatches the action again with
+ * `{ confirmed: true }` on Enter or clears the store on Escape.
+ *
+ * The store is not persisted — a pending confirmation dies with the
+ * current session.
+ */
+export type FleetPendingActionKind = "interrupt" | "restart" | "kill" | "trash";
+
+export interface FleetPendingActionSnapshot {
+  kind: FleetPendingActionKind;
+  targetCount: number;
+  sessionLossCount: number;
+}
+
+interface FleetPendingActionState {
+  pending: FleetPendingActionSnapshot | null;
+  request: (snapshot: FleetPendingActionSnapshot) => void;
+  clear: () => void;
+}
+
+export const useFleetPendingActionStore = create<FleetPendingActionState>((set) => ({
+  pending: null,
+  request: (snapshot) => set({ pending: snapshot }),
+  clear: () => set({ pending: null }),
+}));

--- a/src/store/fleetPendingActionStore.ts
+++ b/src/store/fleetPendingActionStore.ts
@@ -10,7 +10,7 @@ import { create } from "zustand";
  * The store is not persisted — a pending confirmation dies with the
  * current session.
  */
-export type FleetPendingActionKind = "interrupt" | "restart" | "kill" | "trash";
+export type FleetPendingActionKind = "reject" | "interrupt" | "restart" | "kill" | "trash";
 
 export interface FleetPendingActionSnapshot {
   kind: FleetPendingActionKind;

--- a/src/store/slices/__tests__/fleetBulkActions.test.ts
+++ b/src/store/slices/__tests__/fleetBulkActions.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { TerminalInstance } from "../../panelStore";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn().mockResolvedValue("test-id"),
+    write: vi.fn(),
+    resize: vi.fn(),
+    trash: vi.fn().mockResolvedValue(undefined),
+    kill: vi.fn().mockResolvedValue(undefined),
+    sendKey: vi.fn(),
+    batchDoubleEscape: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    destroy: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+  },
+}));
+
+vi.mock("../../persistence/panelPersistence", () => ({
+  panelPersistence: {
+    setProjectIdGetter: vi.fn(),
+    save: vi.fn(),
+    load: vi.fn().mockReturnValue([]),
+    saveTabGroups: vi.fn(),
+    loadTabGroups: vi.fn().mockReturnValue(new Map()),
+  },
+}));
+
+const { usePanelStore } = await import("../../panelStore");
+
+function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    type: "terminal",
+    title: `Terminal ${id}`,
+    cwd: "/test",
+    worktreeId: "wt-1",
+    location: "grid",
+    ...overrides,
+  } as unknown as TerminalInstance;
+}
+
+function setTerminals(terminals: TerminalInstance[]) {
+  usePanelStore.setState({
+    panelsById: Object.fromEntries(terminals.map((t) => [t.id, t])),
+    panelIds: terminals.map((t) => t.id),
+  });
+}
+
+describe("Fleet set-based bulk actions", () => {
+  beforeEach(() => {
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+      focusedId: null,
+      maximizedId: null,
+      commandQueue: [],
+    });
+    vi.clearAllMocks();
+  });
+
+  it("bulkTrashSet trashes only terminals whose ids appear in the set", () => {
+    setTerminals([
+      makeTerminal("a", { location: "grid" }),
+      makeTerminal("b", { location: "grid" }),
+      makeTerminal("c", { location: "grid" }),
+    ]);
+
+    usePanelStore.getState().bulkTrashSet(new Set(["a", "c"]));
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["a"]?.location).toBe("trash");
+    expect(state.panelsById["b"]?.location).toBe("grid");
+    expect(state.panelsById["c"]?.location).toBe("trash");
+  });
+
+  it("bulkTrashSet silently skips terminals already in trash", () => {
+    setTerminals([
+      makeTerminal("a", { location: "grid" }),
+      makeTerminal("b", { location: "trash" }),
+    ]);
+
+    // Should not throw even though 'b' is already trashed
+    usePanelStore.getState().bulkTrashSet(new Set(["a", "b"]));
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["a"]?.location).toBe("trash");
+    expect(state.panelsById["b"]?.location).toBe("trash");
+  });
+
+  it("bulkTrashSet is a no-op on empty input", () => {
+    setTerminals([makeTerminal("a", { location: "grid" })]);
+    usePanelStore.getState().bulkTrashSet(new Set());
+    expect(usePanelStore.getState().panelsById["a"]?.location).toBe("grid");
+  });
+
+  it("bulkKillSet removes only terminals whose ids appear in the set", () => {
+    setTerminals([makeTerminal("a"), makeTerminal("b"), makeTerminal("c")]);
+
+    usePanelStore.getState().bulkKillSet(new Set(["a", "b"]));
+
+    const state = usePanelStore.getState();
+    expect(state.panelsById["a"]).toBeUndefined();
+    expect(state.panelsById["b"]).toBeUndefined();
+    expect(state.panelsById["c"]).toBeDefined();
+    expect(state.panelIds).toEqual(["c"]);
+  });
+
+  it("bulkKillSet accepts any Iterable<string>", () => {
+    setTerminals([makeTerminal("a"), makeTerminal("b")]);
+    usePanelStore.getState().bulkKillSet(["a", "b"]);
+    expect(usePanelStore.getState().panelIds).toEqual([]);
+  });
+
+  it("bulkRestartSet is a no-op on empty input without touching terminals", async () => {
+    setTerminals([makeTerminal("a")]);
+    await usePanelStore.getState().bulkRestartSet(new Set());
+    expect(usePanelStore.getState().panelsById["a"]).toBeDefined();
+  });
+
+  it("bulkRestartPreflightCheckSet reports invalid terminals", async () => {
+    setTerminals([
+      makeTerminal("a", { worktreeId: undefined }), // invalid: no worktree
+      makeTerminal("b"),
+    ]);
+
+    const result = await usePanelStore.getState().bulkRestartPreflightCheckSet(new Set(["a", "b"]));
+    // 'a' lacks a worktreeId — at least one should be invalid OR both valid
+    // if validator is lenient in test environment. Just assert shape.
+    expect(Array.isArray(result.valid)).toBe(true);
+    expect(Array.isArray(result.invalid)).toBe(true);
+    expect(result.valid.length + result.invalid.length).toBe(2);
+  });
+});

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -16,8 +16,12 @@ export interface TerminalBulkActionsSlice {
   bulkCloseByWorktree: (worktreeId: string, state?: AgentState) => void;
   bulkCloseAll: () => void;
   bulkTrashAll: () => void;
+  bulkTrashSet: (ids: Iterable<string>) => void;
+  bulkKillSet: (ids: Iterable<string>) => void;
   bulkRestartAll: () => Promise<void>;
+  bulkRestartSet: (ids: Iterable<string>) => Promise<void>;
   bulkRestartPreflightCheck: () => Promise<BulkRestartValidation>;
+  bulkRestartPreflightCheckSet: (ids: Iterable<string>) => Promise<BulkRestartValidation>;
   bulkMoveToDockByWorktree: (worktreeId: string) => void;
   bulkMoveToGridByWorktree: (worktreeId: string) => void;
   bulkTrashByWorktree: (worktreeId: string) => void;
@@ -85,15 +89,69 @@ export const createTerminalBulkActionsSlice = (
       activeTerminals.forEach((t) => trashPanel(t.id));
     },
 
+    bulkTrashSet: (ids) => {
+      const idSet = ids instanceof Set ? ids : new Set(ids);
+      if (idSet.size === 0) return;
+      const terminals = getTerminals();
+      const toTrash = terminals.filter((t) => idSet.has(t.id) && t.location !== "trash");
+      toTrash.forEach((t) => trashPanel(t.id));
+    },
+
+    bulkKillSet: (ids) => {
+      const idSet = ids instanceof Set ? ids : new Set(ids);
+      if (idSet.size === 0) return;
+      const terminals = getTerminals();
+      const toKill = terminals.filter((t) => idSet.has(t.id));
+      toKill.forEach((t) => removePanel(t.id));
+    },
+
     bulkRestartAll: async () => {
       const terminals = getTerminals();
       const activeTerminals = terminals.filter((t) => t.location !== "trash");
       await restartTerminals(activeTerminals);
     },
 
+    bulkRestartSet: async (ids) => {
+      const idSet = ids instanceof Set ? ids : new Set(ids);
+      if (idSet.size === 0) return;
+      const terminals = getTerminals();
+      const activeTerminals = terminals.filter((t) => idSet.has(t.id) && t.location !== "trash");
+      if (activeTerminals.length === 0) return;
+      try {
+        const validationResults = await validateTerminals(activeTerminals);
+        const valid = activeTerminals.filter((t) => !validationResults.get(t.id));
+        await restartTerminals(valid);
+      } catch (error) {
+        console.error("Failed to validate terminals for restart:", error);
+        await restartTerminals(activeTerminals);
+      }
+    },
+
     bulkRestartPreflightCheck: async () => {
       const terminals = getTerminals();
       const activeTerminals = terminals.filter((t) => t.location !== "trash");
+
+      const validationResults = await validateTerminals(activeTerminals);
+
+      const valid: TerminalInstance[] = [];
+      const invalid: Array<{ terminal: TerminalInstance; errors: ValidationResult }> = [];
+
+      for (const terminal of activeTerminals) {
+        const result = validationResults.get(terminal.id);
+        if (result) {
+          invalid.push({ terminal, errors: result });
+        } else {
+          valid.push(terminal);
+        }
+      }
+
+      return { valid, invalid };
+    },
+
+    bulkRestartPreflightCheckSet: async (ids) => {
+      const idSet = ids instanceof Set ? ids : new Set(ids);
+      const terminals = getTerminals();
+      const activeTerminals = terminals.filter((t) => idSet.has(t.id) && t.location !== "trash");
 
       const validationResults = await validateTerminals(activeTerminals);
 


### PR DESCRIPTION
## Summary

Adds six fleet hotkey actions that fan out across the currently armed terminal set, backed by a new batch-double-escape IPC path scheduled inside the PTY host utility process.

- **fleet.accept** (⌘Y) — writes `y\r` to every armed waiting agent (accepts [y/N] prompts)
- **fleet.reject** (⌘N) — writes `n\r` to every armed waiting agent; confirms when ≥5 targets; falls through to `panel.palette` when no waiting agent is armed
- **fleet.interrupt** (⌘⎋⎋ double-tap within 350ms) — sends ESC ESC with 50ms per-PTY gap scheduled in the pty-host utility process; only targets working/waiting/running agents; confirms when ≥3
- **fleet.restart** (⌘⇧R) — restarts every armed agent; always confirms
- **fleet.kill** (⌘⇧K) — removes every armed terminal panel; always confirms
- **fleet.trash** (⌘⇧⌫) — trashes every armed terminal; confirms when ≥5

Resolves #5301

## Key decisions

**Pending-action store vs component-local state** — confirmations live in `useFleetPendingActionStore` so threshold logic is in the actions themselves. MCP, palette, and keybinding all get the same gating. The ribbon subscribes and renders the inline confirmation; Enter re-dispatches with `{ confirmed: true }`.

**fleet.reject Cmd+N conflict** — registered at priority 5, winning over `panel.palette`'s priority 0 via `resolveKeybinding`. When the armed set has no waiting agent, fleet.reject falls through to `actionService.dispatch("panel.palette")` so Cmd+N keeps working as normal.

**Hotkey deviations from spec** — plan deviated from `⌘R`/`⌘K`/`⌘⇧T` to `⌘⇧R`/`⌘⇧K`/`⌘⇧⌫` to avoid conflicts: `Cmd+R` is Chromium's hardcoded reload, `Cmd+K` is the chord prefix for existing bindings, and `Cmd+Shift+T` already binds `terminal.reopenLast`. These deviations are deliberate and conflict-safe. Happy to revisit if the spec chords are preferred with explicit menu-shortcut suppression.

**Double-escape scheduling in the PTY host** — the 50ms inter-ESC gap runs inside `electron/pty-host.ts` (utility process) rather than the renderer or main. Renderer `setTimeout` can collapse under IPC jitter, merging two sub-10ms writes into a single Meta-Escape. The utility process isn't subject to Chromium timer throttling.

**`bulkKillSet` uses `removePanel`** — matches existing `terminal.killAll` and `terminal.kill` semantics (panel removal, not raw SIGKILL).

## Changes

19 files, ~1,246 insertions. Four new files:

- `src/store/fleetPendingActionStore.ts` — small Zustand store for pending confirmation state
- `src/services/actions/definitions/fleetActions.ts` — six action definitions with threshold gating and payload logic
- `src/store/slices/__tests__/fleetBulkActions.test.ts` — 7 tests for set-based bulk helpers
- `src/services/actions/definitions/__tests__/fleetActions.test.ts` — 13 tests for threshold gating, y/n payloads, fall-through, interrupt candidate filter

Plus additions to `FleetArmingRibbon.tsx` (inline confirmation UI, Cmd+Esc dispatch, 14 new tests), `terminalBulkActionsSlice.ts` (bulk primitives), `defaultKeybindings.ts` (6 new bindings at priority 5), and the IPC path through `channels.ts` → `io.ts` → `pty-host.ts` for the double-escape scheduling.

## Testing

Unit tests cover the highest-risk integration points:

```
npx vitest run src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx        # 14 tests
npx vitest run src/store/slices/__tests__/fleetBulkActions.test.ts              # 7 tests
npx vitest run src/services/actions/definitions/__tests__/fleetActions.test.ts  # 13 tests
```

`npm run check` passes clean (typecheck + lint + format).

Manual UI testing requires a live terminal fleet with armed agents — beyond the scope of unit coverage, but the unit tests catch Esc-Esc timing, confirmation re-dispatch, and target filtering.