### PR TITLE
feat(telemetry): instrument activation funnel and replace newsletter checklist item

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -526,6 +526,7 @@ export const CHANNELS = {
   ONBOARDING_CHECKLIST_DISMISS: "onboarding:checklist-dismiss",
   ONBOARDING_CHECKLIST_MARK_ITEM: "onboarding:checklist-mark-item",
   ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN: "onboarding:checklist-mark-celebration-shown",
+  ONBOARDING_CHECKLIST_PUSH: "onboarding:checklist-push",
 
   // Milestone channels
   MILESTONES_GET: "milestones:get",

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -20,6 +20,10 @@ const storeMock = vi.hoisted(() => {
 
 vi.mock("../../../store.js", () => ({ store: storeMock }));
 
+vi.mock("../../../services/TelemetryService.js", () => ({
+  setOnboardingCompleteTag: vi.fn(),
+}));
+
 import { registerOnboardingHandlers } from "../onboarding.js";
 
 function getHandler(channel: string) {
@@ -49,7 +53,7 @@ function seedOnboarding(partial: Record<string, unknown> = {}) {
         openedProject: false,
         launchedAgent: false,
         createdWorktree: false,
-        subscribedNewsletter: false,
+        ranSecondParallelAgent: false,
       },
     },
     ...partial,
@@ -83,7 +87,7 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
           openedProject: false,
           launchedAgent: false,
           createdWorktree: false,
-          subscribedNewsletter: false,
+          ranSecondParallelAgent: false,
         },
       },
     };

--- a/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/onboarding.handlers.test.ts
@@ -20,8 +20,10 @@ const storeMock = vi.hoisted(() => {
 
 vi.mock("../../../store.js", () => ({ store: storeMock }));
 
+const setOnboardingCompleteTagMock = vi.hoisted(() => vi.fn());
+
 vi.mock("../../../services/TelemetryService.js", () => ({
-  setOnboardingCompleteTag: vi.fn(),
+  setOnboardingCompleteTag: setOnboardingCompleteTagMock,
 }));
 
 import { registerOnboardingHandlers } from "../onboarding.js";
@@ -252,5 +254,42 @@ describe("registerOnboardingHandlers — discovery IPC", () => {
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:mark-agents-seen");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:dismiss-welcome-card");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("onboarding:dismiss-setup-banner");
+  });
+
+  it("complete handler stamps the onboarding_complete Sentry tag with true", () => {
+    registerOnboardingHandlers();
+    seedOnboarding();
+    const complete = getHandler("onboarding:complete");
+    setOnboardingCompleteTagMock.mockClear();
+    complete(null);
+    expect(setOnboardingCompleteTagMock).toHaveBeenCalledWith(true);
+  });
+
+  it("migrate stamps the onboarding_complete Sentry tag when legacy state was fully complete", () => {
+    storeMock._data["privacy"] = { hasSeenPrompt: true };
+    registerOnboardingHandlers();
+    seedOnboarding({ migratedFromLocalStorage: false });
+    const migrate = getHandler("onboarding:migrate");
+    setOnboardingCompleteTagMock.mockClear();
+    migrate(null, {
+      agentSelectionDismissed: true,
+      agentSetupComplete: true,
+      firstRunToastSeen: true,
+    });
+    expect(setOnboardingCompleteTagMock).toHaveBeenCalledWith(true);
+  });
+
+  it("migrate does NOT stamp the onboarding_complete tag when legacy state is partial", () => {
+    storeMock._data["privacy"] = { hasSeenPrompt: false };
+    registerOnboardingHandlers();
+    seedOnboarding({ migratedFromLocalStorage: false });
+    const migrate = getHandler("onboarding:migrate");
+    setOnboardingCompleteTagMock.mockClear();
+    migrate(null, {
+      agentSelectionDismissed: true,
+      agentSetupComplete: false,
+      firstRunToastSeen: true,
+    });
+    expect(setOnboardingCompleteTagMock).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -2,6 +2,7 @@ import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { StoreSchema } from "../../store.js";
 import { typedHandle } from "../utils.js";
+import { setOnboardingCompleteTag } from "../../services/TelemetryService.js";
 
 type OnboardingState = StoreSchema["onboarding"];
 type ChecklistState = OnboardingState["checklist"];
@@ -13,7 +14,7 @@ const DEFAULT_CHECKLIST: ChecklistState = {
     openedProject: false,
     launchedAgent: false,
     createdWorktree: false,
-    subscribedNewsletter: false,
+    ranSecondParallelAgent: false,
   },
 };
 
@@ -46,7 +47,7 @@ function getOnboardingState(): OnboardingState {
           openedProject: true,
           launchedAgent: true,
           createdWorktree: true,
-          subscribedNewsletter: true,
+          ranSecondParallelAgent: true,
         },
       },
     };
@@ -86,8 +87,7 @@ function getOnboardingState(): OnboardingState {
       ...checklist,
       items: {
         ...mergedItems,
-        subscribedNewsletter:
-          mergedItems.subscribedNewsletter || (raw.newsletterPromptSeen ?? false),
+        ranSecondParallelAgent: mergedItems.ranSecondParallelAgent ?? false,
       },
     },
   };
@@ -135,12 +135,15 @@ export function registerOnboardingHandlers(): () => void {
                 openedProject: true,
                 launchedAgent: true,
                 createdWorktree: true,
-                subscribedNewsletter: true,
+                ranSecondParallelAgent: true,
               },
             }
           : state.checklist,
       };
       store.set("onboarding", updated);
+      if (allPreviouslyComplete) {
+        setOnboardingCompleteTag(true);
+      }
       return updated;
     })
   );
@@ -173,6 +176,7 @@ export function registerOnboardingHandlers(): () => void {
         currentStep: null,
         agentSetupIds: [],
       });
+      setOnboardingCompleteTag(true);
     })
   );
 
@@ -274,7 +278,7 @@ export function registerOnboardingHandlers(): () => void {
         "openedProject",
         "launchedAgent",
         "createdWorktree",
-        "subscribedNewsletter",
+        "ranSecondParallelAgent",
       ];
       if (typeof item !== "string" || !validItems.includes(item)) return;
       const state = getOnboardingState();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,6 +1,18 @@
 // Environment setup must run first (GC exposure, userData, flags, sandbox)
 import "./setup/environment.js";
 
+/**
+ * Wall-clock milliseconds at which the Electron process was created, captured
+ * as early as possible. Used to compute `time_to_first_agent_task_ms` for the
+ * activation funnel. Falls back to `Date.now()` on the rare platforms where
+ * `process.getCreationTime()` returns null. Electron 41 does not ship
+ * `app.getStartupTimestamp()`, so this is the earliest reliable origin point.
+ */
+export const APP_LAUNCH_MS: number =
+  typeof process.getCreationTime === "function"
+    ? (process.getCreationTime() ?? Date.now())
+    : Date.now();
+
 import { app, BrowserWindow, crashReporter, protocol } from "electron";
 import { registerGlobalErrorHandlers } from "./setup/globalErrorHandlers.js";
 import path from "path";
