### PR TITLE
fix(a11y): remove nested-interactive violations in worktree cards

### DIFF
--- a/e2e/full/core-accessibility.spec.ts
+++ b/e2e/full/core-accessibility.spec.ts
@@ -28,10 +28,6 @@ function buildAxeScanner(page: import("@playwright/test").Page) {
         // canvas content also triggers false positives. Fires across the entire app, so
         // .exclude() on individual selectors is impractical.
         "color-contrast",
-        // nested-interactive: Worktree cards wrap real <button> descendants in a
-        // role="button" container (WorktreeCard, WorktreeDetailsSection, FileStageRow).
-        // Fixing this requires restructuring the card components, which is out of scope.
-        "nested-interactive",
       ])
   );
 }

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import type React from "react";
 import type { StagingFileEntry } from "@shared/types";
 import type { GitStatus } from "@shared/types";
 import { cn } from "@/lib/utils";
@@ -66,9 +67,13 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
   const config = STATUS_CONFIG[file.status] || STATUS_CONFIG.untracked;
   const { dir, base } = splitPath(file.path);
 
-  const handleToggle = useCallback(() => {
-    onToggle(file.path);
-  }, [onToggle, file.path]);
+  const handleToggle = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onToggle(file.path);
+    },
+    [onToggle, file.path]
+  );
 
   const handleClick = useCallback(() => {
     onFileClick(file.path, file.status);
@@ -76,6 +81,7 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
 
   return (
     <div
+      onClick={handleClick}
       className={cn(
         "group/stagerow flex items-center text-xs rounded px-1.5 py-1.5 transition-colors",
         isStaged ? "bg-status-success/[0.06] hover:bg-status-success/[0.10]" : "hover:bg-tint/5"
@@ -106,7 +112,6 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
 
       <button
         type="button"
-        onClick={handleClick}
         title={file.path}
         aria-label={`View diff: ${file.path}`}
         className={cn(

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import type React from "react";
 import type { StagingFileEntry } from "@shared/types";
 import type { GitStatus } from "@shared/types";
 import { cn } from "@/lib/utils";
@@ -67,44 +66,26 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
   const config = STATUS_CONFIG[file.status] || STATUS_CONFIG.untracked;
   const { dir, base } = splitPath(file.path);
 
-  const handleToggle = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      onToggle(file.path);
-    },
-    [onToggle, file.path]
-  );
+  const handleToggle = useCallback(() => {
+    onToggle(file.path);
+  }, [onToggle, file.path]);
 
   const handleClick = useCallback(() => {
     onFileClick(file.path, file.status);
   }, [onFileClick, file.path, file.status]);
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        onFileClick(file.path, file.status);
-      }
-    },
-    [onFileClick, file.path, file.status]
-  );
-
   return (
     <div
-      role="button"
-      tabIndex={0}
       className={cn(
-        "group/stagerow flex items-center text-xs rounded px-1.5 py-1.5 cursor-pointer transition-colors",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent",
+        "group/stagerow flex items-center text-xs rounded px-1.5 py-1.5 transition-colors",
         isStaged ? "bg-status-success/[0.06] hover:bg-status-success/[0.10]" : "hover:bg-tint/5"
       )}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
     >
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
             <button
+              type="button"
               onClick={handleToggle}
               className={cn(
                 "w-5 h-5 flex items-center justify-center rounded shrink-0 mr-2 transition-colors",
@@ -123,19 +104,27 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
         </Tooltip>
       </TooltipProvider>
 
-      <span
-        aria-hidden="true"
+      <button
+        type="button"
+        onClick={handleClick}
+        title={file.path}
+        aria-label={`View diff: ${file.path}`}
         className={cn(
-          "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
-          "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
-          config.bg,
-          config.text
+          "flex min-w-0 flex-1 items-baseline rounded text-left",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-daintree-accent"
         )}
       >
-        {config.label}
-      </span>
-
-      <div className="flex-1 min-w-0 flex items-baseline" title={file.path}>
+        <span
+          aria-hidden="true"
+          className={cn(
+            "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
+            "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
+            config.bg,
+            config.text
+          )}
+        >
+          {config.label}
+        </span>
         {dir && (
           <span className="shrink truncate text-daintree-text/50 group-hover/stagerow:text-daintree-text/70 font-mono text-[11px] transition-colors">
             {dir}/
@@ -144,7 +133,7 @@ export function FileStageRow({ file, isStaged, onToggle, onFileClick }: FileStag
         <span className="shrink truncate text-daintree-text group-hover/stagerow:text-daintree-text font-medium font-mono text-[11px] transition-colors">
           {base}
         </span>
-      </div>
+      </button>
     </div>
   );
 }

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -665,8 +665,8 @@ describe("ReviewHub", () => {
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={onClose} />);
       await waitFor(() => screen.getByText("index.ts"));
 
-      // Click the file row (div[role="button"]) to open its diff (sets selectedFile)
-      const fileRow = screen.getByTitle("src/index.ts").closest("[role='button']")!;
+      // Click the file row button to open its diff (sets selectedFile)
+      const fileRow = screen.getByTitle("src/index.ts");
       fireEvent.click(fileRow);
 
       // First Escape should clear selectedFile, not close modal

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -671,11 +671,11 @@ export const WorktreeCard = React.memo(function WorktreeCard({
           data-resource-status={resourceStatusLabel ?? undefined}
           role="group"
           aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${isActive ? " (selected)" : ""}${worktree.isCurrent ? " (current)" : ""}, Status: ${spineState}${hasChanges ? ", has uncommitted changes" : ""}`}
+          onClick={onSelect}
+          onDoubleClick={handleDoubleClick}
         >
           <button
             type="button"
-            onClick={onSelect}
-            onDoubleClick={handleDoubleClick}
             className={cn(
               "absolute inset-0 z-0",
               variant === "grid" && "rounded-lg",

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -229,9 +229,6 @@ export const WorktreeCard = React.memo(function WorktreeCard({
   const handleDoubleClick = useCallback(
     (e: React.MouseEvent) => {
       if (!canCollapse) return;
-      // Don't toggle when double-clicking interactive elements
-      const target = e.target as HTMLElement;
-      if (target.closest("button, a, [role='menuitem'], input, textarea, select")) return;
       e.stopPropagation();
       toggleWorktreeCollapsed(worktree.id);
     },
@@ -664,27 +661,29 @@ export const WorktreeCard = React.memo(function WorktreeCard({
               "bg-[var(--sidebar-hover-bg,var(--theme-overlay-hover))]",
             isOver &&
               !isActive &&
-              "ring-2 ring-accent-primary bg-accent-primary/10 border-accent-primary/50 transition-colors duration-200",
-            "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2"
+              "ring-2 ring-accent-primary bg-accent-primary/10 border-accent-primary/50 transition-colors duration-200"
           )}
           data-active={isActive && variant === "sidebar" ? "true" : undefined}
           data-hoverable={!isActive && variant === "sidebar" ? "true" : undefined}
           data-hovered={isFocused && !isActive && variant === "sidebar" ? "true" : undefined}
-          onClick={onSelect}
-          onDoubleClick={handleDoubleClick}
-          onKeyDown={(e) => {
-            if ((e.key === "Enter" || e.key === " ") && e.target === e.currentTarget) {
-              e.preventDefault();
-              onSelect();
-            }
-          }}
-          tabIndex={0}
-          role="button"
           data-worktree-branch={branchLabel}
           data-worktree-is-main={isMainWorktree ? "true" : undefined}
           data-resource-status={resourceStatusLabel ?? undefined}
+          role="group"
           aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${isActive ? " (selected)" : ""}${worktree.isCurrent ? " (current)" : ""}, Status: ${spineState}${hasChanges ? ", has uncommitted changes" : ""}`}
         >
+          <button
+            type="button"
+            onClick={onSelect}
+            onDoubleClick={handleDoubleClick}
+            className={cn(
+              "absolute inset-0 z-0",
+              variant === "grid" && "rounded-lg",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-accent-primary focus-visible:outline-offset-2",
+              (isDraggingSort || isWorktreeSortDragging) && "pointer-events-none"
+            )}
+            aria-label={`Select worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}`}
+          />
           {isOver && !isActive && (
             <div
               className={cn(
@@ -727,7 +726,7 @@ export const WorktreeCard = React.memo(function WorktreeCard({
               </TooltipContent>
             </Tooltip>
           )}
-          <div className="flex">
+          <div className="relative z-10 flex">
             {dragHandleListeners && (
               <div
                 ref={dragHandleActivatorRef}

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -139,6 +139,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
       ) : (
         <div className="-m-3 flex items-stretch">
           <div
+            onClick={onToggleExpand}
             className={cn(
               "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
               onOpenReviewHub && hasChanges
@@ -148,7 +149,6 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
           >
             <button
               type="button"
-              onClick={onToggleExpand}
               aria-expanded={false}
               aria-controls={detailsPanelId}
               id={`${detailsId}-button`}

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -139,27 +139,29 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
       ) : (
         <div className="-m-3 flex items-stretch">
           <div
-            onClick={onToggleExpand}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onToggleExpand(e as unknown as React.MouseEvent);
-              }
-            }}
-            role="button"
-            tabIndex={0}
-            aria-expanded={false}
-            aria-controls={detailsPanelId}
             className={cn(
-              "worktree-section-button flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+              "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
               onOpenReviewHub && hasChanges
                 ? "rounded-l-[var(--radius-lg)]"
                 : "rounded-[var(--radius-lg)]"
             )}
-            id={`${detailsId}-button`}
           >
-            <span className="text-xs truncate min-w-0 flex-1">
+            <button
+              type="button"
+              onClick={onToggleExpand}
+              aria-expanded={false}
+              aria-controls={detailsPanelId}
+              id={`${detailsId}-button`}
+              aria-label="Show details"
+              className={cn(
+                "absolute inset-0",
+                onOpenReviewHub && hasChanges
+                  ? "rounded-l-[var(--radius-lg)]"
+                  : "rounded-[var(--radius-lg)]",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
+              )}
+            />
+            <span className="relative z-10 text-xs truncate min-w-0 flex-1 pointer-events-none">
               {isLifecycleRunning && lifecycleLabel ? (
                 <span className="flex items-center gap-1.5 text-text-secondary">
                   <Spinner size="xs" className="shrink-0" />
@@ -255,7 +257,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
 
             {hasResourceConfig &&
               (showResourceResume || showResourcePause || showResourceConnect) && (
-                <span className="ml-1 inline-flex shrink-0 items-center gap-0.5">
+                <span className="relative z-10 ml-1 inline-flex shrink-0 items-center gap-0.5">
                   {showResourceResume && onResourceResume && (
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -312,7 +314,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
 
             <Tooltip>
               <TooltipTrigger asChild>
-                <div className="ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
+                <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
                   <ActivityLight
                     lastActivityTimestamp={worktree.lastActivityTimestamp}
                     className="w-1.5 h-1.5"


### PR DESCRIPTION
## Summary

- Drops `role="button"` from the outer `WorktreeCard` div, makes the container `role="group"`, and adds a stretched real `<button>` for keyboard/screen-reader access with click delegation preserving the full hit area.
- Applies the same stretched-button pattern to `WorktreeDetailsSection` collapsed state (nested Resume/Pause/Connect buttons remain intact and accessible).
- Restructures `FileStageRow` into sibling buttons with click delegation on the row div so the full hit area is preserved without nesting interactives.
- Re-enables the `nested-interactive` axe rule in `e2e/full/core-accessibility.spec.ts` now that the violations are gone.

Resolves #5405

## Changes

- `src/components/Worktree/WorktreeCard.tsx` — wrapper becomes `role="group"`, stretched `<button>` handles primary select action
- `src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx` — same stretched-button pattern for collapsed state
- `src/components/Worktree/ReviewHub/FileStageRow.tsx` — sibling buttons replace nested-interactive structure
- `e2e/full/core-accessibility.spec.ts` — `nested-interactive` rule re-enabled; axe config comment updated
- `src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx` — test query updated to match new button structure

## Testing

Axe `nested-interactive` rule re-enabled and passing. Unit tests updated and green. The stretched-button approach is the standard WAI-ARIA pattern for this kind of card layout and keeps keyboard, screen reader, and pointer access all working correctly.