### PR TITLE
feat(git): unified git operation error taxonomy and classifier

### DIFF
--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -1165,6 +1165,64 @@ describe("errorHandlers", () => {
       expect(sentError.recoveryHint).toBeUndefined();
     });
 
+    it("populates gitReason and recoveryAction for GitOperationError", async () => {
+      const CHANNELS = await getChannels();
+      const { GitOperationError } = await import("../../utils/errorTypes.js");
+      const mockWindow = createMockWindow();
+      registerErrorHandlers(null, null);
+
+      const spawn = vi.fn(() => {
+        throw new GitOperationError("auth-failed", "Authentication failed for remote", {
+          cwd: "/repo",
+          op: "push",
+        });
+      });
+      registerErrorHandlers(null, createPtyClientMock(spawn));
+
+      const retryHandler = getInvokeHandler(CHANNELS.ERROR_RETRY);
+      await retryHandler({} as never, {
+        errorId: "e",
+        action: "terminal",
+        args: { id: "t", cwd: "/" },
+      }).catch(() => {});
+
+      const sentError = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      )?.[1];
+      expect(sentError.gitReason).toBe("auth-failed");
+      expect(sentError.recoveryAction).toEqual({
+        label: "Sign in with GitHub",
+        actionId: "github.auth",
+      });
+      expect(sentError.recoveryHint).toContain("credentials");
+      expect(sentError.type).toBe("git");
+    });
+
+    it("leaves gitReason and recoveryAction undefined for plain GitError", async () => {
+      const CHANNELS = await getChannels();
+      const { GitError } = await import("../../utils/errorTypes.js");
+      const mockWindow = createMockWindow();
+      registerErrorHandlers(null, null);
+
+      const spawn = vi.fn(() => {
+        throw new GitError("fatal: not a git repository");
+      });
+      registerErrorHandlers(null, createPtyClientMock(spawn));
+
+      const retryHandler = getInvokeHandler(CHANNELS.ERROR_RETRY);
+      await retryHandler({} as never, {
+        errorId: "e",
+        action: "terminal",
+        args: { id: "t", cwd: "/" },
+      }).catch(() => {});
+
+      const sentError = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      )?.[1];
+      expect(sentError.gitReason).toBeUndefined();
+      expect(sentError.recoveryAction).toBeUndefined();
+    });
+
     it("returns reset hint for ECONNRESET", async () => {
       const CHANNELS = await getChannels();
       const mockWindow = createMockWindow();

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -6,6 +6,7 @@ import { getLogFilePath, logError as logErrorUtil } from "../utils/logger.js";
 import { broadcastToRenderer, typedHandle } from "./utils.js";
 import {
   GitError,
+  GitOperationError,
   ProcessError,
   FileSystemError,
   ConfigError,
@@ -13,6 +14,7 @@ import {
   getErrorDetails,
   isTransientError,
 } from "../utils/errorTypes.js";
+import { getGitRecoveryAction, getGitRecoveryHint } from "../../shared/utils/gitOperationErrors.js";
 import { store } from "../store.js";
 import { FAULT_MODE_ENABLED } from "./faultRegistry.js";
 import type { PtyClient } from "../services/PtyClient.js";
@@ -110,6 +112,10 @@ function getRecoveryHint(error: unknown): string | undefined {
     return "The terminal process could not start.";
   }
 
+  if (error instanceof GitOperationError) {
+    return getGitRecoveryHint(error.reason);
+  }
+
   if (error instanceof GitError) {
     const msg = error.message + (error.cause ? ` ${error.cause.message}` : "");
     if (msg.includes("not a git repository")) {
@@ -177,6 +183,9 @@ function createAppError(
   const details = getErrorDetails(error);
   const correlationId = randomUUID();
 
+  const gitReason = error instanceof GitOperationError ? error.reason : undefined;
+  const recoveryAction = gitReason ? getGitRecoveryAction(gitReason) : undefined;
+
   return {
     id: generateErrorId(),
     timestamp: Date.now(),
@@ -191,6 +200,8 @@ function createAppError(
     retryArgs: options.retryArgs,
     correlationId,
     recoveryHint: getRecoveryHint(error),
+    gitReason,
+    recoveryAction,
   };
 }
 

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -7,6 +7,11 @@ import { store } from "../../store.js";
 import { soundService } from "../../services/SoundService.js";
 import { preAgentSnapshotService } from "../../services/PreAgentSnapshotService.js";
 import type { SnapshotInfo, SnapshotRevertResult } from "../../../shared/types/ipc/git.js";
+import type { GitOperationReason, RecoveryAction } from "../../../shared/types/ipc/errors.js";
+import {
+  classifyGitError,
+  getGitRecoveryAction,
+} from "../../../shared/utils/gitOperationErrors.js";
 
 interface StagingFileEntry {
   path: string;
@@ -118,7 +123,12 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   const handlePush = async (payload: {
     cwd: string;
     setUpstream?: boolean;
-  }): Promise<{ success: boolean; error?: string }> => {
+  }): Promise<{
+    success: boolean;
+    error?: string;
+    gitReason?: GitOperationReason;
+    recoveryAction?: RecoveryAction;
+  }> => {
     checkRateLimit(CHANNELS.GIT_PUSH, 5, 10_000);
     validateCwd(payload?.cwd);
 
@@ -134,6 +144,8 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
         try {
           await git.push();
         } catch (pushErr) {
+          // Keep the narrow upstream-missing auto-retry via substring match —
+          // classifier's `config-missing` also covers unrelated config errors.
           const msg = pushErr instanceof Error ? pushErr.message : String(pushErr);
           if (msg.includes("no upstream branch") || msg.includes("has no upstream")) {
             await git.push(["--set-upstream", "origin", branchName]);
@@ -151,7 +163,13 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
         soundService.play("git-push-error");
       }
       const errorMessage = error instanceof Error ? error.message : String(error);
-      return { success: false, error: errorMessage };
+      const gitReason = classifyGitError(error);
+      return {
+        success: false,
+        error: errorMessage,
+        gitReason,
+        recoveryAction: getGitRecoveryAction(gitReason),
+      };
     }
   };
   handlers.push(typedHandle(CHANNELS.GIT_PUSH, handlePush));

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -4,7 +4,7 @@ import { existsSync } from "fs";
 import { readFile, stat } from "fs/promises";
 import { logDebug, logError, logWarn } from "../utils/logger.js";
 import type { GitStatus, WorktreeChanges } from "../../shared/types/index.js";
-import { WorktreeRemovedError, GitError } from "../utils/errorTypes.js";
+import { WorktreeRemovedError, GitError, toGitOperationError } from "../utils/errorTypes.js";
 import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/types/ipc/git.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 
@@ -62,7 +62,7 @@ export class GitService {
       return branches;
     } catch (error) {
       logError("Failed to list branches", { error: (error as Error).message });
-      throw new Error(`Failed to list branches: ${(error as Error).message}`);
+      throw toGitOperationError(error, { cwd: this.rootPath, op: "list-branches" });
     }
   }
 

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -27,7 +27,7 @@ vi.mock("../../utils/logger.js", () => ({
 }));
 
 import { GitService } from "../GitService.js";
-import { GitError, WorktreeRemovedError } from "../../utils/errorTypes.js";
+import { GitError, GitOperationError, WorktreeRemovedError } from "../../utils/errorTypes.js";
 
 describe("GitService", () => {
   let tempDir: string;
@@ -119,6 +119,44 @@ describe("GitService", () => {
     const branches = await service.listBranches();
 
     expect(branches.map((branch) => branch.name)).toEqual(["main", "origin/main"]);
+  });
+
+  it("listBranches throws GitOperationError with classified reason on failure", async () => {
+    gitClientMock.branch.mockRejectedValue(new Error("fatal: not a git repository"));
+    const service = new GitService(tempDir);
+
+    let caught: unknown;
+    try {
+      await service.listBranches();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(GitOperationError);
+    expect(caught).toBeInstanceOf(GitError);
+    const opError = caught as GitOperationError;
+    expect(opError.reason).toBe("not-a-repository");
+    expect(opError.op).toBe("list-branches");
+    expect(opError.context).toEqual(
+      expect.objectContaining({ cwd: tempDir, op: "list-branches", reason: "not-a-repository" })
+    );
+  });
+
+  it("listBranches classifies authentication failures", async () => {
+    gitClientMock.branch.mockRejectedValue(
+      new Error("remote: Authentication failed for 'https://github.com/foo/bar.git/'")
+    );
+    const service = new GitService(tempDir);
+
+    let caught: unknown;
+    try {
+      await service.listBranches();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(GitOperationError);
+    expect((caught as GitOperationError).reason).toBe("auth-failed");
   });
 
   describe("compareWorktrees", () => {

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  GitError,
+  GitOperationError,
+  WorktreeRemovedError,
+  DaintreeError,
+  toGitOperationError,
+} from "../errorTypes.js";
+
+describe("GitOperationError", () => {
+  it("preserves the GitError -> DaintreeError -> Error hierarchy", () => {
+    const err = new GitOperationError("auth-failed", "boom", { cwd: "/repo", op: "push" });
+    expect(err).toBeInstanceOf(GitOperationError);
+    expect(err).toBeInstanceOf(GitError);
+    expect(err).toBeInstanceOf(DaintreeError);
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("still allows existing WorktreeRemovedError instanceof checks to hold", () => {
+    const wt = new WorktreeRemovedError("/missing");
+    expect(wt).toBeInstanceOf(GitError);
+    expect(wt).toBeInstanceOf(WorktreeRemovedError);
+    // WorktreeRemovedError must NOT be conflated with the new taxonomy
+    expect(wt).not.toBeInstanceOf(GitOperationError);
+  });
+
+  it("stamps reason/op/cwd into context and dedicated fields", () => {
+    const err = new GitOperationError("conflict-unresolved", "merge conflict", {
+      cwd: "/w",
+      op: "merge",
+    });
+    expect(err.reason).toBe("conflict-unresolved");
+    expect(err.op).toBe("merge");
+    expect(err.context).toEqual(
+      expect.objectContaining({
+        cwd: "/w",
+        op: "merge",
+        reason: "conflict-unresolved",
+      })
+    );
+  });
+
+  it("defaults rawMessage to the visible message when unset", () => {
+    const err = new GitOperationError("unknown", "hi");
+    expect(err.rawMessage).toBe("hi");
+  });
+});
+
+describe("toGitOperationError", () => {
+  it("wraps a plain Error and classifies its reason", () => {
+    const original = new Error("fatal: not a git repository");
+    const wrapped = toGitOperationError(original, { cwd: "/x", op: "status" });
+    expect(wrapped).toBeInstanceOf(GitOperationError);
+    expect(wrapped.reason).toBe("not-a-repository");
+    expect(wrapped.op).toBe("status");
+    expect(wrapped.cause).toBe(original);
+  });
+
+  it("is idempotent — returns the same instance when given a GitOperationError", () => {
+    const existing = new GitOperationError("auth-failed", "whoops", { op: "push" });
+    const result = toGitOperationError(existing, { cwd: "/y", op: "clone" });
+    expect(result).toBe(existing);
+    // Never rewrites the original's op/cwd/reason
+    expect(result.reason).toBe("auth-failed");
+    expect(result.op).toBe("push");
+  });
+
+  it("coerces non-Error throwables without losing classification", () => {
+    const wrapped = toGitOperationError("fatal: unable to read config file '/etc/gitconfig'");
+    expect(wrapped).toBeInstanceOf(GitOperationError);
+    expect(wrapped.reason).toBe("config-missing");
+  });
+});

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -1,3 +1,6 @@
+import { classifyGitError, extractGitErrorMessage } from "../../shared/utils/gitOperationErrors.js";
+import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
+
 export class DaintreeError extends Error {
   constructor(
     message: string,
@@ -14,6 +17,59 @@ export class GitError extends DaintreeError {
   constructor(message: string, context?: Record<string, unknown>, cause?: Error) {
     super(message, context, cause);
   }
+}
+
+/**
+ * Classified git failure. Extends GitError (not simple-git's GitError) so
+ * existing `instanceof GitError` checks keep working, while new callers can
+ * `instanceof GitOperationError` to branch on the discriminated `reason`.
+ */
+export class GitOperationError extends GitError {
+  readonly reason: GitOperationReason;
+  readonly op?: string;
+  readonly rawMessage: string;
+
+  constructor(
+    reason: GitOperationReason,
+    message: string,
+    opts: {
+      cwd?: string;
+      op?: string;
+      cause?: Error;
+      rawMessage?: string;
+      context?: Record<string, unknown>;
+    } = {}
+  ) {
+    const context: Record<string, unknown> = { ...(opts.context ?? {}) };
+    if (opts.cwd !== undefined) context.cwd = opts.cwd;
+    if (opts.op !== undefined) context.op = opts.op;
+    context.reason = reason;
+    super(message, context, opts.cause);
+    this.reason = reason;
+    this.op = opts.op;
+    this.rawMessage = opts.rawMessage ?? message;
+  }
+}
+
+/**
+ * Wrap any thrown value into a GitOperationError. If the value is already a
+ * GitOperationError it is returned unchanged so repeated wrapping at multiple
+ * layers is a no-op.
+ */
+export function toGitOperationError(
+  error: unknown,
+  opts: { cwd?: string; op?: string } = {}
+): GitOperationError {
+  if (error instanceof GitOperationError) return error;
+  const rawMessage = extractGitErrorMessage(error);
+  const reason = classifyGitError(error);
+  const cause = error instanceof Error ? error : undefined;
+  return new GitOperationError(reason, rawMessage || "Git operation failed", {
+    cwd: opts.cwd,
+    op: opts.op,
+    cause,
+    rawMessage,
+  });
 }
 
 /**

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -2,7 +2,7 @@ import { dirname, resolve } from "path";
 import { realpathSync, promises as fs } from "fs";
 import type { SimpleGit, StatusResult } from "simple-git";
 import type { FileChangeDetail, GitStatus, WorktreeChanges } from "../types/index.js";
-import { GitError, WorktreeRemovedError } from "./errorTypes.js";
+import { WorktreeRemovedError, toGitOperationError } from "./errorTypes.js";
 import { logWarn, logError } from "./logger.js";
 import { Cache } from "./cache.js";
 import { createHardenedGit } from "./hardenedGit.js";
@@ -454,8 +454,7 @@ export async function getWorktreeChangesWithStats(
         throw new WorktreeRemovedError(cwd, error instanceof Error ? error : undefined);
       }
 
-      const cause = error instanceof Error ? error : new Error(String(error));
-      const gitError = new GitError("Failed to get git worktree changes", { cwd }, cause);
+      const gitError = toGitOperationError(error, { cwd, op: "status" });
       logError("Git worktree changes operation failed", gitError, { cwd });
       throw gitError;
     }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -5,6 +5,7 @@ import { join as pathJoin, dirname, resolve as pathResolve, isAbsolute } from "p
 import { generateProjectId, settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
 import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
+import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
 import type { Worktree, WorktreeResourceStatus } from "../../shared/types/worktree.js";
 import type {
   WorkspaceHostEvent,
@@ -1330,11 +1331,14 @@ export class WorkspaceService {
       await git.raw(["fetch", "origin", `pull/${prNumber}/head:${headRefName}`]);
       this.sendEvent({ type: "fetch-pr-branch-result", requestId, success: true });
     } catch (error) {
+      const gitReason = classifyGitError(error);
       this.sendEvent({
         type: "fetch-pr-branch-result",
         requestId,
         success: false,
         error: (error as Error).message,
+        gitReason,
+        recoveryAction: getGitRecoveryAction(gitReason),
       });
     }
   }

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -170,6 +170,8 @@ describe("WorkspaceService.fetchPRBranch", () => {
       requestId: "req-2",
       success: false,
       error: "fatal: couldn't find remote ref pull/99999/head",
+      gitReason: "unknown",
+      recoveryAction: undefined,
     });
   });
 
@@ -185,6 +187,45 @@ describe("WorkspaceService.fetchPRBranch", () => {
       requestId: "req-3",
       success: false,
       error: "fatal: unable to access 'https://github.com/...'",
+      gitReason: "unknown",
+      recoveryAction: undefined,
     });
+  });
+
+  it("should include structured gitReason and recoveryAction on auth failure", async () => {
+    mockSimpleGit.raw.mockRejectedValueOnce(
+      new Error("remote: Authentication failed for 'https://github.com/foo/bar.git/'")
+    );
+
+    await service.fetchPRBranch("req-auth", "/test/root", 5, "branch");
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "fetch-pr-branch-result",
+        requestId: "req-auth",
+        success: false,
+        gitReason: "auth-failed",
+        recoveryAction: { label: "Sign in with GitHub", actionId: "github.auth" },
+      })
+    );
+  });
+
+  it("should classify network resolution failure", async () => {
+    mockSimpleGit.raw.mockRejectedValueOnce(
+      new Error(
+        "fatal: unable to access 'https://github.com/foo.git/': Could not resolve host: github.com"
+      )
+    );
+
+    await service.fetchPRBranch("req-net", "/test/root", 5, "branch");
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "fetch-pr-branch-result",
+        requestId: "req-net",
+        success: false,
+        gitReason: "network-unavailable",
+      })
+    );
   });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -170,14 +170,16 @@ describe("WorkspaceService.fetchPRBranch", () => {
       requestId: "req-2",
       success: false,
       error: "fatal: couldn't find remote ref pull/99999/head",
-      gitReason: "unknown",
+      gitReason: "pathspec-invalid",
       recoveryAction: undefined,
     });
   });
 
   it("should handle network errors gracefully", async () => {
     mockSimpleGit.raw.mockRejectedValueOnce(
-      new Error("fatal: unable to access 'https://github.com/...'")
+      new Error(
+        "fatal: unable to access 'https://github.com/foo.git/': Could not resolve host: github.com"
+      )
     );
 
     await service.fetchPRBranch("req-3", "/test/root", 10, "some-branch");
@@ -186,8 +188,9 @@ describe("WorkspaceService.fetchPRBranch", () => {
       type: "fetch-pr-branch-result",
       requestId: "req-3",
       success: false,
-      error: "fatal: unable to access 'https://github.com/...'",
-      gitReason: "unknown",
+      error:
+        "fatal: unable to access 'https://github.com/foo.git/': Could not resolve host: github.com",
+      gitReason: "network-unavailable",
       recoveryAction: undefined,
     });
   });

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -73,7 +73,13 @@ import type {
 } from "./system.js";
 import type { AppState, HydrateResult } from "./app.js";
 import type { LogEntry, LogFilterOptions } from "./logs.js";
-import type { RetryAction, AppError, RetryProgressPayload } from "./errors.js";
+import type {
+  RetryAction,
+  AppError,
+  RetryProgressPayload,
+  GitOperationReason,
+  RecoveryAction,
+} from "./errors.js";
 import type { EventRecord, EventFilterOptions } from "./events.js";
 import type {
   ProjectCloseResult,
@@ -743,7 +749,15 @@ export interface ElectronAPI {
     stageAll(cwd: string): Promise<void>;
     unstageAll(cwd: string): Promise<void>;
     commit(cwd: string, message: string): Promise<{ hash: string; summary: string }>;
-    push(cwd: string, setUpstream?: boolean): Promise<{ success: boolean; error?: string }>;
+    push(
+      cwd: string,
+      setUpstream?: boolean
+    ): Promise<{
+      success: boolean;
+      error?: string;
+      gitReason?: GitOperationReason;
+      recoveryAction?: RecoveryAction;
+    }>;
     getStagingStatus(cwd: string): Promise<StagingStatus>;
     compareWorktrees(
       cwd: string,

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -37,6 +37,39 @@ export function isIpcEnvelope(value: unknown): value is IpcEnvelope {
 /** Error type */
 export type ErrorType = "git" | "process" | "filesystem" | "network" | "config" | "unknown";
 
+/**
+ * Discriminated reason for a failed git operation. The classifier in
+ * `shared/utils/gitOperationErrors.ts` maps simple-git stderr output to one of
+ * these reasons so UI code can branch without substring-matching raw stderr.
+ */
+export type GitOperationReason =
+  | "auth-failed"
+  | "network-unavailable"
+  | "repository-not-found"
+  | "not-a-repository"
+  | "dubious-ownership"
+  | "config-missing"
+  | "worktree-dirty"
+  | "conflict-unresolved"
+  | "push-rejected-outdated"
+  | "push-rejected-policy"
+  | "pathspec-invalid"
+  | "lfs-missing"
+  | "hook-rejected"
+  | "system-io-error"
+  | "unknown";
+
+/**
+ * Structured contextual CTA for an error. `actionId` is dispatched via the
+ * renderer's ActionService when the user clicks the recovery button. All
+ * fields are plain primitives so the object survives structured clone.
+ */
+export interface RecoveryAction {
+  label: string;
+  actionId: string;
+  args?: Record<string, unknown>;
+}
+
 /** Action that can be retried after an error */
 export type RetryAction = "terminal" | "git" | "worktree";
 
@@ -84,4 +117,8 @@ export interface AppError {
   recoveryHint?: string;
   /** Retry progress state (set during active retry loop) */
   retryProgress?: { attempt: number; maxAttempts: number };
+  /** Classified reason when this error originated from a git operation */
+  gitReason?: GitOperationReason;
+  /** Structured CTA the renderer can surface alongside the error */
+  recoveryAction?: RecoveryAction;
 }

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -316,7 +316,14 @@ export type WorkspaceHostEvent =
   // Branch operation responses
   | { type: "list-branches-result"; requestId: string; branches: BranchInfo[]; error?: string }
   | { type: "get-recent-branches-result"; requestId: string; branches: string[]; error?: string }
-  | { type: "fetch-pr-branch-result"; requestId: string; success: boolean; error?: string }
+  | {
+      type: "fetch-pr-branch-result";
+      requestId: string;
+      success: boolean;
+      error?: string;
+      gitReason?: import("./ipc/errors.js").GitOperationReason;
+      recoveryAction?: import("./ipc/errors.js").RecoveryAction;
+    }
   // Git operation responses
   | { type: "get-file-diff-result"; requestId: string; diff: string; error?: string }
   // Spontaneous updates (no requestId - these are pushed events)

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyGitError,
+  extractGitErrorMessage,
+  getGitRecoveryAction,
+  getGitRecoveryHint,
+  normalizeGitErrorMessage,
+} from "../gitOperationErrors.js";
+import type { GitOperationReason } from "../../types/ipc/errors.js";
+
+describe("classifyGitError — table-driven", () => {
+  it.each<[GitOperationReason, string]>([
+    ["not-a-repository", "fatal: not a git repository (or any of the parent directories): .git"],
+    [
+      "dubious-ownership",
+      "fatal: detected dubious ownership in repository at '/Users/greg/code/repo'",
+    ],
+    ["auth-failed", "remote: Authentication failed for 'https://github.com/org/repo.git/'"],
+    ["auth-failed", "Permission denied (publickey)."],
+    [
+      "auth-failed",
+      "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+    ],
+    ["repository-not-found", "remote: ERROR: Repository not found."],
+    ["repository-not-found", "fatal: repository 'https://github.com/foo/bar.git/' not found"],
+    [
+      "repository-not-found",
+      "fatal: Could not read from remote repository.\nPlease make sure you have the correct access rights",
+    ],
+    [
+      "network-unavailable",
+      "fatal: unable to access 'https://github.com/foo.git/': Could not resolve host: github.com",
+    ],
+    [
+      "network-unavailable",
+      "fatal: unable to access 'https://github.com/foo.git/': Failed to connect to github.com port 443: Connection refused",
+    ],
+    [
+      "network-unavailable",
+      "fatal: unable to access 'https://github.com/foo.git/': The requested URL returned error: 503",
+    ],
+    ["hook-rejected", " ! [remote rejected] main -> main (pre-receive hook declined)"],
+    ["hook-rejected", " ! [remote rejected] feature -> feature (update hook declined)"],
+    [
+      "push-rejected-policy",
+      "remote: error: GH006: Protected branch update failed for refs/heads/main.",
+    ],
+    ["push-rejected-policy", "remote: pack exceeds maximum allowed size"],
+    ["push-rejected-outdated", " ! [rejected]        main -> main (non-fast-forward)"],
+    ["conflict-unresolved", "CONFLICT (content): Merge conflict in src/index.ts"],
+    ["conflict-unresolved", "error: merge is not possible because you have unmerged files."],
+    [
+      "worktree-dirty",
+      "error: Your local changes to the following files would be overwritten by merge:\n\tfoo.ts",
+    ],
+    ["pathspec-invalid", "fatal: bad revision 'HEAD~999'"],
+    ["pathspec-invalid", "fatal: pathspec 'nonexistent' did not match any file(s) known to git"],
+    [
+      "lfs-missing",
+      "Smudge error: Error downloading file.bin: external filter 'git-lfs filter-process' failed",
+    ],
+    ["config-missing", "fatal: The current branch feature/foo has no upstream branch."],
+    ["config-missing", "fatal: unable to read config file '/etc/gitconfig': Permission denied"],
+    ["system-io-error", "ENOENT: no such file or directory, open '/path/to/file'"],
+    ["system-io-error", "could not create work tree dir '/path/to/wt': Permission denied"],
+    ["unknown", "some completely unrecognized git message"],
+    ["unknown", ""],
+  ])("maps %s from %j", (expected, input) => {
+    expect(classifyGitError(input)).toBe(expected);
+  });
+});
+
+describe("classifyGitError — ordering and normalization", () => {
+  it("strips 'remote: ' prefix before matching (picks classified reason over raw string)", () => {
+    // Without remote: prefix stripping, the ' ! [rejected] ... (non-fast-forward)' line would
+    // be the only match — classifier must see the hook-rejected text after stripping.
+    const msg =
+      "remote:  ! [remote rejected] main -> main (pre-receive hook declined)\n" +
+      " ! [rejected]        main -> main (non-fast-forward)";
+    expect(classifyGitError(msg)).toBe("hook-rejected");
+  });
+
+  it("classifies GH006 Protected branch when only policy signal is present", () => {
+    const msg =
+      "remote: error: GH006: Protected branch update failed for refs/heads/main.\n" +
+      "remote: error: Required status check 'ci-ok' was not run on this commit";
+    expect(classifyGitError(msg)).toBe("push-rejected-policy");
+  });
+
+  it("prefers hook-rejected over push-rejected-outdated when both present (VS Code #229011)", () => {
+    const msg =
+      "remote: Hook error details...\n" +
+      " ! [remote rejected] main -> main (pre-receive hook declined)\n" +
+      " ! [rejected]        main -> main (non-fast-forward)";
+    expect(classifyGitError(msg)).toBe("hook-rejected");
+  });
+
+  it("normalizes CRLF before matching", () => {
+    const msg = "remote: Repository not found.\r\nfatal: Could not read from remote repository.";
+    expect(classifyGitError(msg)).toBe("repository-not-found");
+  });
+
+  it("handles plain Error objects", () => {
+    const err = new Error("fatal: not a git repository");
+    expect(classifyGitError(err)).toBe("not-a-repository");
+  });
+
+  it("handles non-Error input (null/undefined)", () => {
+    expect(classifyGitError(null)).toBe("unknown");
+    expect(classifyGitError(undefined)).toBe("unknown");
+  });
+
+  it("handles non-Error input (number, object)", () => {
+    expect(classifyGitError(42)).toBe("unknown");
+    expect(classifyGitError({})).toBe("unknown");
+  });
+
+  it("matches case-insensitively where appropriate", () => {
+    expect(classifyGitError("authentication failed")).toBe("auth-failed");
+    expect(classifyGitError("AUTHENTICATION FAILED")).toBe("auth-failed");
+  });
+});
+
+describe("extractGitErrorMessage", () => {
+  it("returns message from an Error instance", () => {
+    expect(extractGitErrorMessage(new Error("hello"))).toBe("hello");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(extractGitErrorMessage(null)).toBe("");
+    expect(extractGitErrorMessage(undefined)).toBe("");
+  });
+
+  it("returns strings as-is", () => {
+    expect(extractGitErrorMessage("plain")).toBe("plain");
+  });
+
+  it("reads .message from error-shaped objects", () => {
+    expect(extractGitErrorMessage({ message: "shaped" })).toBe("shaped");
+  });
+
+  it("coerces primitives", () => {
+    expect(extractGitErrorMessage(42)).toBe("42");
+  });
+});
+
+describe("normalizeGitErrorMessage", () => {
+  it("strips CRLF", () => {
+    expect(normalizeGitErrorMessage("a\r\nb")).toBe("a\nb");
+  });
+
+  it("strips remote: prefix from every line", () => {
+    expect(normalizeGitErrorMessage("remote: line1\nremote: line2")).toBe("line1\nline2");
+  });
+
+  it("only strips remote: at line starts", () => {
+    // Host URLs like 'remote: example.com' (without space match anchor) should not corrupt non-prefixed content
+    expect(normalizeGitErrorMessage("other text remote: inline")).toBe("other text remote: inline");
+  });
+});
+
+describe("getGitRecoveryHint", () => {
+  it("returns a hint for every reason except 'unknown'", () => {
+    const reasons: GitOperationReason[] = [
+      "auth-failed",
+      "network-unavailable",
+      "repository-not-found",
+      "not-a-repository",
+      "dubious-ownership",
+      "config-missing",
+      "worktree-dirty",
+      "conflict-unresolved",
+      "push-rejected-outdated",
+      "push-rejected-policy",
+      "pathspec-invalid",
+      "lfs-missing",
+      "hook-rejected",
+      "system-io-error",
+    ];
+    for (const reason of reasons) {
+      expect(getGitRecoveryHint(reason)).toBeTruthy();
+    }
+    expect(getGitRecoveryHint("unknown")).toBeUndefined();
+  });
+});
+
+describe("getGitRecoveryAction", () => {
+  it("returns structured CTA for key reasons", () => {
+    expect(getGitRecoveryAction("auth-failed")).toEqual({
+      label: "Sign in with GitHub",
+      actionId: "github.auth",
+    });
+    expect(getGitRecoveryAction("push-rejected-outdated")).toEqual({
+      label: "Pull latest",
+      actionId: "git.pull",
+    });
+    expect(getGitRecoveryAction("conflict-unresolved")).toEqual({
+      label: "Resolve conflicts",
+      actionId: "git.resolveConflicts",
+    });
+    expect(getGitRecoveryAction("dubious-ownership")).toEqual({
+      label: "Trust this repo",
+      actionId: "git.trustRepository",
+    });
+  });
+
+  it("returns undefined for reasons without a CTA", () => {
+    expect(getGitRecoveryAction("unknown")).toBeUndefined();
+    expect(getGitRecoveryAction("system-io-error")).toBeUndefined();
+  });
+});

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -21,6 +21,10 @@ describe("classifyGitError — table-driven", () => {
       "auth-failed",
       "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
     ],
+    [
+      "auth-failed",
+      "fatal: unable to access 'https://github.com/acme/private.git/': The requested URL returned error: 403",
+    ],
     ["repository-not-found", "remote: ERROR: Repository not found."],
     ["repository-not-found", "fatal: repository 'https://github.com/foo/bar.git/' not found"],
     [
@@ -45,6 +49,14 @@ describe("classifyGitError — table-driven", () => {
       "push-rejected-policy",
       "remote: error: GH006: Protected branch update failed for refs/heads/main.",
     ],
+    [
+      "push-rejected-policy",
+      "remote: error: GH013: Repository rule violations found for refs/heads/main.",
+    ],
+    [
+      "push-rejected-policy",
+      " ! [remote rejected] main -> main (push declined due to repository rule violations)",
+    ],
     ["push-rejected-policy", "remote: pack exceeds maximum allowed size"],
     ["push-rejected-outdated", " ! [rejected]        main -> main (non-fast-forward)"],
     ["conflict-unresolved", "CONFLICT (content): Merge conflict in src/index.ts"],
@@ -55,11 +67,13 @@ describe("classifyGitError — table-driven", () => {
     ],
     ["pathspec-invalid", "fatal: bad revision 'HEAD~999'"],
     ["pathspec-invalid", "fatal: pathspec 'nonexistent' did not match any file(s) known to git"],
+    ["pathspec-invalid", "fatal: couldn't find remote ref pull/99999/head"],
     [
       "lfs-missing",
       "Smudge error: Error downloading file.bin: external filter 'git-lfs filter-process' failed",
     ],
     ["config-missing", "fatal: The current branch feature/foo has no upstream branch."],
+    ["config-missing", "fatal: no upstream configured for branch 'feature/foo'"],
     ["config-missing", "fatal: unable to read config file '/etc/gitconfig': Permission denied"],
     ["system-io-error", "ENOENT: no such file or directory, open '/path/to/file'"],
     ["system-io-error", "could not create work tree dir '/path/to/wt': Permission denied"],
@@ -118,6 +132,31 @@ describe("classifyGitError — ordering and normalization", () => {
   it("matches case-insensitively where appropriate", () => {
     expect(classifyGitError("authentication failed")).toBe("auth-failed");
     expect(classifyGitError("AUTHENTICATION FAILED")).toBe("auth-failed");
+    // push-rejected-outdated is also case-insensitive to survive wording drift
+    expect(classifyGitError(" ! [Rejected]        main -> main (Non-Fast-Forward)")).toBe(
+      "push-rejected-outdated"
+    );
+  });
+
+  it("prefers network-unavailable over repository-not-found when both signals appear", () => {
+    const msg =
+      "fatal: Could not read from remote repository.\n" +
+      "fatal: unable to access 'https://github.com/foo.git/': Could not resolve host: github.com";
+    expect(classifyGitError(msg)).toBe("network-unavailable");
+  });
+
+  it("prefers auth-failed over repository-not-found when both signals appear", () => {
+    const msg =
+      "fatal: Could not read from remote repository.\n" +
+      "fatal: could not read Username for 'https://github.com': terminal prompts disabled";
+    expect(classifyGitError(msg)).toBe("auth-failed");
+  });
+
+  it("combines CRLF, remote-stripping, and ordering for hook rejection", () => {
+    const msg =
+      "remote:  ! [remote rejected] main -> main (pre-receive hook declined)\r\n" +
+      " ! [rejected]        main -> main (non-fast-forward)";
+    expect(classifyGitError(msg)).toBe("hook-rejected");
   });
 });
 

--- a/shared/utils/__tests__/ipcErrorSerialization.test.ts
+++ b/shared/utils/__tests__/ipcErrorSerialization.test.ts
@@ -222,6 +222,35 @@ describe("round-trip serialization", () => {
     expect(restored.context).toEqual({ noteId: "n-1" });
     expect(restored.currentLastModified).toBe(12345);
   });
+
+  it("round-trips a GitOperationError discriminator through the properties bag", () => {
+    // Synthesize the shape produced by errorTypes.GitOperationError without a
+    // direct import — shared/ tests must not depend on electron/ modules.
+    const original = Object.assign(new Error("fatal: not a git repository"), {
+      name: "GitOperationError",
+      context: { cwd: "/repo", op: "status", reason: "not-a-repository" },
+      reason: "not-a-repository",
+      op: "status",
+      rawMessage: "fatal: not a git repository",
+    });
+
+    const restored = deserializeError(serializeError(original)) as Error & {
+      reason: string;
+      op: string;
+      rawMessage: string;
+      context: Record<string, unknown>;
+    };
+
+    expect(restored.name).toBe("GitOperationError");
+    expect(restored.reason).toBe("not-a-repository");
+    expect(restored.op).toBe("status");
+    expect(restored.rawMessage).toBe("fatal: not a git repository");
+    expect(restored.context).toEqual({
+      cwd: "/repo",
+      op: "status",
+      reason: "not-a-repository",
+    });
+  });
 });
 
 describe("wrapSuccess", () => {

--- a/shared/utils/__tests__/ipcErrorSerialization.test.ts
+++ b/shared/utils/__tests__/ipcErrorSerialization.test.ts
@@ -223,9 +223,16 @@ describe("round-trip serialization", () => {
     expect(restored.currentLastModified).toBe(12345);
   });
 
-  it("round-trips a GitOperationError discriminator through the properties bag", () => {
-    // Synthesize the shape produced by errorTypes.GitOperationError without a
-    // direct import — shared/ tests must not depend on electron/ modules.
+  it("round-trips a GitOperationError discriminator via serialize -> structuredClone -> deserialize", () => {
+    // Shared-layer test synthesizes the GitOperationError shape without importing
+    // the electron/ module — shared/ must not depend on electron/.
+    //
+    // NOTE: electron/setup/security.ts strips `properties` from the IPC envelope in
+    // packaged builds. This test proves the `properties` bag survives a naive
+    // serialize/clone/deserialize cycle, which is what dev-mode IPC uses and what
+    // our renderer event payloads (e.g. fetch-pr-branch-result, handlePush return)
+    // use. In packaged builds we rely on top-level AppError.gitReason, not on the
+    // wrapped-error properties bag.
     const original = Object.assign(new Error("fatal: not a git repository"), {
       name: "GitOperationError",
       context: { cwd: "/repo", op: "status", reason: "not-a-repository" },
@@ -234,7 +241,9 @@ describe("round-trip serialization", () => {
       rawMessage: "fatal: not a git repository",
     });
 
-    const restored = deserializeError(serializeError(original)) as Error & {
+    const serialized = serializeError(original);
+    const cloned = structuredClone(serialized);
+    const restored = deserializeError(cloned) as Error & {
       reason: string;
       op: string;
       rawMessage: string;

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -1,0 +1,127 @@
+import type { GitOperationReason, RecoveryAction } from "../types/ipc/errors.js";
+
+/**
+ * Pure classifier for simple-git errors.
+ *
+ * Works only from the thrown value's `.message` string — simple-git 3.x concats
+ * stdout+stderr into `.message` as UTF-8 and does not expose separate fields.
+ * Renderer-safe: no Node.js built-ins, no Electron deps.
+ *
+ * Normalization order is fixed:
+ *   1. CRLF → LF  (Git for Windows stderr contains `\r\n`)
+ *   2. Strip `^remote: ` per-line  (server output is prefixed — failing to
+ *      strip it causes hook rejections to be misclassified as non-fast-forward
+ *      push failures; precedent: VS Code #229011)
+ *
+ * Regex ordering is specific-before-generic. Hook rejections MUST be tested
+ * before `push-rejected-outdated` because both can appear on `[remote rejected]`
+ * lines. Reordering the PATTERNS array is a regression risk.
+ */
+export function extractGitErrorMessage(error: unknown): string {
+  if (error === null || error === undefined) return "";
+  if (typeof error === "string") return error;
+  if (typeof error !== "object") return String(error);
+  const maybeMessage = (error as { message?: unknown }).message;
+  if (typeof maybeMessage === "string") return maybeMessage;
+  return String(error);
+}
+
+export function normalizeGitErrorMessage(message: string): string {
+  return message.replace(/\r\n/g, "\n").replace(/^remote: /gm, "");
+}
+
+// ORDER MATTERS — specific before generic. Do not reorder without updating tests.
+const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
+  ["not-a-repository", /fatal: not a git repository/i],
+  ["dubious-ownership", /fatal: detected dubious ownership in repository at/i],
+  [
+    "auth-failed",
+    /Authentication failed|Permission denied \(publickey\)|could not read Username for/i,
+  ],
+  [
+    "repository-not-found",
+    /Repository not found|fatal: repository '.*' not found|Could not read from remote repository/i,
+  ],
+  [
+    "network-unavailable",
+    /Could not resolve host:|Failed to connect to.*port.*: Connection refused|unable to access.*: The requested URL returned error: 5\d\d/i,
+  ],
+  [
+    "hook-rejected",
+    /\[remote rejected\].*\((?:pre-receive hook declined|pre-receive hook|update hook|post-receive hook)/i,
+  ],
+  [
+    "push-rejected-policy",
+    /GH006: Protected branch|error:.*protected branch|error:.*file size|pack exceeds maximum allowed size/i,
+  ],
+  ["push-rejected-outdated", /! \[rejected\].*\(non-fast-forward\)/],
+  [
+    "conflict-unresolved",
+    /CONFLICT \(|Merge conflict in |error: (?:merge is not possible because you have unmerged files|pull is not possible because you have unmerged files)/i,
+  ],
+  [
+    "worktree-dirty",
+    /Your local changes to the following files would be overwritten by (?:merge|checkout|pull)|error: (?:cannot|Cannot) (?:pull with rebase|pull )/i,
+  ],
+  [
+    "pathspec-invalid",
+    /fatal: (?:bad revision|needed a single revision|pathspec '.*' did not match|ambiguous argument)/i,
+  ],
+  ["lfs-missing", /external filter 'git-lfs filter-process' failed|smudge filter lfs failed/i],
+  [
+    "config-missing",
+    /fatal: unable to read config file|fatal: bad config|fatal: The current branch .* has no upstream branch/i,
+  ],
+  [
+    "system-io-error",
+    /ENOENT|EACCES|EPERM|EBUSY|Disk full|No space left on device|could not create work tree dir/i,
+  ],
+];
+
+export function classifyGitError(error: unknown): GitOperationReason {
+  const raw = extractGitErrorMessage(error);
+  if (!raw) return "unknown";
+  const normalized = normalizeGitErrorMessage(raw);
+  for (const [reason, pattern] of PATTERNS) {
+    if (pattern.test(normalized)) return reason;
+  }
+  return "unknown";
+}
+
+const RECOVERY_HINTS: Record<GitOperationReason, string | undefined> = {
+  "auth-failed": "Check your Git credentials or SSH key configuration.",
+  "network-unavailable": "Check your internet connection and try again.",
+  "repository-not-found":
+    "The remote repository is unreachable — check the URL or your access permissions.",
+  "not-a-repository": "Run 'git init' or open a folder containing a git repo.",
+  "dubious-ownership":
+    "Git refuses to operate on this repo because its owner doesn't match the current user.",
+  "config-missing": "The current branch is missing upstream or config — set an upstream to push.",
+  "worktree-dirty":
+    "You have local changes that would be overwritten — commit or stash them first.",
+  "conflict-unresolved": "Resolve the merge conflicts and commit before continuing.",
+  "push-rejected-outdated":
+    "The remote has commits you don't have locally — pull or rebase before pushing.",
+  "push-rejected-policy":
+    "The remote rejected this push (protected branch, hook, or size limit). Contact the repo admin.",
+  "pathspec-invalid": "The specified ref or path does not exist.",
+  "lfs-missing": "Git LFS objects are missing — install git-lfs and run 'git lfs pull'.",
+  "hook-rejected": "A server-side hook rejected the push. See the server output for details.",
+  "system-io-error": "A filesystem or permissions problem prevented the git operation.",
+  unknown: undefined,
+};
+
+export function getGitRecoveryHint(reason: GitOperationReason): string | undefined {
+  return RECOVERY_HINTS[reason];
+}
+
+const RECOVERY_ACTIONS: Partial<Record<GitOperationReason, RecoveryAction>> = {
+  "auth-failed": { label: "Sign in with GitHub", actionId: "github.auth" },
+  "push-rejected-outdated": { label: "Pull latest", actionId: "git.pull" },
+  "conflict-unresolved": { label: "Resolve conflicts", actionId: "git.resolveConflicts" },
+  "dubious-ownership": { label: "Trust this repo", actionId: "git.trustRepository" },
+};
+
+export function getGitRecoveryAction(reason: GitOperationReason): RecoveryAction | undefined {
+  return RECOVERY_ACTIONS[reason];
+}

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -36,15 +36,19 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
   ["dubious-ownership", /fatal: detected dubious ownership in repository at/i],
   [
     "auth-failed",
-    /Authentication failed|Permission denied \(publickey\)|could not read Username for/i,
+    // HTTPS 401/403/407 (auth/perm/proxy-auth) as well as the direct SSH/HTTPS messages.
+    /Authentication failed|Permission denied \(publickey\)|could not read Username for|unable to access.*: The requested URL returned error: 40[137]/i,
+  ],
+  [
+    // Run BEFORE repository-not-found: when both signals appear (network failure plus
+    // the generic "Could not read from remote repository" follow-up), the network
+    // classification is the more actionable root cause.
+    "network-unavailable",
+    /Could not resolve host:|Failed to connect to.*port.*: Connection refused|unable to access.*: The requested URL returned error: 5\d\d/i,
   ],
   [
     "repository-not-found",
     /Repository not found|fatal: repository '.*' not found|Could not read from remote repository/i,
-  ],
-  [
-    "network-unavailable",
-    /Could not resolve host:|Failed to connect to.*port.*: Connection refused|unable to access.*: The requested URL returned error: 5\d\d/i,
   ],
   [
     "hook-rejected",
@@ -52,9 +56,11 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
   ],
   [
     "push-rejected-policy",
-    /GH006: Protected branch|error:.*protected branch|error:.*file size|pack exceeds maximum allowed size/i,
+    // GH006: protected branch, GH013: ruleset violation (modern GitHub), generic 'protected
+    // branch' / 'file size' / pack-size / ruleset-violation wording.
+    /GH006: Protected branch|GH013: Repository rule violations|error:.*protected branch|error:.*file size|pack exceeds maximum allowed size|push declined due to repository rule violations/i,
   ],
-  ["push-rejected-outdated", /! \[rejected\].*\(non-fast-forward\)/],
+  ["push-rejected-outdated", /! \[rejected\].*\(non-fast-forward\)/i],
   [
     "conflict-unresolved",
     /CONFLICT \(|Merge conflict in |error: (?:merge is not possible because you have unmerged files|pull is not possible because you have unmerged files)/i,
@@ -65,12 +71,14 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
   ],
   [
     "pathspec-invalid",
-    /fatal: (?:bad revision|needed a single revision|pathspec '.*' did not match|ambiguous argument)/i,
+    // `couldn't find remote ref ...` is also a missing-ref error (e.g. `git fetch pull/99999/head`).
+    /fatal: (?:bad revision|needed a single revision|pathspec '.*' did not match|ambiguous argument)|couldn't find remote ref/i,
   ],
   ["lfs-missing", /external filter 'git-lfs filter-process' failed|smudge filter lfs failed/i],
   [
     "config-missing",
-    /fatal: unable to read config file|fatal: bad config|fatal: The current branch .* has no upstream branch/i,
+    // Covers the older 'has no upstream branch' and the newer 'no upstream configured for branch'.
+    /fatal: unable to read config file|fatal: bad config|fatal: The current branch .* has no upstream branch|fatal: no upstream configured for branch/i,
   ],
   [
     "system-io-error",

--- a/src/components/Worktree/__tests__/worktreeCreationErrors.test.ts
+++ b/src/components/Worktree/__tests__/worktreeCreationErrors.test.ts
@@ -110,5 +110,35 @@ describe("mapCreationError", () => {
     expect(result.friendly).toBe(raw);
     expect(result.raw).toBe(raw);
     expect(result.recovery).toBeUndefined();
+    expect(result.gitReason).toBeUndefined();
+  });
+
+  it("tags existing worktree-specific overlays with a gitReason", () => {
+    const ioRaw = "fatal: could not create work tree dir '/no-permission/path': Permission denied";
+    expect(mapCreationError(ioRaw).gitReason).toBe("system-io-error");
+
+    const invalidRaw = "fatal: 'my..branch' is not a valid branch name";
+    expect(mapCreationError(invalidRaw).gitReason).toBe("pathspec-invalid");
+
+    const existsRaw = "fatal: '/path/to/work tree' already exists";
+    expect(mapCreationError(existsRaw).gitReason).toBe("system-io-error");
+  });
+
+  it("delegates to the shared classifier for generic git failures", () => {
+    const raw = "remote: Authentication failed for 'https://github.com/foo/bar.git/'";
+    const result = mapCreationError(raw);
+
+    expect(result.gitReason).toBe("auth-failed");
+    expect(result.friendly).toContain("credentials");
+    expect(result.raw).toBe(raw);
+  });
+
+  it("uses the classifier hint as the friendly message for network failures", () => {
+    const raw =
+      "fatal: unable to access 'https://github.com/foo.git/': Could not resolve host: github.com";
+    const result = mapCreationError(raw);
+
+    expect(result.gitReason).toBe("network-unavailable");
+    expect(result.friendly).toContain("internet connection");
   });
 });

--- a/src/components/Worktree/worktreeCreationErrors.ts
+++ b/src/components/Worktree/worktreeCreationErrors.ts
@@ -1,9 +1,13 @@
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { classifyGitError, getGitRecoveryHint } from "../../../shared/utils/gitOperationErrors";
+import type { GitOperationReason } from "../../../shared/types/ipc/errors";
 
 export interface WorktreeCreationError {
   friendly: string;
   raw: string;
+  /** Classified git reason when the error comes from a git operation. */
+  gitReason?: GitOperationReason;
   recovery?: {
     label: string;
     onAction: () => void;
@@ -43,6 +47,7 @@ export function mapCreationError(rawMessage: string, onClose?: () => void): Work
     return {
       friendly: "Cannot create directory — check permissions or available disk space.",
       raw: rawMessage,
+      gitReason: "system-io-error",
     };
   }
 
@@ -50,6 +55,7 @@ export function mapCreationError(rawMessage: string, onClose?: () => void): Work
     return {
       friendly: "The branch name contains invalid characters.",
       raw: rawMessage,
+      gitReason: "pathspec-invalid",
     };
   }
 
@@ -57,8 +63,15 @@ export function mapCreationError(rawMessage: string, onClose?: () => void): Work
     return {
       friendly: "A worktree already exists at this path.",
       raw: rawMessage,
+      gitReason: "system-io-error",
     };
   }
 
-  return { friendly: rawMessage, raw: rawMessage };
+  const gitReason = classifyGitError(rawMessage);
+  const hint = getGitRecoveryHint(gitReason);
+  return {
+    friendly: hint ?? rawMessage,
+    raw: rawMessage,
+    gitReason: gitReason === "unknown" ? undefined : gitReason,
+  };
 }


### PR DESCRIPTION
## Summary

- Introduces `GitOperationError extends GitError` with a `GitOperationReason` discriminated union (15 reasons) so callers get a typed failure reason instead of parsing raw error strings.
- New pure classifier in `shared/utils/gitOperationErrors.ts` normalises CRLF and strips `remote:` prefix before running a specific-before-generic regex chain (hook-rejected ahead of push-rejected-outdated, following the VS Code #229011 precedent).
- Adds `gitReason` and a structured `recoveryAction` to `AppError`, populated by `createAppError`, so the renderer can surface contextual recovery actions without any ad-hoc string matching.

Resolves #5369

## Changes

- `shared/utils/gitOperationErrors.ts` — pure classifier, renderer-safe (no Electron imports)
- `shared/types/ipc/errors.ts` — `GitOperationReason` union + `AppError` fields
- `electron/utils/errorTypes.ts` — `GitOperationError` class
- `electron/ipc/errorHandlers.ts` — maps `GitOperationError` into serialised IPC errors
- `electron/services/GitService.ts`, `electron/workspace-host/WorkspaceService.ts`, `electron/ipc/handlers/git-write.ts` — migrated to classify failures
- `src/components/Worktree/worktreeCreationErrors.ts` — renderer fallback now delegates to shared classifier
- 210 tests pass; lint baseline 384 → 383

## Testing

210 unit tests pass across the new classifier, IPC serialisation round-trips, and the migrated service methods. Lint, typecheck, and format all clean.