@@ -236,6 +248,7 @@ if (!gotTheLock) {
       initialProjectId,
       projectViewManager: pvm,
       initialAppView: appView,
+      appLaunchMs: APP_LAUNCH_MS,
     });
 
     if (!powerMonitorInitialized) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1055,6 +1055,7 @@ const CHANNELS = {
   ONBOARDING_CHECKLIST_DISMISS: "onboarding:checklist-dismiss",
   ONBOARDING_CHECKLIST_MARK_ITEM: "onboarding:checklist-mark-item",
   ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN: "onboarding:checklist-mark-celebration-shown",
+  ONBOARDING_CHECKLIST_PUSH: "onboarding:checklist-push",
 
   // Shortcut Hints channels
   MILESTONES_GET: "milestones:get",
@@ -2765,6 +2766,9 @@ const api: ElectronAPI = {
       _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_MARK_ITEM, item),
     markChecklistCelebrationShown: () =>
       _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_MARK_CELEBRATION_SHOWN),
+    onChecklistPush: (
+      callback: (state: IpcEventMap["onboarding:checklist-push"]) => void
+    ): (() => void) => _typedOn(CHANNELS.ONBOARDING_CHECKLIST_PUSH, callback),
   },
 
   milestones: {

--- a/electron/services/ActivationFunnelService.ts
+++ b/electron/services/ActivationFunnelService.ts
@@ -60,7 +60,9 @@ class ActivationFunnelService {
     // two agents already running (no transition event will fire for existing
     // state), we still want the parallel-agents milestone to land in this
     // session. Guarded by the persisted `firstParallelAgentsAt` timestamp so
-    // it's idempotent across restarts.
+    // it's idempotent across restarts. Clear any orphan timer from a prior
+    // initialize call — double-init without dispose would otherwise leak.
+    if (this.reconcileTimer) clearTimeout(this.reconcileTimer);
     this.reconcileTimer = setTimeout(() => {
       this.reconcileTimer = null;
       this.maybeFireFirstParallelAgents();

--- a/electron/services/ActivationFunnelService.ts
+++ b/electron/services/ActivationFunnelService.ts
@@ -1,0 +1,175 @@
+import { events } from "./events.js";
+import { store } from "../store.js";
+import { trackEvent } from "./TelemetryService.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
+import { CHANNELS } from "../ipc/channels.js";
+
+/**
+ * Startup-restored terminals replay spawn and state events. Suppress activation
+ * milestone firing during the grace window so existing users don't have "first
+ * task" events attributed to an app relaunch after the activationFunnel guard
+ * has been cleared (e.g. via migration or store reset).
+ */
+const BOOT_GRACE_PERIOD_MS = 8_000;
+
+const ACTIVE_AGENT_STATES = new Set(["working", "running", "directing"]);
+
+type StateChangePayload = {
+  state: string;
+  previousState?: string;
+  timestamp: number;
+};
+
+type CompletedPayload = {
+  agentId: string;
+  exitCode: number;
+  duration: number;
+  terminalId?: string;
+  worktreeId?: string;
+  timestamp: number;
+};
+
+type ActivationFunnel = {
+  firstAgentTaskStartedAt?: number;
+  firstAgentTaskCompletedAt?: number;
+  firstParallelAgentsAt?: number;
+  timeToFirstAgentTaskMs?: number;
+};
+
+class ActivationFunnelService {
+  private appLaunchMs = 0;
+  private initializedAt = 0;
+  private unsubscribers: Array<() => void> = [];
+
+  initialize(opts: { appLaunchMs: number }): void {
+    this.appLaunchMs = opts.appLaunchMs;
+    this.initializedAt = Date.now();
+
+    const unsubStateChanged = events.on("agent:state-changed", (payload) => {
+      this.handleStateChanged(payload);
+    });
+
+    const unsubCompleted = events.on("agent:completed", (payload) => {
+      this.handleCompleted(payload);
+    });
+
+    this.unsubscribers.push(unsubStateChanged, unsubCompleted);
+  }
+
+  private isWithinBootGrace(): boolean {
+    return Date.now() - this.initializedAt < BOOT_GRACE_PERIOD_MS;
+  }
+
+  private getFunnel(): ActivationFunnel {
+    const value = store.get("activationFunnel") as ActivationFunnel | undefined;
+    return value ?? {};
+  }
+
+  private setFunnel(next: ActivationFunnel): void {
+    store.set("activationFunnel", next);
+  }
+
+  private countActiveAgents(): number {
+    const terminals = store.get("appState").terminals;
+    return terminals.filter(
+      (t: { agentState?: string }) => t.agentState && ACTIVE_AGENT_STATES.has(t.agentState)
+    ).length;
+  }
+
+  private handleStateChanged(payload: StateChangePayload): void {
+    const { state, previousState } = payload;
+
+    const wasActive = previousState !== undefined && ACTIVE_AGENT_STATES.has(previousState);
+    const isActive = ACTIVE_AGENT_STATES.has(state);
+
+    // Transitioning into an active state from a non-active state — a task
+    // just started (either the first one ever, or a later one).
+    if (!wasActive && isActive) {
+      this.maybeFireFirstTaskStarted();
+      this.maybeFireFirstParallelAgents();
+    }
+  }
+
+  private handleCompleted(payload: CompletedPayload): void {
+    // emitAgentCompleted only fires for non-killed agents, so exitCode === 0 is
+    // a clean "successful completion" signal.
+    if (payload.exitCode !== 0) return;
+    if (this.isWithinBootGrace()) return;
+
+    const funnel = this.getFunnel();
+    if (funnel.firstAgentTaskCompletedAt !== undefined) return;
+
+    const now = Date.now();
+    this.setFunnel({ ...funnel, firstAgentTaskCompletedAt: now });
+
+    trackEvent("activation_first_agent_task_completed", {
+      duration_ms: payload.duration,
+      exit_code: payload.exitCode,
+    });
+  }
+
+  private maybeFireFirstTaskStarted(): void {
+    if (this.isWithinBootGrace()) return;
+
+    const funnel = this.getFunnel();
+    if (funnel.firstAgentTaskStartedAt !== undefined) return;
+
+    const now = Date.now();
+    const timeToFirstAgentTaskMs = Math.max(0, now - this.appLaunchMs);
+    this.setFunnel({
+      ...funnel,
+      firstAgentTaskStartedAt: now,
+      timeToFirstAgentTaskMs,
+    });
+
+    trackEvent("activation_first_agent_task_started", {
+      time_to_first_agent_task_ms: timeToFirstAgentTaskMs,
+    });
+  }
+
+  private maybeFireFirstParallelAgents(): void {
+    if (this.isWithinBootGrace()) return;
+
+    const funnel = this.getFunnel();
+    if (funnel.firstParallelAgentsAt !== undefined) return;
+
+    const activeCount = this.countActiveAgents();
+    if (activeCount < 2) return;
+
+    const now = Date.now();
+    this.setFunnel({ ...funnel, firstParallelAgentsAt: now });
+
+    trackEvent("activation_first_parallel_agents", {
+      agent_count: activeCount,
+    });
+
+    this.markChecklistAndBroadcast();
+  }
+
+  private markChecklistAndBroadcast(): void {
+    const onboarding = store.get("onboarding");
+    if (!onboarding?.checklist) return;
+    if (onboarding.checklist.items.ranSecondParallelAgent) return;
+
+    const nextChecklist = {
+      ...onboarding.checklist,
+      items: {
+        ...onboarding.checklist.items,
+        ranSecondParallelAgent: true,
+      },
+    };
+    store.set("onboarding", { ...onboarding, checklist: nextChecklist });
+    broadcastToRenderer(CHANNELS.ONBOARDING_CHECKLIST_PUSH, nextChecklist);
+  }
+
+  dispose(): void {
+    for (const unsub of this.unsubscribers) {
+      unsub();
+    }
+    this.unsubscribers = [];
+    this.appLaunchMs = 0;
+    this.initializedAt = 0;
+  }
+}
+
+export const activationFunnelService = new ActivationFunnelService();

--- a/electron/services/ActivationFunnelService.ts
+++ b/electron/services/ActivationFunnelService.ts
@@ -40,6 +40,7 @@ class ActivationFunnelService {
   private appLaunchMs = 0;
   private initializedAt = 0;
   private unsubscribers: Array<() => void> = [];
+  private reconcileTimer: NodeJS.Timeout | null = null;
 
   initialize(opts: { appLaunchMs: number }): void {
     this.appLaunchMs = opts.appLaunchMs;
@@ -54,6 +55,16 @@ class ActivationFunnelService {
     });
 
     this.unsubscribers.push(unsubStateChanged, unsubCompleted);
+
+    // Reconcile once after the boot grace window: if the user relaunches with
+    // two agents already running (no transition event will fire for existing
+    // state), we still want the parallel-agents milestone to land in this
+    // session. Guarded by the persisted `firstParallelAgentsAt` timestamp so
+    // it's idempotent across restarts.
+    this.reconcileTimer = setTimeout(() => {
+      this.reconcileTimer = null;
+      this.maybeFireFirstParallelAgents();
+    }, BOOT_GRACE_PERIOD_MS + 100);
   }
 
   private isWithinBootGrace(): boolean {
@@ -70,7 +81,7 @@ class ActivationFunnelService {
   }
 
   private countActiveAgents(): number {
-    const terminals = store.get("appState").terminals;
+    const terminals = store.get("appState")?.terminals ?? [];
     return terminals.filter(
       (t: { agentState?: string }) => t.agentState && ACTIVE_AGENT_STATES.has(t.agentState)
     ).length;
@@ -91,8 +102,12 @@ class ActivationFunnelService {
   }
 
   private handleCompleted(payload: CompletedPayload): void {
-    // emitAgentCompleted only fires for non-killed agents, so exitCode === 0 is
-    // a clean "successful completion" signal.
+    // `agent:completed` already excludes user-killed terminals upstream
+    // (`TerminalProcess.ts` only emits when `!wasKilled`). Requiring
+    // `exitCode === 0` further narrows the "first successful task" milestone
+    // to clean exits — interrupted runs (e.g. ctrl-C, 130) are intentionally
+    // excluded so activation telemetry reflects *completed work*, not
+    // abandoned attempts.
     if (payload.exitCode !== 0) return;
     if (this.isWithinBootGrace()) return;
 
@@ -167,6 +182,10 @@ class ActivationFunnelService {
       unsub();
     }
     this.unsubscribers = [];
+    if (this.reconcileTimer) {
+      clearTimeout(this.reconcileTimer);
+      this.reconcileTimer = null;
+    }
     this.appLaunchMs = 0;
     this.initializedAt = 0;
   }

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -2,7 +2,7 @@ import Store from "electron-store";
 import type { StoreSchema } from "../store.js";
 import fs from "fs";
 
-export const LATEST_SCHEMA_VERSION = 14;
+export const LATEST_SCHEMA_VERSION = 15;
 
 export interface Migration {
   version: number;

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -141,12 +141,17 @@ export async function setTelemetryLevel(level: TelemetryLevel): Promise<void> {
 
   if (level === "full") {
     await initializeTelemetry();
+    // If the user flips telemetry on mid-session, Sentry has only just loaded
+    // — stamp the onboarding_complete tag now so the rest of this session's
+    // events carry it (we don't wait for the next launch).
+    setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
     flushPreConsentBuffer();
   } else if (level === "errors") {
     // Errors-only consent covers crash reports, not analytics — drop any
     // buffered onboarding analytics rather than replaying them to Sentry.
     preConsentBuffer.length = 0;
     await initializeTelemetry();
+    setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
   } else {
     preConsentBuffer.length = 0;
   }

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -198,6 +198,23 @@ export function hasTelemetryPromptBeenShown(): boolean {
   return store.get("privacy")?.hasSeenPrompt ?? false;
 }
 
+/**
+ * Sets the `onboarding_complete` Sentry scope tag so all subsequent captured
+ * events are tagged with the user's onboarding state. Lets us separate
+ * first-run crashes from established-user crashes in Sentry issue triage.
+ *
+ * Safe to call before telemetry is initialized — becomes a no-op. When called
+ * after init (or re-called when state changes), it updates the global scope
+ * and applies to all events captured afterward.
+ */
+export function setOnboardingCompleteTag(completed: boolean): void {
+  try {
+    sentryModule?.setTag("onboarding_complete", completed ? "true" : "false");
+  } catch {
+    // never let telemetry errors escape into product code paths
+  }
+}
+
 export function markTelemetryPromptShown(): void {
   const privacy = store.get("privacy") ?? DEFAULT_PRIVACY;
   store.set("privacy", { ...privacy, hasSeenPrompt: true });

--- a/electron/services/__tests__/ActivationFunnelService.test.ts
+++ b/electron/services/__tests__/ActivationFunnelService.test.ts
@@ -264,12 +264,26 @@ describe("ActivationFunnelService", () => {
       { id: "term-1", agentState: "working" },
       { id: "term-2", agentState: "working" },
     ]);
+    trackEventMock.mockClear();
+    broadcastMock.mockClear();
     const now = Date.now();
     activationFunnelService.initialize({ appLaunchMs: now - 500 });
     vi.advanceTimersByTime(8_500);
-    trackEventMock.mockClear();
 
-    // Emit a fresh state change — guard should still hold.
+    // Assert BEFORE any mockClear — catches a reconcile fire that would
+    // otherwise be erased by cleanup between phases of the test.
+    expect(
+      trackEventMock.mock.calls.find((c) => c[0] === "activation_first_parallel_agents")
+    ).toBeUndefined();
+    expect(
+      broadcastMock.mock.calls.find((c) => c[0] === CHANNELS.ONBOARDING_CHECKLIST_PUSH)
+    ).toBeUndefined();
+    expect(
+      (storeMock._data["activationFunnel"] as { firstParallelAgentsAt: number })
+        .firstParallelAgentsAt
+    ).toBe(1_700_000_000_000);
+
+    // A fresh state-change event should also respect the persisted guard.
     setTerminals([
       { id: "term-1", agentState: "working" },
       { id: "term-2", agentState: "working" },

--- a/electron/services/__tests__/ActivationFunnelService.test.ts
+++ b/electron/services/__tests__/ActivationFunnelService.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentState } from "../../../shared/types/agent.js";
+
+const storeMock = vi.hoisted(() => {
+  const data: Record<string, unknown> = {};
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    _data: data,
+  };
+});
+
+const trackEventMock = vi.hoisted(() => vi.fn());
+
+const broadcastMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../store.js", () => ({
+  store: storeMock,
+}));
+
+vi.mock("../TelemetryService.js", () => ({
+  trackEvent: trackEventMock,
+}));
+
+vi.mock("../../ipc/utils.js", () => ({
+  broadcastToRenderer: broadcastMock,
+}));
+
+import { events } from "../events.js";
+import { activationFunnelService } from "../ActivationFunnelService.js";
+import { CHANNELS } from "../../ipc/channels.js";
+
+function setTerminals(terminals: Array<{ id: string; agentState?: string }>) {
+  storeMock._data["appState"] = { activeWorktreeId: "wt-1", terminals };
+}
+
+function emitStateChange(state: AgentState, previousState: AgentState, terminalId = "term-1") {
+  events.emit("agent:state-changed", {
+    state,
+    previousState,
+    worktreeId: "wt-1",
+    terminalId,
+    agentId: `agent-${terminalId}`,
+    timestamp: Date.now(),
+    trigger: "heuristic" as const,
+    confidence: 1,
+  });
+}
+
+function emitCompleted(terminalId = "term-1", exitCode = 0, duration = 12_000) {
+  events.emit("agent:completed", {
+    agentId: `agent-${terminalId}`,
+    exitCode,
+    duration,
+    terminalId,
+    worktreeId: "wt-1",
+    timestamp: Date.now(),
+  });
+}
+
+function seedOnboardingDefaults() {
+  storeMock._data["onboarding"] = {
+    schemaVersion: 1,
+    completed: false,
+    currentStep: null,
+    agentSetupIds: [],
+    firstRunToastSeen: false,
+    newsletterPromptSeen: false,
+    waitingNudgeSeen: false,
+    seenAgentIds: [],
+    welcomeCardDismissed: false,
+    setupBannerDismissed: false,
+    migratedFromLocalStorage: false,
+    checklist: {
+      dismissed: false,
+      celebrationShown: false,
+      items: {
+        openedProject: false,
+        launchedAgent: false,
+        createdWorktree: false,
+        ranSecondParallelAgent: false,
+      },
+    },
+  };
+}
+
+describe("ActivationFunnelService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-18T12:00:00Z"));
+    for (const key of Object.keys(storeMock._data)) {
+      delete storeMock._data[key];
+    }
+    setTerminals([]);
+    seedOnboardingDefaults();
+    // Initialize with appLaunchMs set 2.5s before "now" so time_to_first is
+    // computable, and advance past the 8s boot grace window.
+    const now = Date.now();
+    activationFunnelService.initialize({ appLaunchMs: now - 2_500 });
+    vi.advanceTimersByTime(8_500);
+  });
+
+  afterEach(() => {
+    activationFunnelService.dispose();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("fires activation_first_agent_task_started exactly once with time_to_first_agent_task_ms", () => {
+    setTerminals([{ id: "term-1", agentState: "working" }]);
+    emitStateChange("working", "idle", "term-1");
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      "activation_first_agent_task_started",
+      expect.objectContaining({
+        time_to_first_agent_task_ms: expect.any(Number),
+      })
+    );
+    const payload = trackEventMock.mock.calls.find(
+      (c) => c[0] === "activation_first_agent_task_started"
+    )![1] as { time_to_first_agent_task_ms: number };
+    expect(payload.time_to_first_agent_task_ms).toBeGreaterThanOrEqual(2_500);
+
+    trackEventMock.mockClear();
+    // Second task start — guard blocks second fire
+    emitStateChange("idle", "working", "term-1");
+    emitStateChange("working", "idle", "term-1");
+    expect(
+      trackEventMock.mock.calls.find((c) => c[0] === "activation_first_agent_task_started")
+    ).toBeUndefined();
+  });
+
+  it("persists firstAgentTaskStartedAt and timeToFirstAgentTaskMs to activationFunnel", () => {
+    setTerminals([{ id: "term-1", agentState: "working" }]);
+    emitStateChange("working", "idle", "term-1");
+
+    const funnel = storeMock._data["activationFunnel"] as {
+      firstAgentTaskStartedAt?: number;
+      timeToFirstAgentTaskMs?: number;
+    };
+    expect(funnel.firstAgentTaskStartedAt).toBeGreaterThan(0);
+    expect(funnel.timeToFirstAgentTaskMs).toBeGreaterThanOrEqual(2_500);
+  });
+
+  it("fires activation_first_agent_task_completed exactly once when agent completes with exitCode 0", () => {
+    emitCompleted("term-1", 0, 12_345);
+    expect(trackEventMock).toHaveBeenCalledWith("activation_first_agent_task_completed", {
+      duration_ms: 12_345,
+      exit_code: 0,
+    });
+
+    trackEventMock.mockClear();
+    emitCompleted("term-2", 0, 7_000);
+    expect(
+      trackEventMock.mock.calls.find((c) => c[0] === "activation_first_agent_task_completed")
+    ).toBeUndefined();
+  });
+
+  it("ignores non-zero exit codes for activation_first_agent_task_completed", () => {
+    emitCompleted("term-1", 1, 5_000);
+    expect(
+      trackEventMock.mock.calls.find((c) => c[0] === "activation_first_agent_task_completed")
+    ).toBeUndefined();
+    expect(storeMock._data["activationFunnel"]).toBeUndefined();
+  });
+
+  it("fires activation_first_parallel_agents when 2 agents become active and marks checklist", () => {
+    // First agent working — just fires first_agent_task_started; parallel count is 1 so no parallel fire yet.
+    setTerminals([{ id: "term-1", agentState: "working" }]);
+    emitStateChange("working", "idle", "term-1");
+
+    trackEventMock.mockClear();
+    broadcastMock.mockClear();
+
+    // Second agent becomes active — now parallel count is 2.
+    setTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+    ]);
+    emitStateChange("working", "idle", "term-2");
+
+    expect(trackEventMock).toHaveBeenCalledWith("activation_first_parallel_agents", {
+      agent_count: 2,
+    });
+
+    const onboarding = storeMock._data["onboarding"] as {
+      checklist: { items: { ranSecondParallelAgent: boolean } };
+    };
+    expect(onboarding.checklist.items.ranSecondParallelAgent).toBe(true);
+    expect(broadcastMock).toHaveBeenCalledWith(
+      CHANNELS.ONBOARDING_CHECKLIST_PUSH,
+      expect.objectContaining({
+        items: expect.objectContaining({ ranSecondParallelAgent: true }),
+      })
+    );
+  });
+
+  it("does not fire activation_first_parallel_agents twice", () => {
+    setTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+    ]);
+    emitStateChange("working", "idle", "term-1");
+    emitStateChange("working", "idle", "term-2");
+
+    trackEventMock.mockClear();
+
+    // Additional active transitions shouldn't re-fire.
+    setTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+      { id: "term-3", agentState: "working" },
+    ]);
+    emitStateChange("working", "idle", "term-3");
+
+    expect(
+      trackEventMock.mock.calls.find((c) => c[0] === "activation_first_parallel_agents")
+    ).toBeUndefined();
+  });
+
+  it("suppresses all activation events during the 8-second boot grace window", () => {
+    // Reset to immediately after initialize (still inside boot grace)
+    activationFunnelService.dispose();
+    for (const key of Object.keys(storeMock._data)) {
+      delete storeMock._data[key];
+    }
+    setTerminals([]);
+    seedOnboardingDefaults();
+    const now = Date.now();
+    activationFunnelService.initialize({ appLaunchMs: now - 100 });
+    // Do NOT advance past boot grace
+    trackEventMock.mockClear();
+
+    setTerminals([{ id: "term-1", agentState: "working" }]);
+    emitStateChange("working", "idle", "term-1");
+    emitCompleted("term-1", 0, 5_000);
+
+    expect(trackEventMock).not.toHaveBeenCalled();
+    expect(storeMock._data["activationFunnel"]).toBeUndefined();
+  });
+});

