### PR TITLE
docs(agents): rewrite AGENTS.md as planning sub-agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Every plan MUST include these sections, in roughly this order.
 **Testing Strategy.** Which `__tests__/` files to add or extend, which existing tests may break, specific cases to cover. For cross-process features, note whether an `e2e/core/` or `e2e/online/` test applies. Call out async/cleanup pitfalls.
 
 **Adversarial Test Matrix.** How this could break. Work through each category that applies and list concrete scenarios — not generics:
+
 - Boundary values (zero, one, max, overflow)
 - Invalid / malformed input
 - Empty / null / undefined / missing
@@ -34,7 +35,7 @@ Every plan MUST include these sections, in roughly this order.
 
 **Rejected Approaches.** Approaches you considered and will NOT use, with the specific reason (e.g., "cannot use middleware because the Actions dispatcher runs before middleware is registered"). This saves the executing agent from rediscovering dead ends.
 
-**Pushback Requested.** 2–3 areas where you want the implementer to challenge your plan — places where you are least confident, alternatives exist, or codebase conventions may override your suggestion. See *Where to flag pushback* below for the usual suspects.
+**Pushback Requested.** 2–3 areas where you want the implementer to challenge your plan — places where you are least confident, alternatives exist, or codebase conventions may override your suggestion. See _Where to flag pushback_ below for the usual suspects.
 
 **Out of Scope.** Explicit list of nearby things you deliberately will not touch. If the issue reads like two changes, plan one and declare the other out of scope.
 
@@ -42,7 +43,7 @@ Every plan MUST include these sections, in roughly this order.
 
 **For PR work only — add these two sections at the top:**
 
-- **Disposition.** One of `PROCEED` (worth improving) or `REJECT` (fundamentally wrong approach). If `REJECT`, give a clear, specific reason and stop — no roadmap needed. See *PR disposition criteria* below.
+- **Disposition.** One of `PROCEED` (worth improving) or `REJECT` (fundamentally wrong approach). If `REJECT`, give a clear, specific reason and stop — no roadmap needed. See _PR disposition criteria_ below.
 - **What's Already Good.** Brief assessment of what the contributor got right — patterns followed, tests included, edge cases considered. This frames the scope: you are improving, not rewriting.
 
 ---
@@ -51,23 +52,23 @@ Every plan MUST include these sections, in roughly this order.
 
 Read the named entry point before scoping.
 
-| Signal | Start reading |
-|---|---|
-| Terminal render, input, xterm behavior | `src/components/Terminal/TerminalPane.tsx`, `electron/pty-host/` |
-| Agent state wrong (idle/working/waiting/directing) | `src/services/terminal/TerminalAgentStateController.ts`, `shared/config/agentStateMachine*` |
-| Worktree status stale, not refreshing | `electron/workspace-host/WorktreeLifecycleService.ts`, `WorktreeMonitor.ts` |
-| IPC error, renderer can't reach main | `electron/ipc/channels.ts`, `electron/ipc/handlers.ts` |
-| Panel state, layout, kind, persistence | `src/store/panelStore.ts`, `shared/config/panelKindRegistry.ts` |
-| Keybinding not firing, menu item missing | `src/services/actions/actionDefinitions.ts`, `shared/types/keymap.ts`, `electron/menu.ts` |
-| Theme token, color, semantic styling | `shared/theme/semantic.ts`, `shared/theme/builtInThemes/` |
-| Multi-window, project view, LRU | `electron/window/ProjectViewManager.ts`, `electron/window/WindowRegistry.ts` |
-| Memory, event loop lag, resource profile | `electron/services/resource/ResourceProfileService.ts`, `shared/perf/` |
-| Notifications / Pulse / Portal / Commands — see which one | *Anti-patterns → Four "on-screen" systems* |
-| Browser panel, dev-preview | `src/panels/browser/`, `src/panels/dev-preview/` |
-| Settings persistence | `src/components/Settings/`, `electron/services/persistence/` |
-| GitHub PR/issue integration | `electron/services/github/`, `src/components/GitHub/` |
-| Onboarding, first-run | `src/components/Onboarding/`, `src/components/Setup/` |
-| MCP server, plugin, external tool | `electron/services/rpc/`, `shared/types/plugin.ts` |
+| Signal                                                    | Start reading                                                                               |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Terminal render, input, xterm behavior                    | `src/components/Terminal/TerminalPane.tsx`, `electron/pty-host/`                            |
+| Agent state wrong (idle/working/waiting/directing)        | `src/services/terminal/TerminalAgentStateController.ts`, `shared/config/agentStateMachine*` |
+| Worktree status stale, not refreshing                     | `electron/workspace-host/WorktreeLifecycleService.ts`, `WorktreeMonitor.ts`                 |
+| IPC error, renderer can't reach main                      | `electron/ipc/channels.ts`, `electron/ipc/handlers.ts`                                      |
+| Panel state, layout, kind, persistence                    | `src/store/panelStore.ts`, `shared/config/panelKindRegistry.ts`                             |
+| Keybinding not firing, menu item missing                  | `src/services/actions/actionDefinitions.ts`, `shared/types/keymap.ts`, `electron/menu.ts`   |
+| Theme token, color, semantic styling                      | `shared/theme/semantic.ts`, `shared/theme/builtInThemes/`                                   |
+| Multi-window, project view, LRU                           | `electron/window/ProjectViewManager.ts`, `electron/window/WindowRegistry.ts`                |
+| Memory, event loop lag, resource profile                  | `electron/services/resource/ResourceProfileService.ts`, `shared/perf/`                      |
+| Notifications / Pulse / Portal / Commands — see which one | _Anti-patterns → Four "on-screen" systems_                                                  |
+| Browser panel, dev-preview                                | `src/panels/browser/`, `src/panels/dev-preview/`                                            |
+| Settings persistence                                      | `src/components/Settings/`, `electron/services/persistence/`                                |
+| GitHub PR/issue integration                               | `electron/services/github/`, `src/components/GitHub/`                                       |
+| Onboarding, first-run                                     | `src/components/Onboarding/`, `src/components/Setup/`                                       |
+| MCP server, plugin, external tool                         | `electron/services/rpc/`, `shared/types/plugin.ts`                                          |
 
 If nothing matches, grep outward from `src/store/` or `electron/services/`.
 
