### PR TITLE
feat(git): Git LFS pre-flight check and pointer-stub detection

### DIFF
--- a/electron/ipc/handlers/__tests__/files.read.test.ts
+++ b/electron/ipc/handlers/__tests__/files.read.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "path";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+}));
+
+const fsMock = vi.hoisted(() => ({
+  stat: vi.fn<(p: string) => Promise<{ size: number }>>(),
+  readFile: vi.fn<(p: string) => Promise<Buffer>>(),
+}));
+
+vi.mock("fs/promises", () => ({
+  default: fsMock,
+  ...fsMock,
+}));
+
+const checkRateLimitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../utils.js", () => ({
+  checkRateLimit: checkRateLimitMock,
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+}));
+
+vi.mock("../../../services/FileSearchService.js", () => ({
+  fileSearchService: { search: vi.fn() },
+}));
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../channels.js";
+import { registerFilesHandlers, isLfsPointer } from "../files.js";
+import type { FileReadResult } from "../../../../shared/types/ipc/files.js";
+
+const LFS_HEADER = "version https://git-lfs.github.com/spec/v1\n";
+const VALID_POINTER = Buffer.from(
+  `${LFS_HEADER}oid sha256:3f4e9b7d2c0b5a8f6e1d2c3b4a5968777665544332211aabbccddeeff00112233\nsize 12345\n`,
+  "ascii"
+);
+
+function getReadHandler() {
+  const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+    .calls;
+  const entry = calls.find((c) => c[0] === CHANNELS.FILES_READ);
+  if (!entry) throw new Error("files:read handler not registered");
+  return entry[1] as (event: unknown, payload: unknown) => Promise<FileReadResult>;
+}
+
+describe("isLfsPointer", () => {
+  it("matches a valid v1 pointer stub", () => {
+    expect(isLfsPointer(VALID_POINTER)).toBe(true);
+  });
+
+  it("matches a minimal header-only buffer", () => {
+    expect(isLfsPointer(Buffer.from(LFS_HEADER, "ascii"))).toBe(true);
+  });
+
+  it("rejects files larger than the 1024-byte spec cap", () => {
+    const padded = Buffer.concat([VALID_POINTER, Buffer.alloc(1024, 32)]);
+    expect(padded.length).toBeGreaterThan(1024);
+    expect(isLfsPointer(padded)).toBe(false);
+  });
+
+  it("rejects buffers shorter than the header length", () => {
+    expect(isLfsPointer(Buffer.from("version https://git-lfs", "ascii"))).toBe(false);
+  });
+
+  it("rejects non-LFS text that happens to start with 'version '", () => {
+    expect(isLfsPointer(Buffer.from("version 1.2.3\n", "ascii"))).toBe(false);
+  });
+
+  it("rejects the header when the trailing LF is missing (strict match)", () => {
+    const headerWithoutLf = "version https://git-lfs.github.com/spec/v1";
+    expect(isLfsPointer(Buffer.from(headerWithoutLf, "ascii"))).toBe(false);
+  });
+
+  it("rejects an empty buffer", () => {
+    expect(isLfsPointer(Buffer.alloc(0))).toBe(false);
+  });
+});
+
+describe("files:read handler", () => {
+  const root = path.resolve("/tmp/project");
+  const file = path.join(root, "asset.bin");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns LFS_POINTER when the file is a git-lfs v1 pointer", async () => {
+    fsMock.stat.mockResolvedValue({ size: VALID_POINTER.length });
+    fsMock.readFile.mockResolvedValue(VALID_POINTER);
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: file, rootPath: root });
+
+    expect(result).toEqual({ ok: false, code: "LFS_POINTER" });
+  });
+
+  it("returns plain content for a normal text file", async () => {
+    const content = Buffer.from("hello world\n", "utf-8");
+    fsMock.stat.mockResolvedValue({ size: content.length });
+    fsMock.readFile.mockResolvedValue(content);
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: file, rootPath: root });
+
+    expect(result).toEqual({ ok: true, content: "hello world\n" });
+  });
+
+  it("returns BINARY_FILE before LFS detection when null bytes are present", async () => {
+    const content = Buffer.concat([Buffer.from(LFS_HEADER, "ascii"), Buffer.from([0x00])]);
+    fsMock.stat.mockResolvedValue({ size: content.length });
+    fsMock.readFile.mockResolvedValue(content);
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: file, rootPath: root });
+
+    expect(result).toEqual({ ok: false, code: "BINARY_FILE" });
+  });
+
+  it("returns FILE_TOO_LARGE without reading the buffer for oversized files", async () => {
+    fsMock.stat.mockResolvedValue({ size: 600 * 1024 });
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: file, rootPath: root });
+
+    expect(result).toEqual({ ok: false, code: "FILE_TOO_LARGE" });
+    expect(fsMock.readFile).not.toHaveBeenCalled();
+  });
+
+  it("returns OUTSIDE_ROOT when the file is not under rootPath", async () => {
+    registerFilesHandlers();
+
+    const result = await getReadHandler()(
+      {},
+      { path: path.resolve("/etc/passwd"), rootPath: root }
+    );
+
+    expect(result).toEqual({ ok: false, code: "OUTSIDE_ROOT" });
+    expect(fsMock.stat).not.toHaveBeenCalled();
+  });
+
+  it("returns INVALID_PATH for relative paths", async () => {
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: "./relative", rootPath: root });
+
+    expect(result).toEqual({ ok: false, code: "INVALID_PATH" });
+  });
+
+  it("returns NOT_FOUND when stat raises ENOENT", async () => {
+    const err = Object.assign(new Error("no such file"), { code: "ENOENT" });
+    fsMock.stat.mockRejectedValue(err);
+    registerFilesHandlers();
+
+    const result = await getReadHandler()({}, { path: file, rootPath: root });
+
+    expect(result).toEqual({ ok: false, code: "NOT_FOUND" });
+  });
+});

