### PR TITLE
feat(agents): scope selected preset per worktree

### DIFF
--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -89,8 +89,21 @@ export interface AgentSettingsEntry {
   shareClipboardDirectory?: boolean;
   /** Override the default model for this agent in assistant/help contexts (e.g., "claude-opus-4-6") */
   assistantModelId?: string;
-  /** Selected preset ID for this agent (persisted per-agent across sessions) */
+  /**
+   * Agent-level default preset ID (persists across worktrees). Used as the
+   * fallback when a worktree has no scoped override. Set from Settings →
+   * Presets; the toolbar dropdown writes to `worktreePresets` instead so
+   * picking a preset in one worktree doesn't silently change what launches
+   * in another.
+   */
   presetId?: string;
+  /**
+   * Per-worktree preset overrides, keyed by worktreeId. Wins over `presetId`
+   * when resolving the effective launch preset. Updates via
+   * `updateWorktreePreset` in the renderer store so the IPC shallow-merge
+   * doesn't clobber sibling worktree keys.
+   */
+  worktreePresets?: Record<string, string>;
   /** User-defined custom presets for this agent (persisted, editable from Settings) */
   customPresets?: Array<{
     id: string;
@@ -144,6 +157,22 @@ export function getAgentSettingsEntry(
 ): AgentSettingsEntry {
   if (!settings || !settings.agents) return {};
   return settings.agents[agentId] ?? {};
+}
+
+/**
+ * Resolves the effective preset ID for a launch: worktree-scoped override
+ * wins, then agent-level default, else `undefined`. Single source of truth
+ * shared by `useAgentLauncher` and the toolbar components so resolution
+ * can't drift between call sites.
+ */
+export function resolveEffectivePresetId(
+  entry: AgentSettingsEntry | null | undefined,
+  worktreeId: string | null | undefined
+): string | undefined {
+  if (!entry) return undefined;
+  const scoped =
+    worktreeId && entry.worktreePresets ? entry.worktreePresets[worktreeId] : undefined;
+  return scoped ?? entry.presetId;
 }
 
 export interface GenerateAgentFlagsOptions {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -278,6 +278,7 @@ export {
   DEFAULT_AGENT_SETTINGS,
   DEFAULT_DANGEROUS_ARGS,
   getAgentSettingsEntry,
+  resolveEffectivePresetId,
   generateAgentFlags,
   generateAgentCommand,
   buildAgentLaunchFlags,

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -35,6 +35,7 @@ import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useShallow } from "zustand/react/shallow";
+import { resolveEffectivePresetId } from "@shared/types";
 import {
   getDominantAgentState,
   agentStateDotColor,
@@ -104,7 +105,9 @@ export function AgentButton({
   // Only show the split/chevron UI when there are at least 2 presets; a single
   // preset is implicitly the default and doesn't warrant a picker.
   const hasPresets = presets.length >= 2;
-  const savedPresetId = agentSettings?.agents?.[type]?.presetId;
+  // Worktree-scoped pick wins over the agent-level default so switching
+  // worktrees doesn't silently surface another worktree's selection.
+  const savedPresetId = resolveEffectivePresetId(entry, activeWorktreeId);
   // Group by source. Project presets are identified by membership so that a
   // project preset whose id happens to start with "ccr-" still lands in
   // "Project Shared" rather than being stolen by the CCR group. Everything
@@ -170,6 +173,17 @@ export function AgentButton({
 
   const handleUnpinFromToolbar = () => {
     void useAgentSettingsStore.getState().setAgentPinned(type, false);
+  };
+
+  // Persist the toolbar pick to the worktree-scoped slot so repeated launches
+  // on the same worktree stay stable, while other worktrees keep their own
+  // defaults. Pass `undefined` to clear the worktree override (returning the
+  // button to the agent-level default). Guard on activeWorktreeId — when no
+  // worktree is active we skip persistence entirely rather than polluting the
+  // global scope.
+  const persistWorktreePick = (presetId: string | undefined) => {
+    if (!activeWorktreeId) return;
+    void useAgentSettingsStore.getState().updateWorktreePreset(type, activeWorktreeId, presetId);
   };
 
   const iconElement = (
@@ -346,6 +360,7 @@ export function AgentButton({
                     <DropdownMenuItem
                       className={cn(!savedPresetId && "font-medium")}
                       onSelect={() => {
+                        persistWorktreePick(undefined);
                         void actionService.dispatch(
                           "agent.launch",
                           { agentId: type, presetId: null },
@@ -369,6 +384,7 @@ export function AgentButton({
                             key={preset.id}
                             className={cn(savedPresetId === preset.id && "font-medium")}
                             onSelect={() => {
+                              persistWorktreePick(preset.id);
                               void actionService.dispatch(
                                 "agent.launch",
                                 { agentId: type, presetId: preset.id },
@@ -395,6 +411,7 @@ export function AgentButton({
                             key={preset.id}
                             className={cn(savedPresetId === preset.id && "font-medium")}
                             onSelect={() => {
+                              persistWorktreePick(preset.id);
                               void actionService.dispatch(
                                 "agent.launch",
                                 { agentId: type, presetId: preset.id },
@@ -419,6 +436,7 @@ export function AgentButton({
                             key={preset.id}
                             className={cn(savedPresetId === preset.id && "font-medium")}
                             onSelect={() => {
+                              persistWorktreePick(preset.id);
                               void actionService.dispatch(
                                 "agent.launch",
                                 { agentId: type, presetId: preset.id },
@@ -474,13 +492,14 @@ export function AgentButton({
               {presets.map((preset) => (
                 <ContextMenuItem
                   key={preset.id}
-                  onSelect={() =>
+                  onSelect={() => {
+                    persistWorktreePick(preset.id);
                     void actionService.dispatch(
                       "agent.launch",
                       { agentId: type, presetId: preset.id },
                       { source: "context-menu" }
-                    )
-                  }
+                    );
+                  }}
                 >
                   {preset.name}
                   {savedPresetId === preset.id ? " ✓" : ""}

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -246,6 +246,7 @@ export function AgentTrayButton({
   const ccrPresetsByAgent = useCcrPresetsStore((s) => s.ccrPresetsByAgent);
   const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
+  const updateWorktreePreset = useAgentSettingsStore((s) => s.updateWorktreePreset);
 
   const getSortedActionMruList = useActionMruStore(useShallow((s) => s.getSortedActionMruList));
 
@@ -444,14 +445,25 @@ export function AgentTrayButton({
     projectPresetsByAgent,
   ]);
 
-  const handleLaunch = useCallback((agentId: BuiltInAgentId, presetId?: string | null) => {
-    setOpen(false);
-    void actionService.dispatch(
-      "agent.launch",
-      { agentId, ...(presetId !== undefined ? { presetId } : {}) },
-      { source: "user" }
-    );
-  }, []);
+  const handleLaunch = useCallback(
+    (agentId: BuiltInAgentId, presetId?: string | null) => {
+      setOpen(false);
+      // Persist the pick to the worktree-scoped slot so a subsequent main-
+      // button press on this worktree relaunches the same preset while other
+      // worktrees keep their own. `null` clears the scoped override (and
+      // dispatches with presetId: null to force a preset-free launch);
+      // `undefined` is the plain MRU fall-through and writes nothing.
+      if (activeWorktreeId && presetId !== undefined) {
+        void updateWorktreePreset(agentId, activeWorktreeId, presetId ?? undefined);
+      }
+      void actionService.dispatch(
+        "agent.launch",
+        { agentId, ...(presetId !== undefined ? { presetId } : {}) },
+        { source: "user" }
+      );
+    },
+    [activeWorktreeId, updateWorktreePreset]
+  );
 
   const handleSetup = (agentId: BuiltInAgentId) => {
     void actionService.dispatch(

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -19,8 +19,10 @@ import { render, fireEvent } from "@testing-library/react";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 
 const dispatchMock = vi.fn();
+const updateWorktreePresetMock = vi.fn();
 
 let mockSettings: AgentSettings | null = null;
+let mockActiveWorktreeId: string | null = null;
 let mockCcrPresetsByAgent: Record<string, Array<{ id: string; name: string }>> = {};
 let mockMergedPresetsFn: (
   agentId: string
@@ -35,7 +37,10 @@ vi.mock("@/store/agentSettingsStore", () => ({
     (selector: (s: { settings: AgentSettings | null }) => unknown) =>
       selector({ settings: mockSettings }),
     {
-      getState: () => ({ setAgentPinned: vi.fn() }),
+      getState: () => ({
+        setAgentPinned: vi.fn(),
+        updateWorktreePreset: updateWorktreePresetMock,
+      }),
     }
   ),
 }));
@@ -59,7 +64,7 @@ vi.mock("@/store/panelStore", () => ({
 
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: (selector: (s: { activeWorktreeId: string | null }) => unknown) =>
-    selector({ activeWorktreeId: null }),
+    selector({ activeWorktreeId: mockActiveWorktreeId }),
 }));
 
 vi.mock("@/hooks/useWorktrees", () => ({
@@ -167,7 +172,9 @@ function settingsWith(agents: Record<string, unknown>): AgentSettings {
 describe("AgentButton preset UX", () => {
   beforeEach(() => {
     dispatchMock.mockClear();
+    updateWorktreePresetMock.mockClear();
     mockSettings = null;
+    mockActiveWorktreeId = null;
     mockCcrPresetsByAgent = {};
     mockMergedPresetsFn = () => [];
   });
@@ -289,6 +296,135 @@ describe("AgentButton preset UX", () => {
       const texts = labels.map((el) => el.textContent);
       expect(texts).toContain("CCR Routes");
       expect(texts).toContain("Custom");
+    });
+  });
+
+  describe("worktree-scoped preset", () => {
+    it("primary click reads the worktree override when present, not the agent-level default", () => {
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({
+        claude: {
+          presetId: "user-global",
+          worktreePresets: { "wt-A": "user-scoped" },
+        },
+      });
+      mockMergedPresetsFn = () => [
+        { id: "user-global", name: "Global" },
+        { id: "user-scoped", name: "Scoped" },
+      ];
+
+      const { getAllByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const [primaryBtn] = getAllByRole("button") as HTMLElement[];
+      fireEvent.click(primaryBtn!);
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: "user-scoped" },
+        { source: "user" }
+      );
+    });
+
+    it("primary click falls back to agent-level default when the active worktree has no override", () => {
+      mockActiveWorktreeId = "wt-B";
+      mockSettings = settingsWith({
+        claude: {
+          presetId: "user-global",
+          worktreePresets: { "wt-A": "user-scoped" },
+        },
+      });
+      mockMergedPresetsFn = () => [
+        { id: "user-global", name: "Global" },
+        { id: "user-scoped", name: "Scoped" },
+      ];
+
+      const { getAllByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const [primaryBtn] = getAllByRole("button") as HTMLElement[];
+      fireEvent.click(primaryBtn!);
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: "user-global" },
+        { source: "user" }
+      );
+    });
+
+    it("dropdown preset selection persists the pick to the worktree slot before dispatch", () => {
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [
+        { id: "user-alpha", name: "Alpha" },
+        { id: "user-beta", name: "Beta" },
+      ];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      // Dropdown items: 0 = Default, 1 = Alpha, 2 = Beta (first occurrence only
+      // — presets list is unsorted in tests so take items in render order).
+      const items = getAllByTestId("preset-item") as HTMLElement[];
+      // Pick the preset that is not "Default". Items include one "Default"
+      // menu entry plus one per preset.
+      const alphaItem = items.find((el) => el.textContent?.includes("Alpha"))!;
+      fireEvent.click(alphaItem);
+
+      expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", "user-alpha");
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: "user-alpha" },
+        { source: "user" }
+      );
+    });
+
+    it("dropdown Default clears the worktree override before dispatching null", () => {
+      mockActiveWorktreeId = "wt-A";
+      mockSettings = settingsWith({
+        claude: { worktreePresets: { "wt-A": "user-alpha" } },
+      });
+      mockMergedPresetsFn = () => [
+        { id: "user-alpha", name: "Alpha" },
+        { id: "user-beta", name: "Beta" },
+      ];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const items = getAllByTestId("preset-item") as HTMLElement[];
+      const defaultItem = items.find((el) => el.textContent?.includes("Default"))!;
+      fireEvent.click(defaultItem);
+
+      expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: null },
+        { source: "user" }
+      );
+    });
+
+    it("no-ops the worktree persist when no active worktree is set", () => {
+      mockActiveWorktreeId = null;
+      mockSettings = settingsWith({ claude: {} });
+      mockMergedPresetsFn = () => [
+        { id: "user-alpha", name: "Alpha" },
+        { id: "user-beta", name: "Beta" },
+      ];
+
+      const { getAllByTestId } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      const items = getAllByTestId("preset-item") as HTMLElement[];
+      const alphaItem = items.find((el) => el.textContent?.includes("Alpha"))!;
+      fireEvent.click(alphaItem);
+
+      expect(updateWorktreePresetMock).not.toHaveBeenCalled();
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: "user-alpha" },
+        { source: "user" }
+      );
     });
   });
 

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -6,6 +6,7 @@ import type { ActionFrecencyEntry } from "@shared/types/actions";
 
 const dispatchMock = vi.fn();
 const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
+const updateWorktreePresetMock = vi.fn().mockResolvedValue(undefined);
 const setFocusedMock = vi.fn();
 const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
 let openChangeSpy: ((open: boolean) => void) | null = null;
@@ -47,11 +48,16 @@ vi.mock("@/services/ActionService", () => ({
 type MockAgentStoreState = {
   settings: AgentSettings | null;
   setAgentPinned: typeof setAgentPinnedMock;
+  updateWorktreePreset: typeof updateWorktreePresetMock;
 };
 
 vi.mock("@/store/agentSettingsStore", () => ({
   useAgentSettingsStore: (selector: (s: MockAgentStoreState) => unknown) =>
-    selector({ settings: mockSettings, setAgentPinned: setAgentPinnedMock }),
+    selector({
+      settings: mockSettings,
+      setAgentPinned: setAgentPinnedMock,
+      updateWorktreePreset: updateWorktreePresetMock,
+    }),
 }));
 
 vi.mock("@/store/actionMruStore", () => ({
@@ -266,6 +272,7 @@ describe("AgentTrayButton", () => {
   beforeEach(() => {
     dispatchMock.mockClear();
     setAgentPinnedMock.mockClear();
+    updateWorktreePresetMock.mockClear();
     setFocusedMock.mockClear();
     refreshAvailabilityMock.mockClear();
     openChangeSpy = null;
@@ -892,6 +899,53 @@ describe("AgentTrayButton", () => {
       const { queryByText } = render(<AgentTrayButton agentAvailability={availability} />);
       expect(queryByText("CCR Routes")).toBeNull();
       expect(queryByText("Custom")).toBeNull();
+    });
+  });
+
+  describe("worktree-scoped preset persistence", () => {
+    function arrangeAgentWithPresets() {
+      const availability = { claude: "ready" } as unknown as CliAvailability;
+      mockSettings = settingsWith({ claude: { pinned: false } });
+      mockMergedPresetsFn = (agentId: string) =>
+        agentId === "claude"
+          ? [
+              { id: "user-alpha", name: "Alpha" },
+              { id: "user-beta", name: "Beta" },
+            ]
+          : [];
+      return availability;
+    }
+
+    it("Default keyboard launch clears the scoped override and dispatches presetId: null", () => {
+      mockActiveWorktreeId = "wt-A";
+      const availability = arrangeAgentWithPresets();
+      const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const submenuTrigger = getAllByTestId("submenu-trigger")[0]!;
+
+      fireEvent.keyDown(submenuTrigger, { key: "Enter" });
+
+      expect(updateWorktreePresetMock).toHaveBeenCalledWith("claude", "wt-A", undefined);
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: null },
+        { source: "user" }
+      );
+    });
+
+    it("does not persist the scope when no active worktree is set", () => {
+      mockActiveWorktreeId = null;
+      const availability = arrangeAgentWithPresets();
+      const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+      const submenuTrigger = getAllByTestId("submenu-trigger")[0]!;
+
+      fireEvent.keyDown(submenuTrigger, { key: "Enter" });
+
+      expect(updateWorktreePresetMock).not.toHaveBeenCalled();
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "agent.launch",
+        { agentId: "claude", presetId: null },
+        { source: "user" }
+      );
     });
   });
 });

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -49,7 +49,7 @@ export function PresetSelector({
 
   const selectedItem = useMemo((): Item => {
     if (!selectedPresetId) {
-      return { id: "", label: "Default (no overrides)", color: agentColor, source: "default" };
+      return { id: "", label: "Default (all worktrees)", color: agentColor, source: "default" };
     }
     // Match precedence order from getMergedPresets: custom wins over project
     // wins over CCR on ID collision. Resolve the badge/label against the
@@ -147,7 +147,7 @@ export function PresetSelector({
         <div role="listbox" aria-label="Preset" className="overflow-y-auto max-h-80">
           <PresetOption
             id=""
-            label="Default (no overrides)"
+            label="Default (all worktrees)"
             color={agentColor}
             isSelected={!selectedPresetId}
             onSelect={handleSelect}

--- a/src/components/Settings/__tests__/PresetSelector.test.tsx
+++ b/src/components/Settings/__tests__/PresetSelector.test.tsx
@@ -31,7 +31,7 @@ describe("PresetSelector", () => {
     onChange = vi.fn<(presetId: string | undefined) => void>();
   });
 
-  it("trigger label shows 'Default (no overrides)' when no preset selected", () => {
+  it("trigger label shows the agent-default copy when no preset selected", () => {
     const { getByTestId } = render(
       <PresetSelector
         selectedPresetId={undefined}

--- a/src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts
@@ -49,9 +49,29 @@ function resolvePresetForLaunch(
   const explicitDefault = presetId === null;
   const savedPresetId = resolveEffectivePresetId(entry, worktreeId);
   const resolvedPresetId = explicitDefault ? undefined : (presetId ?? savedPresetId);
-  return isAgent && !explicitDefault
-    ? getMergedPreset(agentId, resolvedPresetId, entry.customPresets, ccrPresets, projectPresets)
-    : undefined;
+  const primary =
+    isAgent && !explicitDefault
+      ? getMergedPreset(agentId, resolvedPresetId, entry.customPresets, ccrPresets, projectPresets)
+      : undefined;
+  if (primary) return primary;
+
+  // Mirror of the launch-time fallback in useAgentLauncher.ts: a stale
+  // worktree-scoped override falls through to the agent-level default so
+  // a deleted scoped pick doesn't silently drop the launch's preset.
+  const scopedId =
+    worktreeId && entry.worktreePresets ? entry.worktreePresets[worktreeId] : undefined;
+  if (
+    isAgent &&
+    !explicitDefault &&
+    presetId === undefined &&
+    scopedId &&
+    scopedId === resolvedPresetId &&
+    entry.presetId &&
+    entry.presetId !== scopedId
+  ) {
+    return getMergedPreset(agentId, entry.presetId, entry.customPresets, ccrPresets, projectPresets);
+  }
+  return undefined;
 }
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
@@ -306,6 +326,36 @@ describe("worktree-scoped preset resolution", () => {
       undefined,
       undefined
     );
+  });
+
+  it("stale worktree override falls back to the agent-level default for the current launch", () => {
+    getMergedPresetMock.mockImplementation((_agentId, presetId) =>
+      presetId === "user-global" ? CUSTOM_PRESET : undefined
+    );
+    const result = resolvePresetForLaunch(
+      undefined,
+      { presetId: "user-global", worktreePresets: { "wt-A": "deleted-id" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      "wt-A"
+    );
+    expect(result).toBe(CUSTOM_PRESET);
+  });
+
+  it("returns undefined when both worktree override and agent default are stale", () => {
+    getMergedPresetMock.mockReturnValue(undefined);
+    const result = resolvePresetForLaunch(
+      undefined,
+      { presetId: "also-deleted", worktreePresets: { "wt-A": "deleted-id" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      "wt-A"
+    );
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AgentPreset } from "@/config/agents";
+import { resolveEffectivePresetId, type AgentSettingsEntry } from "@shared/types";
 
 // ── mocks ────────────────────────────────────────────────────────────────────
 
@@ -38,14 +39,16 @@ import { getMergedPreset } from "@/config/agents";
 
 function resolvePresetForLaunch(
   presetId: string | null | undefined,
-  entry: { presetId?: string; customPresets?: AgentPreset[] },
+  entry: AgentSettingsEntry,
   ccrPresets: AgentPreset[] | undefined,
   agentId: string,
   isAgent: boolean,
-  projectPresets?: AgentPreset[] | undefined
+  projectPresets?: AgentPreset[] | undefined,
+  worktreeId?: string | null
 ): AgentPreset | undefined {
   const explicitDefault = presetId === null;
-  const resolvedPresetId = explicitDefault ? undefined : (presetId ?? entry.presetId);
+  const savedPresetId = resolveEffectivePresetId(entry, worktreeId);
+  const resolvedPresetId = explicitDefault ? undefined : (presetId ?? savedPresetId);
   return isAgent && !explicitDefault
     ? getMergedPreset(agentId, resolvedPresetId, entry.customPresets, ccrPresets, projectPresets)
     : undefined;
@@ -197,5 +200,143 @@ describe("stale preset handling: getMergedPreset returns undefined", () => {
       true
     );
     expect(result).toBeUndefined();
+  });
+});
+
+describe("worktree-scoped preset resolution", () => {
+  it("worktree override wins over agent-level default", () => {
+    getMergedPresetMock.mockReturnValue(CUSTOM_PRESET);
+    resolvePresetForLaunch(
+      undefined,
+      { presetId: "user-global", worktreePresets: { "wt-A": "user-111" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      "wt-A"
+    );
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      "user-111",
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it("falls back to agent-level default when no override exists for this worktree", () => {
+    getMergedPresetMock.mockReturnValue(CUSTOM_PRESET);
+    resolvePresetForLaunch(
+      undefined,
+      { presetId: "user-global", worktreePresets: { "wt-A": "user-111" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      "wt-B"
+    );
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      "user-global",
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it("returns undefined when neither scope has a preset", () => {
+    resolvePresetForLaunch(undefined, {}, undefined, "claude", true, undefined, "wt-A");
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it("null sentinel ignores both worktree override and agent-level default", () => {
+    resolvePresetForLaunch(
+      null,
+      { presetId: "user-global", worktreePresets: { "wt-A": "user-111" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      "wt-A"
+    );
+    expect(getMergedPresetMock).not.toHaveBeenCalled();
+  });
+
+  it("explicit string presetId overrides both scopes", () => {
+    getMergedPresetMock.mockReturnValue(CUSTOM_PRESET);
+    resolvePresetForLaunch(
+      "user-explicit",
+      { presetId: "user-global", worktreePresets: { "wt-A": "user-111" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      "wt-A"
+    );
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      "user-explicit",
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it("worktreeId of null/undefined disables scoped lookup", () => {
+    getMergedPresetMock.mockReturnValue(CUSTOM_PRESET);
+    resolvePresetForLaunch(
+      undefined,
+      { presetId: "user-global", worktreePresets: { "wt-A": "user-111" } },
+      undefined,
+      "claude",
+      true,
+      undefined,
+      null
+    );
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      "user-global",
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+});
+
+describe("resolveEffectivePresetId helper", () => {
+  it("returns worktree override when present", () => {
+    expect(
+      resolveEffectivePresetId(
+        { presetId: "global", worktreePresets: { "wt-A": "scoped" } },
+        "wt-A"
+      )
+    ).toBe("scoped");
+  });
+
+  it("falls back to agent-level default when no override for this worktree", () => {
+    expect(
+      resolveEffectivePresetId(
+        { presetId: "global", worktreePresets: { "wt-A": "scoped" } },
+        "wt-B"
+      )
+    ).toBe("global");
+  });
+
+  it("returns agent-level default when worktreeId is null", () => {
+    expect(resolveEffectivePresetId({ presetId: "global" }, null)).toBe("global");
+  });
+
+  it("returns undefined for an empty entry", () => {
+    expect(resolveEffectivePresetId({}, "wt-A")).toBeUndefined();
+  });
+
+  it("returns undefined when the entry itself is null", () => {
+    expect(resolveEffectivePresetId(null, "wt-A")).toBeUndefined();
   });
 });

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -186,7 +186,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           : (launchOptions?.presetId ?? savedPresetId);
         const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
         const projectPresets = useProjectPresetsStore.getState().presetsByAgent[agentId];
-        preset =
+        const primaryPreset =
           isAgent && !explicitDefault
             ? getMergedPreset(
                 agentId,
@@ -196,17 +196,42 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
                 projectPresets
               )
             : undefined;
+        preset = primaryPreset;
+
+        // Fallback for this launch: if the worktree-scoped pick is stale but
+        // the agent-level default is still valid, use the agent default now.
+        // Without this, a deleted scoped preset would launch preset-free even
+        // when a valid global fallback exists. The stale scoped slot is still
+        // cleared below so the next launch resolves directly against global.
+        const scopedId =
+          targetWorktreeId && entry.worktreePresets
+            ? entry.worktreePresets[targetWorktreeId]
+            : undefined;
+        if (
+          !primaryPreset &&
+          isAgent &&
+          !explicitDefault &&
+          launchOptions?.presetId === undefined &&
+          scopedId &&
+          scopedId === resolvedPresetId &&
+          entry.presetId &&
+          entry.presetId !== scopedId
+        ) {
+          preset = getMergedPreset(
+            agentId,
+            entry.presetId,
+            entry.customPresets,
+            ccrPresets,
+            projectPresets
+          );
+        }
 
         // Stale presetId cleanup: clear whichever scope held the vanished ID.
         // The worktree slot wins at resolution time, so only fall through to
         // clearing the agent-level default when that's what the launch used.
-        if (resolvedPresetId && !preset) {
+        if (resolvedPresetId && !primaryPreset) {
           const { useAgentSettingsStore: settingsStore } =
             await import("@/store/agentSettingsStore");
-          const scopedId =
-            targetWorktreeId && entry.worktreePresets
-              ? entry.worktreePresets[targetWorktreeId]
-              : undefined;
           if (scopedId && scopedId === resolvedPresetId && targetWorktreeId) {
             void settingsStore
               .getState()

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -12,7 +12,11 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import type { AgentSettings, CliAvailability } from "@shared/types";
-import { generateAgentCommand, buildAgentLaunchFlags } from "@shared/types";
+import {
+  generateAgentCommand,
+  buildAgentLaunchFlags,
+  resolveEffectivePresetId,
+} from "@shared/types";
 import {
   getAgentConfig,
   isRegisteredAgent,
@@ -171,11 +175,15 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
       if (agentConfig) {
         const entry = agentSettings?.agents?.[agentId] ?? {};
         // null = explicitly default — skip preset lookup entirely
-        // undefined = use saved presetId (or default if none saved)
+        // undefined = use saved preset for this worktree (or agent-level
+        //   default, or nothing). Worktree-scoped override wins over the
+        //   agent-level `presetId` so switching worktrees doesn't silently
+        //   surface another worktree's pick.
         const explicitDefault = launchOptions?.presetId === null;
+        const savedPresetId = resolveEffectivePresetId(entry, targetWorktreeId);
         const resolvedPresetId = explicitDefault
           ? undefined
-          : (launchOptions?.presetId ?? entry.presetId);
+          : (launchOptions?.presetId ?? savedPresetId);
         const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
         const projectPresets = useProjectPresetsStore.getState().presetsByAgent[agentId];
         preset =
@@ -189,11 +197,23 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               )
             : undefined;
 
-        // Stale presetId cleanup: if saved preset no longer exists, clear it
+        // Stale presetId cleanup: clear whichever scope held the vanished ID.
+        // The worktree slot wins at resolution time, so only fall through to
+        // clearing the agent-level default when that's what the launch used.
         if (resolvedPresetId && !preset) {
           const { useAgentSettingsStore: settingsStore } =
             await import("@/store/agentSettingsStore");
-          void settingsStore.getState().updateAgent(agentId, { presetId: undefined });
+          const scopedId =
+            targetWorktreeId && entry.worktreePresets
+              ? entry.worktreePresets[targetWorktreeId]
+              : undefined;
+          if (scopedId && scopedId === resolvedPresetId && targetWorktreeId) {
+            void settingsStore
+              .getState()
+              .updateWorktreePreset(agentId, targetWorktreeId, undefined);
+          } else if (entry.presetId && entry.presetId === resolvedPresetId) {
+            void settingsStore.getState().updateAgent(agentId, { presetId: undefined });
+          }
         }
 
         // Merge: global env (base) overridden by preset env (preset wins on conflicts)

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -324,6 +324,108 @@ describe("agentSettingsStore adversarial", () => {
     expect(useAgentSettingsStore.getState().settings?.agents.claude?.pinned).toBe(false);
   });
 
+  describe("updateWorktreePreset", () => {
+    it("spreads existing worktree keys so sibling entries are preserved", async () => {
+      useAgentSettingsStore.setState({
+        settings: {
+          agents: {
+            claude: {
+              pinned: true,
+              worktreePresets: { "wt-A": "user-111", "wt-B": "user-222" },
+            },
+          },
+        } as never,
+        isInitialized: true,
+        isLoading: false,
+      });
+      clientMock.set.mockImplementation(
+        async (_agentId: string, updates: Record<string, unknown>) => ({
+          agents: {
+            claude: {
+              pinned: true,
+              worktreePresets: updates.worktreePresets,
+            },
+          },
+        })
+      );
+
+      await useAgentSettingsStore.getState().updateWorktreePreset("claude", "wt-A", "user-new");
+
+      expect(clientMock.set).toHaveBeenCalledWith("claude", {
+        worktreePresets: { "wt-A": "user-new", "wt-B": "user-222" },
+      });
+    });
+
+    it("deletes the target key when presetId is undefined", async () => {
+      useAgentSettingsStore.setState({
+        settings: {
+          agents: {
+            claude: {
+              worktreePresets: { "wt-A": "user-111", "wt-B": "user-222" },
+            },
+          },
+        } as never,
+        isInitialized: true,
+        isLoading: false,
+      });
+      clientMock.set.mockResolvedValue({
+        agents: { claude: { worktreePresets: { "wt-B": "user-222" } } },
+      });
+
+      await useAgentSettingsStore.getState().updateWorktreePreset("claude", "wt-A", undefined);
+
+      expect(clientMock.set).toHaveBeenCalledWith("claude", {
+        worktreePresets: { "wt-B": "user-222" },
+      });
+    });
+
+    it("collapses an empty map to undefined when the last key is removed", async () => {
+      useAgentSettingsStore.setState({
+        settings: {
+          agents: { claude: { worktreePresets: { "wt-A": "user-111" } } },
+        } as never,
+        isInitialized: true,
+        isLoading: false,
+      });
+      clientMock.set.mockResolvedValue({ agents: { claude: {} } });
+
+      await useAgentSettingsStore.getState().updateWorktreePreset("claude", "wt-A", undefined);
+
+      expect(clientMock.set).toHaveBeenCalledWith("claude", {
+        worktreePresets: undefined,
+      });
+    });
+
+    it("creates the map when the entry has no prior worktreePresets", async () => {
+      useAgentSettingsStore.setState({
+        settings: { agents: { claude: { pinned: true } } } as never,
+        isInitialized: true,
+        isLoading: false,
+      });
+      clientMock.set.mockResolvedValue({
+        agents: { claude: { pinned: true, worktreePresets: { "wt-A": "user-111" } } },
+      });
+
+      await useAgentSettingsStore.getState().updateWorktreePreset("claude", "wt-A", "user-111");
+
+      expect(clientMock.set).toHaveBeenCalledWith("claude", {
+        worktreePresets: { "wt-A": "user-111" },
+      });
+    });
+
+    it("no-ops silently when worktreeId is an empty string", async () => {
+      useAgentSettingsStore.setState({
+        settings: { agents: { claude: {} } } as never,
+        isInitialized: true,
+        isLoading: false,
+      });
+
+      await useAgentSettingsStore.getState().updateWorktreePreset("claude", "", "user-111");
+
+      expect(clientMock.set).not.toHaveBeenCalled();
+    });
+  });
+
   it("initialize after a concurrent refresh flips isInitialized even when the result is stale", async () => {
     registryMock.getEffectiveAgentIds.mockReturnValue(["claude"]);
     setAvailability({ claude: "ready" }, true);

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -75,6 +75,18 @@ interface AgentSettingsActions {
   refresh: () => Promise<void>;
   updateAgent: (agentId: string, updates: Partial<AgentSettingsEntry>) => Promise<void>;
   setAgentPinned: (agentId: string, pinned: boolean) => Promise<void>;
+  /**
+   * Set or clear the worktree-scoped preset override for an agent. Reads the
+   * current `worktreePresets` map, spreads sibling keys, then writes the merged
+   * map — bypasses the IPC handler's shallow-merge clobber on the submap.
+   * Passing `undefined` removes the key; the map collapses to `undefined` when
+   * empty.
+   */
+  updateWorktreePreset: (
+    agentId: string,
+    worktreeId: string,
+    presetId: string | undefined
+  ) => Promise<void>;
   reset: (agentId?: string) => Promise<void>;
 }
 
@@ -190,6 +202,23 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
 
   setAgentPinned: async (agentId: string, pinned: boolean) => {
     return get().updateAgent(agentId, { pinned });
+  },
+
+  updateWorktreePreset: async (
+    agentId: string,
+    worktreeId: string,
+    presetId: string | undefined
+  ) => {
+    if (!worktreeId) return;
+    const current = get().settings?.agents?.[agentId]?.worktreePresets ?? {};
+    const next: Record<string, string> = { ...current };
+    if (presetId === undefined) {
+      delete next[worktreeId];
+    } else {
+      next[worktreeId] = presetId;
+    }
+    const merged = Object.keys(next).length > 0 ? next : undefined;
+    await get().updateAgent(agentId, { worktreePresets: merged });
   },
 
   reset: async (agentId?: string) => {


### PR DESCRIPTION
## Summary

- Adds a `worktreePresets` map to `AgentSettingsEntry` so the preset chosen in the toolbar is scoped to the current worktree rather than overwriting the agent-level global default.
- Introduces a shared `resolveEffectivePresetId` helper used by `useAgentLauncher`, `AgentButton`, and `AgentTrayButton` so the resolution logic lives in one place.
- A new `updateWorktreePreset` store action spreads the existing map before writing, avoiding the IPC shallow-merge clobber that would wipe other worktrees' selections.

Resolves #5461

## Changes

- `shared/types/agentSettings.ts` — adds optional `worktreePresets: Record<string, string>` field and `resolveEffectivePresetId` helper
- `src/store/agentSettingsStore.ts` — adds `updateWorktreePreset` action
- `src/hooks/useAgentLauncher.ts` — resolves via `worktreePresets` before falling back to the agent-level default
- `src/components/Layout/AgentButton.tsx`, `AgentTrayButton.tsx` — toolbar persist calls use `updateWorktreePreset`; display resolution uses the shared helper
- `src/components/Settings/PresetSelector.tsx` — label updated to "Default (all worktrees)" to clarify it sets the agent-level default
- Stale-preset cleanup clears whichever scope held the vanished ID; falls back to the agent-level default when only the scoped override is stale

## Testing

108 unit tests pass across the touched files. New test files cover preset resolution (`useAgentLauncher.presetResolution.test.ts`), toolbar button behaviour (`AgentButton.test.tsx`, `AgentTrayButton.test.tsx`), and adversarial store scenarios (`agentSettingsStore.adversarial.test.ts`).