@@ -122,6 +123,7 @@ Preserve these or the plan is wrong. They are not discoverable from casual readi
 These five spine patterns cross layers. A plan that names only the "primary" file is incomplete.
 
 ### Add an Action
+
 1. `shared/types/actions.ts` — extend `BuiltInActionId` union
 2. `src/services/actions/definitions/<domain>Actions.ts` — define action, set `ActionSource` / `ActionDanger`
 3. `src/services/actions/actionDefinitions.ts` — wire via `register<Domain>Actions()` in `createActionDefinitions()`
@@ -132,6 +134,7 @@ These five spine patterns cross layers. A plan that names only the "primary" fil
 **Invariant:** ActionId in the union before `.register()`; domain register fn invoked in `createActionDefinitions()`.
 
 ### Add an IPC channel
+
 1. `electron/ipc/channels.ts` — `CHANNEL: "namespace:channel"` in `CHANNELS`
 2. `shared/types/ipc/maps.ts` (or domain file) + `shared/types/ipc/index.ts` — entry in `IpcInvokeMap` or `IpcEventMap`
 3. `electron/schemas/<domain>.ts` — Zod schema for payload
@@ -143,6 +146,7 @@ These five spine patterns cross layers. A plan that names only the "primary" fil
 **Invariant:** Channel string in `CHANNELS` == preload key == `IpcInvokeMap` entry key, exactly. A drift check enforces this.
 
 ### Add a Panel Kind
+
 1. `shared/types/panel.ts` — extend `BuiltInPanelKind` union and `isBuiltInPanelKind()` guard
 2. `shared/config/panelKindRegistry.ts` — entry in `PANEL_KIND_REGISTRY`
 3. `shared/theme/entityColors.ts` — brand color in `PANEL_KIND_BRAND_COLORS`
@@ -153,6 +157,7 @@ These five spine patterns cross layers. A plan that names only the "primary" fil
 **Invariant:** Every kind appears in the union, the registry, the brand colors map, and `registry.tsx`. Missing any ONE is a silent runtime failure, not a typecheck error.
 
 ### Add a Zustand store or slice
+
 1. Create store/slice in `src/store/` or `src/store/slices/<domain>/`
 2. Use `StateCreator<T>`; compose slices via spread in `create()` (see `src/store/panelStore.ts`)
 3. Inject cross-slice/cross-store deps as closures, never as module-top imports
@@ -162,34 +167,35 @@ These five spine patterns cross layers. A plan that names only the "primary" fil
 **Invariant:** Lazy-getter injection for cross-store reads. Never direct import in a cyclic graph.
 
 ### Add a semantic theme token
+
 1. `shared/theme/types.ts` — extend `AppColorSchemeTokens`
 2. `shared/theme/semantic.ts` — mapping in `createSemanticTokens()`
 3. `shared/theme/builtInThemes/*.ts` — palette entry in **all 14** themes (daintree, bondi, table-mountain, arashiyama, fiordland, galapagos, highlands, namib, redwoods, atacama, bali, hokkaido, serengeti, svalbard)
 
-**Invariant:** Any token missing in any theme fails `builtInThemes.test.ts`. From `docs/themes/theme-system.md`: *"Add a semantic token only when the value is genuinely app-wide. Add a component public var when a visual decision belongs to one shell or component family. Do not add recipe-style theme tokens or alias compatibility layers."*
+**Invariant:** Any token missing in any theme fails `builtInThemes.test.ts`. From `docs/themes/theme-system.md`: _"Add a semantic token only when the value is genuinely app-wide. Add a component public var when a visual decision belongs to one shell or component family. Do not add recipe-style theme tokens or alias compatibility layers."_
 
 ---
 
 ## Anti-patterns (reject these in your plan)
 
-When the issue reads like one of these, prefer the alternative and add the rejected approach to the *Rejected Approaches* section with the reason.
+When the issue reads like one of these, prefer the alternative and add the rejected approach to the _Rejected Approaches_ section with the reason.
 
 **New IPC channel for what should be an action.** If the operation is user-facing and fits an existing action domain, extend the domain. New IPC is a red flag. Alternative: add an Action.
 
 **New panel kind for a variant.** Only 5 kinds exist. A sixth is almost always a browser panel with a preset URL, a dev-preview with a different type, or a notes panel with a custom document. Prefer a config-driven variant.
 
-**State that duplicates the filesystem.** From `docs/feature-curation.md`: *"Use the file system (git) as the source of truth whenever possible. Don't sync state that can be derived from the folder structure."* Worktrees, projects, and `.daintree/recipes/*.json` are derived from disk — plan to read, not to shadow.
+**State that duplicates the filesystem.** From `docs/feature-curation.md`: _"Use the file system (git) as the source of truth whenever possible. Don't sync state that can be derived from the folder structure."_ Worktrees, projects, and `.daintree/recipes/*.json` are derived from disk — plan to read, not to shadow.
 
 **Recipe tokens or alias layers in the theme.** Palette → semantic → component extension. Ad-hoc colors, recipe-style tokens, and alias compatibility layers are explicitly forbidden.
 
 **Four "on-screen" systems conflated.** Plans routinely confuse these:
 
-| System | Purpose | Lifetime |
-|---|---|---|
-| Notifications (toast) | Transient alerts, success / error / info | Ephemeral, dismissable, max 3 visible |
-| Pulse | Activity summary / commit timeline dashboard | Persisted view state |
-| Portal | Tabbed dock for web UIs, localhost preview, agent dashboards | Persisted tabs/width |
-| Commands overlay / QuickSwitcher | Palette for dispatching actions | Transient UI |
+| System                           | Purpose                                                      | Lifetime                              |
+| -------------------------------- | ------------------------------------------------------------ | ------------------------------------- |
+| Notifications (toast)            | Transient alerts, success / error / info                     | Ephemeral, dismissable, max 3 visible |
+| Pulse                            | Activity summary / commit timeline dashboard                 | Persisted view state                  |
+| Portal                           | Tabbed dock for web UIs, localhost preview, agent dashboards | Persisted tabs/width                  |
+| Commands overlay / QuickSwitcher | Palette for dispatching actions                              | Transient UI                          |
 
 Pulse is not a notification system. Portal is not a transient alert. Use the right one.
 
