### PR TITLE
fix(terminal): unblock app shell mount while terminal font loads

### DIFF
--- a/src/components/DevPreview/ConsoleDrawer.tsx
+++ b/src/components/DevPreview/ConsoleDrawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { Suspense, useState, useCallback, useEffect } from "react";
 import { ChevronUp, RotateCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -147,12 +147,14 @@ export function ConsoleDrawer({
         aria-hidden={!isOpen}
       >
         <div className="h-[300px] bg-surface-canvas">
-          <XtermAdapter
-            terminalId={terminalId}
-            getRefreshTier={getRefreshTier}
-            restoreOnAttach={true}
-            className="!rounded-none !px-0 !pt-0 !pb-0"
-          />
+          <Suspense fallback={null}>
+            <XtermAdapter
+              terminalId={terminalId}
+              getRefreshTier={getRefreshTier}
+              restoreOnAttach={true}
+              className="!rounded-none !px-0 !pt-0 !pb-0"
+            />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { X, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
@@ -275,12 +275,14 @@ export function HelpPanel() {
       <div ref={contentRef} className="flex-1 flex flex-col min-h-0 relative">
         {showTerminal ? (
           <div className="absolute inset-0">
-            <XtermAdapter
-              terminalId={terminalId}
-              terminalType={(agentId ?? "terminal") as TerminalType}
-              getRefreshTier={getRefreshTier}
-              cwd={terminal.cwd}
-            />
+            <Suspense fallback={null}>
+              <XtermAdapter
+                terminalId={terminalId}
+                terminalType={(agentId ?? "terminal") as TerminalType}
+                getRefreshTier={getRefreshTier}
+                cwd={terminal.cwd}
+              />
+            </Suspense>
           </div>
         ) : (
           <HelpAgentPicker onSelectAgent={handleSelectAgent} />

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -796,19 +796,21 @@ function TerminalPaneComponent({
             )}
             onPointerDownCapture={handleXtermPointerDownCapture}
           >
-            <XtermAdapter
-              key={`${id}-${restartKey}`}
-              terminalId={id}
-              terminalType={type}
-              isInputLocked={isInputLocked}
-              onReady={handleReady}
-              onExit={handleExit}
-              onInput={handleInput}
-              className="absolute inset-0"
-              getRefreshTier={getRefreshTierCallback}
-              cwd={cwd}
-              hasBottomBar={showHybridInputBar}
-            />
+            <Suspense fallback={null}>
+              <XtermAdapter
+                key={`${id}-${restartKey}`}
+                terminalId={id}
+                terminalType={type}
+                isInputLocked={isInputLocked}
+                onReady={handleReady}
+                onExit={handleExit}
+                onInput={handleInput}
+                className="absolute inset-0"
+                getRefreshTier={getRefreshTierCallback}
+                cwd={cwd}
+                hasBottomBar={showHybridInputBar}
+              />
+            </Suspense>
             <ArtifactOverlay terminalId={id} worktreeId={worktreeId} cwd={cwd} />
             {isSearchOpen && (
               <TerminalSearchBar

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useEffect, useState } from "react";
+import React, {
+  use,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useEffect,
+  useState,
+} from "react";
 import "@xterm/xterm/css/xterm.css";
 import { cn } from "@/lib/utils";
 import { terminalClient } from "@/clients";
@@ -8,6 +16,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { useTerminalAppearance } from "@/hooks/useTerminalAppearance";
 import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrollbackConfig";
 import { getXtermOptions } from "@/config/xtermConfig";
+import { terminalFontReady } from "@/config/terminalFont";
 import { getSoftNewlineSequence } from "../../../shared/utils/terminalInputProtocol.js";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
@@ -42,6 +51,13 @@ function XtermAdapterComponent({
   restoreOnAttach = false,
   hasBottomBar = false,
 }: XtermAdapterProps) {
+  // Gate xterm's grid measurement (which happens at `terminal.open()` inside
+  // `terminalInstanceService.attach`) on the JetBrains Mono font being ready.
+  // xterm does not re-measure after open, so measuring with the fallback stack
+  // would leave a permanently mis-sized grid. The promise is a module-level
+  // singleton so `use()` sees a stable reference across re-renders.
+  use(terminalFontReady);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const prevDimensionsRef = useRef<{ cols: number; rows: number } | null>(null);
   const exitUnsubRef = useRef<(() => void) | null>(null);

--- a/src/config/__tests__/terminalFont.test.ts
+++ b/src/config/__tests__/terminalFont.test.ts
@@ -53,3 +53,33 @@ describe("ensureTerminalFontLoaded", () => {
     await expect(ensureTerminalFontLoaded()).resolves.toBeUndefined();
   });
 });
+
+describe("terminalFontReady", () => {
+  let loadMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    loadMock = vi.fn().mockResolvedValue([{ family: "JetBrains Mono" }]);
+    Object.defineProperty(globalThis, "document", {
+      value: { fonts: { load: loadMock } },
+      configurable: true,
+    });
+  });
+
+  it("is initialised eagerly at module import", async () => {
+    await import("../terminalFont");
+    // Module import alone should have triggered the font load so the
+    // shared promise is already in-flight before any component mounts.
+    expect(loadMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("is the same promise instance as ensureTerminalFontLoaded()", async () => {
+    const mod = await import("../terminalFont");
+    expect(mod.terminalFontReady).toBe(mod.ensureTerminalFontLoaded());
+  });
+
+  it("resolves to undefined (never rejects)", async () => {
+    const { terminalFontReady } = await import("../terminalFont");
+    await expect(terminalFontReady).resolves.toBeUndefined();
+  });
+});

--- a/src/config/terminalFont.ts
+++ b/src/config/terminalFont.ts
@@ -33,3 +33,9 @@ export function ensureTerminalFontLoaded(): Promise<void> {
 
   return fontLoadPromise;
 }
+
+// Eagerly kick off the font load at module import so components can `use()`
+// the same promise reference without having to call `ensureTerminalFontLoaded()`
+// in render. Holding a stable module-level reference is required to prevent
+// `use()` from throwing a new promise on every render (infinite suspense).
+export const terminalFontReady: Promise<void> = ensureTerminalFontLoaded();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,11 @@ import "@fontsource/jetbrains-mono/600.css";
 import "@fontsource/jetbrains-mono/700.css";
 import "./index.css";
 import { applyDefaultAppTheme } from "./theme/applyAppTheme";
-import { ensureTerminalFontLoaded } from "./config/terminalFont";
+// Importing this module has the side effect of starting the font load (via
+// the eagerly-initialised `terminalFontReady` singleton). `XtermAdapter`
+// suspends locally on that same promise so the grid measurement waits while
+// the rest of the app shell mounts immediately.
+import "./config/terminalFont";
 import { initStoreOrchestrator } from "./store/rendererStoreOrchestrator";
 import { useAgentSettingsStore } from "./store/agentSettingsStore";
 import { registerRendererGlobalErrorHandlers } from "./utils/rendererGlobalErrorHandlers";
@@ -46,13 +50,6 @@ async function bootstrap() {
   // without it the store stays null and the orchestrator's availability
   // subscription never gets a chance to reconcile (see issue #5158).
   void useAgentSettingsStore.getState().initialize();
-
-  // Kick off the terminal font load eagerly without blocking first paint.
-  // The app shell (sidebar, toolbar, etc.) doesn't need the monospace font —
-  // only terminal panels do. `XtermAdapter` suspends locally on the same
-  // singleton promise (exported as `terminalFontReady`) so the grid
-  // measurement at `terminal.open()` still waits for the font.
-  void ensureTerminalFontLoaded();
 
   const { default: App } = await import("./App");
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -47,7 +47,12 @@ async function bootstrap() {
   // subscription never gets a chance to reconcile (see issue #5158).
   void useAgentSettingsStore.getState().initialize();
 
-  await ensureTerminalFontLoaded();
+  // Kick off the terminal font load eagerly without blocking first paint.
+  // The app shell (sidebar, toolbar, etc.) doesn't need the monospace font —
+  // only terminal panels do. `XtermAdapter` suspends locally on the same
+  // singleton promise (exported as `terminalFontReady`) so the grid
+  // measurement at `terminal.open()` still waits for the font.
+  void ensureTerminalFontLoaded();
 
   const { default: App } = await import("./App");
 


### PR DESCRIPTION
## Summary

- The terminal font was being loaded via a blocking `await` in the renderer bootstrap, which held up the entire React mount until the font was ready.
- Removed the blocking call from `src/main.tsx` and exported a `terminalFontReady` singleton Promise from `src/config/terminalFont.ts`. The `XtermAdapter` component now suspends locally via React 19's `use(terminalFontReady)`, wrapped in `<Suspense fallback={null}>` at each call site (TerminalPane, HelpPanel, ConsoleDrawer).
- This lets the app shell render immediately while individual terminal panels suspend independently until the font is available.

Resolves #5390

## Changes

- `src/main.tsx` — remove blocking `await ensureTerminalFontLoaded()`; import `terminalFont` as a side-effect to trigger eager singleton initialisation
- `src/config/terminalFont.ts` — export `terminalFontReady` Promise singleton
- `src/components/Terminal/XtermAdapter.tsx` — call `use(terminalFontReady)` to suspend until font is loaded
- `src/components/Terminal/TerminalPane.tsx` — wrap `XtermAdapter` in `<Suspense fallback={null}>`
- `src/components/HelpPanel/HelpPanel.tsx` — same Suspense wrapper
- `src/components/DevPreview/ConsoleDrawer.tsx` — same Suspense wrapper
- `src/config/__tests__/terminalFont.test.ts` — unit tests for eager singleton and Promise identity

## Testing

- Unit tests for the `terminalFontReady` singleton (8/8 pass)
- `ConsoleDrawer` existing test suite (37/37 pass)
- `npm run check` passes — lint, format, and typecheck all clean