### PR TITLE
feat(terminal): Linux copy-on-select and middle-click paste

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -465,6 +465,8 @@ export const CHANNELS = {
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",
   CLIPBOARD_WRITE_IMAGE: "clipboard:write-image",
   CLIPBOARD_WRITE_TEXT: "clipboard:write-text",
+  CLIPBOARD_WRITE_SELECTION: "clipboard:write-selection",
+  CLIPBOARD_READ_SELECTION: "clipboard:read-selection",
 
   APP_THEME_GET: "app-theme:get",
   APP_THEME_SET_COLOR_SCHEME: "app-theme:set-color-scheme",

--- a/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/clipboard.handlers.test.ts
@@ -4,6 +4,7 @@ const clipboardMock = vi.hoisted(() => ({
   writeImage: vi.fn(),
   readImage: vi.fn(),
   writeText: vi.fn(),
+  readText: vi.fn(),
 }));
 
 const nativeImageMock = vi.hoisted(() => ({
@@ -172,5 +173,171 @@ describe("clipboard:write-text handler", () => {
     cleanup();
     const removedChannels = vi.mocked(ipcMain.removeHandler).mock.calls.map(([ch]) => ch);
     expect(removedChannels).toContain("clipboard:write-text");
+  });
+});
+
+describe("clipboard:write-selection handler", () => {
+  const originalPlatform = process.platform;
+  let cleanup: () => void;
+
+  const setPlatform = (value: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPlatform("linux");
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    setPlatform(originalPlatform);
+  });
+
+  it("registers the clipboard:write-selection handler", () => {
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map(([ch]) => ch);
+    expect(channels).toContain("clipboard:write-selection");
+  });
+
+  it("writes to PRIMARY selection on Linux and returns ok", async () => {
+    const handler = getHandler("clipboard:write-selection");
+    const result = await handler(fakeEvent, "selected text");
+
+    expect(clipboardMock.writeText).toHaveBeenCalledWith("selected text", "selection");
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects empty text without calling clipboard", async () => {
+    const handler = getHandler("clipboard:write-selection");
+    const result = await handler(fakeEvent, "");
+
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: "Text must not be empty" });
+  });
+
+  it("rejects non-string input without calling clipboard", async () => {
+    const handler = getHandler("clipboard:write-selection");
+    const result = await handler(fakeEvent, 42 as unknown as string);
+
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: "Text must be a string" });
+  });
+
+  it("short-circuits on macOS without calling clipboard", async () => {
+    cleanup();
+    setPlatform("darwin");
+    cleanup = registerClipboardHandlers();
+
+    const handler = getHandler("clipboard:write-selection");
+    const result = await handler(fakeEvent, "hello");
+
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: "PRIMARY selection is only available on Linux",
+    });
+  });
+
+  it("short-circuits on Windows without calling clipboard", async () => {
+    cleanup();
+    setPlatform("win32");
+    cleanup = registerClipboardHandlers();
+
+    const handler = getHandler("clipboard:write-selection");
+    const result = await handler(fakeEvent, "hello");
+
+    expect(clipboardMock.writeText).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: "PRIMARY selection is only available on Linux",
+    });
+  });
+
+  it("returns error when clipboard.writeText throws", async () => {
+    clipboardMock.writeText.mockImplementationOnce(() => {
+      throw new Error("wayland compositor lacks primary selection");
+    });
+
+    const handler = getHandler("clipboard:write-selection");
+    const result = await handler(fakeEvent, "hello");
+
+    expect(result).toEqual({
+      ok: false,
+      error: "wayland compositor lacks primary selection",
+    });
+  });
+});
+
+describe("clipboard:read-selection handler", () => {
+  const originalPlatform = process.platform;
+  let cleanup: () => void;
+
+  const setPlatform = (value: NodeJS.Platform) => {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPlatform("linux");
+    cleanup = registerClipboardHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    setPlatform(originalPlatform);
+  });
+
+  it("registers the clipboard:read-selection handler", () => {
+    const channels = vi.mocked(ipcMain.handle).mock.calls.map(([ch]) => ch);
+    expect(channels).toContain("clipboard:read-selection");
+  });
+
+  it("reads PRIMARY selection on Linux and returns text", async () => {
+    clipboardMock.readText.mockReturnValueOnce("pasted text");
+
+    const handler = getHandler("clipboard:read-selection");
+    const result = await handler(fakeEvent);
+
+    expect(clipboardMock.readText).toHaveBeenCalledWith("selection");
+    expect(result).toEqual({ ok: true, text: "pasted text" });
+  });
+
+  it("returns empty text when PRIMARY selection is empty", async () => {
+    clipboardMock.readText.mockReturnValueOnce("");
+
+    const handler = getHandler("clipboard:read-selection");
+    const result = await handler(fakeEvent);
+
+    expect(result).toEqual({ ok: true, text: "" });
+  });
+
+  it("short-circuits on macOS without calling clipboard", async () => {
+    cleanup();
+    setPlatform("darwin");
+    cleanup = registerClipboardHandlers();
+
+    const handler = getHandler("clipboard:read-selection");
+    const result = await handler(fakeEvent);
+
+    expect(clipboardMock.readText).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      ok: false,
+      error: "PRIMARY selection is only available on Linux",
+    });
+  });
+
+  it("returns error when clipboard.readText throws", async () => {
+    clipboardMock.readText.mockImplementationOnce(() => {
+      throw new Error("focus required for primary read");
+    });
+
+    const handler = getHandler("clipboard:read-selection");
+    const result = await handler(fakeEvent);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "focus required for primary read",
+    });
   });
 });

