### PR TITLE
fix(notify): default action-bearing toasts to persist

### DIFF
--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -407,6 +407,61 @@ describe("notify()", () => {
       const notification = useNotificationStore.getState().notifications[0];
       expect(notification!.duration).toBe(0);
     });
+
+    it("applies the persist default on coalesce-update when buildAction introduces an action", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      // First event: no action → duration stays undefined.
+      notify({
+        type: "info",
+        message: "First",
+        coalesce: {
+          key: "coalesce-add-action",
+          buildMessage: (n) => `${n} events`,
+          buildAction: (n) => (n > 1 ? { label: "Review", onClick: () => {} } : undefined),
+        },
+      });
+      expect(useNotificationStore.getState().notifications[0]!.duration).toBeUndefined();
+
+      // Second event: buildAction now returns an action → duration should become 0.
+      notify({
+        type: "info",
+        message: "Second",
+        coalesce: {
+          key: "coalesce-add-action",
+          buildMessage: (n) => `${n} events`,
+          buildAction: (n) => (n > 1 ? { label: "Review", onClick: () => {} } : undefined),
+        },
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.action).toBeDefined();
+      expect(notification!.duration).toBe(0);
+    });
+
+    it("preserves stored duration on coalesce-update when duration was explicitly set", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      // First event sets duration explicitly to 5000 — update must not override.
+      notify({
+        type: "info",
+        message: "First",
+        duration: 5000,
+        coalesce: {
+          key: "coalesce-keep-duration",
+          buildMessage: (n) => `${n} events`,
+          buildAction: () => ({ label: "Review", onClick: () => {} }),
+        },
+      });
+      notify({
+        type: "info",
+        message: "Second",
+        coalesce: {
+          key: "coalesce-keep-duration",
+          buildMessage: (n) => `${n} events`,
+          buildAction: () => ({ label: "Review", onClick: () => {} }),
+        },
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBe(5000);
+    });
   });
 
   describe("return value", () => {

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -316,6 +316,99 @@ describe("notify()", () => {
     });
   });
 
+  describe("default duration — action-bearing toasts persist", () => {
+    it("defaults duration to 0 when `action` is present and duration is undefined", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "Undo?",
+        action: { label: "Undo", onClick: () => {} },
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBe(0);
+    });
+
+    it("defaults duration to 0 when `actions` is non-empty and duration is undefined", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "warning",
+        message: "Retry?",
+        actions: [
+          { label: "Retry", onClick: () => {} },
+          { label: "Cancel", onClick: () => {} },
+        ],
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBe(0);
+    });
+
+    it("preserves an explicit positive duration when action is present", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "Timed action",
+        action: { label: "Retry", onClick: () => {} },
+        duration: 5000,
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBe(5000);
+    });
+
+    it("preserves an explicit duration of 0 (redundant but valid)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "Persist",
+        action: { label: "Undo", onClick: () => {} },
+        duration: 0,
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBe(0);
+    });
+
+    it("leaves duration undefined when no action is present (render layer falls back to 3000ms)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({ type: "success", message: "Done" });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBeUndefined();
+    });
+
+    it("leaves duration undefined when `actions` is an empty array", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({ type: "info", message: "No actions", actions: [] });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBeUndefined();
+    });
+
+    it("applies the persist default on the grid-bar placement path", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "Inline",
+        placement: "grid-bar",
+        action: { label: "Dismiss", onClick: () => {} },
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.placement).toBe("grid-bar");
+      expect(notification!.duration).toBe(0);
+    });
+
+    it("applies the persist default on the coalesce-create path", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "First",
+        action: { label: "Open", onClick: () => {} },
+        coalesce: {
+          key: "coalesce-persist",
+          buildMessage: (n) => `${n} events`,
+        },
+      });
+      const notification = useNotificationStore.getState().notifications[0];
+      expect(notification!.duration).toBe(0);
+    });
+  });
+
   describe("return value", () => {
     it("returns notification id for toast notifications", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -168,6 +168,12 @@ export function notify(payload: NotifyPayload): string {
   const historyMessage = inboxMessage ?? (typeof message === "string" ? message : undefined);
 
   const allActions = [...(payload.actions ?? []), ...(payload.action ? [payload.action] : [])];
+
+  // Action-bearing toasts persist by default so users can act; toaster's 3s fallback would otherwise dismiss them.
+  if (payload.duration === undefined && allActions.length > 0) {
+    payload = { ...payload, duration: 0 };
+  }
+
   const historyActions: NotificationHistoryAction[] = allActions
     .filter(
       (a): a is NotificationAction & { actionId: NonNullable<NotificationAction["actionId"]> } =>

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -277,13 +277,14 @@ export function notify(payload: NotifyPayload): string {
         // coalesce — clear any per-item `actions` array from the initial toast
         // so stale buttons (e.g. "Close project-1") don't linger after we
         // collapse multiple notifications together.
+        const patchAction = coalesce.buildAction?.(count) ?? payload.action;
         const patch: Parameters<
           ReturnType<typeof useNotificationStore.getState>["updateNotification"]
         >[1] = {
           message: coalesce.buildMessage(count),
           title: coalesce.buildTitle?.(count) ?? title,
           inboxMessage: coalesce.buildInboxMessage?.(count),
-          action: coalesce.buildAction?.(count) ?? payload.action,
+          action: patchAction,
         };
         if (coalesce.buildAction) {
           patch.actions = undefined;
@@ -294,6 +295,13 @@ export function notify(payload: NotifyPayload): string {
         // with the first project's ID and silently mute the wrong target.
         if (notification.context?.projectId !== context?.projectId) {
           patch.context = undefined;
+        }
+        // Mirror the create-path rule: if the updated toast will be action-bearing
+        // and the stored duration is still `undefined`, persist it.
+        const resultingActionsCount =
+          (patchAction ? 1 : 0) + (coalesce.buildAction ? 0 : (notification.actions?.length ?? 0));
+        if (notification.duration === undefined && resultingActionsCount > 0) {
+          patch.duration = 0;
         }
         useNotificationStore.getState().updateNotification(existing.id, patch);
 


### PR DESCRIPTION
## Summary

- `notify()` was defaulting all toasts to a 3 second auto-dismiss, including ones carrying action buttons. A new call site that forgot to pass `duration: 0` would silently hide the action before the user could act on it.
- The fix normalises `duration` to `0` in `notify()` whenever `action` or `actions` is present and `duration` hasn't been set explicitly. Applied on both the initial call path and the coalesce-update path (when `buildAction` introduces an action into an existing toast).
- All the existing call sites that were manually passing `duration: 0` now get the same behaviour for free, and future call sites are protected by default.

Resolves #5406

## Changes

- `src/lib/notify.ts`: normalise `duration` to `0` when action/actions present and duration is undefined, on both the create and coalesce-update paths
- `src/lib/__tests__/notify.test.ts`: 10 new tests covering the default persist behaviour (single action, array actions, explicit duration override, no-action fallback, and the coalesce-update regression case)

## Testing

All 93 tests in `notify.test.ts` pass. Lint, format, and typecheck clean.