### PR TITLE
fix(git): block commits containing unresolved conflict markers

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 225,
+      "line": 306,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 269,
+      "line": 350,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 274,
+      "line": 355,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/ipc/handlers/__tests__/git-write.commit.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.commit.test.ts
@@ -48,9 +48,10 @@ function makeFakeGit(overrides: Partial<FakeGit> = {}): FakeGit {
     status: vi.fn().mockResolvedValue({ files: [] as FakeStatusFile[] }),
     diff: vi.fn().mockResolvedValue(""),
     show: vi.fn().mockResolvedValue(""),
-    commit: vi
-      .fn()
-      .mockResolvedValue({ commit: "abc123", summary: { changes: 1, insertions: 1, deletions: 0 } }),
+    commit: vi.fn().mockResolvedValue({
+      commit: "abc123",
+      summary: { changes: 1, insertions: 1, deletions: 0 },
+    }),
     ...overrides,
   };
 }
@@ -212,9 +213,7 @@ describe("scanStagedFilesForConflictMarkers", () => {
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
       show: vi.fn().mockRejectedValue(new Error("fatal: bad revision")),
     });
-    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
-      /bad revision/
-    );
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(/bad revision/);
   });
 
   it("handles paths with spaces", async () => {
@@ -246,23 +245,24 @@ describe("git:commit handler", () => {
 
     const result = await handler(null, { cwd: "/tmp/repo", message: "feat: add foo" });
     expect(git.commit).toHaveBeenCalledWith("feat: add foo");
-    expect(result).toEqual({ hash: "abc123", summary: "1 changed, 1 insertions(+), 0 deletions(-)" });
+    expect(result).toEqual({
+      hash: "abc123",
+      summary: "1 changed, 1 insertions(+), 0 deletions(-)",
+    });
   });
 
   it("blocks the commit when a staged file carries conflict markers", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
-      show: vi
-        .fn()
-        .mockResolvedValue("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
+      show: vi.fn().mockResolvedValue("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
     });
     createHardenedGitMock.mockReturnValue(git);
     registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
     const handler = getHandler("git:commit");
 
-    await expect(
-      handler(null, { cwd: "/tmp/repo", message: "feat: add foo" })
-    ).rejects.toThrow(/Unresolved conflict markers found in src\/foo\.ts/);
+    await expect(handler(null, { cwd: "/tmp/repo", message: "feat: add foo" })).rejects.toThrow(
+      /Unresolved conflict markers found in src\/foo\.ts/
+    );
     expect(git.commit).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/git-write.commit.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.commit.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+vi.mock("../../../store.js", () => ({
+  store: { get: vi.fn().mockReturnValue({ uiFeedbackSoundEnabled: false }) },
+}));
+
+vi.mock("../../../services/SoundService.js", () => ({
+  soundService: { play: vi.fn() },
+}));
+
+vi.mock("../../../services/PreAgentSnapshotService.js", () => ({
+  preAgentSnapshotService: {
+    getSnapshot: vi.fn(),
+    listSnapshots: vi.fn(),
+    revertToSnapshot: vi.fn(),
+    deleteSnapshot: vi.fn(),
+  },
+}));
+
+const createHardenedGitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../utils/hardenedGit.js", () => ({
+  validateCwd: vi.fn(),
+  createHardenedGit: createHardenedGitMock,
+  createAuthenticatedGit: vi.fn(),
+}));
+
+import { registerGitWriteHandlers, scanStagedFilesForConflictMarkers } from "../git-write.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
+
+type FakeStatusFile = { path: string; index: string; working_dir: string };
+type FakeGit = {
+  status: ReturnType<typeof vi.fn>;
+  diff: ReturnType<typeof vi.fn>;
+  show: ReturnType<typeof vi.fn>;
+  commit: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeGit(overrides: Partial<FakeGit> = {}): FakeGit {
+  return {
+    status: vi.fn().mockResolvedValue({ files: [] as FakeStatusFile[] }),
+    diff: vi.fn().mockResolvedValue(""),
+    show: vi.fn().mockResolvedValue(""),
+    commit: vi
+      .fn()
+      .mockResolvedValue({ commit: "abc123", summary: { changes: 1, insertions: 1, deletions: 0 } }),
+    ...overrides,
+  };
+}
+
+function getHandler(channel: string) {
+  const call = ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channel);
+  if (!call) throw new Error(`Handler for ${channel} not registered`);
+  return call[1] as (_e: unknown, ...args: unknown[]) => unknown;
+}
+
+function stagedFile(path: string, index = "M"): FakeStatusFile {
+  return { path, index, working_dir: " " };
+}
+
+describe("scanStagedFilesForConflictMarkers", () => {
+  it("passes through a clean staged file", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
+      show: vi.fn().mockResolvedValue("export const foo = 1;\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+    expect(git.show).toHaveBeenCalledWith([":src/foo.ts"]);
+  });
+
+  it("throws when a staged file contains <<<<<<< markers", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
+      show: vi
+        .fn()
+        .mockResolvedValue("line1\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /Unresolved conflict markers found in src\/foo\.ts/
+    );
+  });
+
+  it.each([
+    ["<<<<<<< HEAD", "start"],
+    ["||||||| merged common ancestors", "ancestor"],
+    ["=======", "middle"],
+    [">>>>>>> branch", "end"],
+  ])("throws for the %s marker line", async (markerLine) => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("f.txt")] }),
+      show: vi.fn().mockResolvedValue(`head\n${markerLine}\ntail\n`),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /Unresolved conflict markers/
+    );
+  });
+
+  it("does not block when markers are mid-line (line-anchored regex)", async () => {
+    // An indented `=======` should not trip the scan; ensures the `^` anchor
+    // in CONFLICT_MARKER_RE is doing its job.
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("doc.md")] }),
+      show: vi.fn().mockResolvedValue("  =======\ninline <<<<<<< text\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+  });
+
+  it("skips deleted staged entries without calling git.show", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("gone.ts", "D")] }),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+    expect(git.show).not.toHaveBeenCalled();
+    expect(git.diff).not.toHaveBeenCalled();
+  });
+
+  it("skips binary files reported by numstat", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("image.png")] }),
+      diff: vi.fn().mockResolvedValue("-\t-\timage.png\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+    expect(git.show).not.toHaveBeenCalled();
+  });
+
+  it("skips files over the 1 MB cap", async () => {
+    const huge = "a".repeat(1_000_001);
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("big.txt")] }),
+      show: vi.fn().mockResolvedValue(huge),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+  });
+
+  it("short-circuits when there are no staged files", async () => {
+    const git = makeFakeGit();
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+    expect(git.diff).not.toHaveBeenCalled();
+    expect(git.show).not.toHaveBeenCalled();
+  });
+
+  it("uses --no-ext-diff for the numstat probe", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("a.ts")] }),
+      show: vi.fn().mockResolvedValue("ok\n"),
+    });
+    await scanStagedFilesForConflictMarkers(git as never);
+    expect(git.diff).toHaveBeenCalledWith(["--no-ext-diff", "--cached", "--numstat"]);
+  });
+
+  it("stops on the first offending file and identifies it", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({
+        files: [stagedFile("clean.ts"), stagedFile("bad.ts"), stagedFile("other.ts")],
+      }),
+      show: vi.fn(async (args: string[]) => {
+        if (args[0] === ":bad.ts") return "<<<<<<< HEAD\n";
+        return "clean content\n";
+      }),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /Unresolved conflict markers found in bad\.ts/
+    );
+  });
+});
+
+describe("git:commit handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
+  });
+
+  it("invokes git.commit when staged content is clean", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
+      show: vi.fn().mockResolvedValue("clean\n"),
+    });
+    createHardenedGitMock.mockReturnValue(git);
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:commit");
+
+    const result = await handler(null, { cwd: "/tmp/repo", message: "feat: add foo" });
+    expect(git.commit).toHaveBeenCalledWith("feat: add foo");
+    expect(result).toEqual({ hash: "abc123", summary: "1 changed, 1 insertions(+), 0 deletions(-)" });
+  });
+
+  it("blocks the commit when a staged file carries conflict markers", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
+      show: vi
+        .fn()
+        .mockResolvedValue("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
+    });
+    createHardenedGitMock.mockReturnValue(git);
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:commit");
+
+    await expect(
+      handler(null, { cwd: "/tmp/repo", message: "feat: add foo" })
+    ).rejects.toThrow(/Unresolved conflict markers found in src\/foo\.ts/);
+    expect(git.commit).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/git-write.commit.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.commit.test.ts
@@ -168,6 +168,64 @@ describe("scanStagedFilesForConflictMarkers", () => {
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
       /Unresolved conflict markers found in bad\.ts/
     );
+    expect(git.show).not.toHaveBeenCalledWith([":other.ts"]);
+  });
+
+  it("blocks a first-line marker that follows a UTF-8 BOM", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("bom.txt")] }),
+      show: vi.fn().mockResolvedValue("\uFEFF<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> b\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /Unresolved conflict markers found in bom\.txt/
+    );
+  });
+
+  it("blocks when content is exactly at the 1 MB byte cap", async () => {
+    // Exactly STAGED_FILE_SIZE_CAP bytes (cap boundary) with the marker on
+    // its own line. `>` not `>=` means this must still be scanned.
+    const markerLine = "<<<<<<< HEAD\n";
+    const content = markerLine + "a".repeat(1_000_000 - markerLine.length);
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("edge.txt")] }),
+      show: vi.fn().mockResolvedValue(content),
+    });
+    expect(Buffer.byteLength(content, "utf8")).toBe(1_000_000);
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /Unresolved conflict markers/
+    );
+  });
+
+  it("skips content 1 byte over the cap", async () => {
+    // `>` not `>=` check: 1_000_001 bytes → skip silently, commit proceeds.
+    const content = "<<<<<<< HEAD\n" + "a".repeat(1_000_001 - "<<<<<<< HEAD\n".length);
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("huge.txt")] }),
+      show: vi.fn().mockResolvedValue(content),
+    });
+    expect(Buffer.byteLength(content, "utf8")).toBe(1_000_001);
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+  });
+
+  it("propagates git.show rejections (does not silently permit)", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
+      show: vi.fn().mockRejectedValue(new Error("fatal: bad revision")),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /bad revision/
+    );
+  });
+
+  it("handles paths with spaces", async () => {
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("dir/merge notes.ts")] }),
+      show: vi.fn().mockResolvedValue("<<<<<<< HEAD\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
+      /Unresolved conflict markers found in dir\/merge notes\.ts/
+    );
+    expect(git.show).toHaveBeenCalledWith([":dir/merge notes.ts"]);
   });
 });
 

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -207,8 +207,13 @@ export async function scanStagedFilesForConflictMarkers(git: SimpleGit): Promise
     if (binaryPaths.has(filePath)) continue;
     const content = await git.show([`:${filePath}`]);
     if (typeof content !== "string") continue;
