### PR TITLE
feat(settings): add validation error indicator to settings tabs

### DIFF
--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -5,6 +5,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { SettingsSection } from "./SettingsSection";
 import { isSensitiveEnvKey } from "@shared/utils/envVars";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 
 interface EnvVar {
   id: string;
@@ -45,6 +46,10 @@ export function EnvironmentSettingsTab() {
   const [rowErrors, setRowErrors] = useState<Record<string, string>>({});
   const [isDirty, setIsDirty] = useState(false);
   const [savedSnapshot, setSavedSnapshot] = useState<Record<string, string>>({});
+
+  // Report validation state to sidebar
+  const hasError = Object.keys(rowErrors).length > 0;
+  useSettingsTabValidation("environment", hasError);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -117,6 +117,11 @@ export function EnvironmentSettingsTab() {
       next.delete(id);
       return next;
     });
+    setRowErrors((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
     setIsDirty(true);
   }, []);
 

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -7,6 +7,7 @@ import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect } from "./SettingsSelect";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 
 function ServiceIcon({ name, size = 16 }: { name: string; size?: number }) {
   const className = size === 16 ? "w-4 h-4" : size === 32 ? "w-8 h-8" : "w-4 h-4";
@@ -60,6 +61,10 @@ export function PortalSettingsTab() {
   const [customUrlError, setCustomUrlError] = useState("");
   const customUrlErrorId = useId();
   const addLinkErrorId = useId();
+
+  // Report validation state to sidebar
+  const hasError = Boolean(urlError || customUrlError);
+  useSettingsTabValidation("portal", hasError);
 
   const systemLinks = links.filter((l) => l.type === "system");
   const userLinks = links.filter((l) => l.type === "user");

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useRef,
   useCallback,
+  useContext,
   type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import {
@@ -153,6 +154,10 @@ import { RecipesTab as ProjectRecipesTab } from "@/components/Project/RecipesTab
 import { CommandOverridesTab } from "./CommandOverridesTab";
 import { ProjectNotificationsTab } from "@/components/Project/ProjectNotificationsTab";
 import { GitHubTab as ProjectGitHubTab } from "@/components/Project/GitHubTab";
+import {
+  SettingsValidationProvider,
+  SettingsValidationContext,
+} from "./SettingsValidationRegistry";
 
 let rememberedTab: SettingsTab = "general";
 let rememberedProjectTab: SettingsTab = "project:general";
@@ -401,6 +406,10 @@ export function SettingsDialog({
   const projectForm = useProjectSettingsForm({ projectId: projectId ?? null, isOpen });
   const projectLabel =
     projectForm.currentProject?.name ?? projectForm.currentProject?.id ?? "project";
+
+  // Validation error tracking from the registry provider
+  const validationRegistry = useContext(SettingsValidationContext);
+  const tabsWithErrors = validationRegistry?.tabsWithErrors ?? new Set();
 
   const [globalEnvVars, setGlobalEnvVars] = useState<Record<string, string>>({});
   useEffect(() => {
@@ -735,6 +744,7 @@ export function SettingsDialog({
                     isSearching={isSearching}
                     matchCount={matchCounts.general}
                     modified={modifiedTabs.has("general")}
+                    hasError={tabsWithErrors.has("general")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -745,6 +755,7 @@ export function SettingsDialog({
                     isSearching={isSearching}
                     matchCount={matchCounts.terminalAppearance}
                     modified={modifiedTabs.has("terminalAppearance")}
+                    hasError={tabsWithErrors.has("terminalAppearance")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -754,6 +765,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.keyboard}
+                    hasError={tabsWithErrors.has("keyboard")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -763,6 +775,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.notifications}
+                    hasError={tabsWithErrors.has("notifications")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -772,6 +785,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.privacy}
+                    hasError={tabsWithErrors.has("privacy")}
                     onSelect={handleNavSelect}
                   />
                 </NavGroup>
@@ -784,6 +798,7 @@ export function SettingsDialog({
                     isSearching={isSearching}
                     matchCount={matchCounts.terminal}
                     modified={modifiedTabs.has("terminal")}
+                    hasError={tabsWithErrors.has("terminal")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -793,6 +808,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.worktree}
+                    hasError={tabsWithErrors.has("worktree")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -802,6 +818,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.toolbar}
+                    hasError={tabsWithErrors.has("toolbar")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -811,6 +828,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.environment}
+                    hasError={tabsWithErrors.has("environment")}
                     onSelect={handleNavSelect}
                   />
                 </NavGroup>
@@ -822,6 +840,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.agents}
+                    hasError={tabsWithErrors.has("agents")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -831,6 +850,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.github}
+                    hasError={tabsWithErrors.has("github")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -840,6 +860,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.integrations}
+                    hasError={tabsWithErrors.has("integrations")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -849,6 +870,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.voice}
+                    hasError={tabsWithErrors.has("voice")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -858,6 +880,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.portal}
+                    hasError={tabsWithErrors.has("portal")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
@@ -867,6 +890,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.mcp}
+                    hasError={tabsWithErrors.has("mcp")}
                     onSelect={handleNavSelect}
                   />
                 </NavGroup>
@@ -879,6 +903,7 @@ export function SettingsDialog({
                     activeTab={activeTab}
                     isSearching={isSearching}
                     matchCount={matchCounts.troubleshooting}
+                    hasError={tabsWithErrors.has("troubleshooting")}
                     onSelect={handleNavSelect}
                   />
                 </NavGroup>
@@ -892,6 +917,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:general"]}
+                  hasError={tabsWithErrors.has("project:general")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -901,6 +927,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:context"]}
+                  hasError={tabsWithErrors.has("project:context")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -910,6 +937,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:variables"]}
+                  hasError={tabsWithErrors.has("project:variables")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -919,6 +947,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:automation"]}
+                  hasError={tabsWithErrors.has("project:automation")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -928,6 +957,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:recipes"]}
+                  hasError={tabsWithErrors.has("project:recipes")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -937,6 +967,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:commands"]}
+                  hasError={tabsWithErrors.has("project:commands")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -946,6 +977,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:notifications"]}
+                  hasError={tabsWithErrors.has("project:notifications")}
                   onSelect={handleNavSelect}
                 />
                 <NavItem
@@ -955,6 +987,7 @@ export function SettingsDialog({
                   activeTab={activeTab}
                   isSearching={isSearching}
                   matchCount={matchCounts["project:github"]}
+                  hasError={tabsWithErrors.has("project:github")}
                   onSelect={handleNavSelect}
                 />
               </NavGroup>
@@ -1002,7 +1035,7 @@ export function SettingsDialog({
                 />
               </div>
             ) : (
-              <>
+              <SettingsValidationProvider>
                 {hiddenSettingBanner && (
                   <div
                     className="text-sm text-status-warning bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)] p-3 mb-4 flex items-start justify-between gap-3"
@@ -1512,7 +1545,7 @@ export function SettingsDialog({
                     )}
                   </>
                 )}
-              </>
+              </SettingsValidationProvider>
             )}
           </ScrollShadow>
         </div>
@@ -1545,6 +1578,7 @@ interface NavItemProps {
   isSearching: boolean;
   matchCount?: number;
   modified?: boolean;
+  hasError?: boolean;
   onSelect: (tab: SettingsTab) => void;
 }
 
@@ -1556,6 +1590,7 @@ function NavItem({
   isSearching,
   matchCount,
   modified,
+  hasError,
   onSelect,
 }: NavItemProps) {
   const active = activeTab === tab && !isSearching;
@@ -1581,10 +1616,13 @@ function NavItem({
     >
       <span className="relative">
         {icon}
-        {modified && (
+        {(hasError || modified) && (
           <span
-            className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-daintree-accent"
-            title="Modified from default"
+            className={cn(
+              "absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full",
+              hasError ? "bg-status-warning" : "bg-daintree-accent"
+            )}
+            title={hasError ? "Contains validation errors" : "Modified from default"}
           />
         )}
       </span>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -654,902 +654,906 @@ export function SettingsDialog({
       maxHeight="h-[75vh]"
       className="settings-shell min-h-[500px] max-h-[800px]"
     >
-      <div className="flex h-full overflow-hidden">
-        <div className="settings-sidebar w-52 border-r border-daintree-border p-3 flex flex-col shrink-0">
-          <div className="flex items-center justify-between mb-3 pl-2">
-            <h2 className="text-sm font-semibold text-daintree-text">Settings</h2>
-            {hasProject && (
-              <div className="relative flex items-center">
-                <select
-                  value={activeScope}
-                  aria-label="Settings scope"
-                  onChange={(e) => {
-                    handleScopeSwitch(e.target.value as SettingsScope);
-                    e.target.blur();
+      <SettingsValidationProvider>
+        <div className="flex h-full overflow-hidden">
+          <div className="settings-sidebar w-52 border-r border-daintree-border p-3 flex flex-col shrink-0">
+            <div className="flex items-center justify-between mb-3 pl-2">
+              <h2 className="text-sm font-semibold text-daintree-text">Settings</h2>
+              {hasProject && (
+                <div className="relative flex items-center">
+                  <select
+                    value={activeScope}
+                    aria-label="Settings scope"
+                    onChange={(e) => {
+                      handleScopeSwitch(e.target.value as SettingsScope);
+                      e.target.blur();
+                    }}
+                    className="appearance-none text-xs py-1 pl-2 pr-6 rounded-[var(--radius-md)] bg-transparent border border-border-strong text-text-secondary hover:text-daintree-text hover:border-daintree-text/30 focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/20 outline-none cursor-pointer transition-colors"
+                  >
+                    <option value="global">Global</option>
+                    <option value="project">Project</option>
+                  </select>
+                  <ChevronDown
+                    size={12}
+                    className="pointer-events-none absolute right-1.5 text-text-secondary"
+                  />
+                </div>
+              )}
+            </div>
+
+            <div
+              className={cn(
+                "flex items-center gap-1.5 px-2 py-1.5 mb-3 rounded-[var(--radius-md)]",
+                "settings-search border border-border-strong",
+                "focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
+              )}
+            >
+              <Search
+                className="settings-search-icon w-3.5 h-3.5 shrink-0 pointer-events-none"
+                aria-hidden="true"
+              />
+              <input
+                ref={searchInputRef}
+                type="text"
+                placeholder="Search…"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={handleSearchKeyDown}
+                aria-label="Search settings"
+                className="settings-search-input flex-1 min-w-0 text-xs bg-transparent text-daintree-text focus:outline-none"
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSearchQuery("");
+                    searchInputRef.current?.focus();
                   }}
-                  className="appearance-none text-xs py-1 pl-2 pr-6 rounded-[var(--radius-md)] bg-transparent border border-border-strong text-text-secondary hover:text-daintree-text hover:border-daintree-text/30 focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/20 outline-none cursor-pointer transition-colors"
+                  aria-label="Clear search"
+                  className="flex items-center justify-center w-5 h-5 rounded shrink-0 text-daintree-text/40 hover:text-daintree-text"
                 >
-                  <option value="global">Global</option>
-                  <option value="project">Project</option>
-                </select>
-                <ChevronDown
-                  size={12}
-                  className="pointer-events-none absolute right-1.5 text-text-secondary"
-                />
-              </div>
-            )}
-          </div>
+                  <X className="w-3 h-3" />
+                </button>
+              )}
+            </div>
 
-          <div
-            className={cn(
-              "flex items-center gap-1.5 px-2 py-1.5 mb-3 rounded-[var(--radius-md)]",
-              "settings-search border border-border-strong",
-              "focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
+            {isSearching && (
+              <p aria-live="polite" className="sr-only">
+                {searchResults.length === 0
+                  ? "No results found"
+                  : `${searchResults.length} result${searchResults.length === 1 ? "" : "s"} found`}
+              </p>
             )}
-          >
-            <Search
-              className="settings-search-icon w-3.5 h-3.5 shrink-0 pointer-events-none"
-              aria-hidden="true"
-            />
-            <input
-              ref={searchInputRef}
-              type="text"
-              placeholder="Search…"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyDown={handleSearchKeyDown}
-              aria-label="Search settings"
-              className="settings-search-input flex-1 min-w-0 text-xs bg-transparent text-daintree-text focus:outline-none"
-            />
-            {searchQuery && (
-              <button
-                type="button"
-                onClick={() => {
-                  setSearchQuery("");
-                  searchInputRef.current?.focus();
-                }}
-                aria-label="Clear search"
-                className="flex items-center justify-center w-5 h-5 rounded shrink-0 text-daintree-text/40 hover:text-daintree-text"
-              >
-                <X className="w-3 h-3" />
-              </button>
-            )}
-          </div>
 
-          {isSearching && (
-            <p aria-live="polite" className="sr-only">
-              {searchResults.length === 0
-                ? "No results found"
-                : `${searchResults.length} result${searchResults.length === 1 ? "" : "s"} found`}
-            </p>
-          )}
+            <ScrollShadow
+              className="flex-1 min-h-0"
+              scrollClassName="space-y-3"
+              ref={tablistRef}
+              role="tablist"
+              aria-orientation="vertical"
+              aria-label="Settings sections"
+              onKeyDown={handleTablistKeyDown}
+            >
+              {activeScope === "global" ? (
+                <>
+                  <NavGroup label="General">
+                    <NavItem
+                      tab="general"
+                      icon={<Settings2 className="w-4 h-4" />}
+                      label="General"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.general}
+                      modified={modifiedTabs.has("general")}
+                      hasError={tabsWithErrors.has("general")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="terminalAppearance"
+                      icon={<SquareTerminal className="w-4 h-4" />}
+                      label="Appearance"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.terminalAppearance}
+                      modified={modifiedTabs.has("terminalAppearance")}
+                      hasError={tabsWithErrors.has("terminalAppearance")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="keyboard"
+                      icon={<Keyboard className="w-4 h-4" />}
+                      label="Keyboard"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.keyboard}
+                      hasError={tabsWithErrors.has("keyboard")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="notifications"
+                      icon={<Bell className="w-4 h-4" />}
+                      label="Notifications"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.notifications}
+                      hasError={tabsWithErrors.has("notifications")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="privacy"
+                      icon={<Shield className="w-4 h-4" />}
+                      label="Privacy & Data"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.privacy}
+                      hasError={tabsWithErrors.has("privacy")}
+                      onSelect={handleNavSelect}
+                    />
+                  </NavGroup>
+                  <NavGroup label="Terminal">
+                    <NavItem
+                      tab="terminal"
+                      icon={<LayoutGrid className="w-4 h-4" />}
+                      label="Panel Grid"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.terminal}
+                      modified={modifiedTabs.has("terminal")}
+                      hasError={tabsWithErrors.has("terminal")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="worktree"
+                      icon={<WorktreeIcon className="w-4 h-4" />}
+                      label="Worktree"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.worktree}
+                      hasError={tabsWithErrors.has("worktree")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="toolbar"
+                      icon={<SettingsIcon className="w-4 h-4" />}
+                      label="Toolbar"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.toolbar}
+                      hasError={tabsWithErrors.has("toolbar")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="environment"
+                      icon={<KeyRound className="w-4 h-4" />}
+                      label="Environment"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.environment}
+                      hasError={tabsWithErrors.has("environment")}
+                      onSelect={handleNavSelect}
+                    />
+                  </NavGroup>
+                  <NavGroup label="Integrations">
+                    <NavItem
+                      tab="agents"
+                      icon={<DaintreeAgentIcon className="w-4 h-4" />}
+                      label="CLI Agents"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.agents}
+                      hasError={tabsWithErrors.has("agents")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="github"
+                      icon={<Github className="w-4 h-4" />}
+                      label="GitHub"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.github}
+                      hasError={tabsWithErrors.has("github")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="integrations"
+                      icon={<Blocks className="w-4 h-4" />}
+                      label="Integrations"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.integrations}
+                      hasError={tabsWithErrors.has("integrations")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="voice"
+                      icon={<Mic className="w-4 h-4" />}
+                      label="Voice Input"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.voice}
+                      hasError={tabsWithErrors.has("voice")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="portal"
+                      icon={<PanelRight className="w-4 h-4" />}
+                      label="Portal"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.portal}
+                      hasError={tabsWithErrors.has("portal")}
+                      onSelect={handleNavSelect}
+                    />
+                    <NavItem
+                      tab="mcp"
+                      icon={<McpServerIcon className="w-4 h-4" />}
+                      label="MCP Server"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.mcp}
+                      hasError={tabsWithErrors.has("mcp")}
+                      onSelect={handleNavSelect}
+                    />
+                  </NavGroup>
 
-          <ScrollShadow
-            className="flex-1 min-h-0"
-            scrollClassName="space-y-3"
-            ref={tablistRef}
-            role="tablist"
-            aria-orientation="vertical"
-            aria-label="Settings sections"
-            onKeyDown={handleTablistKeyDown}
-          >
-            {activeScope === "global" ? (
-              <>
-                <NavGroup label="General">
+                  <NavGroup label="Support">
+                    <NavItem
+                      tab="troubleshooting"
+                      icon={<LifeBuoy className="w-4 h-4" />}
+                      label="Troubleshooting"
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts.troubleshooting}
+                      hasError={tabsWithErrors.has("troubleshooting")}
+                      onSelect={handleNavSelect}
+                    />
+                  </NavGroup>
+                </>
+              ) : (
+                <NavGroup label="Project">
                   <NavItem
-                    tab="general"
-                    icon={<Settings2 className="w-4 h-4" />}
+                    tab="project:general"
+                    icon={<SettingsIcon className="w-4 h-4" />}
                     label="General"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts.general}
-                    modified={modifiedTabs.has("general")}
-                    hasError={tabsWithErrors.has("general")}
+                    matchCount={matchCounts["project:general"]}
+                    hasError={tabsWithErrors.has("project:general")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="terminalAppearance"
-                    icon={<SquareTerminal className="w-4 h-4" />}
-                    label="Appearance"
+                    tab="project:context"
+                    icon={<FileCode className="w-4 h-4" />}
+                    label="Context"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts.terminalAppearance}
-                    modified={modifiedTabs.has("terminalAppearance")}
-                    hasError={tabsWithErrors.has("terminalAppearance")}
+                    matchCount={matchCounts["project:context"]}
+                    hasError={tabsWithErrors.has("project:context")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="keyboard"
-                    icon={<Keyboard className="w-4 h-4" />}
-                    label="Keyboard"
+                    tab="project:variables"
+                    icon={<KeyRound className="w-4 h-4" />}
+                    label="Variables"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts.keyboard}
-                    hasError={tabsWithErrors.has("keyboard")}
+                    matchCount={matchCounts["project:variables"]}
+                    hasError={tabsWithErrors.has("project:variables")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="notifications"
+                    tab="project:automation"
+                    icon={<GitBranch className="w-4 h-4" />}
+                    label="Worktree Setup"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts["project:automation"]}
+                    hasError={tabsWithErrors.has("project:automation")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="project:recipes"
+                    icon={<TerminalRecipeIcon className="w-4 h-4" />}
+                    label="Recipes"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts["project:recipes"]}
+                    hasError={tabsWithErrors.has("project:recipes")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="project:commands"
+                    icon={<Command className="w-4 h-4" />}
+                    label="Commands"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts["project:commands"]}
+                    hasError={tabsWithErrors.has("project:commands")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="project:notifications"
                     icon={<Bell className="w-4 h-4" />}
                     label="Notifications"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts.notifications}
-                    hasError={tabsWithErrors.has("notifications")}
+                    matchCount={matchCounts["project:notifications"]}
+                    hasError={tabsWithErrors.has("project:notifications")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="privacy"
-                    icon={<Shield className="w-4 h-4" />}
-                    label="Privacy & Data"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.privacy}
-                    hasError={tabsWithErrors.has("privacy")}
-                    onSelect={handleNavSelect}
-                  />
-                </NavGroup>
-                <NavGroup label="Terminal">
-                  <NavItem
-                    tab="terminal"
-                    icon={<LayoutGrid className="w-4 h-4" />}
-                    label="Panel Grid"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.terminal}
-                    modified={modifiedTabs.has("terminal")}
-                    hasError={tabsWithErrors.has("terminal")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="worktree"
-                    icon={<WorktreeIcon className="w-4 h-4" />}
-                    label="Worktree"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.worktree}
-                    hasError={tabsWithErrors.has("worktree")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="toolbar"
-                    icon={<SettingsIcon className="w-4 h-4" />}
-                    label="Toolbar"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.toolbar}
-                    hasError={tabsWithErrors.has("toolbar")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="environment"
-                    icon={<KeyRound className="w-4 h-4" />}
-                    label="Environment"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.environment}
-                    hasError={tabsWithErrors.has("environment")}
-                    onSelect={handleNavSelect}
-                  />
-                </NavGroup>
-                <NavGroup label="Integrations">
-                  <NavItem
-                    tab="agents"
-                    icon={<DaintreeAgentIcon className="w-4 h-4" />}
-                    label="CLI Agents"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.agents}
-                    hasError={tabsWithErrors.has("agents")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="github"
+                    tab="project:github"
                     icon={<Github className="w-4 h-4" />}
                     label="GitHub"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts.github}
-                    hasError={tabsWithErrors.has("github")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="integrations"
-                    icon={<Blocks className="w-4 h-4" />}
-                    label="Integrations"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.integrations}
-                    hasError={tabsWithErrors.has("integrations")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="voice"
-                    icon={<Mic className="w-4 h-4" />}
-                    label="Voice Input"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.voice}
-                    hasError={tabsWithErrors.has("voice")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="portal"
-                    icon={<PanelRight className="w-4 h-4" />}
-                    label="Portal"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.portal}
-                    hasError={tabsWithErrors.has("portal")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="mcp"
-                    icon={<McpServerIcon className="w-4 h-4" />}
-                    label="MCP Server"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.mcp}
-                    hasError={tabsWithErrors.has("mcp")}
+                    matchCount={matchCounts["project:github"]}
+                    hasError={tabsWithErrors.has("project:github")}
                     onSelect={handleNavSelect}
                   />
                 </NavGroup>
-
-                <NavGroup label="Support">
-                  <NavItem
-                    tab="troubleshooting"
-                    icon={<LifeBuoy className="w-4 h-4" />}
-                    label="Troubleshooting"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts.troubleshooting}
-                    hasError={tabsWithErrors.has("troubleshooting")}
-                    onSelect={handleNavSelect}
-                  />
-                </NavGroup>
-              </>
-            ) : (
-              <NavGroup label="Project">
-                <NavItem
-                  tab="project:general"
-                  icon={<SettingsIcon className="w-4 h-4" />}
-                  label="General"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:general"]}
-                  hasError={tabsWithErrors.has("project:general")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:context"
-                  icon={<FileCode className="w-4 h-4" />}
-                  label="Context"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:context"]}
-                  hasError={tabsWithErrors.has("project:context")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:variables"
-                  icon={<KeyRound className="w-4 h-4" />}
-                  label="Variables"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:variables"]}
-                  hasError={tabsWithErrors.has("project:variables")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:automation"
-                  icon={<GitBranch className="w-4 h-4" />}
-                  label="Worktree Setup"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:automation"]}
-                  hasError={tabsWithErrors.has("project:automation")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:recipes"
-                  icon={<TerminalRecipeIcon className="w-4 h-4" />}
-                  label="Recipes"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:recipes"]}
-                  hasError={tabsWithErrors.has("project:recipes")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:commands"
-                  icon={<Command className="w-4 h-4" />}
-                  label="Commands"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:commands"]}
-                  hasError={tabsWithErrors.has("project:commands")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:notifications"
-                  icon={<Bell className="w-4 h-4" />}
-                  label="Notifications"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:notifications"]}
-                  hasError={tabsWithErrors.has("project:notifications")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:github"
-                  icon={<Github className="w-4 h-4" />}
-                  label="GitHub"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:github"]}
-                  hasError={tabsWithErrors.has("project:github")}
-                  onSelect={handleNavSelect}
-                />
-              </NavGroup>
-            )}
-          </ScrollShadow>
-
-          <div className="pt-2 mt-2 border-t border-daintree-border px-2">
-            <span className="settings-meta font-mono">{appVersion}</span>
-          </div>
-        </div>
-
-        <div className="settings-shell flex-1 flex flex-col min-w-0">
-          <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-daintree-border shrink-0">
-            <h3 className="text-lg font-medium text-daintree-text flex items-center gap-2">
-              {isSearching ? (
-                <>
-                  <Search className="w-5 h-5 text-text-secondary" />
-                  Search Results
-                </>
-              ) : (
-                <>
-                  {tabIcons[activeTab]}
-                  {tabTitles[activeTab]}
-                </>
               )}
-            </h3>
-            <button
-              onClick={handleClose}
-              className="text-daintree-text/60 hover:text-daintree-text transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-              aria-label="Close settings"
-            >
-              <X className="h-5 w-5" />
-            </button>
+            </ScrollShadow>
+
+            <div className="pt-2 mt-2 border-t border-daintree-border px-2">
+              <span className="settings-meta font-mono">{appVersion}</span>
+            </div>
           </div>
 
-          <ScrollShadow className="flex-1" scrollClassName="p-6">
-            {isSearching ? (
-              <div role="region" aria-label="Search results">
-                <SearchResults
-                  results={searchResults}
-                  query={deferredQuery}
-                  cleanQuery={cleanSearchQuery}
-                  onResultClick={handleResultClick}
-                  activeIndex={activeResultIndex}
-                />
-              </div>
-            ) : (
-              <SettingsValidationProvider>
-                {hiddenSettingBanner && (
-                  <div
-                    className="text-sm text-status-warning bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)] p-3 mb-4 flex items-start justify-between gap-3"
-                    role="alert"
-                  >
-                    <div className="flex items-start gap-2">
-                      <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-                      <span>
-                        This setting is only visible when{" "}
-                        <button
-                          className="underline font-medium hover:opacity-80"
-                          onClick={() => {
-                            const parent = SETTINGS_SEARCH_INDEX.find(
-                              (e) => e.id === hiddenSettingBanner.settingId
-                            );
-                            if (parent) {
-                              handleResultClick(
-                                {
-                                  tab: parent.tab,
-                                  subtab: parent.subtab,
-                                  sectionId: parent.id,
-                                },
-                                parent.requiresEnabled
-                              );
-                            }
-                          }}
-                        >
-                          {hiddenSettingBanner.label}
-                        </button>{" "}
-                        is enabled.
-                      </span>
-                    </div>
-                    <button
-                      aria-label="Dismiss"
-                      onClick={() => setHiddenSettingBanner(null)}
-                      className="shrink-0 opacity-60 hover:opacity-100"
-                    >
-                      <X className="w-4 h-4" />
-                    </button>
-                  </div>
-                )}
-                <div
-                  role="tabpanel"
-                  id="settings-panel-general"
-                  aria-labelledby="settings-tab-general"
-                  tabIndex={0}
-                  className={activeTab === "general" ? "" : "hidden"}
-                >
-                  <GeneralTab
-                    appVersion={appVersion}
-                    onNavigateToAgents={(agentId?: string) => {
-                      markTabVisited("agents");
-                      if (agentId) {
-                        setActiveSubtabs((prev) => ({ ...prev, agents: agentId }));
-                      }
-                      startTransition(() => setActiveTab("agents"));
-                    }}
-                    activeSubtab={activeSubtabs["general"] ?? null}
-                    onSubtabChange={(id) => setActiveSubtabs((prev) => ({ ...prev, general: id }))}
-                  />
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-keyboard"
-                  aria-labelledby="settings-tab-keyboard"
-                  tabIndex={0}
-                  className={activeTab === "keyboard" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("keyboard") && (
-                    <Suspense fallback={null}>
-                      <LazyKeyboardShortcutsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-terminal"
-                  aria-labelledby="settings-tab-terminal"
-                  tabIndex={0}
-                  className={activeTab === "terminal" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("terminal") && (
-                    <Suspense fallback={null}>
-                      <LazyTerminalSettingsTab
-                        activeSubtab={activeSubtabs["terminal"] ?? null}
-                        onSubtabChange={(id) =>
-                          setActiveSubtabs((prev) => ({ ...prev, terminal: id }))
-                        }
-                      />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-terminalAppearance"
-                  aria-labelledby="settings-tab-terminalAppearance"
-                  tabIndex={0}
-                  className={activeTab === "terminalAppearance" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("terminalAppearance") && (
-                    <Suspense fallback={null}>
-                      <LazyTerminalAppearanceTab
-                        activeSubtab={activeSubtabs["terminalAppearance"] ?? null}
-                        onSubtabChange={(id) =>
-                          setActiveSubtabs((prev) => ({ ...prev, terminalAppearance: id }))
-                        }
-                      />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-worktree"
-                  aria-labelledby="settings-tab-worktree"
-                  tabIndex={0}
-                  className={activeTab === "worktree" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("worktree") && (
-                    <Suspense fallback={null}>
-                      <LazyWorktreeSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-agents"
-                  aria-labelledby="settings-tab-agents"
-                  tabIndex={0}
-                  className={activeTab === "agents" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("agents") && (
-                    <Suspense fallback={null}>
-                      <LazyAgentSettings
-                        activeSubtab={activeSubtabs["agents"] ?? null}
-                        onSubtabChange={(id) =>
-                          setActiveSubtabs((prev) => ({ ...prev, agents: id }))
-                        }
-                        onSettingsChange={onSettingsChange}
-                      />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-github"
-                  aria-labelledby="settings-tab-github"
-                  tabIndex={0}
-                  className={activeTab === "github" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("github") && (
-                    <Suspense fallback={null}>
-                      <LazyGitHubSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-portal"
-                  aria-labelledby="settings-tab-portal"
-                  tabIndex={0}
-                  className={activeTab === "portal" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("portal") && (
-                    <Suspense fallback={null}>
-                      <LazyPortalSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-toolbar"
-                  aria-labelledby="settings-tab-toolbar"
-                  tabIndex={0}
-                  className={activeTab === "toolbar" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("toolbar") && (
-                    <Suspense fallback={null}>
-                      <LazyToolbarSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-notifications"
-                  aria-labelledby="settings-tab-notifications"
-                  tabIndex={0}
-                  className={activeTab === "notifications" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("notifications") && (
-                    <Suspense fallback={null}>
-                      <LazyNotificationSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-integrations"
-                  aria-labelledby="settings-tab-integrations"
-                  tabIndex={0}
-                  className={activeTab === "integrations" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("integrations") && (
-                    <Suspense fallback={null}>
-                      <LazyIntegrationsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-voice"
-                  aria-labelledby="settings-tab-voice"
-                  tabIndex={0}
-                  className={activeTab === "voice" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("voice") && (
-                    <Suspense fallback={null}>
-                      <LazyVoiceInputSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-mcp"
-                  aria-labelledby="settings-tab-mcp"
-                  tabIndex={0}
-                  className={activeTab === "mcp" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("mcp") && (
-                    <Suspense fallback={null}>
-                      <LazyMcpServerSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-environment"
-                  aria-labelledby="settings-tab-environment"
-                  tabIndex={0}
-                  className={activeTab === "environment" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("environment") && (
-                    <Suspense fallback={null}>
-                      <LazyEnvironmentSettingsTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-privacy"
-                  aria-labelledby="settings-tab-privacy"
-                  tabIndex={0}
-                  className={activeTab === "privacy" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("privacy") && (
-                    <Suspense fallback={null}>
-                      <LazyPrivacyDataTab
-                        activeSubtab={activeSubtabs["privacy"] ?? null}
-                        onSubtabChange={(id) =>
-                          setActiveSubtabs((prev) => ({ ...prev, privacy: id }))
-                        }
-                      />
-                    </Suspense>
-                  )}
-                </div>
-
-                <div
-                  role="tabpanel"
-                  id="settings-panel-troubleshooting"
-                  aria-labelledby="settings-tab-troubleshooting"
-                  tabIndex={0}
-                  className={activeTab === "troubleshooting" ? "" : "hidden"}
-                >
-                  {visitedTabs.has("troubleshooting") && (
-                    <Suspense fallback={null}>
-                      <LazyTroubleshootingTab />
-                    </Suspense>
-                  )}
-                </div>
-
-                {/* Project settings panels */}
-                {activeScope === "project" && projectId && (
+          <div className="settings-shell flex-1 flex flex-col min-w-0">
+            <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-daintree-border shrink-0">
+              <h3 className="text-lg font-medium text-daintree-text flex items-center gap-2">
+                {isSearching ? (
                   <>
-                    {projectForm.projectIsLoading && (
-                      <div className="text-sm text-daintree-text/60 text-center py-8">
-                        Loading settings...
-                      </div>
-                    )}
-                    {projectForm.projectError && (
-                      <div
-                        className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
-                        role="alert"
-                      >
-                        Failed to load settings: {projectForm.projectError}
-                      </div>
-                    )}
-                    {projectForm.projectAutoSaveError && (
-                      <div
-                        className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
-                        role="alert"
-                      >
-                        {projectForm.projectAutoSaveError}
-                      </div>
-                    )}
-                    {!projectForm.projectIsLoading && !projectForm.projectError && (
-                      <>
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:general"
-                          aria-labelledby="settings-tab-project:general"
-                          tabIndex={0}
-                          className={activeTab === "project:general" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:general") && (
-                            <ProjectGeneralTab
-                              currentProject={projectForm.currentProject}
-                              name={projectForm.projectName}
-                              onNameChange={projectForm.setProjectName}
-                              emoji={projectForm.projectEmoji}
-                              onEmojiChange={projectForm.setProjectEmoji}
-                              color={projectForm.projectColor}
-                              onColorChange={projectForm.setProjectColor}
-                              devServerCommand={projectForm.devServerCommand}
-                              onDevServerCommandChange={projectForm.setDevServerCommand}
-                              devServerLoadTimeout={projectForm.devServerLoadTimeout}
-                              onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
-                              turbopackEnabled={projectForm.turbopackEnabled}
-                              onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
-                              projectIconSvg={projectForm.projectIconSvg}
-                              onProjectIconSvgChange={projectForm.setProjectIconSvg}
-                              enableInRepoSettings={projectForm.enableInRepoSettings}
-                              disableInRepoSettings={projectForm.disableInRepoSettings}
-                              projectId={projectId}
-                              isOpen={isOpen}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:context"
-                          aria-labelledby="settings-tab-project:context"
-                          tabIndex={0}
-                          className={activeTab === "project:context" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:context") && (
-                            <ProjectContextTab
-                              excludedPaths={projectForm.excludedPaths}
-                              onExcludedPathsChange={projectForm.setExcludedPaths}
-                              copyTreeSettings={projectForm.copyTreeSettings}
-                              onCopyTreeSettingsChange={projectForm.setCopyTreeSettings}
-                              worktrees={projectForm.worktrees}
-                              isOpen={isOpen}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:variables"
-                          aria-labelledby="settings-tab-project:variables"
-                          tabIndex={0}
-                          className={activeTab === "project:variables" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:variables") && (
-                            <EnvironmentVariablesEditor
-                              environmentVariables={projectForm.environmentVariables}
-                              onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
-                              settings={projectForm.projectSettings}
-                              isOpen={isOpen}
-                              onFlush={projectForm.flush}
-                              projectLabel={projectLabel}
-                              globalEnvironmentVariables={globalEnvVars}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:automation"
-                          aria-labelledby="settings-tab-project:automation"
-                          tabIndex={0}
-                          className={activeTab === "project:automation" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:automation") && (
-                            <ProjectAutomationTab
-                              currentProject={projectForm.currentProject}
-                              runCommands={projectForm.runCommands}
-                              onRunCommandsChange={projectForm.setRunCommands}
-                              defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-                              onDefaultWorktreeRecipeIdChange={
-                                projectForm.setDefaultWorktreeRecipeId
-                              }
-                              branchPrefixMode={projectForm.branchPrefixMode}
-                              onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
-                              branchPrefixCustom={projectForm.branchPrefixCustom}
-                              onBranchPrefixCustomChange={projectForm.setBranchPrefixCustom}
-                              worktreePathPattern={projectForm.worktreePathPattern}
-                              onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
-                              terminalShell={projectForm.terminalShell}
-                              onTerminalShellChange={projectForm.setTerminalShell}
-                              terminalShellArgs={projectForm.terminalShellArgs}
-                              onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
-                              terminalDefaultCwd={projectForm.terminalDefaultCwd}
-                              onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
-                              terminalScrollback={projectForm.terminalScrollback}
-                              onTerminalScrollbackChange={projectForm.setTerminalScrollback}
-                              recipes={projectForm.recipes}
-                              recipesLoading={projectForm.recipesLoading}
-                              onNavigateToRecipes={() => {
-                                markTabVisited("project:recipes");
-                                startTransition(() => setActiveTab("project:recipes"));
-                              }}
-                              resourceEnvironments={projectForm.resourceEnvironments}
-                              onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
-                              activeResourceEnvironment={projectForm.activeResourceEnvironment}
-                              onActiveResourceEnvironmentChange={
-                                projectForm.setActiveResourceEnvironment
-                              }
-                              defaultWorktreeMode={projectForm.defaultWorktreeMode}
-                              onDefaultWorktreeModeChange={projectForm.setDefaultWorktreeMode}
-                              isOpen={isOpen}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:recipes"
-                          aria-labelledby="settings-tab-project:recipes"
-                          tabIndex={0}
-                          className={activeTab === "project:recipes" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:recipes") && (
-                            <ProjectRecipesTab
-                              projectId={projectId}
-                              defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-                              onDefaultWorktreeRecipeIdChange={
-                                projectForm.setDefaultWorktreeRecipeId
-                              }
-                              worktreeMap={projectForm.worktreeMap}
-                              isOpen={isOpen}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:commands"
-                          aria-labelledby="settings-tab-project:commands"
-                          tabIndex={0}
-                          className={activeTab === "project:commands" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:commands") && (
-                            <CommandOverridesTab
-                              projectId={projectId}
-                              overrides={projectForm.commandOverrides}
-                              onChange={projectForm.setCommandOverrides}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:notifications"
-                          aria-labelledby="settings-tab-project:notifications"
-                          tabIndex={0}
-                          className={activeTab === "project:notifications" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:notifications") && (
-                            <ProjectNotificationsTab
-                              overrides={projectForm.notificationOverrides}
-                              onChange={projectForm.setNotificationOverrides}
-                            />
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:github"
-                          aria-labelledby="settings-tab-project:github"
-                          tabIndex={0}
-                          className={activeTab === "project:github" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:github") && projectForm.currentProject && (
-                            <ProjectGitHubTab
-                              githubRemote={projectForm.githubRemote}
-                              onGithubRemoteChange={projectForm.setGithubRemote}
-                              projectPath={projectForm.currentProject.path}
-                            />
-                          )}
-                        </div>
-                      </>
-                    )}
+                    <Search className="w-5 h-5 text-text-secondary" />
+                    Search Results
+                  </>
+                ) : (
+                  <>
+                    {tabIcons[activeTab]}
+                    {tabTitles[activeTab]}
                   </>
                 )}
-              </SettingsValidationProvider>
-            )}
-          </ScrollShadow>
+              </h3>
+              <button
+                onClick={handleClose}
+                className="text-daintree-text/60 hover:text-daintree-text transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                aria-label="Close settings"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <ScrollShadow className="flex-1" scrollClassName="p-6">
+              {isSearching ? (
+                <div role="region" aria-label="Search results">
+                  <SearchResults
+                    results={searchResults}
+                    query={deferredQuery}
+                    cleanQuery={cleanSearchQuery}
+                    onResultClick={handleResultClick}
+                    activeIndex={activeResultIndex}
+                  />
+                </div>
+              ) : (
+                <>
+                  {hiddenSettingBanner && (
+                    <div
+                      className="text-sm text-status-warning bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)] p-3 mb-4 flex items-start justify-between gap-3"
+                      role="alert"
+                    >
+                      <div className="flex items-start gap-2">
+                        <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                        <span>
+                          This setting is only visible when{" "}
+                          <button
+                            className="underline font-medium hover:opacity-80"
+                            onClick={() => {
+                              const parent = SETTINGS_SEARCH_INDEX.find(
+                                (e) => e.id === hiddenSettingBanner.settingId
+                              );
+                              if (parent) {
+                                handleResultClick(
+                                  {
+                                    tab: parent.tab,
+                                    subtab: parent.subtab,
+                                    sectionId: parent.id,
+                                  },
+                                  parent.requiresEnabled
+                                );
+                              }
+                            }}
+                          >
+                            {hiddenSettingBanner.label}
+                          </button>{" "}
+                          is enabled.
+                        </span>
+                      </div>
+                      <button
+                        aria-label="Dismiss"
+                        onClick={() => setHiddenSettingBanner(null)}
+                        className="shrink-0 opacity-60 hover:opacity-100"
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-general"
+                    aria-labelledby="settings-tab-general"
+                    tabIndex={0}
+                    className={activeTab === "general" ? "" : "hidden"}
+                  >
+                    <GeneralTab
+                      appVersion={appVersion}
+                      onNavigateToAgents={(agentId?: string) => {
+                        markTabVisited("agents");
+                        if (agentId) {
+                          setActiveSubtabs((prev) => ({ ...prev, agents: agentId }));
+                        }
+                        startTransition(() => setActiveTab("agents"));
+                      }}
+                      activeSubtab={activeSubtabs["general"] ?? null}
+                      onSubtabChange={(id) =>
+                        setActiveSubtabs((prev) => ({ ...prev, general: id }))
+                      }
+                    />
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-keyboard"
+                    aria-labelledby="settings-tab-keyboard"
+                    tabIndex={0}
+                    className={activeTab === "keyboard" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("keyboard") && (
+                      <Suspense fallback={null}>
+                        <LazyKeyboardShortcutsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-terminal"
+                    aria-labelledby="settings-tab-terminal"
+                    tabIndex={0}
+                    className={activeTab === "terminal" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("terminal") && (
+                      <Suspense fallback={null}>
+                        <LazyTerminalSettingsTab
+                          activeSubtab={activeSubtabs["terminal"] ?? null}
+                          onSubtabChange={(id) =>
+                            setActiveSubtabs((prev) => ({ ...prev, terminal: id }))
+                          }
+                        />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-terminalAppearance"
+                    aria-labelledby="settings-tab-terminalAppearance"
+                    tabIndex={0}
+                    className={activeTab === "terminalAppearance" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("terminalAppearance") && (
+                      <Suspense fallback={null}>
+                        <LazyTerminalAppearanceTab
+                          activeSubtab={activeSubtabs["terminalAppearance"] ?? null}
+                          onSubtabChange={(id) =>
+                            setActiveSubtabs((prev) => ({ ...prev, terminalAppearance: id }))
+                          }
+                        />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-worktree"
+                    aria-labelledby="settings-tab-worktree"
+                    tabIndex={0}
+                    className={activeTab === "worktree" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("worktree") && (
+                      <Suspense fallback={null}>
+                        <LazyWorktreeSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-agents"
+                    aria-labelledby="settings-tab-agents"
+                    tabIndex={0}
+                    className={activeTab === "agents" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("agents") && (
+                      <Suspense fallback={null}>
+                        <LazyAgentSettings
+                          activeSubtab={activeSubtabs["agents"] ?? null}
+                          onSubtabChange={(id) =>
+                            setActiveSubtabs((prev) => ({ ...prev, agents: id }))
+                          }
+                          onSettingsChange={onSettingsChange}
+                        />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-github"
+                    aria-labelledby="settings-tab-github"
+                    tabIndex={0}
+                    className={activeTab === "github" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("github") && (
+                      <Suspense fallback={null}>
+                        <LazyGitHubSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-portal"
+                    aria-labelledby="settings-tab-portal"
+                    tabIndex={0}
+                    className={activeTab === "portal" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("portal") && (
+                      <Suspense fallback={null}>
+                        <LazyPortalSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-toolbar"
+                    aria-labelledby="settings-tab-toolbar"
+                    tabIndex={0}
+                    className={activeTab === "toolbar" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("toolbar") && (
+                      <Suspense fallback={null}>
+                        <LazyToolbarSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-notifications"
+                    aria-labelledby="settings-tab-notifications"
+                    tabIndex={0}
+                    className={activeTab === "notifications" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("notifications") && (
+                      <Suspense fallback={null}>
+                        <LazyNotificationSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-integrations"
+                    aria-labelledby="settings-tab-integrations"
+                    tabIndex={0}
+                    className={activeTab === "integrations" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("integrations") && (
+                      <Suspense fallback={null}>
+                        <LazyIntegrationsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-voice"
+                    aria-labelledby="settings-tab-voice"
+                    tabIndex={0}
+                    className={activeTab === "voice" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("voice") && (
+                      <Suspense fallback={null}>
+                        <LazyVoiceInputSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-mcp"
+                    aria-labelledby="settings-tab-mcp"
+                    tabIndex={0}
+                    className={activeTab === "mcp" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("mcp") && (
+                      <Suspense fallback={null}>
+                        <LazyMcpServerSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-environment"
+                    aria-labelledby="settings-tab-environment"
+                    tabIndex={0}
+                    className={activeTab === "environment" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("environment") && (
+                      <Suspense fallback={null}>
+                        <LazyEnvironmentSettingsTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-privacy"
+                    aria-labelledby="settings-tab-privacy"
+                    tabIndex={0}
+                    className={activeTab === "privacy" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("privacy") && (
+                      <Suspense fallback={null}>
+                        <LazyPrivacyDataTab
+                          activeSubtab={activeSubtabs["privacy"] ?? null}
+                          onSubtabChange={(id) =>
+                            setActiveSubtabs((prev) => ({ ...prev, privacy: id }))
+                          }
+                        />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  <div
+                    role="tabpanel"
+                    id="settings-panel-troubleshooting"
+                    aria-labelledby="settings-tab-troubleshooting"
+                    tabIndex={0}
+                    className={activeTab === "troubleshooting" ? "" : "hidden"}
+                  >
+                    {visitedTabs.has("troubleshooting") && (
+                      <Suspense fallback={null}>
+                        <LazyTroubleshootingTab />
+                      </Suspense>
+                    )}
+                  </div>
+
+                  {/* Project settings panels */}
+                  {activeScope === "project" && projectId && (
+                    <>
+                      {projectForm.projectIsLoading && (
+                        <div className="text-sm text-daintree-text/60 text-center py-8">
+                          Loading settings...
+                        </div>
+                      )}
+                      {projectForm.projectError && (
+                        <div
+                          className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
+                          role="alert"
+                        >
+                          Failed to load settings: {projectForm.projectError}
+                        </div>
+                      )}
+                      {projectForm.projectAutoSaveError && (
+                        <div
+                          className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
+                          role="alert"
+                        >
+                          {projectForm.projectAutoSaveError}
+                        </div>
+                      )}
+                      {!projectForm.projectIsLoading && !projectForm.projectError && (
+                        <>
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:general"
+                            aria-labelledby="settings-tab-project:general"
+                            tabIndex={0}
+                            className={activeTab === "project:general" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:general") && (
+                              <ProjectGeneralTab
+                                currentProject={projectForm.currentProject}
+                                name={projectForm.projectName}
+                                onNameChange={projectForm.setProjectName}
+                                emoji={projectForm.projectEmoji}
+                                onEmojiChange={projectForm.setProjectEmoji}
+                                color={projectForm.projectColor}
+                                onColorChange={projectForm.setProjectColor}
+                                devServerCommand={projectForm.devServerCommand}
+                                onDevServerCommandChange={projectForm.setDevServerCommand}
+                                devServerLoadTimeout={projectForm.devServerLoadTimeout}
+                                onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
+                                turbopackEnabled={projectForm.turbopackEnabled}
+                                onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
+                                projectIconSvg={projectForm.projectIconSvg}
+                                onProjectIconSvgChange={projectForm.setProjectIconSvg}
+                                enableInRepoSettings={projectForm.enableInRepoSettings}
+                                disableInRepoSettings={projectForm.disableInRepoSettings}
+                                projectId={projectId}
+                                isOpen={isOpen}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:context"
+                            aria-labelledby="settings-tab-project:context"
+                            tabIndex={0}
+                            className={activeTab === "project:context" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:context") && (
+                              <ProjectContextTab
+                                excludedPaths={projectForm.excludedPaths}
+                                onExcludedPathsChange={projectForm.setExcludedPaths}
+                                copyTreeSettings={projectForm.copyTreeSettings}
+                                onCopyTreeSettingsChange={projectForm.setCopyTreeSettings}
+                                worktrees={projectForm.worktrees}
+                                isOpen={isOpen}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:variables"
+                            aria-labelledby="settings-tab-project:variables"
+                            tabIndex={0}
+                            className={activeTab === "project:variables" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:variables") && (
+                              <EnvironmentVariablesEditor
+                                environmentVariables={projectForm.environmentVariables}
+                                onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
+                                settings={projectForm.projectSettings}
+                                isOpen={isOpen}
+                                onFlush={projectForm.flush}
+                                projectLabel={projectLabel}
+                                globalEnvironmentVariables={globalEnvVars}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:automation"
+                            aria-labelledby="settings-tab-project:automation"
+                            tabIndex={0}
+                            className={activeTab === "project:automation" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:automation") && (
+                              <ProjectAutomationTab
+                                currentProject={projectForm.currentProject}
+                                runCommands={projectForm.runCommands}
+                                onRunCommandsChange={projectForm.setRunCommands}
+                                defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
+                                onDefaultWorktreeRecipeIdChange={
+                                  projectForm.setDefaultWorktreeRecipeId
+                                }
+                                branchPrefixMode={projectForm.branchPrefixMode}
+                                onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
+                                branchPrefixCustom={projectForm.branchPrefixCustom}
+                                onBranchPrefixCustomChange={projectForm.setBranchPrefixCustom}
+                                worktreePathPattern={projectForm.worktreePathPattern}
+                                onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
+                                terminalShell={projectForm.terminalShell}
+                                onTerminalShellChange={projectForm.setTerminalShell}
+                                terminalShellArgs={projectForm.terminalShellArgs}
+                                onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
+                                terminalDefaultCwd={projectForm.terminalDefaultCwd}
+                                onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
+                                terminalScrollback={projectForm.terminalScrollback}
+                                onTerminalScrollbackChange={projectForm.setTerminalScrollback}
+                                recipes={projectForm.recipes}
+                                recipesLoading={projectForm.recipesLoading}
+                                onNavigateToRecipes={() => {
+                                  markTabVisited("project:recipes");
+                                  startTransition(() => setActiveTab("project:recipes"));
+                                }}
+                                resourceEnvironments={projectForm.resourceEnvironments}
+                                onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
+                                activeResourceEnvironment={projectForm.activeResourceEnvironment}
+                                onActiveResourceEnvironmentChange={
+                                  projectForm.setActiveResourceEnvironment
+                                }
+                                defaultWorktreeMode={projectForm.defaultWorktreeMode}
+                                onDefaultWorktreeModeChange={projectForm.setDefaultWorktreeMode}
+                                isOpen={isOpen}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:recipes"
+                            aria-labelledby="settings-tab-project:recipes"
+                            tabIndex={0}
+                            className={activeTab === "project:recipes" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:recipes") && (
+                              <ProjectRecipesTab
+                                projectId={projectId}
+                                defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
+                                onDefaultWorktreeRecipeIdChange={
+                                  projectForm.setDefaultWorktreeRecipeId
+                                }
+                                worktreeMap={projectForm.worktreeMap}
+                                isOpen={isOpen}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:commands"
+                            aria-labelledby="settings-tab-project:commands"
+                            tabIndex={0}
+                            className={activeTab === "project:commands" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:commands") && (
+                              <CommandOverridesTab
+                                projectId={projectId}
+                                overrides={projectForm.commandOverrides}
+                                onChange={projectForm.setCommandOverrides}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:notifications"
+                            aria-labelledby="settings-tab-project:notifications"
+                            tabIndex={0}
+                            className={activeTab === "project:notifications" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:notifications") && (
+                              <ProjectNotificationsTab
+                                overrides={projectForm.notificationOverrides}
+                                onChange={projectForm.setNotificationOverrides}
+                              />
+                            )}
+                          </div>
+
+                          <div
+                            role="tabpanel"
+                            id="settings-panel-project:github"
+                            aria-labelledby="settings-tab-project:github"
+                            tabIndex={0}
+                            className={activeTab === "project:github" ? "" : "hidden"}
+                          >
+                            {visitedTabs.has("project:github") && projectForm.currentProject && (
+                              <ProjectGitHubTab
+                                githubRemote={projectForm.githubRemote}
+                                onGithubRemoteChange={projectForm.setGithubRemote}
+                                projectPath={projectForm.currentProject.path}
+                              />
+                            )}
+                          </div>
+                        </>
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+            </ScrollShadow>
+          </div>
         </div>
-      </div>
+      </SettingsValidationProvider>
     </AppDialog>
   );
 }

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -210,7 +210,17 @@ function scopeForTab(tab: SettingsTab): SettingsScope {
   return tab.startsWith("project:") ? "project" : "global";
 }
 
-export function SettingsDialog({
+export function SettingsDialog(props: SettingsDialogProps) {
+  // Provider must wrap SettingsDialogInner: the inner component reads the registry
+  // via useContext to render nav-sidebar error dots.
+  return (
+    <SettingsValidationProvider>
+      <SettingsDialogInner {...props} />
+    </SettingsValidationProvider>
+  );
+}
+
+function SettingsDialogInner({
   isOpen,
   onClose,
   defaultTab,
@@ -654,906 +664,902 @@ export function SettingsDialog({
       maxHeight="h-[75vh]"
       className="settings-shell min-h-[500px] max-h-[800px]"
     >
-      <SettingsValidationProvider>
-        <div className="flex h-full overflow-hidden">
-          <div className="settings-sidebar w-52 border-r border-daintree-border p-3 flex flex-col shrink-0">
-            <div className="flex items-center justify-between mb-3 pl-2">
-              <h2 className="text-sm font-semibold text-daintree-text">Settings</h2>
-              {hasProject && (
-                <div className="relative flex items-center">
-                  <select
-                    value={activeScope}
-                    aria-label="Settings scope"
-                    onChange={(e) => {
-                      handleScopeSwitch(e.target.value as SettingsScope);
-                      e.target.blur();
-                    }}
-                    className="appearance-none text-xs py-1 pl-2 pr-6 rounded-[var(--radius-md)] bg-transparent border border-border-strong text-text-secondary hover:text-daintree-text hover:border-daintree-text/30 focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/20 outline-none cursor-pointer transition-colors"
-                  >
-                    <option value="global">Global</option>
-                    <option value="project">Project</option>
-                  </select>
-                  <ChevronDown
-                    size={12}
-                    className="pointer-events-none absolute right-1.5 text-text-secondary"
-                  />
-                </div>
-              )}
-            </div>
-
-            <div
-              className={cn(
-                "flex items-center gap-1.5 px-2 py-1.5 mb-3 rounded-[var(--radius-md)]",
-                "settings-search border border-border-strong",
-                "focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
-              )}
-            >
-              <Search
-                className="settings-search-icon w-3.5 h-3.5 shrink-0 pointer-events-none"
-                aria-hidden="true"
-              />
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder="Search…"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={handleSearchKeyDown}
-                aria-label="Search settings"
-                className="settings-search-input flex-1 min-w-0 text-xs bg-transparent text-daintree-text focus:outline-none"
-              />
-              {searchQuery && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSearchQuery("");
-                    searchInputRef.current?.focus();
+      <div className="flex h-full overflow-hidden">
+        <div className="settings-sidebar w-52 border-r border-daintree-border p-3 flex flex-col shrink-0">
+          <div className="flex items-center justify-between mb-3 pl-2">
+            <h2 className="text-sm font-semibold text-daintree-text">Settings</h2>
+            {hasProject && (
+              <div className="relative flex items-center">
+                <select
+                  value={activeScope}
+                  aria-label="Settings scope"
+                  onChange={(e) => {
+                    handleScopeSwitch(e.target.value as SettingsScope);
+                    e.target.blur();
                   }}
-                  aria-label="Clear search"
-                  className="flex items-center justify-center w-5 h-5 rounded shrink-0 text-daintree-text/40 hover:text-daintree-text"
+                  className="appearance-none text-xs py-1 pl-2 pr-6 rounded-[var(--radius-md)] bg-transparent border border-border-strong text-text-secondary hover:text-daintree-text hover:border-daintree-text/30 focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/20 outline-none cursor-pointer transition-colors"
                 >
-                  <X className="w-3 h-3" />
-                </button>
-              )}
-            </div>
-
-            {isSearching && (
-              <p aria-live="polite" className="sr-only">
-                {searchResults.length === 0
-                  ? "No results found"
-                  : `${searchResults.length} result${searchResults.length === 1 ? "" : "s"} found`}
-              </p>
+                  <option value="global">Global</option>
+                  <option value="project">Project</option>
+                </select>
+                <ChevronDown
+                  size={12}
+                  className="pointer-events-none absolute right-1.5 text-text-secondary"
+                />
+              </div>
             )}
+          </div>
 
-            <ScrollShadow
-              className="flex-1 min-h-0"
-              scrollClassName="space-y-3"
-              ref={tablistRef}
-              role="tablist"
-              aria-orientation="vertical"
-              aria-label="Settings sections"
-              onKeyDown={handleTablistKeyDown}
-            >
-              {activeScope === "global" ? (
-                <>
-                  <NavGroup label="General">
-                    <NavItem
-                      tab="general"
-                      icon={<Settings2 className="w-4 h-4" />}
-                      label="General"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.general}
-                      modified={modifiedTabs.has("general")}
-                      hasError={tabsWithErrors.has("general")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="terminalAppearance"
-                      icon={<SquareTerminal className="w-4 h-4" />}
-                      label="Appearance"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.terminalAppearance}
-                      modified={modifiedTabs.has("terminalAppearance")}
-                      hasError={tabsWithErrors.has("terminalAppearance")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="keyboard"
-                      icon={<Keyboard className="w-4 h-4" />}
-                      label="Keyboard"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.keyboard}
-                      hasError={tabsWithErrors.has("keyboard")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="notifications"
-                      icon={<Bell className="w-4 h-4" />}
-                      label="Notifications"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.notifications}
-                      hasError={tabsWithErrors.has("notifications")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="privacy"
-                      icon={<Shield className="w-4 h-4" />}
-                      label="Privacy & Data"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.privacy}
-                      hasError={tabsWithErrors.has("privacy")}
-                      onSelect={handleNavSelect}
-                    />
-                  </NavGroup>
-                  <NavGroup label="Terminal">
-                    <NavItem
-                      tab="terminal"
-                      icon={<LayoutGrid className="w-4 h-4" />}
-                      label="Panel Grid"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.terminal}
-                      modified={modifiedTabs.has("terminal")}
-                      hasError={tabsWithErrors.has("terminal")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="worktree"
-                      icon={<WorktreeIcon className="w-4 h-4" />}
-                      label="Worktree"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.worktree}
-                      hasError={tabsWithErrors.has("worktree")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="toolbar"
-                      icon={<SettingsIcon className="w-4 h-4" />}
-                      label="Toolbar"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.toolbar}
-                      hasError={tabsWithErrors.has("toolbar")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="environment"
-                      icon={<KeyRound className="w-4 h-4" />}
-                      label="Environment"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.environment}
-                      hasError={tabsWithErrors.has("environment")}
-                      onSelect={handleNavSelect}
-                    />
-                  </NavGroup>
-                  <NavGroup label="Integrations">
-                    <NavItem
-                      tab="agents"
-                      icon={<DaintreeAgentIcon className="w-4 h-4" />}
-                      label="CLI Agents"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.agents}
-                      hasError={tabsWithErrors.has("agents")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="github"
-                      icon={<Github className="w-4 h-4" />}
-                      label="GitHub"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.github}
-                      hasError={tabsWithErrors.has("github")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="integrations"
-                      icon={<Blocks className="w-4 h-4" />}
-                      label="Integrations"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.integrations}
-                      hasError={tabsWithErrors.has("integrations")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="voice"
-                      icon={<Mic className="w-4 h-4" />}
-                      label="Voice Input"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.voice}
-                      hasError={tabsWithErrors.has("voice")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="portal"
-                      icon={<PanelRight className="w-4 h-4" />}
-                      label="Portal"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.portal}
-                      hasError={tabsWithErrors.has("portal")}
-                      onSelect={handleNavSelect}
-                    />
-                    <NavItem
-                      tab="mcp"
-                      icon={<McpServerIcon className="w-4 h-4" />}
-                      label="MCP Server"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.mcp}
-                      hasError={tabsWithErrors.has("mcp")}
-                      onSelect={handleNavSelect}
-                    />
-                  </NavGroup>
+          <div
+            className={cn(
+              "flex items-center gap-1.5 px-2 py-1.5 mb-3 rounded-[var(--radius-md)]",
+              "settings-search border border-border-strong",
+              "focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
+            )}
+          >
+            <Search
+              className="settings-search-icon w-3.5 h-3.5 shrink-0 pointer-events-none"
+              aria-hidden="true"
+            />
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+              aria-label="Search settings"
+              className="settings-search-input flex-1 min-w-0 text-xs bg-transparent text-daintree-text focus:outline-none"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => {
+                  setSearchQuery("");
+                  searchInputRef.current?.focus();
+                }}
+                aria-label="Clear search"
+                className="flex items-center justify-center w-5 h-5 rounded shrink-0 text-daintree-text/40 hover:text-daintree-text"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
 
-                  <NavGroup label="Support">
-                    <NavItem
-                      tab="troubleshooting"
-                      icon={<LifeBuoy className="w-4 h-4" />}
-                      label="Troubleshooting"
-                      activeTab={activeTab}
-                      isSearching={isSearching}
-                      matchCount={matchCounts.troubleshooting}
-                      hasError={tabsWithErrors.has("troubleshooting")}
-                      onSelect={handleNavSelect}
-                    />
-                  </NavGroup>
-                </>
-              ) : (
-                <NavGroup label="Project">
+          {isSearching && (
+            <p aria-live="polite" className="sr-only">
+              {searchResults.length === 0
+                ? "No results found"
+                : `${searchResults.length} result${searchResults.length === 1 ? "" : "s"} found`}
+            </p>
+          )}
+
+          <ScrollShadow
+            className="flex-1 min-h-0"
+            scrollClassName="space-y-3"
+            ref={tablistRef}
+            role="tablist"
+            aria-orientation="vertical"
+            aria-label="Settings sections"
+            onKeyDown={handleTablistKeyDown}
+          >
+            {activeScope === "global" ? (
+              <>
+                <NavGroup label="General">
                   <NavItem
-                    tab="project:general"
-                    icon={<SettingsIcon className="w-4 h-4" />}
+                    tab="general"
+                    icon={<Settings2 className="w-4 h-4" />}
                     label="General"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts["project:general"]}
-                    hasError={tabsWithErrors.has("project:general")}
+                    matchCount={matchCounts.general}
+                    modified={modifiedTabs.has("general")}
+                    hasError={tabsWithErrors.has("general")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="project:context"
-                    icon={<FileCode className="w-4 h-4" />}
-                    label="Context"
+                    tab="terminalAppearance"
+                    icon={<SquareTerminal className="w-4 h-4" />}
+                    label="Appearance"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts["project:context"]}
-                    hasError={tabsWithErrors.has("project:context")}
+                    matchCount={matchCounts.terminalAppearance}
+                    modified={modifiedTabs.has("terminalAppearance")}
+                    hasError={tabsWithErrors.has("terminalAppearance")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="project:variables"
-                    icon={<KeyRound className="w-4 h-4" />}
-                    label="Variables"
+                    tab="keyboard"
+                    icon={<Keyboard className="w-4 h-4" />}
+                    label="Keyboard"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts["project:variables"]}
-                    hasError={tabsWithErrors.has("project:variables")}
+                    matchCount={matchCounts.keyboard}
+                    hasError={tabsWithErrors.has("keyboard")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="project:automation"
-                    icon={<GitBranch className="w-4 h-4" />}
-                    label="Worktree Setup"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts["project:automation"]}
-                    hasError={tabsWithErrors.has("project:automation")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="project:recipes"
-                    icon={<TerminalRecipeIcon className="w-4 h-4" />}
-                    label="Recipes"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts["project:recipes"]}
-                    hasError={tabsWithErrors.has("project:recipes")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="project:commands"
-                    icon={<Command className="w-4 h-4" />}
-                    label="Commands"
-                    activeTab={activeTab}
-                    isSearching={isSearching}
-                    matchCount={matchCounts["project:commands"]}
-                    hasError={tabsWithErrors.has("project:commands")}
-                    onSelect={handleNavSelect}
-                  />
-                  <NavItem
-                    tab="project:notifications"
+                    tab="notifications"
                     icon={<Bell className="w-4 h-4" />}
                     label="Notifications"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts["project:notifications"]}
-                    hasError={tabsWithErrors.has("project:notifications")}
+                    matchCount={matchCounts.notifications}
+                    hasError={tabsWithErrors.has("notifications")}
                     onSelect={handleNavSelect}
                   />
                   <NavItem
-                    tab="project:github"
+                    tab="privacy"
+                    icon={<Shield className="w-4 h-4" />}
+                    label="Privacy & Data"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.privacy}
+                    hasError={tabsWithErrors.has("privacy")}
+                    onSelect={handleNavSelect}
+                  />
+                </NavGroup>
+                <NavGroup label="Terminal">
+                  <NavItem
+                    tab="terminal"
+                    icon={<LayoutGrid className="w-4 h-4" />}
+                    label="Panel Grid"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.terminal}
+                    modified={modifiedTabs.has("terminal")}
+                    hasError={tabsWithErrors.has("terminal")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="worktree"
+                    icon={<WorktreeIcon className="w-4 h-4" />}
+                    label="Worktree"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.worktree}
+                    hasError={tabsWithErrors.has("worktree")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="toolbar"
+                    icon={<SettingsIcon className="w-4 h-4" />}
+                    label="Toolbar"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.toolbar}
+                    hasError={tabsWithErrors.has("toolbar")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="environment"
+                    icon={<KeyRound className="w-4 h-4" />}
+                    label="Environment"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.environment}
+                    hasError={tabsWithErrors.has("environment")}
+                    onSelect={handleNavSelect}
+                  />
+                </NavGroup>
+                <NavGroup label="Integrations">
+                  <NavItem
+                    tab="agents"
+                    icon={<DaintreeAgentIcon className="w-4 h-4" />}
+                    label="CLI Agents"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.agents}
+                    hasError={tabsWithErrors.has("agents")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="github"
                     icon={<Github className="w-4 h-4" />}
                     label="GitHub"
                     activeTab={activeTab}
                     isSearching={isSearching}
-                    matchCount={matchCounts["project:github"]}
-                    hasError={tabsWithErrors.has("project:github")}
+                    matchCount={matchCounts.github}
+                    hasError={tabsWithErrors.has("github")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="integrations"
+                    icon={<Blocks className="w-4 h-4" />}
+                    label="Integrations"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.integrations}
+                    hasError={tabsWithErrors.has("integrations")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="voice"
+                    icon={<Mic className="w-4 h-4" />}
+                    label="Voice Input"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.voice}
+                    hasError={tabsWithErrors.has("voice")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="portal"
+                    icon={<PanelRight className="w-4 h-4" />}
+                    label="Portal"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.portal}
+                    hasError={tabsWithErrors.has("portal")}
+                    onSelect={handleNavSelect}
+                  />
+                  <NavItem
+                    tab="mcp"
+                    icon={<McpServerIcon className="w-4 h-4" />}
+                    label="MCP Server"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.mcp}
+                    hasError={tabsWithErrors.has("mcp")}
                     onSelect={handleNavSelect}
                   />
                 </NavGroup>
-              )}
-            </ScrollShadow>
 
-            <div className="pt-2 mt-2 border-t border-daintree-border px-2">
-              <span className="settings-meta font-mono">{appVersion}</span>
-            </div>
-          </div>
-
-          <div className="settings-shell flex-1 flex flex-col min-w-0">
-            <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-daintree-border shrink-0">
-              <h3 className="text-lg font-medium text-daintree-text flex items-center gap-2">
-                {isSearching ? (
-                  <>
-                    <Search className="w-5 h-5 text-text-secondary" />
-                    Search Results
-                  </>
-                ) : (
-                  <>
-                    {tabIcons[activeTab]}
-                    {tabTitles[activeTab]}
-                  </>
-                )}
-              </h3>
-              <button
-                onClick={handleClose}
-                className="text-daintree-text/60 hover:text-daintree-text transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                aria-label="Close settings"
-              >
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-
-            <ScrollShadow className="flex-1" scrollClassName="p-6">
-              {isSearching ? (
-                <div role="region" aria-label="Search results">
-                  <SearchResults
-                    results={searchResults}
-                    query={deferredQuery}
-                    cleanQuery={cleanSearchQuery}
-                    onResultClick={handleResultClick}
-                    activeIndex={activeResultIndex}
+                <NavGroup label="Support">
+                  <NavItem
+                    tab="troubleshooting"
+                    icon={<LifeBuoy className="w-4 h-4" />}
+                    label="Troubleshooting"
+                    activeTab={activeTab}
+                    isSearching={isSearching}
+                    matchCount={matchCounts.troubleshooting}
+                    hasError={tabsWithErrors.has("troubleshooting")}
+                    onSelect={handleNavSelect}
                   />
-                </div>
-              ) : (
-                <>
-                  {hiddenSettingBanner && (
-                    <div
-                      className="text-sm text-status-warning bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)] p-3 mb-4 flex items-start justify-between gap-3"
-                      role="alert"
-                    >
-                      <div className="flex items-start gap-2">
-                        <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
-                        <span>
-                          This setting is only visible when{" "}
-                          <button
-                            className="underline font-medium hover:opacity-80"
-                            onClick={() => {
-                              const parent = SETTINGS_SEARCH_INDEX.find(
-                                (e) => e.id === hiddenSettingBanner.settingId
-                              );
-                              if (parent) {
-                                handleResultClick(
-                                  {
-                                    tab: parent.tab,
-                                    subtab: parent.subtab,
-                                    sectionId: parent.id,
-                                  },
-                                  parent.requiresEnabled
-                                );
-                              }
-                            }}
-                          >
-                            {hiddenSettingBanner.label}
-                          </button>{" "}
-                          is enabled.
-                        </span>
-                      </div>
-                      <button
-                        aria-label="Dismiss"
-                        onClick={() => setHiddenSettingBanner(null)}
-                        className="shrink-0 opacity-60 hover:opacity-100"
-                      >
-                        <X className="w-4 h-4" />
-                      </button>
-                    </div>
-                  )}
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-general"
-                    aria-labelledby="settings-tab-general"
-                    tabIndex={0}
-                    className={activeTab === "general" ? "" : "hidden"}
-                  >
-                    <GeneralTab
-                      appVersion={appVersion}
-                      onNavigateToAgents={(agentId?: string) => {
-                        markTabVisited("agents");
-                        if (agentId) {
-                          setActiveSubtabs((prev) => ({ ...prev, agents: agentId }));
-                        }
-                        startTransition(() => setActiveTab("agents"));
-                      }}
-                      activeSubtab={activeSubtabs["general"] ?? null}
-                      onSubtabChange={(id) =>
-                        setActiveSubtabs((prev) => ({ ...prev, general: id }))
-                      }
-                    />
-                  </div>
+                </NavGroup>
+              </>
+            ) : (
+              <NavGroup label="Project">
+                <NavItem
+                  tab="project:general"
+                  icon={<SettingsIcon className="w-4 h-4" />}
+                  label="General"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:general"]}
+                  hasError={tabsWithErrors.has("project:general")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:context"
+                  icon={<FileCode className="w-4 h-4" />}
+                  label="Context"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:context"]}
+                  hasError={tabsWithErrors.has("project:context")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:variables"
+                  icon={<KeyRound className="w-4 h-4" />}
+                  label="Variables"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:variables"]}
+                  hasError={tabsWithErrors.has("project:variables")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:automation"
+                  icon={<GitBranch className="w-4 h-4" />}
+                  label="Worktree Setup"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:automation"]}
+                  hasError={tabsWithErrors.has("project:automation")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:recipes"
+                  icon={<TerminalRecipeIcon className="w-4 h-4" />}
+                  label="Recipes"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:recipes"]}
+                  hasError={tabsWithErrors.has("project:recipes")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:commands"
+                  icon={<Command className="w-4 h-4" />}
+                  label="Commands"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:commands"]}
+                  hasError={tabsWithErrors.has("project:commands")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:notifications"
+                  icon={<Bell className="w-4 h-4" />}
+                  label="Notifications"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:notifications"]}
+                  hasError={tabsWithErrors.has("project:notifications")}
+                  onSelect={handleNavSelect}
+                />
+                <NavItem
+                  tab="project:github"
+                  icon={<Github className="w-4 h-4" />}
+                  label="GitHub"
+                  activeTab={activeTab}
+                  isSearching={isSearching}
+                  matchCount={matchCounts["project:github"]}
+                  hasError={tabsWithErrors.has("project:github")}
+                  onSelect={handleNavSelect}
+                />
+              </NavGroup>
+            )}
+          </ScrollShadow>
 
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-keyboard"
-                    aria-labelledby="settings-tab-keyboard"
-                    tabIndex={0}
-                    className={activeTab === "keyboard" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("keyboard") && (
-                      <Suspense fallback={null}>
-                        <LazyKeyboardShortcutsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-terminal"
-                    aria-labelledby="settings-tab-terminal"
-                    tabIndex={0}
-                    className={activeTab === "terminal" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("terminal") && (
-                      <Suspense fallback={null}>
-                        <LazyTerminalSettingsTab
-                          activeSubtab={activeSubtabs["terminal"] ?? null}
-                          onSubtabChange={(id) =>
-                            setActiveSubtabs((prev) => ({ ...prev, terminal: id }))
-                          }
-                        />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-terminalAppearance"
-                    aria-labelledby="settings-tab-terminalAppearance"
-                    tabIndex={0}
-                    className={activeTab === "terminalAppearance" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("terminalAppearance") && (
-                      <Suspense fallback={null}>
-                        <LazyTerminalAppearanceTab
-                          activeSubtab={activeSubtabs["terminalAppearance"] ?? null}
-                          onSubtabChange={(id) =>
-                            setActiveSubtabs((prev) => ({ ...prev, terminalAppearance: id }))
-                          }
-                        />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-worktree"
-                    aria-labelledby="settings-tab-worktree"
-                    tabIndex={0}
-                    className={activeTab === "worktree" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("worktree") && (
-                      <Suspense fallback={null}>
-                        <LazyWorktreeSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-agents"
-                    aria-labelledby="settings-tab-agents"
-                    tabIndex={0}
-                    className={activeTab === "agents" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("agents") && (
-                      <Suspense fallback={null}>
-                        <LazyAgentSettings
-                          activeSubtab={activeSubtabs["agents"] ?? null}
-                          onSubtabChange={(id) =>
-                            setActiveSubtabs((prev) => ({ ...prev, agents: id }))
-                          }
-                          onSettingsChange={onSettingsChange}
-                        />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-github"
-                    aria-labelledby="settings-tab-github"
-                    tabIndex={0}
-                    className={activeTab === "github" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("github") && (
-                      <Suspense fallback={null}>
-                        <LazyGitHubSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-portal"
-                    aria-labelledby="settings-tab-portal"
-                    tabIndex={0}
-                    className={activeTab === "portal" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("portal") && (
-                      <Suspense fallback={null}>
-                        <LazyPortalSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-toolbar"
-                    aria-labelledby="settings-tab-toolbar"
-                    tabIndex={0}
-                    className={activeTab === "toolbar" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("toolbar") && (
-                      <Suspense fallback={null}>
-                        <LazyToolbarSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-notifications"
-                    aria-labelledby="settings-tab-notifications"
-                    tabIndex={0}
-                    className={activeTab === "notifications" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("notifications") && (
-                      <Suspense fallback={null}>
-                        <LazyNotificationSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-integrations"
-                    aria-labelledby="settings-tab-integrations"
-                    tabIndex={0}
-                    className={activeTab === "integrations" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("integrations") && (
-                      <Suspense fallback={null}>
-                        <LazyIntegrationsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-voice"
-                    aria-labelledby="settings-tab-voice"
-                    tabIndex={0}
-                    className={activeTab === "voice" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("voice") && (
-                      <Suspense fallback={null}>
-                        <LazyVoiceInputSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-mcp"
-                    aria-labelledby="settings-tab-mcp"
-                    tabIndex={0}
-                    className={activeTab === "mcp" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("mcp") && (
-                      <Suspense fallback={null}>
-                        <LazyMcpServerSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-environment"
-                    aria-labelledby="settings-tab-environment"
-                    tabIndex={0}
-                    className={activeTab === "environment" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("environment") && (
-                      <Suspense fallback={null}>
-                        <LazyEnvironmentSettingsTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-privacy"
-                    aria-labelledby="settings-tab-privacy"
-                    tabIndex={0}
-                    className={activeTab === "privacy" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("privacy") && (
-                      <Suspense fallback={null}>
-                        <LazyPrivacyDataTab
-                          activeSubtab={activeSubtabs["privacy"] ?? null}
-                          onSubtabChange={(id) =>
-                            setActiveSubtabs((prev) => ({ ...prev, privacy: id }))
-                          }
-                        />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  <div
-                    role="tabpanel"
-                    id="settings-panel-troubleshooting"
-                    aria-labelledby="settings-tab-troubleshooting"
-                    tabIndex={0}
-                    className={activeTab === "troubleshooting" ? "" : "hidden"}
-                  >
-                    {visitedTabs.has("troubleshooting") && (
-                      <Suspense fallback={null}>
-                        <LazyTroubleshootingTab />
-                      </Suspense>
-                    )}
-                  </div>
-
-                  {/* Project settings panels */}
-                  {activeScope === "project" && projectId && (
-                    <>
-                      {projectForm.projectIsLoading && (
-                        <div className="text-sm text-daintree-text/60 text-center py-8">
-                          Loading settings...
-                        </div>
-                      )}
-                      {projectForm.projectError && (
-                        <div
-                          className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
-                          role="alert"
-                        >
-                          Failed to load settings: {projectForm.projectError}
-                        </div>
-                      )}
-                      {projectForm.projectAutoSaveError && (
-                        <div
-                          className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
-                          role="alert"
-                        >
-                          {projectForm.projectAutoSaveError}
-                        </div>
-                      )}
-                      {!projectForm.projectIsLoading && !projectForm.projectError && (
-                        <>
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:general"
-                            aria-labelledby="settings-tab-project:general"
-                            tabIndex={0}
-                            className={activeTab === "project:general" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:general") && (
-                              <ProjectGeneralTab
-                                currentProject={projectForm.currentProject}
-                                name={projectForm.projectName}
-                                onNameChange={projectForm.setProjectName}
-                                emoji={projectForm.projectEmoji}
-                                onEmojiChange={projectForm.setProjectEmoji}
-                                color={projectForm.projectColor}
-                                onColorChange={projectForm.setProjectColor}
-                                devServerCommand={projectForm.devServerCommand}
-                                onDevServerCommandChange={projectForm.setDevServerCommand}
-                                devServerLoadTimeout={projectForm.devServerLoadTimeout}
-                                onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
-                                turbopackEnabled={projectForm.turbopackEnabled}
-                                onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
-                                projectIconSvg={projectForm.projectIconSvg}
-                                onProjectIconSvgChange={projectForm.setProjectIconSvg}
-                                enableInRepoSettings={projectForm.enableInRepoSettings}
-                                disableInRepoSettings={projectForm.disableInRepoSettings}
-                                projectId={projectId}
-                                isOpen={isOpen}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:context"
-                            aria-labelledby="settings-tab-project:context"
-                            tabIndex={0}
-                            className={activeTab === "project:context" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:context") && (
-                              <ProjectContextTab
-                                excludedPaths={projectForm.excludedPaths}
-                                onExcludedPathsChange={projectForm.setExcludedPaths}
-                                copyTreeSettings={projectForm.copyTreeSettings}
-                                onCopyTreeSettingsChange={projectForm.setCopyTreeSettings}
-                                worktrees={projectForm.worktrees}
-                                isOpen={isOpen}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:variables"
-                            aria-labelledby="settings-tab-project:variables"
-                            tabIndex={0}
-                            className={activeTab === "project:variables" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:variables") && (
-                              <EnvironmentVariablesEditor
-                                environmentVariables={projectForm.environmentVariables}
-                                onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
-                                settings={projectForm.projectSettings}
-                                isOpen={isOpen}
-                                onFlush={projectForm.flush}
-                                projectLabel={projectLabel}
-                                globalEnvironmentVariables={globalEnvVars}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:automation"
-                            aria-labelledby="settings-tab-project:automation"
-                            tabIndex={0}
-                            className={activeTab === "project:automation" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:automation") && (
-                              <ProjectAutomationTab
-                                currentProject={projectForm.currentProject}
-                                runCommands={projectForm.runCommands}
-                                onRunCommandsChange={projectForm.setRunCommands}
-                                defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-                                onDefaultWorktreeRecipeIdChange={
-                                  projectForm.setDefaultWorktreeRecipeId
-                                }
-                                branchPrefixMode={projectForm.branchPrefixMode}
-                                onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
-                                branchPrefixCustom={projectForm.branchPrefixCustom}
-                                onBranchPrefixCustomChange={projectForm.setBranchPrefixCustom}
-                                worktreePathPattern={projectForm.worktreePathPattern}
-                                onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
-                                terminalShell={projectForm.terminalShell}
-                                onTerminalShellChange={projectForm.setTerminalShell}
-                                terminalShellArgs={projectForm.terminalShellArgs}
-                                onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
-                                terminalDefaultCwd={projectForm.terminalDefaultCwd}
-                                onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
-                                terminalScrollback={projectForm.terminalScrollback}
-                                onTerminalScrollbackChange={projectForm.setTerminalScrollback}
-                                recipes={projectForm.recipes}
-                                recipesLoading={projectForm.recipesLoading}
-                                onNavigateToRecipes={() => {
-                                  markTabVisited("project:recipes");
-                                  startTransition(() => setActiveTab("project:recipes"));
-                                }}
-                                resourceEnvironments={projectForm.resourceEnvironments}
-                                onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
-                                activeResourceEnvironment={projectForm.activeResourceEnvironment}
-                                onActiveResourceEnvironmentChange={
-                                  projectForm.setActiveResourceEnvironment
-                                }
-                                defaultWorktreeMode={projectForm.defaultWorktreeMode}
-                                onDefaultWorktreeModeChange={projectForm.setDefaultWorktreeMode}
-                                isOpen={isOpen}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:recipes"
-                            aria-labelledby="settings-tab-project:recipes"
-                            tabIndex={0}
-                            className={activeTab === "project:recipes" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:recipes") && (
-                              <ProjectRecipesTab
-                                projectId={projectId}
-                                defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-                                onDefaultWorktreeRecipeIdChange={
-                                  projectForm.setDefaultWorktreeRecipeId
-                                }
-                                worktreeMap={projectForm.worktreeMap}
-                                isOpen={isOpen}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:commands"
-                            aria-labelledby="settings-tab-project:commands"
-                            tabIndex={0}
-                            className={activeTab === "project:commands" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:commands") && (
-                              <CommandOverridesTab
-                                projectId={projectId}
-                                overrides={projectForm.commandOverrides}
-                                onChange={projectForm.setCommandOverrides}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:notifications"
-                            aria-labelledby="settings-tab-project:notifications"
-                            tabIndex={0}
-                            className={activeTab === "project:notifications" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:notifications") && (
-                              <ProjectNotificationsTab
-                                overrides={projectForm.notificationOverrides}
-                                onChange={projectForm.setNotificationOverrides}
-                              />
-                            )}
-                          </div>
-
-                          <div
-                            role="tabpanel"
-                            id="settings-panel-project:github"
-                            aria-labelledby="settings-tab-project:github"
-                            tabIndex={0}
-                            className={activeTab === "project:github" ? "" : "hidden"}
-                          >
-                            {visitedTabs.has("project:github") && projectForm.currentProject && (
-                              <ProjectGitHubTab
-                                githubRemote={projectForm.githubRemote}
-                                onGithubRemoteChange={projectForm.setGithubRemote}
-                                projectPath={projectForm.currentProject.path}
-                              />
-                            )}
-                          </div>
-                        </>
-                      )}
-                    </>
-                  )}
-                </>
-              )}
-            </ScrollShadow>
+          <div className="pt-2 mt-2 border-t border-daintree-border px-2">
+            <span className="settings-meta font-mono">{appVersion}</span>
           </div>
         </div>
-      </SettingsValidationProvider>
+
+        <div className="settings-shell flex-1 flex flex-col min-w-0">
+          <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-daintree-border shrink-0">
+            <h3 className="text-lg font-medium text-daintree-text flex items-center gap-2">
+              {isSearching ? (
+                <>
+                  <Search className="w-5 h-5 text-text-secondary" />
+                  Search Results
+                </>
+              ) : (
+                <>
+                  {tabIcons[activeTab]}
+                  {tabTitles[activeTab]}
+                </>
+              )}
+            </h3>
+            <button
+              onClick={handleClose}
+              className="text-daintree-text/60 hover:text-daintree-text transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              aria-label="Close settings"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          <ScrollShadow className="flex-1" scrollClassName="p-6">
+            {isSearching ? (
+              <div role="region" aria-label="Search results">
+                <SearchResults
+                  results={searchResults}
+                  query={deferredQuery}
+                  cleanQuery={cleanSearchQuery}
+                  onResultClick={handleResultClick}
+                  activeIndex={activeResultIndex}
+                />
+              </div>
+            ) : (
+              <>
+                {hiddenSettingBanner && (
+                  <div
+                    className="text-sm text-status-warning bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)] p-3 mb-4 flex items-start justify-between gap-3"
+                    role="alert"
+                  >
+                    <div className="flex items-start gap-2">
+                      <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+                      <span>
+                        This setting is only visible when{" "}
+                        <button
+                          className="underline font-medium hover:opacity-80"
+                          onClick={() => {
+                            const parent = SETTINGS_SEARCH_INDEX.find(
+                              (e) => e.id === hiddenSettingBanner.settingId
+                            );
+                            if (parent) {
+                              handleResultClick(
+                                {
+                                  tab: parent.tab,
+                                  subtab: parent.subtab,
+                                  sectionId: parent.id,
+                                },
+                                parent.requiresEnabled
+                              );
+                            }
+                          }}
+                        >
+                          {hiddenSettingBanner.label}
+                        </button>{" "}
+                        is enabled.
+                      </span>
+                    </div>
+                    <button
+                      aria-label="Dismiss"
+                      onClick={() => setHiddenSettingBanner(null)}
+                      className="shrink-0 opacity-60 hover:opacity-100"
+                    >
+                      <X className="w-4 h-4" />
+                    </button>
+                  </div>
+                )}
+                <div
+                  role="tabpanel"
+                  id="settings-panel-general"
+                  aria-labelledby="settings-tab-general"
+                  tabIndex={0}
+                  className={activeTab === "general" ? "" : "hidden"}
+                >
+                  <GeneralTab
+                    appVersion={appVersion}
+                    onNavigateToAgents={(agentId?: string) => {
+                      markTabVisited("agents");
+                      if (agentId) {
+                        setActiveSubtabs((prev) => ({ ...prev, agents: agentId }));
+                      }
+                      startTransition(() => setActiveTab("agents"));
+                    }}
+                    activeSubtab={activeSubtabs["general"] ?? null}
+                    onSubtabChange={(id) => setActiveSubtabs((prev) => ({ ...prev, general: id }))}
+                  />
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-keyboard"
+                  aria-labelledby="settings-tab-keyboard"
+                  tabIndex={0}
+                  className={activeTab === "keyboard" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("keyboard") && (
+                    <Suspense fallback={null}>
+                      <LazyKeyboardShortcutsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-terminal"
+                  aria-labelledby="settings-tab-terminal"
+                  tabIndex={0}
+                  className={activeTab === "terminal" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("terminal") && (
+                    <Suspense fallback={null}>
+                      <LazyTerminalSettingsTab
+                        activeSubtab={activeSubtabs["terminal"] ?? null}
+                        onSubtabChange={(id) =>
+                          setActiveSubtabs((prev) => ({ ...prev, terminal: id }))
+                        }
+                      />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-terminalAppearance"
+                  aria-labelledby="settings-tab-terminalAppearance"
+                  tabIndex={0}
+                  className={activeTab === "terminalAppearance" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("terminalAppearance") && (
+                    <Suspense fallback={null}>
+                      <LazyTerminalAppearanceTab
+                        activeSubtab={activeSubtabs["terminalAppearance"] ?? null}
+                        onSubtabChange={(id) =>
+                          setActiveSubtabs((prev) => ({ ...prev, terminalAppearance: id }))
+                        }
+                      />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-worktree"
+                  aria-labelledby="settings-tab-worktree"
+                  tabIndex={0}
+                  className={activeTab === "worktree" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("worktree") && (
+                    <Suspense fallback={null}>
+                      <LazyWorktreeSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-agents"
+                  aria-labelledby="settings-tab-agents"
+                  tabIndex={0}
+                  className={activeTab === "agents" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("agents") && (
+                    <Suspense fallback={null}>
+                      <LazyAgentSettings
+                        activeSubtab={activeSubtabs["agents"] ?? null}
+                        onSubtabChange={(id) =>
+                          setActiveSubtabs((prev) => ({ ...prev, agents: id }))
+                        }
+                        onSettingsChange={onSettingsChange}
+                      />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-github"
+                  aria-labelledby="settings-tab-github"
+                  tabIndex={0}
+                  className={activeTab === "github" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("github") && (
+                    <Suspense fallback={null}>
+                      <LazyGitHubSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-portal"
+                  aria-labelledby="settings-tab-portal"
+                  tabIndex={0}
+                  className={activeTab === "portal" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("portal") && (
+                    <Suspense fallback={null}>
+                      <LazyPortalSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-toolbar"
+                  aria-labelledby="settings-tab-toolbar"
+                  tabIndex={0}
+                  className={activeTab === "toolbar" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("toolbar") && (
+                    <Suspense fallback={null}>
+                      <LazyToolbarSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-notifications"
+                  aria-labelledby="settings-tab-notifications"
+                  tabIndex={0}
+                  className={activeTab === "notifications" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("notifications") && (
+                    <Suspense fallback={null}>
+                      <LazyNotificationSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-integrations"
+                  aria-labelledby="settings-tab-integrations"
+                  tabIndex={0}
+                  className={activeTab === "integrations" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("integrations") && (
+                    <Suspense fallback={null}>
+                      <LazyIntegrationsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-voice"
+                  aria-labelledby="settings-tab-voice"
+                  tabIndex={0}
+                  className={activeTab === "voice" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("voice") && (
+                    <Suspense fallback={null}>
+                      <LazyVoiceInputSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-mcp"
+                  aria-labelledby="settings-tab-mcp"
+                  tabIndex={0}
+                  className={activeTab === "mcp" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("mcp") && (
+                    <Suspense fallback={null}>
+                      <LazyMcpServerSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-environment"
+                  aria-labelledby="settings-tab-environment"
+                  tabIndex={0}
+                  className={activeTab === "environment" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("environment") && (
+                    <Suspense fallback={null}>
+                      <LazyEnvironmentSettingsTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-privacy"
+                  aria-labelledby="settings-tab-privacy"
+                  tabIndex={0}
+                  className={activeTab === "privacy" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("privacy") && (
+                    <Suspense fallback={null}>
+                      <LazyPrivacyDataTab
+                        activeSubtab={activeSubtabs["privacy"] ?? null}
+                        onSubtabChange={(id) =>
+                          setActiveSubtabs((prev) => ({ ...prev, privacy: id }))
+                        }
+                      />
+                    </Suspense>
+                  )}
+                </div>
+
+                <div
+                  role="tabpanel"
+                  id="settings-panel-troubleshooting"
+                  aria-labelledby="settings-tab-troubleshooting"
+                  tabIndex={0}
+                  className={activeTab === "troubleshooting" ? "" : "hidden"}
+                >
+                  {visitedTabs.has("troubleshooting") && (
+                    <Suspense fallback={null}>
+                      <LazyTroubleshootingTab />
+                    </Suspense>
+                  )}
+                </div>
+
+                {/* Project settings panels */}
+                {activeScope === "project" && projectId && (
+                  <>
+                    {projectForm.projectIsLoading && (
+                      <div className="text-sm text-daintree-text/60 text-center py-8">
+                        Loading settings...
+                      </div>
+                    )}
+                    {projectForm.projectError && (
+                      <div
+                        className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
+                        role="alert"
+                      >
+                        Failed to load settings: {projectForm.projectError}
+                      </div>
+                    )}
+                    {projectForm.projectAutoSaveError && (
+                      <div
+                        className="text-sm text-status-error bg-status-error/10 border border-status-error/20 rounded p-3 mb-4"
+                        role="alert"
+                      >
+                        {projectForm.projectAutoSaveError}
+                      </div>
+                    )}
+                    {!projectForm.projectIsLoading && !projectForm.projectError && (
+                      <>
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:general"
+                          aria-labelledby="settings-tab-project:general"
+                          tabIndex={0}
+                          className={activeTab === "project:general" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:general") && (
+                            <ProjectGeneralTab
+                              currentProject={projectForm.currentProject}
+                              name={projectForm.projectName}
+                              onNameChange={projectForm.setProjectName}
+                              emoji={projectForm.projectEmoji}
+                              onEmojiChange={projectForm.setProjectEmoji}
+                              color={projectForm.projectColor}
+                              onColorChange={projectForm.setProjectColor}
+                              devServerCommand={projectForm.devServerCommand}
+                              onDevServerCommandChange={projectForm.setDevServerCommand}
+                              devServerLoadTimeout={projectForm.devServerLoadTimeout}
+                              onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
+                              turbopackEnabled={projectForm.turbopackEnabled}
+                              onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
+                              projectIconSvg={projectForm.projectIconSvg}
+                              onProjectIconSvgChange={projectForm.setProjectIconSvg}
+                              enableInRepoSettings={projectForm.enableInRepoSettings}
+                              disableInRepoSettings={projectForm.disableInRepoSettings}
+                              projectId={projectId}
+                              isOpen={isOpen}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:context"
+                          aria-labelledby="settings-tab-project:context"
+                          tabIndex={0}
+                          className={activeTab === "project:context" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:context") && (
+                            <ProjectContextTab
+                              excludedPaths={projectForm.excludedPaths}
+                              onExcludedPathsChange={projectForm.setExcludedPaths}
+                              copyTreeSettings={projectForm.copyTreeSettings}
+                              onCopyTreeSettingsChange={projectForm.setCopyTreeSettings}
+                              worktrees={projectForm.worktrees}
+                              isOpen={isOpen}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:variables"
+                          aria-labelledby="settings-tab-project:variables"
+                          tabIndex={0}
+                          className={activeTab === "project:variables" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:variables") && (
+                            <EnvironmentVariablesEditor
+                              environmentVariables={projectForm.environmentVariables}
+                              onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
+                              settings={projectForm.projectSettings}
+                              isOpen={isOpen}
+                              onFlush={projectForm.flush}
+                              projectLabel={projectLabel}
+                              globalEnvironmentVariables={globalEnvVars}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:automation"
+                          aria-labelledby="settings-tab-project:automation"
+                          tabIndex={0}
+                          className={activeTab === "project:automation" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:automation") && (
+                            <ProjectAutomationTab
+                              currentProject={projectForm.currentProject}
+                              runCommands={projectForm.runCommands}
+                              onRunCommandsChange={projectForm.setRunCommands}
+                              defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
+                              onDefaultWorktreeRecipeIdChange={
+                                projectForm.setDefaultWorktreeRecipeId
+                              }
+                              branchPrefixMode={projectForm.branchPrefixMode}
+                              onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
+                              branchPrefixCustom={projectForm.branchPrefixCustom}
+                              onBranchPrefixCustomChange={projectForm.setBranchPrefixCustom}
+                              worktreePathPattern={projectForm.worktreePathPattern}
+                              onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
+                              terminalShell={projectForm.terminalShell}
+                              onTerminalShellChange={projectForm.setTerminalShell}
+                              terminalShellArgs={projectForm.terminalShellArgs}
+                              onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
+                              terminalDefaultCwd={projectForm.terminalDefaultCwd}
+                              onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
+                              terminalScrollback={projectForm.terminalScrollback}
+                              onTerminalScrollbackChange={projectForm.setTerminalScrollback}
+                              recipes={projectForm.recipes}
+                              recipesLoading={projectForm.recipesLoading}
+                              onNavigateToRecipes={() => {
+                                markTabVisited("project:recipes");
+                                startTransition(() => setActiveTab("project:recipes"));
+                              }}
+                              resourceEnvironments={projectForm.resourceEnvironments}
+                              onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
+                              activeResourceEnvironment={projectForm.activeResourceEnvironment}
+                              onActiveResourceEnvironmentChange={
+                                projectForm.setActiveResourceEnvironment
+                              }
+                              defaultWorktreeMode={projectForm.defaultWorktreeMode}
+                              onDefaultWorktreeModeChange={projectForm.setDefaultWorktreeMode}
+                              isOpen={isOpen}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:recipes"
+                          aria-labelledby="settings-tab-project:recipes"
+                          tabIndex={0}
+                          className={activeTab === "project:recipes" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:recipes") && (
+                            <ProjectRecipesTab
+                              projectId={projectId}
+                              defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
+                              onDefaultWorktreeRecipeIdChange={
+                                projectForm.setDefaultWorktreeRecipeId
+                              }
+                              worktreeMap={projectForm.worktreeMap}
+                              isOpen={isOpen}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:commands"
+                          aria-labelledby="settings-tab-project:commands"
+                          tabIndex={0}
+                          className={activeTab === "project:commands" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:commands") && (
+                            <CommandOverridesTab
+                              projectId={projectId}
+                              overrides={projectForm.commandOverrides}
+                              onChange={projectForm.setCommandOverrides}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:notifications"
+                          aria-labelledby="settings-tab-project:notifications"
+                          tabIndex={0}
+                          className={activeTab === "project:notifications" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:notifications") && (
+                            <ProjectNotificationsTab
+                              overrides={projectForm.notificationOverrides}
+                              onChange={projectForm.setNotificationOverrides}
+                            />
+                          )}
+                        </div>
+
+                        <div
+                          role="tabpanel"
+                          id="settings-panel-project:github"
+                          aria-labelledby="settings-tab-project:github"
+                          tabIndex={0}
+                          className={activeTab === "project:github" ? "" : "hidden"}
+                        >
+                          {visitedTabs.has("project:github") && projectForm.currentProject && (
+                            <ProjectGitHubTab
+                              githubRemote={projectForm.githubRemote}
+                              onGithubRemoteChange={projectForm.setGithubRemote}
+                              projectPath={projectForm.currentProject.path}
+                            />
+                          )}
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+              </>
+            )}
+          </ScrollShadow>
+        </div>
+      </div>
     </AppDialog>
   );
 }

--- a/src/components/Settings/SettingsValidationRegistry.tsx
+++ b/src/components/Settings/SettingsValidationRegistry.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import type { SettingsTab } from "./SettingsDialog";
+
+interface ValidationRegistryApi {
+  setTabHasError: (tab: SettingsTab, hasError: boolean) => void;
+  clearTab: (tab: SettingsTab) => void;
+  tabsWithErrors: ReadonlySet<SettingsTab>;
+}
+
+const ValidationContext = createContext<ValidationRegistryApi | null>(null);
+export { ValidationContext as SettingsValidationContext };
+
+interface ProviderProps {
+  children: ReactNode;
+}
+
+export function SettingsValidationProvider({ children }: ProviderProps) {
+  const [tabsWithErrors, setTabsWithErrors] = useState<Set<SettingsTab>>(new Set());
+
+  const setTabHasError = (tab: SettingsTab, hasError: boolean) => {
+    setTabsWithErrors((prev) => {
+      const next = new Set(prev);
+      if (hasError) {
+        next.add(tab);
+      } else {
+        next.delete(tab);
+      }
+      return next;
+    });
+  };
+
+  const clearTab = (tab: SettingsTab) => {
+    setTabsWithErrors((prev) => {
+      const next = new Set(prev);
+      next.delete(tab);
+      return next;
+    });
+  };
+
+  return (
+    <ValidationContext.Provider value={{ setTabHasError, clearTab, tabsWithErrors }}>
+      {children}
+    </ValidationContext.Provider>
+  );
+}
+
+/**
+ * Hook for tabs to report their validation error state to the settings sidebar.
+ * Automatically clears the error state when the component unmounts.
+ *
+ * @param tab - The tab ID to report errors for
+ * @param hasError - Whether the tab currently has validation errors
+ */
+export function useSettingsTabValidation(tab: SettingsTab, hasError: boolean) {
+  const context = useContext(ValidationContext);
+
+  if (!context) {
+    throw new Error("useSettingsTabValidation must be used within a SettingsValidationProvider");
+  }
+
+  useEffect(() => {
+    context.setTabHasError(tab, hasError);
+    return () => {
+      context.clearTab(tab);
+    };
+  }, [context, tab, hasError]);
+}

--- a/src/components/Settings/SettingsValidationRegistry.tsx
+++ b/src/components/Settings/SettingsValidationRegistry.tsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import type { SettingsTab } from "./SettingsDialog";
 
 interface ValidationRegistryApi {
@@ -17,8 +25,9 @@ interface ProviderProps {
 export function SettingsValidationProvider({ children }: ProviderProps) {
   const [tabsWithErrors, setTabsWithErrors] = useState<Set<SettingsTab>>(new Set());
 
-  const setTabHasError = (tab: SettingsTab, hasError: boolean) => {
+  const setTabHasError = useCallback((tab: SettingsTab, hasError: boolean) => {
     setTabsWithErrors((prev) => {
+      if (prev.has(tab) === hasError) return prev;
       const next = new Set(prev);
       if (hasError) {
         next.add(tab);
@@ -27,21 +36,23 @@ export function SettingsValidationProvider({ children }: ProviderProps) {
       }
       return next;
     });
-  };
+  }, []);
 
-  const clearTab = (tab: SettingsTab) => {
+  const clearTab = useCallback((tab: SettingsTab) => {
     setTabsWithErrors((prev) => {
+      if (!prev.has(tab)) return prev;
       const next = new Set(prev);
       next.delete(tab);
       return next;
     });
-  };
+  }, []);
 
-  return (
-    <ValidationContext.Provider value={{ setTabHasError, clearTab, tabsWithErrors }}>
-      {children}
-    </ValidationContext.Provider>
+  const value = useMemo(
+    () => ({ setTabHasError, clearTab, tabsWithErrors }),
+    [setTabHasError, clearTab, tabsWithErrors]
   );
+
+  return <ValidationContext.Provider value={value}>{children}</ValidationContext.Provider>;
 }
 
 /**

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -11,6 +11,7 @@ import { ColorSchemePicker } from "./ColorSchemePicker";
 import { AppThemePicker } from "./AppThemePicker";
 import { ColorVisionPicker } from "./ColorVisionPicker";
 import { DockDensityPicker } from "./DockDensityPicker";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 
 const MIN_FONT_SIZE = 8;
 const MAX_FONT_SIZE = 24;
@@ -53,6 +54,9 @@ export function TerminalAppearanceTab({
   const fontSizeErrorId = useId();
   const [fontSizeInput, setFontSizeInput] = useState<string>(String(fontSize));
   const [fontSizeError, setFontSizeError] = useState<string | null>(null);
+
+  // Report validation state to sidebar
+  useSettingsTabValidation("terminalAppearance", fontSizeError != null);
 
   useEffect(() => {
     setFontSizeInput(String(fontSize));

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -55,8 +55,11 @@ export function TerminalAppearanceTab({
   const [fontSizeInput, setFontSizeInput] = useState<string>(String(fontSize));
   const [fontSizeError, setFontSizeError] = useState<string | null>(null);
 
-  // Report validation state to sidebar
-  useSettingsTabValidation("terminalAppearance", fontSizeError != null);
+  // Report validation state to sidebar (only when terminal subtab is active)
+  useSettingsTabValidation(
+    "terminalAppearance",
+    effectiveSubtab === "terminal" ? fontSizeError != null : false
+  );
 
   useEffect(() => {
     setFontSizeInput(String(fontSize));

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -11,6 +11,7 @@ import {
 } from "@shared/utils/pathPattern";
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 
 const PATTERN_PRESETS = [
   {
@@ -89,6 +90,9 @@ export function WorktreeSettingsTab() {
     if (!pattern.trim()) return { valid: false, error: "Pattern cannot be empty" };
     return validatePathPattern(pattern);
   }, [pattern]);
+
+  // Report validation state to sidebar
+  useSettingsTabValidation("worktree", !validation.valid);
 
   const preview = useMemo(() => {
     if (!validation.valid) return null;

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -91,8 +91,8 @@ export function WorktreeSettingsTab() {
     return validatePathPattern(pattern);
   }, [pattern]);
 
-  // Report validation state to sidebar
-  useSettingsTabValidation("worktree", !validation.valid);
+  // Report validation state to sidebar (only after loading completes)
+  useSettingsTabValidation("worktree", !isLoading && !validation.valid);
 
   const preview = useMemo(() => {
     if (!validation.valid) return null;

--- a/src/components/Settings/__tests__/EnvironmentSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/EnvironmentSettingsTab.test.tsx
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { EnvironmentSettingsTab } from "../EnvironmentSettingsTab";
+import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -14,9 +15,17 @@ beforeEach(() => {
   } as unknown as typeof window.electron;
 });
 
+function renderTab() {
+  return render(
+    <SettingsValidationProvider>
+      <EnvironmentSettingsTab />
+    </SettingsValidationProvider>
+  );
+}
+
 describe("EnvironmentSettingsTab", () => {
   it("renders without a project open (no empty-state guard)", async () => {
-    render(<EnvironmentSettingsTab />);
+    renderTab();
 
     await waitFor(() => {
       expect(screen.getByText("Environment Variables")).toBeTruthy();
@@ -32,7 +41,7 @@ describe("EnvironmentSettingsTab", () => {
       },
     } as unknown as typeof window.electron;
 
-    render(<EnvironmentSettingsTab />);
+    renderTab();
 
     await waitFor(() => {
       expect(window.electron.globalEnv.get).toHaveBeenCalledTimes(1);
@@ -50,7 +59,7 @@ describe("EnvironmentSettingsTab", () => {
       },
     } as unknown as typeof window.electron;
 
-    render(<EnvironmentSettingsTab />);
+    renderTab();
 
     await waitFor(() => {
       expect(screen.getAllByLabelText("Environment variable name")).toHaveLength(1);
@@ -68,7 +77,7 @@ describe("EnvironmentSettingsTab", () => {
   });
 
   it("shows description about global scope", async () => {
-    render(<EnvironmentSettingsTab />);
+    renderTab();
 
     await waitFor(() => {
       expect(
@@ -87,7 +96,7 @@ describe("EnvironmentSettingsTab", () => {
       },
     } as unknown as typeof window.electron;
 
-    render(<EnvironmentSettingsTab />);
+    renderTab();
 
     await waitFor(() => {
       expect(screen.getByText("No environment variables configured yet")).toBeTruthy();
@@ -104,7 +113,7 @@ describe("EnvironmentSettingsTab", () => {
       },
     } as unknown as typeof window.electron;
 
-    render(<EnvironmentSettingsTab />);
+    renderTab();
 
     await waitFor(() => {
       expect(screen.getByText("No environment variables configured yet")).toBeTruthy();


### PR DESCRIPTION
## Summary

- Added amber warning dot on settings tab entries when any field has a validation error
- Validation state tracked centrally via new SettingsValidationRegistry component
- Warning dot takes precedence over existing modified-dot (blue) when both apply
- Implemented across Environment, Portal, Terminal Appearance, and Worktree tabs

Resolves #5420

## Changes

- Created `SettingsValidationRegistry` to centralise validation state tracking
- Modified `SettingsDialog` to render warning dot in tab nav based on registry
- Updated affected tab components to register/deregister validation state
- Validation error indicator is visually distinct from modified-dot (amber vs blue)

## Testing

Manual verification of warning dot behaviour:
- Warning dot appears when validation errors are present on a tab
- Warning dot disappears when errors are resolved
- Warning dot takes precedence when both validation error and modified state exist
- Navigation away from and back to tabs maintains correct indicator state
- All affected tabs (Environment, Portal, Terminal Appearance, Worktree) properly track validation state