--- a/electron/ipc/handlers/files.ts
+++ b/electron/ipc/handlers/files.ts
@@ -4,8 +4,16 @@ import { CHANNELS } from "../channels.js";
 import { checkRateLimit, typedHandle } from "../utils.js";
 import { fileSearchService } from "../../services/FileSearchService.js";
 import { FileSearchPayloadSchema, FileReadPayloadSchema } from "../../schemas/ipc.js";
+import type { FileReadResult } from "../../../shared/types/ipc/files.js";
 
 const FILE_SIZE_LIMIT = 512 * 1024; // 500 KB
+
+// Git LFS pointer files are plain ASCII with a fixed v1 header. The spec caps
+// pointer files at 1024 bytes total, so any larger file cannot be a pointer.
+// See https://github.com/git-lfs/git-lfs/blob/main/docs/spec.md
+const LFS_POINTER_MAX_SIZE = 1024;
+const LFS_POINTER_HEADER = "version https://git-lfs.github.com/spec/v1\n";
+const LFS_POINTER_HEADER_BYTES = Buffer.from(LFS_POINTER_HEADER, "ascii");
 
 export function registerFilesHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -36,15 +44,7 @@ export function registerFilesHandlers(): () => void {
 
   handlers.push(typedHandle(CHANNELS.FILES_SEARCH, handleSearch));
 
-  const handleRead = async (
-    payload: unknown
-  ): Promise<
-    | { ok: true; content: string }
-    | {
-        ok: false;
-        code: "BINARY_FILE" | "FILE_TOO_LARGE" | "NOT_FOUND" | "OUTSIDE_ROOT" | "INVALID_PATH";
-      }
-  > => {
+  const handleRead = async (payload: unknown): Promise<FileReadResult> => {
     const parsed = FileReadPayloadSchema.safeParse(payload);
     if (!parsed.success) {
       console.error("[IPC] Invalid files:read payload:", parsed.error.format());
@@ -84,6 +84,10 @@ export function registerFilesHandlers(): () => void {
         }
       }
 
+      if (isLfsPointer(buffer)) {
+        return { ok: false, code: "LFS_POINTER" };
+      }
+
       return { ok: true, content: buffer.toString("utf-8") };
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
@@ -98,4 +102,15 @@ export function registerFilesHandlers(): () => void {
   handlers.push(typedHandle(CHANNELS.FILES_READ, handleRead));
 
   return () => handlers.forEach((cleanup) => cleanup());
+}
+
+/**
+ * Matches a Git LFS v1 pointer stub. Pointers are ASCII and capped at 1024 bytes
+ * by the LFS spec; anything larger cannot be a pointer. Detection must happen
+ * before `buffer.toString("utf-8")` so the text isn't surfaced to the UI.
+ */
+export function isLfsPointer(buffer: Buffer): boolean {
+  if (buffer.length > LFS_POINTER_MAX_SIZE) return false;
+  if (buffer.length < LFS_POINTER_HEADER_BYTES.length) return false;
+  return buffer.subarray(0, LFS_POINTER_HEADER_BYTES.length).equals(LFS_POINTER_HEADER_BYTES);
 }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1,5 +1,6 @@
 import os from "os";
 import PQueue from "p-queue";
+import { execFile } from "child_process";
 import { mkdir, writeFile, stat, readFile } from "fs/promises";
 import { join as pathJoin, dirname, resolve as pathResolve, isAbsolute } from "path";
 import { generateProjectId, settingsFilePath } from "../services/projectStorePaths.js";
@@ -32,6 +33,61 @@ import { waitForPathExists } from "../utils/fs.js";
 // Configuration
 const DEFAULT_ACTIVE_WORKTREE_INTERVAL_MS = 2000;
 const DEFAULT_BACKGROUND_WORKTREE_INTERVAL_MS = 10000;
+
+// Hard ceiling on the `git lfs version` probe. `git` is already on PATH, so a
+// healthy probe returns in milliseconds; the 3 s cap only matters on slow/
+// network-mounted filesystems or misconfigured shells. On timeout we treat LFS
+// as unavailable rather than delay the load-project-result event (precedent:
+// #4852 — don't block startup on optional probes).
+const LFS_PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Probe whether `git lfs` is installed on the user's PATH. Uses raw `execFile`
+ * (not simple-git / hardenedGit) because LFS availability is a read-only CLI
+ * check that has nothing to do with the project's git repo; routing it through
+ * hardenedGit would strip credential helpers for no reason. Returns `false` on
+ * any error, non-matching stdout, or timeout.
+ */
+export function probeGitLfsAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const child = execFile(
+      "git",
+      ["lfs", "version"],
+      { timeout: LFS_PROBE_TIMEOUT_MS, windowsHide: true },
+      (err, stdout) => {
+        if (err) {
+          done(false);
+          return;
+        }
+        done(/^git-lfs\//.test(stdout.trim()));
+      }
+    );
+
+    // Defence in depth: if execFile's timeout fails to fire (e.g. child is
+    // detached from the event loop), cap the wait ourselves.
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        // Best-effort — process may already have exited.
+      }
+      done(false);
+    }, LFS_PROBE_TIMEOUT_MS + 500);
+
+    child.on("exit", () => clearTimeout(timer));
+    child.on("error", () => {
+      clearTimeout(timer);
+      done(false);
+    });
+  });
+}
 
 async function ensureNoteFile(worktreePath: string): Promise<void> {
   const gitDir = getGitDir(worktreePath);
@@ -181,9 +237,16 @@ export class WorkspaceService {
       const rawWorktrees = await this.listService.list();
       const worktrees = this.listService.mapToWorktrees(rawWorktrees);
 
-      await this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true);
+      // Run the LFS probe concurrently with monitor sync so we don't add its
+      // 3s worst case on top of sync latency. The probe is a read-only CLI
+      // check (no PATH side-effects); its result travels on the load-project
+      // event so the renderer can warn proactively when a repo uses LFS.
+      const [, lfsAvailable] = await Promise.all([
+        this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true),
+        probeGitLfsAvailable(),
+      ]);
 