--- a/electron/ipc/handlers/clipboard.ts
+++ b/electron/ipc/handlers/clipboard.ts
@@ -147,10 +147,46 @@ export function registerClipboardHandlers(): () => void {
     }
   };
 
+  // Linux PRIMARY selection — underpins copy-on-select and middle-click paste.
+  // The 'selection' clipboard type only exists on Linux; short-circuit elsewhere.
+  const handleWriteSelection = (text: string): { ok: true } | { ok: false; error: string } => {
+    try {
+      if (process.platform !== "linux") {
+        return { ok: false, error: "PRIMARY selection is only available on Linux" };
+      }
+      if (typeof text !== "string") {
+        return { ok: false, error: "Text must be a string" };
+      }
+      if (text.length === 0) {
+        return { ok: false, error: "Text must not be empty" };
+      }
+      clipboard.writeText(text, "selection");
+      return { ok: true };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  };
+
+  const handleReadSelection = (): { ok: true; text: string } | { ok: false; error: string } => {
+    try {
+      if (process.platform !== "linux") {
+        return { ok: false, error: "PRIMARY selection is only available on Linux" };
+      }
+      const text = clipboard.readText("selection");
+      return { ok: true, text };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: message };
+    }
+  };
+
   handlers.push(typedHandle(CHANNELS.CLIPBOARD_SAVE_IMAGE, handleSaveImage));
   handlers.push(typedHandle(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, handleThumbnailFromPath));
   handlers.push(typedHandle(CHANNELS.CLIPBOARD_WRITE_IMAGE, handleWriteImage));
   handlers.push(typedHandle(CHANNELS.CLIPBOARD_WRITE_TEXT, handleWriteText));
