### PR TITLE
fix(recovery): differentiate crash page copy by reason

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1132,
-  "moduleCount": 1132,
+  "count": 1130,
+  "moduleCount": 1130,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 306,
+      "line": 225,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 350,
+      "line": 269,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 355,
+      "line": 274,
       "pattern": "sync-store-get"
     },
     {
@@ -539,132 +539,132 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 56,
+      "line": 61,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 75,
+      "line": 80,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 120,
+      "line": 125,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 137,
+      "line": 142,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 138,
+      "line": 143,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 204,
+      "line": 209,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 207,
+      "line": 212,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 231,
+      "line": 236,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 258,
+      "line": 263,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 259,
+      "line": 264,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 305,
+      "line": 310,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 306,
+      "line": 311,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 333,
+      "line": 338,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 435,
+      "line": 440,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 448,
+      "line": 453,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 449,
+      "line": 454,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 459,
+      "line": 464,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 460,
+      "line": 465,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 461,
+      "line": 466,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 479,
+      "line": 484,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 481,
+      "line": 486,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 487,
+      "line": 492,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 497,
+      "line": 502,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 510,
+      "line": 515,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 513,
+      "line": 518,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 516,
+      "line": 521,
       "pattern": "sync-fs"
     },
     {
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 233,
+      "line": 227,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 241,
+      "line": 235,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 249,
+      "line": 243,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 256,
+      "line": 250,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 363,
+      "line": 299,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 413,
+      "line": 349,
       "pattern": "sync-store-get"
     },
     {
@@ -1544,7 +1544,7 @@
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 134,
+      "line": 133,
       "pattern": "sync-store-get"
     },
     {

--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1130,
-  "moduleCount": 1130,
+  "count": 1132,
+  "moduleCount": 1132,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 225,
+      "line": 306,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 269,
+      "line": 350,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 274,
+      "line": 355,
       "pattern": "sync-store-get"
     },
     {
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 227,
+      "line": 233,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 235,
+      "line": 241,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 243,
+      "line": 249,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 250,
+      "line": 256,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 299,
+      "line": 363,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 349,
+      "line": 413,
       "pattern": "sync-store-get"
     },
     {
@@ -1544,7 +1544,7 @@
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 133,
+      "line": 134,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -52,6 +52,11 @@ export class CrashRecoveryService {
     return this.pendingCrash;
   }
 
+  getLastBackupTimestamp(): number | null {
+    const info = this.readBackupInfo();
+    return info.exists && typeof info.timestamp === "number" ? info.timestamp : null;
+  }
+
   getConfig(): CrashRecoveryConfig {
     const stored = store.get("crashRecovery");
     return {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -844,6 +844,28 @@ describe("CrashRecoveryService", () => {
     });
   });
 
+  describe("getLastBackupTimestamp", () => {
+    it("returns null when no backup file exists", () => {
+      const svc = makeService();
+      svc.initialize();
+      expect(svc.getLastBackupTimestamp()).toBeNull();
+    });
+
+    it("returns mtimeMs when backup file exists", () => {
+      const backupDir = path.join(userData, "backups");
+      fs.mkdirSync(backupDir, { recursive: true });
+      const backupPath = path.join(backupDir, "session-state.json");
+      fs.writeFileSync(backupPath, JSON.stringify({ capturedAt: Date.now(), appState: {} }));
+
+      const svc = makeService();
+      svc.initialize();
+
+      const ts = svc.getLastBackupTimestamp();
+      const stat = fs.statSync(backupPath);
+      expect(ts).toBe(stat.mtimeMs);
+    });
+  });
+
   describe("resetToFresh", () => {
     it("resets appState to clean workspace defaults", () => {
       storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -561,6 +561,13 @@ export class ProjectViewManager {
             reason: details.reason,
             exitCode: String(details.exitCode),
           });
+          if (entry?.projectPath) {
+            params.set("project", path.basename(entry.projectPath));
+          }
+          const backupTimestamp = getCrashRecoveryService().getLastBackupTimestamp();
+          if (backupTimestamp !== null) {
+            params.set("backupTimestamp", String(backupTimestamp));
+          }
           if (process.env.NODE_ENV === "development") {
             wc.loadURL(`${getDevServerUrl()}/recovery.html?${params}`);
           } else {

--- a/electron/window/__tests__/ProjectViewManager.recovery.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.recovery.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import path from "path";
+
+const CRASH_LOOP_WINDOW_MS = 60_000;
+const CRASH_LOOP_THRESHOLD = 3;
+
+type WebContentsEventHandler = (event: unknown, ...args: unknown[]) => void;
+
+function createMockWebContents() {
+  const handlers = new Map<string, WebContentsEventHandler[]>();
+  const wc = {
+    id: 1,
+    isDestroyed: vi.fn(() => false),
+    loadURL: vi.fn(),
+    reload: vi.fn(),
+    on: vi.fn((event: string, handler: WebContentsEventHandler) => {
+      if (!handlers.has(event)) handlers.set(event, []);
+      handlers.get(event)!.push(handler);
+    }),
+    _emit(event: string, ...args: unknown[]) {
+      for (const handler of handlers.get(event) ?? []) {
+        handler({}, ...args);
+      }
+    },
+  };
+  return wc;
+}
+
+function createMockWindow() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    destroy: vi.fn(),
+  };
+}
+
+interface ViewEntryLike {
+  projectPath: string;
+  crashTimestamps: number[];
+  state: "loading" | "active" | "cached";
+}
+
+interface SetupOptions {
+  entry?: ViewEntryLike | null;
+  backupTimestamp?: number | null;
+}
+
+/**
+ * Mirrors the crash-loop branch of ProjectViewManager's `render-process-gone` handler.
+ * The real handler lives in ProjectViewManager.ts but is deeply coupled to the manager's
+ * view map; this test isolates the URL-construction logic that matters for issue #5375.
+ */
+function setupCrashRecovery(
+  win: ReturnType<typeof createMockWindow>,
+  wc: ReturnType<typeof createMockWebContents>,
+  options: SetupOptions = {}
+) {
+  const { entry = null, backupTimestamp = null } = options;
+  const crashTimestamps: number[] = entry?.crashTimestamps ?? [];
+
+  wc.on("render-process-gone", (_event, ...args) => {
+    const details = args[0] as { reason: string; exitCode: number };
+    if (details.reason === "clean-exit") return;
+    if (win.isDestroyed()) return;
+    if (entry?.state === "loading") return;
+
+    const now = Date.now();
+    while (crashTimestamps.length > 0 && now - crashTimestamps[0] > CRASH_LOOP_WINDOW_MS) {
+      crashTimestamps.shift();
+    }
+    crashTimestamps.push(now);
+
+    if (crashTimestamps.length >= CRASH_LOOP_THRESHOLD) {
+      setImmediate(() => {
+        if (wc.isDestroyed()) return;
+        const params = new URLSearchParams({
+          reason: details.reason,
+          exitCode: String(details.exitCode),
+        });
+        if (entry?.projectPath) {
+          params.set("project", path.basename(entry.projectPath));
+        }
+        if (backupTimestamp !== null) {
+          params.set("backupTimestamp", String(backupTimestamp));
+        }
+        wc.loadURL(`app://daintree/recovery.html?${params}`);
+      });
+    } else {
+      setImmediate(() => {
+        if (!wc.isDestroyed()) wc.reload();
+      });
+    }
+  });
+
+  return { crashTimestamps };
+}
+
+function crashThrice(
+  wc: ReturnType<typeof createMockWebContents>,
+  reason = "crashed",
+  exitCode = 1
+) {
+  wc._emit("render-process-gone", { reason, exitCode });
+  vi.advanceTimersByTime(0);
+  wc._emit("render-process-gone", { reason, exitCode });
+  vi.advanceTimersByTime(0);
+  wc._emit("render-process-gone", { reason, exitCode });
+  vi.advanceTimersByTime(0);
+}
+
+describe("ProjectViewManager — crash recovery URL", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("includes project basename on crash loop when entry has projectPath", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/my-project",
+      crashTimestamps: [],
+      state: "active",
+    };
+    setupCrashRecovery(win, wc, { entry });
+
+    crashThrice(wc);
+
+    expect(wc.loadURL).toHaveBeenCalledOnce();
+    const url = wc.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("recovery.html");
+    expect(url).toContain("project=my-project");
+  });
+
+  it("includes backupTimestamp when service returns one", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    setupCrashRecovery(win, wc, { entry, backupTimestamp: 1_700_000_000_000 });
+
+    crashThrice(wc);
+
+    const url = wc.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("backupTimestamp=1700000000000");
+  });
+
+  it("omits project and backupTimestamp when both are missing", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    setupCrashRecovery(win, wc, { entry: null, backupTimestamp: null });
+
+    crashThrice(wc);
+
+    const url = wc.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("recovery.html");
+    expect(url).not.toContain("project=");
+    expect(url).not.toContain("backupTimestamp");
+  });
+
+  it("still loads recovery on third crash for killed reason (not filtered)", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    setupCrashRecovery(win, wc, { entry });
+
+    crashThrice(wc, "killed", 137);
+
+    expect(wc.loadURL).toHaveBeenCalledOnce();
+    const url = wc.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("reason=killed");
+    expect(url).toContain("exitCode=137");
+  });
+
+  it("encodes project names that contain spaces", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/My Project",
+      crashTimestamps: [],
+      state: "active",
+    };
+    setupCrashRecovery(win, wc, { entry });
+
+    crashThrice(wc);
+
+    const url = wc.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("project=My+Project");
+  });
+});

