### PR TITLE
feat(keyboard): extract SettingsShortcutCapture primitive

### DIFF
--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -1,0 +1,200 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { AlertTriangle } from "lucide-react";
+import { isMac } from "@/lib/platform";
+import { keybindingService, normalizeKeyForBinding } from "@/services/KeybindingService";
+
+const CHORD_TIMEOUT_MS = 1000;
+
+export interface SettingsShortcutCaptureProps {
+  /** Called when user saves the captured key combination */
+  onCapture: (combo: string) => void;
+  /** Called when user cancels recording */
+  onCancel: () => void;
+  /** Action ID to exclude from conflict detection */
+  excludeActionId: string;
+}
+
+export function SettingsShortcutCapture({
+  onCapture,
+  onCancel,
+  excludeActionId,
+}: SettingsShortcutCaptureProps) {
+  const [recording, setRecording] = useState(false);
+  const [capturedCombos, setCapturedCombos] = useState<string[]>([]);
+  const [chordStep, setChordStep] = useState<"first" | "waiting" | "complete">("first");
+  const chordTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chordTokenRef = useRef(0);
+
+  const capturedCombo = capturedCombos.length > 0 ? capturedCombos.join(" ") : null;
+
+  const conflicts = useMemo(() => {
+    if (!capturedCombo) return [];
+    return keybindingService.findConflicts(capturedCombo, excludeActionId);
+  }, [capturedCombo, excludeActionId]);
+
+  const clearChordTimeout = useCallback(() => {
+    if (chordTimeoutRef.current) {
+      clearTimeout(chordTimeoutRef.current);
+      chordTimeoutRef.current = null;
+    }
+  }, []);
+
+  const finishRecording = useCallback(
+    (combos: string[]) => {
+      clearChordTimeout();
+      setCapturedCombos(combos);
+      setRecording(false);
+      setChordStep("complete");
+    },
+    [clearChordTimeout]
+  );
+
+  useEffect(() => {
+    if (!recording) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      const parts: string[] = [];
+      const mac = isMac();
+
+      if (mac && e.metaKey) parts.push("Cmd");
+      if (!mac && e.ctrlKey) parts.push("Cmd");
+      if (e.shiftKey) parts.push("Shift");
+      if (e.altKey) parts.push("Alt");
+
+      // Use normalizeKeyForBinding to handle physical key codes correctly
+      // This fixes issues where Option+/ records as ÷ instead of /
+      const key = normalizeKeyForBinding(e);
+      if (!["Meta", "Control", "Alt", "Shift"].includes(key)) {
+        parts.push(key);
+        const combo = parts.join("+");
+
+        setCapturedCombos((prev) => {
+          const newCombos = [...prev, combo];
+
+          if (prev.length === 0) {
+            setChordStep("waiting");
+            clearChordTimeout();
+            chordTokenRef.current += 1;
+            const token = chordTokenRef.current;
+            chordTimeoutRef.current = setTimeout(() => {
+              if (chordTokenRef.current !== token) return;
+              finishRecording(newCombos);
+            }, CHORD_TIMEOUT_MS);
+          } else {
+            chordTokenRef.current += 1;
+            finishRecording(newCombos);
+          }
+
+          return newCombos;
+        });
+      }
+    };
+
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handler, { capture: true });
+      clearChordTimeout();
+    };
+  }, [recording, clearChordTimeout, finishRecording]);
+
+  const handleStartRecording = () => {
+    setCapturedCombos([]);
+    setChordStep("first");
+    setRecording(true);
+  };
+
+  const handleSave = () => {
+    if (capturedCombo) {
+      clearChordTimeout();
+      setRecording(false);
+      onCapture(capturedCombo);
+    }
+  };
+
+  const handleClear = () => {
+    clearChordTimeout();
+    setRecording(false);
+    onCapture("");
+  };
+
+  const handleCancel = () => {
+    clearChordTimeout();
+    setRecording(false);
+    onCancel();
+  };
+
+  const isChord = capturedCombos.length > 1;
+
+  return (
+    <div className="bg-daintree-bg/50 border border-daintree-border rounded-[var(--radius-lg)] p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        {recording ? (
+          <div className="flex-1 px-4 py-2 border border-daintree-accent rounded bg-daintree-accent/10 text-daintree-accent animate-pulse text-center">
+            {chordStep === "first" ? (
+              "Press key combination..."
+            ) : chordStep === "waiting" ? (
+              <span>
+                <span className="font-mono">
+                  {keybindingService.formatComboForDisplay(capturedCombos[0]!)}
+                </span>
+                <span className="text-daintree-accent/70">
+                  {" "}
+                  — press second key or wait to finish
+                </span>
+              </span>
+            ) : null}
+          </div>
+        ) : capturedCombo ? (
+          <div className="flex-1 px-4 py-2 border border-daintree-border rounded bg-daintree-bg text-daintree-text text-center font-mono">
+            <span>{keybindingService.formatComboForDisplay(capturedCombo)}</span>
+            {isChord && <span className="ml-2 text-xs text-daintree-text/50">(chord)</span>}
+          </div>
+        ) : (
+          <button
+            onClick={handleStartRecording}
+            className="flex-1 px-4 py-2 border border-daintree-border rounded bg-daintree-bg text-daintree-text/60 hover:text-daintree-text hover:border-daintree-accent transition-colors"
+          >
+            Click to record shortcut
+          </button>
+        )}
+      </div>
+
+      {conflicts.length > 0 && (
+        <div className="flex items-start gap-2 text-status-warning text-sm">
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>
+            Conflicts with: {conflicts.map((c) => c.description || c.actionId).join(", ")}
+          </span>
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <button
+          onClick={handleCancel}
+          className="px-3 py-1.5 text-sm text-daintree-text/60 hover:text-daintree-text transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleClear}
+          className="px-3 py-1.5 text-sm text-daintree-text/60 hover:text-daintree-text transition-colors"
+        >
+          Clear
+        </button>
+        {capturedCombo && (
+          <button
+            onClick={handleSave}
+            className="px-3 py-1.5 text-sm bg-daintree-accent text-daintree-bg rounded hover:bg-daintree-accent/90 transition-colors"
+          >
+            Save
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -255,7 +255,13 @@ describe("SettingsShortcutCapture", () => {
   it("displays conflict warnings when conflicts exist", async () => {
     const { keybindingService } = await import("@/services/KeybindingService");
     vi.mocked(keybindingService.findConflicts).mockReturnValue([
-      { actionId: "conflict.action", description: "Conflicting Action" },
+      {
+        actionId: "conflict.action",
+        description: "Conflicting Action",
+        combo: "Cmd+A",
+        scope: "global",
+        priority: 0,
+      },
     ]);
 
     render(

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -1,0 +1,395 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { SettingsShortcutCapture } from "../SettingsShortcutCapture";
+
+// Mock dependencies
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    findConflicts: vi.fn(() => []),
+    formatComboForDisplay: vi.fn((combo: string) => combo),
+  },
+  normalizeKeyForBinding: vi.fn((e: KeyboardEvent) => e.key),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isMac: vi.fn(() => false),
+}));
+
+describe("SettingsShortcutCapture", () => {
+  const mockOnCapture = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("renders idle state with 'Click to record shortcut' button", () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    expect(screen.getByText("Click to record shortcut")).toBeTruthy();
+    expect(screen.getByText("Cancel")).toBeTruthy();
+    expect(screen.getByText("Clear")).toBeTruthy();
+    expect(screen.queryByText("Save")).toBeNull();
+  });
+
+  it("enters recording state when clicking record button", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    expect(screen.getByText("Press key combination...")).toBeTruthy();
+  });
+
+  it("captures single key combination and displays it", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+    });
+
+    // Should transition to recording complete after timeout
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.getByText("Save")).toBeTruthy();
+  });
+
+  it("captures two-step chord combination", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    // First key of chord
+    const firstEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(firstEvent);
+    });
+
+    // Should show waiting state
+    expect(screen.getByText(/press second key or wait to finish/)).toBeTruthy();
+
+    // Second key of chord
+    const secondEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(secondEvent);
+    });
+
+    expect(screen.getByText("Save")).toBeTruthy();
+  });
+
+  it("finalizes single key after 1-second timeout", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+    });
+
+    // Save button appears immediately after capturing a combo
+    expect(screen.getByText("Save")).toBeTruthy();
+
+    // After timeout, recording state should be finalized (no longer in waiting state)
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+
+    // Recording should be stopped (recording state is false)
+    // The "press second key or wait" message should be gone
+    expect(screen.queryByText(/press second key or wait to finish/)).toBeNull();
+  });
+
+  it("calls onCapture with empty string when Clear is clicked", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Clear"));
+
+    expect(mockOnCapture).toHaveBeenCalledWith("");
+  });
+
+  it("calls onCancel when Cancel is clicked", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it("ignores modifier-only key presses (Meta)", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const metaEvent = new KeyboardEvent("keydown", {
+      key: "Meta",
+      code: "MetaLeft",
+      metaKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(metaEvent);
+    });
+
+    // Should still be in first step, not captured
+    expect(screen.getByText("Press key combination...")).toBeTruthy();
+  });
+
+  it("ignores repeated events (e.repeat)", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    // Manually set repeat to simulate a held key
+    Object.defineProperty(keyEvent, "repeat", {
+      get: () => true,
+      configurable: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+    });
+
+    // Should still be in first step, repeated key was ignored
+    expect(screen.getByText("Press key combination...")).toBeTruthy();
+  });
+
+  it("displays conflict warnings when conflicts exist", async () => {
+    const { keybindingService } = await import("@/services/KeybindingService");
+    vi.mocked(keybindingService.findConflicts).mockReturnValue([
+      { actionId: "conflict.action", description: "Conflicting Action" },
+    ]);
+
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.getByText("Conflicts with: Conflicting Action")).toBeTruthy();
+  });
+
+  it("uses normalizeKeyForBinding for key normalization", async () => {
+    const { normalizeKeyForBinding } = await import("@/services/KeybindingService");
+    vi.mocked(normalizeKeyForBinding).mockReturnValue("k");
+
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+    });
+
+    expect(normalizeKeyForBinding).toHaveBeenCalledWith(keyEvent);
+  });
+
+  it("calls onCapture with combo when Save is clicked", async () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "s",
+      code: "KeyS",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+      vi.advanceTimersByTime(1100);
+    });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(mockOnCapture).toHaveBeenCalled();
+  });
+
+  it("cleans up event listeners on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    // Start recording to add the event listener
+    act(() => {
+      screen.getByText("Click to record shortcut").click();
+    });
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function), { capture: true });
+  });
+
+  it("clears timeout on unmount", () => {
+    const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+    const { unmount } = render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    // Start recording
+    act(() => {
+      screen.getByText("Click to record shortcut").click();
+    });
+
+    // Dispatch a key event to set a timeout
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+    });
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/KeyboardShortcuts/index.ts
+++ b/src/components/KeyboardShortcuts/index.ts
@@ -1,1 +1,3 @@
 export { ShortcutReferenceDialog } from "./ShortcutReferenceDialog";