--- a/electron/services/__tests__/ActivationFunnelService.test.ts
+++ b/electron/services/__tests__/ActivationFunnelService.test.ts
@@ -220,6 +220,68 @@ describe("ActivationFunnelService", () => {
     ).toBeUndefined();
   });
 
+  it("reconciles parallel-agents milestone after boot grace when agents were already active at launch", () => {
+    // Reset: simulate a relaunch where two agents are already in `working`
+    // state from a prior session (no state-change events will fire for them).
+    activationFunnelService.dispose();
+    for (const key of Object.keys(storeMock._data)) {
+      delete storeMock._data[key];
+    }
+    seedOnboardingDefaults();
+    setTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+    ]);
+    const now = Date.now();
+    activationFunnelService.initialize({ appLaunchMs: now - 500 });
+    trackEventMock.mockClear();
+    broadcastMock.mockClear();
+
+    // Advance past the boot grace window + reconcile timer delay (8100ms)
+    vi.advanceTimersByTime(8_200);
+
+    expect(trackEventMock).toHaveBeenCalledWith("activation_first_parallel_agents", {
+      agent_count: 2,
+    });
+    const onboarding = storeMock._data["onboarding"] as {
+      checklist: { items: { ranSecondParallelAgent: boolean } };
+    };
+    expect(onboarding.checklist.items.ranSecondParallelAgent).toBe(true);
+    expect(broadcastMock).toHaveBeenCalledWith(
+      CHANNELS.ONBOARDING_CHECKLIST_PUSH,
+      expect.objectContaining({
+        items: expect.objectContaining({ ranSecondParallelAgent: true }),
+      })
+    );
+  });
+
+  it("does not re-fire a persisted activation_first_parallel_agents milestone across re-initialize", () => {
+    // Seed a persisted milestone from a prior session.
+    storeMock._data["activationFunnel"] = { firstParallelAgentsAt: 1_700_000_000_000 };
+    // Fresh service — re-initialize path must honor the persisted guard.
+    activationFunnelService.dispose();
+    setTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+    ]);
+    const now = Date.now();
+    activationFunnelService.initialize({ appLaunchMs: now - 500 });
+    vi.advanceTimersByTime(8_500);
+    trackEventMock.mockClear();
+
+    // Emit a fresh state change — guard should still hold.
+    setTerminals([
+      { id: "term-1", agentState: "working" },
+      { id: "term-2", agentState: "working" },
+      { id: "term-3", agentState: "working" },
+    ]);
+    emitStateChange("working", "idle", "term-3");
+
+    expect(
+      trackEventMock.mock.calls.find((c) => c[0] === "activation_first_parallel_agents")
+    ).toBeUndefined();
+  });
+
   it("suppresses all activation events during the 8-second boot grace window", () => {
     // Reset to immediately after initialize (still inside boot grace)
     activationFunnelService.dispose();

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -4,6 +4,7 @@ import os from "os";
 const sentryInitMock = vi.hoisted(() => vi.fn());
 const captureEventMock = vi.hoisted(() => vi.fn(() => "mock-event-id"));
 const sentryCloseMock = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+const sentrySetTagMock = vi.hoisted(() => vi.fn());
 
 const storeMock = vi.hoisted(() => {
   const data: Record<string, unknown> = {
@@ -28,6 +29,7 @@ vi.mock("@sentry/electron/main", () => ({
   init: sentryInitMock,
   captureEvent: captureEventMock,
   close: sentryCloseMock,
+  setTag: sentrySetTagMock,
 }));
 
 import {
@@ -163,6 +165,82 @@ describe("setTelemetryLevel", () => {
       "privacy",
       expect.objectContaining({ telemetryLevel: "full", hasSeenPrompt: true })
     );
+  });
+});
+
+describe("setTelemetryLevel — onboarding_complete re-stamp", () => {
+  // Use isolated module instances so each test starts with a clean `initialized` flag.
+  async function loadFreshModule() {
+    vi.resetModules();
+    return await import("../TelemetryService.js");
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+  });
+
+  it("re-stamps onboarding_complete=true when switching mid-session to 'full' while onboarding is complete", async () => {
+    storeMock._data.onboarding = {
+      completed: true,
+    } as unknown as typeof storeMock._data.onboarding;
+    const mod = await loadFreshModule();
+    await mod.setTelemetryLevel("full");
+    expect(sentrySetTagMock).toHaveBeenCalledWith("onboarding_complete", "true");
+  });
+
+  it("re-stamps onboarding_complete=false when switching mid-session to 'errors' while onboarding is incomplete", async () => {
+    storeMock._data.onboarding = {
+      completed: false,
+    } as unknown as typeof storeMock._data.onboarding;
+    const mod = await loadFreshModule();
+    await mod.setTelemetryLevel("errors");
+    expect(sentrySetTagMock).toHaveBeenCalledWith("onboarding_complete", "false");
+  });
+
+  it("does NOT re-stamp when switching to 'off' (SDK is unloaded)", async () => {
+    storeMock._data.onboarding = {
+      completed: true,
+    } as unknown as typeof storeMock._data.onboarding;
+    const mod = await loadFreshModule();
+    setPrivacy({ telemetryLevel: "full" });
+    sentrySetTagMock.mockClear();
+    await mod.setTelemetryLevel("off");
+    expect(sentrySetTagMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("setOnboardingCompleteTag", () => {
+  async function loadFreshModule() {
+    vi.resetModules();
+    return await import("../TelemetryService.js");
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+  });
+
+  it("is a safe no-op when Sentry has not been initialized", async () => {
+    const mod = await loadFreshModule();
+    expect(() => mod.setOnboardingCompleteTag(true)).not.toThrow();
+    expect(sentrySetTagMock).not.toHaveBeenCalled();
+  });
+
+  it("calls Sentry.setTag with string booleans once Sentry is initialized", async () => {
+    setPrivacy({ telemetryLevel: "errors" });
+    process.env.SENTRY_DSN = "https://example@sentry.io/123";
+    try {
+      const mod = await loadFreshModule();
+      await mod.initializeTelemetry();
+      mod.setOnboardingCompleteTag(true);
+      expect(sentrySetTagMock).toHaveBeenCalledWith("onboarding_complete", "true");
+      mod.setOnboardingCompleteTag(false);
+      expect(sentrySetTagMock).toHaveBeenCalledWith("onboarding_complete", "false");
+    } finally {
+      delete process.env.SENTRY_DSN;
+    }
   });
 });
 

--- a/electron/services/migrations/015-activation-funnel-and-checklist-rename.ts
+++ b/electron/services/migrations/015-activation-funnel-and-checklist-rename.ts
@@ -1,0 +1,47 @@
+import type { Migration } from "../StoreMigrations.js";
+
+interface ChecklistLike {
+  dismissed?: boolean;
+  celebrationShown?: boolean;
+  items?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface OnboardingLike {
+  checklist?: ChecklistLike;
+  [key: string]: unknown;
+}
+
+export const migration015: Migration = {
+  version: 15,
+  description:
+    "Add activationFunnel store key and replace subscribedNewsletter checklist item with ranSecondParallelAgent (issue #5132)",
+  up: (store) => {
+    const existingActivation = (store as unknown as { get: (k: string) => unknown }).get(
+      "activationFunnel"
+    );
+    if (typeof existingActivation !== "object" || existingActivation === null) {
+      store.set("activationFunnel", {} as never);
+    }
+
+    const onboardingRaw = store.get("onboarding") as OnboardingLike | undefined;
+    if (!onboardingRaw || !onboardingRaw.checklist) {
+      return;
+    }
+
+    const checklist = onboardingRaw.checklist;
+    const items = { ...(checklist.items ?? {}) } as Record<string, unknown>;
+
+    const hadNewsletter = "subscribedNewsletter" in items;
+    if (hadNewsletter) {
+      delete items.subscribedNewsletter;
+    }
+
+    if (typeof items.ranSecondParallelAgent !== "boolean") {
+      items.ranSecondParallelAgent = false;
+    }
+
+    const nextChecklist = { ...checklist, items };
+    store.set("onboarding", { ...onboardingRaw, checklist: nextChecklist } as never);
+  },
+};

--- a/electron/services/migrations/__tests__/015-activation-funnel-and-checklist-rename.test.ts
+++ b/electron/services/migrations/__tests__/015-activation-funnel-and-checklist-rename.test.ts
@@ -33,9 +33,8 @@ describe("migration015 — activation funnel + checklist rename", () => {
     });
     migration015.up(store);
     // set should NOT be called for activationFunnel since it's already a non-null object
-    expect(
-      store.set.mock.calls.filter((c: [string, unknown]) => c[0] === "activationFunnel")
-    ).toHaveLength(0);
+    const setSpy = store.set as unknown as ReturnType<typeof vi.fn>;
+    expect(setSpy.mock.calls.filter((c: unknown[]) => c[0] === "activationFunnel")).toHaveLength(0);
   });
 
   it("renames checklist.items.subscribedNewsletter to ranSecondParallelAgent (reset to false regardless)", () => {

--- a/electron/services/migrations/__tests__/015-activation-funnel-and-checklist-rename.test.ts
+++ b/electron/services/migrations/__tests__/015-activation-funnel-and-checklist-rename.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import { migration015 } from "../015-activation-funnel-and-checklist-rename.js";
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    delete: vi.fn((key: string) => {
+      delete data[key];
+    }),
+    _data: data,
+  } as unknown as Parameters<typeof migration015.up>[0] & {
+    _data: Record<string, unknown>;
+  };
+}
+
+describe("migration015 — activation funnel + checklist rename", () => {
+  it("has version 15", () => {
+    expect(migration015.version).toBe(15);
+  });
+
+  it("initializes activationFunnel to {} when missing", () => {
+    const store = makeStoreMock({});
+    migration015.up(store);
+    expect(store.set).toHaveBeenCalledWith("activationFunnel", {});
+  });
+
+  it("leaves an existing activationFunnel object untouched", () => {
+    const store = makeStoreMock({
+      activationFunnel: { firstAgentTaskStartedAt: 12345, timeToFirstAgentTaskMs: 5000 },
+    });
+    migration015.up(store);
+    // set should NOT be called for activationFunnel since it's already a non-null object
+    expect(
+      store.set.mock.calls.filter((c: [string, unknown]) => c[0] === "activationFunnel")
+    ).toHaveLength(0);
+  });
+
+  it("renames checklist.items.subscribedNewsletter to ranSecondParallelAgent (reset to false regardless)", () => {
+    const store = makeStoreMock({
+      onboarding: {
+        completed: false,
+        checklist: {
+          dismissed: false,
+          celebrationShown: false,
+          items: {
+            openedProject: true,
+            launchedAgent: true,
+            createdWorktree: false,
+            subscribedNewsletter: true,
+          },
+        },
+      },
+    });
+    migration015.up(store);
+    const onboarding = store._data.onboarding as {
+      checklist: { items: Record<string, unknown> };
+    };
+    expect(onboarding.checklist.items.subscribedNewsletter).toBeUndefined();
+    expect(onboarding.checklist.items.ranSecondParallelAgent).toBe(false);
+    expect(onboarding.checklist.items.openedProject).toBe(true);
+    expect(onboarding.checklist.items.launchedAgent).toBe(true);
+    expect(onboarding.checklist.items.createdWorktree).toBe(false);
+  });
+
+  it("adds ranSecondParallelAgent: false when no subscribedNewsletter existed", () => {
+    const store = makeStoreMock({
+      onboarding: {
+        completed: false,
+        checklist: {
+          dismissed: false,
+          celebrationShown: false,
+          items: { openedProject: true },
+        },
+      },
+    });
+    migration015.up(store);
+    const onboarding = store._data.onboarding as {
+      checklist: { items: Record<string, unknown> };
+    };
+    expect(onboarding.checklist.items.ranSecondParallelAgent).toBe(false);
+  });
+
+  it("is idempotent — no change on a second run", () => {
+    const data: Record<string, unknown> = {
+      onboarding: {
+        completed: false,
+        checklist: {
+          dismissed: false,
+          celebrationShown: false,
+          items: {
+            openedProject: true,
+            launchedAgent: true,
+            createdWorktree: true,
+            subscribedNewsletter: true,
+          },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration015.up(store);
+    const afterFirst = JSON.stringify(data.onboarding);
+    migration015.up(store);
+    expect(JSON.stringify(data.onboarding)).toBe(afterFirst);
+  });
+
+  it("does not throw on missing onboarding state", () => {
+    const store = makeStoreMock({});
+    expect(() => migration015.up(store)).not.toThrow();
+    expect(store._data.activationFunnel).toEqual({});
+    expect(store._data.onboarding).toBeUndefined();
+  });
+
+  it("does not throw on onboarding without checklist", () => {
+    const store = makeStoreMock({
+      onboarding: { completed: false },
+    });
+    expect(() => migration015.up(store)).not.toThrow();
+  });
+});

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -12,6 +12,7 @@ import { migration011 } from "./011-minimal-soundscape-defaults.js";
 import { migration012 } from "./012-default-pin-agents.js";
 import { migration013 } from "./013-cleanup-phantom-pins.js";
 import { migration014 } from "./014-consolidate-telemetry-consent.js";
+import { migration015 } from "./015-activation-funnel-and-checklist-rename.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -27,4 +28,5 @@ export const migrations: Migration[] = [
   migration012,
   migration013,
   migration014,
+  migration015,
 ];

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -196,9 +196,15 @@ export interface StoreSchema {
         openedProject: boolean;
         launchedAgent: boolean;
         createdWorktree: boolean;
-        subscribedNewsletter: boolean;
+        ranSecondParallelAgent: boolean;
       };
     };
+  };
+  activationFunnel: {
+    firstAgentTaskStartedAt?: number;
+    firstAgentTaskCompletedAt?: number;
+    firstParallelAgentsAt?: number;
+    timeToFirstAgentTaskMs?: number;
   };
   orchestrationMilestones: Record<string, boolean>;
   shortcutHintCounts: Record<string, number>;
@@ -322,10 +328,11 @@ const storeOptions = {
           openedProject: false,
           launchedAgent: false,
           createdWorktree: false,
-          subscribedNewsletter: false,
+          ranSecondParallelAgent: false,
         },
       },
     },
+    activationFunnel: {},
     orchestrationMilestones: {},
     shortcutHintCounts: {},
     updateChannel: "stable" as const,

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -23,7 +23,8 @@ import { projectStore } from "../services/ProjectStore.js";
 import { taskQueueService } from "../services/TaskQueueService.js";
 import { store } from "../store.js";
 import { LATEST_SCHEMA_VERSION, MigrationRunner } from "../services/StoreMigrations.js";
-import { initializeTelemetry } from "../services/TelemetryService.js";
+import { initializeTelemetry, setOnboardingCompleteTag } from "../services/TelemetryService.js";
+import { activationFunnelService } from "../services/ActivationFunnelService.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { secureStorage } from "../services/SecureStorage.js";
 import { notificationService } from "../services/NotificationService.js";
@@ -261,6 +262,13 @@ export interface SetupWindowServicesOptions {
   initialProjectId?: string;
   projectViewManager?: import("./ProjectViewManager.js").ProjectViewManager;
   initialAppView?: import("electron").WebContentsView;
+  /**
+   * Wall-clock ms at which the Electron process started (captured as early as
+   * possible in the entry point). Threaded through so the activation funnel
+   * service can compute `time_to_first_agent_task_ms` without reaching back
+   * into the main-module singleton.
+   */
+  appLaunchMs?: number;
 }
 
 export async function setupWindowServices(
@@ -312,8 +320,13 @@ export async function setupWindowServices(
     }
 
     // Initialize Sentry after migrations — reads privacy.telemetryLevel,
-    // which is guaranteed populated by migration014.
-    void initializeTelemetry();
+    // which is guaranteed populated by migration014. Once the SDK is ready,
+    // stamp the `onboarding_complete` scope tag so every subsequent event
+    // (crashes, analytics) is filterable by whether the user has finished
+    // first-run onboarding.
+    void initializeTelemetry().then(() => {
+      setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
+    });
 
     // Initialize GitHubAuth
     GitHubAuth.initializeStorage({
@@ -348,6 +361,7 @@ export async function setupWindowServices(
     // Notifications (global singletons)
     agentNotificationService.initialize();
     preAgentSnapshotService.initialize();
+    activationFunnelService.initialize({ appLaunchMs: opts.appLaunchMs ?? Date.now() });
 
     // Auto-updater
     autoUpdaterService.initialize();
@@ -1063,6 +1077,7 @@ export async function setupWindowServices(
     getSystemSleepService().dispose();
     notificationService.dispose();
     agentNotificationService.dispose();
+    activationFunnelService.dispose();
     preAgentSnapshotService.dispose();
     autoUpdaterService.dispose();
   });

--- a/shared/config/telemetry.ts
+++ b/shared/config/telemetry.ts
@@ -3,6 +3,9 @@ export const ANALYTICS_EVENTS = [
   "onboarding_step_skipped",
   "onboarding_completed",
   "onboarding_abandoned",
+  "activation_first_agent_task_started",
+  "activation_first_agent_task_completed",
+  "activation_first_parallel_agents",
 ] as const;
 
 export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[number];

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1152,6 +1152,7 @@ export interface ElectronAPI {
     dismissChecklist(): Promise<void>;
     markChecklistItem(item: ChecklistItemId): Promise<void>;
     markChecklistCelebrationShown(): Promise<void>;
+    onChecklistPush(callback: (state: ChecklistState) => void): () => void;
   };
   milestones: {
     get(): Promise<Record<string, boolean>>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -180,13 +180,13 @@ export type ChecklistItemId =
   | "openedProject"
   | "launchedAgent"
   | "createdWorktree"
-  | "subscribedNewsletter";
+  | "ranSecondParallelAgent";
 
 export interface ChecklistItems {
   openedProject: boolean;
   launchedAgent: boolean;
   createdWorktree: boolean;
-  subscribedNewsletter: boolean;
+  ranSecondParallelAgent: boolean;
 }
 
 export interface ChecklistState {
@@ -2337,6 +2337,9 @@ export interface IpcEventMap {
     level: "off" | "errors" | "full";
     hasSeenPrompt: boolean;
   };
+
+  // Onboarding checklist push (main → renderer)
+  "onboarding:checklist-push": ChecklistState;
 }
 
 export type IpcInvokeArgs<K extends keyof IpcInvokeMap> = IpcInvokeMap[K]["args"];

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -26,7 +26,7 @@ const allIncomplete: ChecklistState = {
     openedProject: false,
     launchedAgent: false,
     createdWorktree: false,
-    subscribedNewsletter: false,
+    ranSecondParallelAgent: false,
   },
 };
 
@@ -37,7 +37,7 @@ const allComplete: ChecklistState = {
     openedProject: true,
     launchedAgent: true,
     createdWorktree: true,
-    subscribedNewsletter: true,
+    ranSecondParallelAgent: true,
   },
 };
 
@@ -48,7 +48,7 @@ const mixedState: ChecklistState = {
     openedProject: true,
     launchedAgent: false,
     createdWorktree: false,
-    subscribedNewsletter: false,
+    ranSecondParallelAgent: false,
   },
 };
 
@@ -68,7 +68,7 @@ describe("GettingStartedChecklist", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
 
     const buttons = screen.getAllByRole("button", {
-      name: /open your project|ask ai to help with your code|start a parallel task|stay in the loop/i,
+      name: /open your project|ask ai to help with your code|start a parallel task|run two agents in parallel/i,
     });
     expect(buttons).toHaveLength(4);
   });
@@ -77,21 +77,21 @@ describe("GettingStartedChecklist", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
 
     const stepButtons = screen.queryAllByRole("button", {
-      name: /open your project|ask ai to help with your code|start a parallel task|stay in the loop/i,
+      name: /open your project|ask ai to help with your code|start a parallel task|run two agents in parallel/i,
     });
     expect(stepButtons).toHaveLength(0);
 
     expect(screen.getByText("Open your project")).toBeTruthy();
     expect(screen.getByText("Ask AI to help with your code")).toBeTruthy();
     expect(screen.getByText("Start a parallel task")).toBeTruthy();
-    expect(screen.getByText("Stay in the loop")).toBeTruthy();
+    expect(screen.getByText("Run two agents in parallel")).toBeTruthy();
   });
 
   it("renders mixed state correctly — only incomplete steps are buttons", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
 
     const stepButtons = screen.getAllByRole("button", {
-      name: /ask ai to help with your code|start a parallel task|stay in the loop/i,
+      name: /ask ai to help with your code|start a parallel task|run two agents in parallel/i,
     });
     expect(stepButtons).toHaveLength(3);
 
@@ -125,17 +125,15 @@ describe("GettingStartedChecklist", () => {
     });
   });
 
-  it("dispatches system.openExternal with newsletter URL and calls onMarkItem when 'Stay in the loop' is clicked", () => {
+  it("dispatches worktree.createDialog.open when 'Run two agents in parallel' is clicked and does NOT mark the item (auto-mark is owned by the activation funnel service)", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /stay in the loop/i }));
+    fireEvent.click(screen.getByRole("button", { name: /run two agents in parallel/i }));
     expect(dispatchMock).toHaveBeenCalledTimes(1);
-    expect(dispatchMock).toHaveBeenCalledWith(
-      "system.openExternal",
-      { url: "https://daintree.org/newsletter" },
-      { source: "user" }
-    );
-    expect(defaultProps.onMarkItem).toHaveBeenCalledWith("subscribedNewsletter");
+    expect(dispatchMock).toHaveBeenCalledWith("worktree.createDialog.open", undefined, {
+      source: "user",
+    });
+    expect(defaultProps.onMarkItem).not.toHaveBeenCalled();
   });
 
   it("does not call onMarkItem for non-markOnClick items", () => {

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -24,7 +24,7 @@ const defaultOnboardingState: OnboardingState = {
       openedProject: false,
       launchedAgent: false,
       createdWorktree: false,
-      subscribedNewsletter: false,
+      ranSecondParallelAgent: false,
     },
   },
 };

