### PR TITLE
fix(a11y): stop worktree row indicators spamming live regions

### DIFF
--- a/src/components/Worktree/ActivityLight.tsx
+++ b/src/components/Worktree/ActivityLight.tsx
@@ -1,55 +1,43 @@
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { getActivityColor } from "@/utils/colorInterpolation";
-import { formatTimestampExact } from "@/utils/textParsing";
+import { DECAY_DURATION, getActivityColor } from "@/utils/colorInterpolation";
 import { useGlobalSecondTicker } from "@/hooks/useGlobalSecondTicker";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface ActivityLightProps {
   lastActivityTimestamp?: number | null;
   className?: string;
 }
 
-const GRAY_COLOR = "#52525b";
+function isActivelyWorking(timestamp: number | null | undefined): boolean {
+  if (timestamp == null || !Number.isFinite(timestamp)) return false;
+  return Date.now() - timestamp < DECAY_DURATION;
+}
 
 /**
- * Activity indicator that fades from green to gray over 90 seconds.
- * Uses a shared global ticker for efficiency.
+ * Activity indicator that fades from accent to idle over 90 seconds.
+ * Conveys state via both colour (fade) and shape (filled dot active,
+ * hollow ring idle) to satisfy WCAG 1.4.1. Decorative — usage sites
+ * always render adjacent `LiveTimeAgo` text, so it is `aria-hidden`.
  */
 export function ActivityLight({ lastActivityTimestamp, className }: ActivityLightProps) {
   const globalTick = useGlobalSecondTicker();
   const [color, setColor] = useState(() => getActivityColor(lastActivityTimestamp));
+  const [active, setActive] = useState(() => isActivelyWorking(lastActivityTimestamp));
 
   useEffect(() => {
-    if (lastActivityTimestamp == null) {
-      setColor(GRAY_COLOR);
-      return;
-    }
-
-    const newColor = getActivityColor(lastActivityTimestamp);
-    setColor(newColor);
-
-    if (newColor === GRAY_COLOR) {
-      return;
-    }
+    setColor(getActivityColor(lastActivityTimestamp));
+    setActive(isActivelyWorking(lastActivityTimestamp));
   }, [lastActivityTimestamp, globalTick]);
 
-  const tooltipText = formatTimestampExact(lastActivityTimestamp);
-
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <div
-          className={cn(
-            "w-2.5 h-2.5 rounded-full transition-colors duration-1000 ease-linear",
-            className
-          )}
-          style={{ backgroundColor: color }}
-          role="status"
-          aria-label={tooltipText}
-        />
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{tooltipText}</TooltipContent>
-    </Tooltip>
+    <div
+      aria-hidden="true"
+      className={cn(
+        "w-2.5 h-2.5 rounded-full transition-colors duration-1000 ease-linear",
+        active ? "" : "border bg-transparent",
+        className
+      )}
+      style={active ? { backgroundColor: color } : { borderColor: color }}
+    />
   );
 }

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -92,7 +92,7 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
             config.pulse && "animate-agent-pulse",
             className
           )}
-          role="status"
+          role="img"
           aria-label={`Agent status: ${config.label}`}
         >
           {config.icon}

--- a/src/components/Worktree/__tests__/ActivityLight.test.tsx
+++ b/src/components/Worktree/__tests__/ActivityLight.test.tsx
@@ -2,22 +2,46 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { act, render, cleanup } from "@testing-library/react";
 import { ActivityLight } from "../ActivityLight";
 import { DECAY_DURATION } from "@/utils/colorInterpolation";
 
