### PR TITLE
feat(telemetry): live preview of outbound payloads

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1130,
-  "moduleCount": 1130,
+  "count": 1131,
+  "moduleCount": 1131,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -1104,32 +1104,32 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 227,
+      "line": 233,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 235,
+      "line": 241,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 243,
+      "line": 249,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 250,
+      "line": 256,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 299,
+      "line": 363,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 349,
+      "line": 413,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -483,6 +483,12 @@ export const CHANNELS = {
   TELEMETRY_SET_ENABLED: "telemetry:set-enabled",
   TELEMETRY_MARK_PROMPT_SHOWN: "telemetry:mark-prompt-shown",
   TELEMETRY_TRACK: "telemetry:track",
+  TELEMETRY_PREVIEW_GET_STATE: "telemetry:preview-get-state",
+  TELEMETRY_PREVIEW_TOGGLE: "telemetry:preview-toggle",
+  TELEMETRY_PREVIEW_SUBSCRIBE: "telemetry:preview-subscribe",
+  TELEMETRY_PREVIEW_UNSUBSCRIBE: "telemetry:preview-unsubscribe",
+  TELEMETRY_PREVIEW_EVENT_BATCH: "telemetry:preview-event-batch",
+  TELEMETRY_PREVIEW_STATE_CHANGED: "telemetry:preview-state-changed",
 
   // Privacy & Data channels
   PRIVACY_GET_SETTINGS: "privacy:get-settings",

--- a/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/telemetry.handlers.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),
   removeHandler: vi.fn(),
+  on: vi.fn(),
+  removeListener: vi.fn(),
 }));
 
 vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
