### PR TITLE
fix(review-hub): classify push errors into actionable banners

### DIFF
--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useRef, useSta
 import { createPortal } from "react-dom";
 import type { StagingStatus, GitStatus } from "@shared/types";
 import type { CrossWorktreeFile } from "@shared/types/ipc/git";
+import type { GitOperationReason } from "@shared/types/ipc/errors";
 import { cn } from "@/lib/utils";
 import { useOverlayState } from "@/hooks";
 import {
@@ -25,6 +26,7 @@ import { debounce } from "@/utils/debounce";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useShallow } from "zustand/react/shallow";
 import { githubClient } from "@/clients/githubClient";
+import { actionService } from "@/services/ActionService";
 
 interface ReviewHubProps {
   isOpen: boolean;
@@ -33,6 +35,53 @@ interface ReviewHubProps {
 }
 
 type DiffMode = "working-tree" | "base-branch";
+
+interface PushErrorState {
+  reason: GitOperationReason;
+  rawMessage: string;
+}
+
+type PushBannerCta = { kind: "settings-github"; label: string } | { kind: "retry"; label: string };
+
+interface PushBannerConfig {
+  message: string;
+  showRaw: boolean;
+  cta?: PushBannerCta;
+}
+
+function getPushBannerConfig(reason: GitOperationReason): PushBannerConfig {
+  switch (reason) {
+    case "auth-failed":
+      return {
+        message: "Authentication failed — check your credentials or SSH key.",
+        showRaw: false,
+        cta: { kind: "settings-github", label: "Open GitHub settings" },
+      };
+    case "push-rejected-outdated":
+      return {
+        message: "The remote has new commits. Pull or rebase before pushing.",
+        showRaw: false,
+      };
+    case "push-rejected-policy":
+      return {
+        message: "The remote rejected this push (protected branch or repository rule).",
+        showRaw: true,
+      };
+    case "hook-rejected":
+      return {
+        message: "A server-side hook rejected the push.",
+        showRaw: true,
+      };
+    case "network-unavailable":
+      return {
+        message: "Could not reach the remote. Check your internet connection.",
+        showRaw: false,
+        cta: { kind: "retry", label: "Retry push" },
+      };
+    default:
+      return { message: "Push failed. See details below.", showRaw: true };
+  }
+}
 
 function statusLabel(status: string): { label: string; className: string } {
   switch (status) {
@@ -57,7 +106,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
   const [isBackgroundRefreshing, setIsBackgroundRefreshing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const [pushError, setPushError] = useState<string | null>(null);
+  const [pushError, setPushError] = useState<PushErrorState | null>(null);
   const [commitMessage, setCommitMessage] = useState("");
   const [selectedFile, setSelectedFile] = useState<{
     path: string;
@@ -326,6 +375,25 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     [worktreePath]
   );
 
+  const runPush = useCallback(async () => {
+    try {
+      const result = await window.electron.git.push(worktreePath);
+      if (result.success) {
+        setPushError(null);
+      } else {
+        setPushError({
+          reason: result.gitReason ?? "unknown",
+          rawMessage: result.error ?? "",
+        });
+      }
+    } catch (err) {
+      setPushError({
+        reason: "unknown",
+        rawMessage: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [worktreePath]);
+
   const handleCommitAndPush = useCallback(
     async (message: string) => {
       setActionError(null);
@@ -338,17 +406,16 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
         throw err;
       }
       await refresh();
-      try {
-        const result = await window.electron.git.push(worktreePath);
-        if (!result.success) {
-          setPushError(`Push failed: ${result.error}`);
-        }
-      } catch (err) {
-        setPushError(`Push failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
+      await runPush();
     },
-    [worktreePath, refresh]
+    [worktreePath, refresh, runPush]
   );
+
+  const handleRetryPush = useCallback(async () => {
+    setPushError(null);
+    debouncedBgRefreshRef.current?.cancel();
+    await runPush();
+  }, [runPush]);
 
   useLayoutEffect(() => {
     if (scrollContainerRef.current && status) {
@@ -594,12 +661,63 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
               <span>{actionError}</span>
             </div>
           )}
-          {pushError && (
-            <div className="px-4 py-2 text-xs text-status-warning bg-status-warning/10 flex items-start gap-2 shrink-0">
-              <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
-              <span>Committed locally. {pushError}</span>
-            </div>
-          )}
+          {pushError &&
+            (() => {
+              const config = getPushBannerConfig(pushError.reason);
+              const onCtaClick = () => {
+                if (!config.cta) return;
+                if (config.cta.kind === "settings-github") {
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "github" },
+                    { source: "user" }
+                  );
+                } else {
+                  void handleRetryPush();
+                }
+              };
+              return (
+                <div
+                  role="alert"
+                  data-testid="review-hub-push-error"
+                  data-reason={pushError.reason}
+                  className="px-4 py-2 text-xs text-status-warning bg-status-warning/10 flex items-start gap-2 shrink-0"
+                >
+                  <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <div>
+                      <span className="font-medium">Committed locally.</span>{" "}
+                      <span>{config.message}</span>
+                    </div>
+                    {config.showRaw && pushError.rawMessage && (
+                      <pre
+                        data-testid="review-hub-push-error-details"
+                        className="mt-1 text-[10px] font-mono whitespace-pre-wrap break-all opacity-70"
+                      >
+                        {pushError.rawMessage}
+                      </pre>
+                    )}
+                    {config.cta && (
+                      <div className="mt-1.5">
+                        <button
+                          type="button"
+                          onClick={onCtaClick}
+                          data-testid="review-hub-push-error-cta"
+                          className={cn(
+                            "inline-flex items-center gap-1 px-2 py-0.5 rounded",
+                            "bg-status-warning/20 hover:bg-status-warning/30",
+                            "text-status-warning text-[11px] font-medium transition-colors",
+                            "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-status-warning"
+                          )}
+                        >
+                          {config.cta.label}
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })()}
 
           {/* Content */}
           <div

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -17,6 +17,9 @@ const {
   continueRepositoryOperationMock,
   openInEditorMock,
   stageFileMock,
+  commitMock,
+  pushMock,
+  actionDispatchMock,
   worktreeStoreData,
 } = vi.hoisted(() => ({
   getStagingStatusMock: vi.fn(),
@@ -28,6 +31,9 @@ const {
   continueRepositoryOperationMock: vi.fn().mockResolvedValue(undefined),
   openInEditorMock: vi.fn().mockResolvedValue(undefined),
   stageFileMock: vi.fn().mockResolvedValue(undefined),
+  commitMock: vi.fn(),
+  pushMock: vi.fn(),
+  actionDispatchMock: vi.fn().mockResolvedValue({ ok: true }),
   worktreeStoreData: {
     current: new Map<string, Partial<WorktreeState>>([
       [
@@ -74,6 +80,10 @@ vi.mock("@/hooks/useWorktreeStore", () => ({
 
 vi.mock("@/clients/githubClient", () => ({
   githubClient: { openPR: openPRMock },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: actionDispatchMock },
 }));
 
 vi.mock("@/components/ui/button", () => ({
@@ -214,6 +224,9 @@ describe("ReviewHub", () => {
     continueRepositoryOperationMock.mockReset().mockResolvedValue(undefined);
     openInEditorMock.mockReset().mockResolvedValue(undefined);
     stageFileMock.mockReset().mockResolvedValue(undefined);
+    commitMock.mockReset().mockResolvedValue({ hash: "abc123", summary: "commit" });
+    pushMock.mockReset().mockResolvedValue({ success: true });
+    actionDispatchMock.mockReset().mockResolvedValue({ ok: true });
 
     Object.defineProperty(window, "electron", {
       value: {
@@ -223,8 +236,8 @@ describe("ReviewHub", () => {
           unstageFile: vi.fn().mockResolvedValue(undefined),
           stageAll: vi.fn().mockResolvedValue(undefined),
           unstageAll: vi.fn().mockResolvedValue(undefined),
-          commit: vi.fn().mockResolvedValue(undefined),
-          push: vi.fn().mockResolvedValue({ success: true }),
+          commit: commitMock,
+          push: pushMock,
           compareWorktrees: compareWorktreesMock,
           abortRepositoryOperation: abortRepositoryOperationMock,
           continueRepositoryOperation: continueRepositoryOperationMock,
@@ -957,6 +970,152 @@ describe("ReviewHub", () => {
 
       await waitFor(() => screen.getByText("index.ts"));
       expect(screen.queryByTestId("conflict-panel")).toBeNull();
+    });
+  });
+
+  describe("push error banner", () => {
+    async function triggerCommitAndPush() {
+      getStagingStatusMock.mockResolvedValue(makeStatus({ hasRemote: true }));
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…");
+      fireEvent.change(textarea, { target: { value: "feat: do the thing" } });
+
+      const commitPushBtn = screen.getByRole("button", { name: /Commit & Push/i });
+      await act(async () => {
+        fireEvent.click(commitPushBtn);
+        await Promise.resolve();
+      });
+    }
+
+    it("shows auth-failed banner with Open GitHub settings CTA and dispatches settings tab", async () => {
+      pushMock.mockResolvedValue({
+        success: false,
+        gitReason: "auth-failed",
+        error: "fatal: Authentication failed for 'https://github.com/foo/bar.git/'",
+      });
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("auth-failed");
+      expect(banner.textContent).toMatch(/Authentication failed/i);
+      expect(banner.textContent).toMatch(/Committed locally/i);
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+
+      const cta = screen.getByTestId("review-hub-push-error-cta");
+      expect(cta.textContent).toMatch(/Open GitHub settings/i);
+      fireEvent.click(cta);
+
+      expect(actionDispatchMock).toHaveBeenCalledWith(
+        "app.settings.openTab",
+        { tab: "github" },
+        { source: "user" }
+      );
+    });
+
+    it("shows push-rejected-outdated banner without a CTA", async () => {
+      pushMock.mockResolvedValue({
+        success: false,
+        gitReason: "push-rejected-outdated",
+        error: "! [rejected] main -> main (non-fast-forward)",
+      });
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("push-rejected-outdated");
+      expect(banner.textContent).toMatch(/remote has new commits/i);
+      expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+    });
+
+    it("shows push-rejected-policy banner with raw stderr and no CTA", async () => {
+      const rawError = "GH006: Protected branch update failed for refs/heads/main.";
+      pushMock.mockResolvedValue({
+        success: false,
+        gitReason: "push-rejected-policy",
+        error: rawError,
+      });
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("push-rejected-policy");
+      expect(banner.textContent).toMatch(/protected branch or repository rule/i);
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
+      expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
+    });
+
+    it("shows hook-rejected banner with raw stderr", async () => {
+      const rawError = "[remote rejected] main -> main (pre-receive hook declined)";
+      pushMock.mockResolvedValue({
+        success: false,
+        gitReason: "hook-rejected",
+        error: rawError,
+      });
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("hook-rejected");
+      expect(banner.textContent).toMatch(/server-side hook rejected/i);
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
+    });
+
+    it("shows network-unavailable banner with Retry push button that re-pushes without re-committing", async () => {
+      pushMock.mockResolvedValueOnce({
+        success: false,
+        gitReason: "network-unavailable",
+        error: "Could not resolve host: github.com",
+      });
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("network-unavailable");
+      expect(banner.textContent).toMatch(/Could not reach the remote/i);
+      expect(commitMock).toHaveBeenCalledTimes(1);
+      expect(pushMock).toHaveBeenCalledTimes(1);
+
+      pushMock.mockResolvedValueOnce({ success: true });
+
+      const retryBtn = screen.getByTestId("review-hub-push-error-cta");
+      expect(retryBtn.textContent).toMatch(/Retry push/i);
+      await act(async () => {
+        fireEvent.click(retryBtn);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(pushMock).toHaveBeenCalledTimes(2));
+      expect(commitMock).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(screen.queryByTestId("review-hub-push-error")).toBeNull());
+    });
+
+    it("falls back to generic copy + raw stderr for an unclassified failure", async () => {
+      const rawError = "unexpected: something weird happened";
+      pushMock.mockResolvedValue({
+        success: false,
+        error: rawError,
+      });
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("unknown");
+      expect(banner.textContent).toMatch(/Push failed\. See details below\./i);
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
+      expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
+    });
+
+    it("does not render the banner on successful push", async () => {
+      pushMock.mockResolvedValue({ success: true });
+
+      await triggerCommitAndPush();
+
+      await waitFor(() => expect(pushMock).toHaveBeenCalled());
+      expect(screen.queryByTestId("review-hub-push-error")).toBeNull();
     });
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -990,10 +990,11 @@ describe("ReviewHub", () => {
     }
 
     it("shows auth-failed banner with Open GitHub settings CTA and dispatches settings tab", async () => {
+      const rawError = "fatal: Authentication failed for 'https://github.com/foo/bar.git/'";
       pushMock.mockResolvedValue({
         success: false,
         gitReason: "auth-failed",
-        error: "fatal: Authentication failed for 'https://github.com/foo/bar.git/'",
+        error: rawError,
       });
 
       await triggerCommitAndPush();
@@ -1002,6 +1003,7 @@ describe("ReviewHub", () => {
       expect(banner.getAttribute("data-reason")).toBe("auth-failed");
       expect(banner.textContent).toMatch(/Authentication failed/i);
       expect(banner.textContent).toMatch(/Committed locally/i);
+      expect(banner.textContent).not.toContain(rawError);
       expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
 
       const cta = screen.getByTestId("review-hub-push-error-cta");
@@ -1065,10 +1067,11 @@ describe("ReviewHub", () => {
     });
 
     it("shows network-unavailable banner with Retry push button that re-pushes without re-committing", async () => {
+      const rawError = "Could not resolve host: github.com";
       pushMock.mockResolvedValueOnce({
         success: false,
         gitReason: "network-unavailable",
-        error: "Could not resolve host: github.com",
+        error: rawError,
       });
 
       await triggerCommitAndPush();
@@ -1076,6 +1079,7 @@ describe("ReviewHub", () => {
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("network-unavailable");
       expect(banner.textContent).toMatch(/Could not reach the remote/i);
+      expect(banner.textContent).not.toContain(rawError);
       expect(commitMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledTimes(1);
 
@@ -1091,6 +1095,98 @@ describe("ReviewHub", () => {
       await waitFor(() => expect(pushMock).toHaveBeenCalledTimes(2));
       expect(commitMock).toHaveBeenCalledTimes(1);
       await waitFor(() => expect(screen.queryByTestId("review-hub-push-error")).toBeNull());
+    });
+
+    it("renders the banner with the unknown reason when push rejects (throws)", async () => {
+      pushMock.mockRejectedValueOnce(new Error("Could not resolve host: github.com"));
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.getAttribute("data-reason")).toBe("unknown");
+      expect(banner.textContent).toMatch(/Push failed\. See details below\./i);
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(
+        "Could not resolve host: github.com"
+      );
+    });
+
+    it("updates the banner when a retry fails with a different reason", async () => {
+      pushMock.mockResolvedValueOnce({
+        success: false,
+        gitReason: "network-unavailable",
+        error: "Could not resolve host: github.com",
+      });
+
+      await triggerCommitAndPush();
+
+      await screen.findByTestId("review-hub-push-error");
+
+      pushMock.mockResolvedValueOnce({
+        success: false,
+        gitReason: "hook-rejected",
+        error: "[remote rejected] main -> main (pre-receive hook declined)",
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("review-hub-push-error-cta"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId("review-hub-push-error").getAttribute("data-reason")).toBe(
+          "hook-rejected"
+        )
+      );
+      expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
+    });
+
+    it("clears the push banner when the modal is closed and reopened", async () => {
+      pushMock.mockResolvedValue({
+        success: false,
+        gitReason: "auth-failed",
+        error: "Authentication failed",
+      });
+
+      getStagingStatusMock.mockResolvedValue(makeStatus({ hasRemote: true }));
+      const { rerender } = render(
+        <ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />
+      );
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      fireEvent.change(screen.getByPlaceholderText("Commit message…"), {
+        target: { value: "feat: thing" },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Commit & Push/i }));
+        await Promise.resolve();
+      });
+      await screen.findByTestId("review-hub-push-error");
+
+      rerender(<ReviewHub isOpen={false} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      rerender(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => expect(screen.queryByTestId("review-hub-push-error")).toBeNull());
+    });
+
+    it("does not call push when commit itself fails", async () => {
+      commitMock.mockRejectedValueOnce(new Error("nothing to commit"));
+      getStagingStatusMock.mockResolvedValue(makeStatus({ hasRemote: true }));
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      fireEvent.change(screen.getByPlaceholderText("Commit message…"), {
+        target: { value: "feat: thing" },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: /Commit & Push/i }));
+        await Promise.resolve();
+      });
+
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("review-hub-push-error")).toBeNull();
+      await waitFor(() => screen.getByText("nothing to commit"));
     });
 
     it("falls back to generic copy + raw stderr for an unclassified failure", async () => {


### PR DESCRIPTION
## Summary

- Push failures from ReviewHub now classify into five distinct reasons (auth, network, non-fast-forward, policy-rejected, unknown) instead of dumping raw stderr into a generic banner.
- Each reason gets tailored copy and, where appropriate, a CTA: auth failures link to GitHub settings, network failures show a retry button (without re-committing), policy-rejected failures expose the remote's own message since it usually explains the fix.
- Non-fast-forward (`push-rejected-outdated`) intentionally has no CTA since auto-pull is too destructive.

Resolves #5373

## Changes

- `src/components/Worktree/ReviewHub/ReviewHub.tsx` — promoted `pushError` state to `{ reason, rawMessage }`, added a `PushBannerConfig` switch for all five classified reasons, split `handleCommitAndPush` into a shared `runPush()` helper and a separate `handleRetryPush()` so retries don't trigger a new commit. Auth CTA dispatches `app.settings.openTab { tab: "github" }`; network CTA calls `handleRetryPush`. The backend classifier returns `RecoveryAction` with action IDs (`github.auth`, `git.pull`) that aren't registered in `BuiltInActionId`, so the implementation maps locally rather than dispatching them blind.
- `src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx` — 11 new tests covering all five `gitReason` cases, unknown fallback, rejected push promise, retry success, retry failure updating the banner, close/reopen clearing state, and commit-failure short-circuit.

## Testing

- 56 unit tests pass (`npx vitest run src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx`)
- Typecheck, lint-ratchet, format, and `check:channels` all pass