-vi.mock("@/hooks/useGlobalSecondTicker", () => ({
-  useGlobalSecondTicker: () => 0,
-}));
+let tickValue = 0;
+const tickListeners = new Set<(tick: number) => void>();
+
+vi.mock("@/hooks/useGlobalSecondTicker", async () => {
+  const { useState, useEffect } = await import("react");
+  return {
+    useGlobalSecondTicker: () => {
+      const [tick, setTick] = useState(tickValue);
+      useEffect(() => {
+        tickListeners.add(setTick);
+        return () => {
+          tickListeners.delete(setTick);
+        };
+      }, []);
+      return tick;
+    },
+  };
+});
+
+function advanceTicker() {
+  tickValue += 1;
+  act(() => {
+    tickListeners.forEach((listener) => listener(tickValue));
+  });
+}
 
 describe("ActivityLight", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    tickValue = 0;
   });
 
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    tickListeners.clear();
   });
 
   function getDot(container: HTMLElement): HTMLElement {
@@ -37,9 +61,11 @@ describe("ActivityLight", () => {
     expect(getDot(container).getAttribute("aria-hidden")).toBe("true");
   });
 
-  it("does not render a tooltip subtree", () => {
+  it("does not render a tooltip subtree or live region", () => {
     const { container } = render(<ActivityLight lastActivityTimestamp={Date.now()} />);
-    expect(container.querySelectorAll("div").length).toBe(1);
+    expect(container.querySelector('[role="tooltip"]')).toBeNull();
+    expect(container.querySelector("[aria-live]")).toBeNull();
+    expect(container.querySelector("[aria-label]")).toBeNull();
   });
 
   it("renders a filled dot when actively working", () => {
@@ -82,5 +108,39 @@ describe("ActivityLight", () => {
     );
     expect(getDot(container).className).toContain("w-1.5");
     expect(getDot(container).className).toContain("h-1.5");
+  });
+
+  it.each([
+    ["just before boundary", -1, "active"],
+    ["at boundary", 0, "idle"],
+    ["just past boundary", 1, "idle"],
+  ] as const)("%s: elapsed=DECAY_DURATION+(%sms) → %s", (_label, offsetMs, expectedState) => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const timestamp = now - DECAY_DURATION - offsetMs;
+    const { container } = render(<ActivityLight lastActivityTimestamp={timestamp} />);
+    const dot = getDot(container);
+    if (expectedState === "active") {
+      expect(dot.className).not.toMatch(/\bborder\b/);
+    } else {
+      expect(dot.className).toMatch(/\bborder\b/);
+    }
+  });
+
+  it("transitions from filled dot to hollow ring when time advances past DECAY_DURATION", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const { container } = render(<ActivityLight lastActivityTimestamp={now} />);
+
+    // Starts active (filled).
+    expect(getDot(container).className).not.toMatch(/\bborder\b/);
+
+    // Advance past the decay window and drive the ticker.
+    vi.setSystemTime(now + DECAY_DURATION + 1);
+    advanceTicker();
+
+    // Now idle (hollow ring).
+    expect(getDot(container).className).toMatch(/\bborder\b/);
+    expect(getDot(container).className).toMatch(/bg-transparent/);
   });
 });

