### PR TITLE
fix(ccr): track poll promise for clean teardown

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1132,
-  "moduleCount": 1132,
+  "count": 1130,
+  "moduleCount": 1130,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 306,
+      "line": 225,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 350,
+      "line": 269,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 355,
+      "line": 274,
       "pattern": "sync-store-get"
     },
     {
@@ -539,132 +539,132 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 61,
+      "line": 56,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 80,
+      "line": 75,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 125,
+      "line": 120,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 142,
+      "line": 137,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 143,
+      "line": 138,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 209,
+      "line": 204,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 212,
+      "line": 207,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 236,
+      "line": 231,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 263,
+      "line": 258,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 264,
+      "line": 259,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 310,
+      "line": 305,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 311,
+      "line": 306,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 338,
+      "line": 333,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 440,
+      "line": 435,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 453,
+      "line": 448,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 454,
+      "line": 449,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 464,
+      "line": 459,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 465,
+      "line": 460,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 466,
+      "line": 461,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 484,
+      "line": 479,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 486,
+      "line": 481,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 492,
+      "line": 487,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 502,
+      "line": 497,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 515,
+      "line": 510,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 518,
+      "line": 513,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 521,
+      "line": 516,
       "pattern": "sync-fs"
     },
     {
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 233,
+      "line": 227,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 241,
+      "line": 235,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 249,
+      "line": 243,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 256,
+      "line": 250,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 363,
+      "line": 299,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 413,
+      "line": 349,
       "pattern": "sync-store-get"
     },
     {
@@ -1544,7 +1544,7 @@
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 134,
+      "line": 133,
       "pattern": "sync-store-get"
     },
     {
@@ -1559,17 +1559,17 @@
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 189,
+      "line": 190,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 287,
+      "line": 288,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 519,
+      "line": 520,
       "pattern": "sync-store-get"
     },
     {

--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1130,
-  "moduleCount": 1130,
+  "count": 1132,
+  "moduleCount": 1132,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 225,
+      "line": 306,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 269,
+      "line": 350,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 274,
+      "line": 355,
       "pattern": "sync-store-get"
     },
     {
@@ -539,132 +539,132 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 56,
+      "line": 61,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 75,
+      "line": 80,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 120,
+      "line": 125,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 137,
+      "line": 142,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 138,
+      "line": 143,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 204,
+      "line": 209,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 207,
+      "line": 212,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 231,
+      "line": 236,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 258,
+      "line": 263,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 259,
+      "line": 264,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 305,
+      "line": 310,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 306,
+      "line": 311,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 333,
+      "line": 338,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 435,
+      "line": 440,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 448,
+      "line": 453,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 449,
+      "line": 454,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 459,
+      "line": 464,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 460,
+      "line": 465,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 461,
+      "line": 466,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 479,
+      "line": 484,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 481,
+      "line": 486,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 487,
+      "line": 492,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 497,
+      "line": 502,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 510,
+      "line": 515,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 513,
+      "line": 518,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 516,
+      "line": 521,
       "pattern": "sync-fs"
     },
     {
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 227,
+      "line": 233,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 235,
+      "line": 241,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 243,
+      "line": 249,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 250,
+      "line": 256,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 299,
+      "line": 363,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 349,
+      "line": 413,
       "pattern": "sync-store-get"
     },
     {
@@ -1544,7 +1544,7 @@
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 133,
+      "line": 134,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/services/CcrConfigService.ts
+++ b/electron/services/CcrConfigService.ts
@@ -131,7 +131,12 @@ export class CcrConfigService {
           break;
         }
         if (signal.aborted) break;
-        await this.loadAndApply();
+        try {
+          await this.loadAndApply();
+        } catch (err) {
+          // A transient failure must not kill the poll loop silently.
+          console.warn("[CcrConfigService] poll iteration failed:", err);
+        }
       }
     };
 

--- a/electron/services/CcrConfigService.ts
+++ b/electron/services/CcrConfigService.ts
@@ -6,6 +6,24 @@ import { setAgentPresets } from "../../shared/config/agentRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new Error("aborted"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 interface CcrModelEntry {
   id?: string;
   name?: string;