-      this.sendEvent({ type: "load-project-result", requestId, success: true });
+      this.sendEvent({ type: "load-project-result", requestId, success: true, lfsAvailable });
 
       void Promise.allSettled([this.initializePRService(), this.refreshAll()]).then((results) => {
         const [prResult, refreshResult] = results;

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -497,11 +497,13 @@ describe("WorkspaceService.loadProject performance behavior", () => {
 
     await service.loadProject("req-1", "/test/root");
 
-    expect(mockSendEvent).toHaveBeenCalledWith({
-      type: "load-project-result",
-      requestId: "req-1",
-      success: true,
-    });
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "load-project-result",
+        requestId: "req-1",
+        success: true,
+      })
+    );
     expect(service["initializePRService"]).toHaveBeenCalledTimes(1);
     expect(service["refreshAll"]).toHaveBeenCalledTimes(1);
 

--- a/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+
+const execFileMock =
+  vi.hoisted(
+    () =>
+      vi.fn<
+        (
+          cmd: string,
+          args: string[],
+          opts: unknown,
+          cb: (err: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void
+        ) => { kill: () => void; on: (event: string, handler: () => void) => void }
+      >()
+  );
+
+vi.mock("child_process", () => ({
+  execFile: execFileMock,
+}));
+
+// WorkspaceService's module initialization pulls in a lot of modules that
+// touch Electron. Stub the heavy dependencies before importing so the probe
+// function can be exercised in isolation.
+vi.mock("simple-git", () => ({ simpleGit: vi.fn() }));
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(),
+  createAuthenticatedGit: vi.fn(),
+  validateCwd: vi.fn(),
+}));
+vi.mock("../../services/events.js", () => ({ events: { on: vi.fn(), off: vi.fn() } }));
+vi.mock("../../services/PullRequestService.js", () => ({ pullRequestService: {} }));
+vi.mock("../../services/github/GitHubAuth.js", () => ({ GitHubAuth: vi.fn() }));
+vi.mock("../../services/projectDirMigration.js", () => ({
+  ensureDaintreeDirMigrated: vi.fn(),
+}));
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumber: vi.fn(),
+  extractIssueNumberSync: vi.fn(),
+}));
+vi.mock("../WorktreeLifecycleService.js", () => ({ WorktreeLifecycleService: vi.fn() }));
+vi.mock("../WorktreeMonitor.js", () => ({ WorktreeMonitor: vi.fn() }));
+vi.mock("../WorktreeListService.js", () => ({ WorktreeListService: vi.fn() }));
+vi.mock("../PRIntegrationService.js", () => ({ PRIntegrationService: vi.fn() }));
+vi.mock("../../utils/git.js", () => ({ invalidateGitStatusCache: vi.fn() }));
+vi.mock("../../utils/gitUtils.js", () => ({ getGitDir: vi.fn(), clearGitDirCache: vi.fn() }));
+vi.mock("../../utils/fs.js", () => ({ waitForPathExists: vi.fn() }));
+vi.mock("../../services/projectStorePaths.js", () => ({
+  generateProjectId: vi.fn(),
+  settingsFilePath: vi.fn(),
+}));
+
+import { probeGitLfsAvailable } from "../WorkspaceService.js";
+
+type ExecFileCallback = (
+  err: NodeJS.ErrnoException | null,
+  stdout: string,
+  stderr: string
+) => void;
+
+function mockExecFile(
+  handler: (cb: ExecFileCallback) => void,
+  childOverrides?: { kill?: () => void }
+) {
+  execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+    // Fire the callback on the next tick to better mimic real execFile semantics
+    // (it never invokes its callback synchronously).
+    setImmediate(() => handler(cb as ExecFileCallback));
+    return {
+      kill: childOverrides?.kill ?? (() => undefined),
+      on: () => undefined,
+    } as unknown as ReturnType<typeof execFileMock>;
+  });
+}
+
+describe("probeGitLfsAvailable", () => {
+  it("returns true when git-lfs is installed and reports its version", async () => {
+    mockExecFile((cb) => cb(null, "git-lfs/3.4.0 (GitHub; darwin arm64; go 1.22.0)\n", ""));
+
+    await expect(probeGitLfsAvailable()).resolves.toBe(true);
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      ["lfs", "version"],
+      expect.objectContaining({ timeout: 3000, windowsHide: true }),
+      expect.any(Function)
+    );
+  });
+
+  it("returns false when git-lfs is not on PATH (ENOENT)", async () => {
+    mockExecFile((cb) => {
+      const err = Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" });
+      cb(err, "", "");
+    });
+
+    await expect(probeGitLfsAvailable()).resolves.toBe(false);
+  });
+
+  it("returns false when `git lfs` subcommand is not installed (non-zero exit)", async () => {
+    mockExecFile((cb) => {
+      const err = Object.assign(new Error("git: 'lfs' is not a git command"), { code: 1 });
+      cb(err, "", "git: 'lfs' is not a git command. See 'git --help'.");
+    });
+
+    await expect(probeGitLfsAvailable()).resolves.toBe(false);
+  });
+
+  it("returns false when stdout does not match the git-lfs banner", async () => {
+    mockExecFile((cb) => cb(null, "git version 2.40.0\n", ""));
+
+    await expect(probeGitLfsAvailable()).resolves.toBe(false);
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
@@ -1,17 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 
-const execFileMock =
-  vi.hoisted(
-    () =>
-      vi.fn<
-        (
-          cmd: string,
-          args: string[],
-          opts: unknown,
-          cb: (err: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void
-        ) => { kill: () => void; on: (event: string, handler: () => void) => void }
-      >()
-  );
+const execFileMock = vi.hoisted(() =>
+  vi.fn<
+    (
+      cmd: string,
+      args: string[],
+      opts: unknown,
+      cb: (err: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void
+    ) => { kill: () => void; on: (event: string, handler: () => void) => void }
+  >()
+);
 
 vi.mock("child_process", () => ({
   execFile: execFileMock,
@@ -50,11 +48,7 @@ vi.mock("../../services/projectStorePaths.js", () => ({
 
 import { probeGitLfsAvailable } from "../WorkspaceService.js";
 
-type ExecFileCallback = (
-  err: NodeJS.ErrnoException | null,
-  stdout: string,
-  stderr: string
-) => void;
+type ExecFileCallback = (err: NodeJS.ErrnoException | null, stdout: string, stderr: string) => void;
 
 function mockExecFile(
   handler: (cb: ExecFileCallback) => void,
@@ -95,7 +89,9 @@ describe("probeGitLfsAvailable", () => {
 
   it("returns false when `git lfs` subcommand is not installed (non-zero exit)", async () => {
     mockExecFile((cb) => {
-      const err = Object.assign(new Error("git: 'lfs' is not a git command"), { code: 1 });
+      const err = Object.assign(new Error("git: 'lfs' is not a git command"), {
+        code: "1",
+      }) as NodeJS.ErrnoException;
       cb(err, "", "git: 'lfs' is not a git command. See 'git --help'.");
     });
 

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -55,6 +55,7 @@ export type GitOperationReason =
   | "push-rejected-policy"
   | "pathspec-invalid"
   | "lfs-missing"
+  | "lfs-quota-exceeded"
   | "hook-rejected"
   | "system-io-error"
   | "unknown";

--- a/shared/types/ipc/files.ts
+++ b/shared/types/ipc/files.ts
@@ -16,6 +16,7 @@ export interface FileReadPayload {
 export type FileReadErrorCode =
   | "BINARY_FILE"
   | "FILE_TOO_LARGE"
+  | "LFS_POINTER"
   | "NOT_FOUND"
   | "OUTSIDE_ROOT"
   | "INVALID_PATH";

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -295,7 +295,19 @@ export type WorkspaceHostEvent =
   | { type: "pong" }
   | { type: "error"; error: string; requestId?: string }
   // Project lifecycle responses
-  | { type: "load-project-result"; requestId: string; success: boolean; error?: string }
+  | {
+      type: "load-project-result";
+      requestId: string;
+      success: boolean;
+      error?: string;
+      /**
+       * Whether `git lfs` is available on PATH for this machine. Probed during
+       * load-project via `git lfs version`. `undefined` means the probe did not
+       * run (e.g. project load failed before the probe) and the renderer should
+       * treat it as unknown rather than unavailable.
+       */
+      lfsAvailable?: boolean;
+    }
   | { type: "sync-result"; requestId: string; success: boolean; error?: string }
   | { type: "update-monitor-config-result"; requestId: string; success: boolean; error?: string }
   | { type: "project-switch-result"; requestId: string; success: boolean }

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -72,6 +72,20 @@ describe("classifyGitError — table-driven", () => {
       "lfs-missing",
       "Smudge error: Error downloading file.bin: external filter 'git-lfs filter-process' failed",
     ],
+    [
+      "lfs-quota-exceeded",
+      "batch response: This repository exceeded its LFS budget. Please contact the owner.",
+    ],
+    [
+      "lfs-quota-exceeded",
+      "batch response: This repository is over its data quota. Please contact the owner.",
+    ],
+    ["lfs-quota-exceeded", "You have reached the free storage limit of 10 GiB for Git LFS"],
+    ["lfs-quota-exceeded", "VS403658: You cannot upload more than 10 GB of Git LFS files"],
+    [
+      "lfs-quota-exceeded",
+      "fatal: unable to access 'https://dev.azure.com/org/_git/repo.git/': The requested URL returned error: HTTP 413 LFS upload too large",
+    ],
     ["config-missing", "fatal: The current branch feature/foo has no upstream branch."],
     ["config-missing", "fatal: no upstream configured for branch 'feature/foo'"],
     ["config-missing", "fatal: unable to read config file '/etc/gitconfig': Permission denied"],
@@ -152,6 +166,15 @@ describe("classifyGitError — ordering and normalization", () => {
     expect(classifyGitError(msg)).toBe("auth-failed");
   });
 
+  it("prefers lfs-missing over lfs-quota-exceeded when both signals appear", () => {
+    // PATTERNS ordering: lfs-missing is listed before lfs-quota-exceeded — the missing
+    // binary is the more actionable root cause when both error classes co-occur.
+    const msg =
+      "Smudge error: external filter 'git-lfs filter-process' failed\n" +
+      "batch response: This repository exceeded its LFS budget";
+    expect(classifyGitError(msg)).toBe("lfs-missing");
+  });
+
   it("combines CRLF, remote-stripping, and ordering for hook rejection", () => {
     const msg =
       "remote:  ! [remote rejected] main -> main (pre-receive hook declined)\r\n" +
@@ -213,6 +236,7 @@ describe("getGitRecoveryHint", () => {
       "push-rejected-policy",
       "pathspec-invalid",
       "lfs-missing",
+      "lfs-quota-exceeded",
       "hook-rejected",
       "system-io-error",
     ];

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -166,13 +166,34 @@ describe("classifyGitError — ordering and normalization", () => {
     expect(classifyGitError(msg)).toBe("auth-failed");
   });
 
-  it("prefers lfs-missing over lfs-quota-exceeded when both signals appear", () => {
-    // PATTERNS ordering: lfs-missing is listed before lfs-quota-exceeded — the missing
-    // binary is the more actionable root cause when both error classes co-occur.
+  it("prefers lfs-quota-exceeded over lfs-missing when both signals appear", () => {
+    // Regardless of PATTERNS order, a quota signal is the more actionable root
+    // cause when a user sees both (the filter-process failure is a downstream
+    // consequence of the quota block, not a missing binary).
     const msg =
       "Smudge error: external filter 'git-lfs filter-process' failed\n" +
       "batch response: This repository exceeded its LFS budget";
-    expect(classifyGitError(msg)).toBe("lfs-missing");
+    expect(classifyGitError(msg)).toBe("lfs-quota-exceeded");
+  });
+
+  it("prefers lfs-quota-exceeded over auth-failed on HTTP 403 batch responses (GitHub LFS)", () => {
+    // Regression: GitHub's LFS batch API returns HTTP 403 when the repo exceeds
+    // its LFS quota. Before the ordering fix, `auth-failed` matched the 403
+    // fragment first and users saw "Sign in with GitHub" instead of a quota
+    // explanation. The quota signal must win the tie.
+    const msg =
+      "batch response: This repository exceeded its LFS budget. Please contact the owner.\n" +
+      "error: failed to push some refs to 'https://github.com/acme/media.git'\n" +
+      "fatal: unable to access 'https://github.com/acme/media.git/': The requested URL returned error: 403";
+    expect(classifyGitError(msg)).toBe("lfs-quota-exceeded");
+  });
+
+  it("does not classify a general GitLab namespace storage-limit message as lfs-quota-exceeded", () => {
+    // The regex arm for `reached ... free storage limit` requires an LFS token
+    // nearby so that a plain namespace-level storage warning does not
+    // misclassify as LFS-specific.
+    const msg = "You have reached the free storage limit of 5 GiB for your namespace";
+    expect(classifyGitError(msg)).toBe("unknown");
   });
 
   it("combines CRLF, remote-stripping, and ordering for hook rejection", () => {

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -76,6 +76,15 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
   ],
   ["lfs-missing", /external filter 'git-lfs filter-process' failed|smudge filter lfs failed/i],
   [
+    // LFS storage/bandwidth quota signals across major providers.
+    //   - GitHub (current): "batch response: This repository exceeded its LFS budget"
+    //   - GitHub (classic): "batch response: This repository is over its data quota"
+    //   - GitLab:           "reached ... free storage limit"
+    //   - Azure DevOps:     VS403658 or HTTP 413 on LFS pushes
+    "lfs-quota-exceeded",
+    /batch response:.*(?:exceeded.*LFS budget|over.*data quota|LFS budget)|reached.*free storage limit|HTTP 413.*LFS|VS403658:/i,
+  ],
+  [
     "config-missing",
     // Covers the older 'has no upstream branch' and the newer 'no upstream configured for branch'.
     /fatal: unable to read config file|fatal: bad config|fatal: The current branch .* has no upstream branch|fatal: no upstream configured for branch/i,
@@ -114,6 +123,8 @@ const RECOVERY_HINTS: Record<GitOperationReason, string | undefined> = {
     "The remote rejected this push (protected branch, hook, or size limit). Contact the repo admin.",
   "pathspec-invalid": "The specified ref or path does not exist.",
   "lfs-missing": "Git LFS objects are missing — install git-lfs and run 'git lfs pull'.",
+  "lfs-quota-exceeded":
+    "This repository has exceeded its Git LFS storage or bandwidth quota. Contact the repo owner or upgrade the plan.",
   "hook-rejected": "A server-side hook rejected the push. See the server output for details.",
   "system-io-error": "A filesystem or permissions problem prevented the git operation.",
   unknown: undefined,

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -35,6 +35,25 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
   ["not-a-repository", /fatal: not a git repository/i],
   ["dubious-ownership", /fatal: detected dubious ownership in repository at/i],
   [
+    // MUST run before `auth-failed`: GitHub's LFS batch API returns HTTP 403
+    // when a repo exceeds its LFS quota, so the quota-specific batch response
+    // co-occurs with the same "URL returned error: 403" fragment that
+    // `auth-failed` matches. The quota signal is the more actionable root
+    // cause, so it has to win the tie. Do not reorder without updating the
+    // "prefers lfs-quota-exceeded over auth-failed" test.
+    //
+    // LFS storage/bandwidth quota signals across major providers:
+    //   - GitHub (current): "batch response: This repository exceeded its LFS budget"
+    //   - GitHub (classic): "batch response: This repository is over its data quota"
+    //   - GitLab:           "reached ... free storage limit ... Git LFS"
+    //   - Azure DevOps:     VS403658 or HTTP 413 on LFS pushes
+    //
+    // The GitLab arm requires an "LFS"/"git-lfs" token nearby so that a plain
+    // namespace-level storage limit message does not misclassify as LFS.
+    "lfs-quota-exceeded",
+    /batch response:.*(?:exceeded.*LFS budget|over.*data quota|LFS budget)|reached.*free storage limit.*(?:Git LFS|git[- ]lfs|LFS)|(?:Git LFS|git[- ]lfs|LFS).*reached.*free storage limit|HTTP 413.*LFS|VS403658:/i,
+  ],
+  [
     "auth-failed",
     // HTTPS 401/403/407 (auth/perm/proxy-auth) as well as the direct SSH/HTTPS messages.
     /Authentication failed|Permission denied \(publickey\)|could not read Username for|unable to access.*: The requested URL returned error: 40[137]/i,
@@ -75,15 +94,6 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
     /fatal: (?:bad revision|needed a single revision|pathspec '.*' did not match|ambiguous argument)|couldn't find remote ref/i,
   ],
   ["lfs-missing", /external filter 'git-lfs filter-process' failed|smudge filter lfs failed/i],
-  [
-    // LFS storage/bandwidth quota signals across major providers.
-    //   - GitHub (current): "batch response: This repository exceeded its LFS budget"
-    //   - GitHub (classic): "batch response: This repository is over its data quota"
-    //   - GitLab:           "reached ... free storage limit"
-    //   - Azure DevOps:     VS403658 or HTTP 413 on LFS pushes
-    "lfs-quota-exceeded",
-    /batch response:.*(?:exceeded.*LFS budget|over.*data quota|LFS budget)|reached.*free storage limit|HTTP 413.*LFS|VS403658:/i,
-  ],
   [
     "config-missing",
     // Covers the older 'has no upstream branch' and the newer 'no upstream configured for branch'.

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -48,6 +48,7 @@ function buildDaintreeFileUrl(filePath: string, rootPath: string): string {
 const ERROR_MESSAGES: Record<FileReadErrorCode, string> = {
   BINARY_FILE: "Binary file — cannot display",
   FILE_TOO_LARGE: "File too large to display (> 500 KB)",
+  LFS_POINTER: "Git LFS pointer — run `git lfs pull` to download the file contents",
   NOT_FOUND: "File no longer exists",
   OUTSIDE_ROOT: "File is outside the project root",
   INVALID_PATH: "Invalid file path",


### PR DESCRIPTION
## Summary

- Adds a Git LFS pre-flight probe on project load that runs `git lfs version` and caches the result, flagging the project if LFS is not installed
- Detects LFS v1 pointer stubs in `files:read` and returns a new `LFS_POINTER` error code so the UI can surface a clear affordance instead of showing garbage content
- Classifies LFS-specific stderr patterns (`lfs-quota-exceeded`) in `gitOperationErrors` so the error banner shows a meaningful message rather than raw git output

Resolves #5404

## Changes

- `electron/workspace-host/WorkspaceService.ts` — LFS probe runs on project load, result cached on `WorktreeStatus` via new `lfsAvailable` field
- `shared/types/workspace-host.ts` — `lfsAvailable?: boolean` added to worktree status type
- `electron/ipc/handlers/files.ts` — pointer-stub detection reads first ~150 bytes and returns `{ code: 'LFS_POINTER' }` before attempting to decode the rest of the file
- `shared/types/ipc/files.ts` — `LFS_POINTER` added to the `FileReadErrorCode` union
- `shared/types/ipc/errors.ts` — `lfs-quota-exceeded` added to the `GitOperationErrorReason` union
- `shared/utils/gitOperationErrors.ts` — LFS quota and auth error patterns classified, quota prioritised over generic auth failure
- `src/components/FileViewer/FileViewerModal.tsx` — handles `LFS_POINTER` code in the file viewer

## Testing

79+ unit tests passing across three new spec files:

- `shared/utils/__tests__/gitOperationErrors.test.ts` — LFS quota and auth pattern classification
- `electron/ipc/handlers/__tests__/files.read.test.ts` — pointer-stub detection, normal file reads, binary guard
- `electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts` — probe success, probe failure (LFS not installed), probe error handling