### PR TITLE
fix(perf): deduplicate MAIN_WINDOW_CREATED performance mark

### DIFF
--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -239,7 +239,7 @@ export async function setupWindowServices(
     return;
   }
 
-  markPerformance(PERF_MARKS.MAIN_WINDOW_CREATED);
+  markPerformance(PERF_MARKS.WINDOW_SERVICES_START);
 
   // ── One-time global initialization (first window only) ──
   if (!globalServicesInitialized) {

--- a/shared/perf/__tests__/marks.test.ts
+++ b/shared/perf/__tests__/marks.test.ts
@@ -5,6 +5,7 @@ describe("PERF_MARKS", () => {
   it("contains required instrumentation marks", () => {
     expect(PERF_MARKS.APP_BOOT_START).toBe("app_boot_start");
     expect(PERF_MARKS.MAIN_WINDOW_CREATED).toBe("main_window_created");
+    expect(PERF_MARKS.WINDOW_SERVICES_START).toBe("window_services_start");
     expect(PERF_MARKS.RENDERER_READY).toBe("renderer_ready");
     expect(PERF_MARKS.HYDRATE_START).toBe("hydrate_start");
     expect(PERF_MARKS.HYDRATE_COMPLETE).toBe("hydrate_complete");

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -5,6 +5,7 @@ export const PERF_MARKS = {
   RENDERER_FIRST_INTERACTIVE: "renderer_first_interactive",
 
   SERVICE_INIT_START: "service_init_start",
+  WINDOW_SERVICES_START: "window_services_start",
   SERVICE_INIT_MIGRATIONS_DONE: "service_init_migrations_done",
   SERVICE_INIT_PTY_READY: "service_init_pty_ready",
   SERVICE_INIT_WORKSPACE_READY: "service_init_workspace_ready",


### PR DESCRIPTION
## Summary
- MAIN_WINDOW_CREATED was being emitted twice: once at window creation and again after service init
- This caused performance dashboards to report inconsistent startup times depending on which entry they read
- Added a new WINDOW_SERVICES_START mark to capture the service initialization milestone separately
- Removed the duplicate emission from windowServices.ts, keeping only the canonical emission from createWindow.ts

Resolves #5374

## Changes
- Added `WINDOW_SERVICES_START` to shared/perf/marks.ts enum
- Replaced duplicate `PERF_MARKS.MAIN_WINDOW_CREATED` with `PERF_MARKS.WINDOW_SERVICES_START` in windowServices.ts
- Added test coverage for the new mark in perf marks test

## Testing
- Verified MAIN_WINDOW_CREATED is now emitted exactly once at the correct semantic location
- Confirmed WINDOW_SERVICES_START captures the services initialization milestone
- Updated unit tests pass