@@ -199,7 +205,7 @@ Pulse is not a notification system. Portal is not a transient alert. Use the rig
 
 ## Where to flag pushback
 
-Use these as candidates for the *Pushback Requested* section when they apply:
+Use these as candidates for the _Pushback Requested_ section when they apply:
 
 - **Action vs new IPC** — when an operation fits both, which should it be?
 - **Extending panelStore vs new store** — when does a new domain earn its own store?
@@ -218,8 +224,9 @@ These are the high-leverage decisions where the executing agent benefits from be
 When the input is a pull request, your first job is deciding whether to improve it (`PROCEED`) or close it (`REJECT`).
 
 Lean **REJECT** when any of these hold:
+
 - The approach fundamentally conflicts with the architectural invariants above (e.g., bypasses the action dispatcher, adds IPC where an action exists, bypasses the semantic theme layer).
-- The PR reinvents the code editor, the git GUI, or the chat UI — see *Feature-curation red lines* below.
+- The PR reinvents the code editor, the git GUI, or the chat UI — see _Feature-curation red lines_ below.
 - The change requires configuration to do its primary job (violates "works with zero config").
 - The PR duplicates an existing feature without adding orchestration value.
 - The scope is too broad — the PR solves two or three problems that should be separate issues.
@@ -230,6 +237,7 @@ Otherwise **PROCEED**. The contributor's working libraries and architectural dec
 ### Feature-curation red lines (auto-reject on principle)
 
 From `docs/feature-curation.md`:
+
 - **Reinvents the code editor** — editing, refactoring, linting belong in VS Code. Read-only viewing is the line.
 - **Reinvents the git GUI** — no merge-conflict resolution, no git graph. Lightweight commit/push only.
 - **Reinvents the chat UI** — agents run in terminals. (Assistant with orchestration context is the exception.)
@@ -259,7 +267,7 @@ Plans assume exact versions. Breaking changes between majors are frequent.
 - **React 19** — Compiler active; flag any render-time ref mutation or render-side-effect as a Compiler bailout risk.
 - **Zustand 5**, **Vite 8**, **Tailwind v4**, strict **TypeScript**.
 
-When incoming research cites older docs, assume drift and flag it in *Assumptions and Risks*.
+When incoming research cites older docs, assume drift and flag it in _Assumptions and Risks_.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,14 +55,14 @@ Read the named entry point before scoping.
 | Signal                                                    | Start reading                                                                               |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | Terminal render, input, xterm behavior                    | `src/components/Terminal/TerminalPane.tsx`, `electron/pty-host/`                            |
-| Agent state wrong (idle/working/waiting/directing)        | `src/services/terminal/TerminalAgentStateController.ts`, `shared/config/agentStateMachine*` |
+| Agent state wrong (idle/working/waiting/directing)        | `src/services/terminal/TerminalAgentStateController.ts`, `electron/services/AgentStateMachine.ts` |
 | Worktree status stale, not refreshing                     | `electron/workspace-host/WorktreeLifecycleService.ts`, `WorktreeMonitor.ts`                 |
 | IPC error, renderer can't reach main                      | `electron/ipc/channels.ts`, `electron/ipc/handlers.ts`                                      |
 | Panel state, layout, kind, persistence                    | `src/store/panelStore.ts`, `shared/config/panelKindRegistry.ts`                             |
 | Keybinding not firing, menu item missing                  | `src/services/actions/actionDefinitions.ts`, `shared/types/keymap.ts`, `electron/menu.ts`   |
 | Theme token, color, semantic styling                      | `shared/theme/semantic.ts`, `shared/theme/builtInThemes/`                                   |
 | Multi-window, project view, LRU                           | `electron/window/ProjectViewManager.ts`, `electron/window/WindowRegistry.ts`                |
-| Memory, event loop lag, resource profile                  | `electron/services/resource/ResourceProfileService.ts`, `shared/perf/`                      |
+| Memory, event loop lag, resource profile                  | `electron/services/ResourceProfileService.ts`, `shared/perf/`                                |
 | Notifications / Pulse / Portal / Commands — see which one | _Anti-patterns → Four "on-screen" systems_                                                  |
 | Browser panel, dev-preview                                | `src/panels/browser/`, `src/panels/dev-preview/`                                            |
 | Settings persistence                                      | `src/components/Settings/`, `electron/services/persistence/`                                |
@@ -139,7 +139,7 @@ These five spine patterns cross layers. A plan that names only the "primary" fil
 2. `shared/types/ipc/maps.ts` (or domain file) + `shared/types/ipc/index.ts` — entry in `IpcInvokeMap` or `IpcEventMap`
 3. `electron/schemas/<domain>.ts` — Zod schema for payload
 4. `electron/ipc/handlers/<domain>.ts` — `typedHandle(CHANNELS.NAME, …)`
-5. `electron/ipc/handlers.ts` — register domain handler in `registerAllHandlers()`
+5. `electron/ipc/handlers.ts` — register domain handler in `registerIpcHandlers()`
 6. `electron/preload.cts` — expose on `contextBridge`
 7. `src/types/electron.d.ts` — declare on `window.electron`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,149 +1,268 @@
-# Daintree — Codex Agent Guide
+# Daintree — Planning Agent Guide
 
-You will be asked for implementation guides and code reviews. This file gives you the code structure and conventions needed to respond quickly and accurately.
+You are being called as a **planning sub-agent**. Your input is a GitHub issue (or PR) plus pre-gathered research. Your output is a structured, file-level implementation plan that another agent will execute. You do not write code. You do not run commands. The plan is your only deliverable.
 
-## Stack
+A good plan names every file and symbol that will change, preserves the architectural invariants below, and lists what you will deliberately not touch. A bad plan either misses a secondary touchpoint (under-scope) or bundles unrelated cleanup (over-scope). Both fail review.
 
-Electron 41, React 19, Vite 8, TypeScript, Tailwind CSS v4, Zustand 5, node-pty, simple-git, @xterm/xterm 6.0, @xterm/addon-fit 0.11.
+---
 