+export { SettingsShortcutCapture } from "./SettingsShortcutCapture";
+export type { SettingsShortcutCaptureProps } from "./SettingsShortcutCapture";

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -1,209 +1,16 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { isMac } from "@/lib/platform";
-import { Search, X, RotateCcw, AlertTriangle } from "lucide-react";
+import { Search, X, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import {
-  keybindingService,
-  KeybindingConfig,
-  normalizeKeyForBinding,
-} from "@/services/KeybindingService";
+import { keybindingService, KeybindingConfig } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import { KeybindingProfileActions } from "./KeybindingProfileActions";
+import { SettingsShortcutCapture } from "@/components/KeyboardShortcuts";
 
 interface ShortcutBinding extends KeybindingConfig {
   effectiveCombo: string;
   isOverridden: boolean;
-}
-
-interface KeyRecorderProps {
-  onCapture: (combo: string) => void;
-  onCancel: () => void;
-  excludeActionId: string;
-}
-
-const CHORD_TIMEOUT_MS = 1000;
-
-function KeyRecorder({ onCapture, onCancel, excludeActionId }: KeyRecorderProps) {
-  const [recording, setRecording] = useState(false);
-  const [capturedCombos, setCapturedCombos] = useState<string[]>([]);
-  const [chordStep, setChordStep] = useState<"first" | "waiting" | "complete">("first");
-  const chordTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const chordTokenRef = useRef(0);
-
-  const capturedCombo = capturedCombos.length > 0 ? capturedCombos.join(" ") : null;
-
-  const conflicts = useMemo(() => {
-    if (!capturedCombo) return [];
-    return keybindingService.findConflicts(capturedCombo, excludeActionId);
-  }, [capturedCombo, excludeActionId]);
-
-  const clearChordTimeout = useCallback(() => {
-    if (chordTimeoutRef.current) {
-      clearTimeout(chordTimeoutRef.current);
-      chordTimeoutRef.current = null;
-    }
-  }, []);
-
-  const finishRecording = useCallback(
-    (combos: string[]) => {
-      clearChordTimeout();
-      setCapturedCombos(combos);
-      setRecording(false);
-      setChordStep("complete");
-    },
-    [clearChordTimeout]
-  );
-
-  useEffect(() => {
-    if (!recording) return;
-
-    const handler = (e: KeyboardEvent) => {
-      if (e.repeat) return;
-
-      e.preventDefault();
-      e.stopPropagation();
-
-      const parts: string[] = [];
-      const mac = isMac();
-
-      if (mac && e.metaKey) parts.push("Cmd");
-      if (!mac && e.ctrlKey) parts.push("Cmd");
-      if (e.shiftKey) parts.push("Shift");
-      if (e.altKey) parts.push("Alt");
-
-      // Use normalizeKeyForBinding to handle physical key codes correctly
-      // This fixes issues where Option+/ records as ÷ instead of /
-      const key = normalizeKeyForBinding(e);
-      if (!["Meta", "Control", "Alt", "Shift"].includes(key)) {
-        parts.push(key);
-        const combo = parts.join("+");
-
-        setCapturedCombos((prev) => {
-          const newCombos = [...prev, combo];
-
-          if (prev.length === 0) {
-            setChordStep("waiting");
-            clearChordTimeout();
-            chordTokenRef.current += 1;
-            const token = chordTokenRef.current;
-            chordTimeoutRef.current = setTimeout(() => {
-              if (chordTokenRef.current !== token) return;
-              finishRecording(newCombos);
-            }, CHORD_TIMEOUT_MS);
-          } else {
-            chordTokenRef.current += 1;
-            finishRecording(newCombos);
-          }
-
-          return newCombos;
-        });
-      }
-    };
-
-    window.addEventListener("keydown", handler, { capture: true });
-    return () => {
-      window.removeEventListener("keydown", handler, { capture: true });
-      clearChordTimeout();
-    };
-  }, [recording, clearChordTimeout, finishRecording]);
-
-  const handleStartRecording = () => {
-    setCapturedCombos([]);
-    setChordStep("first");
-    setRecording(true);
-  };
-
-  const handleSave = () => {
-    if (capturedCombo) {
-      clearChordTimeout();
-      setRecording(false);
-      onCapture(capturedCombo);
-    }
-  };
-
-  const handleClear = () => {
-    clearChordTimeout();
-    setRecording(false);
-    onCapture("");
-  };
-
-  const handleCancel = () => {
-    clearChordTimeout();
-    setRecording(false);
-    onCancel();
-  };
-
-  const isChord = capturedCombos.length > 1;
-
-  return (
-    <div className="bg-daintree-bg/50 border border-daintree-border rounded-[var(--radius-lg)] p-4 space-y-3">
-      <div className="flex items-center gap-2">
-        {recording ? (
-          <div className="flex-1 px-4 py-2 border border-daintree-accent rounded bg-daintree-accent/10 text-daintree-accent animate-pulse text-center">
-            {chordStep === "first" ? (
-              "Press key combination..."
-            ) : chordStep === "waiting" ? (
-              <span>
-                <span className="font-mono">
-                  {keybindingService.formatComboForDisplay(capturedCombos[0]!)}
-                </span>
-                <span className="text-daintree-accent/70">
-                  {" "}
-                  — press second key or wait to finish
-                </span>
-              </span>
-            ) : null}
-          </div>
-        ) : capturedCombo ? (
-          <div className="flex-1 px-4 py-2 border border-daintree-border rounded bg-daintree-bg text-daintree-text text-center font-mono">
-            <span>{keybindingService.formatComboForDisplay(capturedCombo)}</span>
-            {isChord && <span className="ml-2 text-xs text-daintree-text/50">(chord)</span>}
-          </div>
-        ) : (
-          <button
-            onClick={handleStartRecording}
-            className="flex-1 px-4 py-2 border border-daintree-border rounded bg-daintree-bg text-daintree-text/60 hover:text-daintree-text hover:border-daintree-accent transition-colors"
-          >
-            Click to record shortcut
-          </button>
-        )}
-      </div>
-
-      {conflicts.length > 0 && (
-        <div className="flex items-start gap-2 text-status-warning text-sm">
-          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-          <span>
-            Conflicts with: {conflicts.map((c) => c.description || c.actionId).join(", ")}
-          </span>
-        </div>
-      )}
-
-      <div className="flex gap-2 justify-end">
-        <button
-          onClick={handleCancel}
-          className="px-3 py-1.5 text-sm text-daintree-text/60 hover:text-daintree-text transition-colors"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={handleClear}
-          className="px-3 py-1.5 text-sm text-daintree-text/60 hover:text-daintree-text transition-colors"
-        >
-          Clear
-        </button>
-        {capturedCombo && (
-          <button
-            onClick={handleSave}
-            className="px-3 py-1.5 text-sm bg-daintree-accent text-daintree-bg rounded hover:bg-daintree-accent/90 transition-colors"
-          >
-            Save
-          </button>
-        )}
-      </div>
-    </div>
-  );
 }
 
 interface ShortcutRowProps {
@@ -228,7 +35,7 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
             {binding.description || binding.actionId}
           </span>
         </div>
-        <KeyRecorder
+        <SettingsShortcutCapture
           onCapture={handleCapture}
           onCancel={onCancel}
           excludeActionId={binding.actionId}


### PR DESCRIPTION
## Summary

- Extracted `SettingsShortcutCapture` from `KeyboardShortcutsTab` into a reusable primitive
- Preserved all existing behaviour: chord-aware capture, conflict detection, proper key normalization
- Added comprehensive test coverage (400+ lines) with mocks for keybinding registry and state
- Updated keyboard shortcuts tab to use the new component

Resolves #5454

## Changes

- Created `src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx` — stable API for shortcut capture
- Added `src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx` — full test suite
- Refactored `KeyboardShortcutsTab.tsx` to use the extracted component
- Exported new component from `src/components/KeyboardShortcuts/index.ts`

## Testing

- All existing tests pass
- New test suite covers: capture flow, chord detection, conflict resolution, key normalization, validation states
- Typecheck and lint pass with no errors