--- a/src/components/Onboarding/checklistItems.ts
+++ b/src/components/Onboarding/checklistItems.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from "react";
-import { FolderOpen, Mail } from "lucide-react";
+import { FolderOpen } from "lucide-react";
 import { DaintreeAgentIcon, WorktreeIcon } from "@/components/icons";
 import type { ActionId } from "@shared/types/actions";
 import type { ChecklistItemId } from "@shared/types/ipc/maps";
@@ -37,12 +37,11 @@ export const CHECKLIST_ITEMS: ChecklistItemDef[] = [
     actionId: "worktree.createDialog.open",
   },
   {
-    id: "subscribedNewsletter",
-    label: "Stay in the loop",
-    description: "Get product updates and tips in your inbox.",
-    icon: Mail,
-    actionId: "system.openExternal",
-    actionArgs: { url: "https://daintree.org/newsletter" },
-    markOnClick: true,
+    id: "ranSecondParallelAgent",
+    label: "Run two agents in parallel",
+    description:
+      "Kick off a second agent while the first keeps working — that's the Daintree superpower.",
+    icon: DaintreeAgentIcon,
+    actionId: "worktree.createDialog.open",
   },
 ];

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -201,7 +201,7 @@ const allIncomplete: ChecklistState = {
     openedProject: false,
     launchedAgent: false,
     createdWorktree: false,
-    subscribedNewsletter: false,
+    ranSecondParallelAgent: false,
   },
 };
 
