### PR TITLE
fix(git): stabilise internal git env for locale and SSH first-connect

### DIFF
--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -502,6 +502,8 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   const withNonInteractiveEnv = (git: SimpleGit): SimpleGit =>
     git.env({
       ...process.env,
+      LC_MESSAGES: "C",
+      LANGUAGE: "",
       GIT_EDITOR: "true",
       GIT_MERGE_AUTOEDIT: "no",
       GIT_TERMINAL_PROMPT: "0",

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -114,8 +114,6 @@ export function registerGitCloneHandlers(): () => void {
         extraConfig: ["transfer.bundleURI=false"],
       });
 
-      git.env({ ...process.env, GIT_TERMINAL_PROMPT: "0" });
-
       await git.clone(url, trimmedFolder, shallowClone ? ["--depth", "1"] : []);
 
       emitProgress("complete", 100, "Clone complete");

--- a/electron/services/__tests__/FileSearchService.test.ts
+++ b/electron/services/__tests__/FileSearchService.test.ts
@@ -4,11 +4,18 @@ import os from "os";
 import path from "path";
 
 const simpleGitMock = vi.hoisted(() => vi.fn());
-const gitClientMock = vi.hoisted(() => ({
+const gitClientMock: {
+  env: ReturnType<typeof vi.fn>;
+  checkIsRepo: ReturnType<typeof vi.fn>;
+  revparse: ReturnType<typeof vi.fn>;
+  raw: ReturnType<typeof vi.fn>;
+} = vi.hoisted(() => ({
+  env: vi.fn(),
   checkIsRepo: vi.fn<() => Promise<boolean>>(),
   revparse: vi.fn<(args: string[]) => Promise<string>>(),
   raw: vi.fn<(args: string[]) => Promise<string>>(),
 }));
+gitClientMock.env.mockReturnValue(gitClientMock);
 
 vi.mock("simple-git", () => ({
   simpleGit: simpleGitMock,
@@ -30,6 +37,7 @@ describe("FileSearchService", () => {
     vi.resetModules();
     vi.clearAllMocks();
     simpleGitMock.mockImplementation(() => gitClientMock);
+    gitClientMock.env.mockReturnValue(gitClientMock);
     gitClientMock.checkIsRepo.mockResolvedValue(false);
     gitClientMock.revparse.mockResolvedValue("");
     gitClientMock.raw.mockResolvedValue("");

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -157,6 +157,62 @@ describe("createHardenedGit", () => {
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options).not.toHaveProperty("abort");
   });
+
+  it("sets LC_MESSAGES=C and LANGUAGE empty via .env()", () => {
+    createHardenedGit("/test/repo");
+
+    expect(mockGitInstance.env).toHaveBeenCalledWith(
+      expect.objectContaining({
+        LC_MESSAGES: "C",
+        LANGUAGE: "",
+      })
+    );
+  });
+
+  it("does not apply hardened SSH command (blocked via config instead)", () => {
+    const origSsh = process.env.GIT_SSH_COMMAND;
+    delete process.env.GIT_SSH_COMMAND;
+    try {
+      createHardenedGit("/test/repo");
+
+      const envArg = mockGitInstance.env.mock.calls[0][0];
+      expect(envArg.GIT_SSH_COMMAND).toBeUndefined();
+    } finally {
+      if (origSsh !== undefined) process.env.GIT_SSH_COMMAND = origSsh;
+    }
+  });
+
+  it("spreads process.env into hardenedGit .env() call", () => {
+    process.env.DAINTREE_TEST_SENTINEL = "sentinel_value";
+    try {
+      createHardenedGit("/test/repo");
+
+      const envArg = mockGitInstance.env.mock.calls[0][0];
+      expect(envArg.PATH).toBe(process.env.PATH);
+      expect(envArg.DAINTREE_TEST_SENTINEL).toBe("sentinel_value");
+    } finally {
+      delete process.env.DAINTREE_TEST_SENTINEL;
+    }
+  });
+
+  it("locale env values override conflicting process.env entries", () => {
+    const origMessages = process.env.LC_MESSAGES;
+    const origLanguage = process.env.LANGUAGE;
+    process.env.LC_MESSAGES = "fr_FR.UTF-8";
+    process.env.LANGUAGE = "fr_FR";
+    try {
+      createHardenedGit("/test/repo");
+
+      const envArg = mockGitInstance.env.mock.calls[0][0];
+      expect(envArg.LC_MESSAGES).toBe("C");
+      expect(envArg.LANGUAGE).toBe("");
+    } finally {
+      if (origMessages === undefined) delete process.env.LC_MESSAGES;
+      else process.env.LC_MESSAGES = origMessages;
+      if (origLanguage === undefined) delete process.env.LANGUAGE;
+      else process.env.LANGUAGE = origLanguage;
+    }
+  });
 });
 
 describe("createAuthenticatedGit", () => {
@@ -195,13 +251,25 @@ describe("createAuthenticatedGit", () => {
     expect(options.config).toContain("core.hooksPath=");
   });
 
-  it("sets GIT_TERMINAL_PROMPT and GIT_SSH_COMMAND via .env()", () => {
+  it("sets GIT_TERMINAL_PROMPT and hardened GIT_SSH_COMMAND via .env()", () => {
     createAuthenticatedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
       expect.objectContaining({
         GIT_TERMINAL_PROMPT: "0",
-        GIT_SSH_COMMAND: "ssh",
+        GIT_SSH_COMMAND:
+          "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
+      })
+    );
+  });
+
+  it("sets LC_MESSAGES=C and LANGUAGE empty via .env()", () => {
+    createAuthenticatedGit("/test/repo");
+
+    expect(mockGitInstance.env).toHaveBeenCalledWith(
+      expect.objectContaining({
+        LC_MESSAGES: "C",
+        LANGUAGE: "",
       })
     );
   });
@@ -223,19 +291,31 @@ describe("createAuthenticatedGit", () => {
   it("forced env values override conflicting process.env entries", () => {
     const origPrompt = process.env.GIT_TERMINAL_PROMPT;
     const origSsh = process.env.GIT_SSH_COMMAND;
+    const origMessages = process.env.LC_MESSAGES;
+    const origLanguage = process.env.LANGUAGE;
     process.env.GIT_TERMINAL_PROMPT = "1";
     process.env.GIT_SSH_COMMAND = "ssh -i /custom/key";
+    process.env.LC_MESSAGES = "fr_FR.UTF-8";
+    process.env.LANGUAGE = "fr_FR";
     try {
       createAuthenticatedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.GIT_TERMINAL_PROMPT).toBe("0");
-      expect(envArg.GIT_SSH_COMMAND).toBe("ssh");
+      expect(envArg.GIT_SSH_COMMAND).toBe(
+        "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15"
+      );
+      expect(envArg.LC_MESSAGES).toBe("C");
+      expect(envArg.LANGUAGE).toBe("");
     } finally {
       if (origPrompt === undefined) delete process.env.GIT_TERMINAL_PROMPT;
       else process.env.GIT_TERMINAL_PROMPT = origPrompt;
       if (origSsh === undefined) delete process.env.GIT_SSH_COMMAND;
       else process.env.GIT_SSH_COMMAND = origSsh;
+      if (origMessages === undefined) delete process.env.LC_MESSAGES;
+      else process.env.LC_MESSAGES = origMessages;
+      if (origLanguage === undefined) delete process.env.LANGUAGE;
+      else process.env.LANGUAGE = origLanguage;
     }
   });
 

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -53,6 +53,10 @@ export function createHardenedGit(cwd: string, signal?: AbortSignal): SimpleGit 
     timeout: { block: GIT_BLOCK_TIMEOUT_MS },
     ...(signal ? { abort: signal } : {}),
     unsafe: UNSAFE_FLAGS,
+  }).env({
+    ...process.env,
+    LC_MESSAGES: "C",
+    LANGUAGE: "",
   });
 }
 
@@ -73,7 +77,10 @@ export function createAuthenticatedGit(cwd: string, opts: AuthenticatedGitOption
     unsafe: UNSAFE_FLAGS,
   }).env({
     ...process.env,
+    LC_MESSAGES: "C",
+    LANGUAGE: "",
     GIT_TERMINAL_PROMPT: "0",
-    GIT_SSH_COMMAND: "ssh",
+    GIT_SSH_COMMAND:
+      "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
   });
 }


### PR DESCRIPTION
## Summary

- Sets `LC_MESSAGES=C` and `LANGUAGE=""` on all internal git invocations so stderr output is always in English, regardless of the user's system locale. Non-English machines were silently breaking stderr-regex classifiers (see #5369) because git emits localised error strings.
- Adds hardened `GIT_SSH_COMMAND` to `authenticatedGit` with `StrictHostKeyChecking=accept-new`, `BatchMode=yes`, and `ConnectTimeout=15`. Without this, agent-driven clones to any SSH remote without a cached host key hang indefinitely (no TTY, no prompt).
- Extends the same locale env to `withNonInteractiveEnv` in `git-write.ts` so continue operations (merge/rebase/cherry-pick/revert `--continue`) inherit the English-locale guarantee.

Resolves #5399

## Changes

- `electron/utils/hardenedGit.ts` — `.env()` chain added to both factories with `LC_MESSAGES=C` / `LANGUAGE=""`; `authenticatedGit` also gets hardened `GIT_SSH_COMMAND`
- `electron/ipc/handlers/git-write.ts` — locale vars added to `withNonInteractiveEnv`
- `electron/ipc/handlers/projectCrud/gitClone.ts` — removed redundant `.env()` call that was overwriting the factory env
- `electron/utils/__tests__/hardenedGit.test.ts` — updated and expanded to 40 passing tests

## Testing

All 40 unit tests pass. Lint, format, and typecheck clean. Locale vars verified present on both `baseGit` and `authenticatedGit` factory outputs, with `GIT_SSH_COMMAND` confirmed on `authenticatedGit` only.