@@ -48,6 +66,7 @@ export class CcrConfigService {
   private cachedPresets: AgentPreset[] | null = null;
   private pendingBroadcast = true;
   private watchAbortController: AbortController | null = null;
+  private pollPromise: Promise<void> | null = null;
 
   static getInstance(): CcrConfigService {
     if (!CcrConfigService.instance) {
@@ -104,18 +123,30 @@ export class CcrConfigService {
 
     const poll = async () => {
       while (!signal.aborted) {
-        await new Promise((resolve) => setTimeout(resolve, 30_000));
+        try {
+          // Abortable sleep — stopWatching() triggers this to reject immediately
+          // instead of blocking teardown up to 30s on the next iteration.
+          await abortableSleep(30_000, signal);
+        } catch {
+          break;
+        }
         if (signal.aborted) break;
         await this.loadAndApply();
       }
     };
 
-    void poll().catch(() => {});
+    this.pollPromise = poll().catch(() => {});
   }
 
-  stopWatching(): void {
-    this.watchAbortController?.abort();
+  async stopWatching(): Promise<void> {
+    // Capture locals before nulling so a racing startWatching() can install a fresh
+    // loop without having its fields clobbered by this teardown.
+    const controller = this.watchAbortController;
+    const promise = this.pollPromise;
     this.watchAbortController = null;
+    this.pollPromise = null;
+    controller?.abort();
+    await promise;
   }
 
   private entryToPreset(entry: CcrModelEntry): AgentPreset {

--- a/electron/services/__tests__/CcrConfigService.test.ts
+++ b/electron/services/__tests__/CcrConfigService.test.ts
@@ -165,17 +165,17 @@ describe("CcrConfigService", () => {
     });
 
     it("stopWatching awaits in-flight loadAndApply before resolving", async () => {
-      let resolveLoad: (() => void) | null = null;
+      const resolveRef: { fn: (() => void) | null } = { fn: null };
       const loadSpy = vi.spyOn(service, "loadAndApply").mockImplementation(
         () =>
           new Promise<AgentPreset[]>((resolve) => {
-            resolveLoad = () => resolve([]);
+            resolveRef.fn = () => resolve([]);
           })
       );
 
       service.startWatching();
       // Enter the poll loop and trigger the first iteration (loadAndApply starts
-      // but does not resolve — we control it via resolveLoad).
+      // but does not resolve — we control it via resolveRef.fn).
       await vi.advanceTimersByTimeAsync(30_000);
       expect(loadSpy).toHaveBeenCalledTimes(1);
 
@@ -190,7 +190,7 @@ describe("CcrConfigService", () => {
       expect(settled).toBe(false);
 
       // Releasing loadAndApply lets the loop observe the abort and exit.
-      resolveLoad?.();
+      resolveRef.fn?.();
       await stopped;
       expect(settled).toBe(true);
 
@@ -268,11 +268,11 @@ describe("CcrConfigService", () => {
     });
 
     it("start → stop → start does not orphan the new watcher", async () => {
-      let resolveFirst: (() => void) | null = null;
+      const firstRef: { fn: (() => void) | null } = { fn: null };
       const loadSpy = vi.spyOn(service, "loadAndApply").mockImplementationOnce(
         () =>
           new Promise<AgentPreset[]>((resolve) => {
-            resolveFirst = () => resolve([]);
+            firstRef.fn = () => resolve([]);
           })
       );
       loadSpy.mockResolvedValue([]);
@@ -286,7 +286,7 @@ describe("CcrConfigService", () => {
       service.startWatching();
 
       // Release the first iteration so the old loop can exit.
-      resolveFirst?.();
+      firstRef.fn?.();
       await stopped;
 
       // The second watcher (newly started) must still be live and firing polls.

--- a/electron/services/__tests__/CcrConfigService.test.ts
+++ b/electron/services/__tests__/CcrConfigService.test.ts
@@ -234,6 +234,65 @@ describe("CcrConfigService", () => {
 
       loadSpy.mockRestore();
     });
+
+    it("stopWatching resolves immediately during the sleep phase (no 30s wait)", async () => {
+      const loadSpy = vi.spyOn(service, "loadAndApply").mockResolvedValue([]);
+
+      service.startWatching();
+      // Loop is parked in abortableSleep; stopWatching() must wake it without
+      // advancing real or fake timers.
+      await service.stopWatching();
+
+      expect(loadSpy).not.toHaveBeenCalled();
+      loadSpy.mockRestore();
+    });
+
+    it("transient loadAndApply failure does not kill subsequent polls", async () => {
+      const loadSpy = vi
+        .spyOn(service, "loadAndApply")
+        .mockRejectedValueOnce(new Error("transient"))
+        .mockResolvedValue([]);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      service.startWatching();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(loadSpy).toHaveBeenCalledTimes(1);
+
+      // Next iteration must still run despite prior failure.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(loadSpy).toHaveBeenCalledTimes(2);
+
+      loadSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it("start → stop → start does not orphan the new watcher", async () => {
+      let resolveFirst: (() => void) | null = null;
+      const loadSpy = vi.spyOn(service, "loadAndApply").mockImplementationOnce(
+        () =>
+          new Promise<AgentPreset[]>((resolve) => {
+            resolveFirst = () => resolve([]);
+          })
+      );
+      loadSpy.mockResolvedValue([]);
+
+      service.startWatching();
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(loadSpy).toHaveBeenCalledTimes(1);
+
+      // stop in-flight; new start races while old teardown is pending
+      const stopped = service.stopWatching();
+      service.startWatching();
+
+      // Release the first iteration so the old loop can exit.
+      resolveFirst?.();
+      await stopped;
+
+      // The second watcher (newly started) must still be live and firing polls.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(loadSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("getInstance", () => {

--- a/electron/services/__tests__/CcrConfigService.test.ts
+++ b/electron/services/__tests__/CcrConfigService.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { AgentPreset } from "../../../shared/config/agentRegistry.js";
 import { CcrConfigService } from "../CcrConfigService.js";
 
 vi.mock("fs/promises", () => ({
@@ -148,8 +149,90 @@ describe("CcrConfigService", () => {
   });
 
   describe("startWatching / stopWatching", () => {
-    it("does not throw on stop when not started", () => {
-      expect(() => service.stopWatching()).not.toThrow();
+    it("does not throw on stop when not started", async () => {
+      await expect(service.stopWatching()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("startWatching / stopWatching — async teardown", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(async () => {
+      await service.stopWatching().catch(() => {});
+      vi.useRealTimers();
+    });
+
+    it("stopWatching awaits in-flight loadAndApply before resolving", async () => {
+      let resolveLoad: (() => void) | null = null;
+      const loadSpy = vi.spyOn(service, "loadAndApply").mockImplementation(
+        () =>
+          new Promise<AgentPreset[]>((resolve) => {
+            resolveLoad = () => resolve([]);
+          })
+      );
+
+      service.startWatching();
+      // Enter the poll loop and trigger the first iteration (loadAndApply starts
+      // but does not resolve — we control it via resolveLoad).
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(loadSpy).toHaveBeenCalledTimes(1);
+
+      const stopped = service.stopWatching();
+      let settled = false;
+      void stopped.then(() => {
+        settled = true;
+      });
+
+      // Microtasks drain but loadAndApply is still pending, so stop must not resolve.
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      // Releasing loadAndApply lets the loop observe the abort and exit.
+      resolveLoad?.();
+      await stopped;
+      expect(settled).toBe(true);
+
+      loadSpy.mockRestore();
+    });
+
+    it("poll loop does not call loadAndApply after stopWatching resolves", async () => {
+      const loadSpy = vi.spyOn(service, "loadAndApply").mockResolvedValue([]);
+
+      service.startWatching();
+      await vi.advanceTimersByTimeAsync(30_000);
+      const callsBeforeStop = loadSpy.mock.calls.length;
+
+      await service.stopWatching();
+
+      // Fast-forward well past subsequent scheduled polls — none may fire.
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(loadSpy.mock.calls.length).toBe(callsBeforeStop);
+
+      loadSpy.mockRestore();
+    });
+
+    it("stopWatching called twice is safe", async () => {
+      const loadSpy = vi.spyOn(service, "loadAndApply").mockResolvedValue([]);
+
+      service.startWatching();
+      await service.stopWatching();
+      await expect(service.stopWatching()).resolves.toBeUndefined();
+
+      loadSpy.mockRestore();
+    });
+
+    it("startWatching called twice does not create a second concurrent loop", async () => {
+      const loadSpy = vi.spyOn(service, "loadAndApply").mockResolvedValue([]);
+
+      service.startWatching();
+      service.startWatching();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(loadSpy).toHaveBeenCalledTimes(1);
+
+      loadSpy.mockRestore();
     });
   });
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -1096,7 +1096,15 @@ export async function setupWindowServices(
       return;
     }
 
-    // Last window closed — dispose global services
+    // Last window closed — dispose global services.
+    // Stop the CCR config watcher first, before any guard resets or IPC teardown.
+    // Awaiting here blocks a new window from racing into the init block (which would
+    // restart the singleton watcher) and finding this handler about to null the ref.
+    if (ccrConfigService) {
+      await ccrConfigService.stopWatching();
+      ccrConfigService = null;
+    }
+
     if (stopEventLoopLagMonitor) {
       stopEventLoopLagMonitor();
       stopEventLoopLagMonitor = null;
@@ -1153,10 +1161,5 @@ export async function setupWindowServices(
     activationFunnelService.dispose();
     preAgentSnapshotService.dispose();
     autoUpdaterService.dispose();
-
-    if (ccrConfigService) {
-      await ccrConfigService.stopWatching();
-      ccrConfigService = null;
-    }
   });
 }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -105,6 +105,7 @@ let stopDiskSpaceMonitor: (() => void) | null = null;
 let resourceProfileService: ResourceProfileService | null = null;
 let worktreePortBroker: import("../services/WorktreePortBroker.js").WorktreePortBroker | null =
   null;
+let ccrConfigService: import("../services/CcrConfigService.js").CcrConfigService | null = null;
 
 // Guard: IPC handlers are globally scoped (ipcMain.handle throws on re-registration)
 let ipcHandlersRegistered = false;
@@ -345,9 +346,9 @@ export async function setupWindowServices(
     // CCR config — discover Claude Code Router models as agent presets
     try {
       const { CcrConfigService } = await import("../services/CcrConfigService.js");
-      const ccrService = CcrConfigService.getInstance();
-      await ccrService.loadAndApply();
-      ccrService.startWatching();
+      ccrConfigService = CcrConfigService.getInstance();
+      await ccrConfigService.loadAndApply();
+      ccrConfigService.startWatching();
       console.log("[MAIN] CcrConfigService initialized");
     } catch (err) {
       console.warn("[MAIN] CcrConfigService init failed (non-fatal):", err);
@@ -1152,5 +1153,10 @@ export async function setupWindowServices(
     activationFunnelService.dispose();
     preAgentSnapshotService.dispose();
     autoUpdaterService.dispose();
+
+    if (ccrConfigService) {
+      await ccrConfigService.stopWatching();
+      ccrConfigService = null;
+    }
   });
 }


### PR DESCRIPTION
## Summary

- `CcrConfigService.startWatching()` was fire-and-forget: the poll loop could complete a `readFile` and broadcast to renderers after `stopWatching()` returned, leaving teardown in an undefined state.
- Captures the poll promise in a `pollPromise` field; `stopWatching()` is now async and awaits it. Added `abortableSleep` so aborting during the 30s sleep wakes it immediately rather than sitting out the full wait.
- Wired `await ccrConfigService.stopWatching()` into the last-window-close handler before the guard resets, closing a macOS reopen race identified during review. Also added log-and-continue for transient `loadAndApply` failures so one bad read doesn't kill the loop.

Resolves #5465

## Changes

- `electron/services/CcrConfigService.ts`: `pollPromise` field, async `stopWatching()`, `abortableSleep(ms, signal)` helper, transient-error resilience in poll loop
- `electron/services/__tests__/CcrConfigService.test.ts`: 5 new fake-timer cases (23 total) covering in-flight await, post-stop quiescence, double-stop, double-start, stop-during-sleep, and start→stop→start race
- `electron/window/windowServices.ts`: module-level `ccrConfigService` var, `await stopWatching()` before guard reset on last-window-close

## Testing

23 unit tests, all passing. `npm run check` green. No E2E surface area for this change.