@@ -212,7 +212,7 @@ const oneComplete: ChecklistState = {
     openedProject: true,
     launchedAgent: false,
     createdWorktree: false,
-    subscribedNewsletter: false,
+    ranSecondParallelAgent: false,
   },
 };
 
@@ -223,7 +223,7 @@ const allComplete: ChecklistState = {
     openedProject: true,
     launchedAgent: true,
     createdWorktree: true,
-    subscribedNewsletter: true,
+    ranSecondParallelAgent: true,
   },
 };
 
@@ -234,7 +234,7 @@ const dismissed: ChecklistState = {
     openedProject: false,
     launchedAgent: false,
     createdWorktree: false,
-    subscribedNewsletter: false,
+    ranSecondParallelAgent: false,
   },
 };
 

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -108,6 +108,17 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
       .catch(console.error);
   }, [isStateLoaded]);
 
+  // Subscribe to main-process checklist pushes (e.g., parallel-agents milestone
+  // auto-marks the `ranSecondParallelAgent` item from the activation funnel
+  // service). Every active WebContentsView receives the push via
+  // `broadcastToRenderer`, so cached views stay in sync.
+  useEffect(() => {
+    if (!isElectronAvailable() || !window.electron?.onboarding?.onChecklistPush) return;
+    return window.electron.onboarding.onChecklistPush((next) => {
+      setChecklist(next);
+    });
+  }, []);
+
   // Set up Zustand subscriptions for auto-completion + reconcile current state
   useEffect(() => {
     if (!isElectronAvailable() || !isStateLoaded) return;

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -111,11 +111,25 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
   // Subscribe to main-process checklist pushes (e.g., parallel-agents milestone
   // auto-marks the `ranSecondParallelAgent` item from the activation funnel
   // service). Every active WebContentsView receives the push via
-  // `broadcastToRenderer`, so cached views stay in sync.
+  // `broadcastToRenderer`, so cached views stay in sync. We merge by taking
+  // the union of truthy items rather than overwriting — this prevents a
+  // pre-push `getChecklist()` hydration promise from clobbering a newer push.
   useEffect(() => {
     if (!isElectronAvailable() || !window.electron?.onboarding?.onChecklistPush) return;
     return window.electron.onboarding.onChecklistPush((next) => {
-      setChecklist(next);
+      setChecklist((prev) => {
+        if (!prev) return next;
+        const mergedItems = { ...prev.items } as typeof prev.items;
+        for (const key of Object.keys(next.items) as Array<keyof typeof next.items>) {
+          if (next.items[key] || prev.items[key]) mergedItems[key] = true;
+        }
+        return {
+          ...next,
+          items: mergedItems,
+          dismissed: prev.dismissed || next.dismissed,
+          celebrationShown: prev.celebrationShown || next.celebrationShown,
+        };
+      });
     });
   }, []);
 


### PR DESCRIPTION
## Summary

- Adds three one-shot activation-funnel telemetry events (`activation_first_agent_task_started`, `activation_first_agent_task_completed`, `activation_first_parallel_agents`) tracked by a new `ActivationFunnelService` with an 8-second boot grace to suppress event replay.
- Stamps an `onboarding_complete` Sentry scope tag so crash reports can be filtered to activated vs first-run users. Tag is set on init, re-set on onboarding completion, and re-stamped after mid-session telemetry-level changes.
- Replaces the `subscribedNewsletter` checklist slot with `ranSecondParallelAgent`, auto-marked when two or more agents reach working/running/directing state. Main owns the write and broadcasts via a new `onboarding:checklist-push` channel so all cached `WebContentsView` instances stay in sync.

Resolves #5132

## Changes

- NEW `electron/services/ActivationFunnelService.ts` — main-process singleton subscribing to `agent:state-changed` and `agent:completed`
- NEW `electron/services/migrations/015-activation-funnel-and-checklist-rename.ts` — bumps schema to v15, initialises `activationFunnel: {}`, renames checklist slot
- `electron/services/TelemetryService.ts` — new `setOnboardingCompleteTag()`, re-stamps tag after `setTelemetryLevel()`
- `electron/ipc/handlers/onboarding.ts` — renames `subscribedNewsletter` → `ranSecondParallelAgent`, calls `setOnboardingCompleteTag(true)` from completion paths
- `electron/store.ts` + shared types — new `activationFunnel` store key, renamed checklist field, new `onboarding:checklist-push` event type
- `src/components/Onboarding/checklistItems.ts` — replaces newsletter entry with "Run two agents in parallel"
- `src/hooks/app/useGettingStartedChecklist.ts` — subscribes to `onChecklistPush` with a union-merge to prevent stale hydrate promises clobbering a push

## Testing

New test suites: `ActivationFunnelService.test.ts` (9 cases), migration `015` test (8 cases). Extended `TelemetryService.test.ts` with 5 new cases covering `setTelemetryLevel` re-stamp and `setOnboardingCompleteTag`. Extended `onboarding.handlers.test.ts` with 3 new Sentry-tag call-site assertions. Updated `GettingStartedChecklist.test.tsx`, `OnboardingFlow.test.tsx`, and `WelcomeScreen.test.tsx` for the rename. `npm run check` passes (typecheck + lint ratchet 401/401 + format).