### PR TITLE
fix(terminal): use xterm hover state for right-click URL detection

### DIFF
--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { isMac } from "@/lib/platform";
 import type React from "react";
-import type { Terminal as XTermTerminal } from "@xterm/xterm";
 import { type PanelLocation, type TerminalType } from "@/types";
 import { usePanelStore } from "@/store";
 import { useShallow } from "zustand/react/shallow";
@@ -59,36 +58,6 @@ import {
 } from "@/components/ui/context-menu";
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
-
-const URL_REGEX = /(?:https?|ftp):\/\/[^\s"'<>()[\]{}]+/g;
-
-export function extractUrlAtPoint(
-  terminal: XTermTerminal,
-  clientX: number,
-  clientY: number
-): string | null {
-  const el = terminal.element;
-  if (!el) return null;
-  const rect = el.getBoundingClientRect();
-  if (clientX < rect.left || clientX > rect.right || clientY < rect.top || clientY > rect.bottom)
-    return null;
-  const col = Math.floor(((clientX - rect.left) / rect.width) * terminal.cols);
-  const row = Math.floor(((clientY - rect.top) / rect.height) * terminal.rows);
-  if (row < 0 || row >= terminal.rows || col < 0 || col >= terminal.cols) return null;
-  const bufferRow = terminal.buffer.active.viewportY + row;
-  const line = terminal.buffer.active.getLine(bufferRow);
-  if (!line) return null;
-  const text = line.translateToString(true);
-  URL_REGEX.lastIndex = 0;
-  let match;
-  while ((match = URL_REGEX.exec(text)) !== null) {
-    const url = match[0].replace(/[.,;:!?'")\]]+$/, "");
-    if (col >= match.index && col < match.index + url.length) {
-      return url;
-    }
-  }
-  return null;
-}
 
 export interface CreateNoteArgs {
   title: string;
@@ -170,7 +139,7 @@ export function TerminalContextMenu({
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
 
   const handleContextMenu = useCallback(
-    (e: React.MouseEvent) => {
+    (_e: React.MouseEvent) => {
       const managed = terminalInstanceService.get(terminalId);
       if (!managed?.terminal) {
         setHasSelection(false);
@@ -180,7 +149,7 @@ export function TerminalContextMenu({
       const selection = managed.terminal.getSelection();
       setHasSelection(!!selection);
       setSelectionText(selection);
-      setHoveredUrl(extractUrlAtPoint(managed.terminal, e.clientX, e.clientY));
+      setHoveredUrl(terminalInstanceService.getHoveredLinkText(terminalId));
     },
     [terminalId]
   );
@@ -196,9 +165,8 @@ export function TerminalContextMenu({
     (actionId: string) => {
       if (!terminal) return;
 
-      if (actionId.startsWith("open-link:")) {
-        const url = actionId.slice("open-link:".length);
-        void actionService.dispatch("system.openExternal", { url }, { source: "context-menu" });
+      if (actionId === "open-link") {
+        terminalInstanceService.openHoveredLink(terminalId);
         return;
       }
 
@@ -698,7 +666,7 @@ export function TerminalContextMenu({
             {hoveredUrl && (
               <>
                 <ContextMenuSeparator />
-                <ContextMenuItem onSelect={() => handleAction(`open-link:${hoveredUrl}`)}>
+                <ContextMenuItem onSelect={() => handleAction("open-link")}>
                   <ExternalLink className={ICON_CLASS} aria-hidden="true" />
                   Open Link
                 </ContextMenuItem>

--- a/src/components/Terminal/__tests__/TerminalContextMenu.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalContextMenu.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { AGENT_IDS, getAgentConfig } from "@/config/agents";
 import type { CliAvailability } from "@shared/types";
 import type { MenuItemOption } from "@shared/types";
-import { extractUrlAtPoint, buildCreateNoteArgs } from "../TerminalContextMenu";
+import { buildCreateNoteArgs } from "../TerminalContextMenu";
 import { computeGridSelectedAgentIds } from "../contentGridAgentFilter";
 
 describe("TerminalContextMenu - Convert To Submenu", () => {
@@ -281,97 +281,6 @@ describe("TerminalContextMenu - Convert To Submenu", () => {
       expect(firstAgent).toBeDefined();
       expect(secondAgent).toBeDefined();
     });
-  });
-});
-
-describe("extractUrlAtPoint", () => {
-  function makeMockTerminal(opts: {
-    text: string;
-    cols?: number;
-    rows?: number;
-    rect?: { left: number; top: number; width: number; height: number };
-    elementNull?: boolean;
-    viewportY?: number;
-  }) {
-    const cols = opts.cols ?? 80;
-    const rows = opts.rows ?? 24;
-    const rect = opts.rect ?? { left: 0, top: 0, width: 800, height: 480, right: 800, bottom: 480 };
-    return {
-      element: opts.elementNull
-        ? undefined
-        : {
-            getBoundingClientRect: () => ({
-              ...rect,
-              right: rect.left + rect.width,
-              bottom: rect.top + rect.height,
-            }),
-          },
-      cols,
-      rows,
-      buffer: {
-        active: {
-          viewportY: opts.viewportY ?? 0,
-          getLine: () => ({
-            translateToString: () => opts.text,
-          }),
-        },
-      },
-    } as never;
-  }
-
-  it("returns URL when click lands on a URL in the line", () => {
-    const text = "Visit https://example.com for more info";
-    const terminal = makeMockTerminal({
-      text,
-      cols: 80,
-      rows: 24,
-      rect: { left: 0, top: 0, width: 800, height: 480 },
-    });
-    // "https://example.com" starts at index 6, length 19
-    // col 6 = clientX = (6/80)*800 + some offset to land in the cell
-    const clientX = (6.5 / 80) * 800;
-    const clientY = (0.5 / 24) * 480;
-    expect(extractUrlAtPoint(terminal, clientX, clientY)).toBe("https://example.com");
-  });
-
-  it("returns null when click is outside the URL", () => {
-    const text = "Visit https://example.com for more info";
-    const terminal = makeMockTerminal({ text });
-    const clientX = (0.5 / 80) * 800;
-    const clientY = (0.5 / 24) * 480;
-    expect(extractUrlAtPoint(terminal, clientX, clientY)).toBeNull();
-  });
-
-  it("strips trailing punctuation from matched URL", () => {
-    const text = "See https://example.com/path.";
-    const terminal = makeMockTerminal({ text });
-    // URL starts at index 4, "https://example.com/path." -> stripped to "https://example.com/path"
-    const clientX = (10.5 / 80) * 800;
-    const clientY = (0.5 / 24) * 480;
-    expect(extractUrlAtPoint(terminal, clientX, clientY)).toBe("https://example.com/path");
-  });
-
-  it("returns null when no URL on line", () => {
-    const text = "just some plain text here";
-    const terminal = makeMockTerminal({ text });
-    const clientX = (5.5 / 80) * 800;
-    const clientY = (0.5 / 24) * 480;
-    expect(extractUrlAtPoint(terminal, clientX, clientY)).toBeNull();
-  });
-
-  it("returns null when terminal.element is null/undefined", () => {
-    const terminal = makeMockTerminal({ text: "https://example.com", elementNull: true });
-    expect(extractUrlAtPoint(terminal, 100, 100)).toBeNull();
-  });
-
-  it("returns null when click is outside terminal element bounds", () => {
-    const text = "https://example.com";
-    const terminal = makeMockTerminal({
-      text,
-      rect: { left: 100, top: 100, width: 800, height: 480 },
-    });
-    // Click at (50, 50) which is outside the rect starting at (100, 100)
-    expect(extractUrlAtPoint(terminal, 50, 50)).toBeNull();
   });
 });
 

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -14,13 +14,17 @@ const FILE_PATH_REGEX =
 
 const WINDOWS_ABS = /^(?:[a-zA-Z]:[\\/]|\\\\)/;
 
+export type HoverCallback = (link: ILink | null) => void;
+
 export class FileLinksAddon implements ILinkProvider {
   private _terminal: Terminal;
   private _getCwd: () => string;
+  private _onHover?: HoverCallback;
 
-  constructor(terminal: Terminal, getCwd: () => string) {
+  constructor(terminal: Terminal, getCwd: () => string, onHover?: HoverCallback) {
     this._terminal = terminal;
     this._getCwd = getCwd;
+    this._onHover = onHover;
   }
 
   provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
@@ -65,7 +69,8 @@ export class FileLinksAddon implements ILinkProvider {
           resolved.absolutePath,
           resolved.line,
           resolved.col,
-          this._getCwd()
+          this._getCwd(),
+          this._onHover
         )
       );
     }
@@ -125,7 +130,8 @@ class FileLink implements ILink {
     private _absolutePath: string,
     private _line?: number,
     private _col?: number,
-    private _rootPath?: string
+    private _rootPath?: string,
+    private _onHover?: HoverCallback
   ) {}
 
   activate(event: MouseEvent, _text: string): void {
@@ -166,9 +172,13 @@ class FileLink implements ILink {
     }
   }
 
-  hover?(_event: MouseEvent, _text: string): void {}
+  hover?(_event: MouseEvent, _text: string): void {
+    this._onHover?.(this);
+  }
 
-  leave?(_event: MouseEvent, _text: string): void {}
+  leave?(_event: MouseEvent, _text: string): void {
+    this._onHover?.(null);
+  }
 
   dispose?(): void {}
 }

--- a/src/services/terminal/TerminalAddonManager.ts
+++ b/src/services/terminal/TerminalAddonManager.ts
@@ -4,7 +4,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { FileLinksAddon } from "./FileLinksAddon";
+import { FileLinksAddon, HoverCallback } from "./FileLinksAddon";
 
 const IMAGE_ADDON_OPTIONS = { pixelLimit: 2_000_000, storageLimit: 8 };
 
@@ -17,10 +17,17 @@ export interface TerminalAddons {
   webLinksAddon: WebLinksAddon | null;
 }
 
+export interface WebLinksHoverHandlers {
+  hover: (event: MouseEvent, text: string) => void;
+  leave: () => void;
+}
+
 export function setupTerminalAddons(
   terminal: Terminal,
   getCwd: () => string,
-  onLinkActivate?: (event: MouseEvent, uri: string) => void
+  onLinkActivate?: (event: MouseEvent, uri: string) => void,
+  onFileLinkHover?: HoverCallback,
+  webLinksHover?: WebLinksHoverHandlers
 ): TerminalAddons {
   // Base addons loaded for all terminals. WebGL is managed separately
   // by TerminalWebGLManager (attached only to the focused terminal).
@@ -36,12 +43,15 @@ export function setupTerminalAddons(
   const searchAddon = new SearchAddon();
   terminal.loadAddon(searchAddon);
 
-  const fileLinksAddon = new FileLinksAddon(terminal, getCwd);
+  const fileLinksAddon = new FileLinksAddon(terminal, getCwd, onFileLinkHover);
   const fileLinksDisposable = terminal.registerLinkProvider(fileLinksAddon);
 
   let webLinksAddon: WebLinksAddon | null = null;
   if (onLinkActivate) {
-    webLinksAddon = new WebLinksAddon(onLinkActivate);
+    webLinksAddon = new WebLinksAddon(onLinkActivate, {
+      hover: webLinksHover ? (event, text) => webLinksHover.hover(event, text) : undefined,
+      leave: webLinksHover ? () => webLinksHover.leave() : undefined,
+    });
     terminal.loadAddon(webLinksAddon);
   }
 
@@ -61,16 +71,24 @@ export function createImageAddon(terminal: Terminal): ImageAddon {
   return addon;
 }
 
-export function createFileLinksAddon(terminal: Terminal, getCwd: () => string): IDisposable {
-  const addon = new FileLinksAddon(terminal, getCwd);
+export function createFileLinksAddon(
+  terminal: Terminal,
+  getCwd: () => string,
+  onHover?: HoverCallback
+): IDisposable {
+  const addon = new FileLinksAddon(terminal, getCwd, onHover);
   return terminal.registerLinkProvider(addon);
 }
 
 export function createWebLinksAddon(
   terminal: Terminal,
-  onActivate: (event: MouseEvent, uri: string) => void
+  onActivate: (event: MouseEvent, uri: string) => void,
+  hoverHandlers?: WebLinksHoverHandlers
 ): WebLinksAddon {
-  const addon = new WebLinksAddon(onActivate);
+  const addon = new WebLinksAddon(onActivate, {
+    hover: hoverHandlers ? (event, text) => hoverHandlers.hover(event, text) : undefined,
+    leave: hoverHandlers ? () => hoverHandlers.leave() : undefined,
+  });
   terminal.loadAddon(addon);
   return addon;
 }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1,4 +1,4 @@
-import { Terminal } from "@xterm/xterm";
+import { Terminal, ILink, IBufferRange } from "@xterm/xterm";
 import { isMac } from "@/lib/platform";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier, TerminalType } from "@/types";
@@ -232,6 +232,7 @@ class TerminalInstanceService {
             }
             managed.webLinksAddon = null;
           }
+          managed.hoveredLink = null;
         } else {
           restoreScrollback(managed);
 
@@ -244,8 +245,14 @@ class TerminalInstanceService {
           }
           if (!managed.fileLinksDisposable) {
             try {
-              managed.fileLinksDisposable = createFileLinksAddon(managed.terminal, () =>
-                (this.cwdProviders.get(id) ?? (() => ""))()
+              managed.fileLinksDisposable = createFileLinksAddon(
+                managed.terminal,
+                () => (this.cwdProviders.get(id) ?? (() => ""))(),
+                (link) => {
+                  const current = this.instances.get(id);
+                  if (!current) return;
+                  current.hoveredLink = link;
+                }
               );
             } catch (err) {
               logWarn("Failed to recreate FileLinksAddon", { id, error: err });
@@ -253,8 +260,21 @@ class TerminalInstanceService {
           }
           if (!managed.webLinksAddon) {
             try {
-              managed.webLinksAddon = createWebLinksAddon(managed.terminal, (event, uri) =>
-                this.linkHandler.openLink(uri, id, event)
+              managed.webLinksAddon = createWebLinksAddon(
+                managed.terminal,
+                (event, uri) => this.linkHandler.openLink(uri, id, event),
+                {
+                  hover: (_event, text) => {
+                    const current = this.instances.get(id);
+                    if (!current) return;
+                    current.hoveredLink = this.makeSyntheticLink(text, null, id);
+                  },
+                  leave: () => {
+                    const current = this.instances.get(id);
+                    if (!current) return;
+                    current.hoveredLink = null;
+                  },
+                }
               );
             } catch (err) {
               logWarn("Failed to recreate WebLinksAddon", { id, error: err });
@@ -287,6 +307,48 @@ class TerminalInstanceService {
 
   notifyUserInput(id: string, data = ""): void {
     this.onUserInput(id, data);
+  }
+
+  /**
+   * Returns the text of the currently-hovered link, if any. Used by the
+   * right-click context menu to show "Open Link"/"Copy Link Address" based
+   * on the same detection xterm uses (WebLinksAddon, FileLinksAddon, OSC 8).
+   */
+  getHoveredLinkText(id: string): string | null {
+    return this.instances.get(id)?.hoveredLink?.text ?? null;
+  }
+
+  /**
+   * Opens the currently-hovered link by delegating to its own activate()
+   * method. File links route through the actionService (file.view); URL and
+   * OSC 8 links route through TerminalLinkHandler (localhost → browser panel
+   * when modifier pressed, external open otherwise).
+   */
+  openHoveredLink(id: string, event?: MouseEvent): void {
+    const managed = this.instances.get(id);
+    const link = managed?.hoveredLink;
+    if (!link) return;
+    const mouseEvent = event ?? new MouseEvent("click");
+    try {
+      link.activate(mouseEvent, link.text);
+    } catch (error) {
+      logWarn("Failed to activate hovered link", { id, error });
+    }
+  }
+
+  /**
+   * Builds a synthetic ILink for WebLinksAddon and OSC 8 link sources (which
+   * don't expose an ILink natively). activate() routes through the link
+   * handler so localhost URLs hit the browser-panel path when needed.
+   */
+  private makeSyntheticLink(text: string, range: IBufferRange | null, terminalId: string): ILink {
+    return {
+      range: range ?? { start: { x: 0, y: 0 }, end: { x: 0, y: 0 } },
+      text,
+      activate: (event: MouseEvent, uri: string) => {
+        this.linkHandler.openLink(uri, terminalId, event);
+      },
+    };
   }
 
   /**
@@ -639,10 +701,20 @@ class TerminalInstanceService {
       this.linkHandler.openLink(url, id, event);
     };
 
+    const setHoveredLink = (link: ILink | null) => {
+      const current = this.instances.get(id);
+      if (!current) return;
+      current.hoveredLink = link;
+    };
+
     const terminalOptions = {
       ...options,
       linkHandler: {
         activate: (event: MouseEvent, text: string) => openLink(text, event),
+        hover: (_event: MouseEvent, text: string, range: IBufferRange) => {
+          setHoveredLink(this.makeSyntheticLink(text, range, id));
+        },
+        leave: () => setHoveredLink(null),
       },
     };
 
@@ -651,7 +723,12 @@ class TerminalInstanceService {
     const addons = setupTerminalAddons(
       terminal,
       () => (this.cwdProviders.get(id) ?? (() => ""))(),
-      (event, uri) => openLink(uri, event)
+      (event, uri) => openLink(uri, event),
+      (link) => setHoveredLink(link),
+      {
+        hover: (_event, text) => setHoveredLink(this.makeSyntheticLink(text, null, id)),
+        leave: () => setHoveredLink(null),
+      }
     );
 
     const hostElement = document.createElement("div");
@@ -697,6 +774,7 @@ class TerminalInstanceService {
       agentState: undefined,
       agentStateSubscribers,
       ...addons,
+      hoveredLink: null,
       hostElement,
       isOpened: false,
       listeners,
@@ -1281,6 +1359,7 @@ class TerminalInstanceService {
       }
     }
     managed.terminal.blur();
+    managed.hoveredLink = null;
     managed.lastDetachAt = Date.now();
     managed.isDetached = true;
   }
@@ -1306,6 +1385,7 @@ class TerminalInstanceService {
     }
 
     managed.terminal.blur();
+    managed.hoveredLink = null;
     managed.lastDetachAt = Date.now();
   }
 

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -178,4 +178,54 @@ describe("FileLinksAddon", () => {
       });
     });
   });
+
+  describe("hover tracking", () => {
+    it("invokes onHover with the link on hover() and null on leave()", () => {
+      return new Promise<void>((resolve) => {
+        const terminal = createMockTerminal();
+        const getCwd = () => "/home/user/project";
+        const calls: Array<unknown> = [];
+        const addon = new FileLinksAddon(terminal, getCwd, (link) => calls.push(link));
+
+        const line = createMockLine("Error at src/App.tsx:10");
+        vi.mocked(terminal.buffer.active.getLine).mockReturnValue(line);
+
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeDefined();
+          const link = links![0]!;
+          const mouseEvent = new Event("mousemove") as unknown as MouseEvent;
+
+          link.hover?.(mouseEvent, link.text);
+          expect(calls.length).toBe(1);
+          expect(calls[0]).toBe(link);
+
+          link.leave?.(mouseEvent, link.text);
+          expect(calls.length).toBe(2);
+          expect(calls[1]).toBeNull();
+
+          resolve();
+        });
+      });
+    });
+
+    it("works without an onHover callback (backwards compatible)", () => {
+      return new Promise<void>((resolve) => {
+        const terminal = createMockTerminal();
+        const getCwd = () => "/home/user/project";
+        const addon = new FileLinksAddon(terminal, getCwd);
+
+        const line = createMockLine("src/App.tsx:10");
+        vi.mocked(terminal.buffer.active.getLine).mockReturnValue(line);
+
+        addon.provideLinks(1, (links) => {
+          expect(links).toBeDefined();
+          const link = links![0]!;
+          const mouseEvent = new Event("mousemove") as unknown as MouseEvent;
+          expect(() => link.hover?.(mouseEvent, link.text)).not.toThrow();
+          expect(() => link.leave?.(mouseEvent, link.text)).not.toThrow();
+          resolve();
+        });
+      });
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalAddonManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalAddonManager.test.ts
@@ -13,8 +13,15 @@ vi.mock("../FileLinksAddon", () => ({
   FileLinksAddon: vi.fn(),
 }));
 
-import { setupTerminalAddons, createImageAddon } from "../TerminalAddonManager";
+import {
+  setupTerminalAddons,
+  createImageAddon,
+  createWebLinksAddon,
+  createFileLinksAddon,
+} from "../TerminalAddonManager";
 import type { Terminal } from "@xterm/xterm";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import { FileLinksAddon } from "../FileLinksAddon";
 
 function createMockTerminal() {
   return {
@@ -56,6 +63,50 @@ describe("TerminalAddonManager", () => {
       createImageAddon(terminal);
 
       expect(terminal.loadAddon).toHaveBeenCalledWith(expect.any(mockImageAddon));
+    });
+  });
+
+  describe("createWebLinksAddon hover wiring", () => {
+    it("passes hover/leave callbacks through to WebLinksAddon options", () => {
+      const terminal = createMockTerminal();
+      const onActivate = vi.fn();
+      const hover = vi.fn();
+      const leave = vi.fn();
+
+      createWebLinksAddon(terminal, onActivate, { hover, leave });
+
+      const opts = vi.mocked(WebLinksAddon).mock.calls[0]?.[1];
+      expect(opts).toBeDefined();
+      opts!.hover?.(new Event("mousemove") as unknown as MouseEvent, "https://example.com", {
+        start: { x: 0, y: 0 },
+        end: { x: 0, y: 0 },
+      });
+      expect(hover).toHaveBeenCalledWith(expect.any(Event), "https://example.com");
+      opts!.leave?.(new Event("mouseleave") as unknown as MouseEvent, "https://example.com");
+      expect(leave).toHaveBeenCalled();
+    });
+
+    it("constructs WebLinksAddon with undefined hover/leave when no handlers provided", () => {
+      const terminal = createMockTerminal();
+      const onActivate = vi.fn();
+
+      createWebLinksAddon(terminal, onActivate);
+
+      const opts = vi.mocked(WebLinksAddon).mock.calls[0]?.[1];
+      expect(opts?.hover).toBeUndefined();
+      expect(opts?.leave).toBeUndefined();
+    });
+  });
+
+  describe("createFileLinksAddon hover wiring", () => {
+    it("forwards onHover callback to FileLinksAddon constructor", () => {
+      const terminal = createMockTerminal();
+      const getCwd = () => "/tmp";
+      const onHover = vi.fn();
+
+      createFileLinksAddon(terminal, getCwd, onHover);
+
+      expect(FileLinksAddon).toHaveBeenCalledWith(terminal, getCwd, onHover);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -151,6 +151,7 @@ function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal 
     searchAddon: {} as ManagedTerminal["searchAddon"],
     fileLinksDisposable: null,
     webLinksAddon: null,
+    hoveredLink: null,
     hostElement,
     isOpened: true,
     listeners: [],

--- a/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
@@ -75,6 +75,7 @@ describe("TerminalInstanceService detach blur", () => {
       isDetached: false,
       isVisible: true,
       lastDetachAt: 0,
+      hoveredLink: null as unknown,
     };
   };
 
@@ -124,5 +125,40 @@ describe("TerminalInstanceService detach blur", () => {
 
     expect(managed.terminal.blur).toHaveBeenCalledTimes(1);
     expect(managed.isDetached).toBe(true);
+  });
+
+  it("detach() clears hoveredLink", () => {
+    const managed = makeMockManaged("t3");
+    managed.hoveredLink = { text: "https://example.com", range: {}, activate: vi.fn() };
+    const container = document.createElement("div");
+    container.appendChild(managed.hostElement);
+    service.instances.set("t3", managed);
+
+    vi.spyOn(service.offscreenManager, "getOffscreenSlot").mockReturnValue(undefined);
+    vi.spyOn(service.offscreenManager, "ensureHiddenContainer").mockReturnValue(
+      document.createElement("div")
+    );
+
+    service.detach("t3", container);
+
+    expect(managed.hoveredLink).toBeNull();
+  });
+
+  it("detachForProjectSwitch() clears hoveredLink", () => {
+    const managed = makeMockManaged("t4");
+    managed.hoveredLink = { text: "/file.tsx:1:1", range: {}, activate: vi.fn() };
+    const parent = document.createElement("div");
+    parent.appendChild(managed.hostElement);
+    service.instances.set("t4", managed);
+
+    vi.spyOn(service.offscreenManager, "ensureHiddenContainer").mockReturnValue(
+      document.createElement("div")
+    );
+    vi.spyOn(service.resizeController, "clearResizeJob").mockImplementation(() => {});
+    vi.spyOn(service.resizeController, "clearSettledTimer").mockImplementation(() => {});
+
+    service.detachForProjectSwitch("t4");
+
+    expect(managed.hoveredLink).toBeNull();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({
+      visualBuffers: [],
+      signalBuffer: null,
+    })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+describe("TerminalInstanceService hovered link API", () => {
+  type HoveredLinkTestService = {
+    instances: Map<string, unknown>;
+    getHoveredLinkText: (id: string) => string | null;
+    openHoveredLink: (id: string, event?: MouseEvent) => void;
+  };
+
+  let service: HoveredLinkTestService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: HoveredLinkTestService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+  });
+
+  it("getHoveredLinkText returns null when terminal is missing", () => {
+    expect(service.getHoveredLinkText("missing")).toBeNull();
+  });
+
+  it("getHoveredLinkText returns null when no link is hovered", () => {
+    service.instances.set("t1", { hoveredLink: null });
+    expect(service.getHoveredLinkText("t1")).toBeNull();
+  });
+
+  it("getHoveredLinkText returns the text of the currently hovered link", () => {
+    const link = { text: "https://example.com", range: {}, activate: vi.fn() };
+    service.instances.set("t1", { hoveredLink: link });
+    expect(service.getHoveredLinkText("t1")).toBe("https://example.com");
+  });
+
+  it("openHoveredLink delegates to the link's activate() with link.text", () => {
+    const activate = vi.fn();
+    const link = { text: "https://example.com", range: {}, activate };
+    service.instances.set("t1", { hoveredLink: link });
+
+    service.openHoveredLink("t1");
+
+    expect(activate).toHaveBeenCalledTimes(1);
+    expect(activate.mock.calls[0]?.[1]).toBe("https://example.com");
+    expect(activate.mock.calls[0]?.[0]).toBeInstanceOf(MouseEvent);
+  });
+
+  it("openHoveredLink forwards a provided event", () => {
+    const activate = vi.fn();
+    const link = { text: "https://example.com", range: {}, activate };
+    service.instances.set("t1", { hoveredLink: link });
+    const event = new MouseEvent("click", { metaKey: true });
+
+    service.openHoveredLink("t1", event);
+
+    expect(activate).toHaveBeenCalledWith(event, "https://example.com");
+  });
+
+  it("openHoveredLink is a no-op when no link is hovered", () => {
+    service.instances.set("t1", { hoveredLink: null });
+    expect(() => service.openHoveredLink("t1")).not.toThrow();
+  });
+
+  it("openHoveredLink swallows errors thrown by activate()", () => {
+    const link = {
+      text: "x",
+      range: {},
+      activate: vi.fn(() => {
+        throw new Error("boom");
+      }),
+    };
+    service.instances.set("t1", { hoveredLink: link });
+    expect(() => service.openHoveredLink("t1")).not.toThrow();
+  });
+});

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -1,4 +1,4 @@
-import { Terminal, IDisposable, IMarker } from "@xterm/xterm";
+import { Terminal, IDisposable, IMarker, ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { ImageAddon } from "@xterm/addon-image";
@@ -26,6 +26,10 @@ export interface ManagedTerminal {
   searchAddon: SearchAddon;
   fileLinksDisposable: IDisposable | null;
   webLinksAddon: WebLinksAddon | null;
+  // Currently-hovered link (tracked via xterm addon hover/leave callbacks).
+  // Read synchronously by the right-click context menu so it reflects the
+  // same detection xterm uses for plain URLs, file paths, and OSC 8 links.
+  hoveredLink: ILink | null;
   hostElement: HTMLDivElement;
   isOpened: boolean;
   listeners: Array<() => void>;


### PR DESCRIPTION
## Summary

- Right-click "Open Link" / "Copy Link Address" now reads the link xterm is already tracking via hover callbacks, rather than running a third regex pass over the terminal buffer.
- Covers all three link sources: plain URLs (WebLinksAddon), file paths (FileLinksAddon), and OSC 8 hyperlinks. Previously OSC 8 links emitted by `gh`, `cargo`, and Claude Code tooling were invisible to the context menu entirely.
- `openHoveredLink` delegates to each link's own `activate()`, so FileLink's editor routing and WebLink's localhost-to-browser-panel routing are both preserved.

Resolves #5365

## Changes

- Added `hoveredLink: ILink | null` to `ManagedTerminal` in `types.ts`
- Wired hover/leave callbacks into all three link sources (initial creation and BACKGROUND tier recreation paths) in `TerminalAddonManager` and `FileLinksAddon`
- Added `getHoveredLinkText(id)` and `openHoveredLink(id, event?)` to `TerminalInstanceService`
- `hoveredLink` clears on BACKGROUND tier, detach, and detachForProjectSwitch
- Deleted `URL_REGEX` and `extractUrlAtPoint` from `TerminalContextMenu.tsx`; simplified `open-link:${url}` action string to sentinel `"open-link"`
- Routes "Open Link" through `TerminalLinkHandler.openLink` instead of direct `system.openExternal`

## Testing

977+ terminal-service and Terminal-component tests pass. Added 7 new tests covering `getHoveredLinkText`, `openHoveredLink`, FileLinksAddon hover callback, and the detach clear paths. Typecheck and lint clean.