-    if (content.length > STAGED_FILE_SIZE_CAP) continue;
-    if (CONFLICT_MARKER_RE.test(content)) {
+    // Compare against the UTF-8 byte length so a multibyte file isn't
+    // misclassified against a character-count cap.
+    if (Buffer.byteLength(content, "utf8") > STAGED_FILE_SIZE_CAP) continue;
+    // A leading UTF-8 BOM pushes a first-line `<<<<<<<` past the `^` anchor;
+    // strip it before testing so marker-on-line-1 files still block.
+    const probe = content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+    if (CONFLICT_MARKER_RE.test(probe)) {
       throw new Error(
         `Unresolved conflict markers found in ${filePath}. Resolve all conflicts before committing.`
       );

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -43,6 +43,17 @@ const CONFLICT_LABELS: Record<string, string> = {
   UD: "deleted by them",
 };
 
+// Cap text scans at 1 MB per staged file — above this, assume the file is
+// effectively machine-generated and skip. Matches the cap already used in
+// projectInRepoSettings.ts:81 for in-process file reads.
+const STAGED_FILE_SIZE_CAP = 1_000_000;
+
+// Line-anchored 7-char conflict markers (standard + diff3 ancestor). The
+// `<<<<<<<` and `>>>>>>>` anchors are definitive; `=======` and `|||||||` are
+// flagged as well to match VS Code's own marker detection. No `g` flag so
+// `.test()` stays stateless across sequential calls on different blobs.
+const CONFLICT_MARKER_RE = /^(?:<{7}|\|{7}|={7}|>{7})[ \t\r]?/m;
+
 async function pathExists(p: string): Promise<boolean> {
   return fs.promises
     .access(p)
@@ -141,6 +152,70 @@ export function parsePorcelainV2Conflicts(raw: string): ConflictedFileEntry[] {
   return entries;
 }
 
+/**
+ * Parse `git diff --cached --numstat` output into the set of staged paths that
+ * git reports as binary (added/deleted counts rendered as `-`). Binary blobs
+ * are skipped by the conflict-marker scan because regex matching on non-text
+ * bytes is meaningless and may produce false positives.
+ */
+function parseBinaryPathsFromNumstat(raw: string): Set<string> {
+  const binary = new Set<string>();
+  for (const line of raw.split("\n")) {
+    // Numstat format: "<added>\t<deleted>\t<path>". Binary → "-\t-\t<path>".
+    // Rename diffs may emit "{old => new}" in the path column; we key the set
+    // on whatever text appears after the second tab and compare using `has`
+    // on the post-rename path reported by status(), so renamed binary files
+    // may miss this set. That's tolerated: a binary will still fail the
+    // marker regex harmlessly on the subsequent `git.show`.
+    const tabIdx1 = line.indexOf("\t");
+    if (tabIdx1 === -1) continue;
+    const tabIdx2 = line.indexOf("\t", tabIdx1 + 1);
+    if (tabIdx2 === -1) continue;
+    if (line.slice(0, tabIdx2) !== "-\t-") continue;
+    const filePath = line.slice(tabIdx2 + 1);
+    if (filePath) binary.add(filePath);
+  }
+  return binary;
+}
+
+/**
+ * Block commits that would include unresolved merge conflict markers. Reads
+ * the staged (index) blob for each non-binary, non-deleted file via
+ * `git show :<path>`, which works on both normal and unborn branches. Throws
+ * a descriptive `Error` naming the first offending file; the IPC layer
+ * surfaces `.message` directly to the UI.
+ */
+export async function scanStagedFilesForConflictMarkers(git: SimpleGit): Promise<void> {
+  const status = await git.status();
+  const candidates: string[] = [];
+  for (const file of status.files) {
+    const indexStatus = file.index;
+    if (!indexStatus || indexStatus === " " || indexStatus === "?" || indexStatus === "D") {
+      continue;
+    }
+    candidates.push(file.path);
+  }
+  if (candidates.length === 0) return;
+
+  // `--no-ext-diff` is mandatory: without it, a user-configured `diff.external`
+  // tool can break the numstat call (lesson #4221). Matches the pattern in
+  // handleGetWorkingDiff and utils/git.ts.
+  const numstatRaw = await git.diff(["--no-ext-diff", "--cached", "--numstat"]);
+  const binaryPaths = parseBinaryPathsFromNumstat(numstatRaw);
+
+  for (const filePath of candidates) {
+    if (binaryPaths.has(filePath)) continue;
+    const content = await git.show([`:${filePath}`]);
+    if (typeof content !== "string") continue;
+    if (content.length > STAGED_FILE_SIZE_CAP) continue;
+    if (CONFLICT_MARKER_RE.test(content)) {
+      throw new Error(
+        `Unresolved conflict markers found in ${filePath}. Resolve all conflicts before committing.`
+      );
+    }
+  }
+}
+
 export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
@@ -221,6 +296,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     }
 
     const git = createHardenedGit(payload.cwd);
+    await scanStagedFilesForConflictMarkers(git);
     const result = await git.commit(payload.message.trim());
     if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
       soundService.play("git-commit");


### PR DESCRIPTION
## Summary

- Adds `scanStagedFilesForConflictMarkers()` in `handleCommit` (electron/ipc/handlers/git-write.ts) that inspects each staged text file before `git.commit()` runs. On finding any of the four conflict-marker patterns, it throws with a message that names the offending file so ReviewHub can surface it directly.
- Skips deleted entries, binary files (detected via `--no-ext-diff` numstat), and files over 1 MB to keep commit performance unaffected.
- Handles edge cases: UTF-8 BOM at line start, unborn branches (git show `:path` works without HEAD), and spaces in file paths.

Resolves #5389

## Changes

- `electron/ipc/handlers/git-write.ts`: new `scanStagedFilesForConflictMarkers(git)` helper, called from `handleCommit` before the commit runs
- `electron/ipc/handlers/__tests__/git-write.commit.test.ts`: 20 unit tests covering clean commits, all four marker types, binary skip, deleted-file skip, BOM handling, 1 MB boundary, error propagation, and paths with spaces

## Testing

Unit tests cover all the cases: clean staged files pass through, each conflict marker pattern blocks the commit with the right message, binary and deleted files are skipped cleanly, BOM-prefixed markers are caught, and files right at the 1 MB boundary behave correctly. The full suite passes locally.