### PR TITLE
fix(ci): run performance workflow on develop

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,9 +2,9 @@ name: Performance
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
   push:
-    branches: [main]
+    branches: [develop]
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

The performance workflow was configured to run on `main` only. Every development PR targets `develop`, so the `perf-smoke` job never fired on PRs and `perf-ci` never ran on develop pushes. This swaps the branch filters from `main` to `develop`.

- PRs against develop now trigger `perf-smoke` (fast smoke suite, gates PRs)
- Pushes to develop now trigger `perf-ci` (full benchmarks, runs on merge)
- Nightly schedule and manual dispatch are unchanged

Resolves #5379.

## Testing

Pushed to the branch and verified the workflow graph in GitHub Actions shows the trigger paths correctly.