### PR TITLE
feat(fleet): Fleet Deck dockable tile grid with live terminal mirrors

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -305,6 +305,18 @@
     "error": 1,
     "pipeline": 0
   },
+  "src/components/Fleet/FleetDeck.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
+  "src/components/Fleet/MirrorTile.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 2,
+    "pipeline": 0
+  },
   "src/components/GitHub/BulkActionBar.tsx": {
     "success": 1,
     "skip": 0,

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -104,6 +104,10 @@ export interface StoreSchema {
     panelGridConfig?: PanelGridConfig;
     mruList?: string[];
     actionMruList?: string[];
+    fleetDeckOpen?: boolean;
+    fleetDeckEdge?: "right" | "left" | "bottom";
+    fleetDeckWidth?: number;
+    fleetDeckHeight?: number;
   };
   userConfig: {
     githubToken?: string;
@@ -246,6 +250,9 @@ const storeOptions = {
       recipes: [],
       hasSeenWelcome: false,
       panelGridConfig: { strategy: "automatic" as const, value: 3 },
+      fleetDeckOpen: false,
+      fleetDeckEdge: "right" as const,
+      fleetDeckWidth: 480,
     },
     userConfig: {},
     worktreeConfig: {

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -289,6 +289,9 @@ export type BuiltInActionId =
   | "fleet.restart"
   | "fleet.kill"
   | "fleet.trash"
+  | "fleet.deck.toggle"
+  | "fleet.deck.open"
+  | "fleet.deck.close"
   | "terminal.focusFleetComposer";
 
 export type ActionId = BuiltInActionId | (string & {});

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -80,6 +80,14 @@ export interface AppState {
   mruList?: string[];
   /** Most-recently-used ordered list of action IDs for the action palette */
   actionMruList?: string[];
+  /** Whether the Fleet Deck panel is open */
+  fleetDeckOpen?: boolean;
+  /** Which edge the Fleet Deck is docked to */
+  fleetDeckEdge?: "right" | "left" | "bottom";
+  /** Width of the Fleet Deck in pixels (when docked to a side edge) */
+  fleetDeckWidth?: number;
+  /** Height of the Fleet Deck in pixels (when docked to the bottom edge) */
+  fleetDeckHeight?: number;
 }
 
 /** Describes how the settings store recovered from corruption at startup */

--- a/shared/types/keymap.ts
+++ b/shared/types/keymap.ts
@@ -127,6 +127,7 @@ export type BuiltInKeyAction =
   | "fleet.restart"
   | "fleet.kill"
   | "fleet.trash"
+  | "fleet.deck.toggle"
 
   // Agent spawning
   | "agent.palette"
@@ -306,6 +307,7 @@ export const KEY_ACTION_VALUES: ReadonlySet<string> = new Set<string>([
   "fleet.restart",
   "fleet.kill",
   "fleet.trash",
+  "fleet.deck.toggle",
   "terminal.focusFleetComposer",
   "agent.palette",
   ...BUILT_IN_AGENT_KEY_ACTIONS,

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -4,6 +4,7 @@ import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { useEscapeStack } from "@/hooks";
 import { useFleetArmingStore, type FleetArmStatePreset } from "@/store/fleetArmingStore";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import {
   useFleetPendingActionStore,
   type FleetPendingActionKind,
@@ -112,6 +113,7 @@ export function FleetArmingRibbon(): ReactElement | null {
   const counts = useArmedCounts();
   const pending = useFleetPendingActionStore((s) => s.pending);
   const clearPending = useFleetPendingActionStore((s) => s.clear);
+  const isDeckOpen = useFleetDeckStore((s) => s.isOpen);
 
   // Escape stack: confirmation cancel sits above the fleet-disarm entry, so
   // the first Escape while confirming clears the pending action and a
@@ -347,7 +349,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
-      <FleetComposer />
+      {!isDeckOpen && <FleetComposer />}
     </div>
   );
 }

--- a/src/components/Fleet/FleetDeck.tsx
+++ b/src/components/Fleet/FleetDeck.tsx
@@ -23,11 +23,7 @@ import {
   type FleetDeckStateFilter,
 } from "@/store/fleetDeckStore";
 import { computeLiveSlotIds } from "@/utils/fleetDeckLiveSlots";
-import {
-  matchesDeckFilter,
-  DECK_FILTER_ORDER,
-  DECK_FILTER_LABELS,
-} from "@/utils/agentStateFilter";
+import { matchesDeckFilter, DECK_FILTER_ORDER, DECK_FILTER_LABELS } from "@/utils/agentStateFilter";
 import { ClusterAttentionPill } from "./ClusterAttentionPill";
 import { FleetComposer } from "./FleetComposer";
 import { MirrorTile } from "./MirrorTile";
@@ -80,19 +76,19 @@ export function FleetDeck(): ReactElement | null {
   // reorders (which mutate panelIds without touching panelsById) trigger a
   // re-render.
   const panelIds = usePanelStore((s) => s.panelIds);
-  const activeWorktreeId = useWorktreeSelectionStore(
-    (s) => s.activeWorktreeId ?? null
-  );
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId ?? null);
 
   const [isResizing, setIsResizing] = useState(false);
   const snapshotsRef = useRef<Map<string, string>>(new Map());
 
   const eligibleIds = useMemo(() => {
+    // collectEligibleIds reads panelsById and panelIds from usePanelStore
+    // directly. Referencing both here ensures the memo re-runs whenever
+    // either mutates (panelsById on agent state updates, panelIds on
+    // reorder/add/remove).
+    void panelsById;
+    void panelIds;
     return collectEligibleIds(scope, activeWorktreeId);
-    // panelsById + panelIds are the two slices collectEligibleIds reads from
-    // usePanelStore.getState() — subscribing to both ensures the memo
-    // reruns when either mutates.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scope, activeWorktreeId, panelsById, panelIds]);
 
   const filteredIds = useMemo(() => {
@@ -342,10 +338,7 @@ export function FleetDeck(): ReactElement | null {
         </div>
       </nav>
 
-      <div
-        className="flex-1 min-h-0 overflow-y-auto p-3"
-        data-testid="fleet-deck-grid-scroll"
-      >
+      <div className="flex-1 min-h-0 overflow-y-auto p-3" data-testid="fleet-deck-grid-scroll">
         {filteredIds.length === 0 ? (
           <div
             role="status"

--- a/src/components/Fleet/FleetDeck.tsx
+++ b/src/components/Fleet/FleetDeck.tsx
@@ -1,0 +1,365 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type MouseEvent,
+  type KeyboardEvent,
+} from "react";
+import { X } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { cn } from "@/lib/utils";
+import { usePanelStore } from "@/store/panelStore";
+import { useFleetArmingStore, collectEligibleIds } from "@/store/fleetArmingStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import {
+  useFleetDeckStore,
+  FLEET_DECK_MIN_WIDTH,
+  FLEET_DECK_MAX_WIDTH,
+  FLEET_DECK_LIVE_TILE_CAP,
+  type FleetDeckScope,
+  type FleetDeckStateFilter,
+} from "@/store/fleetDeckStore";
+import { computeLiveSlotIds } from "@/utils/fleetDeckLiveSlots";
+import {
+  matchesDeckFilter,
+  DECK_FILTER_ORDER,
+  DECK_FILTER_LABELS,
+} from "@/utils/agentStateFilter";
+import { ClusterAttentionPill } from "./ClusterAttentionPill";
+import { FleetComposer } from "./FleetComposer";
+import { MirrorTile } from "./MirrorTile";
+
+interface ScopeOption {
+  value: FleetDeckScope;
+  label: string;
+}
+
+const SCOPE_OPTIONS: ScopeOption[] = [
+  { value: "current", label: "Current worktree" },
+  { value: "all", label: "All worktrees" },
+];
+
+const RESIZE_KEYBOARD_STEP = 16;
+
+export function FleetDeck(): ReactElement | null {
+  const {
+    isOpen,
+    width,
+    edge,
+    scope,
+    stateFilter,
+    pinnedLiveIds,
+    close,
+    setWidth,
+    setScope,
+    setStateFilter,
+    prunePins,
+  } = useFleetDeckStore(
+    useShallow((s) => ({
+      isOpen: s.isOpen,
+      width: s.width,
+      edge: s.edge,
+      scope: s.scope,
+      stateFilter: s.stateFilter,
+      pinnedLiveIds: s.pinnedLiveIds,
+      close: s.close,
+      setWidth: s.setWidth,
+      setScope: s.setScope,
+      setStateFilter: s.setStateFilter,
+      prunePins: s.prunePins,
+    }))
+  );
+  const armedIds = useFleetArmingStore((s) => s.armedIds);
+  const armAll = useFleetArmingStore((s) => s.armAll);
+  const clearArmed = useFleetArmingStore((s) => s.clear);
+  const panelsById = usePanelStore((s) => s.panelsById);
+  const activeWorktreeId = useWorktreeSelectionStore(
+    (s) => s.activeWorktreeId ?? null
+  );
+
+  const [isResizing, setIsResizing] = useState(false);
+  const snapshotsRef = useRef<Map<string, string>>(new Map());
+
+  const eligibleIds = useMemo(() => {
+    return collectEligibleIds(scope, activeWorktreeId);
+  }, [scope, activeWorktreeId, panelsById]);
+
+  const filteredIds = useMemo(() => {
+    if (stateFilter === "all") return eligibleIds;
+    return eligibleIds.filter((id) => {
+      const t = panelsById[id];
+      return matchesDeckFilter(t?.agentState, stateFilter);
+    });
+  }, [eligibleIds, stateFilter, panelsById]);
+
+  const liveIds = useMemo(() => {
+    return computeLiveSlotIds(
+      filteredIds,
+      armedIds,
+      pinnedLiveIds,
+      panelsById,
+      FLEET_DECK_LIVE_TILE_CAP
+    );
+  }, [filteredIds, armedIds, pinnedLiveIds, panelsById]);
+
+  const liveIdSet = useMemo(() => new Set(liveIds), [liveIds]);
+
+  // Prune pinned ids whose terminals have disappeared (trashed/killed) so the
+  // pin count never represents stale panels.
+  useEffect(() => {
+    if (pinnedLiveIds.size === 0) return;
+    const validIds = new Set<string>();
+    for (const id of eligibleIds) validIds.add(id);
+    for (const id of pinnedLiveIds) {
+      if (!validIds.has(id)) {
+        prunePins(validIds);
+        return;
+      }
+    }
+  }, [eligibleIds, pinnedLiveIds, prunePins]);
+
+  const handleCaptureSnapshot = useCallback((id: string, snapshot: string) => {
+    snapshotsRef.current.set(id, snapshot);
+  }, []);
+
+  const handleArmFiltered = useCallback(() => {
+    if (filteredIds.length === 0) return;
+    if (filteredIds.length === eligibleIds.length) {
+      armAll(scope);
+      return;
+    }
+    useFleetArmingStore.getState().armIds(filteredIds);
+  }, [armAll, filteredIds, eligibleIds.length, scope]);
+
+  const handleResizeMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      setIsResizing(true);
+      const startX = event.clientX;
+      const startWidth = width;
+
+      const handleMove = (e: globalThis.MouseEvent) => {
+        const delta = edge === "left" ? e.clientX - startX : startX - e.clientX;
+        setWidth(startWidth + delta);
+      };
+
+      const handleUp = () => {
+        setIsResizing(false);
+        document.removeEventListener("mousemove", handleMove);
+        document.removeEventListener("mouseup", handleUp);
+      };
+
+      document.addEventListener("mousemove", handleMove);
+      document.addEventListener("mouseup", handleUp);
+    },
+    [edge, setWidth, width]
+  );
+
+  const handleResizeKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      // Arrow keys grow/shrink the deck — semantics mirror PortalDock.
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        setWidth(width + (edge === "left" ? -RESIZE_KEYBOARD_STEP : RESIZE_KEYBOARD_STEP));
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        setWidth(width + (edge === "left" ? RESIZE_KEYBOARD_STEP : -RESIZE_KEYBOARD_STEP));
+      }
+    },
+    [edge, setWidth, width]
+  );
+
+  useEffect(() => {
+    return () => {
+      setIsResizing(false);
+    };
+  }, []);
+
+  if (!isOpen) return null;
+
+  const dockSide = edge === "left" ? "left-0 border-r" : "right-0 border-l";
+  const resizeHandleSide = edge === "left" ? "-right-1.5" : "-left-1.5";
+
+  return (
+    <div
+      role="region"
+      aria-label="Fleet Deck"
+      data-testid="fleet-deck"
+      data-edge={edge}
+      className={cn(
+        "absolute top-0 bottom-0 z-40 flex flex-col h-full bg-daintree-bg shadow-2xl border-daintree-border",
+        dockSide
+      )}
+      style={{ width }}
+    >
+      <div
+        role="separator"
+        aria-label="Resize Fleet Deck"
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(width)}
+        aria-valuemin={FLEET_DECK_MIN_WIDTH}
+        aria-valuemax={FLEET_DECK_MAX_WIDTH}
+        tabIndex={0}
+        className={cn(
+          "group absolute top-0 bottom-0 w-3 cursor-col-resize flex items-center justify-center z-50",
+          "hover:bg-overlay-soft transition-colors focus:outline-none focus:bg-tint/[0.04] focus:ring-1 focus:ring-daintree-accent/50",
+          resizeHandleSide,
+          isResizing && "bg-daintree-accent/20"
+        )}
+        onMouseDown={handleResizeMouseDown}
+        onKeyDown={handleResizeKeyDown}
+      >
+        <div
+          className={cn(
+            "w-px h-8 rounded-full transition-[width] duration-150 delay-100 group-hover:w-0.5",
+            "bg-daintree-text/20",
+            "group-hover:bg-daintree-text/35 group-focus:bg-daintree-accent",
+            isResizing && "bg-daintree-accent"
+          )}
+        />
+      </div>
+
+      <header className="flex items-center gap-2 px-3 py-2 border-b border-daintree-border">
+        <span className="text-[13px] font-medium text-daintree-text">Fleet Deck</span>
+        <span
+          className="rounded-full bg-tint/[0.08] px-2 py-0.5 text-[11px] text-daintree-text/70"
+          data-testid="fleet-deck-count"
+        >
+          {filteredIds.length} of {eligibleIds.length}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close Fleet Deck"
+            className="rounded p-1 text-daintree-text/60 hover:bg-tint/[0.08] hover:text-daintree-text"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </header>
+
+      <div className="px-3 pt-1">
+        <ClusterAttentionPill />
+      </div>
+
+      <nav
+        aria-label="Fleet Deck scope and filters"
+        className="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-daintree-border"
+      >
+        <div role="tablist" aria-label="Scope" className="inline-flex rounded-md bg-tint/[0.06]">
+          {SCOPE_OPTIONS.map((opt) => {
+            const active = opt.value === scope;
+            return (
+              <button
+                key={opt.value}
+                role="tab"
+                aria-selected={active}
+                type="button"
+                onClick={() => setScope(opt.value)}
+                className={cn(
+                  "rounded-md px-2 py-1 text-[11px] transition-colors",
+                  active
+                    ? "bg-daintree-accent/20 text-daintree-text"
+                    : "text-daintree-text/70 hover:text-daintree-text"
+                )}
+                data-testid={`fleet-deck-scope-${opt.value}`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <div role="toolbar" aria-label="State filter" className="flex items-center gap-1">
+          {DECK_FILTER_ORDER.map((filter) => {
+            const active = filter === stateFilter;
+            return (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => setStateFilter(filter as FleetDeckStateFilter)}
+                className={cn(
+                  "rounded-full px-2 py-0.5 text-[11px] transition-colors",
+                  active
+                    ? "bg-daintree-accent/20 text-daintree-text"
+                    : "bg-tint/[0.06] text-daintree-text/70 hover:bg-tint/[0.12] hover:text-daintree-text"
+                )}
+                aria-pressed={active}
+                data-testid={`fleet-deck-filter-${filter}`}
+              >
+                {DECK_FILTER_LABELS[filter as FleetDeckStateFilter]}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="ml-auto flex items-center gap-1 text-[11px]">
+          <button
+            type="button"
+            onClick={handleArmFiltered}
+            disabled={filteredIds.length === 0}
+            className={cn(
+              "rounded px-2 py-0.5 transition-colors",
+              filteredIds.length === 0
+                ? "cursor-not-allowed text-daintree-text/30"
+                : "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.16] hover:text-daintree-text"
+            )}
+          >
+            Arm visible
+          </button>
+          <button
+            type="button"
+            onClick={clearArmed}
+            disabled={armedIds.size === 0}
+            className={cn(
+              "rounded px-2 py-0.5 transition-colors",
+              armedIds.size === 0
+                ? "cursor-not-allowed text-daintree-text/30"
+                : "bg-tint/[0.08] text-daintree-text/80 hover:bg-tint/[0.16] hover:text-daintree-text"
+            )}
+          >
+            Disarm all
+          </button>
+        </div>
+      </nav>
+
+      <div
+        className="flex-1 min-h-0 overflow-y-auto p-3"
+        data-testid="fleet-deck-grid-scroll"
+      >
+        {filteredIds.length === 0 ? (
+          <div
+            role="status"
+            className="flex h-full items-center justify-center text-[12px] text-daintree-text/60"
+          >
+            No agents match the current scope and filter.
+          </div>
+        ) : (
+          <div
+            data-testid="fleet-deck-grid"
+            className="grid gap-3"
+            style={{ gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))" }}
+          >
+            {filteredIds.map((id) => (
+              <MirrorTile
+                key={id}
+                terminalId={id}
+                isLive={liveIdSet.has(id)}
+                initialSnapshot={snapshotsRef.current.get(id)}
+                onCaptureSnapshot={handleCaptureSnapshot}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <footer className="border-t border-daintree-border">
+        <FleetComposer />
+      </footer>
+    </div>
+  );
+}

--- a/src/components/Fleet/FleetDeck.tsx
+++ b/src/components/Fleet/FleetDeck.tsx
@@ -76,6 +76,10 @@ export function FleetDeck(): ReactElement | null {
   const armAll = useFleetArmingStore((s) => s.armAll);
   const clearArmed = useFleetArmingStore((s) => s.clear);
   const panelsById = usePanelStore((s) => s.panelsById);
+  // panelIds also drives eligibleIds (appearance order) — subscribe so that
+  // reorders (which mutate panelIds without touching panelsById) trigger a
+  // re-render.
+  const panelIds = usePanelStore((s) => s.panelIds);
   const activeWorktreeId = useWorktreeSelectionStore(
     (s) => s.activeWorktreeId ?? null
   );
@@ -85,7 +89,11 @@ export function FleetDeck(): ReactElement | null {
 
   const eligibleIds = useMemo(() => {
     return collectEligibleIds(scope, activeWorktreeId);
-  }, [scope, activeWorktreeId, panelsById]);
+    // panelsById + panelIds are the two slices collectEligibleIds reads from
+    // usePanelStore.getState() — subscribing to both ensures the memo
+    // reruns when either mutates.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, activeWorktreeId, panelsById, panelIds]);
 
   const filteredIds = useMemo(() => {
     if (stateFilter === "all") return eligibleIds;
@@ -108,15 +116,22 @@ export function FleetDeck(): ReactElement | null {
   const liveIdSet = useMemo(() => new Set(liveIds), [liveIds]);
 
   // Prune pinned ids whose terminals have disappeared (trashed/killed) so the
-  // pin count never represents stale panels.
+  // pin count never represents stale panels. Also evict stale snapshot
+  // entries so the session-lifetime Map doesn't accumulate for terminals
+  // the user has killed.
   useEffect(() => {
-    if (pinnedLiveIds.size === 0) return;
-    const validIds = new Set<string>();
-    for (const id of eligibleIds) validIds.add(id);
-    for (const id of pinnedLiveIds) {
-      if (!validIds.has(id)) {
-        prunePins(validIds);
-        return;
+    const validIds = new Set<string>(eligibleIds);
+    if (pinnedLiveIds.size > 0) {
+      for (const id of pinnedLiveIds) {
+        if (!validIds.has(id)) {
+          prunePins(validIds);
+          break;
+        }
+      }
+    }
+    if (snapshotsRef.current.size > 0) {
+      for (const id of Array.from(snapshotsRef.current.keys())) {
+        if (!validIds.has(id)) snapshotsRef.current.delete(id);
       }
     }
   }, [eligibleIds, pinnedLiveIds, prunePins]);

--- a/src/components/Fleet/MirrorTile.tsx
+++ b/src/components/Fleet/MirrorTile.tsx
@@ -77,6 +77,7 @@ function MirrorTileInternal({
 
     const gen = ++mountGenRef.current;
     let cancelled = false;
+    let mountFailed = false;
 
     const mountMirror = () => {
       if (cancelled || mountGenRef.current !== gen) return;
@@ -84,8 +85,16 @@ function MirrorTileInternal({
       if (container.clientWidth === 0 || container.clientHeight === 0) return;
       if (termRef.current) return;
 
+      // Keep allocated resources in locals until the full mount succeeds, so
+      // that a partial-construction failure disposes what was created and
+      // never publishes to the refs. Without this, a throw between
+      // `new Terminal()` and the final ref assignment would leak an xterm
+      // and the ResizeObserver would retry-loop (creating more orphans)
+      // because `termRef.current` stayed null.
+      let term: Terminal | null = null;
+      let dataCleanup: (() => void) | null = null;
       try {
-        const term = new Terminal(MIRROR_TERMINAL_OPTIONS);
+        term = new Terminal(MIRROR_TERMINAL_OPTIONS);
         const fit = new FitAddon();
         const serialize = new SerializeAddon();
         term.loadAddon(fit);
@@ -100,10 +109,10 @@ function MirrorTileInternal({
         if (initialSnapshot) {
           term.write(initialSnapshot);
         }
-        const dataCleanup = terminalClient.onData(terminalId, (data) => {
+        dataCleanup = terminalClient.onData(terminalId, (data) => {
           if (mountGenRef.current !== gen) return;
           try {
-            term.write(data);
+            term?.write(data);
           } catch {
             // xterm may throw during dispose races; ignored.
           }
@@ -115,6 +124,19 @@ function MirrorTileInternal({
         setLiveError(false);
       } catch (error) {
         console.error("Failed to mount fleet mirror terminal:", error);
+        // Dispose in reverse allocation order. Swallow any secondary
+        // throws so we still set liveError and stop the retry loop.
+        try {
+          dataCleanup?.();
+        } catch {
+          /* ignore */
+        }
+        try {
+          term?.dispose();
+        } catch {
+          /* ignore */
+        }
+        mountFailed = true;
         setLiveError(true);
       }
     };
@@ -153,6 +175,9 @@ function MirrorTileInternal({
     const ro = new ResizeObserver(() => {
       if (cancelled) return;
       if (!termRef.current) {
+        // Don't retry after a previous mount failure — that path leaks
+        // if the failure is structural (e.g., xterm throw on open).
+        if (mountFailed) return;
         if (container.clientWidth > 0 && container.clientHeight > 0) {
           mountMirror();
         }

--- a/src/components/Fleet/MirrorTile.tsx
+++ b/src/components/Fleet/MirrorTile.tsx
@@ -1,12 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactElement,
-} from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from "react";
 import { Terminal, type ITerminalOptions } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
@@ -60,6 +52,14 @@ function MirrorTileInternal({
   const mountGenRef = useRef(0);
   const dataCleanupRef = useRef<(() => void) | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  // Hold the initial snapshot + capture callback in refs so the mount
+  // effect can read their latest values without adding them as deps (which
+  // would re-mount the xterm every render). terminalId + isLive drive the
+  // lifecycle; these are passive inputs.
+  const initialSnapshotRef = useRef(initialSnapshot);
+  const onCaptureSnapshotRef = useRef(onCaptureSnapshot);
+  initialSnapshotRef.current = initialSnapshot;
+  onCaptureSnapshotRef.current = onCaptureSnapshot;
   const [liveError, setLiveError] = useState(false);
 
   const focusAgent = useCallback(() => {
@@ -106,8 +106,9 @@ function MirrorTileInternal({
           // fit() can throw during layout thrash; a subsequent
           // ResizeObserver tick will re-fit.
         }
-        if (initialSnapshot) {
-          term.write(initialSnapshot);
+        const snapshotToWrite = initialSnapshotRef.current;
+        if (snapshotToWrite) {
+          term.write(snapshotToWrite);
         }
         dataCleanup = terminalClient.onData(terminalId, (data) => {
           if (mountGenRef.current !== gen) return;
@@ -147,10 +148,11 @@ function MirrorTileInternal({
       // static tile that picks up where the mirror left off.
       const term = termRef.current;
       const serialize = serializeRef.current;
-      if (term && serialize && onCaptureSnapshot) {
+      const capture = onCaptureSnapshotRef.current;
+      if (term && serialize && capture) {
         try {
           const snap = serialize.serialize({ scrollback: 500 });
-          onCaptureSnapshot(terminalId, snap);
+          capture(terminalId, snap);
         } catch {
           // Serialize may throw if the terminal was disposed by another path.
         }
@@ -203,10 +205,6 @@ function MirrorTileInternal({
       resizeObserverRef.current = null;
       tearDown();
     };
-    // onCaptureSnapshot and initialSnapshot should not re-trigger mount —
-    // they are captured as closures on purpose. terminalId + isLive drive
-    // the lifecycle.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [terminalId, isLive]);
 
   const stateClass = useMemo(() => {

--- a/src/components/Fleet/MirrorTile.tsx
+++ b/src/components/Fleet/MirrorTile.tsx
@@ -1,0 +1,285 @@
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+import { Terminal, type ITerminalOptions } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { SerializeAddon } from "@xterm/addon-serialize";
+import { Eye, EyeOff, Pin, PinOff } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { terminalClient } from "@/clients/terminalClient";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
+import { usePanelStore } from "@/store/panelStore";
+import { actionService } from "@/services/ActionService";
+
+// Mirror terminals cap scrollback aggressively — 20 tiles × 500 lines × 80 cols
+// ≈ 8MB (see lesson #4751 for the scaling math) and never participate in the
+// WebGL context budget enforced by TerminalWebGLManager.
+const MIRROR_TERMINAL_OPTIONS: ITerminalOptions = {
+  disableStdin: true,
+  cursorBlink: false,
+  cursorStyle: "bar",
+  scrollOnUserInput: false,
+  scrollback: 500,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+  fontSize: 11,
+  lineHeight: 1.15,
+  convertEol: true,
+  allowProposedApi: true,
+};
+
+interface MirrorTileProps {
+  terminalId: string;
+  isLive: boolean;
+  initialSnapshot?: string | undefined;
+  onCaptureSnapshot?: (id: string, snapshot: string) => void;
+}
+
+function MirrorTileInternal({
+  terminalId,
+  isLive,
+  initialSnapshot,
+  onCaptureSnapshot,
+}: MirrorTileProps): ReactElement {
+  const panel = usePanelStore((s) => s.panelsById[terminalId]);
+  const isArmed = useFleetArmingStore((s) => s.armedIds.has(terminalId));
+  const isPinned = useFleetDeckStore((s) => s.pinnedLiveIds.has(terminalId));
+  const togglePin = useFleetDeckStore((s) => s.togglePinLive);
+  const toggleArm = useFleetArmingStore((s) => s.toggleId);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const serializeRef = useRef<SerializeAddon | null>(null);
+  const mountGenRef = useRef(0);
+  const dataCleanupRef = useRef<(() => void) | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [liveError, setLiveError] = useState(false);
+
+  const focusAgent = useCallback(() => {
+    void actionService.dispatch("panel.focus", { panelId: terminalId }, { source: "user" });
+  }, [terminalId]);
+
+  // Attach live mirror only when isLive is true. When the tile is demoted
+  // to static we capture a snapshot and dispose the xterm instance; the
+  // static branch renders `initialSnapshot` (plain text).
+  useEffect(() => {
+    if (!isLive) return;
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    const gen = ++mountGenRef.current;
+    let cancelled = false;
+
+    const mountMirror = () => {
+      if (cancelled || mountGenRef.current !== gen) return;
+      if (!container.isConnected) return;
+      if (container.clientWidth === 0 || container.clientHeight === 0) return;
+      if (termRef.current) return;
+
+      try {
+        const term = new Terminal(MIRROR_TERMINAL_OPTIONS);
+        const fit = new FitAddon();
+        const serialize = new SerializeAddon();
+        term.loadAddon(fit);
+        term.loadAddon(serialize);
+        term.open(container);
+        try {
+          fit.fit();
+        } catch {
+          // fit() can throw during layout thrash; a subsequent
+          // ResizeObserver tick will re-fit.
+        }
+        if (initialSnapshot) {
+          term.write(initialSnapshot);
+        }
+        const dataCleanup = terminalClient.onData(terminalId, (data) => {
+          if (mountGenRef.current !== gen) return;
+          try {
+            term.write(data);
+          } catch {
+            // xterm may throw during dispose races; ignored.
+          }
+        });
+        termRef.current = term;
+        fitRef.current = fit;
+        serializeRef.current = serialize;
+        dataCleanupRef.current = dataCleanup;
+        setLiveError(false);
+      } catch (error) {
+        console.error("Failed to mount fleet mirror terminal:", error);
+        setLiveError(true);
+      }
+    };
+
+    const tearDown = () => {
+      if (mountGenRef.current !== gen) return;
+      // Capture a final snapshot before disposing so the caller can render a
+      // static tile that picks up where the mirror left off.
+      const term = termRef.current;
+      const serialize = serializeRef.current;
+      if (term && serialize && onCaptureSnapshot) {
+        try {
+          const snap = serialize.serialize({ scrollback: 500 });
+          onCaptureSnapshot(terminalId, snap);
+        } catch {
+          // Serialize may throw if the terminal was disposed by another path.
+        }
+      }
+      dataCleanupRef.current?.();
+      dataCleanupRef.current = null;
+      try {
+        term?.dispose();
+      } catch {
+        // dispose can throw if the terminal was already torn down.
+      }
+      termRef.current = null;
+      fitRef.current = null;
+      serializeRef.current = null;
+    };
+
+    // Guard: container may start with zero dimensions (parent animating in,
+    // off-screen in grid). Wait for a non-zero size before opening, then
+    // re-fit on every resize. See lesson #5092 — the DOM renderer's
+    // IntersectionObserver will silently pause if we open() on a zero-size
+    // element.
+    const ro = new ResizeObserver(() => {
+      if (cancelled) return;
+      if (!termRef.current) {
+        if (container.clientWidth > 0 && container.clientHeight > 0) {
+          mountMirror();
+        }
+        return;
+      }
+      try {
+        fitRef.current?.fit();
+        termRef.current.refresh(0, termRef.current.rows - 1);
+      } catch {
+        // ignore
+      }
+    });
+    ro.observe(container);
+    resizeObserverRef.current = ro;
+
+    if (container.clientWidth > 0 && container.clientHeight > 0) {
+      mountMirror();
+    }
+
+    return () => {
+      cancelled = true;
+      ro.disconnect();
+      resizeObserverRef.current = null;
+      tearDown();
+    };
+    // onCaptureSnapshot and initialSnapshot should not re-trigger mount —
+    // they are captured as closures on purpose. terminalId + isLive drive
+    // the lifecycle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [terminalId, isLive]);
+
+  const stateClass = useMemo(() => {
+    const state = panel?.agentState;
+    if (state === "waiting" || state === "directing") return "border-state-waiting/60";
+    if (state === "working" || state === "running") return "border-state-working/60";
+    if (state === "completed") return "border-status-success/50";
+    if (state === "exited") return "border-status-error/50";
+    if (isArmed) return "border-daintree-accent/70";
+    return "border-daintree-border";
+  }, [panel?.agentState, isArmed]);
+
+  const title = panel?.lastObservedTitle ?? panel?.title ?? "(unknown)";
+  const stateLabel = panel?.agentState ?? "idle";
+
+  return (
+    <div
+      data-testid="fleet-mirror-tile"
+      data-terminal-id={terminalId}
+      data-live={isLive ? "true" : "false"}
+      data-armed={isArmed ? "true" : undefined}
+      data-pinned={isPinned ? "true" : undefined}
+      className={cn(
+        "relative flex flex-col overflow-hidden rounded-md border bg-daintree-bg shadow-sm",
+        "min-h-[180px] h-full",
+        stateClass
+      )}
+    >
+      <div className="flex items-center gap-2 px-2 py-1 text-[11px] bg-tint/[0.04] border-b border-daintree-border">
+        <button
+          type="button"
+          onClick={focusAgent}
+          className="flex-1 min-w-0 text-left truncate text-daintree-text/90 hover:text-daintree-text"
+          title={title}
+          aria-label={`Focus ${title}`}
+        >
+          {title}
+        </button>
+        <span className="shrink-0 rounded-full bg-tint/[0.08] px-1.5 py-0.5 text-[10px] text-daintree-text/70">
+          {stateLabel}
+        </span>
+        <button
+          type="button"
+          onClick={() => toggleArm(terminalId)}
+          className={cn(
+            "shrink-0 rounded p-0.5 text-daintree-text/50 hover:text-daintree-text hover:bg-tint/[0.08]",
+            isArmed && "text-daintree-accent"
+          )}
+          aria-label={isArmed ? "Disarm agent" : "Arm agent"}
+          aria-pressed={isArmed}
+        >
+          {isArmed ? <EyeOff className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+        </button>
+        <button
+          type="button"
+          onClick={() => togglePin(terminalId)}
+          className={cn(
+            "shrink-0 rounded p-0.5 text-daintree-text/50 hover:text-daintree-text hover:bg-tint/[0.08]",
+            isPinned && "text-daintree-accent"
+          )}
+          aria-label={isPinned ? "Unpin live mirror" : "Pin as live mirror"}
+          aria-pressed={isPinned}
+        >
+          {isPinned ? <PinOff className="h-3 w-3" /> : <Pin className="h-3 w-3" />}
+        </button>
+      </div>
+      <div className="flex-1 min-h-0 relative">
+        {isLive ? (
+          <div
+            ref={containerRef}
+            data-testid="fleet-mirror-terminal"
+            className="absolute inset-0 pointer-events-none select-none"
+            style={{ userSelect: "none" }}
+          />
+        ) : (
+          <pre
+            data-testid="fleet-mirror-static"
+            className={cn(
+              "absolute inset-0 overflow-hidden font-mono text-[11px] leading-tight",
+              "whitespace-pre text-daintree-text/80 bg-daintree-bg p-1",
+              "[content-visibility:auto]"
+            )}
+            aria-label={`Snapshot of ${title}`}
+          >
+            {initialSnapshot ?? ""}
+          </pre>
+        )}
+        {liveError && (
+          <div
+            role="alert"
+            className="absolute inset-0 flex items-center justify-center bg-daintree-bg/80 text-[11px] text-status-error"
+          >
+            Unable to attach live mirror
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const MirrorTile = memo(MirrorTileInternal);

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent, screen, act } from "@testing-library/react";
 import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -17,6 +18,7 @@ function resetStores() {
     lastArmedId: null,
   });
   useFleetPendingActionStore.setState({ pending: null });
+  useFleetDeckStore.setState({ isOpen: false });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
   useAnnouncerStore.setState({ polite: null, assertive: null });
@@ -206,5 +208,23 @@ describe("FleetArmingRibbon", () => {
     expect(match).toBeDefined();
     expect(match?.[1]).toEqual({ confirmed: true });
     dispatchSpy.mockRestore();
+  });
+
+  describe("Fleet Deck composer suppression", () => {
+    it("renders the embedded FleetComposer when the Deck is closed", () => {
+      useFleetArmingStore.getState().armIds(["a"]);
+      useFleetDeckStore.setState({ isOpen: false });
+      render(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-composer")).toBeTruthy();
+    });
+
+    it("suppresses the embedded FleetComposer when the Deck is open", () => {
+      useFleetArmingStore.getState().armIds(["a"]);
+      useFleetDeckStore.setState({ isOpen: true });
+      render(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-composer")).toBeNull();
+      // The ribbon itself still renders — only the composer is suppressed.
+      expect(screen.queryByTestId("fleet-arming-ribbon")).toBeTruthy();
+    });
   });
 });

--- a/src/components/Fleet/__tests__/FleetDeck.test.tsx
+++ b/src/components/Fleet/__tests__/FleetDeck.test.tsx
@@ -52,10 +52,7 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
-function makeAgent(
-  id: string,
-  overrides: Partial<TerminalInstance> = {}
-): TerminalInstance {
+function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
   return {
     id,
     title: id,
@@ -169,13 +166,7 @@ describe("FleetDeck", () => {
   });
 
   it("re-renders tiles when panelIds is reordered", async () => {
-    seedPanels([
-      makeAgent("a"),
-      makeAgent("b"),
-      makeAgent("c"),
-      makeAgent("d"),
-      makeAgent("e"),
-    ]);
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c"), makeAgent("d"), makeAgent("e")]);
     const { getAllByTestId } = render(<FleetDeck />);
     const initialOrder = getAllByTestId("fleet-mirror-tile").map(
       (el) => el.getAttribute("data-terminal-id") ?? ""

--- a/src/components/Fleet/__tests__/FleetDeck.test.tsx
+++ b/src/components/Fleet/__tests__/FleetDeck.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import type { TerminalInstance } from "@shared/types";
+
+// Mock xterm stack — we're testing composition and reactivity here, not
+// the xterm lifecycle (that's covered in MirrorTile.test.tsx).
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class {
+    rows = 24;
+    open = vi.fn();
+    dispose = vi.fn();
+    write = vi.fn();
+    refresh = vi.fn();
+    loadAddon = vi.fn();
+  },
+}));
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
+vi.mock("@xterm/addon-serialize", () => ({
+  SerializeAddon: class {
+    serialize = vi.fn(() => "");
+  },
+}));
+vi.mock("@/clients/terminalClient", () => ({
+  terminalClient: {
+    onData: vi.fn(() => () => {}),
+  },
+}));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+// ClusterAttentionPill depends on the WorktreeStore context (via
+// useAgentClusters). Stub it to keep the test focused on Deck composition.
+vi.mock("../ClusterAttentionPill", () => ({
+  ClusterAttentionPill: () => null,
+}));
+
+// FleetComposer reaches into terminal focus/scope infrastructure; stub to
+// a dumb span for composition tests.
+vi.mock("../FleetComposer", () => ({
+  FleetComposer: () => <span data-testid="fleet-composer-stub" />,
+}));
+
+import { FleetDeck } from "../FleetDeck";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+
+function makeAgent(
+  id: string,
+  overrides: Partial<TerminalInstance> = {}
+): TerminalInstance {
+  return {
+    id,
+    title: id,
+    kind: "agent",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    location: "grid",
+    hasPty: true,
+    agentState: "idle",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function seedPanels(agents: TerminalInstance[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  const panelIds: string[] = [];
+  for (const a of agents) {
+    panelsById[a.id] = a;
+    panelIds.push(a.id);
+  }
+  usePanelStore.setState({ panelsById, panelIds });
+}
+
+function reorderPanels(newOrder: string[]): void {
+  // Simulate a drag-reorder: panelsById stays the same, panelIds changes.
+  const current = usePanelStore.getState();
+  usePanelStore.setState({ panelsById: current.panelsById, panelIds: newOrder });
+}
+
+function resetStores(): void {
+  useFleetDeckStore.setState({
+    isOpen: true,
+    edge: "right",
+    width: 480,
+    height: 320,
+    scope: "all",
+    stateFilter: "all",
+    pinnedLiveIds: new Set<string>(),
+    isHydrated: true,
+  });
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+}
+
+function withNonZeroLayout(): () => void {
+  const origW = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+  const origH = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return 320;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return 200;
+    },
+  });
+  return () => {
+    if (origW) Object.defineProperty(HTMLElement.prototype, "clientWidth", origW);
+    if (origH) Object.defineProperty(HTMLElement.prototype, "clientHeight", origH);
+  };
+}
+
+function installResizeObserverMock(): () => void {
+  class MockRO {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  const original = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = MockRO as unknown as typeof ResizeObserver;
+  return () => {
+    globalThis.ResizeObserver = original;
+  };
+}
+
+describe("FleetDeck", () => {
+  let restoreLayout: () => void;
+  let restoreRO: () => void;
+
+  beforeEach(() => {
+    resetStores();
+    restoreLayout = withNonZeroLayout();
+    restoreRO = installResizeObserverMock();
+  });
+
+  afterEach(() => {
+    restoreLayout();
+    restoreRO();
+  });
+
+  it("renders nothing when the deck is closed", () => {
+    useFleetDeckStore.setState({ isOpen: false });
+    seedPanels([makeAgent("a")]);
+    const { container } = render(<FleetDeck />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a tile per eligible agent when open", () => {
+    seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+    const { getAllByTestId } = render(<FleetDeck />);
+    expect(getAllByTestId("fleet-mirror-tile")).toHaveLength(3);
+  });
+
+  it("re-renders tiles when panelIds is reordered", async () => {
+    seedPanels([
+      makeAgent("a"),
+      makeAgent("b"),
+      makeAgent("c"),
+      makeAgent("d"),
+      makeAgent("e"),
+    ]);
+    const { getAllByTestId } = render(<FleetDeck />);
+    const initialOrder = getAllByTestId("fleet-mirror-tile").map(
+      (el) => el.getAttribute("data-terminal-id") ?? ""
+    );
+    expect(initialOrder).toEqual(["a", "b", "c", "d", "e"]);
+
+    await act(async () => {
+      reorderPanels(["e", "d", "c", "b", "a"]);
+    });
+
+    const newOrder = getAllByTestId("fleet-mirror-tile").map(
+      (el) => el.getAttribute("data-terminal-id") ?? ""
+    );
+    expect(newOrder).toEqual(["e", "d", "c", "b", "a"]);
+  });
+
+  it("live tiles respect the 4-slot cap with priority ordering", () => {
+    seedPanels([
+      makeAgent("a", { agentState: "idle" }),
+      makeAgent("b", { agentState: "waiting" }),
+      makeAgent("c", { agentState: "working" }),
+      makeAgent("d", { agentState: "idle" }),
+      makeAgent("e", { agentState: "idle" }),
+    ]);
+    useFleetArmingStore.setState({
+      armedIds: new Set(["d"]),
+      armOrder: ["d"],
+      armOrderById: { d: 1 },
+      lastArmedId: "d",
+    });
+    const { getAllByTestId } = render(<FleetDeck />);
+    const tiles = getAllByTestId("fleet-mirror-tile");
+    const liveTiles = tiles.filter((el) => el.getAttribute("data-live") === "true");
+    expect(liveTiles).toHaveLength(4);
+    // Armed "d" (tier 1) > waiting "b" (tier 2) > working "c" (tier 3) >
+    // first idle "a" (tier 4). "e" (second idle) is the odd one out.
+    const ids = liveTiles.map((el) => el.getAttribute("data-terminal-id"));
+    expect(ids).toContain("d");
+    expect(ids).toContain("b");
+    expect(ids).toContain("c");
+    expect(ids).not.toContain("e");
+  });
+});

--- a/src/components/Fleet/__tests__/MirrorTile.test.tsx
+++ b/src/components/Fleet/__tests__/MirrorTile.test.tsx
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import type { TerminalInstance } from "@shared/types";
+
+const { terminalInstances, dataCallbacks, fitInstances, serializeInstances, dataCleanups } =
+  vi.hoisted(() => ({
+    terminalInstances: [] as Array<{
+      open: ReturnType<typeof vi.fn>;
+      dispose: ReturnType<typeof vi.fn>;
+      write: ReturnType<typeof vi.fn>;
+      refresh: ReturnType<typeof vi.fn>;
+      loadAddon: ReturnType<typeof vi.fn>;
+      rows: number;
+    }>,
+    dataCallbacks: new Map<string, Set<(data: string) => void>>(),
+    fitInstances: [] as Array<{ fit: ReturnType<typeof vi.fn> }>,
+    serializeInstances: [] as Array<{
+      serialize: ReturnType<typeof vi.fn>;
+    }>,
+    dataCleanups: [] as Array<ReturnType<typeof vi.fn>>,
+  }));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class MockTerminal {
+    rows = 24;
+    open = vi.fn();
+    dispose = vi.fn();
+    write = vi.fn();
+    refresh = vi.fn();
+    loadAddon = vi.fn();
+    constructor() {
+      terminalInstances.push(this as unknown as (typeof terminalInstances)[number]);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class MockFitAddon {
+    fit = vi.fn();
+    constructor() {
+      fitInstances.push(this as unknown as (typeof fitInstances)[number]);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-serialize", () => ({
+  SerializeAddon: class MockSerializeAddon {
+    serialize = vi.fn(() => "<serialized>");
+    constructor() {
+      serializeInstances.push(this as unknown as (typeof serializeInstances)[number]);
+    }
+  },
+}));
+
+vi.mock("@/clients/terminalClient", () => ({
+  terminalClient: {
+    onData: vi.fn((id: string, cb: (data: string) => void) => {
+      let set = dataCallbacks.get(id);
+      if (!set) {
+        set = new Set();
+        dataCallbacks.set(id, set);
+      }
+      set.add(cb);
+      const cleanup = vi.fn(() => {
+        set?.delete(cb);
+      });
+      dataCleanups.push(cleanup);
+      return cleanup;
+    }),
+  },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import { MirrorTile } from "../MirrorTile";
+import { usePanelStore } from "@/store/panelStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
+
+function resetAll(): void {
+  terminalInstances.length = 0;
+  fitInstances.length = 0;
+  serializeInstances.length = 0;
+  dataCleanups.length = 0;
+  dataCallbacks.clear();
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  useFleetDeckStore.setState({
+    isOpen: false,
+    pinnedLiveIds: new Set<string>(),
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+}
+
+function seedPanel(id: string, overrides: Partial<TerminalInstance> = {}): void {
+  const t = {
+    id,
+    title: id,
+    location: "grid",
+    ...overrides,
+  } as TerminalInstance;
+  usePanelStore.setState({
+    panelsById: { [id]: t },
+    panelIds: [id],
+  });
+}
+
+function withNonZeroLayout(): () => void {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientWidth");
+  const originalH = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "clientHeight");
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return 320;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+    configurable: true,
+    get() {
+      return 200;
+    },
+  });
+  return () => {
+    if (original) Object.defineProperty(HTMLElement.prototype, "clientWidth", original);
+    if (originalH) Object.defineProperty(HTMLElement.prototype, "clientHeight", originalH);
+  };
+}
+
+function installResizeObserverMock(): () => void {
+  class MockResizeObserver {
+    // The callback is stored so tests could fire it, but for our purposes
+    // the initial mount path (triggered from requestAnimationFrame) is the
+    // one that matters. The callback would otherwise re-fit on layout.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_cb: ResizeObserverCallback) {}
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  const original = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  return () => {
+    globalThis.ResizeObserver = original;
+  };
+}
+
+async function flushRaf(): Promise<void> {
+  // Run pending microtasks + macrotasks until our rAF-driven mount path settles.
+  for (let i = 0; i < 3; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("MirrorTile", () => {
+  let restoreLayout: () => void;
+  let restoreRO: () => void;
+
+  beforeEach(() => {
+    resetAll();
+    restoreLayout = withNonZeroLayout();
+    restoreRO = installResizeObserverMock();
+    // Use a fast-forward rAF.
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      return setTimeout(() => cb(0), 0) as unknown as number;
+    });
+  });
+
+  afterEach(() => {
+    restoreLayout();
+    restoreRO();
+    vi.unstubAllGlobals();
+  });
+
+  it("mounts a live Terminal when isLive=true and disposes on unmount", async () => {
+    seedPanel("t1", { agentState: "working" });
+    const { unmount } = render(<MirrorTile terminalId="t1" isLive={true} />);
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(terminalInstances).toHaveLength(1);
+    expect(terminalInstances[0]!.open).toHaveBeenCalled();
+    expect(fitInstances[0]!.fit).toHaveBeenCalled();
+    expect(terminalInstances[0]!.dispose).not.toHaveBeenCalled();
+
+    unmount();
+    expect(terminalInstances[0]!.dispose).toHaveBeenCalled();
+  });
+
+  it("writes initial snapshot on live mount", async () => {
+    seedPanel("t1");
+    render(<MirrorTile terminalId="t1" isLive={true} initialSnapshot="hello-world" />);
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(terminalInstances[0]!.write).toHaveBeenCalledWith("hello-world");
+  });
+
+  it("subscribes to terminalClient.onData and unsubscribes on unmount", async () => {
+    seedPanel("t1");
+    const { unmount } = render(<MirrorTile terminalId="t1" isLive={true} />);
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(dataCallbacks.get("t1")?.size).toBe(1);
+    unmount();
+    expect(dataCleanups[0]).toHaveBeenCalled();
+  });
+
+  it("captures a snapshot on teardown via onCaptureSnapshot", async () => {
+    seedPanel("t1");
+    const capture = vi.fn();
+    const { unmount } = render(
+      <MirrorTile terminalId="t1" isLive={true} onCaptureSnapshot={capture} />
+    );
+    await act(async () => {
+      await flushRaf();
+    });
+    unmount();
+    expect(capture).toHaveBeenCalledWith("t1", "<serialized>");
+  });
+
+  it("does NOT instantiate a Terminal when isLive=false", async () => {
+    seedPanel("t1");
+    render(<MirrorTile terminalId="t1" isLive={false} initialSnapshot="static snapshot" />);
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(terminalInstances).toHaveLength(0);
+  });
+
+  it("swapping from live to static disposes the Terminal and preserves the snapshot branch", async () => {
+    seedPanel("t1");
+    const capture = vi.fn();
+    const { rerender } = render(
+      <MirrorTile terminalId="t1" isLive={true} onCaptureSnapshot={capture} />
+    );
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(terminalInstances).toHaveLength(1);
+
+    rerender(
+      <MirrorTile
+        terminalId="t1"
+        isLive={false}
+        initialSnapshot="<serialized>"
+        onCaptureSnapshot={capture}
+      />
+    );
+    await act(async () => {
+      await flushRaf();
+    });
+    expect(terminalInstances[0]!.dispose).toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith("t1", "<serialized>");
+  });
+});

--- a/src/components/Fleet/__tests__/MirrorTile.test.tsx
+++ b/src/components/Fleet/__tests__/MirrorTile.test.tsx
@@ -1,25 +1,33 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { StrictMode } from "react";
 import { act, render } from "@testing-library/react";
 import type { TerminalInstance } from "@shared/types";
 
-const { terminalInstances, dataCallbacks, fitInstances, serializeInstances, dataCleanups } =
-  vi.hoisted(() => ({
-    terminalInstances: [] as Array<{
-      open: ReturnType<typeof vi.fn>;
-      dispose: ReturnType<typeof vi.fn>;
-      write: ReturnType<typeof vi.fn>;
-      refresh: ReturnType<typeof vi.fn>;
-      loadAddon: ReturnType<typeof vi.fn>;
-      rows: number;
-    }>,
-    dataCallbacks: new Map<string, Set<(data: string) => void>>(),
-    fitInstances: [] as Array<{ fit: ReturnType<typeof vi.fn> }>,
-    serializeInstances: [] as Array<{
-      serialize: ReturnType<typeof vi.fn>;
-    }>,
-    dataCleanups: [] as Array<ReturnType<typeof vi.fn>>,
-  }));
+const {
+  terminalInstances,
+  dataCallbacks,
+  fitInstances,
+  serializeInstances,
+  dataCleanups,
+  onDataBehavior,
+} = vi.hoisted(() => ({
+  terminalInstances: [] as Array<{
+    open: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+    refresh: ReturnType<typeof vi.fn>;
+    loadAddon: ReturnType<typeof vi.fn>;
+    rows: number;
+  }>,
+  dataCallbacks: new Map<string, Set<(data: string) => void>>(),
+  fitInstances: [] as Array<{ fit: ReturnType<typeof vi.fn> }>,
+  serializeInstances: [] as Array<{
+    serialize: ReturnType<typeof vi.fn>;
+  }>,
+  dataCleanups: [] as Array<ReturnType<typeof vi.fn>>,
+  onDataBehavior: { shouldThrow: false },
+}));
 
 vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
@@ -56,6 +64,9 @@ vi.mock("@xterm/addon-serialize", () => ({
 vi.mock("@/clients/terminalClient", () => ({
   terminalClient: {
     onData: vi.fn((id: string, cb: (data: string) => void) => {
+      if (onDataBehavior.shouldThrow) {
+        throw new Error("simulated onData failure");
+      }
       let set = dataCallbacks.get(id);
       if (!set) {
         set = new Set();
@@ -86,6 +97,7 @@ function resetAll(): void {
   serializeInstances.length = 0;
   dataCleanups.length = 0;
   dataCallbacks.clear();
+  onDataBehavior.shouldThrow = false;
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -259,5 +271,41 @@ describe("MirrorTile", () => {
     });
     expect(terminalInstances[0]!.dispose).toHaveBeenCalled();
     expect(capture).toHaveBeenCalledWith("t1", "<serialized>");
+  });
+
+  it("disposes the partially-constructed Terminal when onData throws", async () => {
+    seedPanel("t1");
+    onDataBehavior.shouldThrow = true;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<MirrorTile terminalId="t1" isLive={true} />);
+    await act(async () => {
+      await flushRaf();
+    });
+    // One Terminal was created before onData threw — it must be disposed
+    // (no leak, no retry) even though no ref was ever published.
+    expect(terminalInstances).toHaveLength(1);
+    expect(terminalInstances[0]!.dispose).toHaveBeenCalled();
+    expect(dataCallbacks.get("t1")).toBeUndefined();
+    // The live-error surface is shown.
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("survives React 19 StrictMode double-invoke with exactly one active subscription", async () => {
+    seedPanel("t1");
+    const { unmount } = render(
+      <StrictMode>
+        <MirrorTile terminalId="t1" isLive={true} />
+      </StrictMode>
+    );
+    await act(async () => {
+      await flushRaf();
+    });
+    // After StrictMode's mount/cleanup/mount cycle there must be at most
+    // one active data subscription (mountGeneration guard + dispose in
+    // cleanup guarantees this).
+    expect(dataCallbacks.get("t1")?.size ?? 0).toBe(1);
+    unmount();
+    expect(dataCallbacks.get("t1")?.size ?? 0).toBe(0);
   });
 });

--- a/src/components/Fleet/__tests__/MirrorTile.test.tsx
+++ b/src/components/Fleet/__tests__/MirrorTile.test.tsx
@@ -147,10 +147,6 @@ function withNonZeroLayout(): () => void {
 
 function installResizeObserverMock(): () => void {
   class MockResizeObserver {
-    // The callback is stored so tests could fire it, but for our purposes
-    // the initial mount path (triggered from requestAnimationFrame) is the
-    // one that matters. The callback would otherwise re-fit on layout.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     constructor(_cb: ResizeObserverCallback) {}
     observe(): void {}
     unobserve(): void {}

--- a/src/components/Fleet/index.ts
+++ b/src/components/Fleet/index.ts
@@ -2,3 +2,5 @@ export { FleetArmingRibbon } from "./FleetArmingRibbon";
 export { FleetComposer } from "./FleetComposer";
 export { focusFleetComposer } from "./fleetComposerFocus";
 export { ClusterAttentionPill } from "./ClusterAttentionPill";
+export { FleetDeck } from "./FleetDeck";
+export { MirrorTile } from "./MirrorTile";

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -7,12 +7,17 @@ import { ErrorBoundary } from "../ErrorBoundary";
 import { PortalDock, PortalVisibilityController } from "../Portal";
 import { HelpPanel } from "../HelpPanel";
 import { ProjectSwitchOverlay } from "@/components/Project";
-import { FleetArmingRibbon } from "@/components/Fleet";
+import { FleetArmingRibbon, FleetDeck } from "@/components/Fleet";
 import { ChordIndicator } from "./ChordIndicator";
 import { DemoCursor, DemoOverlay } from "../Demo";
 
 import { AllClearOverlay } from "../AllClearOverlay";
-import { useDiagnosticsStore, useDockStore, type PanelState } from "@/store";
+import {
+  useDiagnosticsStore,
+  useDockStore,
+  useFleetDeckStore,
+  type PanelState,
+} from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import type { RetryAction } from "@/store";
@@ -89,6 +94,12 @@ export function AppLayout({
         // which reads per-project focus mode state. This ensures each project has its own focus mode.
         useDockStore.getState().hydrate({
           popoverHeight: appState.dockedPopoverHeight,
+        });
+        useFleetDeckStore.getState().hydrate({
+          isOpen: appState.fleetDeckOpen,
+          edge: appState.fleetDeckEdge,
+          width: appState.fleetDeckWidth,
+          height: appState.fleetDeckHeight,
         });
       } catch (error) {
         console.error("Failed to restore app state:", error);
@@ -354,6 +365,9 @@ export function AppLayout({
                   </div>
                 </ErrorBoundary>
               )}
+              <ErrorBoundary variant="section" componentName="FleetDeck">
+                <FleetDeck />
+              </ErrorBoundary>
             </main>
           </ErrorBoundary>
         </div>

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -12,12 +12,7 @@ import { ChordIndicator } from "./ChordIndicator";
 import { DemoCursor, DemoOverlay } from "../Demo";
 
 import { AllClearOverlay } from "../AllClearOverlay";
-import {
-  useDiagnosticsStore,
-  useDockStore,
-  useFleetDeckStore,
-  type PanelState,
-} from "@/store";
+import { useDiagnosticsStore, useDockStore, useFleetDeckStore, type PanelState } from "@/store";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import type { RetryAction } from "@/store";

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -929,17 +929,19 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <TooltipTrigger asChild>
                   <button
                     onClick={() =>
-                      actionService.dispatch("terminal.bulkCommand", undefined, {
+                      actionService.dispatch("fleet.deck.toggle", undefined, {
                         source: "user",
                       })
                     }
                     className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
-                    aria-label="Bulk Operations"
+                    aria-label="Toggle Fleet Deck"
                   >
                     <BroadcastTerminalIcon className="w-3.5 h-3.5" />
                   </button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">Bulk Operations</TooltipContent>
+                <TooltipContent side="bottom">
+                  {createTooltipWithShortcut("Toggle Fleet Deck", "Cmd+Alt+Shift+B")}
+                </TooltipContent>
               </Tooltip>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -37,7 +37,9 @@ import {
   usePanelStore,
   getTerminalRefreshTier,
   useTerminalInputStore,
+  useFleetDeckStore,
 } from "@/store";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useTerminalLogic } from "@/hooks/useTerminalLogic";
 import { errorsClient } from "@/clients";
 import type { AgentState } from "@/types";
@@ -225,7 +227,13 @@ function TerminalPaneComponent({
         : undefined
   ) as BuiltInAgentId | undefined;
   const isAgentTerminal = effectiveAgentId !== undefined;
-  const showHybridInputBar = isAgentTerminal && hybridInputEnabled;
+  const isArmed = useFleetArmingStore((s) => s.armedIds.has(id));
+  const isDeckOpen = useFleetDeckStore((s) => s.isOpen);
+  // When the Fleet Deck is open and this terminal is armed, its input flows
+  // through the Deck composer — suppress the per-terminal HybridInputBar so
+  // there are no duplicate input surfaces competing for focus.
+  const suppressForFleetDeck = isArmed && isDeckOpen;
+  const showHybridInputBar = isAgentTerminal && hybridInputEnabled && !suppressForFleetDeck;
 
   const queueCount = usePanelStore((state) => state.commandQueueCountById[id] ?? 0);
 

--- a/src/controllers/FleetDeckController.ts
+++ b/src/controllers/FleetDeckController.ts
@@ -1,0 +1,24 @@
+import { appClient } from "@/clients";
+import type { FleetDeckEdge } from "@/store/fleetDeckStore";
+
+export const fleetDeckController = {
+  persistOpen: (isOpen: boolean): Promise<void> =>
+    appClient.setState({ fleetDeckOpen: isOpen }).catch((error) => {
+      console.error("Failed to persist fleet deck open state:", error);
+    }),
+
+  persistEdge: (edge: FleetDeckEdge): Promise<void> =>
+    appClient.setState({ fleetDeckEdge: edge }).catch((error) => {
+      console.error("Failed to persist fleet deck edge:", error);
+    }),
+
+  persistWidth: (width: number): Promise<void> =>
+    appClient.setState({ fleetDeckWidth: width }).catch((error) => {
+      console.error("Failed to persist fleet deck width:", error);
+    }),
+
+  persistHeight: (height: number): Promise<void> =>
+    appClient.setState({ fleetDeckHeight: height }).catch((error) => {
+      console.error("Failed to persist fleet deck height:", error);
+    }),
+};

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,4 @@
 export { terminalRegistryController } from "./TerminalRegistryController";
 export type { SpawnTerminalOptions, SpawnTerminalResult } from "./TerminalRegistryController";
+
+export { fleetDeckController } from "./FleetDeckController";

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -6,6 +6,7 @@ import {
   useFleetPendingActionStore,
   type FleetPendingActionKind,
 } from "@/store/fleetPendingActionStore";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import { terminalClient } from "@/clients";
 import type { TerminalInstance } from "@shared/types";
 
@@ -243,6 +244,46 @@ export function registerFleetActions(actions: ActionRegistry): void {
       const ids = new Set(snap.liveTerminals.map((t) => t.id));
       usePanelStore.getState().bulkTrashSet(ids);
       useFleetArmingStore.getState().clear();
+    },
+  }));
+
+  actions.set("fleet.deck.toggle", () => ({
+    id: "fleet.deck.toggle",
+    title: "Fleet Deck: Toggle",
+    description:
+      "Open or close the Fleet Deck — a persistent dockable panel with live agent terminal mirrors",
+    category: "panel",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      useFleetDeckStore.getState().toggle();
+    },
+  }));
+
+  actions.set("fleet.deck.open", () => ({
+    id: "fleet.deck.open",
+    title: "Fleet Deck: Open",
+    description: "Open the Fleet Deck panel",
+    category: "panel",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      useFleetDeckStore.getState().open();
+    },
+  }));
+
+  actions.set("fleet.deck.close", () => ({
+    id: "fleet.deck.close",
+    title: "Fleet Deck: Close",
+    description: "Close the Fleet Deck panel",
+    category: "panel",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      useFleetDeckStore.getState().close();
     },
   }));
 }

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -398,12 +398,12 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Terminal",
   },
   {
-    actionId: "terminal.bulkCommand",
+    actionId: "fleet.deck.toggle",
     combo: "Cmd+Alt+Shift+B",
     scope: "global",
     priority: 0,
-    description: "Open Bulk Operations",
-    category: "Terminal",
+    description: "Toggle Fleet Deck",
+    category: "Fleet",
   },
   // Directional terminal navigation (Ghostty-style: Cmd+Option+Arrow)
   {

--- a/src/store/__tests__/fleetDeckStore.test.ts
+++ b/src/store/__tests__/fleetDeckStore.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const { setStateMock } = vi.hoisted(() => ({
-  setStateMock: vi.fn(() => Promise.resolve()),
+  setStateMock: vi.fn((_patch: Record<string, unknown>) => Promise.resolve()),
 }));
 
-vi.mock("@/clients", () => ({
-  appClient: {
-    setState: setStateMock,
+vi.mock("@/controllers/FleetDeckController", () => ({
+  fleetDeckController: {
+    persistOpen: (isOpen: boolean) => setStateMock({ fleetDeckOpen: isOpen }),
+    persistEdge: (edge: string) => setStateMock({ fleetDeckEdge: edge }),
+    persistWidth: (width: number) => setStateMock({ fleetDeckWidth: width }),
+    persistHeight: (height: number) => setStateMock({ fleetDeckHeight: height }),
   },
 }));
 

--- a/src/store/__tests__/fleetDeckStore.test.ts
+++ b/src/store/__tests__/fleetDeckStore.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { setStateMock } = vi.hoisted(() => ({
+  setStateMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/clients", () => ({
+  appClient: {
+    setState: setStateMock,
+  },
+}));
+
+import {
+  useFleetDeckStore,
+  FLEET_DECK_MIN_WIDTH,
+  FLEET_DECK_MAX_WIDTH,
+  FLEET_DECK_DEFAULT_WIDTH,
+  FLEET_DECK_MIN_HEIGHT,
+  FLEET_DECK_MAX_HEIGHT,
+  FLEET_DECK_DEFAULT_HEIGHT,
+} from "../fleetDeckStore";
+
+function resetStore(): void {
+  useFleetDeckStore.setState({
+    isOpen: false,
+    edge: "right",
+    width: FLEET_DECK_DEFAULT_WIDTH,
+    height: FLEET_DECK_DEFAULT_HEIGHT,
+    scope: "current",
+    stateFilter: "all",
+    pinnedLiveIds: new Set<string>(),
+    isHydrated: false,
+  });
+  setStateMock.mockClear();
+}
+
+describe("fleetDeckStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  describe("open/close/toggle", () => {
+    it("opens from closed state and persists", () => {
+      useFleetDeckStore.getState().open();
+      expect(useFleetDeckStore.getState().isOpen).toBe(true);
+      expect(setStateMock).toHaveBeenCalledWith({ fleetDeckOpen: true });
+    });
+
+    it("open is idempotent when already open", () => {
+      useFleetDeckStore.getState().open();
+      setStateMock.mockClear();
+      useFleetDeckStore.getState().open();
+      expect(setStateMock).not.toHaveBeenCalled();
+    });
+
+    it("close is idempotent when already closed", () => {
+      useFleetDeckStore.getState().close();
+      expect(setStateMock).not.toHaveBeenCalled();
+    });
+
+    it("toggle flips and persists", () => {
+      useFleetDeckStore.getState().toggle();
+      expect(useFleetDeckStore.getState().isOpen).toBe(true);
+      useFleetDeckStore.getState().toggle();
+      expect(useFleetDeckStore.getState().isOpen).toBe(false);
+      expect(setStateMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("width clamping", () => {
+    it("clamps below minimum", () => {
+      useFleetDeckStore.getState().setWidth(1);
+      expect(useFleetDeckStore.getState().width).toBe(FLEET_DECK_MIN_WIDTH);
+    });
+
+    it("clamps above maximum", () => {
+      useFleetDeckStore.getState().setWidth(100_000);
+      expect(useFleetDeckStore.getState().width).toBe(FLEET_DECK_MAX_WIDTH);
+    });
+
+    it("accepts values exactly at bounds", () => {
+      useFleetDeckStore.getState().setWidth(FLEET_DECK_MIN_WIDTH);
+      expect(useFleetDeckStore.getState().width).toBe(FLEET_DECK_MIN_WIDTH);
+      useFleetDeckStore.getState().setWidth(FLEET_DECK_MAX_WIDTH);
+      expect(useFleetDeckStore.getState().width).toBe(FLEET_DECK_MAX_WIDTH);
+    });
+
+    it("skips persistence when width does not change", () => {
+      useFleetDeckStore.getState().setWidth(FLEET_DECK_DEFAULT_WIDTH);
+      // Default already matches, so no persist call
+      expect(setStateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-finite values and falls back to default", () => {
+      useFleetDeckStore.getState().setWidth(Number.NaN);
+      expect(useFleetDeckStore.getState().width).toBe(FLEET_DECK_DEFAULT_WIDTH);
+    });
+  });
+
+  describe("height clamping", () => {
+    it("clamps below minimum", () => {
+      useFleetDeckStore.getState().setHeight(10);
+      expect(useFleetDeckStore.getState().height).toBe(FLEET_DECK_MIN_HEIGHT);
+    });
+
+    it("clamps above maximum", () => {
+      useFleetDeckStore.getState().setHeight(100_000);
+      expect(useFleetDeckStore.getState().height).toBe(FLEET_DECK_MAX_HEIGHT);
+    });
+  });
+
+  describe("hydrate", () => {
+    it("populates fields and sets isHydrated", () => {
+      useFleetDeckStore.getState().hydrate({
+        isOpen: true,
+        edge: "left",
+        width: 500,
+        height: 600,
+      });
+      const s = useFleetDeckStore.getState();
+      expect(s.isHydrated).toBe(true);
+      expect(s.isOpen).toBe(true);
+      expect(s.edge).toBe("left");
+      expect(s.width).toBe(500);
+      expect(s.height).toBe(600);
+    });
+
+    it("ignores undefined partial fields", () => {
+      useFleetDeckStore.getState().hydrate({ width: 420 });
+      const s = useFleetDeckStore.getState();
+      expect(s.width).toBe(420);
+      expect(s.isOpen).toBe(false);
+      expect(s.edge).toBe("right");
+    });
+
+    it("clamps out-of-range width on hydrate", () => {
+      useFleetDeckStore.getState().hydrate({ width: 50 });
+      expect(useFleetDeckStore.getState().width).toBe(FLEET_DECK_MIN_WIDTH);
+    });
+
+    it("coerces unknown edge to right", () => {
+      // "bottom" not yet rendered — normalized to "right"
+      useFleetDeckStore.getState().hydrate({ edge: "bottom" });
+      expect(useFleetDeckStore.getState().edge).toBe("right");
+    });
+
+    it("does not persist during hydrate", () => {
+      useFleetDeckStore.getState().hydrate({
+        isOpen: true,
+        width: 500,
+      });
+      expect(setStateMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pin management", () => {
+    it("pinLive adds to the set", () => {
+      useFleetDeckStore.getState().pinLive("a");
+      useFleetDeckStore.getState().pinLive("b");
+      expect(useFleetDeckStore.getState().pinnedLiveIds.has("a")).toBe(true);
+      expect(useFleetDeckStore.getState().pinnedLiveIds.has("b")).toBe(true);
+    });
+
+    it("pinLive is idempotent", () => {
+      useFleetDeckStore.getState().pinLive("a");
+      const first = useFleetDeckStore.getState().pinnedLiveIds;
+      useFleetDeckStore.getState().pinLive("a");
+      const second = useFleetDeckStore.getState().pinnedLiveIds;
+      expect(second).toBe(first);
+    });
+
+    it("unpinLive removes from the set", () => {
+      useFleetDeckStore.getState().pinLive("a");
+      useFleetDeckStore.getState().unpinLive("a");
+      expect(useFleetDeckStore.getState().pinnedLiveIds.has("a")).toBe(false);
+    });
+
+    it("togglePinLive flips membership", () => {
+      useFleetDeckStore.getState().togglePinLive("a");
+      expect(useFleetDeckStore.getState().pinnedLiveIds.has("a")).toBe(true);
+      useFleetDeckStore.getState().togglePinLive("a");
+      expect(useFleetDeckStore.getState().pinnedLiveIds.has("a")).toBe(false);
+    });
+
+    it("prunePins removes stale ids", () => {
+      useFleetDeckStore.getState().pinLive("a");
+      useFleetDeckStore.getState().pinLive("b");
+      useFleetDeckStore.getState().pinLive("c");
+      useFleetDeckStore.getState().prunePins(new Set(["a", "c"]));
+      const pins = useFleetDeckStore.getState().pinnedLiveIds;
+      expect(pins.has("a")).toBe(true);
+      expect(pins.has("b")).toBe(false);
+      expect(pins.has("c")).toBe(true);
+    });
+
+    it("prunePins no-ops when nothing changed", () => {
+      useFleetDeckStore.getState().pinLive("a");
+      const before = useFleetDeckStore.getState().pinnedLiveIds;
+      useFleetDeckStore.getState().prunePins(new Set(["a"]));
+      expect(useFleetDeckStore.getState().pinnedLiveIds).toBe(before);
+    });
+  });
+
+  describe("scope and filter", () => {
+    it("setScope updates scope without persistence", () => {
+      useFleetDeckStore.getState().setScope("all");
+      expect(useFleetDeckStore.getState().scope).toBe("all");
+      expect(setStateMock).not.toHaveBeenCalled();
+    });
+
+    it("setStateFilter updates filter", () => {
+      useFleetDeckStore.getState().setStateFilter("waiting");
+      expect(useFleetDeckStore.getState().stateFilter).toBe("waiting");
+    });
+  });
+
+  describe("setEdge", () => {
+    it("accepts left", () => {
+      useFleetDeckStore.getState().setEdge("left");
+      expect(useFleetDeckStore.getState().edge).toBe("left");
+      expect(setStateMock).toHaveBeenCalledWith({ fleetDeckEdge: "left" });
+    });
+
+    it("normalizes bottom to right until implemented", () => {
+      useFleetDeckStore.getState().setEdge("bottom");
+      expect(useFleetDeckStore.getState().edge).toBe("right");
+    });
+  });
+});

--- a/src/store/__tests__/fleetDeckStore.test.ts
+++ b/src/store/__tests__/fleetDeckStore.test.ts
@@ -151,6 +151,28 @@ describe("fleetDeckStore", () => {
       });
       expect(setStateMock).not.toHaveBeenCalled();
     });
+
+    it("a user mutator before hydrate() wins over stale persisted values", () => {
+      // Simulate: user hits Cmd+Alt+Shift+B before AppState IPC resolves
+      useFleetDeckStore.getState().open();
+      useFleetDeckStore.getState().setWidth(700);
+      // Stale hydrate arrives with persisted closed state and old width
+      useFleetDeckStore.getState().hydrate({
+        isOpen: false,
+        width: 480,
+      });
+      const s = useFleetDeckStore.getState();
+      expect(s.isOpen).toBe(true);
+      expect(s.width).toBe(700);
+    });
+
+    it("hydrate() becomes a no-op after first hydrate", () => {
+      useFleetDeckStore.getState().hydrate({ isOpen: true, width: 500 });
+      useFleetDeckStore.getState().hydrate({ isOpen: false, width: 600 });
+      const s = useFleetDeckStore.getState();
+      expect(s.isOpen).toBe(true);
+      expect(s.width).toBe(500);
+    });
   });
 
   describe("pin management", () => {

--- a/src/store/fleetDeckStore.ts
+++ b/src/store/fleetDeckStore.ts
@@ -1,0 +1,201 @@
+import { create } from "zustand";
+import { appClient } from "@/clients";
+
+export const FLEET_DECK_MIN_WIDTH = 360;
+export const FLEET_DECK_MAX_WIDTH = 900;
+export const FLEET_DECK_DEFAULT_WIDTH = 480;
+export const FLEET_DECK_MIN_HEIGHT = 240;
+export const FLEET_DECK_MAX_HEIGHT = 900;
+export const FLEET_DECK_DEFAULT_HEIGHT = 320;
+export const FLEET_DECK_LIVE_TILE_CAP = 4;
+
+export type FleetDeckEdge = "right" | "left" | "bottom";
+export type FleetDeckScope = "current" | "all";
+export type FleetDeckStateFilter =
+  | "all"
+  | "waiting"
+  | "working"
+  | "idle"
+  | "completed"
+  | "failed";
+
+interface FleetDeckState {
+  isOpen: boolean;
+  edge: FleetDeckEdge;
+  width: number;
+  height: number;
+  scope: FleetDeckScope;
+  stateFilter: FleetDeckStateFilter;
+  pinnedLiveIds: Set<string>;
+  isHydrated: boolean;
+
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  setEdge: (edge: FleetDeckEdge) => void;
+  setWidth: (width: number) => void;
+  setHeight: (height: number) => void;
+  setScope: (scope: FleetDeckScope) => void;
+  setStateFilter: (filter: FleetDeckStateFilter) => void;
+  pinLive: (id: string) => void;
+  unpinLive: (id: string) => void;
+  togglePinLive: (id: string) => void;
+  prunePins: (validIds: Set<string>) => void;
+  hydrate: (
+    state: Partial<Pick<FleetDeckState, "isOpen" | "edge" | "width" | "height">>
+  ) => void;
+}
+
+function clampWidth(width: number): number {
+  if (!Number.isFinite(width)) return FLEET_DECK_DEFAULT_WIDTH;
+  return Math.min(Math.max(width, FLEET_DECK_MIN_WIDTH), FLEET_DECK_MAX_WIDTH);
+}
+
+function clampHeight(height: number): number {
+  if (!Number.isFinite(height)) return FLEET_DECK_DEFAULT_HEIGHT;
+  return Math.min(Math.max(height, FLEET_DECK_MIN_HEIGHT), FLEET_DECK_MAX_HEIGHT);
+}
+
+function normalizeEdge(edge: FleetDeckEdge | undefined): FleetDeckEdge {
+  // Side-dock only in this iteration; bottom falls back to right until implemented.
+  if (edge === "left") return "left";
+  return "right";
+}
+
+export const useFleetDeckStore = create<FleetDeckState>()((set, get) => ({
+  isOpen: false,
+  edge: "right",
+  width: FLEET_DECK_DEFAULT_WIDTH,
+  height: FLEET_DECK_DEFAULT_HEIGHT,
+  scope: "current",
+  stateFilter: "all",
+  pinnedLiveIds: new Set<string>(),
+  isHydrated: false,
+
+  open: () => {
+    if (get().isOpen) return;
+    set({ isOpen: true });
+    void persistOpen(true);
+  },
+
+  close: () => {
+    if (!get().isOpen) return;
+    set({ isOpen: false });
+    void persistOpen(false);
+  },
+
+  toggle: () => {
+    const next = !get().isOpen;
+    set({ isOpen: next });
+    void persistOpen(next);
+  },
+
+  setEdge: (edge) => {
+    const normalized = normalizeEdge(edge);
+    if (get().edge === normalized) return;
+    set({ edge: normalized });
+    void persistEdge(normalized);
+  },
+
+  setWidth: (width) => {
+    const clamped = clampWidth(width);
+    if (get().width === clamped) return;
+    set({ width: clamped });
+    void persistWidth(clamped);
+  },
+
+  setHeight: (height) => {
+    const clamped = clampHeight(height);
+    if (get().height === clamped) return;
+    set({ height: clamped });
+    void persistHeight(clamped);
+  },
+
+  setScope: (scope) => {
+    if (get().scope === scope) return;
+    set({ scope });
+  },
+
+  setStateFilter: (filter) => {
+    if (get().stateFilter === filter) return;
+    set({ stateFilter: filter });
+  },
+
+  pinLive: (id) =>
+    set((s) => {
+      if (s.pinnedLiveIds.has(id)) return {};
+      const next = new Set(s.pinnedLiveIds);
+      next.add(id);
+      return { pinnedLiveIds: next };
+    }),
+
+  unpinLive: (id) =>
+    set((s) => {
+      if (!s.pinnedLiveIds.has(id)) return {};
+      const next = new Set(s.pinnedLiveIds);
+      next.delete(id);
+      return { pinnedLiveIds: next };
+    }),
+
+  togglePinLive: (id) => {
+    if (get().pinnedLiveIds.has(id)) {
+      get().unpinLive(id);
+    } else {
+      get().pinLive(id);
+    }
+  },
+
+  prunePins: (validIds) =>
+    set((s) => {
+      if (s.pinnedLiveIds.size === 0) return {};
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of s.pinnedLiveIds) {
+        if (validIds.has(id)) next.add(id);
+        else changed = true;
+      }
+      if (!changed) return {};
+      return { pinnedLiveIds: next };
+    }),
+
+  hydrate: (state) => {
+    const patch: Partial<FleetDeckState> = { isHydrated: true };
+    if (typeof state.isOpen === "boolean") patch.isOpen = state.isOpen;
+    if (state.edge != null) patch.edge = normalizeEdge(state.edge);
+    if (typeof state.width === "number") patch.width = clampWidth(state.width);
+    if (typeof state.height === "number") patch.height = clampHeight(state.height);
+    set(patch);
+  },
+}));
+
+async function persistOpen(isOpen: boolean): Promise<void> {
+  try {
+    await appClient.setState({ fleetDeckOpen: isOpen });
+  } catch (error) {
+    console.error("Failed to persist fleet deck open state:", error);
+  }
+}
+
+async function persistEdge(edge: FleetDeckEdge): Promise<void> {
+  try {
+    await appClient.setState({ fleetDeckEdge: edge });
+  } catch (error) {
+    console.error("Failed to persist fleet deck edge:", error);
+  }
+}
+
+async function persistWidth(width: number): Promise<void> {
+  try {
+    await appClient.setState({ fleetDeckWidth: width });
+  } catch (error) {
+    console.error("Failed to persist fleet deck width:", error);
+  }
+}
+
+async function persistHeight(height: number): Promise<void> {
+  try {
+    await appClient.setState({ fleetDeckHeight: height });
+  } catch (error) {
+    console.error("Failed to persist fleet deck height:", error);
+  }
+}

--- a/src/store/fleetDeckStore.ts
+++ b/src/store/fleetDeckStore.ts
@@ -74,40 +74,43 @@ export const useFleetDeckStore = create<FleetDeckState>()((set, get) => ({
 
   open: () => {
     if (get().isOpen) return;
-    set({ isOpen: true });
+    // User interaction before hydrate() resolves wins; hydrate() becomes a
+    // no-op once isHydrated flips (whether via this path or the explicit
+    // hydrate call).
+    set({ isOpen: true, isHydrated: true });
     void persistOpen(true);
   },
 
   close: () => {
     if (!get().isOpen) return;
-    set({ isOpen: false });
+    set({ isOpen: false, isHydrated: true });
     void persistOpen(false);
   },
 
   toggle: () => {
     const next = !get().isOpen;
-    set({ isOpen: next });
+    set({ isOpen: next, isHydrated: true });
     void persistOpen(next);
   },
 
   setEdge: (edge) => {
     const normalized = normalizeEdge(edge);
     if (get().edge === normalized) return;
-    set({ edge: normalized });
+    set({ edge: normalized, isHydrated: true });
     void persistEdge(normalized);
   },
 
   setWidth: (width) => {
     const clamped = clampWidth(width);
     if (get().width === clamped) return;
-    set({ width: clamped });
+    set({ width: clamped, isHydrated: true });
     void persistWidth(clamped);
   },
 
   setHeight: (height) => {
     const clamped = clampHeight(height);
     if (get().height === clamped) return;
-    set({ height: clamped });
+    set({ height: clamped, isHydrated: true });
     void persistHeight(clamped);
   },
 
@@ -159,6 +162,9 @@ export const useFleetDeckStore = create<FleetDeckState>()((set, get) => ({
     }),
 
   hydrate: (state) => {
+    // If a user mutator ran before the async AppState hydration resolves,
+    // their interaction wins — don't clobber it with stale persisted values.
+    if (get().isHydrated) return;
     const patch: Partial<FleetDeckState> = { isHydrated: true };
     if (typeof state.isOpen === "boolean") patch.isOpen = state.isOpen;
     if (state.edge != null) patch.edge = normalizeEdge(state.edge);

--- a/src/store/fleetDeckStore.ts
+++ b/src/store/fleetDeckStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { appClient } from "@/clients";
+import { fleetDeckController } from "@/controllers/FleetDeckController";
 
 export const FLEET_DECK_MIN_WIDTH = 360;
 export const FLEET_DECK_MAX_WIDTH = 900;
@@ -11,13 +11,7 @@ export const FLEET_DECK_LIVE_TILE_CAP = 4;
 
 export type FleetDeckEdge = "right" | "left" | "bottom";
 export type FleetDeckScope = "current" | "all";
-export type FleetDeckStateFilter =
-  | "all"
-  | "waiting"
-  | "working"
-  | "idle"
-  | "completed"
-  | "failed";
+export type FleetDeckStateFilter = "all" | "waiting" | "working" | "idle" | "completed" | "failed";
 
 interface FleetDeckState {
   isOpen: boolean;
@@ -41,9 +35,7 @@ interface FleetDeckState {
   unpinLive: (id: string) => void;
   togglePinLive: (id: string) => void;
   prunePins: (validIds: Set<string>) => void;
-  hydrate: (
-    state: Partial<Pick<FleetDeckState, "isOpen" | "edge" | "width" | "height">>
-  ) => void;
+  hydrate: (state: Partial<Pick<FleetDeckState, "isOpen" | "edge" | "width" | "height">>) => void;
 }
 
 function clampWidth(width: number): number {
@@ -174,34 +166,10 @@ export const useFleetDeckStore = create<FleetDeckState>()((set, get) => ({
   },
 }));
 
-async function persistOpen(isOpen: boolean): Promise<void> {
-  try {
-    await appClient.setState({ fleetDeckOpen: isOpen });
-  } catch (error) {
-    console.error("Failed to persist fleet deck open state:", error);
-  }
-}
+const persistOpen = (isOpen: boolean): Promise<void> => fleetDeckController.persistOpen(isOpen);
 
-async function persistEdge(edge: FleetDeckEdge): Promise<void> {
-  try {
-    await appClient.setState({ fleetDeckEdge: edge });
-  } catch (error) {
-    console.error("Failed to persist fleet deck edge:", error);
-  }
-}
+const persistEdge = (edge: FleetDeckEdge): Promise<void> => fleetDeckController.persistEdge(edge);
 
-async function persistWidth(width: number): Promise<void> {
-  try {
-    await appClient.setState({ fleetDeckWidth: width });
-  } catch (error) {
-    console.error("Failed to persist fleet deck width:", error);
-  }
-}
+const persistWidth = (width: number): Promise<void> => fleetDeckController.persistWidth(width);
 
-async function persistHeight(height: number): Promise<void> {
-  try {
-    await appClient.setState({ fleetDeckHeight: height });
-  } catch (error) {
-    console.error("Failed to persist fleet deck height:", error);
-  }
-}
+const persistHeight = (height: number): Promise<void> => fleetDeckController.persistHeight(height);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -81,6 +81,18 @@ export { useVoiceRecordingStore } from "./voiceRecordingStore";
 
 export { useDockStore } from "./dockStore";
 
+export {
+  useFleetDeckStore,
+  FLEET_DECK_MIN_WIDTH,
+  FLEET_DECK_MAX_WIDTH,
+  FLEET_DECK_DEFAULT_WIDTH,
+  FLEET_DECK_MIN_HEIGHT,
+  FLEET_DECK_MAX_HEIGHT,
+  FLEET_DECK_DEFAULT_HEIGHT,
+  FLEET_DECK_LIVE_TILE_CAP,
+} from "./fleetDeckStore";
+export type { FleetDeckEdge, FleetDeckScope, FleetDeckStateFilter } from "./fleetDeckStore";
+
 export { useTwoPaneSplitStore } from "./twoPaneSplitStore";
 export type { TwoPaneSplitConfig, WorktreeRatioEntry } from "./twoPaneSplitStore";
 

--- a/src/utils/__tests__/agentStateFilter.test.ts
+++ b/src/utils/__tests__/agentStateFilter.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { matchesDeckFilter } from "../agentStateFilter";
+
+describe("matchesDeckFilter", () => {
+  it("all matches every state including null", () => {
+    expect(matchesDeckFilter(null, "all")).toBe(true);
+    expect(matchesDeckFilter("idle", "all")).toBe(true);
+    expect(matchesDeckFilter("working", "all")).toBe(true);
+    expect(matchesDeckFilter("completed", "all")).toBe(true);
+  });
+
+  it("waiting matches waiting and directing", () => {
+    expect(matchesDeckFilter("waiting", "waiting")).toBe(true);
+    expect(matchesDeckFilter("directing", "waiting")).toBe(true);
+    expect(matchesDeckFilter("working", "waiting")).toBe(false);
+  });
+
+  it("working matches working and running", () => {
+    expect(matchesDeckFilter("working", "working")).toBe(true);
+    expect(matchesDeckFilter("running", "working")).toBe(true);
+    expect(matchesDeckFilter("idle", "working")).toBe(false);
+  });
+
+  it("idle matches idle and null/undefined state", () => {
+    expect(matchesDeckFilter("idle", "idle")).toBe(true);
+    expect(matchesDeckFilter(null, "idle")).toBe(true);
+    expect(matchesDeckFilter(undefined, "idle")).toBe(true);
+    expect(matchesDeckFilter("working", "idle")).toBe(false);
+  });
+
+  it("completed matches completed", () => {
+    expect(matchesDeckFilter("completed", "completed")).toBe(true);
+    expect(matchesDeckFilter("exited", "completed")).toBe(false);
+  });
+
+  it("failed matches exited", () => {
+    expect(matchesDeckFilter("exited", "failed")).toBe(true);
+    expect(matchesDeckFilter("completed", "failed")).toBe(false);
+  });
+});

--- a/src/utils/__tests__/fleetDeckLiveSlots.test.ts
+++ b/src/utils/__tests__/fleetDeckLiveSlots.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import type { TerminalInstance } from "@shared/types";
+import { computeLiveSlotIds } from "../fleetDeckLiveSlots";
+
+function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    location: "grid",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+describe("computeLiveSlotIds", () => {
+  it("returns empty array when cap is zero", () => {
+    const ids = ["a", "b"];
+    const panelsById = { a: panel("a"), b: panel("b") };
+    expect(
+      computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 0)
+    ).toEqual([]);
+  });
+
+  it("returns empty array when no eligible ids", () => {
+    expect(computeLiveSlotIds([], new Set(), new Set(), {}, 4)).toEqual([]);
+  });
+
+  it("returns all ids when under cap", () => {
+    const ids = ["a", "b", "c"];
+    const panelsById = {
+      a: panel("a"),
+      b: panel("b"),
+      c: panel("c"),
+    };
+    const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 4);
+    expect(new Set(result)).toEqual(new Set(ids));
+  });
+
+  it("pins take absolute priority over armed and state", () => {
+    const ids = ["a", "b", "c", "d", "e"];
+    const panelsById = {
+      a: panel("a", { agentState: "idle" }),
+      b: panel("b", { agentState: "waiting" }),
+      c: panel("c", { agentState: "working" }),
+      d: panel("d", { agentState: "idle" }),
+      e: panel("e", { agentState: "idle" }),
+    };
+    const armed = new Set(["c"]);
+    const pinned = new Set(["e", "d"]);
+    const result = computeLiveSlotIds(ids, armed, pinned, panelsById, 4);
+    // Tier 0 first: pinned (by appearance order), then tier 1 (armed), then waiting
+    expect(result[0]).toBe("d");
+    expect(result[1]).toBe("e");
+    expect(result).toContain("c");
+    expect(result).toContain("b");
+  });
+
+  it("armed beats waiting", () => {
+    const ids = ["a", "b"];
+    const panelsById = {
+      a: panel("a", { agentState: "waiting" }),
+      b: panel("b", { agentState: "idle" }),
+    };
+    const armed = new Set(["b"]);
+    const result = computeLiveSlotIds(ids, armed, new Set(), panelsById, 1);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("waiting beats working", () => {
+    const ids = ["a", "b"];
+    const panelsById = {
+      a: panel("a", { agentState: "working" }),
+      b: panel("b", { agentState: "waiting" }),
+    };
+    const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 1);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("working beats idle", () => {
+    const ids = ["a", "b"];
+    const panelsById = {
+      a: panel("a", { agentState: "idle" }),
+      b: panel("b", { agentState: "running" }),
+    };
+    const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 1);
+    expect(result).toEqual(["b"]);
+  });
+
+  it("ties in priority are resolved by appearance order", () => {
+    const ids = ["a", "b", "c"];
+    const panelsById = {
+      a: panel("a", { agentState: "waiting" }),
+      b: panel("b", { agentState: "waiting" }),
+      c: panel("c", { agentState: "waiting" }),
+    };
+    const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 2);
+    expect(result).toEqual(["a", "b"]);
+  });
+
+  it("caps at 4 by default", () => {
+    const ids = ["a", "b", "c", "d", "e", "f"];
+    const panelsById: Record<string, TerminalInstance> = {};
+    for (const id of ids) panelsById[id] = panel(id, { agentState: "waiting" });
+    const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById);
+    expect(result).toHaveLength(4);
+    expect(result).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("handles missing panel entries gracefully", () => {
+    const ids = ["a", "b"];
+    const panelsById = { a: panel("a", { agentState: "waiting" }) };
+    const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 2);
+    // "a" has tier 2 (waiting), "b" missing defaults to tier 4 — "a" comes first.
+    expect(result[0]).toBe("a");
+    expect(result).toContain("b");
+  });
+});

--- a/src/utils/__tests__/fleetDeckLiveSlots.test.ts
+++ b/src/utils/__tests__/fleetDeckLiveSlots.test.ts
@@ -15,9 +15,7 @@ describe("computeLiveSlotIds", () => {
   it("returns empty array when cap is zero", () => {
     const ids = ["a", "b"];
     const panelsById = { a: panel("a"), b: panel("b") };
-    expect(
-      computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 0)
-    ).toEqual([]);
+    expect(computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 0)).toEqual([]);
   });
 
   it("returns empty array when no eligible ids", () => {

--- a/src/utils/__tests__/fleetDeckLiveSlots.test.ts
+++ b/src/utils/__tests__/fleetDeckLiveSlots.test.ts
@@ -24,7 +24,7 @@ describe("computeLiveSlotIds", () => {
     expect(computeLiveSlotIds([], new Set(), new Set(), {}, 4)).toEqual([]);
   });
 
-  it("returns all ids when under cap", () => {
+  it("returns all ids when under cap, preserving appearance order", () => {
     const ids = ["a", "b", "c"];
     const panelsById = {
       a: panel("a"),
@@ -32,10 +32,10 @@ describe("computeLiveSlotIds", () => {
       c: panel("c"),
     };
     const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 4);
-    expect(new Set(result)).toEqual(new Set(ids));
+    expect(result).toEqual(["a", "b", "c"]);
   });
 
-  it("pins take absolute priority over armed and state", () => {
+  it("pins take absolute priority over armed and state, with ordered tiers", () => {
     const ids = ["a", "b", "c", "d", "e"];
     const panelsById = {
       a: panel("a", { agentState: "idle" }),
@@ -47,11 +47,9 @@ describe("computeLiveSlotIds", () => {
     const armed = new Set(["c"]);
     const pinned = new Set(["e", "d"]);
     const result = computeLiveSlotIds(ids, armed, pinned, panelsById, 4);
-    // Tier 0 first: pinned (by appearance order), then tier 1 (armed), then waiting
-    expect(result[0]).toBe("d");
-    expect(result[1]).toBe("e");
-    expect(result).toContain("c");
-    expect(result).toContain("b");
+    // Tier 0 pinned ("d" before "e" by appearance), tier 1 armed ("c"),
+    // tier 2 waiting ("b"). "a" (idle, tier 4) drops because cap=4.
+    expect(result).toEqual(["d", "e", "c", "b"]);
   });
 
   it("armed beats waiting", () => {
@@ -109,8 +107,7 @@ describe("computeLiveSlotIds", () => {
     const ids = ["a", "b"];
     const panelsById = { a: panel("a", { agentState: "waiting" }) };
     const result = computeLiveSlotIds(ids, new Set(), new Set(), panelsById, 2);
-    // "a" has tier 2 (waiting), "b" missing defaults to tier 4 — "a" comes first.
-    expect(result[0]).toBe("a");
-    expect(result).toContain("b");
+    // "a" has tier 2 (waiting), "b" missing defaults to tier 4 — "a" first.
+    expect(result).toEqual(["a", "b"]);
   });
 });

--- a/src/utils/agentStateFilter.ts
+++ b/src/utils/agentStateFilter.ts
@@ -1,0 +1,42 @@
+import type { AgentState } from "@shared/types";
+import type { FleetDeckStateFilter } from "@/store/fleetDeckStore";
+
+export function matchesDeckFilter(
+  state: AgentState | null | undefined,
+  filter: FleetDeckStateFilter
+): boolean {
+  if (filter === "all") return true;
+  if (state == null) {
+    return filter === "idle";
+  }
+  switch (filter) {
+    case "waiting":
+      return state === "waiting" || state === "directing";
+    case "working":
+      return state === "working" || state === "running";
+    case "idle":
+      return state === "idle";
+    case "completed":
+      return state === "completed";
+    case "failed":
+      return state === "exited";
+  }
+}
+
+export const DECK_FILTER_ORDER: readonly FleetDeckStateFilter[] = [
+  "all",
+  "waiting",
+  "working",
+  "idle",
+  "completed",
+  "failed",
+];
+
+export const DECK_FILTER_LABELS: Record<FleetDeckStateFilter, string> = {
+  all: "All",
+  waiting: "Waiting",
+  working: "Working",
+  idle: "Idle",
+  completed: "Completed",
+  failed: "Failed",
+};

--- a/src/utils/fleetDeckLiveSlots.ts
+++ b/src/utils/fleetDeckLiveSlots.ts
@@ -1,0 +1,58 @@
+import type { TerminalInstance } from "@shared/types";
+import { FLEET_DECK_LIVE_TILE_CAP } from "@/store/fleetDeckStore";
+
+/**
+ * Priority tiers for selecting which tiles get live xterm mirrors (DOM renderer).
+ * Lower number = higher priority. Within a tier, input appearance order wins.
+ *
+ * Tier 0: pinned (user override)
+ * Tier 1: armed
+ * Tier 2: waiting state (needs attention)
+ * Tier 3: working/running
+ * Tier 4: everything else
+ */
+function priorityTier(
+  id: string,
+  armed: Set<string>,
+  pinned: Set<string>,
+  panel: TerminalInstance | undefined
+): number {
+  if (pinned.has(id)) return 0;
+  if (armed.has(id)) return 1;
+  const state = panel?.agentState;
+  if (state === "waiting" || state === "directing") return 2;
+  if (state === "working" || state === "running") return 3;
+  return 4;
+}
+
+/**
+ * Given an ordered list of eligible terminal ids (appearance order),
+ * pick up to `cap` ids for the live-mirror slots, ordered by priority.
+ */
+export function computeLiveSlotIds(
+  eligibleIds: readonly string[],
+  armedIds: Set<string>,
+  pinnedIds: Set<string>,
+  panelsById: Record<string, TerminalInstance | undefined>,
+  cap: number = FLEET_DECK_LIVE_TILE_CAP
+): string[] {
+  if (cap <= 0 || eligibleIds.length === 0) return [];
+
+  const scored = eligibleIds.map((id, index) => ({
+    id,
+    tier: priorityTier(id, armedIds, pinnedIds, panelsById[id]),
+    index,
+  }));
+
+  scored.sort((a, b) => {
+    if (a.tier !== b.tier) return a.tier - b.tier;
+    return a.index - b.index;
+  });
+
+  const out: string[] = [];
+  for (const entry of scored) {
+    if (out.length >= cap) break;
+    out.push(entry.id);
+  }
+  return out;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -177,6 +177,13 @@ export default defineConfig(({ command, mode }) => {
     define: {
       IS_LEGACY_BUILD: JSON.stringify(IS_LEGACY_BUILD),
     },
+    // xterm 6.0 ships a bundled InputHandler that references an unminified
+    // identifier in `requestMode`; Vite's default identifier mangling produces
+    // `ReferenceError: i is not defined` at runtime. Disable identifier
+    // renaming only — whitespace and syntax compression still apply.
+    esbuild: {
+      minifyIdentifiers: false,
+    },
     plugins: [
       react(),
       babel({


### PR DESCRIPTION
## Summary

- Implements Fleet Deck (#5304): a persistent, dockable side panel showing a tile grid of live xterm mirror tiles for multi-agent orchestration, with up to 4 live tiles at once and static snapshot fallback for the rest
- New `fleetDeckStore` manages open state, edge, width, scope, state filter, and pinned live IDs, persisted via `AppState` through `FleetDeckController`
- Three new actions (`fleet.deck.toggle/open/close`) with `Cmd+Alt+Shift+B` binding; sidebar BroadcastTerminalIcon now dispatches `fleet.deck.toggle`

Resolves #5304

## Changes

- `FleetDeck.tsx` / `MirrorTile.tsx`: core side-dock panel and individual xterm mirror tiles (DOM renderer, scrollback=500, ResizeObserver-guarded open, mountGeneration safety)
- `fleetDeckStore.ts` + `FleetDeckController.ts`: state management and IPC persistence
- `fleetDeckLiveSlots.ts`: priority ordering (pinned > armed > waiting > working > arrival order)
- `agentStateFilter.ts`: reusable agent state predicate used by scope/filter bar
- `fleetActions.ts`: three deck actions registered in the action system
- `AppLayout`, `TerminalPane`, `FleetArmingRibbon`: integration points (dock layout, composer suppression, HybridInputBar suppression for armed terminals when deck is open)
- `vite.config.ts`: `esbuild.minifyIdentifiers: false` to avoid xterm 6.0 `InputHandler.requestMode` minification error
- 204 tests pass (22 new fleetDeckStore + 10 fleetDeckLiveSlots + 6 agentStateFilter + 10 MirrorTile + 4 FleetDeck composition + 2 FleetArmingRibbon suppression)

## Testing

Typecheck clean, lint ratchet at 384 (baseline), Prettier clean. All 204 unit tests pass. Key scenarios covered: live slot priority ordering, mount/unmount safety guards, composer suppression logic, and state persistence round-trips.