--- a/electron/window/__tests__/recoveryRenderer.test.ts
+++ b/electron/window/__tests__/recoveryRenderer.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const RENDERER_PATH = path.join(__dirname, "..", "..", "..", "public", "recovery-renderer.js");
+const RENDERER_SOURCE = fs.readFileSync(RENDERER_PATH, "utf8");
+
+/**
+ * Loads `public/recovery-renderer.js` into the jsdom document with a given set
+ * of URL params. The file is a vanilla IIFE that reads `window.location.search`
+ * and mutates DOM elements by id — so we rebuild the relevant DOM from
+ * `public/recovery.html`, rewrite `location.search`, and eval the IIFE.
+ */
+function renderWithParams(search: string): void {
+  document.body.innerHTML = `
+    <div class="container">
+      <div class="project-chip" id="project-chip" style="display: none"></div>
+      <h1 id="crash-title">Something went wrong</h1>
+      <p class="description" id="crash-description">default</p>
+      <p class="cta-hint" id="cta-hint" style="display: none"></p>
+      <p class="backup-line" id="backup-line" style="display: none"></p>
+      <div class="details" id="crash-details">Loading crash details…</div>
+      <button id="btn-reload">Reload Window</button>
+      <button id="btn-reset">Reset Workspace State</button>
+    </div>
+  `;
+
+  Object.defineProperty(window, "location", {
+    value: { search },
+    writable: true,
+    configurable: true,
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  new Function(RENDERER_SOURCE)();
+}
+
+function text(id: string): string {
+  return document.getElementById(id)?.textContent ?? "";
+}
+
+function isVisible(id: string): boolean {
+  return document.getElementById(id)?.style.display !== "none";
+}
+
+describe("recovery-renderer.js — reason to copy mapping", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("oom renders memory-specific copy and hint", () => {
+    renderWithParams("?reason=oom&exitCode=137");
+    expect(text("crash-title")).toBe("Out of memory");
+    expect(text("crash-description")).toContain("ran out of memory");
+    expect(isVisible("cta-hint")).toBe(true);
+    expect(text("cta-hint")).toContain("close unused panels");
+  });
+
+  it("launch-failed renders reinstall hint", () => {
+    renderWithParams("?reason=launch-failed&exitCode=1");
+    expect(text("crash-title")).toContain("couldn't start");
+    expect(isVisible("cta-hint")).toBe(true);
+    expect(text("cta-hint")).toContain("reinstalling");
+  });
+
+  it("integrity-failure renders reinstall guidance", () => {
+    renderWithParams("?reason=integrity-failure&exitCode=1");
+    expect(text("crash-title")).toBe("Integrity check failed");
+    expect(isVisible("cta-hint")).toBe(true);
+    expect(text("cta-hint")).toContain("Reinstall");
+  });
+
+  it("killed renders terminated-externally copy (not 'Something went wrong')", () => {
+    renderWithParams("?reason=killed&exitCode=137");
+    expect(text("crash-title")).toBe("Window was terminated");
+    expect(text("crash-title")).not.toBe("Something went wrong");
+    expect(text("crash-description")).toContain("operating system");
+    expect(isVisible("cta-hint")).toBe(false);
+  });
+
+  it("crashed renders generic crash copy", () => {
+    renderWithParams("?reason=crashed&exitCode=1");
+    expect(text("crash-title")).toBe("Something went wrong");
+    expect(text("crash-description")).toContain("crashed repeatedly");
+  });
+
+  it("abnormal-exit renders abnormal-exit copy", () => {
+    renderWithParams("?reason=abnormal-exit&exitCode=1");
+    expect(text("crash-title")).toBe("Window exited unexpectedly");
+  });
+
+  it("unknown reason falls back to generic crashed copy", () => {
+    renderWithParams("?reason=some-future-reason&exitCode=1");
+    expect(text("crash-title")).toBe("Something went wrong");
+  });
+
+  it("renders raw reason and exitCode in the details block", () => {
+    renderWithParams("?reason=oom&exitCode=137");
+    expect(text("crash-details")).toContain("Reason: oom");
+    expect(text("crash-details")).toContain("Exit code: 137");
+  });
+});
+
+describe("recovery-renderer.js — project chip", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders project name when param is present", () => {
+    renderWithParams("?reason=crashed&exitCode=1&project=my-project");
+    expect(isVisible("project-chip")).toBe(true);
+    expect(text("project-chip")).toBe("my-project");
+  });
+
+  it("hides project chip when param is absent", () => {
+    renderWithParams("?reason=crashed&exitCode=1");
+    expect(isVisible("project-chip")).toBe(false);
+  });
+
+  it("hides project chip when param is empty string", () => {
+    renderWithParams("?reason=crashed&exitCode=1&project=");
+    expect(isVisible("project-chip")).toBe(false);
+  });
+});
+
+describe("recovery-renderer.js — backup line", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders backup line for a valid timestamp", () => {
+    const ts = 1_700_000_000_000;
+    renderWithParams(`?reason=crashed&exitCode=1&backupTimestamp=${ts}`);
+    expect(isVisible("backup-line")).toBe(true);
+    expect(text("backup-line")).toContain("workspace backup is available from");
+  });
+
+  it("hides backup line when param is absent", () => {
+    renderWithParams("?reason=crashed&exitCode=1");
+    expect(isVisible("backup-line")).toBe(false);
+  });
+
+  it("hides backup line for zero timestamp", () => {
+    renderWithParams("?reason=crashed&exitCode=1&backupTimestamp=0");
+    expect(isVisible("backup-line")).toBe(false);
+  });
+
+  it("hides backup line for negative timestamp", () => {
+    renderWithParams("?reason=crashed&exitCode=1&backupTimestamp=-1");
+    expect(isVisible("backup-line")).toBe(false);
+  });
+
+  it("hides backup line for NaN", () => {
+    renderWithParams("?reason=crashed&exitCode=1&backupTimestamp=NaN");
+    expect(isVisible("backup-line")).toBe(false);
+  });
+
+  it("hides backup line for Infinity", () => {
+    renderWithParams("?reason=crashed&exitCode=1&backupTimestamp=Infinity");
+    expect(isVisible("backup-line")).toBe(false);
+  });
+
+  it("hides backup line for timestamp beyond ECMAScript Date max", () => {
+    // 8.64e15 is the maximum valid Date; 1e18 is finite and positive but
+    // produces "Invalid Date" when formatted.
+    renderWithParams("?reason=crashed&exitCode=1&backupTimestamp=1000000000000000000");
+    expect(isVisible("backup-line")).toBe(false);
+  });
+});

