### PR TITLE
fix(reviewhub): surface merge/rebase/cherry-pick/revert conflict state

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -287,8 +287,14 @@
     "error": 0,
     "pipeline": 0
   },
-  "src/components/Fleet/FleetArmingRibbon.tsx": {
+  "src/components/Fleet/ClusterAttentionPill.tsx": {
     "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Fleet/FleetArmingRibbon.tsx": {
+    "success": 2,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -747,6 +753,12 @@
     "success": 0,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Project/ProjectMruSwitcherOverlay.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/components/Project/ProjectNotificationsTab.tsx": {
@@ -1517,6 +1529,12 @@
     "error": 2,
     "pipeline": 0
   },
+  "src/components/Worktree/ReviewHub/ConflictPanel.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 3,
+    "pipeline": 0
+  },
   "src/components/Worktree/ReviewHub/FileStageRow.tsx": {
     "success": 1,
     "skip": 0,
@@ -2111,6 +2129,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/hooks/app/useContextFilesOffer.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/hooks/app/useCrashRecoveryGate.ts": {
     "success": 1,
     "skip": 0,
@@ -2193,6 +2217,12 @@
     "success": 0,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/hooks/useAgentClusters.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/hooks/useAgentLauncher.ts": {
@@ -2469,6 +2499,12 @@
     "success": 0,
     "skip": 0,
     "error": 1,
+    "pipeline": 0
+  },
+  "src/hooks/useProjectMruSwitcher.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
     "pipeline": 0
   },
   "src/hooks/useProjectSettings.ts": {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -296,6 +296,8 @@ export const CHANNELS = {
   GIT_SNAPSHOT_LIST: "git:snapshot-list",
   GIT_SNAPSHOT_REVERT: "git:snapshot-revert",
   GIT_SNAPSHOT_DELETE: "git:snapshot-delete",
+  GIT_ABORT_REPOSITORY_OPERATION: "git:abort-repository-operation",
+  GIT_CONTINUE_REPOSITORY_OPERATION: "git:continue-repository-operation",
 
   PORTAL_CREATE: "portal:create",
   PORTAL_SHOW: "portal:show",

--- a/electron/ipc/handlers/__tests__/gitRepoState.test.ts
+++ b/electron/ipc/handlers/__tests__/gitRepoState.test.ts
@@ -82,6 +82,15 @@ describe("parsePorcelainV2Conflicts", () => {
     expect(result).toEqual([{ path: "ok.ts", xy: "UU", label: "both modified" }]);
   });
 
+  it("passes literal UTF-8 paths through unchanged (core.quotepath=false)", () => {
+    // With core.quotepath=false the path is emitted literally (bytes as UTF-8),
+    // not C-quoted. Regression guard for the quoted-path issue surfaced in
+    // review: ensure the parser preserves non-ASCII bytes verbatim.
+    const line = "u UU N... 100644 100644 100644 100644 a b c src/café.txt";
+    const result = parsePorcelainV2Conflicts(line);
+    expect(result).toEqual([{ path: "src/café.txt", xy: "UU", label: "both modified" }]);
+  });
+
   it("parses multiple entries across many lines", () => {
     const input = [
       "# branch.oid abc",

--- a/electron/ipc/handlers/__tests__/gitRepoState.test.ts
+++ b/electron/ipc/handlers/__tests__/gitRepoState.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+vi.mock("../../../store.js", () => ({
+  store: { get: vi.fn().mockReturnValue({}), set: vi.fn() },
+}));
+
+vi.mock("../../../services/SoundService.js", () => ({
+  soundService: { play: vi.fn() },
+}));
+
+vi.mock("../../../services/PreAgentSnapshotService.js", () => ({
+  preAgentSnapshotService: {
+    getSnapshot: vi.fn(),
+    listSnapshots: vi.fn(),
+    revertToSnapshot: vi.fn(),
+    deleteSnapshot: vi.fn(),
+  },
+}));
+
+import { parsePorcelainV2Conflicts } from "../git-write.js";
+
+describe("parsePorcelainV2Conflicts", () => {
+  it("returns an empty list for empty input", () => {
+    expect(parsePorcelainV2Conflicts("")).toEqual([]);
+  });
+
+  it("ignores non-u lines (headers, 1/2 entries)", () => {
+    const input = [
+      "# branch.oid abc123",
+      "# branch.head main",
+      "1 .M N... 100644 100644 100644 aaa bbb src/other.ts",
+      "2 R. N... 100644 100644 100644 aaa bbb src/new.ts\tsrc/old.ts",
+    ].join("\n");
+    expect(parsePorcelainV2Conflicts(input)).toEqual([]);
+  });
+
+  it("parses a single both-modified unmerged entry", () => {
+    const line = "u UU N... 100644 100644 100644 100644 aaa bbb ccc src/file.ts";
+    const result = parsePorcelainV2Conflicts(line);
+    expect(result).toEqual([{ path: "src/file.ts", xy: "UU", label: "both modified" }]);
+  });
+
+  it("maps all known XY codes to human labels", () => {
+    const codes: Array<[string, string]> = [
+      ["UU", "both modified"],
+      ["AA", "both added"],
+      ["DD", "both deleted"],
+      ["AU", "added by us"],
+      ["UA", "added by them"],
+      ["DU", "deleted by us"],
+      ["UD", "deleted by them"],
+    ];
+    const input = codes
+      .map(([xy], i) => `u ${xy} N... 100644 100644 100644 100644 a b c path${i}.ts`)
+      .join("\n");
+    const result = parsePorcelainV2Conflicts(input);
+    expect(result.map((r) => [r.xy, r.label])).toEqual(codes);
+  });
+
+  it("preserves unknown XY codes as the label fallback", () => {
+    const line = "u ZZ N... 100644 100644 100644 100644 a b c weird.ts";
+    const result = parsePorcelainV2Conflicts(line);
+    expect(result).toEqual([{ path: "weird.ts", xy: "ZZ", label: "ZZ" }]);
+  });
+
+  it("handles filenames containing spaces", () => {
+    const line = "u UU N... 100644 100644 100644 100644 a b c src/file with spaces.ts";
+    const result = parsePorcelainV2Conflicts(line);
+    expect(result).toEqual([{ path: "src/file with spaces.ts", xy: "UU", label: "both modified" }]);
+  });
+
+  it("skips malformed u lines with too few fields", () => {
+    const lines = ["u UU short", "u UU N... 100644 100644 100644 100644 a b c ok.ts"].join("\n");
+    const result = parsePorcelainV2Conflicts(lines);
+    expect(result).toEqual([{ path: "ok.ts", xy: "UU", label: "both modified" }]);
+  });
+
+  it("parses multiple entries across many lines", () => {
+    const input = [
+      "# branch.oid abc",
+      "1 .M N... 100644 100644 100644 aaa bbb src/a.ts",
+      "u UU N... 100644 100644 100644 100644 a b c src/b.ts",
+      "u AA N... 100644 100644 100644 100644 a b c src/c.ts",
+      "",
+    ].join("\n");
+    const result = parsePorcelainV2Conflicts(input);
+    expect(result.map((r) => r.path)).toEqual(["src/b.ts", "src/c.ts"]);
+  });
+});

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -1,7 +1,15 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { SimpleGit } from "simple-git";
 import { CHANNELS } from "../channels.js";
 import { checkRateLimit, typedHandle } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
-import type { GitStatus } from "../../../shared/types/git.js";
+import type {
+  ConflictedFileEntry,
+  GitStatus,
+  RepoState,
+  StagingStatus,
+} from "../../../shared/types/git.js";
 import { validateCwd, createHardenedGit, createAuthenticatedGit } from "../../utils/hardenedGit.js";
 import { store } from "../../store.js";
 import { soundService } from "../../services/SoundService.js";
@@ -20,13 +28,112 @@ interface StagingFileEntry {
   deletions: number | null;
 }
 
-export interface StagingStatus {
-  staged: StagingFileEntry[];
-  unstaged: StagingFileEntry[];
-  conflicted: string[];
-  isDetachedHead: boolean;
-  currentBranch: string | null;
-  hasRemote: boolean;
+const CONFLICT_LABELS: Record<string, string> = {
+  UU: "both modified",
+  AA: "both added",
+  DD: "both deleted",
+  AU: "added by us",
+  UA: "added by them",
+  DU: "deleted by us",
+  UD: "deleted by them",
+};
+
+async function pathExists(p: string): Promise<boolean> {
+  return fs.promises
+    .access(p)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function readTextOrNull(p: string): Promise<string | null> {
+  return fs.promises.readFile(p, "utf8").catch(() => null);
+}
+
+async function resolveGitDir(git: SimpleGit, cwd: string): Promise<string> {
+  const raw = (await git.revparse(["--git-dir"])).trim();
+  return path.isAbsolute(raw) ? raw : path.resolve(cwd, raw);
+}
+
+interface RepoOperationState {
+  state: RepoState;
+  rebaseStep: number | null;
+  rebaseTotalSteps: number | null;
+}
+
+async function detectRepoOperationState(
+  gitDir: string,
+  hasUnmerged: boolean
+): Promise<RepoOperationState> {
+  const [hasMergeHead, hasRebaseMerge, hasRebaseApply, hasCherryPickHead, hasRevertHead] =
+    await Promise.all([
+      pathExists(path.join(gitDir, "MERGE_HEAD")),
+      pathExists(path.join(gitDir, "rebase-merge")),
+      pathExists(path.join(gitDir, "rebase-apply")),
+      pathExists(path.join(gitDir, "CHERRY_PICK_HEAD")),
+      pathExists(path.join(gitDir, "REVERT_HEAD")),
+    ]);
+
+  // REBASING takes precedence: during rebase conflict, MERGE_HEAD may also appear.
+  if (hasRebaseMerge || hasRebaseApply) {
+    const { step, total } = await readRebaseProgress(gitDir, hasRebaseMerge ? "merge" : "apply");
+    return { state: "REBASING", rebaseStep: step, rebaseTotalSteps: total };
+  }
+  if (hasCherryPickHead) {
+    return { state: "CHERRY_PICKING", rebaseStep: null, rebaseTotalSteps: null };
+  }
+  if (hasRevertHead) {
+    return { state: "REVERTING", rebaseStep: null, rebaseTotalSteps: null };
+  }
+  if (hasMergeHead) {
+    return { state: "MERGING", rebaseStep: null, rebaseTotalSteps: null };
+  }
+  return {
+    state: hasUnmerged ? "DIRTY" : "CLEAN",
+    rebaseStep: null,
+    rebaseTotalSteps: null,
+  };
+}
+
+async function readRebaseProgress(
+  gitDir: string,
+  backend: "merge" | "apply"
+): Promise<{ step: number | null; total: number | null }> {
+  const dir = path.join(gitDir, backend === "merge" ? "rebase-merge" : "rebase-apply");
+  const [stepRaw, totalRaw] = await Promise.all([
+    readTextOrNull(path.join(dir, backend === "merge" ? "msgnum" : "next")),
+    readTextOrNull(path.join(dir, backend === "merge" ? "end" : "last")),
+  ]);
+  const toInt = (raw: string | null): number | null => {
+    if (raw == null) return null;
+    const n = Number.parseInt(raw.trim(), 10);
+    return Number.isFinite(n) ? n : null;
+  };
+  return { step: toInt(stepRaw), total: toInt(totalRaw) };
+}
+
+/**
+ * Parse `u` lines from `git status --porcelain=v2` (no `-z`) into conflict
+ * entries. Each u-line has the form:
+ *   `u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>`
+ */
+export function parsePorcelainV2Conflicts(raw: string): ConflictedFileEntry[] {
+  const entries: ConflictedFileEntry[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.startsWith("u ")) continue;
+    // Ten whitespace-separated fields before the path; the path itself may
+    // contain spaces, so split with a small limit and rejoin the tail.
+    const parts = line.split(" ");
+    if (parts.length < 11) continue;
+    const xy = parts[1] ?? "";
+    const filePath = parts.slice(10).join(" ");
+    if (!filePath) continue;
+    entries.push({
+      path: filePath,
+      xy,
+      label: CONFLICT_LABELS[xy] ?? xy,
+    });
+  }
+  return entries;
 }
 
 export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void {
@@ -265,9 +372,113 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       // no remotes
     }
 
-    return { staged, unstaged, conflicted, isDetachedHead, currentBranch, hasRemote };
+    let conflictedFiles: ConflictedFileEntry[] = [];
+    if (conflicted.length > 0) {
+      try {
+        const porcelain = await git.raw(["status", "--porcelain=v2"]);
+        conflictedFiles = parsePorcelainV2Conflicts(porcelain);
+      } catch {
+        // Fall back to the simple-git path list without XY labels.
+      }
+      if (conflictedFiles.length === 0) {
+        conflictedFiles = conflicted.map((p) => ({ path: p, xy: "UU", label: "conflicted" }));
+      }
+    }
+
+    let repoState: RepoState = conflicted.length > 0 ? "DIRTY" : "CLEAN";
+    let rebaseStep: number | null = null;
+    let rebaseTotalSteps: number | null = null;
+    try {
+      const gitDir = await resolveGitDir(git, cwd);
+      const detected = await detectRepoOperationState(gitDir, conflicted.length > 0);
+      repoState = detected.state;
+      rebaseStep = detected.rebaseStep;
+      rebaseTotalSteps = detected.rebaseTotalSteps;
+    } catch {
+      // If git-dir resolution fails, fall back to CLEAN/DIRTY from index alone.
+    }
+
+    return {
+      staged,
+      unstaged,
+      conflicted,
+      conflictedFiles,
+      isDetachedHead,
+      currentBranch,
+      hasRemote,
+      repoState,
+      rebaseStep,
+      rebaseTotalSteps,
+    };
   };
   handlers.push(typedHandle(CHANNELS.GIT_GET_STAGING_STATUS, handleGetStagingStatus));
+
+  const withNonInteractiveEnv = (git: SimpleGit): SimpleGit =>
+    git.env({
+      ...process.env,
+      GIT_EDITOR: "true",
+      GIT_MERGE_AUTOEDIT: "no",
+      GIT_TERMINAL_PROMPT: "0",
+    });
+
+  const handleAbortRepositoryOperation = async (cwd: string): Promise<void> => {
+    checkRateLimit(CHANNELS.GIT_ABORT_REPOSITORY_OPERATION, 5, 10_000);
+    validateCwd(cwd);
+
+    const git = createHardenedGit(cwd);
+    const gitDir = await resolveGitDir(git, cwd);
+    const { state } = await detectRepoOperationState(gitDir, false);
+
+    switch (state) {
+      case "MERGING":
+        await git.merge(["--abort"]);
+        return;
+      case "REBASING":
+        await git.rebase(["--abort"]);
+        return;
+      case "CHERRY_PICKING":
+        await git.raw(["cherry-pick", "--abort"]);
+        return;
+      case "REVERTING":
+        await git.raw(["revert", "--abort"]);
+        return;
+      default:
+        throw new Error("No merge, rebase, cherry-pick, or revert operation is in progress");
+    }
+  };
+  handlers.push(
+    typedHandle(CHANNELS.GIT_ABORT_REPOSITORY_OPERATION, handleAbortRepositoryOperation)
+  );
+
+  const handleContinueRepositoryOperation = async (cwd: string): Promise<void> => {
+    checkRateLimit(CHANNELS.GIT_CONTINUE_REPOSITORY_OPERATION, 5, 10_000);
+    validateCwd(cwd);
+
+    const git = withNonInteractiveEnv(createHardenedGit(cwd));
+    const gitDir = await resolveGitDir(git, cwd);
+    const { state } = await detectRepoOperationState(gitDir, false);
+
+    switch (state) {
+      case "MERGING":
+        await git.merge(["--continue", "--no-edit"]);
+        return;
+      case "REBASING":
+        // `git rebase --continue` has no `--no-edit`; the env overlay covers it.
+        await git.rebase(["--continue"]);
+        return;
+      case "CHERRY_PICKING":
+        await git.raw(["cherry-pick", "--continue", "--no-edit"]);
+        return;
+      case "REVERTING":
+        await git.raw(["revert", "--continue", "--no-edit"]);
+        return;
+      default:
+        throw new Error("No merge, rebase, cherry-pick, or revert operation is in progress");
+    }
+  };
+  handlers.push(
+    typedHandle(CHANNELS.GIT_CONTINUE_REPOSITORY_OPERATION, handleContinueRepositoryOperation)
+  );
 
   const DIFF_LINE_LIMIT = 500;
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2097,6 +2097,12 @@ const api: ElectronAPI = {
 
     getStagingStatus: (cwd: string) => _unwrappingInvoke(CHANNELS.GIT_GET_STAGING_STATUS, cwd),
 
+    abortRepositoryOperation: (cwd: string) =>
+      _unwrappingInvoke(CHANNELS.GIT_ABORT_REPOSITORY_OPERATION, cwd),
+
+    continueRepositoryOperation: (cwd: string) =>
+      _unwrappingInvoke(CHANNELS.GIT_CONTINUE_REPOSITORY_OPERATION, cwd),
+
     compareWorktrees: (
       cwd: string,
       branch1: string,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -815,6 +815,8 @@ const CHANNELS = {
   GIT_SNAPSHOT_LIST: "git:snapshot-list",
   GIT_SNAPSHOT_REVERT: "git:snapshot-revert",
   GIT_SNAPSHOT_DELETE: "git:snapshot-delete",
+  GIT_ABORT_REPOSITORY_OPERATION: "git:abort-repository-operation",
+  GIT_CONTINUE_REPOSITORY_OPERATION: "git:continue-repository-operation",
 
   // Portal channels
   PORTAL_CREATE: "portal:create",

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -135,6 +135,7 @@ describe("createHardenedGit", () => {
       "core.sshCommand=",
       "core.gitProxy=",
       "core.hooksPath=",
+      "core.quotepath=false",
     ];
     for (const key of expectedKeys) {
       expect(options.config).toContain(key);
@@ -318,6 +319,7 @@ describe("config constants", () => {
       "protocol.ext.allow=never",
       "core.gitProxy=",
       "core.hooksPath=",
+      "core.quotepath=false",
     ];
     for (const entry of securityEntries) {
       expect(HARDENED_GIT_CONFIG).toContain(entry);

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -9,6 +9,10 @@ const SAFE_GIT_CONFIG = [
   "protocol.ext.allow=never",
   "core.gitProxy=",
   "core.hooksPath=",
+  // Emit literal UTF-8 paths in porcelain/status output so non-ASCII filenames
+  // flow through to IPC consumers unquoted (e.g. conflict detection on
+  // `café.txt` would otherwise be returned as `"caf\303\251.txt"`).
+  "core.quotepath=false",
 ] as const;
 
 /**

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -60,11 +60,39 @@ export interface StagingFileEntry {
   deletions: number | null;
 }
 
+/**
+ * In-progress repository operation state. `CLEAN` means no operation markers
+ * and no unmerged entries; `DIRTY` means unmerged entries exist without an
+ * operation marker (unusual). `MERGING`/`REBASING`/`CHERRY_PICKING`/`REVERTING`
+ * correspond to the matching `.git/` state files.
+ */
+export type RepoState = "CLEAN" | "DIRTY" | "MERGING" | "REBASING" | "CHERRY_PICKING" | "REVERTING";
+
+/** XY code from `git status --porcelain=v2` unmerged (`u`) entries. */
+export type ConflictXYCode = "UU" | "AA" | "DD" | "AU" | "UA" | "DU" | "UD";
+
+export interface ConflictedFileEntry {
+  path: string;
+  /** The two-letter unmerged code (e.g. `UU`). Unknown codes are passed through as-is. */
+  xy: string;
+  /** Human-readable label derived from the XY code (e.g. "both modified"). */
+  label: string;
+}
+
 export interface StagingStatus {
   staged: StagingFileEntry[];
   unstaged: StagingFileEntry[];
+  /** @deprecated Use `conflictedFiles` for richer per-file details. Kept for backward compat. */
   conflicted: string[];
+  /** Per-file conflict entries parsed from `git status --porcelain=v2` u-lines. */
+  conflictedFiles: ConflictedFileEntry[];
   isDetachedHead: boolean;
   currentBranch: string | null;
   hasRemote: boolean;
+  /** Current in-progress repository operation, or `CLEAN`/`DIRTY`. */
+  repoState: RepoState;
+  /** When `repoState === "REBASING"`, the current step number (1-based). Null otherwise. */
+  rebaseStep: number | null;
+  /** When `repoState === "REBASING"`, the total step count. Null otherwise. */
+  rebaseTotalSteps: number | null;
 }

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -12,6 +12,9 @@ export type {
   WorktreeChanges,
   StagingFileEntry,
   StagingStatus,
+  RepoState,
+  ConflictXYCode,
+  ConflictedFileEntry,
 } from "./git.js";
 
 // Worktree types

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -761,6 +761,8 @@ export interface ElectronAPI {
       recoveryAction?: RecoveryAction;
     }>;
     getStagingStatus(cwd: string): Promise<StagingStatus>;
+    abortRepositoryOperation(cwd: string): Promise<void>;
+    continueRepositoryOperation(cwd: string): Promise<void>;
     compareWorktrees(
       cwd: string,
       branch1: string,

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1073,6 +1073,14 @@ export interface IpcInvokeMap {
     args: [cwd: string];
     result: StagingStatus;
   };
+  "git:abort-repository-operation": {
+    args: [cwd: string];
+    result: void;
+  };
+  "git:continue-repository-operation": {
+    args: [cwd: string];
+    result: void;
+  };
   "git:compare-worktrees": {
     args: [payload: GitCompareWorktreesPayload];
     result: CrossWorktreeDiffResult | string;

--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useMemo, useState } from "react";
+import type { RepoState, StagingStatus } from "@shared/types";
+import { cn } from "@/lib/utils";
+import {
+  AlertTriangle,
+  Check,
+  ExternalLink,
+  FileIcon,
+  GitMerge,
+  Play,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Spinner } from "@/components/ui/Spinner";
+
+const OPERATION_LABEL: Record<Exclude<RepoState, "CLEAN" | "DIRTY">, string> = {
+  MERGING: "Merge",
+  REBASING: "Rebase",
+  CHERRY_PICKING: "Cherry-pick",
+  REVERTING: "Revert",
+};
+
+const ABORT_DESCRIPTION: Record<Exclude<RepoState, "CLEAN" | "DIRTY">, string> = {
+  MERGING: "Discards the in-progress merge and restores the working tree to its pre-merge state.",
+  REBASING:
+    "Discards the in-progress rebase, including any commits already replayed, and returns HEAD to the original branch tip.",
+  CHERRY_PICKING:
+    "Discards the in-progress cherry-pick and restores the working tree to the state before the operation started.",
+  REVERTING:
+    "Discards the in-progress revert and restores the working tree to the state before the operation started.",
+};
+
+interface ConflictPanelProps {
+  status: StagingStatus;
+  onMarkResolved: (filePath: string) => Promise<void> | void;
+  onOpenInEditor: (filePath: string) => Promise<void> | void;
+  onAbort: () => Promise<void>;
+  onContinue: () => Promise<void>;
+}
+
+function splitPath(filePath: string): { dir: string; base: string } {
+  const normalized = filePath.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash === -1) return { dir: "", base: normalized };
+  return { dir: normalized.slice(0, lastSlash), base: normalized.slice(lastSlash + 1) };
+}
+
+export function ConflictPanel({
+  status,
+  onMarkResolved,
+  onOpenInEditor,
+  onAbort,
+  onContinue,
+}: ConflictPanelProps) {
+  const [isAbortOpen, setIsAbortOpen] = useState(false);
+  const [isAborting, setIsAborting] = useState(false);
+  const [isContinuing, setIsContinuing] = useState(false);
+  const [busyFile, setBusyFile] = useState<string | null>(null);
+
+  const operationState = status.repoState;
+  const operationLabel = useMemo(() => {
+    if (
+      operationState === "MERGING" ||
+      operationState === "REBASING" ||
+      operationState === "CHERRY_PICKING" ||
+      operationState === "REVERTING"
+    ) {
+      return OPERATION_LABEL[operationState];
+    }
+    return "Operation";
+  }, [operationState]);
+
+  const conflictCount = status.conflictedFiles.length;
+  const canContinue = conflictCount === 0;
+  const hasStagedResolutions = status.staged.length > 0;
+
+  const handleAbort = useCallback(async () => {
+    setIsAborting(true);
+    try {
+      await onAbort();
+      setIsAbortOpen(false);
+    } finally {
+      setIsAborting(false);
+    }
+  }, [onAbort]);
+
+  const handleContinue = useCallback(async () => {
+    setIsContinuing(true);
+    try {
+      await onContinue();
+    } finally {
+      setIsContinuing(false);
+    }
+  }, [onContinue]);
+
+  const handleMarkResolvedClick = useCallback(
+    async (filePath: string) => {
+      setBusyFile(filePath);
+      try {
+        await onMarkResolved(filePath);
+      } finally {
+        setBusyFile((current) => (current === filePath ? null : current));
+      }
+    },
+    [onMarkResolved]
+  );
+
+  return (
+    <div data-testid="conflict-panel">
+      {/* Banner */}
+      <div className="px-4 py-3 bg-status-warning/10 border-b border-divider flex items-start gap-2">
+        <GitMerge className="w-4 h-4 text-status-warning mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-daintree-text">
+              Resolve {operationLabel} Conflicts
+            </span>
+            {operationState === "REBASING" &&
+              status.rebaseStep != null &&
+              status.rebaseTotalSteps != null && (
+                <span
+                  className="text-[11px] tabular-nums text-daintree-text/70 bg-tint/[0.08] border border-tint/[0.08] rounded px-1.5 py-0.5"
+                  data-testid="conflict-rebase-progress"
+                >
+                  Step {status.rebaseStep} of {status.rebaseTotalSteps}
+                </span>
+              )}
+          </div>
+          <p className="text-xs text-daintree-text/60 mt-0.5">
+            {conflictCount > 0
+              ? `${conflictCount} conflicted file${conflictCount !== 1 ? "s" : ""} — resolve each, then continue.`
+              : hasStagedResolutions
+                ? "All conflicts resolved. Continue to finish the operation."
+                : "No conflicts remaining. Continue to finish the operation."}
+          </p>
+        </div>
+      </div>
+
+      {/* Conflicted files */}
+      <div className="border-b border-divider">
+        <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            Conflicted
+            <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+              {conflictCount}
+            </span>
+          </span>
+        </div>
+        {conflictCount > 0 ? (
+          <ul className="px-2 py-1 flex flex-col gap-0.5" role="list">
+            {status.conflictedFiles.map((file) => {
+              const { dir, base } = splitPath(file.path);
+              const isBusy = busyFile === file.path;
+              return (
+                <li
+                  key={`conflict-${file.path}`}
+                  className={cn(
+                    "flex items-center gap-2 px-2 py-1.5 rounded text-xs",
+                    "hover:bg-tint/5 transition-colors"
+                  )}
+                >
+                  <AlertTriangle className="w-3 h-3 shrink-0 text-status-error" />
+                  <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
+                  <div
+                    className="flex-1 min-w-0 flex items-baseline"
+                    title={`${file.path} (${file.label})`}
+                  >
+                    {dir && (
+                      <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
+                        {dir}/
+                      </span>
+                    )}
+                    <span className="shrink truncate text-daintree-text font-medium font-mono text-[11px]">
+                      {base}
+                    </span>
+                    <span className="ml-2 text-[10px] uppercase tracking-wider text-daintree-text/50 font-mono">
+                      {file.label}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void onOpenInEditor(file.path)}
+                      disabled={isBusy}
+                      className="h-5 px-1.5 text-[10px]"
+                      aria-label={`Open ${file.path} in external editor`}
+                    >
+                      <ExternalLink className="w-3 h-3 mr-1" />
+                      Open
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void handleMarkResolvedClick(file.path)}
+                      disabled={isBusy}
+                      className="h-5 px-1.5 text-[10px]"
+                      aria-label={`Mark ${file.path} as resolved`}
+                    >
+                      {isBusy ? (
+                        <Spinner size="sm" className="mr-1" />
+                      ) : (
+                        <Check className="w-3 h-3 mr-1" />
+                      )}
+                      Mark resolved
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <div className="px-4 py-3 text-xs text-daintree-text/60">No conflicted files remain.</div>
+        )}
+      </div>
+
+      {/* Staged resolutions (informational) */}
+      {hasStagedResolutions && (
+        <div className="border-b border-divider">
+          <div className="px-4 py-2 bg-overlay-subtle">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+              Resolved (staged)
+              <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
+                {status.staged.length}
+              </span>
+            </span>
+          </div>
+          <ul className="px-2 py-1 flex flex-col gap-0.5" role="list">
+            {status.staged.map((file) => {
+              const { dir, base } = splitPath(file.path);
+              return (
+                <li
+                  key={`resolved-${file.path}`}
+                  className="flex items-center gap-2 px-2 py-1 text-xs"
+                >
+                  <Check className="w-3 h-3 shrink-0 text-status-success" />
+                  <div className="flex-1 min-w-0 flex items-baseline" title={file.path}>
+                    {dir && (
+                      <span className="shrink truncate text-daintree-text/50 font-mono text-[11px]">
+                        {dir}/
+                      </span>
+                    )}
+                    <span className="shrink truncate text-daintree-text/80 font-mono text-[11px]">
+                      {base}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {/* Footer actions */}
+      <div className="flex items-center gap-2 p-3 border-t border-divider">
+        <Button
+          variant="subtle"
+          size="sm"
+          onClick={() => setIsAbortOpen(true)}
+          disabled={isAborting || isContinuing}
+          className="flex-1"
+          data-testid="conflict-abort"
+        >
+          <XCircle className="w-3.5 h-3.5 mr-1.5" />
+          Abort {operationLabel.toLowerCase()}
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          onClick={() => void handleContinue()}
+          disabled={!canContinue || isAborting || isContinuing}
+          className="flex-1"
+          data-testid="conflict-continue"
+        >
+          {isContinuing ? (
+            <Spinner size="sm" className="mr-1.5" />
+          ) : (
+            <Play className="w-3.5 h-3.5 mr-1.5" />
+          )}
+          Continue {operationLabel.toLowerCase()}
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        isOpen={isAbortOpen}
+        onClose={() => {
+          if (!isAborting) setIsAbortOpen(false);
+        }}
+        title={`Abort ${operationLabel.toLowerCase()}?`}
+        description={
+          ABORT_DESCRIPTION[operationState as Exclude<RepoState, "CLEAN" | "DIRTY">] ??
+          "Discards the in-progress operation."
+        }
+        confirmLabel={`Abort ${operationLabel.toLowerCase()}`}
+        cancelLabel="Keep working"
+        onConfirm={() => void handleAbort()}
+        isConfirmLoading={isAborting}
+        variant="destructive"
+      />
+    </div>
+  );
+}

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -316,11 +316,9 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     async (filePath: string) => {
       setActionError(null);
       try {
-        const separator = worktreePath.includes("\\") ? "\\" : "/";
-        const fullPath = worktreePath.endsWith(separator)
-          ? `${worktreePath}${filePath}`
-          : `${worktreePath}${separator}${filePath}`;
-        await window.electron.system.openInEditor({ path: fullPath });
+        const base = worktreePath.replace(/\\/g, "/").replace(/\/+$/, "");
+        const tail = filePath.replace(/\\/g, "/").replace(/^\/+/, "");
+        await window.electron.system.openInEditor({ path: `${base}/${tail}` });
       } catch (err) {
         setActionError(err instanceof Error ? err.message : String(err));
       }

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -17,6 +17,7 @@ import {
 import { Spinner } from "@/components/ui/Spinner";
 import { FileStageRow } from "./FileStageRow";
 import { CommitPanel } from "./CommitPanel";
+import { ConflictPanel } from "./ConflictPanel";
 import { FileDiffModal } from "../FileDiffModal";
 import { BaseBranchDiffModal } from "./BaseBranchDiffModal";
 import { Button } from "@/components/ui/button";
@@ -287,6 +288,46 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     [worktreePath, refresh]
   );
 
+  const handleAbortOperation = useCallback(async () => {
+    setActionError(null);
+    debouncedBgRefreshRef.current?.cancel();
+    try {
+      await window.electron.git.abortRepositoryOperation(worktreePath);
+      await refresh();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }, [worktreePath, refresh]);
+
+  const handleContinueOperation = useCallback(async () => {
+    setActionError(null);
+    debouncedBgRefreshRef.current?.cancel();
+    try {
+      await window.electron.git.continueRepositoryOperation(worktreePath);
+      await refresh();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }, [worktreePath, refresh]);
+
+  const handleOpenInEditor = useCallback(
+    async (filePath: string) => {
+      setActionError(null);
+      try {
+        const separator = worktreePath.includes("\\") ? "\\" : "/";
+        const fullPath = worktreePath.endsWith(separator)
+          ? `${worktreePath}${filePath}`
+          : `${worktreePath}${separator}${filePath}`;
+        await window.electron.system.openInEditor({ path: fullPath });
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [worktreePath]
+  );
+
   const handleCommitAndPush = useCallback(
     async (message: string) => {
       setActionError(null);
@@ -375,6 +416,12 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     (status?.unstaged.length ?? 0) +
     (status?.conflicted.length ?? 0);
   const hasConflicts = (status?.conflicted.length ?? 0) > 0;
+  const repoState = status?.repoState ?? "CLEAN";
+  const isOperationState =
+    repoState === "MERGING" ||
+    repoState === "REBASING" ||
+    repoState === "CHERRY_PICKING" ||
+    repoState === "REVERTING";
 
   return createPortal(
     <>
@@ -647,6 +694,14 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                       Retry
                     </Button>
                   </div>
+                ) : status && isOperationState ? (
+                  <ConflictPanel
+                    status={status}
+                    onMarkResolved={handleStageFile}
+                    onOpenInEditor={handleOpenInEditor}
+                    onAbort={handleAbortOperation}
+                    onContinue={handleContinueOperation}
+                  />
                 ) : status && totalChanges === 0 ? (
                   <div className="flex flex-col items-center justify-center py-12 text-daintree-text/50">
                     <CheckSquare className="w-8 h-8 mb-2 text-daintree-text/30" />
@@ -756,19 +811,23 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
             )}
           </div>
 
-          {/* Commit panel — only in working-tree mode */}
-          {diffMode === "working-tree" && status && totalChanges > 0 && !loadError && (
-            <CommitPanel
-              stagedCount={status.staged.length}
-              isDetachedHead={status.isDetachedHead}
-              hasConflicts={hasConflicts}
-              hasRemote={status.hasRemote}
-              commitMessage={commitMessage}
-              onCommitMessageChange={setCommitMessage}
-              onCommit={handleCommit}
-              onCommitAndPush={handleCommitAndPush}
-            />
-          )}
+          {/* Commit panel — only in working-tree mode, and never during a conflict op */}
+          {diffMode === "working-tree" &&
+            status &&
+            totalChanges > 0 &&
+            !loadError &&
+            !isOperationState && (
+              <CommitPanel
+                stagedCount={status.staged.length}
+                isDetachedHead={status.isDetachedHead}
+                hasConflicts={hasConflicts}
+                hasRemote={status.hasRemote}
+                commitMessage={commitMessage}
+                onCommitMessageChange={setCommitMessage}
+                onCommit={handleCommit}
+                onCommitAndPush={handleCommitAndPush}
+              />
+            )}
         </div>
       </div>
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -922,6 +922,28 @@ describe("ReviewHub", () => {
       });
     });
 
+    it("renders cherry-pick operation labels", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus({ repoState: "CHERRY_PICKING" }));
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      screen.getByText(/Resolve Cherry-pick Conflicts/i);
+      screen.getByRole("button", { name: /^Abort cherry-pick/i });
+      screen.getByRole("button", { name: /^Continue cherry-pick/i });
+    });
+
+    it("renders revert operation labels", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus({ repoState: "REVERTING" }));
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      screen.getByText(/Resolve Revert Conflicts/i);
+      screen.getByRole("button", { name: /^Abort revert/i });
+      screen.getByRole("button", { name: /^Continue revert/i });
+    });
+
     it("renders normal staging UI when repoState is DIRTY with conflicts", async () => {
       getStagingStatusMock.mockResolvedValue(
         makeStatus({

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, act, fireEvent, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { StagingStatus } from "@shared/types";
 import type { WorktreeState } from "@shared/types";
@@ -13,6 +13,10 @@ const {
   debounceCancelSpy,
   compareWorktreesMock,
   openPRMock,
+  abortRepositoryOperationMock,
+  continueRepositoryOperationMock,
+  openInEditorMock,
+  stageFileMock,
   worktreeStoreData,
 } = vi.hoisted(() => ({
   getStagingStatusMock: vi.fn(),
@@ -20,6 +24,10 @@ const {
   debounceCancelSpy: vi.fn(),
   compareWorktreesMock: vi.fn(),
   openPRMock: vi.fn().mockResolvedValue(undefined),
+  abortRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
+  continueRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
+  openInEditorMock: vi.fn().mockResolvedValue(undefined),
+  stageFileMock: vi.fn().mockResolvedValue(undefined),
   worktreeStoreData: {
     current: new Map<string, Partial<WorktreeState>>([
       [
@@ -73,6 +81,8 @@ vi.mock("@/components/ui/button", () => ({
     children,
     onClick,
     disabled,
+    "aria-label": ariaLabel,
+    "data-testid": testId,
   }: {
     children: ReactNode;
     onClick?: () => void;
@@ -80,11 +90,55 @@ vi.mock("@/components/ui/button", () => ({
     variant?: string;
     size?: string;
     className?: string;
+    "aria-label"?: string;
+    "data-testid"?: string;
   }) => (
-    <button type="button" onClick={onClick} disabled={disabled}>
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      data-testid={testId}
+    >
       {children}
     </button>
   ),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    description,
+    onConfirm,
+    onClose,
+    confirmLabel,
+    cancelLabel,
+  }: {
+    isOpen: boolean;
+    title: ReactNode;
+    description?: ReactNode;
+    onConfirm: () => void;
+    onClose?: () => void;
+    confirmLabel?: string;
+    cancelLabel?: string;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div role="alertdialog" aria-label={typeof title === "string" ? title : "confirm"}>
+        <div>{title}</div>
+        {description && <div>{description}</div>}
+        <button type="button" onClick={onConfirm}>
+          {confirmLabel ?? "Confirm"}
+        </button>
+        {onClose && (
+          <button type="button" onClick={onClose}>
+            {cancelLabel ?? "Cancel"}
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -102,9 +156,13 @@ const makeStatus = (overrides?: Partial<StagingStatus>): StagingStatus => ({
   staged: [{ path: "src/index.ts", status: "modified", insertions: 5, deletions: 2 }],
   unstaged: [{ path: "src/app.ts", status: "modified", insertions: 3, deletions: 1 }],
   conflicted: [],
+  conflictedFiles: [],
   isDetachedHead: false,
   currentBranch: "feature/test",
   hasRemote: false,
+  repoState: "DIRTY",
+  rebaseStep: null,
+  rebaseTotalSteps: null,
   ...overrides,
 });
 
@@ -152,18 +210,26 @@ describe("ReviewHub", () => {
 
     compareWorktreesMock.mockResolvedValue({ branch1: "main", branch2: "feature/test", files: [] });
 
+    abortRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
+    continueRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
+    openInEditorMock.mockReset().mockResolvedValue(undefined);
+    stageFileMock.mockReset().mockResolvedValue(undefined);
+
     Object.defineProperty(window, "electron", {
       value: {
         git: {
           getStagingStatus: getStagingStatusMock,
-          stageFile: vi.fn().mockResolvedValue(undefined),
+          stageFile: stageFileMock,
           unstageFile: vi.fn().mockResolvedValue(undefined),
           stageAll: vi.fn().mockResolvedValue(undefined),
           unstageAll: vi.fn().mockResolvedValue(undefined),
           commit: vi.fn().mockResolvedValue(undefined),
           push: vi.fn().mockResolvedValue({ success: true }),
           compareWorktrees: compareWorktreesMock,
+          abortRepositoryOperation: abortRepositoryOperationMock,
+          continueRepositoryOperation: continueRepositoryOperationMock,
         },
+        system: { openInEditor: openInEditorMock },
         worktree: { onUpdate: onUpdateMock },
       },
       writable: true,
@@ -717,6 +783,158 @@ describe("ReviewHub", () => {
         screen.getByText("#99");
         screen.getByText("merged");
       });
+    });
+  });
+
+  describe("conflict mode", () => {
+    const makeMergingStatus = (overrides?: Partial<StagingStatus>): StagingStatus =>
+      makeStatus({
+        staged: [],
+        unstaged: [],
+        conflicted: ["src/app.ts"],
+        conflictedFiles: [{ path: "src/app.ts", xy: "UU", label: "both modified" }],
+        repoState: "MERGING",
+        ...overrides,
+      });
+
+    it("renders the conflict panel instead of staging sections when merging", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      screen.getByText(/Resolve Merge Conflicts/i);
+      expect(screen.queryByText(/^Staged$/i)).toBeNull();
+      expect(screen.queryByPlaceholderText("Commit message…")).toBeNull();
+    });
+
+    it("shows rebase step progress in the banner", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeMergingStatus({
+          repoState: "REBASING",
+          rebaseStep: 3,
+          rebaseTotalSteps: 8,
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-rebase-progress"));
+      expect(screen.getByTestId("conflict-rebase-progress").textContent).toMatch(/Step 3 of 8/);
+    });
+
+    it("disables Continue when conflicted files remain", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByRole("button", { name: /^Continue /i }));
+      expect(screen.getByRole("button", { name: /^Continue /i }).hasAttribute("disabled")).toBe(
+        true
+      );
+    });
+
+    it("enables Continue when all conflicts are resolved", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeMergingStatus({
+          conflicted: [],
+          conflictedFiles: [],
+          staged: [{ path: "src/app.ts", status: "modified", insertions: 1, deletions: 1 }],
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByRole("button", { name: /^Continue /i }));
+      expect(screen.getByRole("button", { name: /^Continue /i }).hasAttribute("disabled")).toBe(
+        false
+      );
+    });
+
+    it("stages a file when Mark resolved is clicked", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      const resolveBtn = screen.getByRole("button", {
+        name: /Mark src\/app\.ts as resolved/i,
+      });
+      fireEvent.click(resolveBtn);
+
+      await waitFor(() => {
+        expect(stageFileMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/app.ts");
+      });
+    });
+
+    it("opens the file in the external editor with the absolute path", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      const openBtn = screen.getByRole("button", {
+        name: /Open src\/app\.ts in external editor/i,
+      });
+      fireEvent.click(openBtn);
+
+      await waitFor(() => {
+        expect(openInEditorMock).toHaveBeenCalledWith({
+          path: `${WORKTREE_PATH}/src/app.ts`,
+        });
+      });
+    });
+
+    it("opens confirm dialog before aborting and calls abort on confirm", async () => {
+      getStagingStatusMock.mockResolvedValue(makeMergingStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByRole("button", { name: /^Abort /i }));
+      fireEvent.click(screen.getByRole("button", { name: /^Abort /i }));
+
+      const dialog = await screen.findByRole("alertdialog");
+      expect(abortRepositoryOperationMock).not.toHaveBeenCalled();
+
+      fireEvent.click(within(dialog).getByRole("button", { name: /Abort merge/i }));
+
+      await waitFor(() => {
+        expect(abortRepositoryOperationMock).toHaveBeenCalledWith(WORKTREE_PATH);
+      });
+    });
+
+    it("invokes continue when Continue is clicked", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeMergingStatus({
+          conflicted: [],
+          conflictedFiles: [],
+          staged: [{ path: "src/app.ts", status: "modified", insertions: 1, deletions: 1 }],
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByRole("button", { name: /^Continue /i }));
+      fireEvent.click(screen.getByRole("button", { name: /^Continue /i }));
+
+      await waitFor(() => {
+        expect(continueRepositoryOperationMock).toHaveBeenCalledWith(WORKTREE_PATH);
+      });
+    });
+
+    it("renders normal staging UI when repoState is DIRTY with conflicts", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeStatus({
+          conflicted: ["src/weird.ts"],
+          conflictedFiles: [{ path: "src/weird.ts", xy: "UU", label: "both modified" }],
+          repoState: "DIRTY",
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("index.ts"));
+      expect(screen.queryByTestId("conflict-panel")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- ReviewHub now detects in-progress git operations (merge, rebase, cherry-pick, revert) by checking canonical `.git/` sentinel files and renders a dedicated conflict resolution mode instead of the normal staging UI.
- Conflicted files are pulled from `git status --porcelain=v2` unmerged (`u`) lines. Each file has "Mark resolved" (`git add`) and "Open in external editor" actions, with global Abort (with confirmation) and Continue (gated on all conflicts resolved) controls.
- Rebase progress is shown as "N of M commits" read from `.git/rebase-merge/msgnum` and `.git/rebase-merge/end`.

Resolves #5386

## Changes

- `shared/types/git.ts` — new `RepoOperationState` enum (`CLEAN` | `DIRTY` | `MERGING` | `REBASING` | `CHERRY_PICKING` | `REVERTING`) and `ConflictEntry` type
- `electron/ipc/handlers/git-write.ts` — `getRepoOperationState()` reads sentinel files; `getStagingStatus()` extended with `operationState`, `conflictedFiles`, and rebase progress fields; new `abortOperation` and `continueOperation` IPC handlers
- `electron/ipc/channels.ts` / `electron/preload.cts` — channels wired up for abort/continue
- `src/components/Worktree/ReviewHub/ConflictPanel.tsx` — new component rendering the conflict resolution UI
- `src/components/Worktree/ReviewHub/ReviewHub.tsx` — branches on `operationState` to show `ConflictPanel` when in a conflict operation
- Unit tests covering detection logic and the new UI states

## Testing

Typecheck, lint, and unit tests pass clean. The conflict panel renders correctly for merge, rebase, cherry-pick, and revert states, with abort/continue actions behaving as specified in the issue.