+  handlers.push(typedHandle(CHANNELS.CLIPBOARD_WRITE_SELECTION, handleWriteSelection));
+  handlers.push(typedHandle(CHANNELS.CLIPBOARD_READ_SELECTION, handleReadSelection));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -985,6 +985,8 @@ const CHANNELS = {
   CLIPBOARD_THUMBNAIL_FROM_PATH: "clipboard:thumbnail-from-path",
   CLIPBOARD_WRITE_IMAGE: "clipboard:write-image",
   CLIPBOARD_WRITE_TEXT: "clipboard:write-text",
+  CLIPBOARD_WRITE_SELECTION: "clipboard:write-selection",
+  CLIPBOARD_READ_SELECTION: "clipboard:read-selection",
 
   // App Theme channels
   APP_THEME_GET: "app-theme:get",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2768,6 +2768,8 @@ const api: ElectronAPI = {
       _unwrappingInvoke(CHANNELS.CLIPBOARD_THUMBNAIL_FROM_PATH, filePath),
     writeImage: (pngData: Uint8Array) => _unwrappingInvoke(CHANNELS.CLIPBOARD_WRITE_IMAGE, pngData),
     writeText: (text: string) => _unwrappingInvoke(CHANNELS.CLIPBOARD_WRITE_TEXT, text),
+    writeSelection: (text: string) => _unwrappingInvoke(CHANNELS.CLIPBOARD_WRITE_SELECTION, text),
+    readSelection: () => _unwrappingInvoke(CHANNELS.CLIPBOARD_READ_SELECTION),
   },
 
   // Web Utils API

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1171,6 +1171,8 @@ export interface ElectronAPI {
     >;
     writeImage(pngData: Uint8Array): Promise<{ ok: true } | { ok: false; error: string }>;
     writeText(text: string): Promise<{ ok: true } | { ok: false; error: string }>;
+    writeSelection(text: string): Promise<{ ok: true } | { ok: false; error: string }>;
+    readSelection(): Promise<{ ok: true; text: string } | { ok: false; error: string }>;
   };
   webUtils: {
     getPathForFile(file: File): string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1476,6 +1476,14 @@ export interface IpcInvokeMap {
     args: [text: string];
     result: { ok: true } | { ok: false; error: string };
   };
+  "clipboard:write-selection": {
+    args: [text: string];
+    result: { ok: true } | { ok: false; error: string };
+  };
+  "clipboard:read-selection": {
+    args: [];
+    result: { ok: true; text: string } | { ok: false; error: string };
+  };
 
   // Notification settings channels
   "notification:settings-get": {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1,6 +1,7 @@
 import { Terminal, ILink, IBufferRange } from "@xterm/xterm";
-import { isMac } from "@/lib/platform";
+import { isMac, isLinux } from "@/lib/platform";
 import { terminalClient } from "@/clients";
+import { installLinuxPrimarySelectionListeners } from "./primarySelection";
 import { TerminalRefreshTier, TerminalType } from "@/types";
 import type { AgentState } from "@/types";
 import {
@@ -892,11 +893,33 @@ class TerminalInstanceService {
       const sel = terminal.getSelection();
       if (sel) {
         this.cachedSelections.set(id, sel);
-      } else if (managed.lastAppliedTier === TerminalRefreshTier.BACKGROUND) {
-        reduceScrollback(managed, SCROLLBACK_BACKGROUND);
+      } else {
+        this.cachedSelections.delete(id);
+        if (managed.lastAppliedTier === TerminalRefreshTier.BACKGROUND) {
+          reduceScrollback(managed, SCROLLBACK_BACKGROUND);
+        }
       }
     });
     listeners.push(() => selectionDisposable.dispose());
+
+    if (isLinux()) {
+      const removePrimaryListeners = installLinuxPrimarySelectionListeners({
+        hostElement,
+        terminalId: id,
+        getCachedSelection: () => this.cachedSelections.get(id),
+        getBracketedPasteMode: () => {
+          const current = this.instances.get(id);
+          return current?.terminal.modes.bracketedPasteMode ?? false;
+        },
+        isDisposed: () => !this.instances.has(id),
+        isInputLocked: () => this.instances.get(id)?.isInputLocked ?? false,
+        writeToPty: (termId, data) => terminalClient.write(termId, data),
+        notifyUserInput: (termId) => this.notifyUserInput(termId),
+        writeSelection: (text) => window.electron.clipboard.writeSelection(text),
+        readSelection: () => window.electron.clipboard.readSelection(),
+      });
+      listeners.push(removePrimaryListeners);
+    }
 
     if (agentId) {
       const agentConfig = getEffectiveAgentConfig(agentId);

--- a/src/services/terminal/__tests__/primarySelection.test.ts
+++ b/src/services/terminal/__tests__/primarySelection.test.ts
@@ -114,10 +114,11 @@ describe("installLinuxPrimarySelectionListeners", () => {
       await flush();
       expect(writeToPty).toHaveBeenCalledTimes(1);
       const [id, payload] = writeToPty.mock.calls[0]!;
+      const ESC = String.fromCharCode(0x1b);
       expect(id).toBe("term-1");
       expect(payload).toContain("pasted");
-      expect(payload).toMatch(/\x1b\[200~/);
-      expect(payload).toMatch(/\x1b\[201~/);
+      expect(payload).toContain(`${ESC}[200~`);
+      expect(payload).toContain(`${ESC}[201~`);
     });
 
     it("normalizes newlines to carriage returns when bracketed paste is off", async () => {

--- a/src/services/terminal/__tests__/primarySelection.test.ts
+++ b/src/services/terminal/__tests__/primarySelection.test.ts
@@ -75,6 +75,19 @@ describe("installLinuxPrimarySelectionListeners", () => {
       await new Promise((r) => setTimeout(r, 0));
       // No assertion on side effects — the test passes if no unhandled rejection throws.
     });
+
+    it("ignores middle-button and right-button mouseup releases", () => {
+      cachedSelection = "hello";
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { button: 1, bubbles: true }));
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { button: 2, bubbles: true }));
+      expect(writeSelection).not.toHaveBeenCalled();
+    });
+
+    it("skips write after the cache was cleared (post-disposal race)", () => {
+      cachedSelection = undefined;
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      expect(writeSelection).not.toHaveBeenCalled();
+    });
   });
 
   describe("auxclick (middle-click paste)", () => {
@@ -164,6 +177,31 @@ describe("installLinuxPrimarySelectionListeners", () => {
       hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
       await flush();
       expect(writeToPty).not.toHaveBeenCalled();
+    });
+
+    it("fires when auxclick originates from a descendant element (capture phase)", async () => {
+      // xterm mounts its canvas/overlay as a child of hostElement. Capture phase
+      // on hostElement guarantees we see the event before xterm stopPropagation()s.
+      const child = document.createElement("div");
+      hostElement.appendChild(child);
+      readSelection.mockResolvedValueOnce({ ok: true, text: "pasted" });
+      child.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(readSelection).toHaveBeenCalledTimes(1);
+      expect(writeToPty).toHaveBeenCalledWith("term-1", "pasted");
+    });
+
+    it("handles two rapid middle-clicks without corrupting state", async () => {
+      readSelection
+        .mockResolvedValueOnce({ ok: true, text: "first" })
+        .mockResolvedValueOnce({ ok: true, text: "second" });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(readSelection).toHaveBeenCalledTimes(2);
+      expect(writeToPty).toHaveBeenCalledTimes(2);
+      expect(writeToPty).toHaveBeenNthCalledWith(1, "term-1", "first");
+      expect(writeToPty).toHaveBeenNthCalledWith(2, "term-1", "second");
     });
   });
 

--- a/src/services/terminal/__tests__/primarySelection.test.ts
+++ b/src/services/terminal/__tests__/primarySelection.test.ts
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installLinuxPrimarySelectionListeners } from "../primarySelection";
+
+type ReadSelectionResult = { ok: true; text: string } | { ok: false; error: string };
+
+describe("installLinuxPrimarySelectionListeners", () => {
+  let hostElement: HTMLElement;
+  let writeToPty: ReturnType<typeof vi.fn<(id: string, data: string) => void>>;
+  let notifyUserInput: ReturnType<typeof vi.fn<(id: string) => void>>;
+  let writeSelection: ReturnType<typeof vi.fn<(text: string) => Promise<unknown>>>;
+  let readSelection: ReturnType<typeof vi.fn<() => Promise<ReadSelectionResult>>>;
+  let cachedSelection: string | undefined;
+  let bracketedPasteMode: boolean;
+  let disposed: boolean;
+  let inputLocked: boolean;
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    hostElement = document.createElement("div");
+    document.body.appendChild(hostElement);
+    writeToPty = vi.fn<(id: string, data: string) => void>();
+    notifyUserInput = vi.fn<(id: string) => void>();
+    writeSelection = vi.fn<(text: string) => Promise<unknown>>().mockResolvedValue({ ok: true });
+    readSelection = vi
+      .fn<() => Promise<ReadSelectionResult>>()
+      .mockResolvedValue({ ok: true, text: "" });
+    cachedSelection = undefined;
+    bracketedPasteMode = false;
+    disposed = false;
+    inputLocked = false;
+
+    cleanup = installLinuxPrimarySelectionListeners({
+      hostElement,
+      terminalId: "term-1",
+      getCachedSelection: () => cachedSelection,
+      getBracketedPasteMode: () => bracketedPasteMode,
+      isDisposed: () => disposed,
+      isInputLocked: () => inputLocked,
+      writeToPty,
+      notifyUserInput,
+      writeSelection,
+      readSelection,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    hostElement.remove();
+  });
+
+  describe("mouseup (copy-on-select)", () => {
+    it("writes the cached selection to PRIMARY on mouseup", () => {
+      cachedSelection = "hello world";
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      expect(writeSelection).toHaveBeenCalledWith("hello world");
+    });
+
+    it("does not write when the cached selection is empty", () => {
+      cachedSelection = "";
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      expect(writeSelection).not.toHaveBeenCalled();
+    });
+
+    it("does not write when the cached selection is undefined", () => {
+      cachedSelection = undefined;
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      expect(writeSelection).not.toHaveBeenCalled();
+    });
+
+    it("silently swallows rejected writeSelection promises", async () => {
+      cachedSelection = "hello";
+      writeSelection.mockRejectedValueOnce(new Error("compositor lacks primary"));
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+      // No assertion on side effects — the test passes if no unhandled rejection throws.
+    });
+  });
+
+  describe("auxclick (middle-click paste)", () => {
+    it("ignores auxclick when button is not the middle button", async () => {
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 2, bubbles: true }));
+      await flush();
+      expect(readSelection).not.toHaveBeenCalled();
+      expect(writeToPty).not.toHaveBeenCalled();
+    });
+
+    it("reads PRIMARY and writes to the PTY on middle-click", async () => {
+      readSelection.mockResolvedValueOnce({ ok: true, text: "pasted" });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(readSelection).toHaveBeenCalledTimes(1);
+      expect(writeToPty).toHaveBeenCalledWith("term-1", "pasted");
+      expect(notifyUserInput).toHaveBeenCalledWith("term-1");
+    });
+
+    it("wraps the payload with bracketed-paste markers when the mode is active", async () => {
+      bracketedPasteMode = true;
+      readSelection.mockResolvedValueOnce({ ok: true, text: "pasted" });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).toHaveBeenCalledTimes(1);
+      const [id, payload] = writeToPty.mock.calls[0]!;
+      expect(id).toBe("term-1");
+      expect(payload).toContain("pasted");
+      expect(payload).toMatch(/\x1b\[200~/);
+      expect(payload).toMatch(/\x1b\[201~/);
+    });
+
+    it("normalizes newlines to carriage returns when bracketed paste is off", async () => {
+      readSelection.mockResolvedValueOnce({ ok: true, text: "line1\nline2\r\nline3" });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).toHaveBeenCalledWith("term-1", "line1\rline2\rline3");
+    });
+
+    it("skips PTY write when PRIMARY is empty", async () => {
+      readSelection.mockResolvedValueOnce({ ok: true, text: "" });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).not.toHaveBeenCalled();
+      expect(notifyUserInput).not.toHaveBeenCalled();
+    });
+
+    it("skips PTY write when readSelection returns an error", async () => {
+      readSelection.mockResolvedValueOnce({ ok: false, error: "no focus" });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).not.toHaveBeenCalled();
+      expect(notifyUserInput).not.toHaveBeenCalled();
+    });
+
+    it("skips PTY write when the terminal was disposed during the async read", async () => {
+      readSelection.mockImplementationOnce(async () => {
+        disposed = true;
+        return { ok: true, text: "pasted" };
+      });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).not.toHaveBeenCalled();
+      expect(notifyUserInput).not.toHaveBeenCalled();
+    });
+
+    it("skips PTY write when input is locked before the read resolves", async () => {
+      inputLocked = true;
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(readSelection).not.toHaveBeenCalled();
+      expect(writeToPty).not.toHaveBeenCalled();
+    });
+
+    it("skips PTY write when input becomes locked during the async read", async () => {
+      readSelection.mockImplementationOnce(async () => {
+        inputLocked = true;
+        return { ok: true, text: "pasted" };
+      });
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).not.toHaveBeenCalled();
+    });
+
+    it("silently swallows rejected readSelection promises", async () => {
+      readSelection.mockRejectedValueOnce(new Error("ipc unavailable"));
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      await flush();
+      expect(writeToPty).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cleanup", () => {
+    it("removes both listeners so later events are ignored", () => {
+      cleanup();
+      cachedSelection = "after cleanup";
+      hostElement.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+      hostElement.dispatchEvent(new MouseEvent("auxclick", { button: 1, bubbles: true }));
+      expect(writeSelection).not.toHaveBeenCalled();
+      expect(readSelection).not.toHaveBeenCalled();
+    });
+  });
+});
+
+async function flush(): Promise<void> {
+  // Drain pending microtasks so async auxclick handlers can settle.
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}

