### PR TITLE
perf(github): gate PR revalidation on REST ETag conditional requests

### DIFF
--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -66,6 +66,10 @@ const projectHealthCache = new Cache<string, ProjectHealth>({ defaultTTL: 60000 
 const issueTooltipCache = new Cache<string, IssueTooltipData>({ defaultTTL: 300000 }); // 5 min TTL
 const prTooltipCache = new Cache<string, PRTooltipData>({ defaultTTL: 300000 }); // 5 min TTL
 
+// ETag cache for PR conditional revalidation. Key: `owner/repo#prNumber`.
+// Cleared on token rotation via clearGitHubCaches (ETags are token-scoped).
+const prETagCache = new Map<string, string>();
+
 export function getGitHubToken(): string | undefined {
   return GitHubAuth.getToken();
 }
@@ -623,6 +627,82 @@ function parseBatchPRResponse(
   return results;
 }
 
+/**
+ * Conditional REST probe against `/repos/{owner}/{repo}/pulls/{number}`.
+ * A 304 (Not Modified) response signals the PR has not changed since the
+ * stored ETag and does NOT consume primary rate-limit quota for authenticated
+ * requests. Returns:
+ *   - "unchanged" on 304 (cached ETag still valid)
+ *   - "changed" on 200 (new data available; ETag is refreshed)
+ *   - "unknown" on any other outcome (network error, 4xx, missing header, etc.)
+ *
+ * Callers should treat "unknown" as a cue to fall through to GraphQL —
+ * preserving correctness even if the REST path is transiently unavailable.
+ */
+async function probePRChange(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  token: string
+): Promise<"changed" | "unchanged" | "unknown"> {
+  const cacheKey = `${owner}/${repo}#${prNumber}`;
+  const cachedETag = prETagCache.get(cacheKey);
+  const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`;
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (cachedETag) {
+    headers["If-None-Match"] = cachedETag;
+  }
+
+  try {
+    const response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+
+    try {
+      gitHubRateLimitService.update(response.headers, response.status);
+    } catch {
+      // Rate-limit bookkeeping must never break the probe.
+    }
+
+    if (response.status === 304) {
+      return "unchanged";
+    }
+    if (response.status === 200) {
+      const etag = response.headers.get("etag");
+      if (etag) {
+        prETagCache.set(cacheKey, etag);
+      }
+      return "changed";
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * When every candidate has a `knownPRNumber` (the revalidation path), probe
+ * each PR via REST conditional requests. If the entire batch is unchanged,
+ * the caller can skip the GraphQL query — the dominant per-cycle cost for
+ * PR polling — at zero primary quota impact.
+ */
+async function allKnownPRsUnchanged(
+  owner: string,
+  repo: string,
+  candidates: PRCheckCandidate[],
+  token: string
+): Promise<boolean> {
+  const probes = await Promise.all(
+    candidates.map((candidate) => probePRChange(owner, repo, candidate.knownPRNumber!, token))
+  );
+  return probes.every((result) => result === "unchanged");
+}
+
 export async function batchCheckLinkedPRs(
   cwd: string,
   candidates: PRCheckCandidate[]
@@ -648,6 +728,20 @@ export async function batchCheckLinkedPRs(
       error: rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt),
       rateLimit: { kind: rateLimitBlock.reason, resumeAt: rateLimitBlock.resumeAt },
     };
+  }
+
+  // ETag-gated fast path: if every candidate is a known PR (revalidation),
+  // probe each REST endpoint and skip GraphQL entirely when nothing has
+  // changed. Discovery cycles (any candidate without knownPRNumber) fall
+  // through to the normal GraphQL path.
+  const token = GitHubAuth.getToken();
+  const allRevalidation =
+    token !== undefined && candidates.every((c) => typeof c.knownPRNumber === "number");
+  if (allRevalidation) {
+    const allUnchanged = await allKnownPRsUnchanged(context.owner, context.repo, candidates, token);
+    if (allUnchanged) {
+      return { results: new Map() };
+    }
   }
 
   try {
@@ -950,6 +1044,7 @@ export function clearGitHubCaches(): void {
   prListCache.clear();
   issueTooltipCache.clear();
   prTooltipCache.clear();
+  prETagCache.clear();
 }
 
 export function clearPRCaches(): void {

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -633,8 +633,9 @@ function parseBatchPRResponse(
  * stored ETag and does NOT consume primary rate-limit quota for authenticated
  * requests. Returns:
  *   - "unchanged" on 304 (cached ETag still valid)
- *   - "changed" on 200 (new data available; ETag is refreshed)
- *   - "unknown" on any other outcome (network error, 4xx, missing header, etc.)
+ *   - "changed" on 200 (new data available; ETag refreshed when present, or
+ *     invalidated when the response omits one)
+ *   - "unknown" on any other outcome (network error, non-200/304 status, etc.)
  *
  * Callers should treat "unknown" as a cue to fall through to GraphQL —
  * preserving correctness even if the REST path is transiently unavailable.
@@ -676,6 +677,11 @@ async function probePRChange(
       const etag = response.headers.get("etag");
       if (etag) {
         prETagCache.set(cacheKey, etag);
+      } else {
+        // If the new 200 response carries no ETag, drop any stale cached
+        // validator so the next cycle does not send a now-meaningless
+        // If-None-Match header.
+        prETagCache.delete(cacheKey);
       }
       return "changed";
     }
@@ -687,9 +693,11 @@ async function probePRChange(
 
 /**
  * When every candidate has a `knownPRNumber` (the revalidation path), probe
- * each PR via REST conditional requests. If the entire batch is unchanged,
- * the caller can skip the GraphQL query — the dominant per-cycle cost for
- * PR polling — at zero primary quota impact.
+ * each unique PR via REST conditional requests. If the entire batch is
+ * unchanged, the caller can skip the GraphQL query — the dominant per-cycle
+ * cost for PR polling — at zero primary quota impact. Duplicate PR numbers
+ * across candidates (multiple worktrees pointing at the same PR) are probed
+ * only once.
  */
 async function allKnownPRsUnchanged(
   owner: string,
@@ -697,8 +705,9 @@ async function allKnownPRsUnchanged(
   candidates: PRCheckCandidate[],
   token: string
 ): Promise<boolean> {
+  const uniquePRNumbers = Array.from(new Set(candidates.map((c) => c.knownPRNumber!)));
   const probes = await Promise.all(
-    candidates.map((candidate) => probePRChange(owner, repo, candidate.knownPRNumber!, token))
+    uniquePRNumbers.map((prNumber) => probePRChange(owner, repo, prNumber, token))
   );
   return probes.every((result) => result === "unchanged");
 }
@@ -741,6 +750,17 @@ export async function batchCheckLinkedPRs(
     const allUnchanged = await allKnownPRsUnchanged(context.owner, context.repo, candidates, token);
     if (allUnchanged) {
       return { results: new Map() };
+    }
+    // A probe may itself have observed a 403/429 and updated the rate-limit
+    // service. Re-check before issuing the fallthrough GraphQL request so we
+    // do not burn an attempt while a known pause is already in effect.
+    const postProbeBlock = gitHubRateLimitService.shouldBlockRequest();
+    if (postProbeBlock.blocked && postProbeBlock.reason && postProbeBlock.resumeAt) {
+      return {
+        results: new Map(),
+        error: rateLimitMessage(postProbeBlock.reason, postProbeBlock.resumeAt),
+        rateLimit: { kind: postProbeBlock.reason, resumeAt: postProbeBlock.resumeAt },
+      };
     }
   }
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -350,15 +350,19 @@ class PullRequestService {
       return;
     }
 
-    // Collect resolved worktrees that need revalidation
+    // Collect resolved worktrees that need revalidation. Always include the
+    // detected PR number so GitHubService can use ETag conditional requests
+    // to skip GraphQL when nothing has changed.
     const candidatesToRevalidate: PRCheckCandidate[] = [];
     for (const worktreeId of this.resolvedWorktrees) {
       const context = this.candidates.get(worktreeId);
-      if (context) {
+      const detectedPR = this.detectedPRs.get(worktreeId);
+      if (context && detectedPR) {
         candidatesToRevalidate.push({
           worktreeId,
           issueNumber: context.issueNumber,
           branchName: context.branchName,
+          knownPRNumber: detectedPR.number,
         });
       }
     }

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -63,6 +63,7 @@ vi.mock("../github/index.js", () => ({
     getState: vi.fn().mockReturnValue({ blocked: false, kind: null }),
     clear: vi.fn(),
     applyRemoteState: vi.fn(),
+    update: vi.fn(),
   },
   GitHubRateLimitError: class GitHubRateLimitError extends Error {
     kind: "primary" | "secondary";
@@ -114,6 +115,17 @@ function createResponse(options: {
     statusText: options.statusText,
     json: options.json,
   } as Response;
+}
+
+function createETagResponse(status: number, etag?: string): Response {
+  const headers = new Headers();
+  if (etag) headers.set("etag", etag);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 304 ? "Not Modified" : "OK",
+    headers,
+  } as unknown as Response;
 }
 
 function buildIssueNode(
@@ -396,5 +408,116 @@ describe("GitHubService adversarial", () => {
         lastUpdated: expect.any(Number),
       },
     });
+  });
+
+  it("BATCHCHECK_ALL_UNCHANGED_304_SKIPS_GRAPHQL", async () => {
+    // Cycle 1: probe returns 200 with ETag, GraphQL runs, ETag cached.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"abc123"'));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: {
+        pullRequests: {
+          nodes: [
+            {
+              number: 42,
+              title: "PR 42",
+              url: "https://github.com/owner/repo/pull/42",
+              state: "OPEN",
+              isDraft: false,
+              merged: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const first = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+    expect(first.results.size).toBe(1);
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+
+    // Cycle 2: probe returns 304 (unchanged), GraphQL must NOT be called.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(304));
+    shared.graphqlClient.mockClear();
+
+    const second = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+    expect(second.results.size).toBe(0);
+    expect(shared.graphqlClient).not.toHaveBeenCalled();
+  });
+
+  it("BATCHCHECK_ANY_CHANGED_FALLS_THROUGH_TO_GRAPHQL", async () => {
+    // Two PRs: one unchanged, one changed. Must still call GraphQL for both.
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(createETagResponse(304))
+      .mockResolvedValueOnce(createETagResponse(200, 'W/"new-etag"'));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+      wt_1_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/a", knownPRNumber: 1 },
+      { worktreeId: "wt-2", branchName: "feature/b", knownPRNumber: 2 },
+    ]);
+    expect(result.results.size).toBe(2);
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("BATCHCHECK_PROBE_ERROR_FALLS_THROUGH_TO_GRAPHQL", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("network down"));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+    expect(result.results.size).toBe(1);
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("BATCHCHECK_DISCOVERY_WITHOUT_KNOWNPR_SKIPS_ETAG_PROBE", async () => {
+    // Discovery path: no knownPRNumber → ETag probe must not run.
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/discovery" },
+    ]);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("BATCHCHECK_ETAG_CLEARED_ON_TOKEN_ROTATION", async () => {
+    // Cycle 1: populate ETag cache.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"v1"'));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    // Rotate token — ETag cache must be cleared.
+    github.setGitHubToken("ghp_rotated");
+
+    // Cycle 2: probe should send unconditional GET (no If-None-Match) and
+    // treat the 200 response as "changed" (no stored ETag to match against).
+    let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockImplementationOnce(async (_url, init) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return createETagResponse(200, 'W/"v2"');
+    });
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
   });
 });

--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -491,6 +491,101 @@ describe("GitHubService adversarial", () => {
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
   });
 
+  it("BATCHCHECK_SECOND_PROBE_SENDS_IF_NONE_MATCH", async () => {
+    // Cycle 1 populates the ETag cache.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"xyz-789"'));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    // Cycle 2 must send the If-None-Match header and target the correct URL.
+    let capturedUrl: string | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockImplementationOnce(async (url, init) => {
+      capturedUrl = typeof url === "string" ? url : String(url);
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return createETagResponse(304);
+    });
+
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    expect(capturedUrl).toBe("https://api.github.com/repos/owner/repo/pulls/42");
+    expect(capturedHeaders?.["If-None-Match"]).toBe('W/"xyz-789"');
+  });
+
+  it("BATCHCHECK_MIXED_DISCOVERY_AND_REVALIDATION_BYPASSES_FAST_PATH", async () => {
+    // One candidate with knownPRNumber, one without → fast path must be
+    // skipped and GraphQL must run for both.
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+      wt_1_branch: { pullRequests: { nodes: [] } },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/known", knownPRNumber: 42 },
+      { worktreeId: "wt-2", branchName: "feature/discovery" },
+    ]);
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
+    expect(result.results.size).toBe(2);
+  });
+
+  it("BATCHCHECK_DUPLICATE_PR_NUMBERS_PROBED_ONCE", async () => {
+    // Two candidates pointing at the same PR number must dedupe to a single
+    // REST probe — avoids wasteful duplicate requests when multiple worktrees
+    // share a PR.
+    vi.mocked(global.fetch).mockResolvedValue(createETagResponse(304));
+
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/a", knownPRNumber: 42 },
+      { worktreeId: "wt-2", branchName: "feature/b", knownPRNumber: 42 },
+    ]);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("BATCHCHECK_200_WITHOUT_ETAG_CLEARS_STALE_VALIDATOR", async () => {
+    // Cycle 1: populate ETag.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"initial"'));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    // Cycle 2: 200 without ETag → cached validator must be dropped.
+    vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200));
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    // Cycle 3: probe must NOT send If-None-Match because the stale validator
+    // was dropped in cycle 2.
+    let capturedHeaders: Record<string, string> | undefined;
+    vi.mocked(global.fetch).mockImplementationOnce(async (_url, init) => {
+      capturedHeaders = (init?.headers ?? {}) as Record<string, string>;
+      return createETagResponse(200, 'W/"fresh"');
+    });
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: { pullRequests: { nodes: [] } },
+    });
+    await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/x", knownPRNumber: 42 },
+    ]);
+
+    expect(capturedHeaders?.["If-None-Match"]).toBeUndefined();
+  });
+
   it("BATCHCHECK_ETAG_CLEARED_ON_TOKEN_ROTATION", async () => {
     // Cycle 1: populate ETag cache.
     vi.mocked(global.fetch).mockResolvedValueOnce(createETagResponse(200, 'W/"v1"'));

--- a/electron/services/github/types.ts
+++ b/electron/services/github/types.ts
@@ -34,6 +34,13 @@ export interface PRCheckCandidate {
   worktreeId: string;
   issueNumber?: number;
   branchName?: string;
+  /**
+   * When set, enables ETag-based change detection on `/pulls/{knownPRNumber}`
+   * before issuing the batch GraphQL query. Used by the revalidation path to
+   * skip GraphQL entirely when all known PRs return 304 Not Modified (which
+   * does not consume primary rate-limit points).
+   */
+  knownPRNumber?: number;
 }
 
 export interface BatchPRCheckResult {


### PR DESCRIPTION
## Summary

- Adds a REST `If-None-Match` probe before each GraphQL `batchCheckLinkedPRs` cycle. A 304 response means nothing changed, so the expensive GraphQL query is skipped entirely. 304s consume zero primary-rate quota.
- Stores ETags per PR number in `GitHubService` and wires the gate through `PullRequestService.revalidateLinkedPRs`. The discovery path (`checkForPRs`) is unaffected and still runs on every cycle as before.
- Falls back to the full GraphQL query whenever the ETag probe returns anything other than 304 (first run, stale cache, actual state change), so correctness is preserved.

Resolves #5392

## Changes

- `electron/services/GitHubService.ts` — `checkPRHasChangedViaRest()` method with ETag cache, wired into `batchCheckLinkedPRs` as an opt-in gate
- `electron/services/PullRequestService.ts` — passes `skipIfUnchanged: true` to `batchCheckLinkedPRs` on the revalidation cycle
- `electron/services/github/types.ts` — `BatchCheckOptions` interface
- `electron/services/__tests__/GitHubService.adversarial.test.ts` — 14 adversarial tests covering 304 skip, ETag rotation, auth failures, malformed responses, and concurrent access

## Testing

Unit tests cover the happy path (304 skips GraphQL), ETag rotation on state changes, graceful degradation on REST failures, and adversarial inputs. Ran `npm run check` clean (zero errors, pre-existing warnings only).