### PR TITLE
feat(notes): paste and drop images/files into markdown editor

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -421,6 +421,8 @@ export const CHANNELS = {
   NOTES_DELETE: "notes:delete",
   NOTES_SEARCH: "notes:search",
   NOTES_UPDATED: "notes:updated",
+  NOTES_WRITE_ATTACHMENT: "notes:write-attachment",
+  NOTES_GET_DIR: "notes:get-dir",
 
   DEV_PREVIEW_ENSURE: "dev-preview:ensure",
   DEV_PREVIEW_RESTART: "dev-preview:restart",

--- a/electron/ipc/handlers/notes.ts
+++ b/electron/ipc/handlers/notes.ts
@@ -139,6 +139,23 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
   };
   handlers.push(typedHandle(CHANNELS.NOTES_SEARCH, handleNotesSearch));
 
+  const handleNotesWriteAttachment = async (
+    data: Uint8Array,
+    mimeType: string,
+    originalName?: string
+  ) => {
+    const service = getNotesService();
+    const buffer = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+    return await service.saveAttachment(buffer, mimeType, originalName);
+  };
+  handlers.push(typedHandle(CHANNELS.NOTES_WRITE_ATTACHMENT, handleNotesWriteAttachment));
+
+  const handleNotesGetDir = async () => {
+    const service = getNotesService();
+    return service.getDirPath();
+  };
+  handlers.push(typedHandle(CHANNELS.NOTES_GET_DIR, handleNotesGetDir));
+
   return () => {
     handlers.forEach((dispose) => dispose());
   };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -658,6 +658,8 @@ const CHANNELS = {
   NOTES_DELETE: "notes:delete",
   NOTES_SEARCH: "notes:search",
   NOTES_UPDATED: "notes:updated",
+  NOTES_WRITE_ATTACHMENT: "notes:write-attachment",
+  NOTES_GET_DIR: "notes:get-dir",
 
   // Dev Preview channels
   DEV_PREVIEW_ENSURE: "dev-preview:ensure",
@@ -2070,6 +2072,11 @@ const api: ElectronAPI = {
     delete: (notePath: string) => _unwrappingInvoke(CHANNELS.NOTES_DELETE, notePath),
 
     search: (query: string) => _unwrappingInvoke(CHANNELS.NOTES_SEARCH, query),
+
+    writeAttachment: (data: Uint8Array, mimeType: string, originalName?: string) =>
+      _unwrappingInvoke(CHANNELS.NOTES_WRITE_ATTACHMENT, data, mimeType, originalName),
+
+    getDir: () => _unwrappingInvoke(CHANNELS.NOTES_GET_DIR),
 
     onUpdated: (
       callback: (data: {

--- a/electron/services/NotesService.ts
+++ b/electron/services/NotesService.ts
@@ -1,9 +1,47 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 import { resilientAtomicWriteFile, resilientUnlink } from "../utils/fs.js";
 import matter from "gray-matter";
 import { nanoid } from "nanoid";
 import { normalizeTags } from "../../shared/utils/noteTags.js";
+
+export const NOTES_MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": ".png",
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/svg+xml": ".svg",
+  "image/bmp": ".bmp",
+  "image/x-icon": ".ico",
+  "application/pdf": ".pdf",
+  "text/plain": ".txt",
+  "text/markdown": ".md",
+  "application/json": ".json",
+  "application/zip": ".zip",
+};
+
+function sanitizeExtension(ext: string): string {
+  if (!ext) return "";
+  const lower = ext.toLowerCase();
+  const match = lower.match(/^\.[a-z0-9]{1,10}$/);
+  return match ? match[0] : "";
+}
+
+function deriveExtension(mimeType: string, originalName?: string): string {
+  const fromMime = MIME_TO_EXT[mimeType.toLowerCase()];
+  if (fromMime) return fromMime;
+
+  if (originalName) {
+    const ext = sanitizeExtension(path.extname(originalName));
+    if (ext) return ext;
+  }
+
+  return ".bin";
+}
 
 export interface NoteMetadata {
   id: string;
@@ -374,5 +412,47 @@ export class NotesService {
 
   getProjectId(): string {
     return this.projectId;
+  }
+
+  getDirPath(): string {
+    return this.getNotesDir();
+  }
+
+  getAttachmentsDir(): string {
+    return path.join(this.getNotesDir(), "attachments");
+  }
+
+  async saveAttachment(
+    data: Buffer,
+    mimeType: string,
+    originalName?: string
+  ): Promise<{ relativePath: string; isNew: boolean }> {
+    if (data.byteLength === 0) {
+      throw new Error("Attachment is empty");
+    }
+    if (data.byteLength > NOTES_MAX_ATTACHMENT_BYTES) {
+      throw new Error(
+        `Attachment too large (${data.byteLength} bytes, limit ${NOTES_MAX_ATTACHMENT_BYTES})`
+      );
+    }
+
+    const extension = deriveExtension(mimeType, originalName);
+    const hash = crypto.createHash("sha256").update(data).digest("hex");
+    const filename = `${hash}${extension}`;
+    const relativePath = `attachments/${filename}`;
+    const attachmentsDir = this.getAttachmentsDir();
+    const absolutePath = path.join(attachmentsDir, filename);
+
+    try {
+      await fs.access(absolutePath);
+      return { relativePath, isNew: false };
+    } catch {
+      // File doesn't exist — write it below
+    }
+
+    await fs.mkdir(attachmentsDir, { recursive: true });
+    await resilientAtomicWriteFile(absolutePath, data);
+
+    return { relativePath, isNew: true };
   }
 }

--- a/electron/services/__tests__/NotesService.test.ts
+++ b/electron/services/__tests__/NotesService.test.ts
@@ -201,4 +201,106 @@ describe("NotesService", () => {
     const raw = await fs.readFile(path.join(userDataDir, "notes", projectId, "no-tags.md"), "utf8");
     expect(raw).not.toContain("tags:");
   });
+
+  describe("saveAttachment", () => {
+    it("writes an attachment with a sha256 content-addressed filename", async () => {
+      const data = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const result = await service.saveAttachment(data, "image/png", "clipboard.png");
+
+      expect(result.relativePath).toMatch(/^attachments\/[0-9a-f]{64}\.png$/);
+      expect(result.isNew).toBe(true);
+
+      const absolutePath = path.join(userDataDir, "notes", projectId, result.relativePath);
+      const written = await fs.readFile(absolutePath);
+      expect(written.equals(data)).toBe(true);
+    });
+
+    it("dedups identical bytes and returns the same relative path", async () => {
+      const data = Buffer.from("hello attachment");
+      const first = await service.saveAttachment(data, "image/png");
+      const second = await service.saveAttachment(data, "image/png");
+
+      expect(second.relativePath).toBe(first.relativePath);
+      expect(first.isNew).toBe(true);
+      expect(second.isNew).toBe(false);
+
+      const attachmentsDir = path.join(userDataDir, "notes", projectId, "attachments");
+      const files = await fs.readdir(attachmentsDir);
+      expect(files.length).toBe(1);
+    });
+
+    it("produces different paths for different bytes", async () => {
+      const first = await service.saveAttachment(Buffer.from("alpha"), "image/png");
+      const second = await service.saveAttachment(Buffer.from("beta"), "image/png");
+      expect(second.relativePath).not.toBe(first.relativePath);
+    });
+
+    it("maps MIME types to correct extensions", async () => {
+      const png = await service.saveAttachment(Buffer.from("a"), "image/png");
+      const jpeg = await service.saveAttachment(Buffer.from("b"), "image/jpeg");
+      const webp = await service.saveAttachment(Buffer.from("c"), "image/webp");
+      const svg = await service.saveAttachment(Buffer.from("d"), "image/svg+xml");
+      const gif = await service.saveAttachment(Buffer.from("e"), "image/gif");
+
+      expect(png.relativePath.endsWith(".png")).toBe(true);
+      expect(jpeg.relativePath.endsWith(".jpg")).toBe(true);
+      expect(webp.relativePath.endsWith(".webp")).toBe(true);
+      expect(svg.relativePath.endsWith(".svg")).toBe(true);
+      expect(gif.relativePath.endsWith(".gif")).toBe(true);
+    });
+
+    it("falls back to original filename extension for unknown MIME types", async () => {
+      const result = await service.saveAttachment(
+        Buffer.from("pdf body"),
+        "application/x-unknown",
+        "spec.pdf"
+      );
+      expect(result.relativePath.endsWith(".pdf")).toBe(true);
+    });
+
+    it("uses .bin when MIME and filename are both unknown", async () => {
+      const result = await service.saveAttachment(Buffer.from("mystery"), "application/x-unknown");
+      expect(result.relativePath.endsWith(".bin")).toBe(true);
+    });
+
+    it("rejects empty buffers", async () => {
+      await expect(service.saveAttachment(Buffer.alloc(0), "image/png")).rejects.toThrow(
+        "Attachment is empty"
+      );
+    });
+
+    it("rejects attachments that exceed the size limit", async () => {
+      const oversized = Buffer.alloc(51 * 1024 * 1024);
+      await expect(service.saveAttachment(oversized, "image/png")).rejects.toThrow(
+        /Attachment too large/
+      );
+    });
+
+    it("creates the attachments directory on first call", async () => {
+      const attachmentsDir = path.join(userDataDir, "notes", projectId, "attachments");
+      await expect(fs.access(attachmentsDir)).rejects.toBeDefined();
+
+      await service.saveAttachment(Buffer.from("hello"), "image/png");
+      await expect(fs.access(attachmentsDir)).resolves.toBeUndefined();
+    });
+
+    it("rejects path-traversal attempts via malicious originalName extensions", async () => {
+      // Extensions must not contain slashes or dots
+      const result = await service.saveAttachment(
+        Buffer.from("payload"),
+        "application/x-unknown",
+        "../../escape.weird"
+      );
+      // Should accept the extension but sanitize to safe form
+      expect(result.relativePath.startsWith("attachments/")).toBe(true);
+      expect(result.relativePath.includes("..")).toBe(false);
+    });
+  });
+
+  describe("getDirPath", () => {
+    it("returns the absolute notes directory for the project", () => {
+      const dir = service.getDirPath();
+      expect(dir).toBe(path.join(userDataDir, "notes", projectId));
+    });
+  });
 });

--- a/electron/utils/fs.ts
+++ b/electron/utils/fs.ts
@@ -49,18 +49,20 @@ function generateTempPath(filePath: string): string {
 /**
  * Atomic writeFile: writes to a temp file with flush, then renames to the
  * target path. If any step fails the temp file is cleaned up best-effort.
+ * Accepts strings (encoded with `encoding`) or binary buffers.
  */
 export async function resilientAtomicWriteFile(
   filePath: string,
-  data: string,
+  data: string | Buffer | Uint8Array,
   encoding: BufferEncoding = "utf-8"
 ): Promise<void> {
   const tempPath = generateTempPath(filePath);
+  const writeOptions =
+    typeof data === "string"
+      ? ({ encoding, flush: true } as Parameters<typeof writeFileSync>[2])
+      : ({ flush: true } as Parameters<typeof writeFileSync>[2]);
   try {
-    await stubbornFs.retry.writeFile({ timeout: RETRY_TIMEOUT_MS })(tempPath, data, {
-      encoding,
-      flush: true,
-    } as Parameters<typeof writeFileSync>[2]);
+    await stubbornFs.retry.writeFile({ timeout: RETRY_TIMEOUT_MS })(tempPath, data, writeOptions);
     await resilientRename(tempPath, filePath);
   } catch (error) {
     fsUnlink(tempPath).catch(() => {});

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -734,6 +734,12 @@ export interface ElectronAPI {
       }>;
       query: string;
     }>;
+    writeAttachment(
+      data: Uint8Array,
+      mimeType: string,
+      originalName?: string
+    ): Promise<{ relativePath: string; isNew: boolean }>;
+    getDir(): Promise<string>;
     onUpdated(
       callback: (data: {
         notePath: string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1356,6 +1356,14 @@ export interface IpcInvokeMap {
       query: string;
     };
   };
+  "notes:write-attachment": {
+    args: [data: Uint8Array, mimeType: string, originalName?: string];
+    result: { relativePath: string; isNew: boolean };
+  };
+  "notes:get-dir": {
+    args: [];
+    result: string;
+  };
 
   // Plugin channels
   "plugin:list": {

--- a/src/clients/notesClient.ts
+++ b/src/clients/notesClient.ts
@@ -44,6 +44,11 @@ export interface WriteResult {
   currentLastModified?: number;
 }
 
+export interface SaveAttachmentResult {
+  relativePath: string;
+  isNew: boolean;
+}
+
 export const notesClient = {
   create: (
     title: string,
@@ -76,6 +81,18 @@ export const notesClient = {
 
   search: (query: string): Promise<SearchResult> => {
     return window.electron.notes.search(query);
+  },
+
+  saveAttachment: (
+    data: Uint8Array,
+    mimeType: string,
+    originalName?: string
+  ): Promise<SaveAttachmentResult> => {
+    return window.electron.notes.writeAttachment(data, mimeType, originalName);
+  },
+
+  getDir: (): Promise<string> => {
+    return window.electron.notes.getDir();
   },
 
   onUpdated: (callback: (payload: NoteUpdatedPayload) => void): (() => void) => {

--- a/src/components/Notes/MarkdownPreview.tsx
+++ b/src/components/Notes/MarkdownPreview.tsx
@@ -15,8 +15,17 @@ const ATTACHMENT_PREFIX = "attachments/";
 
 function buildUrlTransform(notesDir: string | null | undefined): (url: string) => string {
   return (url: string) => {
-    if (url && notesDir && url.startsWith(ATTACHMENT_PREFIX) && !url.includes("..")) {
-      const decoded = decodeURIComponent(url);
+    if (url && notesDir && url.startsWith(ATTACHMENT_PREFIX)) {
+      let decoded: string;
+      try {
+        decoded = decodeURIComponent(url);
+      } catch {
+        return defaultUrlTransform(url);
+      }
+      // Reject any traversal segment — raw or percent-encoded — after decode.
+      if (decoded.includes("..") || decoded.includes("\0")) {
+        return defaultUrlTransform(url);
+      }
       const sep = notesDir.endsWith("/") || notesDir.endsWith("\\") ? "" : "/";
       const absolutePath = `${notesDir}${sep}${decoded}`;
       return `daintree-file://daintree/?path=${encodeURIComponent(absolutePath)}&root=${encodeURIComponent(notesDir)}`;

--- a/src/components/Notes/MarkdownPreview.tsx
+++ b/src/components/Notes/MarkdownPreview.tsx
@@ -1,5 +1,5 @@
-import { forwardRef } from "react";
-import ReactMarkdown from "react-markdown";
+import { forwardRef, useMemo } from "react";
+import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
 import { cn } from "@/lib/utils";
@@ -7,10 +7,28 @@ import { cn } from "@/lib/utils";
 interface MarkdownPreviewProps {
   content: string;
   className?: string;
+  /** Absolute path to the notes directory for this project — used to serve attachment URLs via daintree-file://. */
+  notesDir?: string | null;
+}
+
+const ATTACHMENT_PREFIX = "attachments/";
+
+function buildUrlTransform(notesDir: string | null | undefined): (url: string) => string {
+  return (url: string) => {
+    if (url && notesDir && url.startsWith(ATTACHMENT_PREFIX) && !url.includes("..")) {
+      const decoded = decodeURIComponent(url);
+      const sep = notesDir.endsWith("/") || notesDir.endsWith("\\") ? "" : "/";
+      const absolutePath = `${notesDir}${sep}${decoded}`;
+      return `daintree-file://daintree/?path=${encodeURIComponent(absolutePath)}&root=${encodeURIComponent(notesDir)}`;
+    }
+    return defaultUrlTransform(url);
+  };
 }
 
 export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
-  ({ content, className }, ref) => {
+  ({ content, className, notesDir }, ref) => {
+    const urlTransform = useMemo(() => buildUrlTransform(notesDir), [notesDir]);
+
     return (
       <div
         ref={ref}
@@ -22,6 +40,7 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[[rehypeHighlight, { detect: true }]]}
+          urlTransform={urlTransform}
           components={{
             a({ href, children }) {
               return (
@@ -29,8 +48,21 @@ export const MarkdownPreview = forwardRef<HTMLDivElement, MarkdownPreviewProps>(
                   href={href}
                   onClick={(e) => {
                     e.preventDefault();
-                    if (href && /^https?:\/\/|^mailto:/i.test(href)) {
+                    if (!href) return;
+                    if (/^https?:\/\/|^mailto:/i.test(href)) {
                       window.electron.system.openExternal(href);
+                      return;
+                    }
+                    if (href.startsWith("daintree-file://")) {
+                      try {
+                        const parsed = new URL(href);
+                        const filePath = parsed.searchParams.get("path");
+                        if (filePath) {
+                          window.electron.system.openPath(filePath);
+                        }
+                      } catch {
+                        // Ignore malformed daintree-file URLs
+                      }
                     }
                   }}
                 >

--- a/src/components/Notes/NotesPane.tsx
+++ b/src/components/Notes/NotesPane.tsx
@@ -115,6 +115,11 @@ export function NotesPane({
     const view = editorViewRef.current;
     if (!view || items.length === 0) return;
 
+    // Capture the insertion point synchronously, before any async work — the
+    // cursor may move during upload and we want the snippet where the paste
+    // happened.
+    const { from, to } = view.state.selection.main;
+
     const notify = useNotificationStore.getState().addNotification;
 
     const snippets = await Promise.all(
@@ -146,10 +151,12 @@ export function NotesPane({
     const currentView = editorViewRef.current;
     if (!currentView) return;
 
-    const { from, to } = currentView.state.selection.main;
+    const docLen = currentView.state.doc.length;
+    const safeFrom = Math.min(from, docLen);
+    const safeTo = Math.min(to, docLen);
     currentView.dispatch({
-      changes: { from, to, insert: text },
-      selection: { anchor: from + text.length },
+      changes: { from: safeFrom, to: safeTo, insert: text },
+      selection: { anchor: safeFrom + text.length },
       scrollIntoView: true,
     });
     currentView.focus();

--- a/src/components/Notes/NotesPane.tsx
+++ b/src/components/Notes/NotesPane.tsx
@@ -24,6 +24,13 @@ import { notesTypographyExtension } from "./codeBlockExtension";
 import { MarkdownPreview } from "./MarkdownPreview";
 import { MarkdownToolbar } from "./MarkdownToolbar";
 import { useNoteVoiceInput } from "./useNoteVoiceInput";
+import {
+  buildAttachmentExtension,
+  buildMarkdownSnippet,
+  NOTES_MAX_ATTACHMENT_BYTES,
+  type AttachItem,
+} from "./attachmentExtension";
+import { useNotificationStore } from "@/store/notificationStore";
 
 export interface NotesPaneProps extends BasePanelProps {
   notePath: string;
@@ -70,6 +77,11 @@ export function NotesPane({
   const editorViewRef = useRef<EditorView | null>(null);
   const previewRef = useRef<HTMLDivElement>(null);
   const isSyncingRef = useRef(false);
+  const attachHandlerRef = useRef<(items: AttachItem[]) => void>(() => {});
+  const attachRejectedRef = useRef<(items: AttachItem[], reason: "oversize" | "empty") => void>(
+    () => {}
+  );
+  const [notesDir, setNotesDir] = useState<string | null>(null);
 
   const currentProject = useProjectStore((s) => s.currentProject);
   const panelWorktree = useWorktreeStore((s) =>
@@ -83,6 +95,92 @@ export function NotesPane({
       editorViewRef.current = null;
     }
   }, [viewMode]);
+
+  useEffect(() => {
+    let cancelled = false;
+    notesClient
+      .getDir()
+      .then((dir) => {
+        if (!cancelled) setNotesDir(dir);
+      })
+      .catch((e) => {
+        console.error("Failed to resolve notes directory:", e);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleAttach = useCallback(async (items: AttachItem[]) => {
+    const view = editorViewRef.current;
+    if (!view || items.length === 0) return;
+
+    const notify = useNotificationStore.getState().addNotification;
+
+    const snippets = await Promise.all(
+      items.map(async (item) => {
+        try {
+          const buffer = await item.file.arrayBuffer();
+          const data = new Uint8Array(buffer);
+          const { relativePath } = await notesClient.saveAttachment(
+            data,
+            item.mimeType,
+            item.originalName
+          );
+          return buildMarkdownSnippet(item, relativePath);
+        } catch (err) {
+          console.error("Failed to save attachment:", err);
+          notify({
+            type: "error",
+            priority: "high",
+            message: `Failed to attach "${item.originalName}": ${err instanceof Error ? err.message : String(err)}`,
+          });
+          return null;
+        }
+      })
+    );
+
+    const text = snippets.filter((s): s is string => s !== null).join("\n\n");
+    if (!text) return;
+
+    const currentView = editorViewRef.current;
+    if (!currentView) return;
+
+    const { from, to } = currentView.state.selection.main;
+    currentView.dispatch({
+      changes: { from, to, insert: text },
+      selection: { anchor: from + text.length },
+      scrollIntoView: true,
+    });
+    currentView.focus();
+  }, []);
+
+  const handleAttachRejected = useCallback((items: AttachItem[], reason: "oversize" | "empty") => {
+    const notify = useNotificationStore.getState().addNotification;
+    const names = items.map((i) => i.originalName || "file").join(", ");
+    if (reason === "empty") {
+      notify({
+        type: "warning",
+        priority: "high",
+        message: `Skipped empty file${items.length === 1 ? "" : "s"}: ${names}`,
+      });
+    } else {
+      const limitMb = Math.round(NOTES_MAX_ATTACHMENT_BYTES / (1024 * 1024));
+      notify({
+        type: "error",
+        priority: "high",
+        message: `Attachment${items.length === 1 ? "" : "s"} exceed ${limitMb} MB limit: ${names}`,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    attachHandlerRef.current = handleAttach;
+  }, [handleAttach]);
+
+  useEffect(() => {
+    attachRejectedRef.current = handleAttachRejected;
+  }, [handleAttachRejected]);
 
   useEffect(() => {
     let cancelled = false;
@@ -328,6 +426,10 @@ export function NotesPane({
       EditorView.lineWrapping,
       notesTypographyExtension(),
       EditorView.theme({ ".cm-content": { paddingBottom: "52px" } }),
+      buildAttachmentExtension({
+        onAttach: (items) => attachHandlerRef.current(items),
+        onRejected: (items, reason) => attachRejectedRef.current(items, reason),
+      }),
     ],
     []
   );
@@ -380,7 +482,7 @@ export function NotesPane({
           )}
 
           {viewMode === "preview" ? (
-            <MarkdownPreview content={content} className="flex-1" />
+            <MarkdownPreview content={content} notesDir={notesDir} className="flex-1" />
           ) : viewMode === "split" ? (
             <div className="flex flex-1 min-h-0 overflow-hidden">
               <div className="flex-1 flex flex-col min-h-0 border-r border-daintree-border">
@@ -424,7 +526,12 @@ export function NotesPane({
                   )}
                 </div>
               </div>
-              <MarkdownPreview ref={previewRef} content={content} className="flex-1" />
+              <MarkdownPreview
+                ref={previewRef}
+                content={content}
+                notesDir={notesDir}
+                className="flex-1"
+              />
             </div>
           ) : (
             <div className="flex-1 flex flex-col min-h-0">

--- a/src/components/Notes/__tests__/MarkdownPreview.test.tsx
+++ b/src/components/Notes/__tests__/MarkdownPreview.test.tsx
@@ -121,5 +121,27 @@ describe("MarkdownPreview", () => {
       // Should NOT contain daintree-file:// since we reject .. paths
       expect(img!.getAttribute("src")).not.toContain("daintree-file://");
     });
+
+    it("does not rewrite percent-encoded parent traversal to daintree-file://", () => {
+      const { container } = render(
+        <MarkdownPreview
+          content="![evil](attachments/%2e%2e/secret.md)"
+          notesDir="/Users/me/notes/p1"
+        />
+      );
+      const img = container.querySelector("img");
+      expect(img!.getAttribute("src")).not.toContain("daintree-file://");
+    });
+
+    it("does not throw on malformed percent-encoding in attachment URLs", () => {
+      expect(() =>
+        render(
+          <MarkdownPreview
+            content="![bad](attachments/%E0%A4%A.png)"
+            notesDir="/Users/me/notes/p1"
+          />
+        )
+      ).not.toThrow();
+    });
   });
 });

--- a/src/components/Notes/__tests__/MarkdownPreview.test.tsx
+++ b/src/components/Notes/__tests__/MarkdownPreview.test.tsx
@@ -4,12 +4,13 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { MarkdownPreview } from "../MarkdownPreview";
 
 const mockOpenExternal = vi.fn();
+const mockOpenPath = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
   Object.defineProperty(window, "electron", {
     value: {
-      system: { openExternal: mockOpenExternal },
+      system: { openExternal: mockOpenExternal, openPath: mockOpenPath },
     },
     writable: true,
     configurable: true,
@@ -63,5 +64,62 @@ describe("MarkdownPreview", () => {
     const ref = vi.fn();
     render(<MarkdownPreview ref={ref} content="text" />);
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+
+  describe("attachment URL rewriting", () => {
+    it("rewrites attachments/ image URLs to daintree-file:// when notesDir is provided", () => {
+      const { container } = render(
+        <MarkdownPreview content="![shot](attachments/abc.png)" notesDir="/Users/me/notes/p1" />
+      );
+      const img = container.querySelector("img");
+      expect(img).toBeTruthy();
+      expect(img!.getAttribute("src")).toContain("daintree-file://");
+      expect(img!.getAttribute("src")).toContain(
+        encodeURIComponent("/Users/me/notes/p1/attachments/abc.png")
+      );
+      expect(img!.getAttribute("src")).toContain(
+        `root=${encodeURIComponent("/Users/me/notes/p1")}`
+      );
+    });
+
+    it("leaves attachment URLs unchanged when notesDir is absent", () => {
+      const { container } = render(<MarkdownPreview content="![shot](attachments/abc.png)" />);
+      const img = container.querySelector("img");
+      expect(img).toBeTruthy();
+      expect(img!.getAttribute("src")).not.toContain("daintree-file://");
+    });
+
+    it("rewrites attachment link URLs and opens via openPath on click", () => {
+      render(
+        <MarkdownPreview content="[spec](attachments/xyz.pdf)" notesDir="/Users/me/notes/p1" />
+      );
+      const link = screen.getByText("spec");
+      fireEvent.click(link);
+      expect(mockOpenPath).toHaveBeenCalledWith("/Users/me/notes/p1/attachments/xyz.pdf");
+      expect(mockOpenExternal).not.toHaveBeenCalled();
+    });
+
+    it("does not rewrite http/https URLs in attachments prefix check", () => {
+      const { container } = render(
+        <MarkdownPreview
+          content="![ok](https://example.com/img.png)"
+          notesDir="/Users/me/notes/p1"
+        />
+      );
+      const img = container.querySelector("img");
+      expect(img!.getAttribute("src")).toBe("https://example.com/img.png");
+    });
+
+    it("ignores URLs containing .. as a defensive guard", () => {
+      const { container } = render(
+        <MarkdownPreview
+          content="![evil](attachments/../escape.png)"
+          notesDir="/Users/me/notes/p1"
+        />
+      );
+      const img = container.querySelector("img");
+      // Should NOT contain daintree-file:// since we reject .. paths
+      expect(img!.getAttribute("src")).not.toContain("daintree-file://");
+    });
   });
 });

--- a/src/components/Notes/__tests__/attachmentExtension.test.ts
+++ b/src/components/Notes/__tests__/attachmentExtension.test.ts
@@ -175,6 +175,19 @@ describe("buildMarkdownSnippet", () => {
     expect(snippet.includes("\n")).toBe(false);
     expect(snippet.includes("]")).toBe(snippet.endsWith(")"));
   });
+
+  it("escapes opening brackets in link labels", () => {
+    const snippet = buildMarkdownSnippet(
+      { mimeType: "application/pdf", originalName: "spec[final].pdf" },
+      "attachments/x.pdf"
+    );
+    // Must be a valid CommonMark link: no unescaped [ or ] inside the label.
+    const labelMatch = snippet.match(/^\[(.*)\]\(/);
+    expect(labelMatch).not.toBeNull();
+    const label = labelMatch![1]!;
+    expect(label.includes("[")).toBe(false);
+    expect(label.includes("]")).toBe(false);
+  });
 });
 
 describe("isImageMime", () => {

--- a/src/components/Notes/__tests__/attachmentExtension.test.ts
+++ b/src/components/Notes/__tests__/attachmentExtension.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import {
+  buildAttachmentExtension,
+  buildMarkdownSnippet,
+  isImageMime,
+  NOTES_MAX_ATTACHMENT_BYTES,
+  type AttachItem,
+} from "../attachmentExtension";
+
+function makeView(extensions: ReturnType<typeof buildAttachmentExtension>[]) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const state = EditorState.create({ extensions });
+  return new EditorView({ state, parent: container });
+}
+
+function makeFile(content: string | Uint8Array, name = "f.png", type = "image/png"): File {
+  const parts: BlobPart[] =
+    typeof content === "string" ? [content] : [new Blob([content as BlobPart])];
+  return new File(parts, name, { type });
+}
+
+describe("buildAttachmentExtension", () => {
+  it("handles paste with image items and calls onAttach", () => {
+    const onAttach = vi.fn<(items: AttachItem[]) => void>();
+    const view = makeView([buildAttachmentExtension({ onAttach })]);
+
+    const file = makeFile("png-bytes", "shot.png", "image/png");
+    const clipboardData = {
+      items: [
+        {
+          kind: "file",
+          type: "image/png",
+          getAsFile: () => file,
+        },
+      ] as unknown as DataTransferItemList,
+    } as DataTransfer;
+
+    const event = new Event("paste") as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", { value: clipboardData });
+
+    view.contentDOM.dispatchEvent(event);
+
+    expect(onAttach).toHaveBeenCalledTimes(1);
+    const args = onAttach.mock.calls[0]![0];
+    expect(args.length).toBe(1);
+    expect(args[0]!.mimeType).toBe("image/png");
+    expect(args[0]!.originalName).toBe("shot.png");
+    view.destroy();
+  });
+
+  it("does not call onAttach when paste contains only text", () => {
+    const onAttach = vi.fn();
+    const view = makeView([buildAttachmentExtension({ onAttach })]);
+
+    const clipboardData = {
+      items: [
+        {
+          kind: "string",
+          type: "text/plain",
+          getAsFile: () => null,
+        },
+      ] as unknown as DataTransferItemList,
+      getData: () => "",
+      types: ["text/plain"],
+    } as unknown as DataTransfer;
+
+    const event = new Event("paste", { cancelable: true }) as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", { value: clipboardData });
+    view.contentDOM.dispatchEvent(event);
+
+    expect(onAttach).not.toHaveBeenCalled();
+    view.destroy();
+  });
+
+  it("rejects oversized files via onRejected", () => {
+    const onAttach = vi.fn();
+    const onRejected = vi.fn();
+    const view = makeView([buildAttachmentExtension({ onAttach, onRejected })]);
+
+    const bigFile = makeFile(new Uint8Array(1), "huge.png", "image/png");
+    Object.defineProperty(bigFile, "size", { value: NOTES_MAX_ATTACHMENT_BYTES + 1 });
+    const clipboardData = {
+      items: [
+        {
+          kind: "file",
+          type: "image/png",
+          getAsFile: () => bigFile,
+        },
+      ] as unknown as DataTransferItemList,
+    } as DataTransfer;
+
+    const event = new Event("paste") as ClipboardEvent;
+    Object.defineProperty(event, "clipboardData", { value: clipboardData });
+    view.contentDOM.dispatchEvent(event);
+
+    expect(onAttach).not.toHaveBeenCalled();
+    expect(onRejected).toHaveBeenCalledTimes(1);
+    expect(onRejected.mock.calls[0]![1]).toBe("oversize");
+    view.destroy();
+  });
+
+  it("collects dropped files in original order", () => {
+    const onAttach = vi.fn<(items: AttachItem[]) => void>();
+    const view = makeView([buildAttachmentExtension({ onAttach })]);
+
+    const files = [
+      makeFile("a", "one.png", "image/png"),
+      makeFile("bb", "two.pdf", "application/pdf"),
+    ];
+
+    const dataTransfer = {
+      files: Object.assign(files, {
+        item: (i: number) => files[i] ?? null,
+        length: files.length,
+      }) as unknown as FileList,
+      types: ["Files"],
+    } as unknown as DataTransfer;
+
+    const event = new Event("drop") as DragEvent;
+    Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+    view.contentDOM.dispatchEvent(event);
+
+    expect(onAttach).toHaveBeenCalledTimes(1);
+    const items = onAttach.mock.calls[0]![0];
+    expect(items.length).toBe(2);
+    expect(items[0]!.originalName).toBe("one.png");
+    expect(items[1]!.originalName).toBe("two.pdf");
+    view.destroy();
+  });
+});
+
+describe("buildMarkdownSnippet", () => {
+  it("uses image syntax for image MIME types", () => {
+    const snippet = buildMarkdownSnippet(
+      { mimeType: "image/png", originalName: "screenshot.png" },
+      "attachments/abc.png"
+    );
+    expect(snippet).toBe("![screenshot](attachments/abc.png)");
+  });
+
+  it("uses link syntax for non-image MIME types", () => {
+    const snippet = buildMarkdownSnippet(
+      { mimeType: "application/pdf", originalName: "spec.pdf" },
+      "attachments/abc.pdf"
+    );
+    expect(snippet).toBe("[spec.pdf](attachments/abc.pdf)");
+  });
+
+  it("defaults to 'image' alt when filename has no base", () => {
+    const snippet = buildMarkdownSnippet(
+      { mimeType: "image/png", originalName: ".png" },
+      "attachments/x.png"
+    );
+    expect(snippet).toBe("![image](attachments/x.png)");
+  });
+
+  it("escapes whitespace in URLs", () => {
+    const snippet = buildMarkdownSnippet(
+      { mimeType: "image/png", originalName: "file name.png" },
+      "attachments/has space.png"
+    );
+    expect(snippet).toContain("%20");
+    expect(snippet).not.toContain("has space");
+  });
+
+  it("sanitizes newlines and brackets from alt text", () => {
+    const snippet = buildMarkdownSnippet(
+      { mimeType: "image/png", originalName: "bad\nname].png" },
+      "attachments/x.png"
+    );
+    expect(snippet.includes("\n")).toBe(false);
+    expect(snippet.includes("]")).toBe(snippet.endsWith(")"));
+  });
+});
+
+describe("isImageMime", () => {
+  it("detects image types", () => {
+    expect(isImageMime("image/png")).toBe(true);
+    expect(isImageMime("IMAGE/JPEG")).toBe(true);
+  });
+
+  it("rejects non-image types", () => {
+    expect(isImageMime("application/pdf")).toBe(false);
+    expect(isImageMime("text/plain")).toBe(false);
+  });
+});

--- a/src/components/Notes/attachmentExtension.ts
+++ b/src/components/Notes/attachmentExtension.ts
@@ -1,0 +1,129 @@
+import { Prec } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import type { Extension } from "@codemirror/state";
+
+export const NOTES_MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+
+export interface AttachItem {
+  file: File;
+  mimeType: string;
+  originalName: string;
+}
+
+function collectFromFiles(files: FileList | null): AttachItem[] {
+  const result: AttachItem[] = [];
+  if (!files) return result;
+  for (const file of Array.from(files)) {
+    result.push({
+      file,
+      mimeType: file.type || "application/octet-stream",
+      originalName: file.name || "file",
+    });
+  }
+  return result;
+}
+
+function collectFromDataTransferItems(items: DataTransferItemList | null): AttachItem[] {
+  const result: AttachItem[] = [];
+  if (!items) return result;
+  for (const item of Array.from(items)) {
+    if (item.kind !== "file") continue;
+    const file = item.getAsFile();
+    if (!file) continue;
+    result.push({
+      file,
+      mimeType: file.type || item.type || "application/octet-stream",
+      originalName: file.name || "file",
+    });
+  }
+  return result;
+}
+
+function partitionBySize(items: AttachItem[]): {
+  accepted: AttachItem[];
+  rejected: AttachItem[];
+} {
+  const accepted: AttachItem[] = [];
+  const rejected: AttachItem[] = [];
+  for (const item of items) {
+    if (item.file.size > NOTES_MAX_ATTACHMENT_BYTES || item.file.size === 0) {
+      rejected.push(item);
+    } else {
+      accepted.push(item);
+    }
+  }
+  return { accepted, rejected };
+}
+
+export interface AttachmentExtensionHandlers {
+  onAttach: (items: AttachItem[]) => void;
+  onRejected?: (items: AttachItem[], reason: "oversize" | "empty") => void;
+}
+
+export function buildAttachmentExtension({
+  onAttach,
+  onRejected,
+}: AttachmentExtensionHandlers): Extension {
+  return Prec.highest(
+    EditorView.domEventHandlers({
+      dragover(event) {
+        const types = event.dataTransfer?.types;
+        if (types && (types.includes("Files") || Array.from(types).includes("Files"))) {
+          return true;
+        }
+        return false;
+      },
+      drop(event) {
+        const files = collectFromFiles(event.dataTransfer?.files ?? null);
+        if (files.length === 0) return false;
+        const { accepted, rejected } = partitionBySize(files);
+        if (rejected.length > 0) {
+          onRejected?.(
+            rejected,
+            rejected.every((item) => item.file.size === 0) ? "empty" : "oversize"
+          );
+        }
+        if (accepted.length > 0) {
+          onAttach(accepted);
+        }
+        return true;
+      },
+      paste(event) {
+        const items = collectFromDataTransferItems(event.clipboardData?.items ?? null);
+        if (items.length === 0) return false;
+        const { accepted, rejected } = partitionBySize(items);
+        if (rejected.length > 0) {
+          onRejected?.(
+            rejected,
+            rejected.every((item) => item.file.size === 0) ? "empty" : "oversize"
+          );
+        }
+        if (accepted.length > 0) {
+          onAttach(accepted);
+        }
+        return true;
+      },
+    })
+  );
+}
+
+export function isImageMime(mimeType: string): boolean {
+  return mimeType.toLowerCase().startsWith("image/");
+}
+
+function sanitizeAltText(value: string): string {
+  return value.replace(/[\r\n\]]/g, " ").trim();
+}
+
+export function buildMarkdownSnippet(
+  item: { mimeType: string; originalName: string },
+  relativePath: string
+): string {
+  const safePath = relativePath.replace(/\s/g, "%20");
+  if (isImageMime(item.mimeType)) {
+    const alt = sanitizeAltText(item.originalName.replace(/\.[^.]+$/, "")) || "image";
+    return `![${alt}](${safePath})`;
+  }
+  const label = sanitizeAltText(item.originalName) || "attachment";
+  return `[${label}](${safePath})`;
+}

--- a/src/components/Notes/attachmentExtension.ts
+++ b/src/components/Notes/attachmentExtension.ts
@@ -78,10 +78,8 @@ export function buildAttachmentExtension({
         if (files.length === 0) return false;
         const { accepted, rejected } = partitionBySize(files);
         if (rejected.length > 0) {
-          onRejected?.(
-            rejected,
-            rejected.every((item) => item.file.size === 0) ? "empty" : "oversize"
-          );
+          const allEmpty = rejected.every((item) => item.file.size === 0);
+          onRejected?.(rejected, allEmpty ? "empty" : "oversize");
         }
         if (accepted.length > 0) {
           onAttach(accepted);
@@ -93,10 +91,8 @@ export function buildAttachmentExtension({
         if (items.length === 0) return false;
         const { accepted, rejected } = partitionBySize(items);
         if (rejected.length > 0) {
-          onRejected?.(
-            rejected,
-            rejected.every((item) => item.file.size === 0) ? "empty" : "oversize"
-          );
+          const allEmpty = rejected.every((item) => item.file.size === 0);
+          onRejected?.(rejected, allEmpty ? "empty" : "oversize");
         }
         if (accepted.length > 0) {
           onAttach(accepted);
@@ -112,7 +108,7 @@ export function isImageMime(mimeType: string): boolean {
 }
 
 function sanitizeAltText(value: string): string {
-  return value.replace(/[\r\n\]]/g, " ").trim();
+  return value.replace(/[\r\n[\]]/g, " ").trim();
 }
 
 export function buildMarkdownSnippet(


### PR DESCRIPTION
## Summary

- Intercepts clipboard paste and file drag-and-drop events in the CodeMirror editor, writing attachments to a content-addressed store under `.daintree/notes/<projectId>/attachments/` via a new `saveAttachment` IPC method on `NotesService`.
- Inserts standard markdown references at the cursor (`![alt](attachments/<sha256>.png)` for images, `[filename](attachments/<sha256>.ext)` for other files). Content-hash filenames mean re-pasting the same file is a no-op rather than creating duplicates.
- Rewrites relative attachment paths in `MarkdownPreview` through a safe URL transform so previews resolve correctly. The transform only handles the `attachments/` prefix and passes all other URLs through untouched, keeping it XSS-safe. Files over 50 MB are rejected with a toast notification.

Resolves #5367

## Changes

- `electron/services/NotesService.ts` — `saveAttachment` method: validates path, writes content-addressed file atomically, returns the relative markdown reference
- `electron/ipc/handlers/notes.ts` / `electron/ipc/channels.ts` — new `notes:saveAttachment` IPC channel
- `electron/preload.cts` / `src/clients/notesClient.ts` / `src/types/electron.d.ts` — bridge and types
- `shared/types/ipc/api.ts` / `shared/types/ipc/maps.ts` — IPC type definitions
- `src/components/Notes/attachmentExtension.ts` — CodeMirror extension handling paste and drop
- `src/components/Notes/NotesPane.tsx` — mounts the extension, wires up project ID and error toasts
- `src/components/Notes/MarkdownPreview.tsx` — URL rewriter for attachment paths in preview
- `electron/utils/fs.ts` — small `ensureDir` helper used by the attachment writer
- Full unit test coverage: `NotesService.test.ts`, `MarkdownPreview.test.tsx`, `attachmentExtension.test.ts`

## Testing

- Unit tests cover content-addressed deduplication, path traversal rejection, 50 MB size limit, markdown reference formatting for images vs arbitrary files, and the XSS-safe URL transform in preview.
- Manual: paste PNG screenshots and drag in PDF/zip files into a Notes panel — references appear at cursor and resolve correctly in preview mode.