--- a/src/services/terminal/primarySelection.ts
+++ b/src/services/terminal/primarySelection.ts
@@ -33,7 +33,10 @@ export function installLinuxPrimarySelectionListeners(deps: PrimarySelectionDeps
     readSelection,
   } = deps;
 
-  const onMouseUp = () => {
+  const onMouseUp = (event: MouseEvent) => {
+    // Only respond to primary-button releases — middle/right-click releases
+    // after an existing selection would otherwise re-issue a redundant write.
+    if (event.button !== 0) return;
     const sel = getCachedSelection();
     if (!sel) return;
     void writeSelection(sel).catch(() => {

--- a/src/services/terminal/primarySelection.ts
+++ b/src/services/terminal/primarySelection.ts
@@ -1,0 +1,71 @@
+import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
+
+export interface PrimarySelectionDeps {
+  hostElement: HTMLElement;
+  terminalId: string;
+  getCachedSelection: () => string | undefined;
+  getBracketedPasteMode: () => boolean;
+  isDisposed: () => boolean;
+  isInputLocked: () => boolean;
+  writeToPty: (id: string, data: string) => void;
+  notifyUserInput: (id: string) => void;
+  writeSelection: (text: string) => Promise<unknown>;
+  readSelection: () => Promise<{ ok: true; text: string } | { ok: false; error: string }>;
+}
+
+// Installs Linux PRIMARY selection listeners on the terminal host element:
+// - mouseup writes the cached selection to PRIMARY (copy-on-select)
+// - auxclick (button 1) reads PRIMARY and pastes into the PTY (middle-click paste)
+//
+// Write-on-mouseup avoids Chromium's per-mousemove selection spam during drag.
+// auxclick uses capture phase because xterm.js 6.0 stopPropagation()s on bubble.
+export function installLinuxPrimarySelectionListeners(deps: PrimarySelectionDeps): () => void {
+  const {
+    hostElement,
+    terminalId,
+    getCachedSelection,
+    getBracketedPasteMode,
+    isDisposed,
+    isInputLocked,
+    writeToPty,
+    notifyUserInput,
+    writeSelection,
+    readSelection,
+  } = deps;
+
+  const onMouseUp = () => {
+    const sel = getCachedSelection();
+    if (!sel) return;
+    void writeSelection(sel).catch(() => {
+      // Silent — PRIMARY writes fail on minimal Wayland compositors without
+      // zwp_primary_selection_v1. Copy-on-select is a convenience, not critical.
+    });
+  };
+
+  const onAuxClick = async (event: MouseEvent) => {
+    if (event.button !== 1) return;
+    if (isInputLocked()) return;
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      const result = await readSelection();
+      if (!result.ok || !result.text) return;
+      if (isDisposed() || isInputLocked()) return;
+      const payload = getBracketedPasteMode()
+        ? formatWithBracketedPaste(result.text)
+        : result.text.replace(/\r?\n/g, "\r");
+      writeToPty(terminalId, payload);
+      notifyUserInput(terminalId);
+    } catch {
+      // IPC can reject if the main process is unavailable.
+    }
+  };
+
+  hostElement.addEventListener("mouseup", onMouseUp);
+  hostElement.addEventListener("auxclick", onAuxClick, { capture: true });
+
+  return () => {
+    hostElement.removeEventListener("mouseup", onMouseUp);
+    hostElement.removeEventListener("auxclick", onAuxClick, { capture: true });
+  };
+}


### PR DESCRIPTION
## Summary

- Adds copy-on-select to the terminal on Linux: when the user finishes a selection, the selected text is written to the X11 PRIMARY selection via Electron's `clipboard.writeText(text, 'selection')` IPC call.
- Adds middle-click paste on Linux: an `auxclick` listener on the terminal element reads from PRIMARY via `clipboard.readText('selection')` and pastes through `terminal.paste()`, honouring bracketed-paste mode.
- macOS and Windows are completely unaffected — both behaviours are gated behind `isLinux()`.

Resolves #5364

## Changes

- `electron/ipc/channels.ts` — two new IPC channels: `CLIPBOARD_WRITE_SELECTION` and `CLIPBOARD_READ_SELECTION`
- `electron/ipc/handlers/clipboard.ts` — handlers for those channels calling `clipboard.read/writeText('selection')`
- `electron/preload.cts` — exposes `clipboard.writeSelection` and `clipboard.readSelection` in the IPC bridge
- `shared/types/ipc/` — updated maps and API types for the new channels
- `src/services/terminal/primarySelection.ts` — new module encapsulating the PRIMARY selection logic (write-on-select, middle-click paste), keeping it isolated and testable
- `src/services/terminal/TerminalInstanceService.ts` — mounts/unmounts the primary selection handler when a terminal instance is attached
- Unit tests for both the clipboard handlers and the `primarySelection` module

## Testing

- Unit tests cover the IPC handlers and the `primarySelection` logic, including Linux/non-Linux branching, primary-button-only guard on selection, and middle-click paste trigger.
- Formatter and linter pass clean with no new warnings introduced by this branch.