### PR TITLE
fix(recovery): add diagnostics export and open-logs actions to recovery page

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -566,6 +566,8 @@ export const CHANNELS = {
   // Renderer Recovery channels (in-session crash recovery)
   RECOVERY_RELOAD_APP: "recovery:reload-app",
   RECOVERY_RESET_AND_RELOAD: "recovery:reset-and-reload",
+  RECOVERY_EXPORT_DIAGNOSTICS: "recovery:export-diagnostics",
+  RECOVERY_OPEN_LOGS: "recovery:open-logs",
 
   // Demo mode channels (dev-only)
   DEMO_MOVE_TO: "demo:move-to",

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -15,7 +15,7 @@ const shellMock = vi.hoisted(() => ({
 }));
 
 const browserWindowMock = vi.hoisted(() => ({
-  fromWebContents: vi.fn(() => null),
+  fromWebContents: vi.fn<() => null | { isDestroyed: () => boolean }>(() => null),
 }));
 
 const fsMock = vi.hoisted(() => ({

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const dialogMock = vi.hoisted(() => ({
+  showSaveDialog: vi.fn(),
+}));
+
+const shellMock = vi.hoisted(() => ({
+  openPath: vi.fn(async () => ""),
+  showItemInFolder: vi.fn(),
+}));
+
+const browserWindowMock = vi.hoisted(() => ({
+  fromWebContents: vi.fn(() => null),
+}));
+
+const fsMock = vi.hoisted(() => ({
+  promises: {
+    writeFile: vi.fn(async () => undefined),
+    access: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  dialog: dialogMock,
+  shell: shellMock,
+  BrowserWindow: browserWindowMock,
+}));
+
+vi.mock("node:fs", () => fsMock);
+
+vi.mock("../../../services/CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: vi.fn(() => ({
+    resetToFresh: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../services/DiagnosticsCollector.js", () => ({
+  collectDiagnostics: vi.fn(async () => ({ version: "test", platform: "darwin" })),
+}));
+
+vi.mock("../../../utils/logger.js", () => ({
+  getLogFilePath: vi.fn(() => "/tmp/daintree/logs/main.log"),
+}));
+
+import { registerRecoveryHandlers } from "../recovery.js";
+import type { HandlerDependencies } from "../../types.js";
+
+function getHandlerFn(channelName: string): (...args: unknown[]) => unknown {
+  const call = ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channelName);
+  if (!call) throw new Error(`No handler registered for ${channelName}`);
+  return call[1] as (...args: unknown[]) => unknown;
+}
+
+const TRUSTED_RECOVERY_URL = "app://daintree/recovery.html";
+const UNTRUSTED_URL = "https://evil.com/recovery.html";
+const MAIN_RENDERER_URL = "app://daintree/index.html";
+
+describe("registerRecoveryHandlers", () => {
+  const deps = { mainWindow: undefined } as HandlerDependencies;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shellMock.openPath.mockResolvedValue("");
+    browserWindowMock.fromWebContents.mockReturnValue(null);
+    fsMock.promises.access.mockResolvedValue(undefined);
+  });
+
+  it("registers export-diagnostics and open-logs via raw ipcMain.handle", () => {
+    registerRecoveryHandlers(deps);
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "recovery:export-diagnostics",
+      expect.any(Function)
+    );
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("recovery:open-logs", expect.any(Function));
+  });
+
+  it("cleanup removes both raw handlers", () => {
+    const cleanup = registerRecoveryHandlers(deps);
+    cleanup();
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:export-diagnostics");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:open-logs");
+  });
+
+  describe("recovery:export-diagnostics", () => {
+    it("rejects untrusted sender and does not write file", async () => {
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+      await expect(handler({ senderFrame: { url: UNTRUSTED_URL } })).rejects.toThrow(
+        "recovery:export-diagnostics rejected: untrusted sender"
+      );
+      expect(dialogMock.showSaveDialog).not.toHaveBeenCalled();
+      expect(fsMock.promises.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("rejects the main renderer URL (not the recovery page)", async () => {
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+      await expect(handler({ senderFrame: { url: MAIN_RENDERER_URL } })).rejects.toThrow(
+        "recovery:export-diagnostics rejected: untrusted sender"
+      );
+      expect(dialogMock.showSaveDialog).not.toHaveBeenCalled();
+    });
+
+    it("rejects missing senderFrame", async () => {
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+      await expect(handler({ senderFrame: null })).rejects.toThrow(
+        "recovery:export-diagnostics rejected: untrusted sender"
+      );
+    });
+
+    it("writes file and reveals it on success", async () => {
+      dialogMock.showSaveDialog.mockResolvedValue({
+        canceled: false,
+        filePath: "/tmp/diagnostics.json",
+      });
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+
+      const result = await handler({
+        senderFrame: { url: TRUSTED_RECOVERY_URL },
+        sender: {},
+      });
+
+      expect(result).toBe(true);
+      expect(fsMock.promises.writeFile).toHaveBeenCalledWith(
+        "/tmp/diagnostics.json",
+        expect.stringContaining('"version"'),
+        "utf-8"
+      );
+      expect(shellMock.showItemInFolder).toHaveBeenCalledWith("/tmp/diagnostics.json");
+    });
+
+    it("returns false and does not write when user cancels", async () => {
+      dialogMock.showSaveDialog.mockResolvedValue({ canceled: true, filePath: undefined });
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+
+      const result = await handler({
+        senderFrame: { url: TRUSTED_RECOVERY_URL },
+        sender: {},
+      });
+
+      expect(result).toBe(false);
+      expect(fsMock.promises.writeFile).not.toHaveBeenCalled();
+      expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+    });
+
+    it("parents the save dialog to the sender's BrowserWindow when available", async () => {
+      const parentWin = { isDestroyed: vi.fn(() => false) };
+      browserWindowMock.fromWebContents.mockReturnValue(parentWin);
+      dialogMock.showSaveDialog.mockResolvedValue({
+        canceled: false,
+        filePath: "/tmp/diagnostics.json",
+      });
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+
+      await handler({
+        senderFrame: { url: TRUSTED_RECOVERY_URL },
+        sender: {},
+      });
+
+      expect(dialogMock.showSaveDialog).toHaveBeenCalledWith(parentWin, expect.any(Object));
+    });
+
+    it("falls back to parentless dialog when no parent window is available", async () => {
+      dialogMock.showSaveDialog.mockResolvedValue({
+        canceled: false,
+        filePath: "/tmp/diagnostics.json",
+      });
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+
+      await handler({
+        senderFrame: { url: TRUSTED_RECOVERY_URL },
+        sender: {},
+      });
+
+      expect(dialogMock.showSaveDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Save Diagnostics" })
+      );
+    });
+  });
+
+  describe("recovery:open-logs", () => {
+    it("rejects untrusted sender and does not open anything", async () => {
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+      await expect(handler({ senderFrame: { url: UNTRUSTED_URL } })).rejects.toThrow(
+        "recovery:open-logs rejected: untrusted sender"
+      );
+      expect(shellMock.openPath).not.toHaveBeenCalled();
+    });
+
+    it("opens the log file when it exists", async () => {
+      fsMock.promises.access.mockResolvedValue(undefined);
+      shellMock.openPath.mockResolvedValue("");
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+
+      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+
+      expect(shellMock.openPath).toHaveBeenCalledWith("/tmp/daintree/logs/main.log");
+    });
+
+    it("creates the log file and opens it when ENOENT", async () => {
+      const enoent = Object.assign(new Error("not found"), { code: "ENOENT" });
+      fsMock.promises.access.mockRejectedValue(enoent);
+      fsMock.promises.mkdir.mockResolvedValue(undefined);
+      fsMock.promises.writeFile.mockResolvedValue(undefined);
+      shellMock.openPath.mockResolvedValue("");
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+
+      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+
+      expect(fsMock.promises.mkdir).toHaveBeenCalledWith("/tmp/daintree/logs", {
+        recursive: true,
+      });
+      expect(fsMock.promises.writeFile).toHaveBeenCalledWith(
+        "/tmp/daintree/logs/main.log",
+        "",
+        "utf8"
+      );
+      expect(shellMock.openPath).toHaveBeenCalledWith("/tmp/daintree/logs/main.log");
+    });
+
+    it("falls back to opening the log directory on non-ENOENT errors", async () => {
+      fsMock.promises.access.mockRejectedValue(
+        Object.assign(new Error("permission denied"), { code: "EACCES" })
+      );
+      shellMock.openPath.mockResolvedValue("");
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+
+      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+
+      expect(shellMock.openPath).toHaveBeenCalledWith("/tmp/daintree/logs");
+    });
+
+    it("falls back to opening the directory when openPath returns an error string", async () => {
+      fsMock.promises.access.mockResolvedValue(undefined);
+      shellMock.openPath.mockResolvedValueOnce("Error: no association").mockResolvedValueOnce("");
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+
+      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+
+      expect(shellMock.openPath).toHaveBeenNthCalledWith(1, "/tmp/daintree/logs/main.log");
+      expect(shellMock.openPath).toHaveBeenNthCalledWith(2, "/tmp/daintree/logs");
+    });
+  });
+});

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -37,6 +37,22 @@ vi.mock("electron", () => ({
 
 vi.mock("node:fs", () => fsMock);
 
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: vi.fn(() => null),
+  getAppWebContents: vi.fn(),
+  getAllAppWebContents: vi.fn(() => []),
+}));
+
+vi.mock("../../../window/windowRef.js", () => ({
+  getProjectViewManager: vi.fn(() => null),
+}));
+
+vi.mock("../../../utils/performance.js", () => ({
+  isPerformanceCaptureEnabled: vi.fn(() => false),
+  markPerformance: vi.fn(),
+  sampleIpcTiming: vi.fn(),
+}));
+
 vi.mock("../../../services/CrashRecoveryService.js", () => ({
   getCrashRecoveryService: vi.fn(() => ({
     resetToFresh: vi.fn(),
@@ -64,6 +80,15 @@ const TRUSTED_RECOVERY_URL = "app://daintree/recovery.html";
 const UNTRUSTED_URL = "https://evil.com/recovery.html";
 const MAIN_RENDERER_URL = "app://daintree/index.html";
 
+const SENDER = { id: 1 };
+
+function buildEvent(url: string | null) {
+  return {
+    senderFrame: url === null ? null : { url },
+    sender: SENDER,
+  };
+}
+
 describe("registerRecoveryHandlers", () => {
   const deps = { mainWindow: undefined } as HandlerDependencies;
 
@@ -77,7 +102,7 @@ describe("registerRecoveryHandlers", () => {
     collectDiagnosticsMock.mockResolvedValue({ version: "test", platform: "darwin" });
   });
 
-  it("registers export-diagnostics and open-logs via raw ipcMain.handle", () => {
+  it("registers export-diagnostics and open-logs via typedHandleWithContext", () => {
     registerRecoveryHandlers(deps);
     expect(ipcMainMock.handle).toHaveBeenCalledWith(
       "recovery:export-diagnostics",
@@ -86,7 +111,7 @@ describe("registerRecoveryHandlers", () => {
     expect(ipcMainMock.handle).toHaveBeenCalledWith("recovery:open-logs", expect.any(Function));
   });
 
-  it("cleanup removes both raw handlers", () => {
+  it("cleanup removes the handlers", () => {
     const cleanup = registerRecoveryHandlers(deps);
     cleanup();
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:export-diagnostics");
@@ -97,7 +122,7 @@ describe("registerRecoveryHandlers", () => {
     it("rejects untrusted sender and does not collect diagnostics, show dialog, or write file", async () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
-      await expect(handler({ senderFrame: { url: UNTRUSTED_URL } })).rejects.toThrow(
+      await expect(handler(buildEvent(UNTRUSTED_URL))).rejects.toThrow(
         "recovery:export-diagnostics rejected: untrusted sender"
       );
       expect(collectDiagnosticsMock).not.toHaveBeenCalled();
@@ -116,16 +141,14 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
 
-      await expect(
-        handler({ senderFrame: { url: TRUSTED_RECOVERY_URL }, sender: {} })
-      ).rejects.toThrow("no space");
+      await expect(handler(buildEvent(TRUSTED_RECOVERY_URL))).rejects.toThrow("no space");
       expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
     });
 
     it("rejects the main renderer URL (not the recovery page)", async () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
-      await expect(handler({ senderFrame: { url: MAIN_RENDERER_URL } })).rejects.toThrow(
+      await expect(handler(buildEvent(MAIN_RENDERER_URL))).rejects.toThrow(
         "recovery:export-diagnostics rejected: untrusted sender"
       );
       expect(dialogMock.showSaveDialog).not.toHaveBeenCalled();
@@ -134,7 +157,7 @@ describe("registerRecoveryHandlers", () => {
     it("rejects missing senderFrame", async () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
-      await expect(handler({ senderFrame: null })).rejects.toThrow(
+      await expect(handler(buildEvent(null))).rejects.toThrow(
         "recovery:export-diagnostics rejected: untrusted sender"
       );
     });
@@ -147,10 +170,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
 
-      const result = await handler({
-        senderFrame: { url: TRUSTED_RECOVERY_URL },
-        sender: {},
-      });
+      const result = await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(result).toBe(true);
       expect(fsMock.promises.writeFile).toHaveBeenCalledWith(
@@ -166,10 +186,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
 
-      const result = await handler({
-        senderFrame: { url: TRUSTED_RECOVERY_URL },
-        sender: {},
-      });
+      const result = await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(result).toBe(false);
       expect(fsMock.promises.writeFile).not.toHaveBeenCalled();
@@ -186,10 +203,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
 
-      await handler({
-        senderFrame: { url: TRUSTED_RECOVERY_URL },
-        sender: {},
-      });
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(dialogMock.showSaveDialog).toHaveBeenCalledWith(parentWin, expect.any(Object));
     });
@@ -202,10 +216,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
 
-      await handler({
-        senderFrame: { url: TRUSTED_RECOVERY_URL },
-        sender: {},
-      });
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(dialogMock.showSaveDialog).toHaveBeenCalledWith(
         expect.objectContaining({ title: "Save Diagnostics" })
@@ -217,7 +228,7 @@ describe("registerRecoveryHandlers", () => {
     it("rejects untrusted sender and does not open anything", async () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
-      await expect(handler({ senderFrame: { url: UNTRUSTED_URL } })).rejects.toThrow(
+      await expect(handler(buildEvent(UNTRUSTED_URL))).rejects.toThrow(
         "recovery:open-logs rejected: untrusted sender"
       );
       expect(shellMock.openPath).not.toHaveBeenCalled();
@@ -229,7 +240,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
 
-      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(shellMock.openPath).toHaveBeenCalledTimes(1);
       expect(shellMock.openPath).toHaveBeenCalledWith("/tmp/daintree/logs/main.log");
@@ -244,7 +255,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
 
-      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(fsMock.promises.mkdir).toHaveBeenCalledWith("/tmp/daintree/logs", {
         recursive: true,
@@ -265,7 +276,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
 
-      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(shellMock.openPath).toHaveBeenCalledWith("/tmp/daintree/logs");
     });
@@ -276,7 +287,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
 
-      await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(shellMock.openPath).toHaveBeenNthCalledWith(1, "/tmp/daintree/logs/main.log");
       expect(shellMock.openPath).toHaveBeenNthCalledWith(2, "/tmp/daintree/logs");
@@ -288,7 +299,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
 
-      await expect(handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } })).rejects.toThrow(
+      await expect(handler(buildEvent(TRUSTED_RECOVERY_URL))).rejects.toThrow(
         "recovery:open-logs failed"
       );
       expect(shellMock.openPath).toHaveBeenNthCalledWith(1, "/tmp/daintree/logs/main.log");
@@ -304,7 +315,7 @@ describe("registerRecoveryHandlers", () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:open-logs");
 
-      await expect(handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } })).rejects.toThrow(
+      await expect(handler(buildEvent(TRUSTED_RECOVERY_URL))).rejects.toThrow(
         "recovery:open-logs failed"
       );
     });

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -20,11 +20,13 @@ const browserWindowMock = vi.hoisted(() => ({
 
 const fsMock = vi.hoisted(() => ({
   promises: {
-    writeFile: vi.fn(async () => undefined),
-    access: vi.fn(async () => undefined),
-    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined) as ReturnType<typeof vi.fn>,
+    access: vi.fn(async () => undefined) as ReturnType<typeof vi.fn>,
+    mkdir: vi.fn(async () => undefined) as ReturnType<typeof vi.fn>,
   },
 }));
+
+const collectDiagnosticsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
@@ -42,7 +44,7 @@ vi.mock("../../../services/CrashRecoveryService.js", () => ({
 }));
 
 vi.mock("../../../services/DiagnosticsCollector.js", () => ({
-  collectDiagnostics: vi.fn(async () => ({ version: "test", platform: "darwin" })),
+  collectDiagnostics: collectDiagnosticsMock,
 }));
 
 vi.mock("../../../utils/logger.js", () => ({
@@ -70,6 +72,9 @@ describe("registerRecoveryHandlers", () => {
     shellMock.openPath.mockResolvedValue("");
     browserWindowMock.fromWebContents.mockReturnValue(null);
     fsMock.promises.access.mockResolvedValue(undefined);
+    fsMock.promises.writeFile.mockResolvedValue(undefined);
+    fsMock.promises.mkdir.mockResolvedValue(undefined);
+    collectDiagnosticsMock.mockResolvedValue({ version: "test", platform: "darwin" });
   });
 
   it("registers export-diagnostics and open-logs via raw ipcMain.handle", () => {
@@ -89,14 +94,32 @@ describe("registerRecoveryHandlers", () => {
   });
 
   describe("recovery:export-diagnostics", () => {
-    it("rejects untrusted sender and does not write file", async () => {
+    it("rejects untrusted sender and does not collect diagnostics, show dialog, or write file", async () => {
       registerRecoveryHandlers(deps);
       const handler = getHandlerFn("recovery:export-diagnostics");
       await expect(handler({ senderFrame: { url: UNTRUSTED_URL } })).rejects.toThrow(
         "recovery:export-diagnostics rejected: untrusted sender"
       );
+      expect(collectDiagnosticsMock).not.toHaveBeenCalled();
       expect(dialogMock.showSaveDialog).not.toHaveBeenCalled();
       expect(fsMock.promises.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("propagates fs.writeFile failures without calling showItemInFolder", async () => {
+      dialogMock.showSaveDialog.mockResolvedValue({
+        canceled: false,
+        filePath: "/tmp/diagnostics.json",
+      });
+      fsMock.promises.writeFile.mockRejectedValueOnce(
+        Object.assign(new Error("no space"), { code: "ENOSPC" })
+      );
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:export-diagnostics");
+
+      await expect(
+        handler({ senderFrame: { url: TRUSTED_RECOVERY_URL }, sender: {} })
+      ).rejects.toThrow("no space");
+      expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
     });
 
     it("rejects the main renderer URL (not the recovery page)", async () => {
@@ -200,7 +223,7 @@ describe("registerRecoveryHandlers", () => {
       expect(shellMock.openPath).not.toHaveBeenCalled();
     });
 
-    it("opens the log file when it exists", async () => {
+    it("opens the log file exactly once when the file exists and openPath succeeds", async () => {
       fsMock.promises.access.mockResolvedValue(undefined);
       shellMock.openPath.mockResolvedValue("");
       registerRecoveryHandlers(deps);
@@ -208,6 +231,7 @@ describe("registerRecoveryHandlers", () => {
 
       await handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } });
 
+      expect(shellMock.openPath).toHaveBeenCalledTimes(1);
       expect(shellMock.openPath).toHaveBeenCalledWith("/tmp/daintree/logs/main.log");
     });
 
@@ -256,6 +280,33 @@ describe("registerRecoveryHandlers", () => {
 
       expect(shellMock.openPath).toHaveBeenNthCalledWith(1, "/tmp/daintree/logs/main.log");
       expect(shellMock.openPath).toHaveBeenNthCalledWith(2, "/tmp/daintree/logs");
+    });
+
+    it("throws when every openPath attempt returns an error string", async () => {
+      fsMock.promises.access.mockResolvedValue(undefined);
+      shellMock.openPath.mockResolvedValue("Error: no association");
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+
+      await expect(handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } })).rejects.toThrow(
+        "recovery:open-logs failed"
+      );
+      expect(shellMock.openPath).toHaveBeenNthCalledWith(1, "/tmp/daintree/logs/main.log");
+      expect(shellMock.openPath).toHaveBeenNthCalledWith(2, "/tmp/daintree/logs");
+    });
+
+    it("throws when ENOENT recovery also fails to open the directory", async () => {
+      const enoent = Object.assign(new Error("not found"), { code: "ENOENT" });
+      fsMock.promises.access.mockRejectedValue(enoent);
+      fsMock.promises.mkdir.mockResolvedValue(undefined);
+      fsMock.promises.writeFile.mockResolvedValue(undefined);
+      shellMock.openPath.mockResolvedValue("Error: no association");
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:open-logs");
+
+      await expect(handler({ senderFrame: { url: TRUSTED_RECOVERY_URL } })).rejects.toThrow(
+        "recovery:open-logs failed"
+      );
     });
   });
 });

--- a/electron/ipc/handlers/recovery.ts
+++ b/electron/ipc/handlers/recovery.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, dialog, ipcMain, shell } from "electron";
+import { BrowserWindow, dialog, shell } from "electron";
 import { promises as fs } from "node:fs";
 import { dirname } from "node:path";
 import { CHANNELS } from "../channels.js";
@@ -8,7 +8,7 @@ import { getDevServerUrl } from "../../../shared/config/devServer.js";
 import { isRecoveryPageUrl } from "../../../shared/utils/trustedRenderer.js";
 import { collectDiagnostics } from "../../services/DiagnosticsCollector.js";
 import { getLogFilePath } from "../../utils/logger.js";
-import { typedHandle } from "../utils.js";
+import { typedHandle, typedHandleWithContext } from "../utils.js";
 
 function getAppUrl(): string {
   if (process.env.NODE_ENV === "development") {
@@ -41,86 +41,89 @@ export function registerRecoveryHandlers(deps: HandlerDependencies): () => void 
     })
   );
 
-  // These two handlers use raw ipcMain.handle to access event.senderFrame.url
-  // synchronously before any await. They are only callable from recovery.html
-  // (not the main renderer), so we scope the allowed origin accordingly.
-  ipcMain.handle(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS, async (event): Promise<boolean> => {
-    const senderUrl = event.senderFrame?.url;
-    if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
-      throw new Error(
-        `recovery:export-diagnostics rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
-      );
-    }
-
-    const payload = await collectDiagnostics(deps);
-    const json = JSON.stringify(payload, null, 2);
-
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const parentWin =
-      BrowserWindow.fromWebContents(event.sender) ??
-      deps.windowRegistry?.getPrimary()?.browserWindow ??
-      deps.mainWindow;
-    const dialogOpts = {
-      title: "Save Diagnostics",
-      defaultPath: `daintree-diagnostics-${timestamp}.json`,
-      filters: [{ name: "JSON", extensions: ["json"] }],
-    };
-    const { filePath, canceled } =
-      parentWin && !parentWin.isDestroyed()
-        ? await dialog.showSaveDialog(parentWin, dialogOpts)
-        : await dialog.showSaveDialog(dialogOpts);
-
-    if (canceled || !filePath) return false;
-
-    await fs.writeFile(filePath, json, "utf-8");
-    shell.showItemInFolder(filePath);
-    return true;
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS));
-
-  ipcMain.handle(CHANNELS.RECOVERY_OPEN_LOGS, async (event): Promise<void> => {
-    const senderUrl = event.senderFrame?.url;
-    if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
-      throw new Error(
-        `recovery:open-logs rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
-      );
-    }
-
-    const logFilePath = getLogFilePath();
-    const dir = dirname(logFilePath);
-    const attempts: string[] = [];
-
-    const tryOpen = async (target: string): Promise<boolean> => {
-      const result = await shell.openPath(target);
-      if (result) {
-        attempts.push(`${target}: ${result}`);
-        return false;
+  // These two handlers validate event.senderFrame.url synchronously (before any
+  // await) to accept calls only from recovery.html — not the main renderer or
+  // arbitrary frames. Using typedHandleWithContext keeps type safety while
+  // exposing the event via ctx for the origin check.
+  handlers.push(
+    typedHandleWithContext(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS, async (ctx): Promise<boolean> => {
+      const senderUrl = ctx.event.senderFrame?.url;
+      if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
+        throw new Error(
+          `recovery:export-diagnostics rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+        );
       }
+
+      const payload = await collectDiagnostics(deps);
+      const json = JSON.stringify(payload, null, 2);
+
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const parentWin =
+        BrowserWindow.fromWebContents(ctx.event.sender) ??
+        deps.windowRegistry?.getPrimary()?.browserWindow ??
+        deps.mainWindow;
+      const dialogOpts = {
+        title: "Save Diagnostics",
+        defaultPath: `daintree-diagnostics-${timestamp}.json`,
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      };
+      const { filePath, canceled } =
+        parentWin && !parentWin.isDestroyed()
+          ? await dialog.showSaveDialog(parentWin, dialogOpts)
+          : await dialog.showSaveDialog(dialogOpts);
+
+      if (canceled || !filePath) return false;
+
+      await fs.writeFile(filePath, json, "utf-8");
+      shell.showItemInFolder(filePath);
       return true;
-    };
+    })
+  );
 
-    try {
-      await fs.access(logFilePath);
-      if (await tryOpen(logFilePath)) return;
-      if (await tryOpen(dir)) return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        try {
-          await fs.mkdir(dir, { recursive: true });
-          await fs.writeFile(logFilePath, "", "utf8");
-          if (await tryOpen(logFilePath)) return;
-        } catch (createErr) {
-          attempts.push(`create ${logFilePath}: ${(createErr as Error).message}`);
-        }
-      } else {
-        attempts.push(`access ${logFilePath}: ${(error as Error).message}`);
+  handlers.push(
+    typedHandleWithContext(CHANNELS.RECOVERY_OPEN_LOGS, async (ctx): Promise<void> => {
+      const senderUrl = ctx.event.senderFrame?.url;
+      if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
+        throw new Error(
+          `recovery:open-logs rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+        );
       }
-      if (await tryOpen(dir)) return;
-    }
 
-    throw new Error(`recovery:open-logs failed: ${attempts.join("; ") || "unknown error"}`);
-  });
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_OPEN_LOGS));
+      const logFilePath = getLogFilePath();
+      const dir = dirname(logFilePath);
+      const attempts: string[] = [];
+
+      const tryOpen = async (target: string): Promise<boolean> => {
+        const result = await shell.openPath(target);
+        if (result) {
+          attempts.push(`${target}: ${result}`);
+          return false;
+        }
+        return true;
+      };
+
+      try {
+        await fs.access(logFilePath);
+        if (await tryOpen(logFilePath)) return;
+        if (await tryOpen(dir)) return;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          try {
+            await fs.mkdir(dir, { recursive: true });
+            await fs.writeFile(logFilePath, "", "utf8");
+            if (await tryOpen(logFilePath)) return;
+          } catch (createErr) {
+            attempts.push(`create ${logFilePath}: ${(createErr as Error).message}`);
+          }
+        } else {
+          attempts.push(`access ${logFilePath}: ${(error as Error).message}`);
+        }
+        if (await tryOpen(dir)) return;
+      }
+
+      throw new Error(`recovery:open-logs failed: ${attempts.join("; ") || "unknown error"}`);
+    })
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/recovery.ts
+++ b/electron/ipc/handlers/recovery.ts
@@ -1,7 +1,13 @@
+import { BrowserWindow, dialog, ipcMain, shell } from "electron";
+import { promises as fs } from "node:fs";
+import { dirname } from "node:path";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { getCrashRecoveryService } from "../../services/CrashRecoveryService.js";
 import { getDevServerUrl } from "../../../shared/config/devServer.js";
+import { isRecoveryPageUrl } from "../../../shared/utils/trustedRenderer.js";
+import { collectDiagnostics } from "../../services/DiagnosticsCollector.js";
+import { getLogFilePath } from "../../utils/logger.js";
 import { typedHandle } from "../utils.js";
 
 function getAppUrl(): string {
@@ -34,6 +40,78 @@ export function registerRecoveryHandlers(deps: HandlerDependencies): () => void 
       }
     })
   );
+
+  // These two handlers use raw ipcMain.handle to access event.senderFrame.url
+  // synchronously before any await. They are only callable from recovery.html
+  // (not the main renderer), so we scope the allowed origin accordingly.
+  ipcMain.handle(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS, async (event): Promise<boolean> => {
+    const senderUrl = event.senderFrame?.url;
+    if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
+      throw new Error(
+        `recovery:export-diagnostics rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+      );
+    }
+
+    const payload = await collectDiagnostics(deps);
+    const json = JSON.stringify(payload, null, 2);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const parentWin =
+      BrowserWindow.fromWebContents(event.sender) ??
+      deps.windowRegistry?.getPrimary()?.browserWindow ??
+      deps.mainWindow;
+    const dialogOpts = {
+      title: "Save Diagnostics",
+      defaultPath: `daintree-diagnostics-${timestamp}.json`,
+      filters: [{ name: "JSON", extensions: ["json"] }],
+    };
+    const { filePath, canceled } =
+      parentWin && !parentWin.isDestroyed()
+        ? await dialog.showSaveDialog(parentWin, dialogOpts)
+        : await dialog.showSaveDialog(dialogOpts);
+
+    if (canceled || !filePath) return false;
+
+    await fs.writeFile(filePath, json, "utf-8");
+    shell.showItemInFolder(filePath);
+    return true;
+  });
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS));
+
+  ipcMain.handle(CHANNELS.RECOVERY_OPEN_LOGS, async (event): Promise<void> => {
+    const senderUrl = event.senderFrame?.url;
+    if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
+      throw new Error(
+        `recovery:open-logs rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+      );
+    }
+
+    const logFilePath = getLogFilePath();
+    try {
+      await fs.access(logFilePath);
+      const openResult = await shell.openPath(logFilePath);
+      if (openResult) {
+        await shell.openPath(dirname(logFilePath));
+      }
+    } catch (error) {
+      const dir = dirname(logFilePath);
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        try {
+          await fs.mkdir(dir, { recursive: true });
+          await fs.writeFile(logFilePath, "", "utf8");
+          const openResult = await shell.openPath(logFilePath);
+          if (openResult) {
+            await shell.openPath(dir);
+          }
+        } catch {
+          await shell.openPath(dir);
+        }
+      } else {
+        await shell.openPath(dir);
+      }
+    }
+  });
+  handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_OPEN_LOGS));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/recovery.ts
+++ b/electron/ipc/handlers/recovery.ts
@@ -87,29 +87,38 @@ export function registerRecoveryHandlers(deps: HandlerDependencies): () => void 
     }
 
     const logFilePath = getLogFilePath();
+    const dir = dirname(logFilePath);
+    const attempts: string[] = [];
+
+    const tryOpen = async (target: string): Promise<boolean> => {
+      const result = await shell.openPath(target);
+      if (result) {
+        attempts.push(`${target}: ${result}`);
+        return false;
+      }
+      return true;
+    };
+
     try {
       await fs.access(logFilePath);
-      const openResult = await shell.openPath(logFilePath);
-      if (openResult) {
-        await shell.openPath(dirname(logFilePath));
-      }
+      if (await tryOpen(logFilePath)) return;
+      if (await tryOpen(dir)) return;
     } catch (error) {
-      const dir = dirname(logFilePath);
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
         try {
           await fs.mkdir(dir, { recursive: true });
           await fs.writeFile(logFilePath, "", "utf8");
-          const openResult = await shell.openPath(logFilePath);
-          if (openResult) {
-            await shell.openPath(dir);
-          }
-        } catch {
-          await shell.openPath(dir);
+          if (await tryOpen(logFilePath)) return;
+        } catch (createErr) {
+          attempts.push(`create ${logFilePath}: ${(createErr as Error).message}`);
         }
       } else {
-        await shell.openPath(dir);
+        attempts.push(`access ${logFilePath}: ${(error as Error).message}`);
       }
+      if (await tryOpen(dir)) return;
     }
+
+    throw new Error(`recovery:open-logs failed: ${attempts.join("; ") || "unknown error"}`);
   });
   handlers.push(() => ipcMain.removeHandler(CHANNELS.RECOVERY_OPEN_LOGS));
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1059,6 +1059,8 @@ const CHANNELS = {
   // Renderer Recovery channels
   RECOVERY_RELOAD_APP: "recovery:reload-app",
   RECOVERY_RESET_AND_RELOAD: "recovery:reset-and-reload",
+  RECOVERY_EXPORT_DIAGNOSTICS: "recovery:export-diagnostics",
+  RECOVERY_OPEN_LOGS: "recovery:open-logs",
 
   // Onboarding channels
   ONBOARDING_GET: "onboarding:get",
@@ -2479,6 +2481,9 @@ const api: ElectronAPI = {
   recovery: {
     reloadApp: (): Promise<void> => _unwrappingInvoke(CHANNELS.RECOVERY_RELOAD_APP),
     resetAndReload: (): Promise<void> => _unwrappingInvoke(CHANNELS.RECOVERY_RESET_AND_RELOAD),
+    exportDiagnostics: (): Promise<boolean> =>
+      _unwrappingInvoke(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS),
+    openLogs: (): Promise<void> => _unwrappingInvoke(CHANNELS.RECOVERY_OPEN_LOGS),
   },
 
   // Notification API

--- a/public/recovery-renderer.js
+++ b/public/recovery-renderer.js
@@ -12,6 +12,13 @@
   }
 
   var api = window.electron;
+  var statusEl = document.getElementById("status");
+
+  function setStatus(message, isError) {
+    if (!statusEl) return;
+    statusEl.textContent = message || "";
+    statusEl.className = "status" + (isError ? " error" : "");
+  }
 
   document.getElementById("btn-reload").addEventListener("click", function () {
     if (api && api.recovery) {
@@ -24,4 +31,46 @@
       api.recovery.resetAndReload();
     }
   });
+
+  var exportBtn = document.getElementById("btn-export-diagnostics");
+  if (exportBtn) {
+    exportBtn.addEventListener("click", function () {
+      if (!api || !api.recovery) return;
+      exportBtn.disabled = true;
+      setStatus("Collecting diagnostics…", false);
+      api.recovery
+        .exportDiagnostics()
+        .then(function (saved) {
+          setStatus(saved ? "Diagnostics saved." : "Save cancelled.", false);
+        })
+        .catch(function (err) {
+          var message = err && err.message ? err.message : String(err);
+          setStatus("Failed to export diagnostics: " + message, true);
+        })
+        .finally(function () {
+          exportBtn.disabled = false;
+        });
+    });
+  }
+
+  var openLogsBtn = document.getElementById("btn-open-logs");
+  if (openLogsBtn) {
+    openLogsBtn.addEventListener("click", function () {
+      if (!api || !api.recovery) return;
+      openLogsBtn.disabled = true;
+      setStatus("Opening logs…", false);
+      api.recovery
+        .openLogs()
+        .then(function () {
+          setStatus("Logs opened.", false);
+        })
+        .catch(function (err) {
+          var message = err && err.message ? err.message : String(err);
+          setStatus("Failed to open logs: " + message, true);
+        })
+        .finally(function () {
+          openLogsBtn.disabled = false;
+        });
+    });
+  }
 })();

--- a/public/recovery-renderer.js
+++ b/public/recovery-renderer.js
@@ -13,11 +13,39 @@
 
   var api = window.electron;
   var statusEl = document.getElementById("status");
+  var buttonIds = ["btn-reload", "btn-reset", "btn-export-diagnostics", "btn-open-logs"];
 
   function setStatus(message, isError) {
     if (!statusEl) return;
     statusEl.textContent = message || "";
     statusEl.className = "status" + (isError ? " error" : "");
+  }
+
+  function setAllButtonsDisabled(disabled) {
+    for (var i = 0; i < buttonIds.length; i++) {
+      var el = document.getElementById(buttonIds[i]);
+      if (el) el.disabled = disabled;
+    }
+  }
+
+  function runAsync(pendingMessage, promiseFactory, successMessage, failurePrefix) {
+    if (!api || !api.recovery) return;
+    setAllButtonsDisabled(true);
+    setStatus(pendingMessage, false);
+    promiseFactory()
+      .then(function (result) {
+        setStatus(
+          typeof successMessage === "function" ? successMessage(result) : successMessage,
+          false
+        );
+      })
+      .catch(function (err) {
+        var message = err && err.message ? err.message : String(err);
+        setStatus(failurePrefix + ": " + message, true);
+      })
+      .finally(function () {
+        setAllButtonsDisabled(false);
+      });
   }
 
   document.getElementById("btn-reload").addEventListener("click", function () {
@@ -35,42 +63,30 @@
   var exportBtn = document.getElementById("btn-export-diagnostics");
   if (exportBtn) {
     exportBtn.addEventListener("click", function () {
-      if (!api || !api.recovery) return;
-      exportBtn.disabled = true;
-      setStatus("Collecting diagnostics…", false);
-      api.recovery
-        .exportDiagnostics()
-        .then(function (saved) {
-          setStatus(saved ? "Diagnostics saved." : "Save cancelled.", false);
-        })
-        .catch(function (err) {
-          var message = err && err.message ? err.message : String(err);
-          setStatus("Failed to export diagnostics: " + message, true);
-        })
-        .finally(function () {
-          exportBtn.disabled = false;
-        });
+      runAsync(
+        "Collecting diagnostics…",
+        function () {
+          return api.recovery.exportDiagnostics();
+        },
+        function (saved) {
+          return saved ? "Diagnostics saved." : "Save cancelled.";
+        },
+        "Failed to export diagnostics"
+      );
     });
   }
 
   var openLogsBtn = document.getElementById("btn-open-logs");
   if (openLogsBtn) {
     openLogsBtn.addEventListener("click", function () {
-      if (!api || !api.recovery) return;
-      openLogsBtn.disabled = true;
-      setStatus("Opening logs…", false);
-      api.recovery
-        .openLogs()
-        .then(function () {
-          setStatus("Logs opened.", false);
-        })
-        .catch(function (err) {
-          var message = err && err.message ? err.message : String(err);
-          setStatus("Failed to open logs: " + message, true);
-        })
-        .finally(function () {
-          openLogsBtn.disabled = false;
-        });
+      runAsync(
+        "Opening logs…",
+        function () {
+          return api.recovery.openLogs();
+        },
+        "Logs opened.",
+        "Failed to open logs"
+      );
     });
   }
 })();

--- a/public/recovery.html
+++ b/public/recovery.html
@@ -89,6 +89,10 @@
       button:active {
         opacity: 0.8;
       }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
       .btn-primary {
         background: #3b82f6;
         color: #fff;
@@ -96,6 +100,15 @@
       .btn-secondary {
         background: #27272a;
         color: #e4e4e7;
+      }
+      .status {
+        margin-top: 12px;
+        font-size: 12px;
+        color: #a1a1aa;
+        min-height: 16px;
+      }
+      .status.error {
+        color: #f87171;
       }
     </style>
   </head>
@@ -118,8 +131,11 @@
       <div class="details" id="crash-details">Loading crash details…</div>
       <div class="actions">
         <button class="btn-primary" id="btn-reload">Reload Window</button>
+        <button class="btn-secondary" id="btn-export-diagnostics">Export Diagnostics</button>
+        <button class="btn-secondary" id="btn-open-logs">Open Logs</button>
         <button class="btn-secondary" id="btn-reset">Reset Workspace State</button>
       </div>
+      <div class="status" id="status" role="status" aria-live="polite"></div>
     </div>
     <script src="recovery-renderer.js"></script>
   </body>

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -994,6 +994,10 @@ export interface ElectronAPI {
     reloadApp(): Promise<void>;
     /** Reset workspace state and reload the main app from the recovery page */
     resetAndReload(): Promise<void>;
+    /** Export a diagnostics bundle via save dialog. Resolves true if saved, false if cancelled. */
+    exportDiagnostics(): Promise<boolean>;
+    /** Open the main log file with the OS default viewer */
+    openLogs(): Promise<void>;
   };
   notification: {
     /** Update window title and dock badge based on terminal attention state */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2114,6 +2114,14 @@ export interface IpcInvokeMap {
     args: [];
     result: void;
   };
+  "recovery:export-diagnostics": {
+    args: [];
+    result: boolean;
+  };
+  "recovery:open-logs": {
+    args: [];
+    result: void;
+  };
 
   // System prerequisite check channels
   "system:check-tool": {

--- a/shared/utils/__tests__/trustedRenderer.test.ts
+++ b/shared/utils/__tests__/trustedRenderer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { isTrustedRendererUrl, getTrustedOrigins } from "../trustedRenderer.js";
+import { isRecoveryPageUrl, isTrustedRendererUrl, getTrustedOrigins } from "../trustedRenderer.js";
 
 describe("trustedRenderer", () => {
   const originalNodeEnv = process.env.NODE_ENV;
@@ -101,6 +101,42 @@ describe("trustedRenderer", () => {
       expect(origins).toContain("app://daintree");
       expect(origins).toContain("http://localhost:5173");
       expect(origins).toContain("http://127.0.0.1:5173");
+    });
+  });
+
+  describe("isRecoveryPageUrl", () => {
+    it("accepts production recovery URL", () => {
+      expect(isRecoveryPageUrl("app://daintree/recovery.html")).toBe(true);
+    });
+
+    it("accepts dev recovery URLs on both localhost and 127.0.0.1", () => {
+      expect(isRecoveryPageUrl("http://localhost:5173/recovery.html")).toBe(true);
+      expect(isRecoveryPageUrl("http://127.0.0.1:5173/recovery.html")).toBe(true);
+    });
+
+    it("accepts recovery URL with query string", () => {
+      expect(isRecoveryPageUrl("app://daintree/recovery.html?reason=crash&exitCode=-1")).toBe(true);
+    });
+
+    it("rejects main index page URL", () => {
+      expect(isRecoveryPageUrl("app://daintree/index.html")).toBe(false);
+      expect(isRecoveryPageUrl("http://localhost:5173/index.html")).toBe(false);
+    });
+
+    it("rejects recovery.html on untrusted origin", () => {
+      expect(isRecoveryPageUrl("https://evil.com/recovery.html")).toBe(false);
+      expect(isRecoveryPageUrl("http://localhost:3000/recovery.html")).toBe(false);
+    });
+
+    it("rejects malformed URLs", () => {
+      expect(isRecoveryPageUrl("")).toBe(false);
+      expect(isRecoveryPageUrl("not-a-url")).toBe(false);
+    });
+
+    it("rejects recovery-like paths that are not /recovery.html", () => {
+      expect(isRecoveryPageUrl("app://daintree/recovery")).toBe(false);
+      expect(isRecoveryPageUrl("app://daintree/recovery.html/evil")).toBe(false);
+      expect(isRecoveryPageUrl("app://daintree/subdir/recovery.html")).toBe(false);
     });
   });
 });

--- a/shared/utils/__tests__/trustedRenderer.test.ts
+++ b/shared/utils/__tests__/trustedRenderer.test.ts
@@ -138,5 +138,12 @@ describe("trustedRenderer", () => {
       expect(isRecoveryPageUrl("app://daintree/recovery.html/evil")).toBe(false);
       expect(isRecoveryPageUrl("app://daintree/subdir/recovery.html")).toBe(false);
     });
+
+    it("rejects localhost recovery URLs in production mode", () => {
+      process.env.NODE_ENV = "production";
+      expect(isRecoveryPageUrl("http://localhost:5173/recovery.html")).toBe(false);
+      expect(isRecoveryPageUrl("http://127.0.0.1:5173/recovery.html")).toBe(false);
+      expect(isRecoveryPageUrl("app://daintree/recovery.html")).toBe(true);
+    });
   });
 });

--- a/shared/utils/trustedRenderer.ts
+++ b/shared/utils/trustedRenderer.ts
@@ -26,6 +26,16 @@ export function isTrustedRendererUrl(urlString: string): boolean {
   return trustedOrigins.includes(origin as any);
 }
 
+export function isRecoveryPageUrl(urlString: string): boolean {
+  if (!isTrustedRendererUrl(urlString)) return false;
+  try {
+    const url = new URL(urlString);
+    return url.pathname === "/recovery.html";
+  } catch {
+    return false;
+  }
+}
+
 export function getTrustedOrigins(): readonly string[] {
   return getTrustedRendererOrigins();
 }


### PR DESCRIPTION
## Summary

- Recovery page now has two working actions: export a diagnostic bundle and open the main log file in the OS viewer. These are the first things you need when the renderer has crash-looped and you're staring at a blank recovery screen.
- IPC handlers (`recovery:export-diagnostics`, `recovery:open-logs`) are registered on raw `ipcMain.handle` and validate `event.senderFrame.url` synchronously via a new `isRecoveryPageUrl` helper, so the main renderer can't reach them.
- Export reuses the existing `DiagnosticsCollector` pipeline, parents the save dialog to the correct `BrowserWindow`, and reveals the file in Finder/Explorer after saving. Open-logs mirrors the existing `logs.ts` pattern with an ENOENT create-and-open fallback.

Resolves #5387

## Changes

- `electron/ipc/handlers/recovery.ts` — two new IPC handlers with frame-URL auth
- `shared/utils/trustedRenderer.ts` — `isRecoveryPageUrl` helper
- `public/recovery.html` + `public/recovery-renderer.js` — two new buttons with in-flight disabled state and a live status region
- `electron/ipc/channels.ts`, `electron/preload.cts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts` — wiring
- 38 new unit tests across `recovery.handlers.test.ts` and `trustedRenderer.test.ts`

## Testing

Unit tests cover auth rejection (wrong URL, no frame), happy paths, user-cancelled save dialog, fs failures, ENOENT create-and-open fallback, and the edge case where every `openPath` attempt fails (should throw so the UI shows an error rather than false success).