@@ -17,6 +19,23 @@ const telemetryServiceMock = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/TelemetryService.js", () => telemetryServiceMock);
+
+const broadcasterMock = vi.hoisted(() => {
+  // Mirror real module behavior: the active flag is module-level, so
+  // setTelemetryPreviewActive must be observable via isTelemetryPreviewActive
+  // for the toggle handler's broadcast-state-changed path to assert correctly.
+  const state = { active: false };
+  return {
+    _state: state,
+    isTelemetryPreviewActive: vi.fn(() => state.active),
+    setTelemetryPreviewActive: vi.fn((next: boolean) => {
+      state.active = next;
+    }),
+    setTelemetryPreviewEnqueue: vi.fn(),
+  };
+});
+
+vi.mock("../../../services/TelemetryPreviewBroadcaster.js", () => broadcasterMock);
 
 const utilsMock = vi.hoisted(() => ({
   typedBroadcast: vi.fn(),
@@ -50,11 +69,15 @@ import { registerTelemetryHandlers } from "../telemetry.js";
 describe("registerTelemetryHandlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    broadcasterMock._state.active = false;
   });
 
-  it("registers all four IPC handlers", () => {
+  it("registers all invoke + subscribe IPC handlers", () => {
     const cleanup = registerTelemetryHandlers();
-    expect(ipcMainMock.handle).toHaveBeenCalledTimes(4);
+    // 4 pre-existing handlers + 2 new preview invoke handlers (get-state, toggle)
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(6);
+    // 2 new preview subscribe/unsubscribe listeners via ipcMain.on
+    expect(ipcMainMock.on).toHaveBeenCalledTimes(2);
     cleanup();
   });
 
@@ -65,7 +88,17 @@ describe("registerTelemetryHandlers", () => {
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("telemetry:set-enabled");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("telemetry:mark-prompt-shown");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("telemetry:track");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(4);
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("telemetry:preview-get-state");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("telemetry:preview-toggle");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(6);
+    expect(ipcMainMock.removeListener).toHaveBeenCalledWith(
+      "telemetry:preview-subscribe",
+      expect.any(Function)
+    );
+    expect(ipcMainMock.removeListener).toHaveBeenCalledWith(
+      "telemetry:preview-unsubscribe",
+      expect.any(Function)
+    );
   });
 
   it("TELEMETRY_GET handler returns enabled and hasSeenPrompt", async () => {
@@ -206,5 +239,44 @@ describe("registerTelemetryHandlers", () => {
 
     await handler(null, "onboarding_step_viewed", [1, 2, 3]);
     expect(telemetryServiceMock.trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("TELEMETRY_PREVIEW_GET_STATE returns the current active flag", async () => {
+    broadcasterMock._state.active = true;
+    registerTelemetryHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch === "telemetry:preview-get-state") ?? [];
+
+    const result = await handler();
+    expect(result).toEqual({ active: true });
+  });
+
+  it("TELEMETRY_PREVIEW_TOGGLE flips state and broadcasts the change on boolean input", async () => {
+    broadcasterMock._state.active = false;
+    registerTelemetryHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch === "telemetry:preview-toggle") ?? [];
+
+    const result = await handler(null, true);
+    expect(broadcasterMock.setTelemetryPreviewActive).toHaveBeenCalledWith(true);
+    expect(result).toEqual({ active: true });
+    expect(utilsMock.typedBroadcast).toHaveBeenCalledWith("telemetry:preview-state-changed", {
+      active: true,
+    });
+  });
+
+  it("TELEMETRY_PREVIEW_TOGGLE ignores non-boolean values and does not broadcast", async () => {
+    broadcasterMock._state.active = false;
+    registerTelemetryHandlers();
+
+    const [, handler] =
+      ipcMainMock.handle.mock.calls.find(([ch]) => ch === "telemetry:preview-toggle") ?? [];
+
+    const result = await handler(null, "true");
+    expect(broadcasterMock.setTelemetryPreviewActive).not.toHaveBeenCalled();
+    expect(result).toEqual({ active: false });
+    expect(utilsMock.typedBroadcast).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/telemetry.ts
+++ b/electron/ipc/handlers/telemetry.ts
@@ -1,3 +1,4 @@
+import { ipcMain, type WebContents } from "electron";
 import { CHANNELS } from "../channels.js";
 import {
   isTelemetryEnabled,
@@ -7,12 +8,78 @@ import {
   getTelemetryLevel,
   trackEvent,
 } from "../../services/TelemetryService.js";
+import {
+  isTelemetryPreviewActive,
+  setTelemetryPreviewActive,
+  setTelemetryPreviewEnqueue,
+} from "../../services/TelemetryPreviewBroadcaster.js";
 import { ANALYTICS_EVENTS } from "../../../shared/config/telemetry.js";
+import type {
+  SanitizedTelemetryEvent,
+  TelemetryPreviewState,
+} from "../../../shared/types/ipc/telemetryPreview.js";
 import { typedBroadcast, typedHandle } from "../utils.js";
+
 const ALLOWED_EVENTS = new Set<string>(ANALYTICS_EVENTS);
+
+// Module-level so the session preview state outlives handler re-registration
+// in hot-reload and preserves enabled state across a single Daintree launch.
+const previewSubscribers = new Map<WebContents, () => void>();
+let pendingBatch: SanitizedTelemetryEvent[] = [];
+let batchTimeout: NodeJS.Timeout | null = null;
+const BATCH_WINDOW_MS = 50;
+const MAX_BATCH_SIZE = 200;
+
+function flushPreviewBatch(): void {
+  if (batchTimeout) {
+    clearTimeout(batchTimeout);
+    batchTimeout = null;
+  }
+  if (pendingBatch.length === 0) return;
+
+  const batch = pendingBatch;
+  pendingBatch = [];
+
+  for (const [webContents, destroyListener] of previewSubscribers.entries()) {
+    if (webContents.isDestroyed()) {
+      webContents.removeListener("destroyed", destroyListener);
+      previewSubscribers.delete(webContents);
+      continue;
+    }
+    try {
+      for (let i = 0; i < batch.length; i += MAX_BATCH_SIZE) {
+        const chunk = batch.slice(i, i + MAX_BATCH_SIZE);
+        webContents.send(CHANNELS.TELEMETRY_PREVIEW_EVENT_BATCH, chunk);
+      }
+    } catch (error) {
+      // Preview is best-effort — the batch for this subscriber is dropped and
+      // won't be retried, but we keep the subscription so the next flush
+      // window delivers cleanly once the renderer recovers.
+      console.warn("[TelemetryPreview] Dropped preview batch for subscriber:", error);
+    }
+  }
+}
+
+function queuePreviewEvent(event: SanitizedTelemetryEvent): void {
+  if (!isTelemetryPreviewActive()) return;
+  pendingBatch.push(event);
+  if (!batchTimeout) {
+    batchTimeout = setTimeout(flushPreviewBatch, BATCH_WINDOW_MS);
+  }
+}
+
+function broadcastPreviewState(): void {
+  const state: TelemetryPreviewState = { active: isTelemetryPreviewActive() };
+  typedBroadcast("telemetry:preview-state-changed", state);
+}
 
 export function registerTelemetryHandlers(): () => void {
   const cleanups: Array<() => void> = [];
+
+  // Wire the broadcaster's enqueue function at handler-register time. This
+  // is the single point where the service gets a direct callback into the
+  // IPC layer without needing to import IPC modules itself.
+  setTelemetryPreviewEnqueue(queuePreviewEvent);
 
   cleanups.push(
     typedHandle(CHANNELS.TELEMETRY_GET, () => ({
@@ -51,5 +118,73 @@ export function registerTelemetryHandlers(): () => void {
     })
   );
 
-  return () => cleanups.forEach((c) => c());
+  cleanups.push(
+    typedHandle(CHANNELS.TELEMETRY_PREVIEW_GET_STATE, () => ({
+      active: isTelemetryPreviewActive(),
+    }))
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.TELEMETRY_PREVIEW_TOGGLE, (active: unknown) => {
+      // Match the strict-boolean guard used by TELEMETRY_SET_ENABLED so a
+      // buggy caller sending `"false"` doesn't coerce to truthy and flip
+      // preview on.
+      if (typeof active !== "boolean") {
+        return { active: isTelemetryPreviewActive() };
+      }
+      const prev = isTelemetryPreviewActive();
+      setTelemetryPreviewActive(active);
+      // Turning preview off flushes whatever is pending so the final batch
+      // arrives in order; subsequent events are ignored by queuePreviewEvent.
+      if (!active) flushPreviewBatch();
+      if (prev !== active) broadcastPreviewState();
+      return { active };
+    })
+  );
+
+  const handleSubscribe = (event: Electron.IpcMainEvent) => {
+    const sender = event.sender;
+    if (sender.isDestroyed()) return;
+    if (previewSubscribers.has(sender)) return;
+
+    const destroyListener = () => {
+      previewSubscribers.delete(sender);
+    };
+    previewSubscribers.set(sender, destroyListener);
+    sender.once("destroyed", destroyListener);
+  };
+  ipcMain.on(CHANNELS.TELEMETRY_PREVIEW_SUBSCRIBE, handleSubscribe);
+  cleanups.push(() =>
+    ipcMain.removeListener(CHANNELS.TELEMETRY_PREVIEW_SUBSCRIBE, handleSubscribe)
+  );
+
+  const handleUnsubscribe = (event: Electron.IpcMainEvent) => {
+    const sender = event.sender;
+    const destroyListener = previewSubscribers.get(sender);
+    if (destroyListener) {
+      sender.removeListener("destroyed", destroyListener);
+      previewSubscribers.delete(sender);
+    }
+  };
+  ipcMain.on(CHANNELS.TELEMETRY_PREVIEW_UNSUBSCRIBE, handleUnsubscribe);
+  cleanups.push(() =>
+    ipcMain.removeListener(CHANNELS.TELEMETRY_PREVIEW_UNSUBSCRIBE, handleUnsubscribe)
+  );
+
+  return () => {
+    cleanups.forEach((c) => c());
+    flushPreviewBatch();
+    for (const [webContents, destroyListener] of previewSubscribers.entries()) {
+      if (!webContents.isDestroyed()) {
+        webContents.removeListener("destroyed", destroyListener);
+      }
+    }
+    previewSubscribers.clear();
+    pendingBatch = [];
+    if (batchTimeout) {
+      clearTimeout(batchTimeout);
+      batchTimeout = null;
+    }
+    setTelemetryPreviewEnqueue(null);
+  };
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1005,6 +1005,12 @@ const CHANNELS = {
   TELEMETRY_SET_ENABLED: "telemetry:set-enabled",
   TELEMETRY_MARK_PROMPT_SHOWN: "telemetry:mark-prompt-shown",
   TELEMETRY_TRACK: "telemetry:track",
+  TELEMETRY_PREVIEW_GET_STATE: "telemetry:preview-get-state",
+  TELEMETRY_PREVIEW_TOGGLE: "telemetry:preview-toggle",
+  TELEMETRY_PREVIEW_SUBSCRIBE: "telemetry:preview-subscribe",
+  TELEMETRY_PREVIEW_UNSUBSCRIBE: "telemetry:preview-unsubscribe",
+  TELEMETRY_PREVIEW_EVENT_BATCH: "telemetry:preview-event-batch",
+  TELEMETRY_PREVIEW_STATE_CHANGED: "telemetry:preview-state-changed",
 
   // GPU channels
   GPU_GET_STATUS: "gpu:get-status",
@@ -2811,6 +2817,22 @@ const api: ElectronAPI = {
     markPromptShown: () => _unwrappingInvoke(CHANNELS.TELEMETRY_MARK_PROMPT_SHOWN),
     track: (event: string, properties: Record<string, unknown>) =>
       _unwrappingInvoke(CHANNELS.TELEMETRY_TRACK, event, properties),
+    preview: {
+      getState: () => _unwrappingInvoke(CHANNELS.TELEMETRY_PREVIEW_GET_STATE),
+      toggle: (active: boolean) => _unwrappingInvoke(CHANNELS.TELEMETRY_PREVIEW_TOGGLE, active),
+      subscribe: () => ipcRenderer.send(CHANNELS.TELEMETRY_PREVIEW_SUBSCRIBE),
+      unsubscribe: () => ipcRenderer.send(CHANNELS.TELEMETRY_PREVIEW_UNSUBSCRIBE),
+      onEventBatch: (
+        callback: (
+          events: import("../shared/types/ipc/telemetryPreview.js").SanitizedTelemetryEvent[]
+        ) => void
+      ) => _typedOn(CHANNELS.TELEMETRY_PREVIEW_EVENT_BATCH, callback),
+      onStateChanged: (
+        callback: (
+          state: import("../shared/types/ipc/telemetryPreview.js").TelemetryPreviewState
+        ) => void
+      ) => _typedOn(CHANNELS.TELEMETRY_PREVIEW_STATE_CHANGED, callback),
+    },
   },
 
   gpu: {

--- a/electron/services/TelemetryPreviewBroadcaster.ts
+++ b/electron/services/TelemetryPreviewBroadcaster.ts
@@ -1,0 +1,40 @@
+/**
+ * Thin module-level bridge between `TelemetryService` (which taps sanitised
+ * events) and the IPC handler (which batches and streams them to renderers).
+ *
+ * Kept in its own file so `TelemetryService` does not import from
+ * `electron/ipc/**` and invert the service/handler dependency direction.
+ */
+import type { SanitizedTelemetryEvent } from "../../shared/types/ipc/telemetryPreview.js";
+
+let previewActive = false;
+let enqueue: ((event: SanitizedTelemetryEvent) => void) | null = null;
+
+export function isTelemetryPreviewActive(): boolean {
+  return previewActive;
+}
+
+export function setTelemetryPreviewActive(active: boolean): void {
+  previewActive = active;
+}
+
+export function setTelemetryPreviewEnqueue(
+  fn: ((event: SanitizedTelemetryEvent) => void) | null
+): void {
+  enqueue = fn;
+}
+
+/**
+ * Called from the Sentry `beforeSend` hook and from `trackEvent` after the
+ * analytics payload is constructed. Must never throw — telemetry failures
+ * must never escape into product code paths.
+ */
+export function emitTelemetryPreview(event: SanitizedTelemetryEvent): void {
+  if (!previewActive) return;
+  if (!enqueue) return;
+  try {
+    enqueue(event);
+  } catch {
+    // swallow — preview must never affect production telemetry
+  }
+}

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -1,8 +1,11 @@
 import os from "os";
+import { randomUUID } from "node:crypto";
 import { app } from "electron";
 import { store } from "../store.js";
 import type { ActionBreadcrumb } from "../../shared/types/ipc/crashRecovery.js";
+import type { SanitizedTelemetryEvent } from "../../shared/types/ipc/telemetryPreview.js";
 import { scrubSecrets } from "../utils/secretScrubber.js";
+import { emitTelemetryPreview, isTelemetryPreviewActive } from "./TelemetryPreviewBroadcaster.js";
 
 export interface SentryBreadcrumb {
   message?: string;
@@ -190,8 +193,11 @@ export async function initializeTelemetry(): Promise<void> {
         // The local `SentryEvent` interface is a narrower projection of the
         // SDK's `Event` type — cast through `unknown` at the hook boundary so
         // our scrubbing logic can use the shape we control.
-        beforeSend: (event) =>
-          sanitizeEvent(event as unknown as SentryEvent) as unknown as typeof event,
+        beforeSend: (event) => {
+          const sanitized = sanitizeEvent(event as unknown as SentryEvent);
+          if (sanitized) capturePreviewFromSanitizedEvent(sanitized);
+          return sanitized as unknown as typeof event;
+        },
         initialScope: {
           tags: {
             platform: process.platform,
@@ -257,16 +263,68 @@ export async function setTelemetryEnabled(enabled: boolean): Promise<void> {
   await setTelemetryLevel(enabled ? "errors" : "off");
 }
 
+function buildAnalyticsSentryEvent(
+  event: string,
+  properties: Record<string, unknown>,
+  timestamp: number
+): SentryEvent {
+  return {
+    message: event,
+    level: "info" as unknown as undefined,
+    extra: { ...properties, timestamp },
+    tags: { kind: "analytics" },
+  } as SentryEvent;
+}
+
+/**
+ * Clone a sanitised Sentry event for the preview stream. Runs only when a
+ * preview subscriber is active — `structuredClone` isn't free and we don't
+ * want to pay for it when nobody is watching. Failure is swallowed: the
+ * preview mirror must never block a real telemetry send.
+ */
+function capturePreviewFromSanitizedEvent(event: SentryEvent): void {
+  if (!isTelemetryPreviewActive()) return;
+  try {
+    const clone = structuredClone(event) as Record<string, unknown>;
+    const isAnalytics =
+      clone.tags && typeof clone.tags === "object"
+        ? (clone.tags as Record<string, unknown>).kind === "analytics"
+        : false;
+    const label = deriveTelemetryPreviewLabel(clone);
+    const record: SanitizedTelemetryEvent = {
+      id: randomUUID(),
+      kind: isAnalytics ? "analytics" : "sentry",
+      timestamp: Date.now(),
+      label,
+      payload: clone,
+    };
+    emitTelemetryPreview(record);
+  } catch {
+    // never let preview capture affect the real telemetry send
+  }
+}
+
+function deriveTelemetryPreviewLabel(event: Record<string, unknown>): string {
+  if (typeof event.message === "string" && event.message.length > 0) {
+    return event.message;
+  }
+  const exception = event.exception as
+    | { values?: Array<{ type?: string; value?: string }> }
+    | undefined;
+  const first = exception?.values?.[0];
+  if (first) {
+    if (first.type && first.value) return `${first.type}: ${first.value}`;
+    if (first.value) return first.value;
+    if (first.type) return first.type;
+  }
+  return "(event)";
+}
+
 function flushPreConsentBuffer(): void {
   if (!captureEventFn) return;
   const events = preConsentBuffer.splice(0);
   for (const { event, properties, timestamp } of events) {
-    captureEventFn({
-      message: event,
-      level: "info" as unknown as undefined,
-      extra: { ...properties, timestamp },
-      tags: { kind: "analytics" },
-    } as SentryEvent);
+    captureEventFn(buildAnalyticsSentryEvent(event, properties, timestamp));
   }
 }
 
@@ -276,13 +334,19 @@ export function trackEvent(event: string, properties: Record<string, unknown> = 
 
   // Only send analytics events at "full" level; "errors" only permits crash reports via Sentry
   if (level === "full" && captureEventFn) {
-    captureEventFn({
-      message: event,
-      level: "info" as unknown as undefined,
-      extra: { ...properties, timestamp: Date.now() },
-      tags: { kind: "analytics" },
-    } as SentryEvent);
+    // `beforeSend` will fire the preview tap as part of the capture path.
+    captureEventFn(buildAnalyticsSentryEvent(event, properties, Date.now()));
     return;
+  }
+
+  // Preview should mirror what *would* be sent even when consent is off or
+  // the user hasn't answered the prompt yet — that's the whole point of the
+  // feature. Build the would-be event, run it through the same sanitiser,
+  // and emit without touching Sentry.
+  if (isTelemetryPreviewActive()) {
+    const previewOnly = buildAnalyticsSentryEvent(event, properties, Date.now());
+    const sanitized = sanitizeEvent(previewOnly);
+    if (sanitized) capturePreviewFromSanitizedEvent(sanitized);
   }
 
   if (!hasSeenPrompt) {

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -915,6 +915,127 @@ describe("addActionBreadcrumb", () => {
   });
 });
 
+describe("telemetry preview tap", () => {
+  async function loadFreshModule() {
+    vi.resetModules();
+    return await import("../TelemetryService.js");
+  }
+
+  async function loadBroadcaster() {
+    return await import("../TelemetryPreviewBroadcaster.js");
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sentryInitMock.mockReset();
+    setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+  });
+
+  it("does not emit when preview is inactive", async () => {
+    const mod = await loadFreshModule();
+    const broadcaster = await loadBroadcaster();
+    const enqueue = vi.fn();
+    broadcaster.setTelemetryPreviewEnqueue(enqueue);
+    // preview inactive by default
+    mod.trackEvent("onboarding_step_viewed", { step: "telemetry" });
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("emits a sanitised analytics payload when preview is active (even with telemetry off)", async () => {
+    const mod = await loadFreshModule();
+    const broadcaster = await loadBroadcaster();
+    const enqueue = vi.fn();
+    broadcaster.setTelemetryPreviewEnqueue(enqueue);
+    broadcaster.setTelemetryPreviewActive(true);
+
+    try {
+      setPrivacy({ telemetryLevel: "off", hasSeenPrompt: false });
+      mod.trackEvent("onboarding_step_viewed", {
+        step: "telemetry",
+        note: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456",
+      });
+
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      const record = enqueue.mock.calls[0]![0];
+      expect(record.kind).toBe("analytics");
+      expect(record.label).toBe("onboarding_step_viewed");
+      expect(typeof record.id).toBe("string");
+      const payload = record.payload as Record<string, unknown>;
+      // Post-sanitisation: the PAT should be redacted in the extra block
+      const extra = payload.extra as { note: string };
+      expect(extra.note).not.toContain("ghp_");
+      expect(extra.note).toContain("[REDACTED]");
+    } finally {
+      broadcaster.setTelemetryPreviewActive(false);
+      broadcaster.setTelemetryPreviewEnqueue(null);
+    }
+  });
+
+  it("emits a sentry-kind preview for events flowing through beforeSend", async () => {
+    const mod = await loadFreshModule();
+    const broadcaster = await loadBroadcaster();
+    const enqueue = vi.fn();
+    broadcaster.setTelemetryPreviewEnqueue(enqueue);
+    broadcaster.setTelemetryPreviewActive(true);
+
+    try {
+      setPrivacy({ telemetryLevel: "errors", hasSeenPrompt: true });
+      process.env.SENTRY_DSN = "https://test@sentry.io/123";
+      await mod.initializeTelemetry();
+      const init = sentryInitMock.mock.calls[0]?.[0] as {
+        beforeSend?: (event: unknown) => unknown;
+      };
+
+      init.beforeSend?.({
+        exception: { values: [{ type: "Error", value: "boom" }] },
+      });
+
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      const record = enqueue.mock.calls[0]![0];
+      expect(record.kind).toBe("sentry");
+      expect(record.label).toContain("boom");
+    } finally {
+      broadcaster.setTelemetryPreviewActive(false);
+      broadcaster.setTelemetryPreviewEnqueue(null);
+      delete process.env.SENTRY_DSN;
+    }
+  });
+
+  it("does not double-emit when trackEvent flows through beforeSend at full level", async () => {
+    const mod = await loadFreshModule();
+    const broadcaster = await loadBroadcaster();
+    const enqueue = vi.fn();
+    broadcaster.setTelemetryPreviewEnqueue(enqueue);
+    broadcaster.setTelemetryPreviewActive(true);
+
+    try {
+      setPrivacy({ telemetryLevel: "full", hasSeenPrompt: true });
+      process.env.SENTRY_DSN = "https://test@sentry.io/123";
+      await mod.initializeTelemetry();
+      captureEventMock.mockClear();
+
+      // The real Sentry SDK would call beforeSend inside captureEvent; in the
+      // test harness captureEvent is mocked so we simulate it manually via
+      // the registered hook. Either way, `trackEvent` should never fire the
+      // preview twice.
+      mod.trackEvent("onboarding_completed", { totalSteps: 3 });
+      expect(captureEventMock).toHaveBeenCalledTimes(1);
+      // No direct preview emission from trackEvent — it relies on beforeSend.
+      expect(enqueue).not.toHaveBeenCalled();
+
+      const init = sentryInitMock.mock.calls[0]?.[0] as {
+        beforeSend?: (event: unknown) => unknown;
+      };
+      init.beforeSend?.(captureEventMock.mock.calls[0]![0]);
+      expect(enqueue).toHaveBeenCalledTimes(1);
+    } finally {
+      broadcaster.setTelemetryPreviewActive(false);
+      broadcaster.setTelemetryPreviewEnqueue(null);
+      delete process.env.SENTRY_DSN;
+    }
+  });
+});
+
 describe("beforeSend wrapper (end-to-end via initializeTelemetry)", () => {
   async function loadFreshModule() {
     vi.resetModules();

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -1026,7 +1026,8 @@ describe("telemetry preview tap", () => {
       const init = sentryInitMock.mock.calls[0]?.[0] as {
         beforeSend?: (event: unknown) => unknown;
       };
-      init.beforeSend?.(captureEventMock.mock.calls[0]![0]);
+      const captured = (captureEventMock.mock.calls[0] as unknown[] | undefined)?.[0];
+      init.beforeSend?.(captured);
       expect(enqueue).toHaveBeenCalledTimes(1);
     } finally {
       broadcaster.setTelemetryPreviewActive(false);

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -134,6 +134,8 @@ export type BuiltInActionId =
   | "eventInspector.subscribe"
   | "eventInspector.unsubscribe"
   | "eventInspector.clear"
+  | "telemetry.togglePreview"
+  | "telemetry.clearPreview"
   | "worktree.refresh"
   | "worktree.refreshPullRequests"
   | "worktree.setActive"

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -470,3 +470,12 @@ export type {
   AppThemeConfig,
   ColorVisionMode,
 } from "./appTheme.js";
+
+// Telemetry preview types — session-scoped payload mirror
+export type {
+  SanitizedTelemetryEvent,
+  SanitizedTelemetryEventKind,
+  SanitizedSentryEvent,
+  SanitizedAnalyticsEvent,
+  TelemetryPreviewState,
+} from "./ipc/telemetryPreview.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -151,6 +151,7 @@ import type { AppAgentConfig } from "../appAgent.js";
 import type { ActionContext } from "../actions.js";
 import type { AgentRegistry, AgentMetadata } from "./agentCapabilities.js";
 import type { AppThemeConfig } from "../appTheme.js";
+import type { SanitizedTelemetryEvent, TelemetryPreviewState } from "./telemetryPreview.js";
 
 export interface NotificationSettings {
   enabled: boolean;
@@ -1195,6 +1196,14 @@ export interface ElectronAPI {
     setEnabled(enabled: boolean): Promise<void>;
     markPromptShown(): Promise<void>;
     track(event: string, properties: Record<string, unknown>): Promise<void>;
+    preview: {
+      getState(): Promise<TelemetryPreviewState>;
+      toggle(active: boolean): Promise<TelemetryPreviewState>;
+      subscribe(): void;
+      unsubscribe(): void;
+      onEventBatch(callback: (events: SanitizedTelemetryEvent[]) => void): () => void;
+      onStateChanged(callback: (state: TelemetryPreviewState) => void): () => void;
+    };
   };
   gpu: {
     getStatus(): Promise<{ hardwareAccelerationDisabled: boolean }>;

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -23,3 +23,4 @@ export * from "./api.js";
 export * from "./crashRecovery.js";
 export * from "./webviewConsole.js";
 export * from "./demo.js";
+export * from "./telemetryPreview.js";

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -130,6 +130,7 @@ import type {
   DevPreviewSessionState,
   DevPreviewStateChangedPayload,
 } from "./devPreview.js";
+import type { SanitizedTelemetryEvent, TelemetryPreviewState } from "./telemetryPreview.js";
 import type { ProjectPulse, PulseRangeDays } from "../pulse.js";
 import type {
   GitCommitListOptions,
@@ -1575,6 +1576,14 @@ export interface IpcInvokeMap {
     args: [event: string, properties: Record<string, unknown>];
     result: void;
   };
+  "telemetry:preview-get-state": {
+    args: [];
+    result: TelemetryPreviewState;
+  };
+  "telemetry:preview-toggle": {
+    args: [active: boolean];
+    result: TelemetryPreviewState;
+  };
 
   // GPU
   "gpu:get-status": {
@@ -2412,6 +2421,10 @@ export interface IpcEventMap {
     level: "off" | "errors" | "full";
     hasSeenPrompt: boolean;
   };
+
+  // Telemetry preview events
+  "telemetry:preview-event-batch": SanitizedTelemetryEvent[];
+  "telemetry:preview-state-changed": TelemetryPreviewState;
 
   // Onboarding checklist push (main → renderer)
   "onboarding:checklist-push": ChecklistState;

--- a/shared/types/ipc/telemetryPreview.ts
+++ b/shared/types/ipc/telemetryPreview.ts
@@ -1,0 +1,36 @@
+/**
+ * Live telemetry preview — session-scoped mirror of outbound payloads.
+ *
+ * When the user enables preview mode, the main process clones every
+ * sanitised Sentry event and analytics `trackEvent` call and streams it to
+ * the renderer so the user can inspect exactly what would leave their
+ * machine. Preview mode is not persisted — it resets at app launch.
+ */
+
+export type SanitizedTelemetryEventKind = "sentry" | "analytics";
+
+export interface SanitizedSentryEvent {
+  id: string;
+  kind: "sentry";
+  timestamp: number;
+  /** Derived label for the list row — exception type or message snippet. */
+  label: string;
+  /** The post-sanitisation event payload that Sentry's transport would send. */
+  payload: Record<string, unknown>;
+}
+
+export interface SanitizedAnalyticsEvent {
+  id: string;
+  kind: "analytics";
+  timestamp: number;
+  /** Analytics event name (e.g. `onboarding.completed`). */
+  label: string;
+  /** The post-sanitisation event payload handed to Sentry's capture. */
+  payload: Record<string, unknown>;
+}
+
+export type SanitizedTelemetryEvent = SanitizedSentryEvent | SanitizedAnalyticsEvent;
+
+export interface TelemetryPreviewState {
+  active: boolean;
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -23,3 +23,4 @@ export { commandsClient } from "./commandsClient";
 export { editorClient } from "./editorClient";
 export { appThemeClient } from "./appThemeClient";
 export { globalRecipesClient } from "./globalRecipesClient";
+export { telemetryPreviewClient } from "./telemetryPreviewClient";

--- a/src/clients/telemetryPreviewClient.ts
+++ b/src/clients/telemetryPreviewClient.ts
@@ -1,0 +1,27 @@
+import type { SanitizedTelemetryEvent, TelemetryPreviewState } from "@shared/types";
+
+export const telemetryPreviewClient = {
+  getState: (): Promise<TelemetryPreviewState> => {
+    return window.electron.telemetry.preview.getState();
+  },
+
+  toggle: (active: boolean): Promise<TelemetryPreviewState> => {
+    return window.electron.telemetry.preview.toggle(active);
+  },
+
+  subscribe: (): void => {
+    window.electron.telemetry.preview.subscribe();
+  },
+
+  unsubscribe: (): void => {
+    window.electron.telemetry.preview.unsubscribe();
+  },
+
+  onEventBatch: (callback: (events: SanitizedTelemetryEvent[]) => void): (() => void) => {
+    return window.electron.telemetry.preview.onEventBatch(callback);
+  },
+
+  onStateChanged: (callback: (state: TelemetryPreviewState) => void): (() => void) => {
+    return window.electron.telemetry.preview.onStateChanged(callback);
+  },
+} as const;

--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { useLogsStore, useErrorStore } from "@/store";
+import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
 import { actionService } from "@/services/ActionService";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 
@@ -94,6 +95,55 @@ export function LogsActions() {
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">Clear logs</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}
+
+export function TelemetryActions() {
+  const active = useTelemetryPreviewStore((state) => state.active);
+  const hasEvents = useTelemetryPreviewStore((state) => state.events.length > 0);
+
+  const handleToggle = useCallback(() => {
+    void actionService.dispatch("telemetry.togglePreview", undefined, { source: "user" });
+  }, []);
+
+  const handleClear = useCallback(() => {
+    void actionService.dispatch("telemetry.clearPreview", undefined, { source: "user" });
+  }, []);
+
+  return (
+    <div className="flex items-center gap-2">
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={active ? "info" : "subtle"}
+              size="xs"
+              onClick={handleToggle}
+              aria-pressed={active}
+            >
+              {active ? "Preview On" : "Preview Off"}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {active
+              ? "Stop mirroring outbound telemetry payloads"
+              : "Start mirroring outbound telemetry payloads"}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex">
+              <Button variant="subtle" size="xs" onClick={handleClear} disabled={!hasEvents}>
+                Clear
+              </Button>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Clear captured events</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -12,7 +12,13 @@ import { useErrorStore } from "@/store";
 import { ProblemsContent } from "./ProblemsContent";
 import { LogsContent } from "./LogsContent";
 import { EventsContent } from "./EventsContent";
-import { ProblemsActions, LogsActions, EventsActions } from "./DiagnosticsActions";
+import { TelemetryContent } from "./TelemetryContent";
+import {
+  ProblemsActions,
+  LogsActions,
+  EventsActions,
+  TelemetryActions,
+} from "./DiagnosticsActions";
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 
@@ -165,6 +171,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
     { id: "problems", label: "Problems", badge: errorCount },
     { id: "logs", label: "Logs" },
     { id: "events", label: "Events" },
+    { id: "telemetry", label: "Telemetry" },
   ];
 
   return (
@@ -223,6 +230,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
           {activeTab === "problems" && <ProblemsActions />}
           {activeTab === "logs" && <LogsActions />}
           {activeTab === "events" && <EventsActions />}
+          {activeTab === "telemetry" && <TelemetryActions />}
 
           <TooltipProvider>
             <Tooltip>
@@ -270,6 +278,16 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
             className="h-full"
           >
             <EventsContent />
+          </div>
+        )}
+        {activeTab === "telemetry" && (
+          <div
+            id="diagnostics-telemetry-panel"
+            role="tabpanel"
+            aria-labelledby="diagnostics-telemetry-tab"
+            className="h-full"
+          >
+            <TelemetryContent />
           </div>
         )}
       </div>

--- a/src/components/Diagnostics/TelemetryContent.tsx
+++ b/src/components/Diagnostics/TelemetryContent.tsx
@@ -1,0 +1,267 @@
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { Check, Copy, ShieldCheck } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
+import { telemetryPreviewClient } from "@/clients";
+import { actionService } from "@/services/ActionService";
+import type { SanitizedTelemetryEvent } from "@shared/types";
+
+export interface TelemetryContentProps {
+  className?: string;
+}
+
+function formatClockTime(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${date.getHours().toString().padStart(2, "0")}:${date
+    .getMinutes()
+    .toString()
+    .padStart(2, "0")}:${date.getSeconds().toString().padStart(2, "0")}.${date
+    .getMilliseconds()
+    .toString()
+    .padStart(3, "0")}`;
+}
+
+function kindLabel(kind: SanitizedTelemetryEvent["kind"]): string {
+  return kind === "sentry" ? "Sentry" : "Analytics";
+}
+
+interface RowProps {
+  event: SanitizedTelemetryEvent;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}
+
+function TelemetryRow({ event, isSelected, onSelect }: RowProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(event.id)}
+      className={cn(
+        "w-full text-left px-3 py-2 border-b border-daintree-border/40 transition-colors",
+        "hover:bg-tint/5 focus-visible:outline-none focus-visible:bg-tint/10",
+        isSelected && "bg-daintree-accent/10"
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wide shrink-0",
+            event.kind === "sentry"
+              ? "bg-status-error/15 text-status-error"
+              : "bg-daintree-accent/15 text-daintree-accent"
+          )}
+        >
+          {kindLabel(event.kind)}
+        </span>
+        <span className="font-mono text-xs text-daintree-text truncate flex-1">{event.label}</span>
+        <span className="text-[10px] text-daintree-text/50 font-mono tabular-nums shrink-0">
+          {formatClockTime(event.timestamp)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+interface DetailProps {
+  event: SanitizedTelemetryEvent | null;
+}
+
+function TelemetryDetail({ event }: DetailProps) {
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    setCopied(false);
+    if (copyTimerRef.current) {
+      clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = null;
+    }
+  }, [event?.id]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  const payloadJson = useMemo(() => {
+    if (!event) return "";
+    try {
+      return JSON.stringify(event.payload, null, 2);
+    } catch {
+      return "(payload could not be serialised)";
+    }
+  }, [event]);
+
+  const handleCopy = useCallback(async () => {
+    if (!event) return;
+    try {
+      await navigator.clipboard.writeText(payloadJson);
+      setCopied(true);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy telemetry payload:", err);
+    }
+  }, [event, payloadJson]);
+
+  if (!event) {
+    return (
+      <div className="flex items-center justify-center h-full text-sm text-daintree-text/60">
+        <p>Select an event to view the sanitised payload</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <div className="flex-shrink-0 p-3 border-b border-daintree-border/60">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "px-1.5 py-0.5 rounded text-[10px] font-mono uppercase tracking-wide",
+                  event.kind === "sentry"
+                    ? "bg-status-error/15 text-status-error"
+                    : "bg-daintree-accent/15 text-daintree-accent"
+                )}
+              >
+                {kindLabel(event.kind)}
+              </span>
+              <span className="font-mono text-sm text-daintree-text truncate">{event.label}</span>
+            </div>
+            <div className="flex items-center gap-2 text-[11px] text-daintree-text/50 font-mono">
+              <span>{new Date(event.timestamp).toISOString()}</span>
+              <span aria-hidden>•</span>
+              <span>ID {event.id.slice(0, 8)}</span>
+            </div>
+          </div>
+          <Button variant="subtle" size="xs" onClick={handleCopy} aria-label="Copy payload JSON">
+            {copied ? (
+              <>
+                <Check className="w-3 h-3 mr-1 text-status-success" /> Copied
+              </>
+            ) : (
+              <>
+                <Copy className="w-3 h-3 mr-1" /> Copy JSON
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-auto">
+        <pre className="text-xs font-mono bg-muted/30 p-3 whitespace-pre-wrap break-all select-text">
+          {payloadJson}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ active }: { active: boolean }) {
+  const handleEnable = useCallback(() => {
+    void actionService.dispatch("telemetry.togglePreview", { active: true }, { source: "user" });
+  }, []);
+
+  return (
+    <div className="h-full flex items-center justify-center p-6">
+      <div className="max-w-sm text-center space-y-3">
+        <ShieldCheck className="w-8 h-8 mx-auto text-daintree-accent/70" aria-hidden />
+        <h3 className="text-sm font-medium text-daintree-text">
+          {active ? "No events captured yet" : "Telemetry preview is off"}
+        </h3>
+        <p className="text-xs text-daintree-text/60">
+          {active
+            ? "Perform an action that emits an analytics event (e.g. finishing onboarding) to see its sanitised payload here. Crash reports only appear in preview once telemetry is set to Errors Only or Full Usage. Nothing is transmitted until you opt in."
+            : "Turn on preview to mirror the sanitised payloads Daintree would transmit — inspect them before deciding whether to enable telemetry."}
+        </p>
+        {!active && (
+          <Button variant="subtle" size="xs" onClick={handleEnable}>
+            Enable preview
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TelemetryContent({ className }: TelemetryContentProps) {
+  const { active, events, selectedEventId, setActive, appendEvents, setSelectedEvent } =
+    useTelemetryPreviewStore(
+      useShallow((state) => ({
+        active: state.active,
+        events: state.events,
+        selectedEventId: state.selectedEventId,
+        setActive: state.setActive,
+        appendEvents: state.appendEvents,
+        setSelectedEvent: state.setSelectedEvent,
+      }))
+    );
+
+  useEffect(() => {
+    let disposed = false;
+    telemetryPreviewClient.subscribe();
+    telemetryPreviewClient
+      .getState()
+      .then((state) => {
+        if (!disposed) setActive(state.active);
+      })
+      .catch((err) => {
+        console.error("Failed to read telemetry preview state:", err);
+      });
+
+    const unsubscribeBatch = telemetryPreviewClient.onEventBatch((incoming) => {
+      if (disposed) return;
+      appendEvents(incoming);
+    });
+    const unsubscribeState = telemetryPreviewClient.onStateChanged((state) => {
+      if (disposed) return;
+      setActive(state.active);
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribeBatch();
+      unsubscribeState();
+      telemetryPreviewClient.unsubscribe();
+    };
+  }, [appendEvents, setActive]);
+
+  const deferredEvents = useDeferredValue(events);
+  const selectedEvent = useMemo(() => {
+    if (!selectedEventId) return null;
+    return events.find((e) => e.id === selectedEventId) ?? null;
+  }, [events, selectedEventId]);
+
+  if (events.length === 0) {
+    return (
+      <div className={cn("h-full", className)}>
+        <EmptyState active={active} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex h-full min-h-0", className)}>
+      <div className="w-1/2 border-r border-daintree-border/60 overflow-y-auto">
+        {deferredEvents
+          .slice()
+          .reverse()
+          .map((event) => (
+            <TelemetryRow
+              key={event.id}
+              event={event}
+              isSelected={event.id === selectedEventId}
+              onSelect={setSelectedEvent}
+            />
+          ))}
+      </div>
+      <div className="w-1/2 overflow-hidden">
+        <TelemetryDetail event={selectedEvent} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { Signal, FolderOpen, Trash2, Clock, HardDrive, AlertTriangle } from "lucide-react";
+import { Signal, FolderOpen, Trash2, Clock, HardDrive, AlertTriangle, Eye } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { notify } from "@/lib/notify";
 import { Button } from "@/components/ui/button";
@@ -7,6 +7,7 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsSubtabBar } from "./SettingsSubtabBar";
 import type { SettingsSubtabItem } from "./SettingsSubtabBar";
 import { ANALYTICS_EVENTS } from "@shared/config/telemetry";
+import { actionService } from "@/services/ActionService";
 
 type TelemetryLevel = "off" | "errors" | "full";
 type LogRetention = 7 | 30 | 90 | 0;
@@ -184,6 +185,10 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
     window.electron.privacy.resetAllData();
   }, []);
 
+  const handleOpenTelemetryPreview = useCallback(() => {
+    void actionService.dispatch("telemetry.togglePreview", { active: true }, { source: "user" });
+  }, []);
+
   return (
     <div className="space-y-6">
       <SettingsSubtabBar
@@ -238,6 +243,20 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           <p className="text-xs text-daintree-text/40 mt-2 select-text">
             Changes to telemetry level take effect on next app restart.
           </p>
+
+          <div className="mt-4 flex items-start gap-3 rounded-[var(--radius-md)] border border-daintree-border/60 bg-daintree-bg/40 p-3">
+            <Eye className="w-4 h-4 mt-0.5 text-daintree-accent/80 shrink-0" aria-hidden />
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium text-daintree-text">Preview outbound telemetry</p>
+              <p className="text-xs text-daintree-text/60 mt-0.5 select-text">
+                Inspect every sanitised payload Daintree would send — live, for this session only,
+                with no transmission to any server.
+              </p>
+            </div>
+            <Button variant="subtle" size="xs" onClick={handleOpenTelemetryPreview}>
+              Open preview
+            </Button>
+          </div>
 
           <div
             aria-labelledby="telemetry-disclosure-heading"

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -21,6 +21,7 @@ import { BUILT_IN_APP_SCHEMES } from "@/config/appColorSchemes";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
 import type { AppColorScheme } from "@shared/types/appTheme";
+import { actionService } from "@/services/ActionService";
 
 const AGENT_ORDER = BUILT_IN_AGENT_IDS;
 const POLL_INTERVAL = 3000;
@@ -817,32 +818,47 @@ function SelectionStep({
       )}
 
       {isFirstRun && onTelemetryChange != null && (
-        <div className="flex items-center justify-between gap-3 pt-4 border-t border-daintree-border">
-          <div>
-            <p className="text-sm font-medium text-daintree-text">Help improve Daintree</p>
-            <p className="text-xs text-daintree-text/50">
-              Send anonymous crash reports. No file contents or credentials.
-            </p>
+        <div className="pt-4 border-t border-daintree-border space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium text-daintree-text">Help improve Daintree</p>
+              <p className="text-xs text-daintree-text/50">
+                Send anonymous crash reports. No file contents or credentials.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={telemetryEnabled}
+              aria-label="Enable crash reporting"
+              onClick={() => onTelemetryChange(!telemetryEnabled)}
+              className={cn(
+                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
+                telemetryEnabled ? "bg-daintree-accent" : "bg-daintree-border"
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
+                  telemetryEnabled
+                    ? "translate-x-4 ml-0.5 bg-text-inverse"
+                    : "translate-x-0 ml-0.5 bg-daintree-text"
+                )}
+              />
+            </button>
           </div>
           <button
             type="button"
-            role="switch"
-            aria-checked={telemetryEnabled}
-            aria-label="Enable crash reporting"
-            onClick={() => onTelemetryChange(!telemetryEnabled)}
-            className={cn(
-              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
-              telemetryEnabled ? "bg-daintree-accent" : "bg-daintree-border"
-            )}
+            className="text-xs text-daintree-accent hover:underline focus-visible:outline-none focus-visible:underline"
+            onClick={() =>
+              void actionService.dispatch(
+                "telemetry.togglePreview",
+                { active: true },
+                { source: "user" }
+              )
+            }
           >
-            <span
-              className={cn(
-                "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
-                telemetryEnabled
-                  ? "translate-x-4 ml-0.5 bg-text-inverse"
-                  : "translate-x-0 ml-0.5 bg-daintree-text"
-              )}
-            />
+            Preview what would be sent
           </button>
         </div>
       )}

--- a/src/services/actions/definitions/logActions.ts
+++ b/src/services/actions/definitions/logActions.ts
@@ -1,9 +1,11 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
-import { errorsClient, eventInspectorClient, logsClient } from "@/clients";
+import { errorsClient, eventInspectorClient, logsClient, telemetryPreviewClient } from "@/clients";
 import { useErrorStore } from "@/store/errorStore";
 import { useEventStore } from "@/store/eventStore";
 import { useLogsStore } from "@/store/logsStore";
+import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
 
 export function registerLogActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("logs.openFile", () => ({
@@ -310,6 +312,42 @@ export function registerLogActions(actions: ActionRegistry, _callbacks: ActionCa
     run: async () => {
       useEventStore.getState().clearEvents();
       await eventInspectorClient.clear();
+    },
+  }));
+
+  actions.set("telemetry.togglePreview", () => ({
+    id: "telemetry.togglePreview",
+    title: "Preview Outbound Telemetry",
+    description:
+      "Toggle a session-only preview that mirrors every sanitised telemetry payload before it is sent.",
+    category: "diagnostics",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ active: z.boolean().optional() }).optional(),
+    run: async (args: unknown) => {
+      const { active } = (args as { active?: boolean } | undefined) ?? {};
+      const current = useTelemetryPreviewStore.getState().active;
+      const next = typeof active === "boolean" ? active : !current;
+      const result = await telemetryPreviewClient.toggle(next);
+      useTelemetryPreviewStore.getState().setActive(result.active);
+      if (result.active) {
+        useDiagnosticsStore.getState().openDock("telemetry");
+      }
+      return result;
+    },
+  }));
+
+  actions.set("telemetry.clearPreview", () => ({
+    id: "telemetry.clearPreview",
+    title: "Clear Telemetry Preview",
+    description: "Clear captured telemetry preview events from the diagnostics dock.",
+    category: "diagnostics",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      useTelemetryPreviewStore.getState().clearEvents();
     },
   }));
 

--- a/src/store/__tests__/telemetryPreviewStore.test.ts
+++ b/src/store/__tests__/telemetryPreviewStore.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useTelemetryPreviewStore, TELEMETRY_PREVIEW_MAX_EVENTS } from "../telemetryPreviewStore";
+import type { SanitizedTelemetryEvent } from "@shared/types";
+
+function makeEvent(
+  id: string,
+  overrides: Partial<SanitizedTelemetryEvent> = {}
+): SanitizedTelemetryEvent {
+  return {
+    id,
+    kind: "analytics",
+    timestamp: 1_700_000_000_000,
+    label: `event-${id}`,
+    payload: { n: id },
+    ...overrides,
+  } as SanitizedTelemetryEvent;
+}
+
+describe("telemetryPreviewStore", () => {
+  beforeEach(() => {
+    useTelemetryPreviewStore.getState().reset();
+  });
+
+  it("defaults to inactive, empty, and no selection", () => {
+    const state = useTelemetryPreviewStore.getState();
+    expect(state.active).toBe(false);
+    expect(state.events).toEqual([]);
+    expect(state.selectedEventId).toBeNull();
+  });
+
+  it("toggles active idempotently", () => {
+    const { setActive } = useTelemetryPreviewStore.getState();
+    setActive(true);
+    expect(useTelemetryPreviewStore.getState().active).toBe(true);
+    setActive(true);
+    expect(useTelemetryPreviewStore.getState().active).toBe(true);
+    setActive(false);
+    expect(useTelemetryPreviewStore.getState().active).toBe(false);
+  });
+
+  it("appends events preserving order", () => {
+    const { appendEvents } = useTelemetryPreviewStore.getState();
+    appendEvents([makeEvent("a"), makeEvent("b")]);
+    appendEvents([makeEvent("c")]);
+    const ids = useTelemetryPreviewStore.getState().events.map((e) => e.id);
+    expect(ids).toEqual(["a", "b", "c"]);
+  });
+
+  it("deduplicates by id", () => {
+    const { appendEvents } = useTelemetryPreviewStore.getState();
+    appendEvents([makeEvent("a"), makeEvent("b")]);
+    appendEvents([makeEvent("b"), makeEvent("c")]);
+    const ids = useTelemetryPreviewStore.getState().events.map((e) => e.id);
+    expect(ids).toEqual(["a", "b", "c"]);
+  });
+
+  it("caps the ring buffer at TELEMETRY_PREVIEW_MAX_EVENTS retaining newest", () => {
+    const { appendEvents } = useTelemetryPreviewStore.getState();
+    const batch: SanitizedTelemetryEvent[] = [];
+    for (let i = 0; i < TELEMETRY_PREVIEW_MAX_EVENTS + 50; i++) {
+      batch.push(makeEvent(String(i)));
+    }
+    appendEvents(batch);
+    const events = useTelemetryPreviewStore.getState().events;
+    expect(events).toHaveLength(TELEMETRY_PREVIEW_MAX_EVENTS);
+    expect(events[events.length - 1]?.id).toBe(String(TELEMETRY_PREVIEW_MAX_EVENTS + 49));
+    expect(events[0]?.id).toBe(String(50));
+  });
+
+  it("clears selection when the selected event is evicted by ring-buffer trim", () => {
+    const { appendEvents, setSelectedEvent } = useTelemetryPreviewStore.getState();
+    appendEvents([makeEvent("early")]);
+    setSelectedEvent("early");
+    // Push enough events to evict "early" from the 200-event ring.
+    const batch: SanitizedTelemetryEvent[] = [];
+    for (let i = 0; i < TELEMETRY_PREVIEW_MAX_EVENTS + 5; i++) {
+      batch.push(makeEvent(`new-${i}`));
+    }
+    appendEvents(batch);
+    const state = useTelemetryPreviewStore.getState();
+    expect(state.events.some((e) => e.id === "early")).toBe(false);
+    expect(state.selectedEventId).toBeNull();
+  });
+
+  it("keeps selection when the selected event is still visible after trim", () => {
+    const { appendEvents, setSelectedEvent } = useTelemetryPreviewStore.getState();
+    // Fill up to right before the cap with events we don't care about.
+    const fill: SanitizedTelemetryEvent[] = [];
+    for (let i = 0; i < TELEMETRY_PREVIEW_MAX_EVENTS - 1; i++) {
+      fill.push(makeEvent(`fill-${i}`));
+    }
+    appendEvents(fill);
+    // Add a distinct event and select it.
+    appendEvents([makeEvent("keepme")]);
+    setSelectedEvent("keepme");
+    // Overflow by exactly 3 — "keepme" is near the tail, should survive.
+    appendEvents([makeEvent("x1"), makeEvent("x2"), makeEvent("x3")]);
+    const state = useTelemetryPreviewStore.getState();
+    expect(state.events.some((e) => e.id === "keepme")).toBe(true);
+    expect(state.selectedEventId).toBe("keepme");
+  });
+
+  it("clearEvents drops events and selection", () => {
+    const { appendEvents, setSelectedEvent, clearEvents } = useTelemetryPreviewStore.getState();
+    appendEvents([makeEvent("a"), makeEvent("b")]);
+    setSelectedEvent("a");
+    clearEvents();
+    const state = useTelemetryPreviewStore.getState();
+    expect(state.events).toEqual([]);
+    expect(state.selectedEventId).toBeNull();
+  });
+
+  it("no-ops on empty append", () => {
+    const { appendEvents } = useTelemetryPreviewStore.getState();
+    const prev = useTelemetryPreviewStore.getState().events;
+    appendEvents([]);
+    expect(useTelemetryPreviewStore.getState().events).toBe(prev);
+  });
+});

--- a/src/store/diagnosticsStore.ts
+++ b/src/store/diagnosticsStore.ts
@@ -1,6 +1,6 @@
 import { create, type StateCreator } from "zustand";
 
-export type DiagnosticsTab = "problems" | "logs" | "events";
+export type DiagnosticsTab = "problems" | "logs" | "events" | "telemetry";
 
 interface DiagnosticsState {
   isOpen: boolean;

--- a/src/store/telemetryPreviewStore.ts
+++ b/src/store/telemetryPreviewStore.ts
@@ -1,0 +1,61 @@
+import { create, type StateCreator } from "zustand";
+import type { SanitizedTelemetryEvent } from "@shared/types";
+
+interface TelemetryPreviewStoreState {
+  active: boolean;
+  events: SanitizedTelemetryEvent[];
+  selectedEventId: string | null;
+
+  setActive: (active: boolean) => void;
+  appendEvents: (events: SanitizedTelemetryEvent[]) => void;
+  clearEvents: () => void;
+  setSelectedEvent: (id: string | null) => void;
+  reset: () => void;
+}
+
+export const TELEMETRY_PREVIEW_MAX_EVENTS = 200;
+
+const createStore: StateCreator<TelemetryPreviewStoreState> = (set) => ({
+  active: false,
+  events: [],
+  selectedEventId: null,
+
+  setActive: (active) =>
+    set((state) => {
+      if (state.active === active) return state;
+      return { active };
+    }),
+
+  appendEvents: (incoming) =>
+    set((state) => {
+      if (incoming.length === 0) return state;
+      const existingIds = new Set(state.events.map((e) => e.id));
+      const next = state.events.slice();
+      for (const event of incoming) {
+        if (existingIds.has(event.id)) continue;
+        existingIds.add(event.id);
+        next.push(event);
+      }
+      if (next.length > TELEMETRY_PREVIEW_MAX_EVENTS) {
+        const trimmed = next.slice(-TELEMETRY_PREVIEW_MAX_EVENTS);
+        // If the selected row was in the evicted head, the detail pane would
+        // silently blank out while the list still renders rows — reconcile
+        // the selection to `null` so the empty-state prompt is shown.
+        const stillVisible =
+          state.selectedEventId !== null && trimmed.some((e) => e.id === state.selectedEventId);
+        return {
+          events: trimmed,
+          selectedEventId: stillVisible ? state.selectedEventId : null,
+        };
+      }
+      return { events: next };
+    }),
+
+  clearEvents: () => set({ events: [], selectedEventId: null }),
+
+  setSelectedEvent: (id) => set({ selectedEventId: id }),
+
+  reset: () => set({ active: false, events: [], selectedEventId: null }),
+});
+
+export const useTelemetryPreviewStore = create<TelemetryPreviewStoreState>(createStore);


### PR DESCRIPTION
## Summary

- Closes #5427 — adds a session-scoped Telemetry tab to the Diagnostics dock that mirrors every sanitised Sentry and analytics payload Daintree would send
- 200-event ring buffer, no persistence, no transmission; the tap runs post-sanitisation so what you see in the preview is exactly what `beforeSend` would emit
- New `telemetry.togglePreview` action wired into Privacy settings and the onboarding privacy step, so users can inspect before committing to a consent level

## Changes

- `TelemetryService`: post-`beforeSend` tap emits sanitised events to the preview broadcaster when active
- `TelemetryPreviewBroadcaster`: IPC broadcast to all windows on state change and each new event
- `telemetryPreviewStore` (renderer): ring-buffered store, 200-event cap, session-only (resets on relaunch)
- `TelemetryContent`: new Diagnostics subtab rendering "Analytics" / "Sentry" pill rows with expandable JSON payloads
- `DiagnosticsActions`: Preview On/Off toggle + Clear button in the dock toolbar
- `PrivacyDataTab` and `AgentSetupWizard`: "Open preview" link routes to the tab and activates preview mode

## Test plan

- [ ] Open Settings → Privacy → Telemetry, click "Open preview" — dock opens to the Telemetry tab
- [ ] Verify the Diagnostics dock shows a new "Telemetry" tab alongside Problems / Logs / Events
- [ ] Toggle "Preview On" and trigger an analytics event (e.g. finish onboarding) — see the row appear with an "Analytics" pill and a sanitised JSON payload
- [ ] Set telemetry level to "Errors Only" or "Full Usage" and trigger a crash — see a "Sentry" pill row with the post-sanitisation event
- [ ] Toggle preview off — no further events arrive
- [ ] Clear button removes captured events; preview toggle state persists until quit
- [ ] Preview state is session-only — quitting and relaunching resets `active: false` and `events: []`
- [ ] Multi-window: toggle preview in window A; window B's Telemetry tab reflects the same state via broadcast