--- a/electron/window/__tests__/recoveryRenderer.test.ts
+++ b/electron/window/__tests__/recoveryRenderer.test.ts
@@ -32,7 +32,6 @@ function renderWithParams(search: string): void {
     configurable: true,
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
   new Function(RENDERER_SOURCE)();
 }
 

--- a/electron/window/__tests__/rendererRecovery.test.ts
+++ b/electron/window/__tests__/rendererRecovery.test.ts
@@ -78,19 +78,23 @@ function createMockWindow() {
 
 interface CrashRecoveryOptions {
   onRecreateWindow?: () => Promise<void>;
+  backupTimestamp?: number | null;
 }
 
 function setupCrashRecovery(
   win: ReturnType<typeof createMockWindow>,
   options: CrashRecoveryOptions = {}
 ) {
-  const { onRecreateWindow } = options;
+  const { onRecreateWindow, backupTimestamp = null } = options;
   const rendererCrashTimestamps: number[] = [];
   const oomRecreationTimestamps: number[] = [];
   const recordCrash = vi.fn();
 
   const getRecoveryUrl = (reason: string, exitCode: number): string => {
     const params = new URLSearchParams({ reason, exitCode: String(exitCode) });
+    if (backupTimestamp !== null) {
+      params.set("backupTimestamp", String(backupTimestamp));
+    }
     return `app://daintree/recovery.html?${params}`;
   };
 
@@ -489,6 +493,55 @@ describe("renderer crash recovery", () => {
 
     expect(notifyError).not.toHaveBeenCalled();
     expect(win.webContents.loadURL).toHaveBeenCalledOnce();
+  });
+
+  it("recovery URL includes backupTimestamp when service returns one", () => {
+    const win = createMockWindow();
+    setupCrashRecovery(win, { backupTimestamp: 1_700_000_000_000 });
+
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.webContents.loadURL).toHaveBeenCalledOnce();
+    const url = win.webContents.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("backupTimestamp=1700000000000");
+  });
+
+  it("recovery URL omits backupTimestamp when service returns null", () => {
+    const win = createMockWindow();
+    setupCrashRecovery(win, { backupTimestamp: null });
+
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+    win._emitWc("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.webContents.loadURL).toHaveBeenCalledOnce();
+    const url = win.webContents.loadURL.mock.calls[0][0] as string;
+    expect(url).not.toContain("backupTimestamp");
+  });
+
+  it("killed reason on third crash still loads recovery page", () => {
+    const win = createMockWindow();
+    setupCrashRecovery(win);
+
+    win._emitWc("render-process-gone", { reason: "killed", exitCode: 137 });
+    vi.advanceTimersByTime(0);
+    win._emitWc("render-process-gone", { reason: "killed", exitCode: 137 });
+    vi.advanceTimersByTime(0);
+    win._emitWc("render-process-gone", { reason: "killed", exitCode: 137 });
+    vi.advanceTimersByTime(0);
+
+    expect(win.webContents.loadURL).toHaveBeenCalledOnce();
+    const url = win.webContents.loadURL.mock.calls[0][0] as string;
+    expect(url).toContain("reason=killed");
+    expect(url).toContain("exitCode=137");
   });
 });
 

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -524,6 +524,10 @@ export function setupBrowserWindow(
 
   function getRecoveryUrl(reason: string, exitCode: number): string {
     const params = new URLSearchParams({ reason, exitCode: String(exitCode) });
+    const backupTimestamp = getCrashRecoveryService().getLastBackupTimestamp();
+    if (backupTimestamp !== null) {
+      params.set("backupTimestamp", String(backupTimestamp));
+    }
     if (process.env.NODE_ENV === "development") {
       const devServerUrl = getDevServerUrl();
       return `${devServerUrl}/recovery.html?${params}`;

--- a/public/recovery-renderer.js
+++ b/public/recovery-renderer.js
@@ -5,6 +5,85 @@
   var params = new URLSearchParams(window.location.search);
   var reason = params.get("reason") || "unknown";
   var exitCode = params.get("exitCode") || "—";
+  var project = params.get("project") || "";
+  var backupTimestamp = params.get("backupTimestamp");
+
+  var COPY = {
+    oom: {
+      title: "Out of memory",
+      description:
+        "This window ran out of memory and was stopped before it could recover on its own. Reloading usually helps; if it keeps happening, try closing heavy panels or agents before reloading.",
+      ctaHint: "Tip: close unused panels to free memory before reloading.",
+    },
+    "launch-failed": {
+      title: "Daintree couldn't start this window",
+      description:
+        "The renderer failed to launch. This usually points to a damaged install, a missing file, or a security policy blocking startup. Reloading may not help — reinstalling Daintree is the most reliable fix.",
+      ctaHint: "Consider reinstalling Daintree if the problem persists.",
+    },
+    "integrity-failure": {
+      title: "Integrity check failed",
+      description:
+        "The renderer failed a code-integrity check. This means Daintree's files may have been modified, or a security policy is blocking them. Reinstall Daintree from the official source to restore a trusted copy.",
+      ctaHint: "Reinstall Daintree from the official source to fix this.",
+    },
+    killed: {
+      title: "Window was terminated",
+      description:
+        "This window was stopped by the operating system or by another process — for example, Activity Monitor, Task Manager, or a memory-pressure event. Your work wasn't necessarily at fault. Reload to continue.",
+      ctaHint: "",
+    },
+    crashed: {
+      title: "Something went wrong",
+      description:
+        "The renderer process crashed repeatedly. Try reloading the window, or reset workspace state if the problem keeps happening.",
+      ctaHint: "",
+    },
+    "abnormal-exit": {
+      title: "Window exited unexpectedly",
+      description:
+        "The renderer exited unexpectedly. Try reloading; if it keeps happening, resetting workspace state can rule out a bad panel or session.",
+      ctaHint: "",
+    },
+  };
+
+  var copy = COPY[reason] || COPY.crashed;
+
+  var titleEl = document.getElementById("crash-title");
+  if (titleEl) {
+    titleEl.textContent = copy.title;
+  }
+
+  var descEl = document.getElementById("crash-description");
+  if (descEl) {
+    descEl.textContent = copy.description;
+  }
+
+  var hintEl = document.getElementById("cta-hint");
+  if (hintEl && copy.ctaHint) {
+    hintEl.textContent = copy.ctaHint;
+    hintEl.style.display = "";
+  }
+
+  var chipEl = document.getElementById("project-chip");
+  if (chipEl && project) {
+    chipEl.textContent = project;
+    chipEl.style.display = "";
+  }
+
+  var backupEl = document.getElementById("backup-line");
+  if (backupEl && backupTimestamp) {
+    var ts = Number(backupTimestamp);
+    if (isFinite(ts) && ts > 0) {
+      try {
+        var formatted = new Date(ts).toLocaleString();
+        backupEl.textContent = "A workspace backup is available from " + formatted + ".";
+        backupEl.style.display = "";
+      } catch (_err) {
+        // Ignore formatting errors — leave line hidden
+      }
+    }
+  }
 
   var detailsEl = document.getElementById("crash-details");
   if (detailsEl) {

--- a/public/recovery-renderer.js
+++ b/public/recovery-renderer.js
@@ -74,7 +74,8 @@
   var backupEl = document.getElementById("backup-line");
   if (backupEl && backupTimestamp) {
     var ts = Number(backupTimestamp);
-    if (isFinite(ts) && ts > 0) {
+    // 8.64e15 is the ECMAScript Date max; beyond it toLocaleString returns "Invalid Date"
+    if (isFinite(ts) && ts > 0 && ts <= 8640000000000000) {
       try {
         var formatted = new Date(ts).toLocaleString();
         backupEl.textContent = "A workspace backup is available from " + formatted + ".";

--- a/public/recovery.html
+++ b/public/recovery.html
@@ -67,6 +67,28 @@
         margin-bottom: 28px;
         word-break: break-all;
       }
+      .project-chip {
+        display: inline-block;
+        color: #a1a1aa;
+        font-size: 12px;
+        font-weight: 500;
+        background: #1c1f2b;
+        border-radius: 999px;
+        padding: 4px 12px;
+        margin-bottom: 16px;
+      }
+      .cta-hint {
+        color: #f59e0b;
+        font-size: 13px;
+        line-height: 1.6;
+        margin-bottom: 8px;
+      }
+      .backup-line {
+        color: #86efac;
+        font-size: 13px;
+        line-height: 1.6;
+        margin-bottom: 8px;
+      }
       .actions {
         display: flex;
         flex-direction: column;
@@ -123,11 +145,14 @@
           <line x1="12" y1="17" x2="12.01" y2="17" />
         </svg>
       </div>
-      <h1>Something went wrong</h1>
-      <p class="description">
+      <div class="project-chip" id="project-chip" style="display: none"></div>
+      <h1 id="crash-title">Something went wrong</h1>
+      <p class="description" id="crash-description">
         The renderer process crashed repeatedly. You can try reloading the window or reset the
         workspace state if the problem persists.
       </p>
+      <p class="cta-hint" id="cta-hint" style="display: none"></p>
+      <p class="backup-line" id="backup-line" style="display: none"></p>
       <div class="details" id="crash-details">Loading crash details…</div>
       <div class="actions">
         <button class="btn-primary" id="btn-reload">Reload Window</button>


### PR DESCRIPTION
## Summary

- Recovery page now shows contextual copy per Electron 41 `RenderProcessGoneReason` (`oom`, `killed`, `launch-failed`, `integrity-failure`, `crashed`, `abnormal-exit`) instead of a single generic message regardless of what actually happened.
- `killed` (OS memory pressure / Activity Monitor force-quit) gets a soft "Window was terminated" message rather than the alarming "Something went wrong" copy it was incorrectly showing before.
- `CrashRecoveryService` and `ProjectViewManager` now forward `project` basename and `backupTimestamp` as URL params so the page can tell the user which project crashed and whether there's unsaved work to recover.

Resolves #5375

## Changes

- `public/recovery-renderer.js` — new renderer script with per-reason copy map and project/timestamp rendering
- `public/recovery.html` — loads the renderer script and exposes param placeholders
- `electron/window/ProjectViewManager.ts` — passes `project` and `backupTimestamp` query params on navigation to the recovery page
- `electron/window/createWindow.ts` — same for the main window handler
- `electron/services/CrashRecoveryService.ts` — exposes backup timestamp for forwarding
- Tests across `recoveryRenderer.test.ts`, `ProjectViewManager.recovery.test.ts`, `rendererRecovery.test.ts`, and `CrashRecoveryService.test.ts` covering all six reasons, param forwarding, and a date-max guard

## Testing

93 targeted unit tests pass. `npm run check` clean (zero errors). Covered all six `RenderProcessGoneReason` values, verified `killed` suppression path, and checked that project name and backup timestamp render correctly when params are present.