### PR TITLE
feat(github): honour rate limits with header-aware backoff and countdown

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -149,6 +149,7 @@ export const CHANNELS = {
   GITHUB_GET_ISSUE_BY_NUMBER: "github:get-issue-by-number",
   GITHUB_GET_PR_BY_NUMBER: "github:get-pr-by-number",
   GITHUB_LIST_REMOTES: "github:list-remotes",
+  GITHUB_RATE_LIMIT_CHANGED: "github:rate-limit-changed",
 
   APP_GET_STATE: "app:get-state",
   APP_SET_STATE: "app:set-state",

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -52,6 +52,7 @@ vi.mock("electron", () => ({
 
 vi.mock("../../utils.js", () => ({
   checkRateLimit: checkRateLimitMock,
+  broadcastToRenderer: vi.fn(),
   typedHandle: (channel: string, handler: unknown) => {
     ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
       (handler as (...a: unknown[]) => unknown)(...args)
@@ -83,6 +84,10 @@ vi.mock("../../../services/WorkspaceClient.js", () => ({
 
 vi.mock("../../../services/github/index.js", () => ({
   GitHubAuth: gitHubAuthMock,
+  gitHubRateLimitService: {
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    getState: vi.fn().mockReturnValue({ blocked: false, kind: null }),
+  },
 }));
 
 vi.mock("../../../services/GitService.js", () => ({

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -85,6 +85,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
       const commitCount = await getCommitCount(resolved).catch(() => 0);
 
+      const { gitHubRateLimitService } = await import("../../services/github/index.js");
+      const rateLimitState = gitHubRateLimitService.getState();
+
       return {
         commitCount,
         issueCount: statsResult.stats?.issueCount ?? null,
@@ -93,6 +96,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         ghError: statsResult.error,
         stale: statsResult.stats?.stale,
         lastUpdated: statsResult.stats?.lastUpdated,
+        rateLimitResetAt:
+          rateLimitState.blocked && rateLimitState.resetAt ? rateLimitState.resetAt : undefined,
+        rateLimitKind: rateLimitState.blocked ? (rateLimitState.kind ?? undefined) : undefined,
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -2,7 +2,7 @@ import { shell } from "electron";
 import fs from "fs/promises";
 import path from "path";
 import { CHANNELS } from "../channels.js";
-import { checkRateLimit, typedHandle } from "../utils.js";
+import { broadcastToRenderer, checkRateLimit, typedHandle } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   RepositoryStats,
@@ -11,6 +11,7 @@ import type {
   GitHubTokenConfig,
   GitHubTokenValidation,
 } from "../../types/index.js";
+import { gitHubRateLimitService } from "../../services/github/index.js";
 import { getWorkspaceClient } from "../../services/WorkspaceClient.js";
 
 export function buildGitHubSearchQuery(
@@ -53,6 +54,15 @@ export function buildGitHubSearchQuery(
 export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
+  // Main-process transport: every time the main-process rate-limit singleton
+  // changes state (either from a local fetch observation or a forwarded
+  // utility-process observation via WorkspaceClient.routeHostEvent), push
+  // the new state to every renderer window.
+  const unsubscribeRateLimit = gitHubRateLimitService.onStateChange((state) => {
+    broadcastToRenderer(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, state);
+  });
+  handlers.push(unsubscribeRateLimit);
+
   const handleGitHubGetRepoStats = async (
     cwd: string,
     bypassCache = false
@@ -85,7 +95,6 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
       const commitCount = await getCommitCount(resolved).catch(() => 0);
 
-      const { gitHubRateLimitService } = await import("../../services/github/index.js");
       const rateLimitState = gitHubRateLimitService.getState();
 
       return {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -32,6 +32,7 @@ import type {
   PRClearedPayload,
   IssueDetectedPayload,
   IssueNotFoundPayload,
+  GitHubRateLimitPayload,
   GitStatus,
   KeyAction,
   TerminalRecipe,
@@ -1994,6 +1995,9 @@ const api: ElectronAPI = {
 
     onIssueNotFound: (callback: (data: IssueNotFoundPayload) => void) =>
       _typedOn(CHANNELS.ISSUE_NOT_FOUND, callback),
+
+    onRateLimitChanged: (callback: (data: GitHubRateLimitPayload) => void) =>
+      _typedOn(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, callback),
   },
 
   // Notes API

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -643,6 +643,7 @@ const CHANNELS = {
   GITHUB_GET_ISSUE_BY_NUMBER: "github:get-issue-by-number",
   GITHUB_GET_PR_BY_NUMBER: "github:get-pr-by-number",
   GITHUB_LIST_REMOTES: "github:list-remotes",
+  GITHUB_RATE_LIMIT_CHANGED: "github:rate-limit-changed",
 
   // Notes channels
   NOTES_CREATE: "notes:create",

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -25,6 +25,8 @@ import {
   GET_ISSUE_QUERY,
   GET_PR_QUERY,
   buildBatchPRQuery,
+  gitHubRateLimitService,
+  GitHubRateLimitError,
 } from "./github/index.js";
 
 import type {
@@ -240,6 +242,24 @@ export async function getRepoStats(
     return { stats: null, error: "GitHub token not configured. Set it in Settings." };
   }
 
+  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+  if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
+    const diskCached = persistentCache.get(cacheKey);
+    const message = rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt);
+    if (diskCached) {
+      return {
+        stats: {
+          issueCount: diskCached.issueCount,
+          prCount: diskCached.prCount,
+          stale: true,
+          lastUpdated: diskCached.lastUpdated,
+        },
+        error: message,
+      };
+    }
+    return { stats: null, error: message };
+  }
+
   if (!bypassCache) {
     const cached = repoStatsCache.get(cacheKey);
     if (cached) {
@@ -398,6 +418,14 @@ export async function getProjectHealth(
   const client = GitHubAuth.createClient();
   if (!client) {
     return { health: null, error: "GitHub token not configured. Set it in Settings." };
+  }
+
+  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+  if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
+    return {
+      health: null,
+      error: rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt),
+    };
   }
 
   if (!bypassCache) {
@@ -612,6 +640,14 @@ export async function batchCheckLinkedPRs(
     return { results: new Map(), error: "Not a GitHub repository" };
   }
 
+  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+  if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
+    return {
+      results: new Map(),
+      error: rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt),
+    };
+  }
+
   try {
     const query = buildBatchPRQuery(context.owner, context.repo, candidates);
     const response = (await client(query, {
@@ -792,7 +828,32 @@ function updateIssueAssigneeInCache(
   }
 }
 
+function rateLimitMessage(kind: "primary" | "secondary", resumeAt: number): string {
+  const seconds = Math.max(0, Math.ceil((resumeAt - Date.now()) / 1000));
+  const human = formatCountdown(seconds);
+  if (kind === "secondary") {
+    return `GitHub secondary rate limit triggered. Resuming in ${human}.`;
+  }
+  return `GitHub rate limit exceeded. Resets in ${human}.`;
+}
+
+function formatCountdown(totalSeconds: number): string {
+  if (totalSeconds <= 0) return "a moment";
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+}
+
 function parseGitHubError(error: unknown): string {
+  if (error instanceof GitHubRateLimitError) {
+    return rateLimitMessage(error.kind, error.resumeAt);
+  }
   const message = error instanceof Error ? error.message : String(error);
   const isTimeout = error instanceof Error && error.name === "TimeoutError";
 
@@ -807,6 +868,11 @@ function parseGitHubError(error: unknown): string {
     message === "Cannot reach GitHub. Check your internet connection."
   ) {
     return message;
+  }
+
+  const blockState = gitHubRateLimitService.shouldBlockRequest();
+  if (blockState.blocked && blockState.reason && blockState.resumeAt) {
+    return rateLimitMessage(blockState.reason, blockState.resumeAt);
   }
 
   if (message.includes("rate limit") || message.includes("API rate limit")) {

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -645,6 +645,7 @@ export async function batchCheckLinkedPRs(
     return {
       results: new Map(),
       error: rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt),
+      rateLimit: { kind: rateLimitBlock.reason, resumeAt: rateLimitBlock.resumeAt },
     };
   }
 
@@ -671,12 +672,27 @@ export async function batchCheckLinkedPRs(
           })) as Record<string, unknown>;
           return { results: parseBatchPRResponse(retryResponse, candidates) };
         } catch (retryError) {
-          return { results: new Map(), error: parseGitHubError(retryError) };
+          return { results: new Map(), error: parseGitHubError(retryError), ...rateLimitMeta() };
         }
       }
     }
-    return { results: new Map(), error: parseGitHubError(error) };
+    return { results: new Map(), error: parseGitHubError(error), ...rateLimitMeta() };
   }
+}
+
+/**
+ * Capture the rate-limit snapshot synchronously after a caller's request
+ * fails, so downstream schedulers can route the failure as a rate-limit
+ * pause even if a concurrent 2xx clears the singleton before `handleError`
+ * reads it. Returns an empty object when no block is active so it spreads
+ * cleanly into result objects via rest-spread.
+ */
+function rateLimitMeta(): { rateLimit?: { kind: "primary" | "secondary"; resumeAt: number } } {
+  const block = gitHubRateLimitService.shouldBlockRequest();
+  if (block.blocked && block.reason && block.resumeAt) {
+    return { rateLimit: { kind: block.reason, resumeAt: block.resumeAt } };
+  }
+  return {};
 }
 
 export async function getRepoUrl(cwd: string): Promise<string | null> {

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -531,6 +531,22 @@ class PullRequestService {
   }
 
   private handleError(errorMsg: string): void {
+    // On the FIRST rate-limited response the fetch wrapper populates
+    // gitHubRateLimitService before batchCheckLinkedPRs throws, so treat
+    // this as a rate-limit pause rather than a generic error. This avoids
+    // the circuit breaker conflating quota exhaustion with flaky network
+    // failures — GitHub's docs explicitly warn that blind retrying through
+    // secondary limits can escalate to a permanent ban.
+    const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+    if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
+      this.nextRetryAt = rateLimitBlock.resumeAt;
+      logWarn("PR check hit a GitHub rate limit — pausing without tripping circuit breaker", {
+        reason: rateLimitBlock.reason,
+        resumeAt: rateLimitBlock.resumeAt,
+      });
+      return;
+    }
+
     this.consecutiveErrors++;
     logWarn("PR check failed", { error: errorMsg, consecutiveErrors: this.consecutiveErrors });
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -5,6 +5,7 @@ import {
   type PRCheckCandidate,
   type LinkedPR,
 } from "./GitHubService.js";
+import { gitHubRateLimitService } from "./github/index.js";
 import { logInfo, logWarn, logDebug } from "../utils/logger.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
 
@@ -339,6 +340,16 @@ class PullRequestService {
       return;
     }
 
+    const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+    if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
+      this.nextRetryAt = rateLimitBlock.resumeAt;
+      logDebug("Skipping PR revalidation — GitHub rate limit active", {
+        reason: rateLimitBlock.reason,
+        resumeAt: rateLimitBlock.resumeAt,
+      });
+      return;
+    }
+
     // Collect resolved worktrees that need revalidation
     const candidatesToRevalidate: PRCheckCandidate[] = [];
     for (const worktreeId of this.resolvedWorktrees) {
@@ -430,6 +441,22 @@ class PullRequestService {
   }
 
   private async checkForPRs(): Promise<void> {
+    const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+    if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
+      // Park polling at the known resume time without incrementing the
+      // circuit breaker. GitHub docs explicitly warn that retrying through a
+      // secondary rate limit can escalate to a permanent ban, so even for
+      // secondary limits we use the same one-shot resume pattern rather than
+      // touching `consecutiveErrors`.
+      this.nextRetryAt = rateLimitBlock.resumeAt;
+      logDebug("Skipping PR check — GitHub rate limit active", {
+        reason: rateLimitBlock.reason,
+        resumeAt: rateLimitBlock.resumeAt,
+        waitMs: rateLimitBlock.resumeAt - Date.now(),
+      });
+      return;
+    }
+
     const activeCandidates: PRCheckCandidate[] = [];
     for (const [worktreeId, context] of this.candidates) {
       if (!this.resolvedWorktrees.has(worktreeId)) {

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -479,7 +479,7 @@ class PullRequestService {
       const result = await batchCheckLinkedPRs(this.cwd, activeCandidates);
 
       if (result.error) {
-        this.handleError(result.error);
+        this.handleError(result.error, result.rateLimit);
         return;
       }
 
@@ -530,19 +530,21 @@ class PullRequestService {
     }
   }
 
-  private handleError(errorMsg: string): void {
-    // On the FIRST rate-limited response the fetch wrapper populates
-    // gitHubRateLimitService before batchCheckLinkedPRs throws, so treat
-    // this as a rate-limit pause rather than a generic error. This avoids
-    // the circuit breaker conflating quota exhaustion with flaky network
-    // failures — GitHub's docs explicitly warn that blind retrying through
-    // secondary limits can escalate to a permanent ban.
-    const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
-    if (rateLimitBlock.blocked && rateLimitBlock.resumeAt) {
-      this.nextRetryAt = rateLimitBlock.resumeAt;
+  private handleError(
+    errorMsg: string,
+    rateLimit?: { kind: "primary" | "secondary"; resumeAt: number }
+  ): void {
+    // Prefer a rate-limit marker captured synchronously alongside the
+    // failing request — checking the mutable singleton here would race
+    // with a concurrent 2xx clearing state between the 429 and this
+    // handler. Treat a rate-limit pause distinctly from a circuit-breaker
+    // trip: GitHub's docs warn that blind retry through secondary limits
+    // can escalate to a permanent ban.
+    if (rateLimit) {
+      this.nextRetryAt = rateLimit.resumeAt;
       logWarn("PR check hit a GitHub rate limit — pausing without tripping circuit breaker", {
-        reason: rateLimitBlock.reason,
-        resumeAt: rateLimitBlock.resumeAt,
+        reason: rateLimit.kind,
+        resumeAt: rateLimit.resumeAt,
       });
       return;
     }

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -13,6 +13,7 @@ import crypto from "crypto";
 import { events } from "./events.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
+import { gitHubRateLimitService } from "./github/index.js";
 import { store } from "../store.js";
 
 import { WorkspaceHostProcess } from "./WorkspaceHostProcess.js";
@@ -261,6 +262,15 @@ export class WorkspaceClient extends EventEmitter {
         };
         events.emit("sys:issue:not-found", notFoundPayload);
         this.sendToEntryWindows(entry, CHANNELS.ISSUE_NOT_FOUND, notFoundPayload);
+        break;
+      }
+
+      case "github-rate-limit-changed": {
+        // Apply the utility-process observation to main's own singleton so
+        // that subsequent main-process GitHub calls preflight-block. The
+        // main-process transport registered in `registerGithubHandlers`
+        // then rebroadcasts the state to all renderer windows.
+        gitHubRateLimitService.applyRemoteState(event.state);
         break;
       }
 

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -73,6 +73,15 @@ export class WorkspaceClient extends EventEmitter {
   // Reverse map: worktree path → project path (populated from worktree-update events)
   private worktreePathToProject = new Map<string, string>();
 
+  // Timestamp of the most recent main-initiated GitHub token change. Used to
+  // discard utility-process rate-limit events that predate the mutation —
+  // without this, a "blocked: true" event emitted by utility *before* the
+  // token change can arrive at main *after* main cleared state, reblocking
+  // main with obsolete pre-token-change observations until the utility
+  // eventually sends its own clear.
+  private githubTokenChangeAt = 0;
+  private static readonly RATE_LIMIT_TOKEN_CHANGE_GUARD_MS = 5_000;
+
   // CopyTree progress callbacks by operationId (manager-level)
   private copyTreeProgressCallbacks = new Map<string, CopyTreeProgressCallback>();
   private activeCopyTreeOperations = new Map<string, string>();
@@ -270,6 +279,19 @@ export class WorkspaceClient extends EventEmitter {
         // that subsequent main-process GitHub calls preflight-block. The
         // main-process transport registered in `registerGithubHandlers`
         // then rebroadcasts the state to all renderer windows.
+        //
+        // Guard against stale "blocked" observations that predate a local
+        // token mutation — they can arrive after main has already cleared
+        // state and would incorrectly re-block main until the utility
+        // eventually catches up with its own clear. Unblock events are
+        // always applied (they never make state worse).
+        if (
+          event.state.blocked &&
+          this.githubTokenChangeAt > 0 &&
+          Date.now() - this.githubTokenChangeAt < WorkspaceClient.RATE_LIMIT_TOKEN_CHANGE_GUARD_MS
+        ) {
+          break;
+        }
         gitHubRateLimitService.applyRemoteState(event.state);
         break;
       }
@@ -787,6 +809,7 @@ export class WorkspaceClient extends EventEmitter {
   }
 
   updateGitHubToken(token: string | null): void {
+    this.githubTokenChangeAt = Date.now();
     for (const entry of this.entries.values()) {
       entry.host.send({ type: "update-github-token", token });
     }

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -57,6 +57,23 @@ vi.mock("../github/index.js", () => ({
   GET_ISSUE_QUERY: "GET_ISSUE_QUERY",
   GET_PR_QUERY: "GET_PR_QUERY",
   buildBatchPRQuery: vi.fn(),
+  gitHubRateLimitService: {
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    shouldBlockRequest: vi.fn().mockReturnValue({ blocked: false, reason: null }),
+    getState: vi.fn().mockReturnValue({ blocked: false, kind: null }),
+    clear: vi.fn(),
+    applyRemoteState: vi.fn(),
+  },
+  GitHubRateLimitError: class GitHubRateLimitError extends Error {
+    kind: "primary" | "secondary";
+    resumeAt: number;
+    constructor(kind: "primary" | "secondary", resumeAt: number) {
+      super("rate limited");
+      this.kind = kind;
+      this.resumeAt = resumeAt;
+      this.name = "GitHubRateLimitError";
+    }
+  },
 }));
 
 vi.mock("../GitHubStatsCache.js", () => ({

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -1,4 +1,5 @@
 import { graphql } from "@octokit/graphql";
+import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 
 export const GITHUB_API_TIMEOUT_MS = 15_000;
 export const GITHUB_AUTH_TIMEOUT_MS = 10_000;
@@ -75,6 +76,7 @@ export class GitHubAuth {
     this.cachedUsername = null;
     this.cachedAvatarUrl = null;
     this.cachedScopes = [];
+    gitHubRateLimitService.clear();
   }
 
   static hasToken(): boolean {
@@ -93,6 +95,7 @@ export class GitHubAuth {
     this.cachedUsername = null;
     this.cachedAvatarUrl = null;
     this.cachedScopes = [];
+    gitHubRateLimitService.clear();
   }
 
   static clearToken(): void {
@@ -103,6 +106,7 @@ export class GitHubAuth {
     this.tokenVersion++;
     this.pendingValidation = null;
     this.storage.delete();
+    gitHubRateLimitService.clear();
   }
 
   private static pendingValidation: Promise<void> | null = null;
@@ -177,6 +181,9 @@ export class GitHubAuth {
       headers: {
         authorization: `token ${token}`,
       },
+      request: {
+        fetch: rateLimitAwareFetch,
+      },
     });
   }
 
@@ -247,4 +254,37 @@ export class GitHubAuth {
       return { valid: false, scopes: [], error: message };
     }
   }
+}
+
+/**
+ * Custom fetch wrapper used by `@octokit/graphql` via `graphql.defaults({ request: { fetch } })`.
+ *
+ * `@octokit/graphql` v9 resolves to the parsed `data.data` payload — the raw
+ * `Response` (and its headers) are dropped before the promise resolves.
+ * Installing this fetch wrapper is the only reliable place to observe GitHub
+ * rate-limit headers on every response (both 2xx and error paths). We read
+ * headers synchronously, hand them to {@link gitHubRateLimitService}, and
+ * return the original response untouched so Octokit can parse it normally.
+ */
+async function rateLimitAwareFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit
+): Promise<Response> {
+  const response = await globalThis.fetch(input, init);
+  let bodyText: string | undefined;
+  if (!response.ok && (response.status === 403 || response.status === 429)) {
+    try {
+      bodyText = await response.clone().text();
+    } catch {
+      // Cloning can fail in rare cases (e.g., an aborted stream). Falling back
+      // to header-only classification is safe — `retry-after` alone suffices
+      // for genuine secondary limits.
+    }
+  }
+  try {
+    gitHubRateLimitService.update(response.headers, response.status, bodyText);
+  } catch {
+    // Rate-limit bookkeeping must never break the underlying request.
+  }
+  return response;
 }

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -257,34 +257,54 @@ export class GitHubAuth {
 }
 
 /**
- * Custom fetch wrapper used by `@octokit/graphql` via `graphql.defaults({ request: { fetch } })`.
+ * Custom fetch wrapper used by `@octokit/graphql` via
+ * `graphql.defaults({ request: { fetch } })`.
  *
  * `@octokit/graphql` v9 resolves to the parsed `data.data` payload — the raw
  * `Response` (and its headers) are dropped before the promise resolves.
  * Installing this fetch wrapper is the only reliable place to observe GitHub
- * rate-limit headers on every response (both 2xx and error paths). We read
- * headers synchronously, hand them to {@link gitHubRateLimitService}, and
- * return the original response untouched so Octokit can parse it normally.
+ * rate-limit headers on every response (both 2xx and error paths).
+ *
+ * The wrapper is intentionally two-phase: a synchronous header-only
+ * classification runs first so the response can return to Octokit
+ * immediately, and the body-text classification (used to detect secondary
+ * rate limits that GitHub reports via a 403 body rather than a `retry-after`
+ * header) runs off the critical path. This prevents a stuck response body
+ * from blocking every GitHub call behind the fetch wrapper.
  */
 async function rateLimitAwareFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
   const response = await globalThis.fetch(input, init);
-  let bodyText: string | undefined;
-  if (!response.ok && (response.status === 403 || response.status === 429)) {
-    try {
-      bodyText = await response.clone().text();
-    } catch {
-      // Cloning can fail in rare cases (e.g., an aborted stream). Falling back
-      // to header-only classification is safe — `retry-after` alone suffices
-      // for genuine secondary limits.
-    }
-  }
+
+  // Phase 1 — header-only classification runs immediately so the Response
+  // can flow back to Octokit without waiting on the body.
   try {
-    gitHubRateLimitService.update(response.headers, response.status, bodyText);
+    gitHubRateLimitService.update(response.headers, response.status);
   } catch {
     // Rate-limit bookkeeping must never break the underlying request.
   }
+
+  // Phase 2 — secondary-limit fallback classification when the 403/429
+  // response carries no `retry-after` but explains the block in its body.
+  // Scheduled off the hot path; any failures are swallowed.
+  if (!response.ok && (response.status === 403 || response.status === 429)) {
+    void response
+      .clone()
+      .text()
+      .then((bodyText) => {
+        try {
+          gitHubRateLimitService.update(response.headers, response.status, bodyText);
+        } catch {
+          // Swallow — see Phase 1 comment.
+        }
+      })
+      .catch(() => {
+        // Cloning can fail on aborted streams; header-only classification
+        // is already safe.
+      });
+  }
+
   return response;
 }

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -1,0 +1,183 @@
+import type {
+  GitHubRateLimitKind,
+  GitHubRateLimitPayload,
+} from "../../../shared/types/ipc/github.js";
+import { CHANNELS } from "../../ipc/channels.js";
+import { broadcastToRenderer } from "../../ipc/utils.js";
+import { logDebug, logInfo, logWarn } from "../../utils/logger.js";
+
+// Buffer applied to GitHub's `x-ratelimit-reset` to absorb clock skew between
+// the local host and api.github.com, and to avoid a poll slipping in a tick
+// before the server clears the quota. Aligns with lesson #4629 guidance.
+const PRIMARY_RESET_BUFFER_MS = 7_000;
+
+// Fallback pause when a 403/429 response carries no `retry-after` header and
+// no primary-quota signal, matching GitHub's documented minimum.
+const SECONDARY_FALLBACK_PAUSE_MS = 60_000;
+
+interface BlockState {
+  kind: GitHubRateLimitKind;
+  resumeAt: number;
+}
+
+export interface ShouldBlockResult {
+  blocked: boolean;
+  reason: GitHubRateLimitKind | null;
+  resumeAt?: number;
+}
+
+class GitHubRateLimitServiceImpl {
+  private state: BlockState | null = null;
+
+  /**
+   * Inspect a GitHub HTTP response's headers/status and update internal
+   * state. Called from the custom fetch wrapper installed in
+   * {@link GitHubAuth.createClient} on every response.
+   */
+  update(headers: HeadersLike, status: number, bodyText?: string): void {
+    const retryAfter = parseRetryAfter(headers.get("retry-after"));
+    if (retryAfter !== null) {
+      this.markBlocked("secondary", Date.now() + retryAfter * 1000);
+      return;
+    }
+
+    const remainingRaw = headers.get("x-ratelimit-remaining");
+    const resetRaw = headers.get("x-ratelimit-reset");
+    const remaining = parseIntOrNull(remainingRaw);
+    const resetSeconds = parseIntOrNull(resetRaw);
+
+    if (remaining === 0 && resetSeconds !== null) {
+      this.markBlocked("primary", resetSeconds * 1000 + PRIMARY_RESET_BUFFER_MS);
+      return;
+    }
+
+    if ((status === 403 || status === 429) && looksLikeSecondaryLimit(bodyText)) {
+      this.markBlocked("secondary", Date.now() + SECONDARY_FALLBACK_PAUSE_MS);
+      return;
+    }
+
+    if (status >= 200 && status < 300 && remaining !== null && remaining > 0) {
+      this.clear();
+    }
+  }
+
+  /**
+   * Main-process check consumed by callers before issuing a GitHub request.
+   * Auto-clears expired state so the caller sees the service as unblocked as
+   * soon as the reset has passed.
+   */
+  shouldBlockRequest(): ShouldBlockResult {
+    if (!this.state) {
+      return { blocked: false, reason: null };
+    }
+    if (this.state.resumeAt <= Date.now()) {
+      this.clear();
+      return { blocked: false, reason: null };
+    }
+    return { blocked: true, reason: this.state.kind, resumeAt: this.state.resumeAt };
+  }
+
+  /** Snapshot for push/pull consumers. */
+  getState(): GitHubRateLimitPayload {
+    if (!this.state || this.state.resumeAt <= Date.now()) {
+      return { blocked: false, kind: null };
+    }
+    return { blocked: true, kind: this.state.kind, resetAt: this.state.resumeAt };
+  }
+
+  /** Drop any active block (token change, fresh 2xx, manual reset). */
+  clear(): void {
+    if (!this.state) return;
+    this.state = null;
+    logInfo("GitHub rate limit cleared");
+    this.broadcast();
+  }
+
+  /** Test-only helper. */
+  _resetForTests(): void {
+    this.state = null;
+  }
+
+  private markBlocked(kind: GitHubRateLimitKind, resumeAt: number): void {
+    const previous = this.state;
+    const changed =
+      !previous || previous.kind !== kind || Math.abs(previous.resumeAt - resumeAt) > 1_000;
+    this.state = { kind, resumeAt };
+    if (changed) {
+      if (kind === "secondary") {
+        logWarn("GitHub secondary rate limit — pausing until resume", {
+          resumeAt,
+          waitMs: resumeAt - Date.now(),
+        });
+      } else {
+        logInfo("GitHub primary rate limit — pausing until reset", {
+          resumeAt,
+          waitMs: resumeAt - Date.now(),
+        });
+      }
+      this.broadcast();
+    } else {
+      logDebug("GitHub rate limit refreshed", { kind, resumeAt });
+    }
+  }
+
+  private broadcast(): void {
+    broadcastToRenderer(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, this.getState());
+  }
+}
+
+export interface HeadersLike {
+  get(name: string): string | null;
+}
+
+function parseIntOrNull(value: string | null): number | null {
+  if (value === null) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseRetryAfter(value: string | null): number | null {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  // Numeric seconds form — the only shape GitHub uses in practice.
+  const seconds = Number.parseInt(trimmed, 10);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds;
+  }
+  // HTTP-date form (rare) — best-effort parse.
+  const dateMs = Date.parse(trimmed);
+  if (Number.isFinite(dateMs)) {
+    const delta = Math.ceil((dateMs - Date.now()) / 1000);
+    return delta > 0 ? delta : 0;
+  }
+  return null;
+}
+
+function looksLikeSecondaryLimit(bodyText: string | undefined): boolean {
+  if (!bodyText) return false;
+  const lower = bodyText.toLowerCase();
+  return lower.includes("secondary rate limit") || lower.includes("abuse detection");
+}
+
+/**
+ * `GitHubRateLimitError` lets callers distinguish a preflight rate-limit block
+ * from ordinary network/API errors and lets the UI render a proper countdown.
+ */
+export class GitHubRateLimitError extends Error {
+  readonly kind: GitHubRateLimitKind;
+  readonly resumeAt: number;
+
+  constructor(kind: GitHubRateLimitKind, resumeAt: number) {
+    super(
+      kind === "primary"
+        ? "GitHub rate limit exceeded. Waiting for quota reset."
+        : "GitHub secondary rate limit triggered. Pausing requests."
+    );
+    this.name = "GitHubRateLimitError";
+    this.kind = kind;
+    this.resumeAt = resumeAt;
+  }
+}
+
+export const gitHubRateLimitService = new GitHubRateLimitServiceImpl();

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -2,8 +2,6 @@ import type {
   GitHubRateLimitKind,
   GitHubRateLimitPayload,
 } from "../../../shared/types/ipc/github.js";
-import { CHANNELS } from "../../ipc/channels.js";
-import { broadcastToRenderer } from "../../ipc/utils.js";
 import { logDebug, logInfo, logWarn } from "../../utils/logger.js";
 
 // Buffer applied to GitHub's `x-ratelimit-reset` to absorb clock skew between
@@ -26,8 +24,38 @@ export interface ShouldBlockResult {
   resumeAt?: number;
 }
 
+type StateChangeListener = (state: GitHubRateLimitPayload) => void;
+
 class GitHubRateLimitServiceImpl {
   private state: BlockState | null = null;
+  private readonly listeners = new Set<StateChangeListener>();
+
+  /**
+   * Register a subscriber that fires on every state transition (entering a
+   * block, changing resume time, or clearing). Transports (main-process
+   * broadcast to renderer, utility-process relay to main) hook in here.
+   */
+  onStateChange(listener: StateChangeListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Apply a state snapshot observed in another process (utility host →
+   * main) without re-emitting transport-level events on this side beyond
+   * the local subscriber notification. The main-process transport in turn
+   * rebroadcasts to all renderers, so a utility-observed limit ends up on
+   * the toolbar even though the utility process can't call BrowserWindow.
+   */
+  applyRemoteState(payload: GitHubRateLimitPayload): void {
+    if (payload.blocked && payload.kind && payload.resetAt) {
+      this.markBlocked(payload.kind, payload.resetAt);
+      return;
+    }
+    this.clear();
+  }
 
   /**
    * Inspect a GitHub HTTP response's headers/status and update internal
@@ -90,7 +118,7 @@ class GitHubRateLimitServiceImpl {
     if (!this.state) return;
     this.state = null;
     logInfo("GitHub rate limit cleared");
-    this.broadcast();
+    this.notifyListeners();
   }
 
   /** Test-only helper. */
@@ -115,14 +143,24 @@ class GitHubRateLimitServiceImpl {
           waitMs: resumeAt - Date.now(),
         });
       }
-      this.broadcast();
+      this.notifyListeners();
     } else {
       logDebug("GitHub rate limit refreshed", { kind, resumeAt });
     }
   }
 
-  private broadcast(): void {
-    broadcastToRenderer(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, this.getState());
+  private notifyListeners(): void {
+    const snapshot = this.getState();
+    for (const listener of this.listeners) {
+      try {
+        listener(snapshot);
+      } catch (err) {
+        // A misbehaving transport must not break rate-limit bookkeeping.
+        logWarn("GitHub rate-limit listener threw", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
   }
 }
 

--- a/electron/services/github/__tests__/GitHubRateLimitService.test.ts
+++ b/electron/services/github/__tests__/GitHubRateLimitService.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+  shell: { openExternal: vi.fn() },
+}));
+
+vi.mock("../../../ipc/utils.js", () => ({
+  broadcastToRenderer: vi.fn(),
+}));
+
+import { broadcastToRenderer } from "../../../ipc/utils.js";
+import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
+
+function makeHeaders(entries: Record<string, string>): Headers {
+  return new Headers(entries);
+}
+
+describe("GitHubRateLimitService", () => {
+  beforeEach(() => {
+    gitHubRateLimitService._resetForTests();
+    (broadcastToRenderer as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  describe("update()", () => {
+    it("marks a secondary block when retry-after is present", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 403);
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.blocked).toBe(true);
+      expect(block.reason).toBe("secondary");
+      expect(block.resumeAt).toBeGreaterThan(Date.now() + 25_000);
+      expect(block.resumeAt).toBeLessThanOrEqual(Date.now() + 30_500);
+    });
+
+    it("prefers retry-after over x-ratelimit-remaining=0", () => {
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "retry-after": "15",
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3_600),
+        }),
+        429
+      );
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.reason).toBe("secondary");
+    });
+
+    it("marks a primary block when x-ratelimit-remaining is 0", () => {
+      const resetSeconds = Math.floor(Date.now() / 1000) + 600;
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+        }),
+        200
+      );
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.blocked).toBe(true);
+      expect(block.reason).toBe("primary");
+      expect(block.resumeAt).toBeGreaterThanOrEqual(resetSeconds * 1000);
+      expect(block.resumeAt).toBeLessThanOrEqual(resetSeconds * 1000 + 10_000);
+    });
+
+    it("falls back to secondary on 403 with abuse-limit body when no retry-after", () => {
+      gitHubRateLimitService.update(
+        makeHeaders({ "x-ratelimit-remaining": "100" }),
+        403,
+        "You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
+      );
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.blocked).toBe(true);
+      expect(block.reason).toBe("secondary");
+      expect(block.resumeAt).toBeGreaterThan(Date.now() + 50_000);
+    });
+
+    it("ignores 2xx responses with remaining > 0 and clears existing blocks", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "4999",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3_600),
+        }),
+        200
+      );
+
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("does not mark a block when no headers suggest a limit", () => {
+      gitHubRateLimitService.update(makeHeaders({}), 200);
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("parses http-date retry-after values", () => {
+      const future = new Date(Date.now() + 45_000).toUTCString();
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": future }), 429);
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.blocked).toBe(true);
+      expect(block.reason).toBe("secondary");
+      expect(block.resumeAt).toBeGreaterThan(Date.now() + 30_000);
+    });
+  });
+
+  describe("shouldBlockRequest()", () => {
+    it("auto-clears expired blocks", () => {
+      // Primary reset in the past (minus even the buffer).
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) - 120),
+        }),
+        200
+      );
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.blocked).toBe(false);
+    });
+  });
+
+  describe("broadcast", () => {
+    it("broadcasts on transition into blocked state", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        "github:rate-limit-changed",
+        expect.objectContaining({ blocked: true, kind: "secondary" })
+      );
+    });
+
+    it("broadcasts on clear()", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      (broadcastToRenderer as ReturnType<typeof vi.fn>).mockClear();
+      gitHubRateLimitService.clear();
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        "github:rate-limit-changed",
+        expect.objectContaining({ blocked: false })
+      );
+    });
+
+    it("does not re-broadcast when a new update produces the same state", () => {
+      const now = Math.floor(Date.now() / 1000);
+      gitHubRateLimitService.update(
+        makeHeaders({ "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(now + 600) }),
+        200
+      );
+      const initialCalls = (broadcastToRenderer as ReturnType<typeof vi.fn>).mock.calls.length;
+      // Identical update: same kind, same resumeAt within 1s tolerance.
+      gitHubRateLimitService.update(
+        makeHeaders({ "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(now + 600) }),
+        200
+      );
+      expect((broadcastToRenderer as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+        initialCalls
+      );
+    });
+  });
+
+  describe("getState()", () => {
+    it("reports unblocked when no state is active", () => {
+      const state = gitHubRateLimitService.getState();
+      expect(state).toEqual({ blocked: false, kind: null });
+    });
+
+    it("reports resumeAt and kind when blocked", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      const state = gitHubRateLimitService.getState();
+      expect(state.blocked).toBe(true);
+      expect(state.kind).toBe("secondary");
+      expect(state.resetAt).toBeGreaterThan(Date.now());
+    });
+  });
+});

--- a/electron/services/github/__tests__/GitHubRateLimitService.test.ts
+++ b/electron/services/github/__tests__/GitHubRateLimitService.test.ts
@@ -1,26 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("electron", () => ({
-  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
-  BrowserWindow: { getAllWindows: () => [] },
-  shell: { openExternal: vi.fn() },
-}));
-
-vi.mock("../../../ipc/utils.js", () => ({
-  broadcastToRenderer: vi.fn(),
-}));
-
-import { broadcastToRenderer } from "../../../ipc/utils.js";
 import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
+import type { GitHubRateLimitPayload } from "../../../../shared/types/ipc/github.js";
 
 function makeHeaders(entries: Record<string, string>): Headers {
   return new Headers(entries);
 }
 
 describe("GitHubRateLimitService", () => {
+  const listener = vi.fn<(state: GitHubRateLimitPayload) => void>();
+  let unsubscribe: (() => void) | null = null;
+
   beforeEach(() => {
     gitHubRateLimitService._resetForTests();
-    (broadcastToRenderer as ReturnType<typeof vi.fn>).mockClear();
+    listener.mockClear();
+    unsubscribe = gitHubRateLimitService.onStateChange(listener);
+  });
+
+  afterEach(() => {
+    unsubscribe?.();
+    unsubscribe = null;
   });
 
   describe("update()", () => {
@@ -125,40 +124,74 @@ describe("GitHubRateLimitService", () => {
     });
   });
 
-  describe("broadcast", () => {
-    it("broadcasts on transition into blocked state", () => {
+  describe("onStateChange listeners", () => {
+    it("notifies on transition into blocked state", () => {
       gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
-      expect(broadcastToRenderer).toHaveBeenCalledWith(
-        "github:rate-limit-changed",
+      expect(listener).toHaveBeenCalledWith(
         expect.objectContaining({ blocked: true, kind: "secondary" })
       );
     });
 
-    it("broadcasts on clear()", () => {
+    it("notifies on clear()", () => {
       gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
-      (broadcastToRenderer as ReturnType<typeof vi.fn>).mockClear();
+      listener.mockClear();
       gitHubRateLimitService.clear();
-      expect(broadcastToRenderer).toHaveBeenCalledWith(
-        "github:rate-limit-changed",
-        expect.objectContaining({ blocked: false })
-      );
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ blocked: false }));
     });
 
-    it("does not re-broadcast when a new update produces the same state", () => {
+    it("does not re-notify when a new update produces the same state", () => {
       const now = Math.floor(Date.now() / 1000);
       gitHubRateLimitService.update(
         makeHeaders({ "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(now + 600) }),
         200
       );
-      const initialCalls = (broadcastToRenderer as ReturnType<typeof vi.fn>).mock.calls.length;
+      const initialCalls = listener.mock.calls.length;
       // Identical update: same kind, same resumeAt within 1s tolerance.
       gitHubRateLimitService.update(
         makeHeaders({ "x-ratelimit-remaining": "0", "x-ratelimit-reset": String(now + 600) }),
         200
       );
-      expect((broadcastToRenderer as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
-        initialCalls
+      expect(listener.mock.calls.length).toBe(initialCalls);
+    });
+
+    it("survives a misbehaving listener without breaking other listeners", () => {
+      const good = vi.fn<(s: GitHubRateLimitPayload) => void>();
+      gitHubRateLimitService.onStateChange(() => {
+        throw new Error("boom");
+      });
+      gitHubRateLimitService.onStateChange(good);
+
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+
+      expect(good).toHaveBeenCalledWith(
+        expect.objectContaining({ blocked: true, kind: "secondary" })
       );
+    });
+  });
+
+  describe("applyRemoteState()", () => {
+    it("marks a block from a remote payload and notifies local listeners", () => {
+      const resetAt = Date.now() + 45_000;
+      gitHubRateLimitService.applyRemoteState({
+        blocked: true,
+        kind: "secondary",
+        resetAt,
+      });
+
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ blocked: true, kind: "secondary" })
+      );
+    });
+
+    it("clears local state when the remote payload is unblocked", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      listener.mockClear();
+
+      gitHubRateLimitService.applyRemoteState({ blocked: false, kind: null });
+
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ blocked: false }));
     });
   });
 

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -1,6 +1,9 @@
 export { GitHubAuth, GITHUB_API_TIMEOUT_MS, GITHUB_AUTH_TIMEOUT_MS } from "./GitHubAuth.js";
 export type { GitHubTokenConfig, GitHubTokenValidation } from "./GitHubAuth.js";
 
+export { gitHubRateLimitService, GitHubRateLimitError } from "./GitHubRateLimitService.js";
+export type { ShouldBlockResult } from "./GitHubRateLimitService.js";
+
 export {
   REPO_STATS_QUERY,
   PROJECT_HEALTH_QUERY,

--- a/electron/services/github/types.ts
+++ b/electron/services/github/types.ts
@@ -39,6 +39,13 @@ export interface PRCheckCandidate {
 export interface BatchPRCheckResult {
   results: Map<string, PRCheckResult>;
   error?: string;
+  /**
+   * When set, the error originated from a GitHub rate limit and includes
+   * the resume timestamp. Callers use this to park retry scheduling at
+   * the known resume time without counting the failure toward a
+   * circuit-breaker threshold.
+   */
+  rateLimit?: { kind: "primary" | "secondary"; resumeAt: number };
 }
 
 export type CIStatus = "success" | "failure" | "error" | "pending" | "expected" | "none";

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -248,6 +248,17 @@ const shutdownController = new AbortController();
 // Create singleton instance
 const workspaceService = new WorkspaceService(sendEvent);
 
+// Forward GitHub rate-limit state changes observed by utility-process HTTP
+// calls (e.g. PullRequestService polling) up to the main process so they
+// reach the toolbar countdown and block main-process GitHub calls too.
+// `broadcastToRenderer` is BrowserWindow-backed and therefore main-only;
+// this relay is how utility-side limits ever become visible elsewhere.
+import("./services/github/index.js").then(({ gitHubRateLimitService }) => {
+  gitHubRateLimitService.onStateChange((state) => {
+    sendEvent({ type: "github-rate-limit-changed", state });
+  });
+});
+
 // Handle requests from Main
 port.on("message", async (rawMsg: any) => {
   const msg = rawMsg?.data ? rawMsg.data : rawMsg;

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -17,6 +17,7 @@ import { projectPulseService } from "./services/ProjectPulseService.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
 import type { WorkspaceHostRequest, WorkspaceHostEvent } from "../shared/types/workspace-host.js";
 import { WorkspaceService } from "./workspace-host/WorkspaceService.js";
+import { gitHubRateLimitService } from "./services/github/index.js";
 import { ensureSerializable } from "../shared/utils/serialization.js";
 
 // Validate we're running in UtilityProcess context
@@ -253,10 +254,10 @@ const workspaceService = new WorkspaceService(sendEvent);
 // reach the toolbar countdown and block main-process GitHub calls too.
 // `broadcastToRenderer` is BrowserWindow-backed and therefore main-only;
 // this relay is how utility-side limits ever become visible elsewhere.
-import("./services/github/index.js").then(({ gitHubRateLimitService }) => {
-  gitHubRateLimitService.onStateChange((state) => {
-    sendEvent({ type: "github-rate-limit-changed", state });
-  });
+// Register synchronously before `ready` is sent — otherwise the first
+// event emitted during startup racing polling would be silently dropped.
+gitHubRateLimitService.onStateChange((state) => {
+  sendEvent({ type: "github-rate-limit-changed", state });
 });
 
 // Handle requests from Main

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -154,6 +154,8 @@ export type {
   GitHubCliStatus,
   GitHubTokenConfig,
   GitHubTokenValidation,
+  GitHubRateLimitPayload,
+  GitHubRateLimitKind,
   // Hibernation types
   HibernationConfig,
   HibernationProjectHibernatedPayload,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -96,6 +96,7 @@ import type {
   GitHubCliStatus,
   GitHubTokenConfig,
   GitHubTokenValidation,
+  GitHubRateLimitPayload,
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
@@ -634,6 +635,7 @@ export interface ElectronAPI {
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;
     onIssueDetected(callback: (data: IssueDetectedPayload) => void): () => void;
     onIssueNotFound(callback: (data: IssueNotFoundPayload) => void): () => void;
+    onRateLimitChanged(callback: (data: GitHubRateLimitPayload) => void): () => void;
   };
   notes: {
     create(

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -1,3 +1,6 @@
+/** Kind of GitHub rate limit currently active */
+export type GitHubRateLimitKind = "primary" | "secondary";
+
 /** Repository stats from GitHub API */
 export interface RepositoryStats {
   /** Total commit count for current branch */
@@ -14,6 +17,20 @@ export interface RepositoryStats {
   stale?: boolean;
   /** Timestamp when stats were last successfully fetched from API */
   lastUpdated?: number;
+  /** Unix epoch milliseconds when a GitHub rate limit resumes */
+  rateLimitResetAt?: number;
+  /** Kind of active GitHub rate limit (primary quota vs secondary abuse) */
+  rateLimitKind?: GitHubRateLimitKind;
+}
+
+/** Push payload describing the current GitHub rate-limit state */
+export interface GitHubRateLimitPayload {
+  /** Whether outbound GitHub calls are currently blocked */
+  blocked: boolean;
+  /** Kind of active rate limit, or null when unblocked */
+  kind: GitHubRateLimitKind | null;
+  /** Unix epoch milliseconds when the block is expected to resume (primary only) */
+  resetAt?: number;
 }
 
 /** Project health data from GitHub API */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -97,6 +97,7 @@ import type {
   GitHubCliStatus,
   GitHubTokenConfig,
   GitHubTokenValidation,
+  GitHubRateLimitPayload,
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
@@ -2193,6 +2194,9 @@ export interface IpcEventMap {
   // Issue detection events
   "issue:detected": IssueDetectedPayload;
   "issue:not-found": IssueNotFoundPayload;
+
+  // GitHub rate-limit state push
+  "github:rate-limit-changed": GitHubRateLimitPayload;
 
   // Error events
   "error:notify": AppError;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -356,6 +356,14 @@ export type WorkspaceHostEvent =
       worktreeId: string;
       issueNumber: number;
     }
+  // GitHub rate-limit state observed in the workspace-host utility process.
+  // The main process applies this to its own `GitHubRateLimitService`
+  // singleton so that main-process callers (IPC handlers, toolbar
+  // countdown) see limits triggered by PullRequestService polling too.
+  | {
+      type: "github-rate-limit-changed";
+      state: import("./ipc/github.js").GitHubRateLimitPayload;
+    }
   // CopyTree events
   | { type: "copytree:progress"; operationId: string; progress: CopyTreeProgress }
   | {

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -4,6 +4,7 @@ import type {
   GitHubCliStatus,
   GitHubTokenConfig,
   GitHubTokenValidation,
+  GitHubRateLimitPayload,
   PRDetectedPayload,
   PRClearedPayload,
   IssueDetectedPayload,
@@ -95,6 +96,10 @@ export const githubClient = {
 
   onIssueNotFound: (callback: (data: IssueNotFoundPayload) => void): (() => void) => {
     return window.electron.github.onIssueNotFound(callback);
+  },
+
+  onRateLimitChanged: (callback: (data: GitHubRateLimitPayload) => void): (() => void) => {
+    return window.electron.github.onRateLimitChanged(callback);
   },
 
   getIssueUrl: (cwd: string, issueNumber: number): Promise<string | null> => {

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -27,6 +27,19 @@ import { GitHubStatusIndicator, type GitHubStatusIndicatorStatus } from "./GitHu
 import type { Project } from "@shared/types";
 import type { RepositoryStats } from "@shared/types";
 
+function formatRateLimitCountdown(remainingMs: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMs / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) {
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
+}
+
 const LazyGitHubResourceList = lazy(() =>
   import("@/components/GitHub/GitHubResourceList").then((m) => ({
     default: m.GitHubResourceList,
@@ -62,6 +75,8 @@ export const GitHubStatsToolbarButton = memo(
       refresh: refreshStats,
       isStale,
       lastUpdated,
+      rateLimitResetAt,
+      rateLimitKind,
     } = useRepositoryStats();
 
     const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
@@ -76,7 +91,33 @@ export const GitHubStatsToolbarButton = memo(
     const [prsOpen, setPrsOpen] = useState(false);
     const [commitsOpen, setCommitsOpen] = useState(false);
     const [statsJustUpdated, setStatsJustUpdated] = useState(false);
+    const [rateLimitCountdown, setRateLimitCountdown] = useState<string | null>(null);
     const prevLastUpdatedRef = useRef<number | null>(null);
+
+    useEffect(() => {
+      if (rateLimitResetAt === null || rateLimitResetAt <= Date.now()) {
+        setRateLimitCountdown(null);
+        return;
+      }
+      const tick = () => {
+        const remainingMs = rateLimitResetAt - Date.now();
+        if (remainingMs <= 0) {
+          setRateLimitCountdown(null);
+          return;
+        }
+        setRateLimitCountdown(formatRateLimitCountdown(remainingMs));
+      };
+      tick();
+      const intervalId = window.setInterval(tick, 1000);
+      return () => window.clearInterval(intervalId);
+    }, [rateLimitResetAt]);
+
+    const rateLimitActive = rateLimitCountdown !== null;
+    const rateLimitLabel = rateLimitActive
+      ? rateLimitKind === "secondary"
+        ? `Paused · resumes in ${rateLimitCountdown}`
+        : `Resets in ${rateLimitCountdown}`
+      : null;
 
     const issuesButtonRef = useRef<HTMLButtonElement>(null);
     const prsButtonRef = useRef<HTMLButtonElement>(null);
@@ -401,6 +442,31 @@ export const GitHubStatsToolbarButton = memo(
           error={statsError ?? undefined}
           onTransitionEnd={handleGitHubStatusTransitionEnd}
         />
+        {rateLimitActive && rateLimitLabel ? (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div
+                  role="status"
+                  aria-live="polite"
+                  aria-label={
+                    rateLimitKind === "secondary"
+                      ? `GitHub secondary rate limit — resuming in ${rateLimitCountdown}`
+                      : `GitHub rate limit — resets in ${rateLimitCountdown}`
+                  }
+                  className="flex h-full items-center px-2 text-[10px] font-medium text-muted-foreground opacity-60"
+                >
+                  {rateLimitLabel}
+                </div>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {rateLimitKind === "secondary"
+                  ? "GitHub triggered a secondary (abuse) rate limit — polling paused until it clears."
+                  : "GitHub API quota exhausted — polling paused until the quota resets."}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : null}
       </div>
     );
   })

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -99,17 +99,28 @@ export const GitHubStatsToolbarButton = memo(
         setRateLimitCountdown(null);
         return;
       }
+      let intervalId: number | null = null;
       const tick = () => {
         const remainingMs = rateLimitResetAt - Date.now();
         if (remainingMs <= 0) {
           setRateLimitCountdown(null);
+          // Stop ticking once we've hit zero — otherwise the 1Hz interval
+          // keeps running uselessly until the component unmounts.
+          if (intervalId !== null) {
+            window.clearInterval(intervalId);
+            intervalId = null;
+          }
           return;
         }
         setRateLimitCountdown(formatRateLimitCountdown(remainingMs));
       };
       tick();
-      const intervalId = window.setInterval(tick, 1000);
-      return () => window.clearInterval(intervalId);
+      intervalId = window.setInterval(tick, 1000);
+      return () => {
+        if (intervalId !== null) {
+          window.clearInterval(intervalId);
+        }
+      };
     }, [rateLimitResetAt]);
 
     const rateLimitActive = rateLimitCountdown !== null;

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -3,11 +3,14 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RepositoryStats } from "@/types";
 
-const { getCurrentMock, onSwitchMock, getRepoStatsMock } = vi.hoisted(() => ({
-  getCurrentMock: vi.fn(),
-  onSwitchMock: vi.fn(),
-  getRepoStatsMock: vi.fn(),
-}));
+const { getCurrentMock, onSwitchMock, getRepoStatsMock, onRateLimitChangedMock } = vi.hoisted(
+  () => ({
+    getCurrentMock: vi.fn(),
+    onSwitchMock: vi.fn(),
+    getRepoStatsMock: vi.fn(),
+    onRateLimitChangedMock: vi.fn<(cb: (payload: unknown) => void) => () => void>(() => () => {}),
+  })
+);
 
 vi.mock("@/clients", () => ({
   projectClient: {
@@ -16,6 +19,7 @@ vi.mock("@/clients", () => ({
   },
   githubClient: {
     getRepoStats: getRepoStatsMock,
+    onRateLimitChanged: onRateLimitChangedMock,
   },
 }));
 
@@ -250,6 +254,73 @@ describe("useRepositoryStats", () => {
       expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
       expect(getRepoStatsMock.mock.calls[1]?.[0]).toBe("/repo/b");
       expect(result.current.stats?.commitCount).toBe(77);
+    });
+  });
+
+  describe("rate limits", () => {
+    it("surfaces rateLimitResetAt and rateLimitKind from the stats payload", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      const resetAt = Date.now() + 60_000;
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        ghError: "GitHub rate limit exceeded. Resets in 1m.",
+        rateLimitResetAt: resetAt,
+        rateLimitKind: "primary",
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.rateLimitResetAt).toBe(resetAt);
+        expect(result.current.rateLimitKind).toBe("primary");
+      });
+    });
+
+    it("applies rate-limit state pushed via onRateLimitChanged and clears on unblock", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo" });
+      onSwitchMock.mockReturnValue(() => {});
+      let pushHandler:
+        | ((p: { blocked: boolean; kind: unknown; resetAt?: number }) => void)
+        | undefined;
+      onRateLimitChangedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb as typeof pushHandler;
+        return () => {};
+      });
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.rateLimitResetAt).toBeNull();
+      });
+
+      const resetAt = Date.now() + 30_000;
+      act(() => {
+        pushHandler?.({ blocked: true, kind: "secondary", resetAt });
+      });
+
+      await waitFor(() => {
+        expect(result.current.rateLimitResetAt).toBe(resetAt);
+        expect(result.current.rateLimitKind).toBe("secondary");
+      });
+
+      act(() => {
+        pushHandler?.({ blocked: false, kind: null });
+      });
+
+      await waitFor(() => {
+        expect(result.current.rateLimitResetAt).toBeNull();
+        expect(result.current.rateLimitKind).toBeNull();
+      });
     });
   });
 });

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -326,6 +326,14 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       setRateLimitResetAt(nextResetAt);
       setRateLimitKind(nextKind);
 
+      // Cancel any pending poll scheduled against the old state so it
+      // can't race with the state-change handler (e.g. firing a
+      // redundant fetch right after our immediate refresh kicks off).
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+
       // When the limit clears, run an immediate refresh so the UI updates
       // without waiting a full poll interval; otherwise reschedule against
       // the new resume time.

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -1,11 +1,17 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import type { RepositoryStats } from "../types";
+import type { GitHubRateLimitKind, RepositoryStats } from "../types";
 import { githubClient, projectClient } from "@/clients";
 import { isTokenRelatedError } from "@/lib/githubErrors";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
 const ERROR_BACKOFF_INTERVAL = 2 * 60 * 1000;
+
+// Add a small buffer to the reset timestamp to avoid scheduling a poll at the
+// exact instant GitHub releases the quota — paired with the main-process
+// buffer in GitHubRateLimitService, this keeps the next attempt safely past
+// reset even under clock skew.
+const RATE_LIMIT_RESUME_BUFFER_MS = 2_000;
 
 export interface UseRepositoryStatsReturn {
   stats: RepositoryStats | null;
@@ -14,6 +20,8 @@ export interface UseRepositoryStatsReturn {
   isTokenError: boolean;
   isStale: boolean;
   lastUpdated: number | null;
+  rateLimitResetAt: number | null;
+  rateLimitKind: GitHubRateLimitKind | null;
   refresh: (options?: { force?: boolean }) => Promise<void>;
 }
 
@@ -42,6 +50,9 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const [error, setError] = useState<string | null>(null);
   const [isStale, setIsStale] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const [rateLimitResetAt, setRateLimitResetAt] = useState<number | null>(null);
+  const [rateLimitKind, setRateLimitKind] = useState<GitHubRateLimitKind | null>(null);
+  const rateLimitResetAtRef = useRef<number | null>(null);
 
   // Preserve last known non-zero counts to prevent empty state flash during refresh
   const lastKnownCountsRef = useRef<{
@@ -149,6 +160,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         setIsStale(repoStats.stale ?? false);
         setLastUpdated(repoStats.lastUpdated ?? null);
 
+        const nextResetAt = repoStats.rateLimitResetAt ?? null;
+        const nextKind = repoStats.rateLimitKind ?? null;
+        rateLimitResetAtRef.current = nextResetAt;
+        setRateLimitResetAt(nextResetAt);
+        setRateLimitKind(nextKind);
+
         if (repoStats.ghError) {
           setError(repoStats.ghError);
           lastErrorRef.current = repoStats.ghError;
@@ -185,6 +202,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     let interval = isVisibleRef.current ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
     if (lastErrorRef.current) {
       interval = ERROR_BACKOFF_INTERVAL;
+    }
+
+    const resetAt = rateLimitResetAtRef.current;
+    if (resetAt !== null && resetAt > Date.now()) {
+      interval = resetAt - Date.now() + RATE_LIMIT_RESUME_BUFFER_MS;
     }
 
     pollTimerRef.current = setTimeout(() => {
@@ -281,6 +303,9 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       setStats(null);
       setIsStale(false);
       setLastUpdated(null);
+      rateLimitResetAtRef.current = null;
+      setRateLimitResetAt(null);
+      setRateLimitKind(null);
 
       fetchStats().then(() => {
         if (mountedRef.current) {
@@ -289,6 +314,31 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       });
     });
 
+    return cleanup;
+  }, [fetchStats, scheduleNextPoll]);
+
+  useEffect(() => {
+    const cleanup = githubClient.onRateLimitChanged((payload) => {
+      if (!mountedRef.current) return;
+      const nextResetAt = payload.blocked && payload.resetAt ? payload.resetAt : null;
+      const nextKind = payload.blocked ? payload.kind : null;
+      rateLimitResetAtRef.current = nextResetAt;
+      setRateLimitResetAt(nextResetAt);
+      setRateLimitKind(nextKind);
+
+      // When the limit clears, run an immediate refresh so the UI updates
+      // without waiting a full poll interval; otherwise reschedule against
+      // the new resume time.
+      if (!payload.blocked) {
+        void fetchStats().then(() => {
+          if (mountedRef.current) {
+            scheduleNextPoll();
+          }
+        });
+      } else if (mountedRef.current) {
+        scheduleNextPoll();
+      }
+    });
     return cleanup;
   }, [fetchStats, scheduleNextPoll]);
 
@@ -301,6 +351,8 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     isTokenError,
     isStale,
     lastUpdated,
+    rateLimitResetAt,
+    rateLimitKind,
     refresh,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `GitHubRateLimitService` that parses `x-ratelimit-*`, `retry-after`, and body text to classify primary vs secondary rate limits, with a 7s clock-skew buffer. A custom fetch wrapper on the `@octokit/graphql` v9 client captures response headers before the library strips them.
- Cross-process propagation forwards utility-process rate-limit observations (from `PullRequestService` polling) to main via a new `github-rate-limit-changed` workspace host event, with a 5s guard window that discards stale "blocked" signals predating a token change.
- Preflight checks in `getRepoStats`, `getProjectHealth`, `batchCheckLinkedPRs`, and `PullRequestService` park scheduling at the known resume timestamp without retrying through secondary limits (which GitHub bans tokens for). The renderer subscribes to push events and renders a live "Resets in Xm Ys" countdown pill next to the existing GitHub status indicator.

Resolves #5383

## Changes

- `electron/services/github/GitHubRateLimitService.ts` — new singleton with classify/block/resume logic
- `electron/services/github/GitHubAuth.ts` — custom fetch wrapper to capture response headers on every octokit call
- `electron/services/GitHubService.ts` / `PullRequestService.ts` — preflight checks park at resume timestamp
- `electron/services/WorkspaceClient.ts` / `electron/workspace-host.ts` — cross-process propagation with stale-event guard
- `electron/ipc/channels.ts` / `electron/preload.cts` / `shared/types/` — `GITHUB_RATE_LIMIT_CHANGED` IPC channel plumbed end-to-end
- `src/hooks/useRepositoryStats.ts` / `src/components/Layout/GitHubStatsToolbarButton.tsx` — countdown pill in renderer
- 13 new `GitHubRateLimitService` tests + 2 new `useRepositoryStats` tests

## Testing

All 3881 tests pass. `npm run check` clean (typecheck + lint ratchet 384/384 + format). Countdown pill verified against mock rate-limit state; preflight park logic confirmed not to re-enter request path while blocked.