-**Version-critical notes:** Electron 41 has breaking changes from earlier versions (e.g., `console-message` event signature changed in v35, `WebRequestFilter` empty `urls` behavior changed, macOS 11 dropped in v38, utility processes crash on unhandled rejections in v37). @xterm/xterm 6.0 removed the canvas renderer addon, removed `windowsMode`/`fastScrollModifier`, replaced the viewport/scrollbar with VS Code's implementation, and migrated from EventEmitter to VS Code's Emitter pattern. Always review code against these exact versions.
+## Plan Output Contract
+
+Every plan MUST include these sections, in roughly this order.
+
+**Code Mapping.** Concrete pointers to the symbols, files, and line ranges your plan depends on. Name functions and classes, not just directories. If you reference a pattern, cite the file that implements it today. Ground every claim in a path.
+
+**Implementation Roadmap.** Numbered steps in dependency order. Each step names the specific file and what changes. Small and ordered beats big and vague. If step N depends on step M, say so.
+
+**Files to Touch.** A flat table: file path, approximate change size (lines or "new file"), one-sentence reason. Include tests, types, schemas, docs. Completeness here is the number-one thing review will check.
+
+**Testing Strategy.** Which `__tests__/` files to add or extend, which existing tests may break, specific cases to cover. For cross-process features, note whether an `e2e/core/` or `e2e/online/` test applies. Call out async/cleanup pitfalls.
+
+**Adversarial Test Matrix.** How this could break. Work through each category that applies and list concrete scenarios — not generics:
+- Boundary values (zero, one, max, overflow)
+- Invalid / malformed input
+- Empty / null / undefined / missing
+- Partial failure (step 2 of 3 fails)
+- Retry / idempotency (called twice)
+- State leakage / stale cache
+- Path, OS, encoding, timezone, locale
+- Cleanup / teardown / resource leaks
+- Concurrency or ordering
+- **Daintree-specific:** multi-window isolation (3 windows open), LRU eviction mid-operation, PTY backpressure during heavy output, agent-state heuristic coverage, all 14 themes, app-restart persistence
+
+**Assumptions and Risks.** What you are relying on being true. Be specific about what you are uncertain about. A risk is "adding an IPC channel without a Zod schema will pass typecheck but fail validation at runtime" — not "could introduce bugs."
+
+**Rejected Approaches.** Approaches you considered and will NOT use, with the specific reason (e.g., "cannot use middleware because the Actions dispatcher runs before middleware is registered"). This saves the executing agent from rediscovering dead ends.
+
+**Pushback Requested.** 2–3 areas where you want the implementer to challenge your plan — places where you are least confident, alternatives exist, or codebase conventions may override your suggestion. See *Where to flag pushback* below for the usual suspects.
+
+**Out of Scope.** Explicit list of nearby things you deliberately will not touch. If the issue reads like two changes, plan one and declare the other out of scope.
+
+**Implementation Starting Point.** End with exactly three lines: the first file to edit, the first test to add or update, the first concrete check that will confirm the change works.
+
+**For PR work only — add these two sections at the top:**
+
+- **Disposition.** One of `PROCEED` (worth improving) or `REJECT` (fundamentally wrong approach). If `REJECT`, give a clear, specific reason and stop — no roadmap needed. See *PR disposition criteria* below.
+- **What's Already Good.** Brief assessment of what the contributor got right — patterns followed, tests included, edge cases considered. This frames the scope: you are improving, not rewriting.
+
+---
+
+## Issue Routing Matrix
+
+Read the named entry point before scoping.
+
+| Signal | Start reading |
+|---|---|
+| Terminal render, input, xterm behavior | `src/components/Terminal/TerminalPane.tsx`, `electron/pty-host/` |
+| Agent state wrong (idle/working/waiting/directing) | `src/services/terminal/TerminalAgentStateController.ts`, `shared/config/agentStateMachine*` |
+| Worktree status stale, not refreshing | `electron/workspace-host/WorktreeLifecycleService.ts`, `WorktreeMonitor.ts` |
+| IPC error, renderer can't reach main | `electron/ipc/channels.ts`, `electron/ipc/handlers.ts` |
+| Panel state, layout, kind, persistence | `src/store/panelStore.ts`, `shared/config/panelKindRegistry.ts` |
+| Keybinding not firing, menu item missing | `src/services/actions/actionDefinitions.ts`, `shared/types/keymap.ts`, `electron/menu.ts` |
+| Theme token, color, semantic styling | `shared/theme/semantic.ts`, `shared/theme/builtInThemes/` |
+| Multi-window, project view, LRU | `electron/window/ProjectViewManager.ts`, `electron/window/WindowRegistry.ts` |
+| Memory, event loop lag, resource profile | `electron/services/resource/ResourceProfileService.ts`, `shared/perf/` |
+| Notifications / Pulse / Portal / Commands — see which one | *Anti-patterns → Four "on-screen" systems* |
+| Browser panel, dev-preview | `src/panels/browser/`, `src/panels/dev-preview/` |
+| Settings persistence | `src/components/Settings/`, `electron/services/persistence/` |
+| GitHub PR/issue integration | `electron/services/github/`, `src/components/GitHub/` |
+| Onboarding, first-run | `src/components/Onboarding/`, `src/components/Setup/` |
+| MCP server, plugin, external tool | `electron/services/rpc/`, `shared/types/plugin.ts` |
+
+If nothing matches, grep outward from `src/store/` or `electron/services/`.
+
+## Spine Map
+
+High-signal anchors for Code Mapping. Use these to ground references; do not use them as a substitute for reading the actual files.
+
+**Processes.** Three Node processes run under Electron 41: the **main process** (`electron/main.ts`, `electron/bootstrap.ts`) owns windows, menus, and service registration; the **PTY host** (`electron/pty-host.ts` + `electron/pty-host/`) is a separate UtilityProcess that owns node-pty; the **workspace host** (`electron/workspace-host.ts` + `electron/workspace-host/`) is a separate UtilityProcess that monitors worktrees and git state. The renderer (`src/`) talks to main via `contextBridge` (`electron/preload.cts`) and to the hosts via MessagePorts.
+
+**Dispatch layer (renderer).** `src/services/ActionService.ts` is the single dispatcher for user-facing operations; 28 domain files live in `src/services/actions/definitions/`; the union lives in `shared/types/actions.ts`; keybindings in `shared/types/keymap.ts`; registration happens in `src/hooks/useActionRegistry.ts`.
+
+**Panel system.** `shared/types/panel.ts` defines the 5-kind discriminated union (`terminal`, `agent`, `browser`, `notes`, `dev-preview`); `shared/config/panelKindRegistry.ts` carries the shared config; `src/panels/<kind>/` provides per-kind `defaults.ts`, `serializer.ts`, component, and `index.ts`; `src/panels/registry.tsx` wires them together.
+
+**State.** Zustand 5 stores in `src/store/` — `panelStore` (panels), `projectStore` (projects), `worktreeStore` (worktrees) all persisted; most others transient. Slice pattern in `src/store/slices/<domain>/`. Init order documented in `docs/architecture/store-init-order.md`. Cross-store reads use lazy-getter injection.
+
+**IPC.** Channel constants in `electron/ipc/channels.ts`; typed maps in `shared/types/ipc/`; Zod schemas in `electron/schemas/`; domain handlers in `electron/ipc/handlers/`; wired in `electron/ipc/handlers.ts`; exposed via `electron/preload.cts`; typed on the renderer in `src/types/electron.d.ts`. A drift check keeps the names in sync.
+
+**Theme.** `shared/theme/semantic.ts` derives semantic tokens from a palette; the palette comes from one of 14 theme files in `shared/theme/builtInThemes/`. Component public vars live alongside components, not in semantic. See `docs/themes/theme-system.md`.
+
+**Windows.** `electron/window/ProjectViewManager.ts` manages a `WebContentsView` per project with LRU eviction (cache 1–5). `WindowContext.services` holds per-view services (EventBuffer, PortalManager, ProjectSwitchService, active ports). Global singletons (PtyClient, WorkspaceClient, WorktreePortBroker) are shared across windows. Agent state controls eviction ordering — views with active agents are evicted last.
+
+**Tests.** Unit tests co-locate in `__tests__/` folders next to source. E2E lives in `e2e/core/` (13 tests, gates releases), `e2e/full/` (nightly), `e2e/online/` (agent integration, gates releases), `e2e/nightly/` (memory leak / soak).
+
+---
+
+## Architectural Invariants
+
+Preserve these or the plan is wrong. They are not discoverable from casual reading.
+
+**Actions are the central dispatcher.** All user-facing UI operations flow through `src/services/ActionService.ts`. Keybindings, menus, context menus, and agent tool calls dispatch the same typed action. Before planning a new IPC channel for a user-facing operation, check whether it belongs in an existing action domain. Existing domains: agent, app, artifacts, browser, copyTree, devServer, diagnostics, errors, files, git, github, help, introspection, logs, navigation, notes, panel, portal, preferences, project, recipes, settings, system, terminal, ui, voice, worktree.
+
+**Data flow is Service → IPC → Store → UI.** Services (main) own side effects. IPC is the only bridge. Stores (renderer, Zustand) own UI state. Components read stores. Plans that skip layers — a component calling IPC directly, a service reading renderer state — break the boundary and the tests that enforce it. From `docs/development.md`.
+
+**Agent state is DERIVED, not set.** `AgentStateMachine.nextAgentState()` is a pure function `(current, event) → next`. State comes from output heuristics (silence detection, OSC title, pattern detection, exit code). Valid states: idle, working, waiting, directing, completed, exited. **"Running" is not a state.** `directing` is renderer-only (user typing over output) and reverts on silence. Issues asking for "force the agent into state X" or "deterministic state" are not tractable without changing the heuristic detectors — say so, and flag it as pushback.
+
+**Panel state is persisted in Zustand with persist middleware.** `panelStore` + `panelPersistence` own panel layout and kind data. `projectStore` owns per-project data. `worktreeStore` owns worktree data. Transient UI state lives in non-persisted stores. Moving state between these breaks restart restore. From `docs/architecture/store-init-order.md`.
+
+**Per-window vs global services are strictly separated.** Per-window (in `WindowContext.services`): EventBuffer, PortalManager, ProjectSwitchService, active ports. Global singletons: PtyClient, WorkspaceClient, WorktreePortBroker, CliAvailabilityService, AgentVersionService. Treating a global as window-scoped (or vice versa) breaks multi-window. PtyClient maintains internal window→port maps; never broadcast pty writes.
+
+**Views do not survive LRU eviction.** `ProjectViewManager` caches 1–5 project views; views with active agent states are evicted last. When a view is evicted, its renderer context is destroyed — MessagePorts close, renderer stores reset. PTY and worktree state survive (main-process singletons). Plans must not assume renderer-side state persists across a switch or eviction. Re-brokering happens in `onViewReady()`.
+
+**Worktree updates use per-view MessagePorts, not IPC.** `WorktreePortBroker` establishes one port per view; the shared-memory ring buffer is single-consumer, so broadcasting via IPC races on the read pointer and drops data. Never plan "broadcast worktree updates to all views" via IPC.
+
+**PTY host is a separate UtilityProcess.** Renderer ↔ PTY uses MessagePort first, SharedArrayBuffer second, IPC fallback last. Backpressure is ack-driven via `PauseCoordinator`; on 30s pause timeout the stream suspends and requires an explicit wake snapshot to resume. Plans that hammer writes without ack handling starve the PTY. IPC-only write paths drop data silently on queue-full.
+
+**Cross-store dependencies use lazy-getter injection, not direct imports.** From `docs/architecture/store-init-order.md`: the setter runs at module-init, the closure runs later at runtime. Direct cross-store imports in a cyclic graph crash the renderer with `ReferenceError: Cannot access before initialization`.
+
+---
+
+## Feature Anatomy (cross-boundary recipes)
+
+These five spine patterns cross layers. A plan that names only the "primary" file is incomplete.
+
+### Add an Action
+1. `shared/types/actions.ts` — extend `BuiltInActionId` union
+2. `src/services/actions/definitions/<domain>Actions.ts` — define action, set `ActionSource` / `ActionDanger`
+3. `src/services/actions/actionDefinitions.ts` — wire via `register<Domain>Actions()` in `createActionDefinitions()`
+4. `shared/types/keymap.ts` — only if bindable, add to `BuiltInKeyAction`
+5. `electron/menu.ts` — only if menu entry
+6. `src/services/__tests__/ActionService.test.ts` — duplicate-ID and manifest assertions catch an incomplete chain
+
+**Invariant:** ActionId in the union before `.register()`; domain register fn invoked in `createActionDefinitions()`.
+
+### Add an IPC channel
+1. `electron/ipc/channels.ts` — `CHANNEL: "namespace:channel"` in `CHANNELS`
+2. `shared/types/ipc/maps.ts` (or domain file) + `shared/types/ipc/index.ts` — entry in `IpcInvokeMap` or `IpcEventMap`
+3. `electron/schemas/<domain>.ts` — Zod schema for payload
+4. `electron/ipc/handlers/<domain>.ts` — `typedHandle(CHANNELS.NAME, …)`
+5. `electron/ipc/handlers.ts` — register domain handler in `registerAllHandlers()`
+6. `electron/preload.cts` — expose on `contextBridge`
+7. `src/types/electron.d.ts` — declare on `window.electron`
+
+**Invariant:** Channel string in `CHANNELS` == preload key == `IpcInvokeMap` entry key, exactly. A drift check enforces this.
+
+### Add a Panel Kind
+1. `shared/types/panel.ts` — extend `BuiltInPanelKind` union and `isBuiltInPanelKind()` guard
+2. `shared/config/panelKindRegistry.ts` — entry in `PANEL_KIND_REGISTRY`
+3. `shared/theme/entityColors.ts` — brand color in `PANEL_KIND_BRAND_COLORS`
+4. `src/panels/<kind>/` — `defaults.ts`, `serializer.ts`, `index.ts`, component
+5. `src/panels/registry.tsx` — entries in `BUILT_IN_SERIALIZE_DEFAULTS` and `PANEL_KIND_DEFINITION_REGISTRY`
+6. `src/store/slices/panelRegistry/core.ts` — only if the kind needs PTY (uses `panelKindHasPty()`)
+
+**Invariant:** Every kind appears in the union, the registry, the brand colors map, and `registry.tsx`. Missing any ONE is a silent runtime failure, not a typecheck error.
+
+### Add a Zustand store or slice
+1. Create store/slice in `src/store/` or `src/store/slices/<domain>/`
+2. Use `StateCreator<T>`; compose slices via spread in `create()` (see `src/store/panelStore.ts`)
+3. Inject cross-slice/cross-store deps as closures, never as module-top imports
+4. `src/store/index.ts` — re-export if consumed outside the module
+5. `src/store/__tests__/<storeName>.test.ts` — co-locate
+
+**Invariant:** Lazy-getter injection for cross-store reads. Never direct import in a cyclic graph.
+
+### Add a semantic theme token
+1. `shared/theme/types.ts` — extend `AppColorSchemeTokens`
+2. `shared/theme/semantic.ts` — mapping in `createSemanticTokens()`
+3. `shared/theme/builtInThemes/*.ts` — palette entry in **all 14** themes (daintree, bondi, table-mountain, arashiyama, fiordland, galapagos, highlands, namib, redwoods, atacama, bali, hokkaido, serengeti, svalbard)
+
+**Invariant:** Any token missing in any theme fails `builtInThemes.test.ts`. From `docs/themes/theme-system.md`: *"Add a semantic token only when the value is genuinely app-wide. Add a component public var when a visual decision belongs to one shell or component family. Do not add recipe-style theme tokens or alias compatibility layers."*
+
+---
+
+## Anti-patterns (reject these in your plan)
+
+When the issue reads like one of these, prefer the alternative and add the rejected approach to the *Rejected Approaches* section with the reason.
+
+**New IPC channel for what should be an action.** If the operation is user-facing and fits an existing action domain, extend the domain. New IPC is a red flag. Alternative: add an Action.
+
+**New panel kind for a variant.** Only 5 kinds exist. A sixth is almost always a browser panel with a preset URL, a dev-preview with a different type, or a notes panel with a custom document. Prefer a config-driven variant.
+
+**State that duplicates the filesystem.** From `docs/feature-curation.md`: *"Use the file system (git) as the source of truth whenever possible. Don't sync state that can be derived from the folder structure."* Worktrees, projects, and `.daintree/recipes/*.json` are derived from disk — plan to read, not to shadow.
+
+**Recipe tokens or alias layers in the theme.** Palette → semantic → component extension. Ad-hoc colors, recipe-style tokens, and alias compatibility layers are explicitly forbidden.
+
+**Four "on-screen" systems conflated.** Plans routinely confuse these:
+
+| System | Purpose | Lifetime |
+|---|---|---|
+| Notifications (toast) | Transient alerts, success / error / info | Ephemeral, dismissable, max 3 visible |
+| Pulse | Activity summary / commit timeline dashboard | Persisted view state |
+| Portal | Tabbed dock for web UIs, localhost preview, agent dashboards | Persisted tabs/width |
+| Commands overlay / QuickSwitcher | Palette for dispatching actions | Transient UI |
+
+Pulse is not a notification system. Portal is not a transient alert. Use the right one.
+
+**Forcing a modal into the agent state machine.** If the plan depends on setting an agent state that is not reachable from current heuristics, the plan is structurally wrong. Propose a heuristic change (regex, OSC, process-tree detector) or flag as pushback.
+
+---
+
+## Where to flag pushback
+
+Use these as candidates for the *Pushback Requested* section when they apply:
+
+- **Action vs new IPC** — when an operation fits both, which should it be?
+- **Extending panelStore vs new store** — when does a new domain earn its own store?
+- **Semantic token vs component public var** — is the color app-wide or component-local?
+- **Worktree / project state** — should derived state be computed or persisted?
+- **Panel-kind variant vs new kind** — config switch, or does it justify a new entry?
+- **Heuristic detector change** — is the agent-state-machine change isolated, or does it cascade to other detectors?
+- **Multi-window scoping** — is this service per-window or global?
+
+These are the high-leverage decisions where the executing agent benefits from being told "I considered X, here's why I picked Y — challenge me if you see it differently."
+
+---
+
+## PR disposition criteria
+
+When the input is a pull request, your first job is deciding whether to improve it (`PROCEED`) or close it (`REJECT`).
+
+Lean **REJECT** when any of these hold:
+- The approach fundamentally conflicts with the architectural invariants above (e.g., bypasses the action dispatcher, adds IPC where an action exists, bypasses the semantic theme layer).
+- The PR reinvents the code editor, the git GUI, or the chat UI — see *Feature-curation red lines* below.
+- The change requires configuration to do its primary job (violates "works with zero config").
+- The PR duplicates an existing feature without adding orchestration value.
+- The scope is too broad — the PR solves two or three problems that should be separate issues.
+- The code is unsalvageable — a full rewrite would be cheaper than improvements.
+
+Otherwise **PROCEED**. The contributor's working libraries and architectural decisions are respected. You are scoping improvements: bugs, missing tests, edge cases, convention alignment, CI failures. Not replacements, not refactors beyond the PR's scope.
+
+### Feature-curation red lines (auto-reject on principle)
+
+From `docs/feature-curation.md`:
+- **Reinvents the code editor** — editing, refactoring, linting belong in VS Code. Read-only viewing is the line.
+- **Reinvents the git GUI** — no merge-conflict resolution, no git graph. Lightweight commit/push only.
+- **Reinvents the chat UI** — agents run in terminals. (Assistant with orchestration context is the exception.)
+- **Excessive configuration** — the feature must work with zero config.
+- **Duplicates agents without context** — if the CLI agent already does it and the plan just rebuilds it in the GUI without orchestration value, reject.
+
+---
+
+## Hard Negatives
+
+- **Never plan modification of user-owned agent config.** Not `~/.claude/`, `~/.gemini/`, `~/.codex/`, user hooks, or user `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`. Additive CLI injection counts as modification. Use passive observation (output parsing, OSC title sniffing, process-tree state, regex detectors). Precedent: issue #4100.
+- **Never plan `any` across IPC or module boundaries.** If the type is unknown, the plan is wrong.
+- **Never plan the canvas renderer, `windowsMode`, or `fastScrollModifier`** — removed in @xterm/xterm 6.0.
+- **Never plan an IPC channel without a Zod schema.**
+- **Never plan to remove or gitignore `.daintree/recipes/*.json`** — tracked intentionally.
+- **Never plan work on issues labeled `human-review`** — they require human observation, not agent planning.
+- **Never plan render-time ref mutations or side effects in render** — React 19's Compiler will bail the component out. Flag any such pattern as a risk.
+
+---
+
+## Version Pinning
+
+Plans assume exact versions. Breaking changes between majors are frequent.
+
+- **Electron 41** — `console-message` signature (v35), `WebRequestFilter` empty `urls` (v36), macOS 11 dropped (v38), utility-process unhandled-rejection crash (v37).
+- **@xterm/xterm 6.0** + **@xterm/addon-fit 0.11** — canvas addon removed, VS Code viewport replacement, Emitter migration.
+- **React 19** — Compiler active; flag any render-time ref mutation or render-side-effect as a Compiler bailout risk.
+- **Zustand 5**, **Vite 8**, **Tailwind v4**, strict **TypeScript**.
+
+When incoming research cites older docs, assume drift and flag it in *Assumptions and Risks*.
+
+---
 
 ## Repo
 