--- a/src/components/Worktree/__tests__/ActivityLight.test.tsx
+++ b/src/components/Worktree/__tests__/ActivityLight.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { ActivityLight } from "../ActivityLight";
+import { DECAY_DURATION } from "@/utils/colorInterpolation";
+
+vi.mock("@/hooks/useGlobalSecondTicker", () => ({
+  useGlobalSecondTicker: () => 0,
+}));
+
+describe("ActivityLight", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  function getDot(container: HTMLElement): HTMLElement {
+    const dot = container.querySelector('div[aria-hidden="true"]');
+    if (!dot) throw new Error("ActivityLight dot not found");
+    return dot as HTMLElement;
+  }
+
+  it("does not spam live regions (no role=status, no role=img)", () => {
+    const { container } = render(<ActivityLight lastActivityTimestamp={Date.now()} />);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector('[role="img"]')).toBeNull();
+  });
+
+  it("marks the dot aria-hidden so adjacent text carries the label", () => {
+    const { container } = render(<ActivityLight lastActivityTimestamp={Date.now()} />);
+    expect(getDot(container).getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("does not render a tooltip subtree", () => {
+    const { container } = render(<ActivityLight lastActivityTimestamp={Date.now()} />);
+    expect(container.querySelectorAll("div").length).toBe(1);
+  });
+
+  it("renders a filled dot when actively working", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const { container } = render(<ActivityLight lastActivityTimestamp={now} />);
+    const dot = getDot(container);
+    expect(dot.style.backgroundColor).not.toBe("");
+    expect(dot.style.borderColor).toBe("");
+    expect(dot.className).not.toMatch(/\bborder\b/);
+  });
+
+  it("renders a hollow ring when idle (elapsed >= DECAY_DURATION)", () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const past = now - DECAY_DURATION - 1;
+    const { container } = render(<ActivityLight lastActivityTimestamp={past} />);
+    const dot = getDot(container);
+    expect(dot.className).toMatch(/\bborder\b/);
+    expect(dot.className).toMatch(/bg-transparent/);
+    expect(dot.style.borderColor).not.toBe("");
+  });
+
+  it("renders hollow ring when timestamp is null", () => {
+    const { container } = render(<ActivityLight lastActivityTimestamp={null} />);
+    const dot = getDot(container);
+    expect(dot.className).toMatch(/\bborder\b/);
+    expect(dot.className).toMatch(/bg-transparent/);
+  });
+
+  it("renders hollow ring when timestamp is undefined", () => {
+    const { container } = render(<ActivityLight />);
+    const dot = getDot(container);
+    expect(dot.className).toMatch(/\bborder\b/);
+  });
+
+  it("applies the className prop", () => {
+    const { container } = render(
+      <ActivityLight lastActivityTimestamp={Date.now()} className="w-1.5 h-1.5" />
+    );
+    expect(getDot(container).className).toContain("w-1.5");
+    expect(getDot(container).className).toContain("h-1.5");
+  });
+});

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { AgentStatusIndicator, getDominantAgentState } from "../AgentStatusIndicator";
+import type { AgentState } from "@/types";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe("AgentStatusIndicator", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it.each([
+    ["working", "⟳"],
+    ["running", "▶"],
+    ["completed", "✓"],
+    ["exited", "–"],
+    ["directing", "✎"],
+  ] as const)("renders role=img with aria-label for state %s", (state, glyph) => {
+    const { container } = render(<AgentStatusIndicator state={state} />);
+    const el = container.querySelector('[role="img"]');
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute("aria-label")).toBe(`Agent status: ${state}`);
+    expect(el?.textContent).toBe(glyph);
+  });
+
+  it("does not render role=status (no live-region spam)", () => {
+    const { container } = render(<AgentStatusIndicator state="working" />);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it.each([null, undefined, "idle", "waiting"] as const)("renders nothing for %s", (state) => {
+    const { container } = render(
+      <AgentStatusIndicator state={state as AgentState | null | undefined} />
+    );
+    expect(container.querySelector('[role="img"]')).toBeNull();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+});
+
+describe("getDominantAgentState", () => {
+  it("returns null when all states are undefined", () => {
+    expect(getDominantAgentState([undefined, undefined])).toBeNull();
+  });
+
+  it("returns null when dominant state is idle", () => {
+    expect(getDominantAgentState(["idle", "idle"])).toBeNull();
+  });
+
+  it("prefers working over lower-priority states", () => {
+    expect(getDominantAgentState(["idle", "running", "working"])).toBe("working");
+  });
+
+  it("prefers directing over running", () => {
+    expect(getDominantAgentState(["running", "directing"])).toBe("directing");
+  });
+});

--- a/src/utils/__tests__/colorInterpolation.test.ts
+++ b/src/utils/__tests__/colorInterpolation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getActivityColor } from "../colorInterpolation";
+import { DECAY_DURATION, getActivityColor } from "../colorInterpolation";
+
+describe("DECAY_DURATION", () => {
+  it("is exported as 90 seconds in milliseconds", () => {
+    expect(DECAY_DURATION).toBe(90_000);
+  });
+});
 
 describe("getActivityColor", () => {
   beforeEach(() => {

--- a/src/utils/colorInterpolation.ts
+++ b/src/utils/colorInterpolation.ts
@@ -4,7 +4,7 @@
  * Colors are read from CSS custom properties with hardcoded fallbacks.
  */
 
-const DECAY_DURATION = 90 * 1000;
+export const DECAY_DURATION = 90 * 1000;
 
 function getCSSColor(property: string, fallback: string): string {
   if (typeof document === "undefined") return fallback;


### PR DESCRIPTION
## Summary

- `ActivityLight` was announcing on every `LiveTimeAgo` tick because it carried `role="status"` (a live region) on the dot element. Replaced with `aria-hidden="true"` since both call sites already render the dot next to human-readable `LiveTimeAgo` text. Claiming independent semantics would just duplicate the adjacent label.
- Added a shape variant to `ActivityLight` so active (filled dot) vs idle (hollow ring) is distinguishable without relying on colour alone, covering WCAG 1.4.1 for colour-blind users.
- Removed `ActivityLight`'s internal `<Tooltip>` — it was nesting inside another `<Tooltip>` in `WorktreeDetailsSection` and double-firing on Radix v1.2.8. The outer tooltip still shows "Last activity: ..." correctly.
- `AgentStatusIndicator`'s role swapped from `status` to `img` as a defensive hygiene fix (that component isn't mounted anywhere in production yet, but it's cleaner when it eventually is).

Resolves #5411

## Changes

- `src/components/Worktree/ActivityLight.tsx` — remove live region, add shape variant (filled dot / hollow ring), drop internal tooltip
- `src/components/Worktree/AgentStatusIndicator.tsx` — role `status` → `img`
- `src/components/Worktree/__tests__/ActivityLight.test.tsx` — new tests covering tick-driven transitions and boundary cases
- `src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx` — new tests for the corrected role
- `src/utils/colorInterpolation.ts` + its test — minor fixup caught during review

## Testing

- Open the fleet dashboard with a screen reader (VoiceOver / NVDA), navigate through multiple worktree rows, and confirm there's no continuous announcement stream on timestamp ticks.
- Run a colour-blindness simulator (deuteranopia) and verify active vs idle worktrees are still distinguishable via shape.
- Hover the activity area in a collapsed worktree card — outer tooltip should still show "Last activity: ..." with no double-firing.
- Expanded worktree details panel: "Last active:" label and `LiveTimeAgo` text should read correctly alongside the dot.
- Unit test suite: `npx vitest run src/components/Worktree/__tests__/ActivityLight.test.tsx`