### PR TITLE
fix(terminal): polish scroll-to-bottom indicator position and hysteresis

### DIFF
--- a/src/components/Terminal/TerminalScrollIndicator.tsx
+++ b/src/components/Terminal/TerminalScrollIndicator.tsx
@@ -10,7 +10,12 @@ export interface TerminalScrollIndicatorProps {
 
 export function TerminalScrollIndicator({ terminalId }: TerminalScrollIndicatorProps) {
   const { hasUnseenOutput } = useUnseenOutput(terminalId);
-  const { isVisible, shouldRender } = useAnimatedPresence({ isOpen: hasUnseenOutput });
+  // Instant hide (animationDuration: 0): once the user catches up the pill
+  // should disappear immediately rather than fade out symmetrically with show.
+  const { isVisible, shouldRender } = useAnimatedPresence({
+    isOpen: hasUnseenOutput,
+    animationDuration: 0,
+  });
 
   if (!shouldRender) return null;
 
@@ -21,7 +26,7 @@ export function TerminalScrollIndicator({ terminalId }: TerminalScrollIndicatorP
   };
 
   return (
-    <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-center pb-4">
+    <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-end pb-4 pr-[14px]">
       <button
         type="button"
         className={cn(

--- a/src/components/Terminal/__tests__/TerminalScrollIndicator.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalScrollIndicator.test.tsx
@@ -85,4 +85,13 @@ describe("TerminalScrollIndicator", () => {
     expect(container.className).toContain("pointer-events-none");
     expect(button.className).toContain("pointer-events-auto");
   });
+
+  it("anchors the pill to the bottom-right flush against the xterm scrollbar gutter", () => {
+    mockHasUnseenOutput = true;
+    render(<TerminalScrollIndicator terminalId="t1" />);
+    const container = screen.getByRole("button").parentElement!;
+    expect(container.className).toContain("justify-end");
+    expect(container.className).toContain("pr-[14px]");
+    expect(container.className).not.toContain("justify-center");
+  });
 });

--- a/src/hooks/__tests__/useUnseenOutput.test.tsx
+++ b/src/hooks/__tests__/useUnseenOutput.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, act } from "@testing-library/react";
 
 let capturedListener: (() => void) | null = null;
 let currentSnapshot = { isUserScrolledBack: false, unseen: 0 };
+let currentLastWheelAt = 0;
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
@@ -14,6 +15,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
       };
     }),
     getUnseenOutputSnapshot: vi.fn(() => currentSnapshot),
+    getLastWheelAt: vi.fn(() => currentLastWheelAt),
   },
 }));
 