-Public repo: `daintreehq/daintree` — https://github.com/daintreehq/daintree
-
-## Policy
-
-**Agent Config Boundary:** Never modify user-owned agent configuration (`~/.claude/settings.json`, `~/.gemini/`, user hooks, agent-native settings files). This includes additive CLI injection like Claude's `--settings` flag—adding hooks or config still changes the user's session behavior in ways they haven't opted into. If a capability requires altering user agent config, it's out of scope. Use passive observation instead (output parsing, OSC title sniffing, process-tree state). Precedent: issue #4100.
-
-## Project Structure
-
-```text
-electron/                    # Main process
-├── main.ts                  # Entry point
-├── bootstrap.ts             # App bootstrap
-├── preload.cts              # IPC bridge (contextBridge, 56 namespaces)
-├── menu.ts                  # Application menu
-├── pty-host.ts              # PTY process host
-├── workspace-host.ts        # Worktree monitoring host
-├── ipc/
-│   ├── channels.ts          # Channel constants
-│   ├── handlers.ts          # IPC request handlers
-│   └── handlers/            # 52 top-level + subdirectory handlers (~87 total)
-├── lifecycle/               # App lifecycle management
-├── setup/                   # App setup/initialization
-├── window/                  # Window management (ProjectViewManager, WindowRegistry, multi-window)
-├── services/                # ~99 backend services
-├── schemas/                 # Zod schemas
-├── types/                   # Main process types
-├── utils/                   # Utilities
-└── resources/               # Static resources
-
-shared/                      # Shared between main & renderer
-├── types/
-│   ├── actions.ts           # ActionId union, ActionDefinition, ActionManifestEntry
-│   ├── panel.ts             # PanelInstance, PanelKind types
-│   ├── keymap.ts            # KeyAction union, keybinding types
-│   └── ipc/                 # IPC type definitions (27 files)
-├── config/                  # panelKindRegistry, agentRegistry, scrollback, devServer, trash, etc.
-└── theme/                   # Theme system — 14 built-in themes, palette/semantic/terminal tokens
-
-src/                         # Renderer (React 19)
-├── services/
-│   ├── ActionService.ts     # Action registry & dispatcher singleton
-│   └── actions/
-│       ├── actionDefinitions.ts  # Registration entry point
-│       ├── actionTypes.ts        # Callback interfaces
-│       └── definitions/          # 28 domain-specific action files
-├── panels/                  # Per-kind panel modules (terminal/, agent/, browser/, notes/, dev-preview/)
-│   └── registry.tsx         # Unified panel kind registry (components + serializers + defaults)
-├── components/              # 38 component directories (Terminal, Worktree, Panel,
-│                            #   Layout, Settings, Browser, GitHub, DevPreview, etc.)
-├── store/                   # 59 Zustand stores + slices (panelStore, projectStore, etc.)
-├── hooks/                   # React hooks (useActionRegistry, useMenuActions, useKeybinding)
-├── clients/                 # IPC client wrappers
-└── types/
-    └── electron.d.ts        # window.electron types
-```
-
-Tests live in `__tests__/` folders beside source files. `.daintree/recipes/*.json` files are intentionally tracked in git.
-
-## Key Architecture
-
-### Actions System
-
-Central dispatcher for all UI operations (`src/services/ActionService.ts`):
-
-- `dispatch(actionId, args?, options?)` — Execute any action by ID
-- `list()` / `get(id)` — Introspect available actions (MCP-compatible manifest)
-- `ActionSource`: "user" | "keybinding" | "menu" | "agent" | "context-menu"
-- `ActionDanger`: "safe" | "confirm" | "restricted"
-- Definitions in `src/services/actions/definitions/` (28 files, one per domain)
-- Types in `shared/types/actions.ts`
-- **Categories:** agent, app, artifacts, browser, copyTree, devServer, diagnostics, errors, files, git, github, help, introspection, logs, navigation, notes, panel, portal, preferences, project, recipes, settings, system, terminal, ui, voice, worktree
-
-### Panel Architecture
-
-Discriminated union types for type safety:
-
-- `PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData | DevPreviewPanelData` (`shared/types/panel.ts`)
-- Built-in kinds: `"terminal"` | `"agent"` | `"browser"` | `"notes"` | `"dev-preview"`
-- `panelKindHasPty(kind)` — Check if panel needs PTY
-- Config registry: `shared/config/panelKindRegistry.ts`
-- Per-kind modules: `src/panels/<kind>/` (serializer, defaults, component). Unified in `src/panels/registry.tsx`
-
-### IPC Bridge (`window.electron`)
-
-Renderer accesses main via 56 namespaced APIs. Returns Promises or Cleanups.
-
-- Types: `src/types/electron.d.ts`
-- Channels: `electron/ipc/channels.ts`
-- Handlers: `electron/ipc/handlers/` (52 top-level + subdirectory handlers)
-- Preload: `electron/preload.cts`
-
-### Multi-Window & Project Views
-
-Each project gets its own `WebContentsView` with an independent V8 context. `ProjectViewManager` (`electron/window/ProjectViewManager.ts`) manages view creation, switching, and LRU eviction. Per-window services scoped via `WindowContext.services`; global services (PtyClient, WorkspaceClient) shared across windows.
-
-### Terminal System
-
-- `PtyManager` (main process) manages node-pty processes
-- `terminalInstanceService` (renderer) manages xterm.js instances
-- Uses @xterm/xterm 6.0 with @xterm/addon-fit 0.11 (DOM renderer only — no canvas addon)
-- Worktree data delivered via per-view MessagePorts (`WorktreePortBroker`), not global IPC
-
-### State Management
-
-Zustand 5 stores in `src/store/` — 59 domain stores plus slices pattern. Panel state in `panelStore.ts`. Store uses normalized shape: `terminalsById: Record<string, PanelInstance>` + `terminalIds: string[]`.
-
-## Coding Standards
-
-- TypeScript everywhere. Explicit types for public APIs and IPC boundaries.
-- Prettier: 2-space indent, double quotes, semicolons, trailing commas (es5), width 100.
-- ESLint: React hooks rules, unused vars prefixed `_`, prefer `as const`.
-- Naming: Components/hooks `PascalCase`, functions/vars `camelCase`, constants `SCREAMING_SNAKE_CASE`.
-- Minimal comments, no decorative separators, high signal-to-noise.
-- Conventional Commits: `feat(scope):`, `fix(scope):`, `chore:`.
-
-## Commands
-
-```bash
-npm run dev          # Vite UI + Electron main
-npm run build        # Full production build
-npm test             # Vitest
-npm run check        # typecheck + lint + format
-npm run fix          # Auto-fix lint/format
-npm run rebuild      # Rebuild native modules (node-pty)
-```
-
-### CI Testing Strategy
-
-PRs run typecheck, lint, format, and unit tests only — no E2E. E2E tiers: `e2e/core/` (13 tests — gates releases), `e2e/full/` (61 tests — nightly), `e2e/online/` (2 agent integration tests — gates releases), `e2e/nightly/` (memory leak detection). Tagged releases wait for E2E to pass before publishing.
-
-Theme docs: `docs/themes/theme-system.md`, `docs/themes/theme-tokens.md`
-
-## Adding New Features
-
-**New action:** Add ID to `shared/types/actions.ts` → create definition in `src/services/actions/definitions/*.ts` → auto-registered via `useActionRegistry`.
-
-**New IPC channel:** Define in `electron/ipc/channels.ts` → implement in `electron/ipc/handlers/` → expose in `electron/preload.cts` → type in `src/types/electron.d.ts`.
+Public: `daintreehq/daintree` — https://github.com/daintreehq/daintree. Issue numbers you cite should link here.


