### PR TITLE
perf(github): virtualize PR/issue list and bound resource cache

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -40,6 +40,70 @@ function sanitizeIpcError(message: string): string {
   return cleaned.length > 120 ? cleaned.slice(0, 117) + "…" : cleaned;
 }
 
+interface LoadMoreFooterContext {
+  hasMore: boolean;
+  loadingMore: boolean;
+  isLoadMoreActive: boolean;
+  loadMoreError: string | null;
+  type: "issue" | "pr";
+  onLoadMore: () => void;
+  onOpenSettings: () => void;
+}
+
+function LoadMoreFooter({ context }: { context?: LoadMoreFooterContext }) {
+  if (!context || !context.hasMore) return null;
+  const { loadingMore, isLoadMoreActive, loadMoreError, type, onLoadMore, onOpenSettings } =
+    context;
+  return (
+    <div className="p-3 space-y-2">
+      {loadMoreError && (
+        <div className="p-2 rounded-[var(--radius-md)] bg-overlay-soft border border-[var(--border-divider)]">
+          <p className="text-xs text-muted-foreground">{sanitizeIpcError(loadMoreError)}</p>
+          {isTokenRelatedError(loadMoreError) ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onOpenSettings}
+              className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
+            >
+              <Settings className="h-3 w-3" />
+              Open GitHub Settings
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onLoadMore}
+              className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
+      <Button
+        id={`github-${type}-load-more`}
+        variant="ghost"
+        onClick={onLoadMore}
+        disabled={loadingMore}
+        className={cn(
+          "w-full text-muted-foreground hover:text-daintree-text",
+          isLoadMoreActive && "ring-1 ring-daintree-accent text-daintree-text"
+        )}
+      >
+        {loadingMore ? (
+          <>
+            <RefreshCw className="animate-spin" />
+            Loading...
+          </>
+        ) : (
+          "Load More"
+        )}
+      </Button>
+    </div>
+  );
+}
+
 interface GitHubResourceListProps {
   type: "issue" | "pr";
   projectPath: string;
@@ -548,67 +612,26 @@ export function GitHubResourceList({
     onClose?.();
   }, [onClose]);
 
-  const LoadMoreFooter = useMemo(() => {
-    if (!hasMore) return () => null;
-    return function ResourceListFooter() {
-      return (
-        <div className="p-3 space-y-2">
-          {loadMoreError && (
-            <div className="p-2 rounded-[var(--radius-md)] bg-overlay-soft border border-[var(--border-divider)]">
-              <p className="text-xs text-muted-foreground">{sanitizeIpcError(loadMoreError)}</p>
-              {isTokenRelatedError(loadMoreError) ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleOpenGitHubSettings}
-                  className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
-                >
-                  <Settings className="h-3 w-3" />
-                  Open GitHub Settings
-                </Button>
-              ) : (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleLoadMore}
-                  className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
-                >
-                  Retry
-                </Button>
-              )}
-            </div>
-          )}
-          <Button
-            id={`github-${type}-load-more`}
-            variant="ghost"
-            onClick={handleLoadMore}
-            disabled={loadingMore}
-            className={cn(
-              "w-full text-muted-foreground hover:text-daintree-text",
-              isLoadMoreActive && "ring-1 ring-daintree-accent text-daintree-text"
-            )}
-          >
-            {loadingMore ? (
-              <>
-                <RefreshCw className="animate-spin" />
-                Loading...
-              </>
-            ) : (
-              "Load More"
-            )}
-          </Button>
-        </div>
-      );
-    };
-  }, [
-    hasMore,
-    loadMoreError,
-    loadingMore,
-    isLoadMoreActive,
-    handleLoadMore,
-    handleOpenGitHubSettings,
-    type,
-  ]);
+  const footerContext = useMemo<LoadMoreFooterContext>(
+    () => ({
+      hasMore,
+      loadingMore,
+      isLoadMoreActive,
+      loadMoreError,
+      type,
+      onLoadMore: handleLoadMore,
+      onOpenSettings: handleOpenGitHubSettings,
+    }),
+    [
+      hasMore,
+      loadingMore,
+      isLoadMoreActive,
+      loadMoreError,
+      type,
+      handleLoadMore,
+      handleOpenGitHubSettings,
+    ]
+  );
 
   const renderEmpty = () => {
     if (exactNumberNotFound !== null) {
@@ -867,6 +890,7 @@ export function GitHubResourceList({
               <Virtuoso
                 ref={virtuosoRef}
                 data={data}
+                context={footerContext}
                 style={{ height: "100%" }}
                 fixedItemHeight={RESOURCE_ITEM_HEIGHT_PX}
                 computeItemKey={(_, item) => item.number}

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef, type KeyboardEvent } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useDebounce } from "@/hooks/useDebounce";
 import { Search, ExternalLink, RefreshCw, WifiOff, Plus, Settings, X, Filter } from "lucide-react";
 import {
@@ -26,7 +27,11 @@ import {
 } from "@/store/githubFilterStore";
 import type { GitHubIssue, GitHubPR, GitHubSortOrder } from "@shared/types/github";
 import { parseNumberQuery, MULTI_FETCH_CAP } from "@/lib/parseNumberQuery";
-import { GitHubResourceRowsSkeleton, MAX_SKELETON_ITEMS } from "./GitHubDropdownSkeletons";
+import {
+  GitHubResourceRowsSkeleton,
+  MAX_SKELETON_ITEMS,
+  RESOURCE_ITEM_HEIGHT_PX,
+} from "./GitHubDropdownSkeletons";
 
 type StateFilter = IssueStateFilter | PRStateFilter;
 
@@ -81,7 +86,7 @@ export function GitHubResourceList({
   const [activeIndex, setActiveIndex] = useState(-1);
   const [sortPopoverOpen, setSortPopoverOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
   const mountedRef = useRef(false);
 
   const selection = useIssueSelection();
@@ -445,15 +450,15 @@ export function GitHubResourceList({
   }, [data]);
 
   useEffect(() => {
-    if (activeIndex >= 0 && listRef.current) {
-      const activeEl = activeItemId
-        ? document.getElementById(activeItemId)
-        : isLoadMoreActive
-          ? document.getElementById(`github-${type}-load-more`)
-          : null;
-      activeEl?.scrollIntoView({ block: "nearest" });
+    if (activeIndex < 0) return;
+    if (isLoadMoreActive) {
+      document.getElementById(`github-${type}-load-more`)?.scrollIntoView({ block: "nearest" });
+      return;
     }
-  }, [activeIndex, activeItemId, isLoadMoreActive, type]);
+    if (activeIndex < data.length) {
+      virtuosoRef.current?.scrollIntoView({ index: activeIndex, behavior: "auto" });
+    }
+  }, [activeIndex, data.length, isLoadMoreActive, type]);
 
   const handleInputKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -534,14 +539,76 @@ export function GitHubResourceList({
 
   const isTokenError = isTokenRelatedError(error);
 
-  const handleOpenGitHubSettings = () => {
+  const handleOpenGitHubSettings = useCallback(() => {
     void actionService.dispatch(
       "app.settings.openTab",
       { tab: "github", sectionId: "github-token" },
       { source: "user" }
     );
     onClose?.();
-  };
+  }, [onClose]);
+
+  const LoadMoreFooter = useMemo(() => {
+    if (!hasMore) return () => null;
+    return function ResourceListFooter() {
+      return (
+        <div className="p-3 space-y-2">
+          {loadMoreError && (
+            <div className="p-2 rounded-[var(--radius-md)] bg-overlay-soft border border-[var(--border-divider)]">
+              <p className="text-xs text-muted-foreground">{sanitizeIpcError(loadMoreError)}</p>
+              {isTokenRelatedError(loadMoreError) ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleOpenGitHubSettings}
+                  className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
+                >
+                  <Settings className="h-3 w-3" />
+                  Open GitHub Settings
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleLoadMore}
+                  className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
+                >
+                  Retry
+                </Button>
+              )}
+            </div>
+          )}
+          <Button
+            id={`github-${type}-load-more`}
+            variant="ghost"
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className={cn(
+              "w-full text-muted-foreground hover:text-daintree-text",
+              isLoadMoreActive && "ring-1 ring-daintree-accent text-daintree-text"
+            )}
+          >
+            {loadingMore ? (
+              <>
+                <RefreshCw className="animate-spin" />
+                Loading...
+              </>
+            ) : (
+              "Load More"
+            )}
+          </Button>
+        </div>
+      );
+    };
+  }, [
+    hasMore,
+    loadMoreError,
+    loadingMore,
+    isLoadMoreActive,
+    handleLoadMore,
+    handleOpenGitHubSettings,
+    type,
+  ]);
 
   const renderEmpty = () => {
     if (exactNumberNotFound !== null) {
@@ -760,15 +827,17 @@ export function GitHubResourceList({
         )}
       </div>
 
-      <div className="overflow-y-auto flex-1 min-h-0">
+      <div className="flex-1 min-h-0 flex flex-col">
         {loading && !data.length ? (
-          <GitHubResourceRowsSkeleton
-            count={initialCount && initialCount > 0 ? initialCount : MAX_SKELETON_ITEMS}
-          />
+          <div className="overflow-y-auto flex-1 min-h-0">
+            <GitHubResourceRowsSkeleton
+              count={initialCount && initialCount > 0 ? initialCount : MAX_SKELETON_ITEMS}
+            />
+          </div>
         ) : data.length > 0 ? (
           <>
             {error && (
-              <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft">
+              <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
                 <WifiOff className="h-3.5 w-3.5 shrink-0" />
                 <span className="text-xs truncate">{sanitizeIpcError(error)}</span>
                 {isTokenError ? (
@@ -794,85 +863,39 @@ export function GitHubResourceList({
                 )}
               </div>
             )}
-            <div
-              ref={listRef}
-              id={listId}
-              role="listbox"
-              aria-multiselectable={true}
-              className="divide-y divide-[var(--border-divider)]"
-            >
-              {data.map((item, index) => (
-                <GitHubListItem
-                  key={item.number}
-                  item={item}
-                  type={type}
-                  onCreateWorktree={handleCreateWorktree}
-                  onSwitchToWorktree={handleSwitchToWorktree}
-                  optionId={`github-${type}-option-${item.number}`}
-                  isActive={activeIndex === index}
-                  isSelected={selection.selectedIds.has(item.number)}
-                  isSelectionActive={selection.isSelectionActive}
-                  onToggleSelect={(e: React.MouseEvent) => {
-                    if (e.shiftKey) {
-                      selection.toggleRange(index, (i) => data[i]!.number);
-                    } else {
-                      selection.toggle(item.number, index);
-                    }
-                  }}
-                />
-              ))}
-            </div>
-
-            {hasMore && (
-              <div className="p-3 space-y-2">
-                {loadMoreError && (
-                  <div className="p-2 rounded-[var(--radius-md)] bg-overlay-soft border border-[var(--border-divider)]">
-                    <p className="text-xs text-muted-foreground">
-                      {sanitizeIpcError(loadMoreError)}
-                    </p>
-                    {isTokenRelatedError(loadMoreError) ? (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleOpenGitHubSettings}
-                        className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
-                      >
-                        <Settings className="h-3 w-3" />
-                        Open GitHub Settings
-                      </Button>
-                    ) : (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleLoadMore}
-                        className="mt-1 text-muted-foreground hover:text-daintree-text h-6 text-xs"
-                      >
-                        Retry
-                      </Button>
-                    )}
-                  </div>
+            <div id={listId} role="listbox" aria-multiselectable={true} className="flex-1 min-h-0">
+              <Virtuoso
+                ref={virtuosoRef}
+                data={data}
+                style={{ height: "100%" }}
+                fixedItemHeight={RESOURCE_ITEM_HEIGHT_PX}
+                computeItemKey={(_, item) => item.number}
+                increaseViewportBy={{ top: 0, bottom: 200 }}
+                endReached={() => {
+                  if (!loadingMore && !loading && hasMore) handleLoadMore();
+                }}
+                components={{ Footer: LoadMoreFooter }}
+                itemContent={(index, item) => (
+                  <GitHubListItem
+                    item={item}
+                    type={type}
+                    onCreateWorktree={handleCreateWorktree}
+                    onSwitchToWorktree={handleSwitchToWorktree}
+                    optionId={`github-${type}-option-${item.number}`}
+                    isActive={activeIndex === index}
+                    isSelected={selection.selectedIds.has(item.number)}
+                    isSelectionActive={selection.isSelectionActive}
+                    onToggleSelect={(e: React.MouseEvent) => {
+                      if (e.shiftKey) {
+                        selection.toggleRange(index, (i) => data[i]!.number);
+                      } else {
+                        selection.toggle(item.number, index);
+                      }
+                    }}
+                  />
                 )}
-                <Button
-                  id={`github-${type}-load-more`}
-                  variant="ghost"
-                  onClick={handleLoadMore}
-                  disabled={loadingMore}
-                  className={cn(
-                    "w-full text-muted-foreground hover:text-daintree-text",
-                    isLoadMoreActive && "ring-1 ring-daintree-accent text-daintree-text"
-                  )}
-                >
-                  {loadingMore ? (
-                    <>
-                      <RefreshCw className="animate-spin" />
-                      Loading...
-                    </>
-                  ) : (
-                    "Load More"
-                  )}
-                </Button>
-              </div>
-            )}
+              />
+            </div>
           </>
         ) : error ? (
           <div className="p-8 text-center text-muted-foreground">

--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -7,6 +7,7 @@ import type { GitHubIssue } from "@shared/types/github";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import { GitHubResourceRowsSkeleton } from "./GitHubDropdownSkeletons";
 
 interface IssueSelectorProps {
   projectPath: string;
@@ -137,7 +138,7 @@ export function IssueSelector({
         </div>
         <div id="issue-list" role="listbox" className="max-h-[300px] overflow-y-auto p-1">
           {loading ? (
-            <div className="py-6 text-center text-sm text-muted-foreground">Loading issues...</div>
+            <GitHubResourceRowsSkeleton count={3} immediate />
           ) : issues.length === 0 ? (
             <div className="py-6 text-center text-sm text-muted-foreground">
               {debouncedQuery ? "No issues found" : "No open issues"}

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -74,10 +74,12 @@ vi.mock("react-virtuoso", () => ({
     data,
     itemContent,
     components,
+    context,
   }: {
     data: unknown[];
     itemContent: (index: number, item: unknown) => ReactNode;
-    components?: { Footer?: () => ReactNode };
+    components?: { Footer?: (props: { context?: unknown }) => ReactNode };
+    context?: unknown;
   }) => {
     const Footer = components?.Footer;
     return (
@@ -85,7 +87,7 @@ vi.mock("react-virtuoso", () => ({
         {data.map((item, index) => (
           <div key={index}>{itemContent(index, item)}</div>
         ))}
-        {Footer ? <Footer /> : null}
+        {Footer ? <Footer context={context} /> : null}
       </div>
     );
   },

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -66,6 +66,29 @@ vi.mock("../BulkActionBar", () => ({
 vi.mock("../GitHubDropdownSkeletons", () => ({
   GitHubResourceRowsSkeleton: () => <div data-testid="skeleton">Loading...</div>,
   MAX_SKELETON_ITEMS: 5,
+  RESOURCE_ITEM_HEIGHT_PX: 68,
+}));
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    data,
+    itemContent,
+    components,
+  }: {
+    data: unknown[];
+    itemContent: (index: number, item: unknown) => ReactNode;
+    components?: { Footer?: () => ReactNode };
+  }) => {
+    const Footer = components?.Footer;
+    return (
+      <div data-testid="virtuoso-mock">
+        {data.map((item, index) => (
+          <div key={index}>{itemContent(index, item)}</div>
+        ))}
+        {Footer ? <Footer /> : null}
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/utils/timeAgo", () => ({
@@ -177,6 +200,43 @@ describe("GitHubResourceList SWR behavior", () => {
       expect(screen.getByText(/Network error/)).toBeTruthy();
     });
     expect(screen.getByTestId("item-20")).toBeTruthy();
+  });
+
+  it("renders Load More footer when hasNextPage is true", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1), makeIssue(2)],
+      endCursor: "cursor-1",
+      hasNextPage: true,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue({
+      items: [makeIssue(1), makeIssue(2)],
+      pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+    });
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /load more/i })).toBeTruthy();
+    });
+  });
+
+  it("omits Load More footer when hasNextPage is false", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.queryByRole("button", { name: /load more/i })).toBeNull();
   });
 
   it("different project paths use separate cache entries", async () => {

--- a/src/lib/__tests__/githubResourceCache.test.ts
+++ b/src/lib/__tests__/githubResourceCache.test.ts
@@ -148,5 +148,16 @@ describe("githubResourceCache", () => {
       expect(getCache("key1")).toBeDefined();
       expect(getCache("key20")).toBeDefined();
     });
+
+    it("bounds the generation map so it cannot grow unbounded", () => {
+      for (let i = 0; i < 20; i++) {
+        nextGeneration(`gen-key-${i}`);
+      }
+      expect(getGeneration("gen-key-0")).toBe(1);
+
+      nextGeneration("gen-key-20");
+      expect(getGeneration("gen-key-0")).toBe(0);
+      expect(getGeneration("gen-key-20")).toBe(1);
+    });
   });
 });

--- a/src/lib/__tests__/githubResourceCache.test.ts
+++ b/src/lib/__tests__/githubResourceCache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   buildCacheKey,
   getCache,
@@ -108,6 +108,45 @@ describe("githubResourceCache", () => {
       _resetForTests();
       expect(getCache("key1")).toBeUndefined();
       expect(getGeneration("key1")).toBe(0);
+    });
+  });
+
+  describe("TTL expiry", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("returns cached entry before TTL elapses", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      setCache("key1", { items: [], endCursor: null, hasNextPage: false, timestamp: 1 });
+
+      vi.advanceTimersByTime(4 * 60 * 1000);
+      expect(getCache("key1")).toBeDefined();
+    });
+
+    it("evicts entries after 5 minute TTL", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+      setCache("key1", { items: [], endCursor: null, hasNextPage: false, timestamp: 1 });
+
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      expect(getCache("key1")).toBeUndefined();
+    });
+  });
+
+  describe("LRU eviction", () => {
+    it("evicts oldest entry when capacity is exceeded", () => {
+      for (let i = 0; i < 20; i++) {
+        setCache(`key${i}`, { items: [], endCursor: null, hasNextPage: false, timestamp: i });
+      }
+      expect(getCache("key0")).toBeDefined();
+
+      setCache("key20", { items: [], endCursor: null, hasNextPage: false, timestamp: 20 });
+
+      expect(getCache("key0")).toBeUndefined();
+      expect(getCache("key1")).toBeDefined();
+      expect(getCache("key20")).toBeDefined();
     });
   });
 });

--- a/src/lib/githubResourceCache.ts
+++ b/src/lib/githubResourceCache.ts
@@ -33,6 +33,10 @@ export function setCache(key: string, entry: GitHubResourceCacheEntry): void {
 
 export function nextGeneration(key: string): number {
   const gen = (generationMap.get(key) ?? 0) + 1;
+  if (!generationMap.has(key) && generationMap.size >= CACHE_MAX_SIZE) {
+    const oldest = generationMap.keys().next().value;
+    if (oldest !== undefined) generationMap.delete(oldest);
+  }
   generationMap.set(key, gen);
   return gen;
 }

--- a/src/lib/githubResourceCache.ts
+++ b/src/lib/githubResourceCache.ts
@@ -1,4 +1,5 @@
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
+import { TtlCache } from "@/utils/ttlCache";
 
 export interface GitHubResourceCacheEntry {
   items: (GitHubIssue | GitHubPR)[];
@@ -7,7 +8,10 @@ export interface GitHubResourceCacheEntry {
   timestamp: number;
 }
 
-const cache = new Map<string, GitHubResourceCacheEntry>();
+const CACHE_MAX_SIZE = 20;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const cache = new TtlCache<string, GitHubResourceCacheEntry>(CACHE_MAX_SIZE, CACHE_TTL_MS);
 const generationMap = new Map<string, number>();
 
 export function buildCacheKey(


### PR DESCRIPTION
## Summary

- Replaces the flat-rendered `GitHubResourceList` with a react-virtuoso virtual list (fixed item height 68px, stable item keys), so large PR/issue lists no longer mount hundreds of DOM nodes at once.
- Migrates `githubResourceCache` from an unbounded `Map` to a `TtlCache` (maxSize=20, ttl=5min) and caps the internal `generationMap` with the same FIFO limit, preventing unbounded memory growth across repo switches.
- Swaps the "Loading issues..." text in `IssueSelector` for the existing `GitHubResourceRowsSkeleton` component for visual consistency.

Resolves #5412

## Changes

- `GitHubResourceList.tsx` — virtual list via react-virtuoso; `Footer` slot drives Load More; `endReached` triggers auto-fetch; `VirtuosoHandle.scrollIntoView` preserves keyboard navigation.
- `githubResourceCache.ts` — bounded TtlCache replaces unbounded Map; generationMap capped at same size.
- `IssueSelector.tsx` — skeleton loader instead of plain text.
- `GitHubResourceList.swr.test.tsx` / `githubResourceCache.test.ts` — updated and extended tests (134 passing).

## Testing

Typecheck, lint, and format all clean. 134 unit tests pass across the affected files. Verified virtual rendering in the PR/issue popover with a repo holding 100+ open issues.