### PR TITLE
fix(store): scope worktree filter state per-project

### DIFF
--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -209,6 +209,15 @@ describe("worktreeFilterStore persistence scoping", () => {
     delete (globalThis as Partial<typeof globalThis>).localStorage;
   }
 
+  function setProjectIdInUrl(projectId: string | null): void {
+    const search = projectId === null ? "" : `?projectId=${encodeURIComponent(projectId)}`;
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search },
+      configurable: true,
+      writable: true,
+    });
+  }
+
   beforeEach(() => {
     // Ensure each test gets a freshly evaluated store module that picks up
     // the installed localStorage mock at module-load time. The file-level
@@ -219,6 +228,7 @@ describe("worktreeFilterStore persistence scoping", () => {
 
   afterEach(() => {
     restoreLocalStorage();
+    setProjectIdInUrl(null);
     vi.resetModules();
     vi.restoreAllMocks();
   });
@@ -394,6 +404,118 @@ describe("worktreeFilterStore persistence scoping", () => {
     expect(parsed.state).not.toHaveProperty("manualOrder");
     expect(parsed.state.orderBy).toBe("recent");
     expect(parsed.state.hideMainWorktree).toBe(true);
+  });
+
+  it("isolates per-project pins across different projectIds in the URL", async () => {
+    // Shared localStorage across both project loads — backing key-value store
+    // persists through module resets, just like real localStorage does.
+    const persistent = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => persistent.get(key) ?? null,
+      setItem: (key, value) => {
+        persistent.set(key, value);
+      },
+      removeItem: (key) => {
+        persistent.delete(key);
+      },
+    });
+
+    // Project A: pin wt-a
+    setProjectIdInUrl("project-a");
+    let mod = await import("../worktreeFilterStore");
+    mod.useWorktreeFilterStore.getState().pinWorktree("wt-a");
+    expect(mod.useWorktreeFilterStore.getState().pinnedWorktrees).toEqual(["wt-a"]);
+
+    // Switch to Project B — module reset simulates a fresh WebContentsView
+    vi.resetModules();
+    setProjectIdInUrl("project-b");
+    mod = await import("../worktreeFilterStore");
+
+    // Project B must not see Project A's pin
+    expect(mod.useWorktreeFilterStore.getState().pinnedWorktrees).toEqual([]);
+    mod.useWorktreeFilterStore.getState().pinWorktree("wt-b");
+    expect(mod.useWorktreeFilterStore.getState().pinnedWorktrees).toEqual(["wt-b"]);
+
+    // Back to Project A — its pin is intact
+    vi.resetModules();
+    setProjectIdInUrl("project-a");
+    mod = await import("../worktreeFilterStore");
+    expect(mod.useWorktreeFilterStore.getState().pinnedWorktrees).toEqual(["wt-a"]);
+
+    // Each project writes to its own scoped key
+    expect(persistent.has("daintree-worktree-filters:project-a")).toBe(true);
+    expect(persistent.has("daintree-worktree-filters:project-b")).toBe(true);
+  });
+
+  it("recovers legacy seed when the scoped key is corrupt JSON", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        query: "recovered",
+        pinnedWorktrees: ["wt-legacy"],
+      },
+    });
+    installLocalStorage({
+      getItem: (key) => {
+        if (key === GLOBAL_KEY) return legacyBlob;
+        if (key === PROJECT_KEY) return "{corrupt";
+        return null;
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    // Corrupt scoped blob should not suppress legacy recovery
+    expect(store.getState().query).toBe("recovered");
+    expect(store.getState().pinnedWorktrees).toEqual(["wt-legacy"]);
+  });
+
+  it("ignores legacy fields with wrong types to avoid silent corruption", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        // Malformed: strings where arrays are expected. Without type guards,
+        // `new Set<StatusFilter>("active")` would split into 6 characters.
+        statusFilters: "active",
+        pinnedWorktrees: "wt-oops",
+        manualOrder: 42,
+      },
+    });
+    installLocalStorage({
+      getItem: (key) => (key === GLOBAL_KEY ? legacyBlob : null),
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    expect(Array.from(store.getState().statusFilters)).toEqual([]);
+    expect(store.getState().pinnedWorktrees).toEqual([]);
+    expect(store.getState().manualOrder).toEqual([]);
+  });
+
+  it("routes functional setState updates to the correct backing stores", async () => {
+    const writes = new Map<string, string>();
+    installLocalStorage({
+      getItem: () => null,
+      setItem: (key, value) => {
+        writes.set(key, value);
+      },
+      removeItem: (key) => {
+        writes.delete(key);
+      },
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    store.setState((state) => ({
+      orderBy: state.orderBy === "created" ? "alpha" : "created",
+      pinnedWorktrees: [...state.pinnedWorktrees, "wt-func"],
+    }));
+
+    const next = store.getState();
+    expect(next.orderBy).toBe("alpha");
+    expect(next.pinnedWorktrees).toEqual(["wt-func"]);
   });
 
   it("keeps global preferences when clearAll runs", async () => {

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useWorktreeFilterStore } from "../worktreeFilterStore";
 
 function resetWorktreeFilterStore() {
@@ -158,5 +159,268 @@ describe("worktreeFilterStore", () => {
     useWorktreeFilterStore.getState().clearAll();
 
     expect(useWorktreeFilterStore.getState().quickStateFilter).toBe("all");
+  });
+});
+
+describe("worktreeFilterStore persistence scoping", () => {
+  const GLOBAL_KEY = "daintree-worktree-filters";
+  const PROJECT_KEY = "daintree-worktree-filters:default";
+
+  type StorageMock = {
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+  };
+
+  const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "localStorage"
+  );
+
+  function installLocalStorage(value: StorageMock): Map<string, string> {
+    const backing = new Map<string, string>();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: (key: string) => {
+          const direct = value.getItem(key);
+          if (direct !== null) return direct;
+          return backing.get(key) ?? null;
+        },
+        setItem: (key: string, val: string) => {
+          backing.set(key, val);
+          value.setItem(key, val);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+          value.removeItem(key);
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    return backing;
+  }
+
+  function restoreLocalStorage(): void {
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(globalThis, "localStorage", originalLocalStorageDescriptor);
+      return;
+    }
+    delete (globalThis as Partial<typeof globalThis>).localStorage;
+  }
+
+  beforeEach(() => {
+    // Ensure each test gets a freshly evaluated store module that picks up
+    // the installed localStorage mock at module-load time. The file-level
+    // static import of useWorktreeFilterStore already evaluated once against
+    // the jsdom default localStorage — we need to drop that and re-import.
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("persists per-project state to the scoped key, not the global key", async () => {
+    const writes = new Map<string, string>();
+    installLocalStorage({
+      getItem: () => null,
+      setItem: (key, value) => {
+        writes.set(key, value);
+      },
+      removeItem: (key) => {
+        writes.delete(key);
+      },
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    store.getState().pinWorktree("wt-scoped");
+
+    expect(writes.has(PROJECT_KEY)).toBe(true);
+    const projectBlob = JSON.parse(writes.get(PROJECT_KEY)!) as {
+      state: { pinnedWorktrees: string[] };
+    };
+    expect(projectBlob.state.pinnedWorktrees).toEqual(["wt-scoped"]);
+
+    // Global key should not receive pinnedWorktrees — only prefs are written
+    // when a global setter runs, and we only ran a per-project action.
+    const globalBlob = writes.get(GLOBAL_KEY);
+    if (globalBlob) {
+      const parsed = JSON.parse(globalBlob) as { state: Record<string, unknown> };
+      expect(parsed.state).not.toHaveProperty("pinnedWorktrees");
+    }
+  });
+
+  it("persists global preferences to the global key, not the scoped key", async () => {
+    const writes = new Map<string, string>();
+    installLocalStorage({
+      getItem: () => null,
+      setItem: (key, value) => {
+        writes.set(key, value);
+      },
+      removeItem: (key) => {
+        writes.delete(key);
+      },
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    store.getState().setOrderBy("alpha");
+
+    expect(writes.has(GLOBAL_KEY)).toBe(true);
+    const globalBlob = JSON.parse(writes.get(GLOBAL_KEY)!) as {
+      state: { orderBy: string };
+      version: number;
+    };
+    expect(globalBlob.state.orderBy).toBe("alpha");
+    expect(globalBlob.version).toBe(1);
+
+    // The scoped key should not contain orderBy (it's not in the project
+    // partialize output).
+    const projectBlob = writes.get(PROJECT_KEY);
+    if (projectBlob) {
+      const parsed = JSON.parse(projectBlob) as { state: Record<string, unknown> };
+      expect(parsed.state).not.toHaveProperty("orderBy");
+    }
+  });
+
+  it("seeds per-project state from the legacy combined blob on first load", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        query: "legacy",
+        orderBy: "alpha",
+        groupByType: false,
+        statusFilters: ["active"],
+        typeFilters: [],
+        githubFilters: [],
+        sessionFilters: [],
+        activityFilters: [],
+        alwaysShowActive: true,
+        alwaysShowWaiting: true,
+        hideMainWorktree: false,
+        pinnedWorktrees: ["wt-legacy-pin"],
+        collapsedWorktrees: ["wt-legacy-collapsed"],
+        manualOrder: ["wt-a", "wt-b"],
+      },
+    });
+
+    installLocalStorage({
+      getItem: (key) => (key === GLOBAL_KEY ? legacyBlob : null),
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    const state = store.getState();
+    expect(state.query).toBe("legacy");
+    expect(state.pinnedWorktrees).toEqual(["wt-legacy-pin"]);
+    expect(state.collapsedWorktrees).toEqual(["wt-legacy-collapsed"]);
+    expect(state.manualOrder).toEqual(["wt-a", "wt-b"]);
+    expect(Array.from(state.statusFilters)).toEqual(["active"]);
+  });
+
+  it("does not re-seed when the scoped key already exists", async () => {
+    const legacyBlob = JSON.stringify({
+      state: { pinnedWorktrees: ["wt-legacy-pin"] },
+    });
+    const scopedBlob = JSON.stringify({
+      state: {
+        query: "",
+        statusFilters: [],
+        typeFilters: [],
+        githubFilters: [],
+        sessionFilters: [],
+        activityFilters: [],
+        pinnedWorktrees: ["wt-scoped-pin"],
+        collapsedWorktrees: [],
+        manualOrder: [],
+      },
+      version: 0,
+    });
+
+    installLocalStorage({
+      getItem: (key) => {
+        if (key === GLOBAL_KEY) return legacyBlob;
+        if (key === PROJECT_KEY) return scopedBlob;
+        return null;
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    expect(store.getState().pinnedWorktrees).toEqual(["wt-scoped-pin"]);
+  });
+
+  it("strips per-project fields from the legacy global blob on version migration", async () => {
+    const legacyBlob = JSON.stringify({
+      state: {
+        orderBy: "alpha",
+        groupByType: true,
+        alwaysShowActive: false,
+        alwaysShowWaiting: false,
+        hideMainWorktree: true,
+        pinnedWorktrees: ["wt-pin"],
+        manualOrder: ["wt-a"],
+      },
+    });
+    const writes = new Map<string, string>();
+    installLocalStorage({
+      getItem: (key) => (key === GLOBAL_KEY ? legacyBlob : null),
+      setItem: (key, value) => {
+        writes.set(key, value);
+      },
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    // Trigger a persist write by nudging a global setter.
+    store.getState().setOrderBy("recent");
+
+    const globalBlob = writes.get(GLOBAL_KEY);
+    expect(globalBlob).toBeDefined();
+    const parsed = JSON.parse(globalBlob!) as {
+      state: Record<string, unknown>;
+      version: number;
+    };
+    expect(parsed.version).toBe(1);
+    expect(parsed.state).not.toHaveProperty("pinnedWorktrees");
+    expect(parsed.state).not.toHaveProperty("manualOrder");
+    expect(parsed.state.orderBy).toBe("recent");
+    expect(parsed.state.hideMainWorktree).toBe(true);
+  });
+
+  it("keeps global preferences when clearAll runs", async () => {
+    installLocalStorage({
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    });
+
+    const { useWorktreeFilterStore: store } = await import("../worktreeFilterStore");
+
+    store.getState().setOrderBy("alpha");
+    store.getState().setAlwaysShowActive(false);
+    store.getState().setAlwaysShowWaiting(false);
+    store.getState().setHideMainWorktree(true);
+    store.getState().pinWorktree("wt-pin");
+    store.getState().setQuery("search");
+
+    store.getState().clearAll();
+
+    const state = store.getState();
+    expect(state.orderBy).toBe("alpha");
+    expect(state.alwaysShowActive).toBe(false);
+    expect(state.alwaysShowWaiting).toBe(false);
+    // hideMainWorktree IS reset by clearAll — preserves existing behavior
+    expect(state.hideMainWorktree).toBe(false);
+    expect(state.pinnedWorktrees).toEqual(["wt-pin"]);
+    expect(state.query).toBe("");
   });
 });

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -152,7 +152,8 @@ const GLOBAL_KEY = "daintree-worktree-filters";
 function resolveProjectIdFromUrl(): string {
   if (typeof window === "undefined") return "default";
   try {
-    return new URLSearchParams(window.location.search).get("projectId") ?? "default";
+    const fromUrl = new URLSearchParams(window.location.search).get("projectId");
+    return fromUrl && fromUrl.length > 0 ? fromUrl : "default";
   } catch {
     return "default";
   }
@@ -173,17 +174,35 @@ function isGlobalField(key: string): boolean {
   return GLOBAL_FIELD_KEYS.has(key as keyof WorktreeFilterStore);
 }
 
+function arrayOrUndefined<T>(value: unknown): T[] | undefined {
+  return Array.isArray(value) ? (value as T[]) : undefined;
+}
+
 /**
- * One-time migration seed: when the per-project key does not yet exist, but a
- * legacy combined blob is present under the global key, copy the per-project
- * fields out of it so existing pins/order survive the upgrade. The global key
- * is left intact — the global store's versioned `migrate` trims the stale
- * per-project fields from it on its own first hydrate.
+ * One-time migration seed: when the per-project key does not yet exist (or is
+ * unparseable), but a legacy combined blob is present under the global key,
+ * copy the per-project fields out of it so existing pins/order survive the
+ * upgrade. The global key is left intact — the global store's versioned
+ * `migrate` trims the stale per-project fields from it on its own first
+ * hydrate.
+ *
+ * The "scoped key exists" gate checks parseability, not raw presence — a
+ * corrupt scoped blob would otherwise silently suppress legacy recovery.
  */
 function loadLegacySeedForProject(): Partial<ProjectPersistedShape> {
-  if (readLocalStorageItemSafely(PROJECT_KEY) !== null) {
-    return {};
+  const scopedRaw = readLocalStorageItemSafely(PROJECT_KEY);
+  if (scopedRaw !== null) {
+    const scopedParsed = safeJSONParse<{ state?: unknown } | null>(
+      scopedRaw,
+      { store: "worktreeFilterStore", key: PROJECT_KEY },
+      null
+    );
+    if (scopedParsed && scopedParsed.state && typeof scopedParsed.state === "object") {
+      return {};
+    }
+    // Fall through — scoped blob was corrupt, try legacy seed instead.
   }
+
   const raw = readLocalStorageItemSafely(GLOBAL_KEY);
   if (raw === null) return {};
 
@@ -193,18 +212,18 @@ function loadLegacySeedForProject(): Partial<ProjectPersistedShape> {
     null
   );
   const state = parsed?.state;
-  if (!state) return {};
+  if (!state || typeof state !== "object") return {};
 
   return {
-    query: state.query,
-    statusFilters: state.statusFilters,
-    typeFilters: state.typeFilters,
-    githubFilters: state.githubFilters,
-    sessionFilters: state.sessionFilters,
-    activityFilters: state.activityFilters,
-    pinnedWorktrees: state.pinnedWorktrees,
-    collapsedWorktrees: state.collapsedWorktrees,
-    manualOrder: state.manualOrder,
+    query: typeof state.query === "string" ? state.query : undefined,
+    statusFilters: arrayOrUndefined<StatusFilter>(state.statusFilters),
+    typeFilters: arrayOrUndefined<TypeFilter>(state.typeFilters),
+    githubFilters: arrayOrUndefined<GitHubFilter>(state.githubFilters),
+    sessionFilters: arrayOrUndefined<SessionFilter>(state.sessionFilters),
+    activityFilters: arrayOrUndefined<ActivityFilter>(state.activityFilters),
+    pinnedWorktrees: arrayOrUndefined<string>(state.pinnedWorktrees),
+    collapsedWorktrees: arrayOrUndefined<string>(state.collapsedWorktrees),
+    manualOrder: arrayOrUndefined<string>(state.manualOrder),
   };
 }
 

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -1,6 +1,10 @@
-import { create } from "zustand";
+import { create, useStore } from "zustand";
 import { persist } from "zustand/middleware";
-import { createSafeJSONStorage } from "./persistence/safeStorage";
+import {
+  createSafeJSONStorage,
+  readLocalStorageItemSafely,
+  safeJSONParse,
+} from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 import type { QuickStateFilter } from "@/lib/worktreeFilters";
 
@@ -80,240 +84,503 @@ interface WorktreeFilterActions {
 
 type WorktreeFilterStore = WorktreeFilterState & WorktreeFilterActions;
 
-interface PersistedState {
-  query: string;
+/**
+ * Fields that are user preferences and persist across all projects. These live
+ * in the global store (`daintree-worktree-filters`).
+ */
+interface GlobalPrefsState {
   orderBy: OrderBy;
   groupByType: boolean;
+  alwaysShowActive: boolean;
+  alwaysShowWaiting: boolean;
+  hideMainWorktree: boolean;
+}
+
+/**
+ * Fields that are query-shaped or identity-scoped — they must not leak across
+ * projects. These live in the per-project store
+ * (`daintree-worktree-filters:{projectId}`). `quickStateFilter` is transient
+ * (not persisted) but is also scoped to the current project's in-memory state.
+ */
+interface ProjectScopedState {
+  query: string;
+  statusFilters: Set<StatusFilter>;
+  typeFilters: Set<TypeFilter>;
+  githubFilters: Set<GitHubFilter>;
+  sessionFilters: Set<SessionFilter>;
+  activityFilters: Set<ActivityFilter>;
+  pinnedWorktrees: string[];
+  collapsedWorktrees: string[];
+  manualOrder: string[];
+  quickStateFilter: QuickStateFilter;
+}
+
+interface GlobalPersistedShape {
+  orderBy: OrderBy;
+  groupByType: boolean;
+  alwaysShowActive: boolean;
+  alwaysShowWaiting: boolean;
+  hideMainWorktree: boolean;
+}
+
+interface ProjectPersistedShape {
+  query: string;
   statusFilters: StatusFilter[];
   typeFilters: TypeFilter[];
   githubFilters: GitHubFilter[];
   sessionFilters: SessionFilter[];
   activityFilters: ActivityFilter[];
-  alwaysShowActive: boolean;
-  alwaysShowWaiting: boolean;
-  hideMainWorktree: boolean;
   pinnedWorktrees: string[];
   collapsedWorktrees: string[];
   manualOrder: string[];
 }
 
-export const useWorktreeFilterStore = create<WorktreeFilterStore>()(
+/**
+ * Shape of the legacy combined persist blob from before issue #5366.
+ */
+interface LegacyPersistedShape extends GlobalPersistedShape, ProjectPersistedShape {}
+
+const GLOBAL_KEY = "daintree-worktree-filters";
+
+/**
+ * Resolve the current renderer's projectId synchronously from the URL query
+ * string. `ProjectViewManager` loads each `WebContentsView` with
+ * `?projectId=...`, so this is available at module-evaluation time. Fallback
+ * to `"default"` for test environments (jsdom defaults `window.location.search`
+ * to `""`) and for any shell view that has no projectId scope.
+ */
+function resolveProjectIdFromUrl(): string {
+  if (typeof window === "undefined") return "default";
+  try {
+    return new URLSearchParams(window.location.search).get("projectId") ?? "default";
+  } catch {
+    return "default";
+  }
+}
+
+const _projectId = resolveProjectIdFromUrl();
+const PROJECT_KEY = `${GLOBAL_KEY}:${_projectId}`;
+
+const GLOBAL_FIELD_KEYS = new Set<keyof WorktreeFilterStore>([
+  "orderBy",
+  "groupByType",
+  "alwaysShowActive",
+  "alwaysShowWaiting",
+  "hideMainWorktree",
+]);
+
+function isGlobalField(key: string): boolean {
+  return GLOBAL_FIELD_KEYS.has(key as keyof WorktreeFilterStore);
+}
+
+/**
+ * One-time migration seed: when the per-project key does not yet exist, but a
+ * legacy combined blob is present under the global key, copy the per-project
+ * fields out of it so existing pins/order survive the upgrade. The global key
+ * is left intact — the global store's versioned `migrate` trims the stale
+ * per-project fields from it on its own first hydrate.
+ */
+function loadLegacySeedForProject(): Partial<ProjectPersistedShape> {
+  if (readLocalStorageItemSafely(PROJECT_KEY) !== null) {
+    return {};
+  }
+  const raw = readLocalStorageItemSafely(GLOBAL_KEY);
+  if (raw === null) return {};
+
+  const parsed = safeJSONParse<{ state?: Partial<LegacyPersistedShape> } | null>(
+    raw,
+    { store: "worktreeFilterStore", key: GLOBAL_KEY },
+    null
+  );
+  const state = parsed?.state;
+  if (!state) return {};
+
+  return {
+    query: state.query,
+    statusFilters: state.statusFilters,
+    typeFilters: state.typeFilters,
+    githubFilters: state.githubFilters,
+    sessionFilters: state.sessionFilters,
+    activityFilters: state.activityFilters,
+    pinnedWorktrees: state.pinnedWorktrees,
+    collapsedWorktrees: state.collapsedWorktrees,
+    manualOrder: state.manualOrder,
+  };
+}
+
+const _legacySeed = loadLegacySeedForProject();
+
+const _globalPrefsStore = create<GlobalPrefsState>()(
   persist(
-    (set, get) => ({
-      query: "",
+    () => ({
       orderBy: "created",
       groupByType: false,
-      statusFilters: new Set<StatusFilter>(),
-      typeFilters: new Set<TypeFilter>(),
-      githubFilters: new Set<GitHubFilter>(),
-      sessionFilters: new Set<SessionFilter>(),
-      activityFilters: new Set<ActivityFilter>(),
       alwaysShowActive: true,
       alwaysShowWaiting: true,
       hideMainWorktree: false,
-      pinnedWorktrees: [],
-      collapsedWorktrees: [],
-      manualOrder: [],
-      quickStateFilter: "all",
-
-      setQuery: (query) => set({ query }),
-      setOrderBy: (orderBy) => set({ orderBy }),
-      setGroupByType: (enabled) =>
-        set((state) => ({
-          groupByType: enabled,
-          orderBy: enabled && state.orderBy === "manual" ? "created" : state.orderBy,
-        })),
-
-      toggleStatusFilter: (filter) =>
-        set((state) => {
-          const newSet = new Set(state.statusFilters);
-          if (newSet.has(filter)) {
-            newSet.delete(filter);
-          } else {
-            newSet.add(filter);
-          }
-          return { statusFilters: newSet };
-        }),
-
-      toggleTypeFilter: (filter) =>
-        set((state) => {
-          const newSet = new Set(state.typeFilters);
-          if (newSet.has(filter)) {
-            newSet.delete(filter);
-          } else {
-            newSet.add(filter);
-          }
-          return { typeFilters: newSet };
-        }),
-
-      toggleGitHubFilter: (filter) =>
-        set((state) => {
-          const newSet = new Set(state.githubFilters);
-          if (newSet.has(filter)) {
-            newSet.delete(filter);
-          } else {
-            newSet.add(filter);
-          }
-          return { githubFilters: newSet };
-        }),
-
-      toggleSessionFilter: (filter) =>
-        set((state) => {
-          const newSet = new Set(state.sessionFilters);
-          if (newSet.has(filter)) {
-            newSet.delete(filter);
-          } else {
-            newSet.add(filter);
-          }
-          return { sessionFilters: newSet };
-        }),
-
-      toggleActivityFilter: (filter) =>
-        set((state) => {
-          const newSet = new Set(state.activityFilters);
-          if (newSet.has(filter)) {
-            newSet.delete(filter);
-          } else {
-            newSet.add(filter);
-          }
-          return { activityFilters: newSet };
-        }),
-
-      setAlwaysShowActive: (enabled) => set({ alwaysShowActive: enabled }),
-      setAlwaysShowWaiting: (enabled) => set({ alwaysShowWaiting: enabled }),
-      setHideMainWorktree: (enabled) => set({ hideMainWorktree: enabled }),
-
-      pinWorktree: (id) =>
-        set((state) => {
-          if (state.pinnedWorktrees.includes(id)) {
-            return state;
-          }
-          return { pinnedWorktrees: [...state.pinnedWorktrees, id] };
-        }),
-
-      unpinWorktree: (id) =>
-        set((state) => ({
-          pinnedWorktrees: state.pinnedWorktrees.filter((wId) => wId !== id),
-        })),
-
-      isWorktreePinned: (id) => get().pinnedWorktrees.includes(id),
-
-      collapseWorktree: (id) =>
-        set((state) => {
-          if (state.collapsedWorktrees.includes(id)) {
-            return state;
-          }
-          return { collapsedWorktrees: [...state.collapsedWorktrees, id] };
-        }),
-
-      expandWorktree: (id) =>
-        set((state) => ({
-          collapsedWorktrees: state.collapsedWorktrees.filter((wId) => wId !== id),
-        })),
-
-      toggleWorktreeCollapsed: (id) => {
-        if (get().collapsedWorktrees.includes(id)) {
-          get().expandWorktree(id);
-        } else {
-          get().collapseWorktree(id);
-        }
-      },
-
-      isWorktreeCollapsed: (id) => get().collapsedWorktrees.includes(id),
-
-      setManualOrder: (order) => set({ manualOrder: order }),
-
-      setQuickStateFilter: (quickStateFilter) => set({ quickStateFilter }),
-
-      clearAll: () =>
-        set({
-          query: "",
-          statusFilters: new Set(),
-          typeFilters: new Set(),
-          githubFilters: new Set(),
-          sessionFilters: new Set(),
-          activityFilters: new Set(),
-          hideMainWorktree: false,
-          quickStateFilter: "all",
-        }),
-
-      getActiveFilterCount: () => {
-        const state = get();
-        const hasQuery = state.query.trim().length > 0;
-        return (
-          (hasQuery ? 1 : 0) +
-          state.statusFilters.size +
-          state.typeFilters.size +
-          state.githubFilters.size +
-          state.sessionFilters.size +
-          state.activityFilters.size +
-          (state.quickStateFilter !== "all" ? 1 : 0)
-        );
-      },
-
-      hasActiveFilters: () => {
-        const state = get();
-        const hasQuery = state.query.trim().length > 0;
-        return (
-          hasQuery ||
-          state.statusFilters.size > 0 ||
-          state.typeFilters.size > 0 ||
-          state.githubFilters.size > 0 ||
-          state.sessionFilters.size > 0 ||
-          state.activityFilters.size > 0 ||
-          state.quickStateFilter !== "all"
-        );
-      },
     }),
     {
-      name: "daintree-worktree-filters",
+      name: GLOBAL_KEY,
+      version: 1,
       storage: createSafeJSONStorage(),
-      partialize: (state): PersistedState => ({
-        query: state.query,
+      partialize: (state): GlobalPersistedShape => ({
         orderBy: state.orderBy,
         groupByType: state.groupByType,
-        statusFilters: Array.from(state.statusFilters),
-        typeFilters: Array.from(state.typeFilters),
-        githubFilters: Array.from(state.githubFilters),
-        sessionFilters: Array.from(state.sessionFilters),
-        activityFilters: Array.from(state.activityFilters),
         alwaysShowActive: state.alwaysShowActive,
         alwaysShowWaiting: state.alwaysShowWaiting,
         hideMainWorktree: state.hideMainWorktree,
-        pinnedWorktrees: state.pinnedWorktrees,
-        collapsedWorktrees: state.collapsedWorktrees,
-        manualOrder: state.manualOrder,
       }),
+      migrate: (persistedState, version) => {
+        // Legacy (version 0 / undefined) wrote a combined blob — strip the
+        // per-project fields and keep only global prefs.
+        if (version < 1) {
+          const legacy = (persistedState ?? {}) as Partial<LegacyPersistedShape>;
+          return {
+            orderBy: legacy.orderBy ?? "created",
+            groupByType: legacy.groupByType ?? false,
+            alwaysShowActive: legacy.alwaysShowActive ?? true,
+            alwaysShowWaiting: legacy.alwaysShowWaiting ?? true,
+            hideMainWorktree: legacy.hideMainWorktree ?? false,
+          } satisfies GlobalPrefsState;
+        }
+        return persistedState as GlobalPrefsState;
+      },
       merge: (persisted, current) => {
-        const p = persisted as PersistedState | undefined;
-        const groupByType = p?.groupByType ?? false;
-        const rawOrderBy = p?.orderBy ?? "created";
+        const p = persisted as Partial<GlobalPersistedShape> | undefined;
+        const groupByType = p?.groupByType ?? current.groupByType;
+        const rawOrderBy = p?.orderBy ?? current.orderBy;
         // Normalize invalid combination: manual + groupByType
         const orderBy = groupByType && rawOrderBy === "manual" ? "created" : rawOrderBy;
         return {
           ...current,
-          query: p?.query ?? "",
           orderBy,
           groupByType,
-          statusFilters: new Set(p?.statusFilters ?? []),
-          typeFilters: new Set(p?.typeFilters ?? []),
-          githubFilters: new Set(p?.githubFilters ?? []),
-          sessionFilters: new Set(p?.sessionFilters ?? []),
-          activityFilters: new Set(p?.activityFilters ?? []),
-          alwaysShowActive: p?.alwaysShowActive ?? true,
-          alwaysShowWaiting: p?.alwaysShowWaiting ?? true,
-          hideMainWorktree: p?.hideMainWorktree ?? false,
-          pinnedWorktrees: p?.pinnedWorktrees ?? [],
-          collapsedWorktrees: p?.collapsedWorktrees ?? [],
-          manualOrder: p?.manualOrder ?? [],
+          alwaysShowActive: p?.alwaysShowActive ?? current.alwaysShowActive,
+          alwaysShowWaiting: p?.alwaysShowWaiting ?? current.alwaysShowWaiting,
+          hideMainWorktree: p?.hideMainWorktree ?? current.hideMainWorktree,
         };
       },
     }
   )
 );
 
+const _projectStore = create<ProjectScopedState>()(
+  persist(
+    () => ({
+      query: _legacySeed.query ?? "",
+      statusFilters: new Set<StatusFilter>(_legacySeed.statusFilters ?? []),
+      typeFilters: new Set<TypeFilter>(_legacySeed.typeFilters ?? []),
+      githubFilters: new Set<GitHubFilter>(_legacySeed.githubFilters ?? []),
+      sessionFilters: new Set<SessionFilter>(_legacySeed.sessionFilters ?? []),
+      activityFilters: new Set<ActivityFilter>(_legacySeed.activityFilters ?? []),
+      pinnedWorktrees: _legacySeed.pinnedWorktrees ?? [],
+      collapsedWorktrees: _legacySeed.collapsedWorktrees ?? [],
+      manualOrder: _legacySeed.manualOrder ?? [],
+      quickStateFilter: "all",
+    }),
+    {
+      name: PROJECT_KEY,
+      storage: createSafeJSONStorage(),
+      partialize: (state): ProjectPersistedShape => ({
+        query: state.query,
+        statusFilters: Array.from(state.statusFilters),
+        typeFilters: Array.from(state.typeFilters),
+        githubFilters: Array.from(state.githubFilters),
+        sessionFilters: Array.from(state.sessionFilters),
+        activityFilters: Array.from(state.activityFilters),
+        pinnedWorktrees: state.pinnedWorktrees,
+        collapsedWorktrees: state.collapsedWorktrees,
+        manualOrder: state.manualOrder,
+      }),
+      merge: (persisted, current) => {
+        const p = persisted as Partial<ProjectPersistedShape> | undefined;
+        return {
+          ...current,
+          query: p?.query ?? current.query,
+          statusFilters: new Set(p?.statusFilters ?? Array.from(current.statusFilters)),
+          typeFilters: new Set(p?.typeFilters ?? Array.from(current.typeFilters)),
+          githubFilters: new Set(p?.githubFilters ?? Array.from(current.githubFilters)),
+          sessionFilters: new Set(p?.sessionFilters ?? Array.from(current.sessionFilters)),
+          activityFilters: new Set(p?.activityFilters ?? Array.from(current.activityFilters)),
+          pinnedWorktrees: p?.pinnedWorktrees ?? current.pinnedWorktrees,
+          collapsedWorktrees: p?.collapsedWorktrees ?? current.collapsedWorktrees,
+          manualOrder: p?.manualOrder ?? current.manualOrder,
+        };
+      },
+    }
+  )
+);
+
+/**
+ * Module-scope, stable action references. Consumers in `useCallback`/`useEffect`
+ * dep arrays rely on these not changing identity across renders.
+ */
+const _actions: WorktreeFilterActions = {
+  setQuery: (query) => {
+    _projectStore.setState({ query });
+  },
+  setOrderBy: (orderBy) => {
+    _globalPrefsStore.setState({ orderBy });
+  },
+  setGroupByType: (enabled) => {
+    const currentOrderBy = _globalPrefsStore.getState().orderBy;
+    _globalPrefsStore.setState({
+      groupByType: enabled,
+      orderBy: enabled && currentOrderBy === "manual" ? "created" : currentOrderBy,
+    });
+  },
+  toggleStatusFilter: (filter) => {
+    _projectStore.setState((state) => {
+      const next = new Set(state.statusFilters);
+      if (next.has(filter)) next.delete(filter);
+      else next.add(filter);
+      return { statusFilters: next };
+    });
+  },
+  toggleTypeFilter: (filter) => {
+    _projectStore.setState((state) => {
+      const next = new Set(state.typeFilters);
+      if (next.has(filter)) next.delete(filter);
+      else next.add(filter);
+      return { typeFilters: next };
+    });
+  },
+  toggleGitHubFilter: (filter) => {
+    _projectStore.setState((state) => {
+      const next = new Set(state.githubFilters);
+      if (next.has(filter)) next.delete(filter);
+      else next.add(filter);
+      return { githubFilters: next };
+    });
+  },
+  toggleSessionFilter: (filter) => {
+    _projectStore.setState((state) => {
+      const next = new Set(state.sessionFilters);
+      if (next.has(filter)) next.delete(filter);
+      else next.add(filter);
+      return { sessionFilters: next };
+    });
+  },
+  toggleActivityFilter: (filter) => {
+    _projectStore.setState((state) => {
+      const next = new Set(state.activityFilters);
+      if (next.has(filter)) next.delete(filter);
+      else next.add(filter);
+      return { activityFilters: next };
+    });
+  },
+  setAlwaysShowActive: (enabled) => {
+    _globalPrefsStore.setState({ alwaysShowActive: enabled });
+  },
+  setAlwaysShowWaiting: (enabled) => {
+    _globalPrefsStore.setState({ alwaysShowWaiting: enabled });
+  },
+  setHideMainWorktree: (enabled) => {
+    _globalPrefsStore.setState({ hideMainWorktree: enabled });
+  },
+  pinWorktree: (id) => {
+    _projectStore.setState((state) => {
+      if (state.pinnedWorktrees.includes(id)) return state;
+      return { pinnedWorktrees: [...state.pinnedWorktrees, id] };
+    });
+  },
+  unpinWorktree: (id) => {
+    _projectStore.setState((state) => ({
+      pinnedWorktrees: state.pinnedWorktrees.filter((wId) => wId !== id),
+    }));
+  },
+  isWorktreePinned: (id) => _projectStore.getState().pinnedWorktrees.includes(id),
+  collapseWorktree: (id) => {
+    _projectStore.setState((state) => {
+      if (state.collapsedWorktrees.includes(id)) return state;
+      return { collapsedWorktrees: [...state.collapsedWorktrees, id] };
+    });
+  },
+  expandWorktree: (id) => {
+    _projectStore.setState((state) => ({
+      collapsedWorktrees: state.collapsedWorktrees.filter((wId) => wId !== id),
+    }));
+  },
+  toggleWorktreeCollapsed: (id) => {
+    if (_projectStore.getState().collapsedWorktrees.includes(id)) {
+      _actions.expandWorktree(id);
+    } else {
+      _actions.collapseWorktree(id);
+    }
+  },
+  isWorktreeCollapsed: (id) => _projectStore.getState().collapsedWorktrees.includes(id),
+  setManualOrder: (order) => {
+    _projectStore.setState({ manualOrder: order });
+  },
+  setQuickStateFilter: (quickStateFilter) => {
+    _projectStore.setState({ quickStateFilter });
+  },
+  clearAll: () => {
+    _projectStore.setState({
+      query: "",
+      statusFilters: new Set(),
+      typeFilters: new Set(),
+      githubFilters: new Set(),
+      sessionFilters: new Set(),
+      activityFilters: new Set(),
+      quickStateFilter: "all",
+    });
+    _globalPrefsStore.setState({ hideMainWorktree: false });
+  },
+  getActiveFilterCount: () => {
+    const p = _projectStore.getState();
+    const hasQuery = p.query.trim().length > 0;
+    return (
+      (hasQuery ? 1 : 0) +
+      p.statusFilters.size +
+      p.typeFilters.size +
+      p.githubFilters.size +
+      p.sessionFilters.size +
+      p.activityFilters.size +
+      (p.quickStateFilter !== "all" ? 1 : 0)
+    );
+  },
+  hasActiveFilters: () => {
+    const p = _projectStore.getState();
+    const hasQuery = p.query.trim().length > 0;
+    return (
+      hasQuery ||
+      p.statusFilters.size > 0 ||
+      p.typeFilters.size > 0 ||
+      p.githubFilters.size > 0 ||
+      p.sessionFilters.size > 0 ||
+      p.activityFilters.size > 0 ||
+      p.quickStateFilter !== "all"
+    );
+  },
+};
+
+/**
+ * Merged view of both backing stores plus actions. Cached so that repeated
+ * `getState()` calls return the same reference until one of the backing stores
+ * changes — this is what `useSyncExternalStore` inside Zustand's `useStore`
+ * relies on to detect changes.
+ */
+let _cachedMergedState: WorktreeFilterStore | null = null;
+
+function _computeMergedState(): WorktreeFilterStore {
+  const g = _globalPrefsStore.getState();
+  const p = _projectStore.getState();
+  return {
+    query: p.query,
+    orderBy: g.orderBy,
+    groupByType: g.groupByType,
+    statusFilters: p.statusFilters,
+    typeFilters: p.typeFilters,
+    githubFilters: p.githubFilters,
+    sessionFilters: p.sessionFilters,
+    activityFilters: p.activityFilters,
+    alwaysShowActive: g.alwaysShowActive,
+    alwaysShowWaiting: g.alwaysShowWaiting,
+    hideMainWorktree: g.hideMainWorktree,
+    pinnedWorktrees: p.pinnedWorktrees,
+    collapsedWorktrees: p.collapsedWorktrees,
+    manualOrder: p.manualOrder,
+    quickStateFilter: p.quickStateFilter,
+    ..._actions,
+  };
+}
+
+function _getMergedState(): WorktreeFilterStore {
+  if (_cachedMergedState === null) {
+    _cachedMergedState = _computeMergedState();
+  }
+  return _cachedMergedState;
+}
+
+// First subscribers on each backing store — run before any external subscriber,
+// so by the time external listeners re-read via `_getMergedState()`, the cache
+// has been invalidated and a fresh merged object is produced.
+_globalPrefsStore.subscribe(() => {
+  _cachedMergedState = null;
+});
+_projectStore.subscribe(() => {
+  _cachedMergedState = null;
+});
+
+const _mergedApi = {
+  getState: _getMergedState,
+  getInitialState: _getMergedState,
+  subscribe: (listener: (state: WorktreeFilterStore, prev: WorktreeFilterStore) => void) => {
+    let prev = _getMergedState();
+    const notify = () => {
+      const next = _getMergedState();
+      if (next === prev) return;
+      const old = prev;
+      prev = next;
+      listener(next, old);
+    };
+    const unsubGlobal = _globalPrefsStore.subscribe(notify);
+    const unsubProject = _projectStore.subscribe(notify);
+    return () => {
+      unsubGlobal();
+      unsubProject();
+    };
+  },
+};
+
+type SetStatePatch =
+  | Partial<WorktreeFilterStore>
+  | ((state: WorktreeFilterStore) => Partial<WorktreeFilterStore>);
+
+function _routedSetState(update: SetStatePatch): void {
+  const patch = typeof update === "function" ? update(_getMergedState()) : update;
+  const globalPatch: Partial<GlobalPrefsState> = {};
+  const projectPatch: Partial<ProjectScopedState> = {};
+  let hasGlobal = false;
+  let hasProject = false;
+
+  for (const key of Object.keys(patch) as Array<keyof WorktreeFilterStore>) {
+    const value = patch[key];
+    if (isGlobalField(key)) {
+      (globalPatch as Record<string, unknown>)[key] = value;
+      hasGlobal = true;
+    } else if (key in _projectStore.getState()) {
+      (projectPatch as Record<string, unknown>)[key] = value;
+      hasProject = true;
+    }
+    // Action functions in the patch (e.g. from a full-state reset object) are
+    // ignored — they live on the facade, not in either backing store.
+  }
+
+  if (hasGlobal) _globalPrefsStore.setState(globalPatch);
+  if (hasProject) _projectStore.setState(projectPatch);
+}
+
+interface UseWorktreeFilterStoreHook {
+  (): WorktreeFilterStore;
+  <U>(selector: (state: WorktreeFilterStore) => U): U;
+  getState: () => WorktreeFilterStore;
+  getInitialState: () => WorktreeFilterStore;
+  setState: (update: SetStatePatch) => void;
+  subscribe: (typeof _mergedApi)["subscribe"];
+  persist: (typeof _globalPrefsStore)["persist"];
+}
+
+function useWorktreeFilterStoreHook(): WorktreeFilterStore;
+function useWorktreeFilterStoreHook<U>(selector: (state: WorktreeFilterStore) => U): U;
+function useWorktreeFilterStoreHook<U>(
+  selector?: (state: WorktreeFilterStore) => U
+): U | WorktreeFilterStore {
+  return selector ? useStore(_mergedApi, selector) : useStore(_mergedApi);
+}
+
+const hook = useWorktreeFilterStoreHook as UseWorktreeFilterStoreHook;
+hook.getState = _getMergedState;
+hook.getInitialState = _getMergedState;
+hook.setState = _routedSetState;
+hook.subscribe = _mergedApi.subscribe;
+hook.persist = _globalPrefsStore.persist;
+
+export const useWorktreeFilterStore: UseWorktreeFilterStoreHook = hook;
+
 registerPersistedStore({
   storeId: "worktreeFilterStore",
-  store: useWorktreeFilterStore,
-  persistedStateType: "PersistedState",
+  store: _globalPrefsStore,
+  persistedStateType: "GlobalPersistedShape",
 });

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -231,7 +231,7 @@ const _legacySeed = loadLegacySeedForProject();
 
 const _globalPrefsStore = create<GlobalPrefsState>()(
   persist(
-    () => ({
+    (): GlobalPrefsState => ({
       orderBy: "created",
       groupByType: false,
       alwaysShowActive: true,
@@ -285,7 +285,7 @@ const _globalPrefsStore = create<GlobalPrefsState>()(
 
 const _projectStore = create<ProjectScopedState>()(
   persist(
-    () => ({
+    (): ProjectScopedState => ({
       query: _legacySeed.query ?? "",
       statusFilters: new Set<StatusFilter>(_legacySeed.statusFilters ?? []),
       typeFilters: new Set<TypeFilter>(_legacySeed.typeFilters ?? []),
@@ -581,12 +581,17 @@ interface UseWorktreeFilterStoreHook {
   persist: (typeof _globalPrefsStore)["persist"];
 }
 
+function identitySelector(state: WorktreeFilterStore): WorktreeFilterStore {
+  return state;
+}
+
 function useWorktreeFilterStoreHook(): WorktreeFilterStore;
 function useWorktreeFilterStoreHook<U>(selector: (state: WorktreeFilterStore) => U): U;
 function useWorktreeFilterStoreHook<U>(
   selector?: (state: WorktreeFilterStore) => U
 ): U | WorktreeFilterStore {
-  return selector ? useStore(_mergedApi, selector) : useStore(_mergedApi);
+  const resolved = (selector ?? identitySelector) as (state: WorktreeFilterStore) => U;
+  return useStore(_mergedApi, resolved);
 }
 
 const hook = useWorktreeFilterStoreHook as UseWorktreeFilterStoreHook;


### PR DESCRIPTION
## Summary

- Worktree sidebar filter state (query, status/type/GitHub/session/activity filters, pins, collapsed rows, manual order) was stored under a single global localStorage key, so switching projects would carry over stale IDs and search strings from another repo entirely.
- Split `useWorktreeFilterStore` into a global prefs store (orderBy, groupByType, alwaysShow\*, hideMainWorktree) and a per-project store keyed `daintree-worktree-filters:{projectId}` for all query-shaped and ID-scoped fields. ProjectId is resolved synchronously from `window.location.search` at module load.
- One-time migration seeds per-project state from the legacy combined blob so existing pins and manual ordering aren't lost on upgrade. The global store bumps to version 1 and strips the stale per-project fields.

Resolves #5366

## Changes

- `src/store/worktreeFilterStore.ts` — two internal persisted stores behind a store-like facade that preserves the existing API for all 7 consumers
- `src/store/__tests__/worktreeFilterStore.test.ts` — extended with multi-project isolation tests and legacy migration coverage; all ~20 existing call sites preserved

## Testing

Unit tests pass. Multi-project isolation verified: pinning a worktree in project A no longer bleeds into project B's filter state. Legacy migration seeds correctly from an existing persisted blob and cleans up the old key.