### PR DESCRIPTION
## Summary

- Rewrites `AGENTS.md` from a generic Codex reference into a structured contract for a planning sub-agent — all execution content (validation commands, CI gates, branching) is removed so the file is purely scoping guidance.
- Adds a 10-section Plan Output Contract (Code Mapping, Implementation Roadmap, Files to Touch, Testing Strategy, Adversarial Test Matrix with Daintree-specific categories, Assumptions/Risks, Rejected Approaches, Pushback Requested, Out of Scope, Implementation Starting Point), an Issue Routing Matrix, a curated Spine Map for code-mapping anchors, 8 architectural invariants (including PTY host, LRU eviction, MessagePort broker, agent-state heuristics, per-window vs global services), 5 cross-boundary Feature Anatomy recipes (Action / IPC / Panel Kind / Store / Theme token), anti-patterns, PR disposition criteria, hard negatives, and version pinning.
- Length: 268 lines / 22 KiB — well under Codex's 32 KiB `project_doc_max_bytes`.

## Test plan

- [ ] Read top-to-bottom and confirm every recipe path resolves to a real file (Action, IPC, Panel Kind, Store, Theme)
- [ ] Spot-check the Issue Routing Matrix against a recent bug fix — does "start reading here" land on the right file?
- [ ] Dry-run: feed a representative GitHub issue to Codex with this file loaded and confirm the plan covers Code Mapping + Adversarial Matrix + Pushback sections as specified
- [ ] Confirm no conflict with CLAUDE.md operational rules (branching, gh CLI, agent-config boundary)