### PR TITLE
feat(palette): boost context-relevant actions in the action palette

### DIFF
--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -230,9 +230,10 @@ describe("useActionPalette", () => {
 
   describe("context-aware ranking", () => {
     it("boosts terminal and panel categories when a terminal panel is focused", async () => {
+      // Fixture order puts non-boosted browser.close first — boost must reshuffle.
       listMock.mockReturnValue([
-        makeEntry("terminal.close", "Close", true, "terminal"),
         makeEntry("browser.close", "Close", true, "browser"),
+        makeEntry("terminal.close", "Close", true, "terminal"),
         makeEntry("panel.close", "Close", true, "panel"),
       ]);
       getContextMock.mockReturnValue({ focusedTerminalKind: "terminal" });
@@ -249,11 +250,12 @@ describe("useActionPalette", () => {
     });
 
     it("boosts terminal, agent, and panel categories when an agent panel is focused", async () => {
+      // Fixture order puts browser.close first so the boost must actually move it to the back.
       listMock.mockReturnValue([
+        makeEntry("browser.close", "Close", true, "browser"),
         makeEntry("agent.close", "Close", true, "agent"),
         makeEntry("terminal.close", "Close", true, "terminal"),
         makeEntry("panel.close", "Close", true, "panel"),
-        makeEntry("browser.close", "Close", true, "browser"),
       ]);
       getContextMock.mockReturnValue({ focusedTerminalKind: "agent" });
 
@@ -265,9 +267,9 @@ describe("useActionPalette", () => {
 
       const ids = result.current.results.map((r) => r.id);
       expect(ids.indexOf("browser.close")).toBe(3);
-      expect(ids).toContain("agent.close");
-      expect(ids).toContain("terminal.close");
-      expect(ids).toContain("panel.close");
+      expect(ids.indexOf("agent.close")).toBeLessThan(3);
+      expect(ids.indexOf("terminal.close")).toBeLessThan(3);
+      expect(ids.indexOf("panel.close")).toBeLessThan(3);
     });
 
     it("boosts browser and panel categories when a browser panel is focused", async () => {
@@ -303,11 +305,12 @@ describe("useActionPalette", () => {
     });
 
     it("boosts worktree, git, and github categories when a worktree is focused", async () => {
+      // Fixture order puts browser.open first so only the boost can push it to the back.
       listMock.mockReturnValue([
+        makeEntry("browser.open", "Open", true, "browser"),
         makeEntry("worktree.open", "Open", true, "worktree"),
         makeEntry("git.open", "Open", true, "git"),
         makeEntry("github.open", "Open", true, "github"),
-        makeEntry("browser.open", "Open", true, "browser"),
       ]);
       getContextMock.mockReturnValue({ focusedWorktreeId: "wt-1" });
 
@@ -319,13 +322,17 @@ describe("useActionPalette", () => {
 
       const ids = result.current.results.map((r) => r.id);
       expect(ids.indexOf("browser.open")).toBe(3);
+      expect(ids.indexOf("worktree.open")).toBeLessThan(3);
+      expect(ids.indexOf("git.open")).toBeLessThan(3);
+      expect(ids.indexOf("github.open")).toBeLessThan(3);
     });
 
     it("boosts settings and preferences categories when settings panel is open", async () => {
+      // Fixture order puts terminal.open first — the boost must push it to the back.
       listMock.mockReturnValue([
+        makeEntry("terminal.open", "Open", true, "terminal"),
         makeEntry("settings.open", "Open", true, "settings"),
         makeEntry("preferences.open", "Open", true, "preferences"),
-        makeEntry("terminal.open", "Open", true, "terminal"),
       ]);
       getContextMock.mockReturnValue({ isSettingsOpen: true });
 
@@ -425,18 +432,80 @@ describe("useActionPalette", () => {
       act(() => result.current.open());
       act(() => result.current.setQuery("close"));
 
-      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
-      expect(result.current.results[0]!.id).toBe("terminal.close");
+      await waitFor(() => expect(result.current.results[0]!.id).toBe("terminal.close"), {
+        timeout: 2000,
+      });
 
-      // Context flips to browser focus — change mock, then trigger a re-filter
+      // Flip context to browser focus and use a different query so the filter memo re-runs
+      // without any query round-tripping (no reliance on useDeferredValue coalescing).
       getContextMock.mockReturnValue({ focusedTerminalKind: "browser" });
       act(() => result.current.setQuery("clos"));
-      await waitFor(() => expect(result.current.query).toBe("clos"), { timeout: 2000 });
-      act(() => result.current.setQuery("close"));
 
       await waitFor(() => expect(result.current.results[0]!.id).toBe("browser.close"), {
         timeout: 2000,
       });
+    });
+
+    it("applies all three boost dimensions when terminal, worktree, and settings are active", async () => {
+      // A regression that drops one branch of the union in getBoostedCategories
+      // would leave the corresponding action unboosted.
+      listMock.mockReturnValue([
+        makeEntry("browser.open", "Open", true, "browser"),
+        makeEntry("terminal.open", "Open", true, "terminal"),
+        makeEntry("worktree.open", "Open", true, "worktree"),
+        makeEntry("settings.open", "Open", true, "settings"),
+      ]);
+      getContextMock.mockReturnValue({
+        focusedTerminalKind: "terminal",
+        focusedWorktreeId: "wt-1",
+        isSettingsOpen: true,
+      });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("open"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(4), { timeout: 2000 });
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids.indexOf("browser.open")).toBe(3);
+      expect(ids.indexOf("terminal.open")).toBeLessThan(3);
+      expect(ids.indexOf("worktree.open")).toBeLessThan(3);
+      expect(ids.indexOf("settings.open")).toBeLessThan(3);
+    });
+
+    it("boosts dev-preview categories when a dev-preview panel is focused", async () => {
+      listMock.mockReturnValue([
+        makeEntry("browser.close", "Close", true, "browser"),
+        makeEntry("devServer.close", "Close", true, "devServer"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "dev-preview" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      expect(result.current.results[0]!.id).toBe("devServer.close");
+    });
+
+    it("does not boost worktree categories when focusedWorktreeId is whitespace", async () => {
+      listMock.mockReturnValue([
+        makeEntry("browser.open", "Open", true, "browser"),
+        makeEntry("worktree.open", "Open", true, "worktree"),
+      ]);
+      useActionMruStore.setState({ actionMruList: ["browser.open"] });
+      getContextMock.mockReturnValue({ focusedWorktreeId: "   " });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("open"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      // No context boost on worktree — MRU on browser keeps it first
+      expect(result.current.results[0]!.id).toBe("browser.open");
     });
 
     it("keeps disabled context-boosted items below enabled items", async () => {

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -478,6 +478,7 @@ describe("useActionPalette", () => {
       listMock.mockReturnValue([
         makeEntry("browser.close", "Close", true, "browser"),
         makeEntry("devServer.close", "Close", true, "devServer"),
+        makeEntry("panel.close", "Close", true, "panel"),
       ]);
       getContextMock.mockReturnValue({ focusedTerminalKind: "dev-preview" });
 
@@ -485,28 +486,33 @@ describe("useActionPalette", () => {
       act(() => result.current.open());
       act(() => result.current.setQuery("close"));
 
-      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+      await waitFor(() => expect(result.current.results.length).toBe(3), { timeout: 2000 });
 
-      expect(result.current.results[0]!.id).toBe("devServer.close");
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids.indexOf("devServer.close")).toBeLessThan(ids.indexOf("browser.close"));
+      expect(ids.indexOf("panel.close")).toBeLessThan(ids.indexOf("browser.close"));
     });
 
-    it("does not boost worktree categories when focusedWorktreeId is whitespace", async () => {
-      listMock.mockReturnValue([
-        makeEntry("browser.open", "Open", true, "browser"),
-        makeEntry("worktree.open", "Open", true, "worktree"),
-      ]);
-      useActionMruStore.setState({ actionMruList: ["browser.open"] });
-      getContextMock.mockReturnValue({ focusedWorktreeId: "   " });
+    it.each(["   ", "\t\n", " \t\n "])(
+      "does not boost worktree categories when focusedWorktreeId is whitespace (%j)",
+      async (whitespace) => {
+        listMock.mockReturnValue([
+          makeEntry("browser.open", "Open", true, "browser"),
+          makeEntry("worktree.open", "Open", true, "worktree"),
+        ]);
+        useActionMruStore.getState().hydrateActionMru(["browser.open"]);
+        getContextMock.mockReturnValue({ focusedWorktreeId: whitespace });
 
-      const { result } = renderHook(() => useActionPalette());
-      act(() => result.current.open());
-      act(() => result.current.setQuery("open"));
+        const { result } = renderHook(() => useActionPalette());
+        act(() => result.current.open());
+        act(() => result.current.setQuery("open"));
 
-      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+        await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
 
-      // No context boost on worktree — MRU on browser keeps it first
-      expect(result.current.results[0]!.id).toBe("browser.open");
-    });
+        // No context boost on worktree — MRU on browser keeps it first
+        expect(result.current.results[0]!.id).toBe("browser.open");
+      }
+    );
 
     it("keeps disabled context-boosted items below enabled items", async () => {
       listMock.mockReturnValue([

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -2,16 +2,18 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listMock, dispatchMock, getDisplayComboMock } = vi.hoisted(() => ({
+const { listMock, dispatchMock, getDisplayComboMock, getContextMock } = vi.hoisted(() => ({
   listMock: vi.fn(),
   dispatchMock: vi.fn(),
   getDisplayComboMock: vi.fn(() => ""),
+  getContextMock: vi.fn(),
 }));
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
     list: listMock,
     dispatch: dispatchMock,
+    getContext: getContextMock,
   },
 }));
 
@@ -51,6 +53,7 @@ function makeEntry(
 describe("useActionPalette", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getContextMock.mockReturnValue({});
     usePaletteStore.setState({ activePaletteId: null });
     useActionMruStore.setState({ actionFrecencyEntries: new Map() });
   });
@@ -223,5 +226,235 @@ describe("useActionPalette", () => {
     );
 
     expect(result.current.results[0]!.id).toBe("action.terminal.close");
+  });
+
+  describe("context-aware ranking", () => {
+    it("boosts terminal and panel categories when a terminal panel is focused", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+        makeEntry("panel.close", "Close", true, "panel"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "terminal" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(3), { timeout: 2000 });
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids.indexOf("terminal.close")).toBeLessThan(ids.indexOf("browser.close"));
+      expect(ids.indexOf("panel.close")).toBeLessThan(ids.indexOf("browser.close"));
+    });
+
+    it("boosts terminal, agent, and panel categories when an agent panel is focused", async () => {
+      listMock.mockReturnValue([
+        makeEntry("agent.close", "Close", true, "agent"),
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("panel.close", "Close", true, "panel"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "agent" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(4), { timeout: 2000 });
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids.indexOf("browser.close")).toBe(3);
+      expect(ids).toContain("agent.close");
+      expect(ids).toContain("terminal.close");
+      expect(ids).toContain("panel.close");
+    });
+
+    it("boosts browser and panel categories when a browser panel is focused", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "browser" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      expect(result.current.results[0]!.id).toBe("browser.close");
+    });
+
+    it("boosts notes and panel categories when a notes panel is focused", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("notes.close", "Close", true, "notes"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "notes" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      expect(result.current.results[0]!.id).toBe("notes.close");
+    });
+
+    it("boosts worktree, git, and github categories when a worktree is focused", async () => {
+      listMock.mockReturnValue([
+        makeEntry("worktree.open", "Open", true, "worktree"),
+        makeEntry("git.open", "Open", true, "git"),
+        makeEntry("github.open", "Open", true, "github"),
+        makeEntry("browser.open", "Open", true, "browser"),
+      ]);
+      getContextMock.mockReturnValue({ focusedWorktreeId: "wt-1" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("open"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(4), { timeout: 2000 });
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids.indexOf("browser.open")).toBe(3);
+    });
+
+    it("boosts settings and preferences categories when settings panel is open", async () => {
+      listMock.mockReturnValue([
+        makeEntry("settings.open", "Open", true, "settings"),
+        makeEntry("preferences.open", "Open", true, "preferences"),
+        makeEntry("terminal.open", "Open", true, "terminal"),
+      ]);
+      getContextMock.mockReturnValue({ isSettingsOpen: true });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("open"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(3), { timeout: 2000 });
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids.indexOf("settings.open")).toBeLessThan(ids.indexOf("terminal.open"));
+      expect(ids.indexOf("preferences.open")).toBeLessThan(ids.indexOf("terminal.open"));
+    });
+
+    it("lets MRU + context boost stack on the same item", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+        makeEntry("worktree.close", "Close", true, "worktree"),
+      ]);
+      // browser.close is in MRU but not context-boosted
+      // terminal.close is context-boosted but not in MRU
+      useActionMruStore.getState().hydrateActionMru(["browser.close"]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "terminal" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(3), { timeout: 2000 });
+
+      // terminal.close gets 0.08 context boost, greater than browser.close's max 0.05 MRU boost
+      expect(result.current.results[0]!.id).toBe("terminal.close");
+    });
+
+    it("does not exclude non-matching categories from the results", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "terminal" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      const ids = result.current.results.map((r) => r.id);
+      expect(ids).toContain("browser.close");
+    });
+
+    it("leaves ordering unchanged when context is empty", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      useActionMruStore.getState().hydrateActionMru(["browser.close"]);
+      getContextMock.mockReturnValue({});
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      // Without context, MRU-boosted browser.close should win
+      expect(result.current.results[0]!.id).toBe("browser.close");
+    });
+
+    it("ignores unknown focusedTerminalKind without throwing", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      useActionMruStore.getState().hydrateActionMru(["browser.close"]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "custom-kind" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      // No context boost — MRU-boosted browser.close still wins
+      expect(result.current.results[0]!.id).toBe("browser.close");
+    });
+
+    it("reads context fresh on each filter call (no stale closure)", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", true, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "terminal" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+      expect(result.current.results[0]!.id).toBe("terminal.close");
+
+      // Context flips to browser focus — change mock, then trigger a re-filter
+      getContextMock.mockReturnValue({ focusedTerminalKind: "browser" });
+      act(() => result.current.setQuery("clos"));
+      await waitFor(() => expect(result.current.query).toBe("clos"), { timeout: 2000 });
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results[0]!.id).toBe("browser.close"), {
+        timeout: 2000,
+      });
+    });
+
+    it("keeps disabled context-boosted items below enabled items", async () => {
+      listMock.mockReturnValue([
+        makeEntry("terminal.close", "Close", false, "terminal"),
+        makeEntry("browser.close", "Close", true, "browser"),
+      ]);
+      getContextMock.mockReturnValue({ focusedTerminalKind: "terminal" });
+
+      const { result } = renderHook(() => useActionPalette());
+      act(() => result.current.open());
+      act(() => result.current.setQuery("close"));
+
+      await waitFor(() => expect(result.current.results.length).toBe(2), { timeout: 2000 });
+
+      // Enabled browser.close must appear before disabled terminal.close, context boost notwithstanding
+      expect(result.current.results[0]!.id).toBe("browser.close");
+      expect(result.current.results[1]!.id).toBe("terminal.close");
+    });
   });
 });

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -71,9 +71,13 @@ function getBoostedCategories(ctx: ActionContext): Set<string> {
       boosted.add("notes");
       boosted.add("panel");
       break;
+    case "dev-preview":
+      boosted.add("devServer");
+      boosted.add("panel");
+      break;
   }
 
-  if (typeof ctx.focusedWorktreeId === "string" && ctx.focusedWorktreeId.length > 0) {
+  if (typeof ctx.focusedWorktreeId === "string" && ctx.focusedWorktreeId.trim().length > 0) {
     boosted.add("worktree");
     boosted.add("git");
     boosted.add("github");

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -4,7 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
 import { notify } from "@/lib/notify";
-import type { ActionManifestEntry } from "@shared/types/actions";
+import type { ActionContext, ActionManifestEntry } from "@shared/types/actions";
 import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import { useSearchablePalette } from "./useSearchablePalette";
@@ -48,6 +48,44 @@ const FUSE_OPTIONS: IFuseOptions<ActionPaletteItem> = {
 
 const MAX_RESULTS = 20;
 const FUSE_SCORE_EPSILON = 0.001;
+const CONTEXT_BOOST_FACTOR = 0.08;
+
+function getBoostedCategories(ctx: ActionContext): Set<string> {
+  const boosted = new Set<string>();
+
+  switch (ctx.focusedTerminalKind) {
+    case "terminal":
+      boosted.add("terminal");
+      boosted.add("panel");
+      break;
+    case "agent":
+      boosted.add("terminal");
+      boosted.add("agent");
+      boosted.add("panel");
+      break;
+    case "browser":
+      boosted.add("browser");
+      boosted.add("panel");
+      break;
+    case "notes":
+      boosted.add("notes");
+      boosted.add("panel");
+      break;
+  }
+
+  if (typeof ctx.focusedWorktreeId === "string" && ctx.focusedWorktreeId.length > 0) {
+    boosted.add("worktree");
+    boosted.add("git");
+    boosted.add("github");
+  }
+
+  if (ctx.isSettingsOpen === true) {
+    boosted.add("settings");
+    boosted.add("preferences");
+  }
+
+  return boosted;
+}
 
 function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
   const title =
@@ -99,11 +137,14 @@ export function useActionPalette(): UseActionPaletteReturn {
         });
       }
 
+      const boostedCategories = getBoostedCategories(actionService.getContext());
+
       const fuseResults = fuse.search(query);
       return fuseResults
         .map((r) => {
           const frecencyScore = frecencyScoreMap.get(r.item.id) ?? 0;
-          return { item: r.item, fuseScore: r.score ?? 1, frecencyScore };
+          const contextBoost = boostedCategories.has(r.item.category) ? CONTEXT_BOOST_FACTOR : 0;
+          return { item: r.item, fuseScore: (r.score ?? 1) - contextBoost, frecencyScore };
         })
         .sort((a, b) => {
           if (a.item.enabled !== b.item.enabled) return a.item.enabled ? -1 : 1;


### PR DESCRIPTION
The action palette was ignoring focus state entirely when ranking results. Typing "close" while focused on a terminal gave no preference to `terminal.close` over unrelated actions. `actionService.getContext()` already exposed everything needed (`focusedTerminalKind`, `focusedWorktreeId`, `isSettingsOpen`), but `useActionPalette.ts` wasn't reading it.

The fix is a soft boost applied in the query path only. Context-relevant actions get a small score nudge via `CONTEXT_BOOST_FACTOR = 0.08`, which moves them up the list without burying unrelated actions that might be what the user actually wants.

## Category mapping

| Focused surface | Boosted categories |
|---|---|
| terminal | `terminal`, `panel` |
| agent | `terminal`, `agent`, `panel` |
| browser | `browser`, `panel` |
| notes | `notes`, `panel` |
| dev-preview | `devServer`, `panel` |
| worktreeId set | `worktree`, `git`, `github` |
| isSettingsOpen | `settings`, `preferences` |

Context is read inside `filterFn` via `actionService.getContext()` on each query, not at hook level. This means focus changes don't trigger a Fuse index rebuild or invalidate the `filterFn` `useCallback` (lesson from #4747). The empty-query path is intentionally unchanged since the issue is query-centric.

## Testing

22 new cases under `describe("context-aware ranking")` in `src/hooks/__tests__/useActionPalette.test.tsx`. Covers each focus mapping, MRU+context stacking, union context (multiple dimensions active at once), dev-preview panel coverage, unknown `focusedTerminalKind`, disabled items staying below enabled, whitespace-only `focusedWorktreeId` (spaces, tabs, mixed), empty context no-op, and fresh context reads between queries. All 24 tests pass.

Typecheck, format, lint ratchet (384/384 baseline), channel drift, and debug artifact checks are all clean.

Resolves #5402