### PR TITLE
perf(window): hoist renderer load ahead of PTY host init behind feature flag

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 306,
+      "line": 225,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 350,
+      "line": 269,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 355,
+      "line": 274,
       "pattern": "sync-store-get"
     },
     {
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 233,
+      "line": 227,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 241,
+      "line": 235,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 249,
+      "line": 243,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 256,
+      "line": 250,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 363,
+      "line": 299,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 413,
+      "line": 349,
       "pattern": "sync-store-get"
     },
     {

--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1132,
-  "moduleCount": 1132,
+  "count": 1133,
+  "moduleCount": 1133,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -154,17 +154,17 @@
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 225,
+      "line": 306,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 269,
+      "line": 350,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 274,
+      "line": 355,
       "pattern": "sync-store-get"
     },
     {
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 227,
+      "line": 233,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 235,
+      "line": 241,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 243,
+      "line": 249,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 250,
+      "line": 256,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 299,
+      "line": 363,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 349,
+      "line": 413,
       "pattern": "sync-store-get"
     },
     {
@@ -1559,17 +1559,17 @@
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 190,
+      "line": 191,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 288,
+      "line": 289,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 520,
+      "line": 521,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/window/__tests__/windowServicesEarlyRenderer.test.ts
+++ b/electron/window/__tests__/windowServicesEarlyRenderer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { shouldEnableEarlyRenderer } from "../earlyRenderer.js";
+
+describe("shouldEnableEarlyRenderer", () => {
+  it("returns false when DAINTREE_EARLY_RENDERER is unset", () => {
+    expect(shouldEnableEarlyRenderer({ isSmokeTest: false, env: {} })).toBe(false);
+  });
+
+  it("returns true when DAINTREE_EARLY_RENDERER=1 and not in smoke test", () => {
+    expect(
+      shouldEnableEarlyRenderer({
+        isSmokeTest: false,
+        env: { DAINTREE_EARLY_RENDERER: "1" },
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when DAINTREE_EARLY_RENDERER is any value other than '1'", () => {
+    for (const value of ["0", "true", "yes", "on", ""]) {
+      expect(
+        shouldEnableEarlyRenderer({
+          isSmokeTest: false,
+          env: { DAINTREE_EARLY_RENDERER: value },
+        })
+      ).toBe(false);
+    }
+  });
+
+  it("returns false in smoke-test mode even with DAINTREE_EARLY_RENDERER=1", () => {
+    // Smoke tests assert deterministic readiness — keep them on the serial path.
+    expect(
+      shouldEnableEarlyRenderer({
+        isSmokeTest: true,
+        env: { DAINTREE_EARLY_RENDERER: "1" },
+      })
+    ).toBe(false);
+  });
+});

--- a/electron/window/earlyRenderer.ts
+++ b/electron/window/earlyRenderer.ts
@@ -1,0 +1,15 @@
+/**
+ * Decide whether to start the renderer in parallel with PTY host bootstrap.
+ *
+ * The default serial path awaits `ptyClient.waitForReady()` before calling
+ * `loadRenderer()`, which blocks first paint behind the PTY handshake (~70–150ms
+ * cold). When `DAINTREE_EARLY_RENDERER=1` is set, the renderer load is hoisted
+ * ahead of the workspace/PTY init block. The smoke test path is excluded so its
+ * deterministic readiness checks keep working unmodified.
+ */
+export function shouldEnableEarlyRenderer(opts: {
+  isSmokeTest: boolean;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  return !opts.isSmokeTest && opts.env.DAINTREE_EARLY_RENDERER === "1";
+}

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -877,6 +877,8 @@ export async function setupWindowServices(
   const { armRestoreQuota } = await import("../ipc/utils.js");
   armRestoreQuota(50, 120_000);
 
+  // Under DAINTREE_EARLY_RENDERER=1 the RENDERER_READY mark can fire before
+  // this point, since the renderer is loading concurrently with workspace init.
   markPerformance(PERF_MARKS.SERVICE_INIT_COMPLETE);
   // Default path: renderer load happens here, after workspace + PTY are ready.
   // With DAINTREE_EARLY_RENDERER=1 this is a no-op (already started above).

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -76,6 +76,7 @@ import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { logInfo } from "../utils/logger.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { isSmokeTest, isDemoMode, smokeTestStart, exposeGc } from "../setup/environment.js";
+import { shouldEnableEarlyRenderer } from "./earlyRenderer.js";
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { getProjectViewManager } from "./windowRef.js";
@@ -761,6 +762,61 @@ export async function setupWindowServices(
     }
   }
 
+  // Renderer load is gated by DAINTREE_EARLY_RENDERER. With the flag, the
+  // did-finish-load handler is registered and loadRenderer() is fired before
+  // the workspace/PTY init block — first paint stops waiting on the PTY
+  // handshake. Without the flag (default), the original serial order is kept:
+  // workspace init → handler → loadRenderer.
+  const earlyRendererEnabled = shouldEnableEarlyRenderer({ isSmokeTest, env: process.env });
+
+  let rendererLoadStarted = false;
+  const startRendererLoad = (reason: string): void => {
+    if (rendererLoadStarted) return;
+    rendererLoadStarted = true;
+
+    // Handle reloads (per-window) — listen on the app view's webContents.
+    // MUST be attached BEFORE loadRenderer() to avoid missing the first did-finish-load.
+    const appWc = getAppWebContents(win);
+    appWc.on("did-finish-load", () => {
+      const currentUrl = appWc.getURL();
+      if (currentUrl.includes("recovery.html")) {
+        console.log("[MAIN] Recovery page loaded, skipping normal renderer bootstrap");
+        return;
+      }
+      console.log("[MAIN] Renderer loaded, ensuring MessagePort connection...");
+      if (isSmokeTest) console.error("[SMOKE] CHECK: Renderer did-finish-load — OK");
+      markPerformance(PERF_MARKS.RENDERER_READY);
+      createAndDistributePorts(win, ctx);
+      // Refresh workspace direct port on reload (preload context is reset).
+      // Under DAINTREE_EARLY_RENDERER, workspaceClient may still be null on the
+      // first did-finish-load — the initial direct-port attach is performed by
+      // the loadProject() path below once the workspace host is ready.
+      if (workspaceClient) {
+        workspaceClient.attachDirectPort(win.id, appWc);
+
+        // Re-broker worktree port for initial view reload
+        if (worktreePortBroker) {
+          const host = workspaceClient.getHostForWindow(win.id);
+          if (host) {
+            worktreePortBroker.brokerPort(host, appWc);
+          }
+        }
+      }
+      flushPendingErrors();
+      const diskStatus = getCurrentDiskSpaceStatus();
+      if (diskStatus.status !== "normal") {
+        sendToRenderer(win, CHANNELS.WINDOW_DISK_SPACE_STATUS, diskStatus);
+      }
+    });
+
+    opts.loadRenderer(reason, opts.initialProjectId);
+  };
+
+  if (earlyRendererEnabled) {
+    console.log("[MAIN] DAINTREE_EARLY_RENDERER=1 — loading renderer in parallel with PTY init");
+    startRendererLoad("early-renderer");
+  }
+
   // Initialize workspace client (first window only) — per-project hosts
   // are started on-demand when loadProject() is called, not at init time.
   if (!workspaceClient) {
@@ -821,40 +877,10 @@ export async function setupWindowServices(
   const { armRestoreQuota } = await import("../ipc/utils.js");
   armRestoreQuota(50, 120_000);
 
-  // Handle reloads (per-window) — listen on the app view's webContents.
-  // MUST be attached BEFORE loadRenderer() to avoid missing the first did-finish-load.
-  const appWc = getAppWebContents(win);
-  appWc.on("did-finish-load", () => {
-    const currentUrl = appWc.getURL();
-    if (currentUrl.includes("recovery.html")) {
-      console.log("[MAIN] Recovery page loaded, skipping normal renderer bootstrap");
-      return;
-    }
-    console.log("[MAIN] Renderer loaded, ensuring MessagePort connection...");
-    if (isSmokeTest) console.error("[SMOKE] CHECK: Renderer did-finish-load — OK");
-    markPerformance(PERF_MARKS.RENDERER_READY);
-    createAndDistributePorts(win, ctx);
-    // Refresh workspace direct port on reload (preload context is reset)
-    if (workspaceClient) {
-      workspaceClient.attachDirectPort(win.id, appWc);
-
-      // Re-broker worktree port for initial view reload
-      if (worktreePortBroker) {
-        const host = workspaceClient.getHostForWindow(win.id);
-        if (host) {
-          worktreePortBroker.brokerPort(host, appWc);
-        }
-      }
-    }
-    flushPendingErrors();
-    const diskStatus = getCurrentDiskSpaceStatus();
-    if (diskStatus.status !== "normal") {
-      sendToRenderer(win, CHANNELS.WINDOW_DISK_SPACE_STATUS, diskStatus);
-    }
-  });
-
   markPerformance(PERF_MARKS.SERVICE_INIT_COMPLETE);
-  opts.loadRenderer("after-services-ready", opts.initialProjectId);
+  // Default path: renderer load happens here, after workspace + PTY are ready.
+  // With DAINTREE_EARLY_RENDERER=1 this is a no-op (already started above).
+  startRendererLoad("after-services-ready");
 
   // Error handlers also use ipcMain.handle — register once
   if (!cleanupErrorHandlers) {


### PR DESCRIPTION
## Summary

- Adds a `DAINTREE_EARLY_RENDERER=1` env flag that hoists `loadRenderer()` ahead of the workspace/PTY init block in `setupWindowServices`, so first paint no longer waits on the `ptyClient.waitForReady()` handshake (~70-150ms cold start saving)
- Default behaviour (flag off) is byte-identical: workspace init runs, then the `did-finish-load` handler fires, then `loadRenderer` is called
- Smoke test path explicitly bypasses the flag to keep deterministic readiness; the `did-finish-load` handler's existing null-guard on `workspaceClient` handles first-load when the renderer finishes before the workspace is constructed

Resolves #5397

## Changes

- `electron/window/earlyRenderer.ts` — pure, side-effect-free helper that reads the env flag and workspace/smoke-test state
- `electron/window/windowServices.ts` — conditional early `loadRenderer()` call before the PTY init block; default path unchanged
- `electron/window/__tests__/windowServicesEarlyRenderer.test.ts` — 4 focused unit tests covering flag-on/off and smoke-test bypass

## Testing

- Run with `DAINTREE_EARLY_RENDERER=1`: first paint timing improves, UI renders identically
- Run without the flag: no behaviour change
- `Cmd+R` reload re-attaches workspace direct port correctly (handler guard runs both paths)
- Smoke tests still pass (`--smoke-test` bypasses the flag regardless of env)