@@ -24,6 +26,7 @@ describe("useUnseenOutput", () => {
   beforeEach(() => {
     capturedListener = null;
     currentSnapshot = { isUserScrolledBack: false, unseen: 0 };
+    currentLastWheelAt = 0;
     vi.clearAllMocks();
   });
 
@@ -41,11 +44,35 @@ describe("useUnseenOutput", () => {
     expect(result.current.isUserScrolledBack).toBe(true);
   });
 
-  it("returns hasUnseenOutput: true when scrolled back with unseen output", () => {
+  it("returns hasUnseenOutput: false when unseen is at or below the hysteresis threshold", () => {
+    currentSnapshot = { isUserScrolledBack: true, unseen: 1 };
+    const { result: r1 } = renderHook(() => useUnseenOutput("t1"));
+    expect(r1.current.hasUnseenOutput).toBe(false);
+
+    currentSnapshot = { isUserScrolledBack: true, unseen: 2 };
+    const { result: r2 } = renderHook(() => useUnseenOutput("t1"));
+    expect(r2.current.hasUnseenOutput).toBe(false);
+  });
+
+  it("returns hasUnseenOutput: true when scrolled back with unseen above threshold", () => {
     currentSnapshot = { isUserScrolledBack: true, unseen: 5 };
     const { result } = renderHook(() => useUnseenOutput("t1"));
     expect(result.current.hasUnseenOutput).toBe(true);
     expect(result.current.isUserScrolledBack).toBe(true);
+  });
+
+  it("suppresses hasUnseenOutput while a wheel event fired within the suppression window", () => {
+    currentSnapshot = { isUserScrolledBack: true, unseen: 5 };
+    currentLastWheelAt = Date.now() - 50; // 50ms ago — inside 200ms window
+    const { result } = renderHook(() => useUnseenOutput("t1"));
+    expect(result.current.hasUnseenOutput).toBe(false);
+  });
+
+  it("shows hasUnseenOutput again after the wheel suppression window elapses", () => {
+    currentSnapshot = { isUserScrolledBack: true, unseen: 5 };
+    currentLastWheelAt = Date.now() - 500; // 500ms ago — well past 200ms window
+    const { result } = renderHook(() => useUnseenOutput("t1"));
+    expect(result.current.hasUnseenOutput).toBe(true);
   });
 
   it("re-renders when subscriber notification fires", () => {
@@ -53,7 +80,7 @@ describe("useUnseenOutput", () => {
     const { result } = renderHook(() => useUnseenOutput("t1"));
     expect(result.current.hasUnseenOutput).toBe(false);
 
-    currentSnapshot = { isUserScrolledBack: true, unseen: 1 };
+    currentSnapshot = { isUserScrolledBack: true, unseen: 3 };
     act(() => capturedListener?.());
     expect(result.current.hasUnseenOutput).toBe(true);
   });

--- a/src/hooks/useUnseenOutput.ts
+++ b/src/hooks/useUnseenOutput.ts
@@ -1,9 +1,6 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-
-// Minimum unseen lines before surfacing the "new output below" pill. Prevents
-// flicker on touchpad jitter / single-line interleavings.
-const UNSEEN_THRESHOLD = 2;
+import { UNSEEN_THRESHOLD } from "@/services/terminal/TerminalUnseenOutputTracker";
 
 // While this many milliseconds have elapsed since the last user wheel event,
 // suppress showing the pill so it does not flash mid-scroll-gesture.

--- a/src/hooks/useUnseenOutput.ts
+++ b/src/hooks/useUnseenOutput.ts
@@ -1,6 +1,14 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 
+// Minimum unseen lines before surfacing the "new output below" pill. Prevents
+// flicker on touchpad jitter / single-line interleavings.
+const UNSEEN_THRESHOLD = 2;
+
+// While this many milliseconds have elapsed since the last user wheel event,
+// suppress showing the pill so it does not flash mid-scroll-gesture.
+const ACTIVE_SCROLL_SUPPRESSION_MS = 200;
+
 export function useUnseenOutput(id: string) {
   const subscribe = useCallback(
     (onStoreChange: () => void) => terminalInstanceService.subscribeUnseenOutput(id, onStoreChange),
@@ -9,8 +17,12 @@ export function useUnseenOutput(id: string) {
   const getSnapshot = useCallback(() => terminalInstanceService.getUnseenOutputSnapshot(id), [id]);
 
   const snapshot = useSyncExternalStore(subscribe, getSnapshot);
+  const lastWheelAt = terminalInstanceService.getLastWheelAt(id);
+  const isActivelyScrolling = Date.now() - lastWheelAt < ACTIVE_SCROLL_SUPPRESSION_MS;
+
   return {
     isUserScrolledBack: snapshot.isUserScrolledBack,
-    hasUnseenOutput: snapshot.isUserScrolledBack && snapshot.unseen > 0,
+    hasUnseenOutput:
+      snapshot.isUserScrolledBack && snapshot.unseen > UNSEEN_THRESHOLD && !isActivelyScrolling,
   };
 }

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -227,6 +227,7 @@ export class TerminalHibernationManager {
     const SCROLL_KEYS = new Set(["PageUp", "PageDown", "Home", "End", "ArrowUp", "ArrowDown"]);
     const onWheel = () => {
       managed._userScrollIntent = true;
+      managed.lastWheelAt = Date.now();
     };
     const onKeydownScroll = (e: KeyboardEvent) => {
       if (SCROLL_KEYS.has(e.key)) managed._userScrollIntent = true;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -878,6 +878,7 @@ class TerminalInstanceService {
     const SCROLL_KEYS = new Set(["PageUp", "PageDown", "Home", "End", "ArrowUp", "ArrowDown"]);
     const onWheel = () => {
       managed._userScrollIntent = true;
+      managed.lastWheelAt = Date.now();
     };
     const onKeydownScroll = (e: KeyboardEvent) => {
       if (SCROLL_KEYS.has(e.key)) managed._userScrollIntent = true;
@@ -1481,6 +1482,10 @@ class TerminalInstanceService {
 
   getUnseenOutputSnapshot(id: string): UnseenOutputSnapshot {
     return this.unseenTracker.getSnapshot(id);
+  }
+
+  getLastWheelAt(id: string): number {
+    return this.instances.get(id)?.lastWheelAt ?? 0;
   }
 
   resumeAutoScroll(id: string): void {

--- a/src/services/terminal/TerminalUnseenOutputTracker.ts
+++ b/src/services/terminal/TerminalUnseenOutputTracker.ts
@@ -3,6 +3,11 @@ export interface UnseenOutputSnapshot {
   unseen: number;
 }
 
+// Minimum unseen lines before the indicator pill is shown. Consumed by
+// `useUnseenOutput` and by the tracker itself to bound listener notifications
+// (we notify on the threshold crossing, not on every increment).
+export const UNSEEN_THRESHOLD = 2;
+
 type Listener = () => void;
 
 export class TerminalUnseenOutputTracker {
@@ -17,8 +22,17 @@ export class TerminalUnseenOutputTracker {
     const next = current + 1;
     this.unseenById.set(id, next);
 
-    this.updateSnapshot(id, isUserScrolledBack, next);
-    this.notify(id);
+    // Bound listener notifications to threshold crossings to avoid re-render
+    // churn during heavy streaming output while scrolled back. Once the pill
+    // is visible (unseen > UNSEEN_THRESHOLD) further increments don't change
+    // UI state, so suppress those notifications. The raw count continues to
+    // accumulate in `unseenById` and the snapshot is refreshed from it on
+    // the next relevant event (clearUnseen / updateScrollState).
+    const crossesThreshold = current === 0 || current === UNSEEN_THRESHOLD;
+    if (crossesThreshold) {
+      this.updateSnapshot(id, isUserScrolledBack, next);
+      this.notify(id);
+    }
   }
 
   clearUnseen(id: string, isUserScrolledBack: boolean): void {

--- a/src/services/terminal/TerminalUnseenOutputTracker.ts
+++ b/src/services/terminal/TerminalUnseenOutputTracker.ts
@@ -17,10 +17,8 @@ export class TerminalUnseenOutputTracker {
     const next = current + 1;
     this.unseenById.set(id, next);
 
-    if (current === 0) {
-      this.updateSnapshot(id, isUserScrolledBack, next);
-      this.notify(id);
-    }
+    this.updateSnapshot(id, isUserScrolledBack, next);
+    this.notify(id);
   }
 
   clearUnseen(id: string, isUserScrolledBack: boolean): void {

--- a/src/services/terminal/__tests__/TerminalUnseenOutputTracker.test.ts
+++ b/src/services/terminal/__tests__/TerminalUnseenOutputTracker.test.ts
@@ -22,28 +22,44 @@ describe("TerminalUnseenOutputTracker", () => {
       expect(snapshot.unseen).toBe(0);
     });
 
-    it("should notify listeners on every increment so threshold gating re-evaluates", () => {
+    it("notifies on the 0→1 entry and on the threshold crossing (UNSEEN_THRESHOLD → UNSEEN_THRESHOLD+1)", () => {
       const listener = vi.fn();
       tracker.subscribe(terminalId, listener);
 
+      // 0 → 1: first unseen, consumers need to know scroll-back + output started
       tracker.incrementUnseen(terminalId, true);
       expect(listener).toHaveBeenCalledTimes(1);
 
+      // 1 → 2: still below threshold, no additional notification
+      tracker.incrementUnseen(terminalId, true);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // 2 → 3: threshold crossing — this is when the pill becomes visible
       tracker.incrementUnseen(terminalId, true);
       expect(listener).toHaveBeenCalledTimes(2);
-
-      tracker.incrementUnseen(terminalId, true);
-      expect(listener).toHaveBeenCalledTimes(3);
     });
 
-    it("should expose the running unseen count in the snapshot on each increment", () => {
+    it("does not wake subscribers for further increments above the threshold", () => {
+      const listener = vi.fn();
+      tracker.subscribe(terminalId, listener);
+
+      for (let i = 0; i < 100; i++) {
+        tracker.incrementUnseen(terminalId, true);
+      }
+
+      // Two notifications total: entry (0→1) and threshold cross (2→3).
+      // All subsequent increments are silent — the pill is already visible
+      // and its label is count-agnostic, so re-renders would be wasted.
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("reflects the running unseen count on notified snapshots", () => {
       tracker.incrementUnseen(terminalId, true);
       expect(tracker.getSnapshot(terminalId).unseen).toBe(1);
 
       tracker.incrementUnseen(terminalId, true);
-      expect(tracker.getSnapshot(terminalId).unseen).toBe(2);
-
       tracker.incrementUnseen(terminalId, true);
+      // Snapshot updates on the threshold crossing (2→3)
       expect(tracker.getSnapshot(terminalId).unseen).toBe(3);
     });
 
@@ -56,7 +72,9 @@ describe("TerminalUnseenOutputTracker", () => {
       tracker.incrementUnseen(terminal2, true);
 
       expect(tracker.getSnapshot(terminal1).unseen).toBe(1);
-      expect(tracker.getSnapshot(terminal2).unseen).toBe(2);
+      // terminal2 has raw count 2 but only the 0→1 crossing refreshed the
+      // snapshot — 1→2 is below the threshold crossing.
+      expect(tracker.getSnapshot(terminal2).unseen).toBe(1);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalUnseenOutputTracker.test.ts
+++ b/src/services/terminal/__tests__/TerminalUnseenOutputTracker.test.ts
@@ -22,7 +22,7 @@ describe("TerminalUnseenOutputTracker", () => {
       expect(snapshot.unseen).toBe(0);
     });
 
-    it("should notify listeners only on 0→1 transition", () => {
+    it("should notify listeners on every increment so threshold gating re-evaluates", () => {
       const listener = vi.fn();
       tracker.subscribe(terminalId, listener);
 
@@ -30,7 +30,21 @@ describe("TerminalUnseenOutputTracker", () => {
       expect(listener).toHaveBeenCalledTimes(1);
 
       tracker.incrementUnseen(terminalId, true);
-      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(listener).toHaveBeenCalledTimes(3);
+    });
+
+    it("should expose the running unseen count in the snapshot on each increment", () => {
+      tracker.incrementUnseen(terminalId, true);
+      expect(tracker.getSnapshot(terminalId).unseen).toBe(1);
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(tracker.getSnapshot(terminalId).unseen).toBe(2);
+
+      tracker.incrementUnseen(terminalId, true);
+      expect(tracker.getSnapshot(terminalId).unseen).toBe(3);
     });
 
     it("should maintain separate counters for different terminals", () => {
@@ -42,7 +56,7 @@ describe("TerminalUnseenOutputTracker", () => {
       tracker.incrementUnseen(terminal2, true);
 
       expect(tracker.getSnapshot(terminal1).unseen).toBe(1);
-      expect(tracker.getSnapshot(terminal2).unseen).toBe(1);
+      expect(tracker.getSnapshot(terminal2).unseen).toBe(2);
     });
   });
 

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -64,6 +64,9 @@ export interface ManagedTerminal {
   _suppressScrollTracking?: boolean;
   // Viewport pinning: set by wheel/keyboard events to distinguish user-initiated scroll
   _userScrollIntent?: boolean;
+  // Timestamp of the most recent wheel event on the host element — used to
+  // suppress the "new output" indicator while the user is actively scrolling.
+  lastWheelAt?: number;
 
   // Last activity marker for scroll-to-last-activity
   lastActivityMarker?: IMarker;


### PR DESCRIPTION
## Summary

- Moves the "New output below" pill to bottom-right, flush against the scrollbar gutter, so it no longer covers the primary text column where attention lives.
- Adds hysteresis: the pill only shows when `unseen > 2` and no wheel event has fired in the last 200ms, eliminating flicker on touchpad scroll jitter and single-line interleavings.
- Instant hide: passes `animationDuration: 0` to `useAnimatedPresence` so the pill disappears the moment the user catches up, while the show path stays lazy.

Resolves #5368

## Changes

- `TerminalScrollIndicator.tsx` — repositioned to bottom-right with a right-inset matching xterm's scrollbar gutter; hide animation disabled.
- `useUnseenOutput.ts` — wheel suppression window (200ms) and unseen threshold (>2) gate the `visible` flag; reads `lastWheelAt` from the tracker.
- `TerminalUnseenOutputTracker.ts` — exposes `lastWheelAt`; `incrementUnseen` now only notifies subscribers on threshold crossings (0→1 and THRESHOLD→THRESHOLD+1), capping per-session re-renders at 2 regardless of output volume.
- `TerminalInstanceService.ts` — stamps `lastWheelAt` on the managed terminal from existing wheel listeners.
- `TerminalHibernationManager.ts` — stamps `lastWheelAt` in the unhibernate wheel listener so the suppression window is re-armed correctly after a terminal wakes.
- `types.ts` — adds `lastWheelAt` and `getLastWheelAt(id)` to the terminal service interface.

## Testing

32 co-located unit tests pass. Added wheel-suppression tests, threshold crossing tests, and bounded-notification tests to `TerminalUnseenOutputTracker.test.ts` and `useUnseenOutput.test.tsx`. `TerminalScrollIndicator.test.tsx` covers the repositioned layout.