### PR TITLE
perf(main): post-first-interactive deferred service queue

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -160,6 +160,7 @@ export const CHANNELS = {
   APP_HYDRATE: "app:hydrate",
   APP_QUIT: "app:quit",
   APP_FORCE_QUIT: "app:force-quit",
+  APP_FIRST_INTERACTIVE: "app:first-interactive",
   MENU_ACTION: "menu:action",
   MENU_SHOW_CONTEXT: "menu:show-context",
 

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -13,7 +13,10 @@ import { isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
 import { isGpuDisabledByFlag } from "../../../services/GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
 import { inferKind } from "../../../../shared/utils/inferPanelKind.js";
-import { typedHandle } from "../../utils.js";
+import { typedHandle, typedHandleWithContext } from "../../utils.js";
+import { signalFirstInteractive } from "../../../window/deferredInitQueue.js";
+import { markPerformance } from "../../../utils/performance.js";
+import { PERF_MARKS } from "../../../../shared/perf/marks.js";
 
 export function registerAppStateHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -484,6 +487,15 @@ export function registerAppStateHandlers(): () => void {
     app.exit(0);
   };
   handlers.push(typedHandle(CHANNELS.APP_FORCE_QUIT, handleAppForceQuit));
+
+  handlers.push(
+    typedHandleWithContext(CHANNELS.APP_FIRST_INTERACTIVE, async (ctx) => {
+      markPerformance(PERF_MARKS.RENDERER_FIRST_INTERACTIVE, {
+        webContentsId: ctx.webContentsId,
+      });
+      signalFirstInteractive(ctx.webContentsId);
+    })
+  );
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -674,6 +674,7 @@ const CHANNELS = {
   APP_HYDRATE: "app:hydrate",
   APP_QUIT: "app:quit",
   APP_FORCE_QUIT: "app:force-quit",
+  APP_FIRST_INTERACTIVE: "app:first-interactive",
   MENU_ACTION: "menu:action",
   MENU_SHOW_CONTEXT: "menu:show-context",
 
@@ -1578,6 +1579,8 @@ const api: ElectronAPI = {
     quit: () => _unwrappingInvoke(CHANNELS.APP_QUIT),
 
     forceQuit: () => _unwrappingInvoke(CHANNELS.APP_FORCE_QUIT),
+
+    notifyFirstInteractive: () => _unwrappingInvoke(CHANNELS.APP_FIRST_INTERACTIVE),
 
     onMenuAction: (callback: (action: string) => void) => _typedOn(CHANNELS.MENU_ACTION, callback),
 

--- a/electron/window/__tests__/deferredInitQueue.test.ts
+++ b/electron/window/__tests__/deferredInitQueue.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../utils/performance.js", () => ({
+  markPerformance: vi.fn(),
+}));
+
+import {
+  registerDeferredTask,
+  finalizeDeferredRegistration,
+  signalFirstInteractive,
+  getDeferredQueueState,
+  resetDeferredQueue,
+} from "../deferredInitQueue.js";
+
+describe("deferredInitQueue", () => {
+  beforeEach(() => {
+    resetDeferredQueue();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetDeferredQueue();
+    vi.useRealTimers();
+  });
+
+  // Helper to drain setImmediate-chained tasks: advance timers and flush
+  // microtasks until the queue reports "drained".
+  async function waitForDrain(timeoutMs = 5000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (getDeferredQueueState().drainState !== "drained") {
+      await vi.advanceTimersByTimeAsync(1);
+      if (Date.now() > deadline) throw new Error("drain timeout");
+    }
+  }
+
+  it("does not drain before first-interactive signal", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "t1", run: task });
+    finalizeDeferredRegistration(10_000);
+
+    // Give setImmediate a chance to run — should NOT drain
+    await vi.advanceTimersByTimeAsync(0);
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+  });
+
+  it("drains sequentially after first-interactive signal", async () => {
+    const order: string[] = [];
+    registerDeferredTask({ name: "a", run: () => void order.push("a") });
+    registerDeferredTask({
+      name: "b",
+      run: async () => {
+        order.push("b-start");
+        await Promise.resolve();
+        order.push("b-end");
+      },
+    });
+    registerDeferredTask({ name: "c", run: () => void order.push("c") });
+
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(42);
+
+    await waitForDrain();
+
+    expect(order).toEqual(["a", "b-start", "b-end", "c"]);
+    expect(getDeferredQueueState().drainState).toBe("drained");
+  });
+
+  it("runs queued signal when finalize arrives after signal", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "early", run: task });
+
+    // Signal arrives before finalize
+    signalFirstInteractive(99);
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+    expect(getDeferredQueueState().firstInteractiveReceived).toBe(true);
+
+    // Finalize — should trigger drain
+    finalizeDeferredRegistration(10_000);
+    await waitForDrain();
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("fallback timer drains if signal never arrives", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "fb", run: task });
+    finalizeDeferredRegistration(5_000);
+
+    expect(task).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await waitForDrain();
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("signal after drain is a no-op", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "once", run: task });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    signalFirstInteractive(1); // same sender
+    signalFirstInteractive(2); // different sender
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates task failures — subsequent tasks still run", async () => {
+    const ran: string[] = [];
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    registerDeferredTask({
+      name: "fail-sync",
+      run: () => {
+        throw new Error("boom");
+      },
+    });
+    registerDeferredTask({
+      name: "fail-async",
+      run: async () => {
+        throw new Error("async-boom");
+      },
+    });
+    registerDeferredTask({ name: "ok", run: () => void ran.push("ok") });
+
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(null);
+    await waitForDrain();
+
+    expect(ran).toEqual(["ok"]);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("late registration after drain runs immediately", async () => {
+    const early = vi.fn();
+    registerDeferredTask({ name: "early", run: early });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const late = vi.fn();
+    registerDeferredTask({ name: "late", run: late });
+
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(consoleWarn).toHaveBeenCalled();
+    consoleWarn.mockRestore();
+  });
+
+  it("finalize is idempotent", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "t", run: task });
+    finalizeDeferredRegistration(10_000);
+    finalizeDeferredRegistration(10_000); // second call ignored
+
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetDeferredQueue clears state for a fresh cycle", async () => {
+    const t1 = vi.fn();
+    registerDeferredTask({ name: "t1", run: t1 });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    resetDeferredQueue();
+    const s = getDeferredQueueState();
+    expect(s.drainState).toBe("idle");
+    expect(s.registrationComplete).toBe(false);
+    expect(s.firstInteractiveReceived).toBe(false);
+    expect(s.taskCount).toBe(0);
+
+    const t2 = vi.fn();
+    registerDeferredTask({ name: "t2", run: t2 });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+    await waitForDrain();
+
+    expect(t1).toHaveBeenCalledTimes(1);
+    expect(t2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/window/__tests__/deferredInitQueue.test.ts
+++ b/electron/window/__tests__/deferredInitQueue.test.ts
@@ -187,4 +187,62 @@ describe("deferredInitQueue", () => {
     expect(t1).toHaveBeenCalledTimes(1);
     expect(t2).toHaveBeenCalledTimes(1);
   });
+
+  it("reset during in-flight drain does not corrupt the fresh cycle", async () => {
+    // Task that never settles — holds the drain chain open indefinitely.
+    let releaseFirst: () => void = () => {};
+    const firstRun = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        })
+    );
+    const secondRun = vi.fn();
+
+    registerDeferredTask({ name: "hang", run: firstRun });
+    registerDeferredTask({ name: "never", run: secondRun });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(1);
+
+    // Let the first task start but not finish
+    await vi.advanceTimersByTimeAsync(0);
+    expect(firstRun).toHaveBeenCalledTimes(1);
+    expect(getDeferredQueueState().drainState).toBe("draining");
+
+    // Simulate last-window-close
+    resetDeferredQueue();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+
+    // Register a fresh task for the next cycle
+    const freshTask = vi.fn();
+    registerDeferredTask({ name: "fresh", run: freshTask });
+    finalizeDeferredRegistration(10_000);
+    signalFirstInteractive(99);
+    await waitForDrain();
+    expect(freshTask).toHaveBeenCalledTimes(1);
+
+    // Now release the stale promise from the previous cycle. The stale
+    // scheduleNext callback must NOT corrupt the fresh cycle's state.
+    releaseFirst();
+    await vi.advanceTimersByTimeAsync(100);
+
+    // secondRun from the old cycle must never run
+    expect(secondRun).not.toHaveBeenCalled();
+    // Fresh cycle stays drained
+    expect(getDeferredQueueState().drainState).toBe("drained");
+  });
+
+  it("does not drain if finalize is never called, even after signal", async () => {
+    const task = vi.fn();
+    registerDeferredTask({ name: "orphan", run: task });
+
+    // Signal arrives (renderer painted) but finalize never happens
+    signalFirstInteractive(42);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(task).not.toHaveBeenCalled();
+    expect(getDeferredQueueState().drainState).toBe("idle");
+    expect(getDeferredQueueState().firstInteractiveReceived).toBe(true);
+  });
 });

--- a/electron/window/deferredInitQueue.ts
+++ b/electron/window/deferredInitQueue.ts
@@ -1,0 +1,146 @@
+import { markPerformance } from "../utils/performance.js";
+import { PERF_MARKS } from "../../shared/perf/marks.js";
+
+export type DeferredTask = {
+  name: string;
+  run: () => void | Promise<void>;
+};
+
+type DrainState = "idle" | "draining" | "drained";
+
+const DEFAULT_FALLBACK_MS = 10_000;
+
+let tasks: DeferredTask[] = [];
+let drainState: DrainState = "idle";
+let registrationComplete = false;
+let firstInteractiveReceived = false;
+let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+const drainedSenderIds = new Set<number>();
+
+export function registerDeferredTask(task: DeferredTask): void {
+  if (drainState !== "idle") {
+    console.warn(
+      `[DeferredInit] Task "${task.name}" registered after drain started — running immediately`
+    );
+    try {
+      const res = task.run();
+      if (res instanceof Promise) {
+        res.catch((err) => console.error(`[DeferredInit] Late task "${task.name}" failed:`, err));
+      }
+    } catch (err) {
+      console.error(`[DeferredInit] Late task "${task.name}" threw:`, err);
+    }
+    return;
+  }
+  tasks.push(task);
+}
+
+export function finalizeDeferredRegistration(fallbackMs: number = DEFAULT_FALLBACK_MS): void {
+  if (registrationComplete) return;
+  registrationComplete = true;
+
+  fallbackTimer = setTimeout(() => {
+    if (drainState === "idle") {
+      console.warn(
+        `[DeferredInit] First-interactive fallback fired after ${fallbackMs}ms — draining queue`
+      );
+      doDrain();
+    }
+  }, fallbackMs);
+  // Timer should not keep the process alive on its own
+  fallbackTimer.unref?.();
+
+  if (firstInteractiveReceived) {
+    doDrain();
+  }
+}
+
+export function signalFirstInteractive(webContentsId: number | null): void {
+  if (webContentsId !== null) {
+    if (drainedSenderIds.has(webContentsId)) return;
+    drainedSenderIds.add(webContentsId);
+  }
+
+  if (drainState !== "idle") return;
+
+  if (!registrationComplete) {
+    firstInteractiveReceived = true;
+    return;
+  }
+
+  doDrain();
+}
+
+export function getDeferredQueueState(): {
+  drainState: DrainState;
+  registrationComplete: boolean;
+  firstInteractiveReceived: boolean;
+  taskCount: number;
+} {
+  return {
+    drainState,
+    registrationComplete,
+    firstInteractiveReceived,
+    taskCount: tasks.length,
+  };
+}
+
+/**
+ * Clear all queue state. Called when the last window closes (so a new window
+ * opened later — e.g. macOS `activate` — gets a fresh queue) and from test
+ * setup.
+ */
+export function resetDeferredQueue(): void {
+  tasks = [];
+  drainState = "idle";
+  registrationComplete = false;
+  firstInteractiveReceived = false;
+  if (fallbackTimer) {
+    clearTimeout(fallbackTimer);
+    fallbackTimer = null;
+  }
+  drainedSenderIds.clear();
+}
+
+function doDrain(): void {
+  if (drainState !== "idle") return;
+  drainState = "draining";
+
+  if (fallbackTimer) {
+    clearTimeout(fallbackTimer);
+    fallbackTimer = null;
+  }
+
+  markPerformance(PERF_MARKS.DEFERRED_SERVICES_START, { taskCount: tasks.length });
+  const startedAt = Date.now();
+  drainNext(0, startedAt);
+}
+
+function drainNext(index: number, startedAt: number): void {
+  if (index >= tasks.length) {
+    drainState = "drained";
+    const elapsed = Date.now() - startedAt;
+    markPerformance(PERF_MARKS.DEFERRED_SERVICES_COMPLETE, { durationMs: elapsed });
+    console.log(`[DeferredInit] Drained ${tasks.length} deferred task(s) in ${elapsed}ms`);
+    return;
+  }
+
+  const task = tasks[index];
+  const scheduleNext = () => setImmediate(() => drainNext(index + 1, startedAt));
+
+  try {
+    const result = task.run();
+    if (result instanceof Promise) {
+      result
+        .catch((err) => {
+          console.error(`[DeferredInit] Task "${task.name}" failed:`, err);
+        })
+        .finally(scheduleNext);
+    } else {
+      scheduleNext();
+    }
+  } catch (err) {
+    console.error(`[DeferredInit] Task "${task.name}" threw:`, err);
+    scheduleNext();
+  }
+}

--- a/electron/window/deferredInitQueue.ts
+++ b/electron/window/deferredInitQueue.ts
@@ -16,6 +16,12 @@ let registrationComplete = false;
 let firstInteractiveReceived = false;
 let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
 const drainedSenderIds = new Set<number>();
+// Incremented on every `resetDeferredQueue()`. Drain callbacks capture the
+// generation at drain start; stale callbacks from a prior cycle that wake up
+// via `setImmediate` after a reset bail out instead of mutating the fresh
+// cycle's state. Without this, a stale `drainNext` could fire against an
+// empty `tasks[]` and mark the fresh queue as "drained" before any work runs.
+let generation = 0;
 
 export function registerDeferredTask(task: DeferredTask): void {
   if (drainState !== "idle") {
@@ -39,7 +45,9 @@ export function finalizeDeferredRegistration(fallbackMs: number = DEFAULT_FALLBA
   if (registrationComplete) return;
   registrationComplete = true;
 
+  const armedGen = generation;
   fallbackTimer = setTimeout(() => {
+    if (armedGen !== generation) return;
     if (drainState === "idle") {
       console.warn(
         `[DeferredInit] First-interactive fallback fired after ${fallbackMs}ms — draining queue`
@@ -88,9 +96,11 @@ export function getDeferredQueueState(): {
 /**
  * Clear all queue state. Called when the last window closes (so a new window
  * opened later — e.g. macOS `activate` — gets a fresh queue) and from test
- * setup.
+ * setup. Increments the generation counter so any in-flight drain callbacks
+ * from the previous cycle bail out instead of mutating fresh state.
  */
 export function resetDeferredQueue(): void {
+  generation++;
   tasks = [];
   drainState = "idle";
   registrationComplete = false;
@@ -113,20 +123,25 @@ function doDrain(): void {
 
   markPerformance(PERF_MARKS.DEFERRED_SERVICES_START, { taskCount: tasks.length });
   const startedAt = Date.now();
-  drainNext(0, startedAt);
+  const drainGen = generation;
+  drainNext(0, startedAt, drainGen);
 }
 
-function drainNext(index: number, startedAt: number): void {
+function drainNext(index: number, startedAt: number, drainGen: number): void {
+  if (drainGen !== generation) return; // queue was reset — abandon this chain
   if (index >= tasks.length) {
     drainState = "drained";
     const elapsed = Date.now() - startedAt;
     markPerformance(PERF_MARKS.DEFERRED_SERVICES_COMPLETE, { durationMs: elapsed });
     console.log(`[DeferredInit] Drained ${tasks.length} deferred task(s) in ${elapsed}ms`);
+    // Release task closures once drained so they don't retain references to
+    // destroyed windows, services, etc. until the next reset.
+    tasks = [];
     return;
   }
 
   const task = tasks[index];
-  const scheduleNext = () => setImmediate(() => drainNext(index + 1, startedAt));
+  const scheduleNext = () => setImmediate(() => drainNext(index + 1, startedAt, drainGen));
 
   try {
     const result = task.run();

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -79,6 +79,11 @@ import { isSmokeTest, isDemoMode, smokeTestStart, exposeGc } from "../setup/envi
 import { extractCliPath, getPendingCliPath, setPendingCliPath } from "../lifecycle/appLifecycle.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { getProjectViewManager } from "./windowRef.js";
+import {
+  registerDeferredTask,
+  finalizeDeferredRegistration,
+  resetDeferredQueue,
+} from "./deferredInitQueue.js";
 
 const DEFAULT_TERMINAL_ID = "default";
 
@@ -167,91 +172,41 @@ function createAndDistributePorts(win: BrowserWindow, ctx: WindowContext): void 
   distributePortsToView(win, ctx, wc, ptyClient);
 }
 
-async function initializeDeferredServices(
-  window: BrowserWindow,
-  cliService: CliAvailabilityService,
-  eventBuf: EventBuffer,
-  windowRegistry?: WindowRegistry
-): Promise<void> {
-  console.log("[MAIN] Initializing deferred services in background...");
-  markPerformance(PERF_MARKS.DEFERRED_SERVICES_START);
-  const startTime = Date.now();
+async function evictStaleSessionFiles(): Promise<void> {
+  try {
+    const allProjects = projectStore.getAllProjects();
+    const knownIds = new Set<string>();
 
-  const results = await Promise.allSettled([
-    cliService.checkAvailability().then((availability) => {
-      console.log("[MAIN] CLI availability checked:", availability);
-      console.log("[MAIN] Rebuilding menu with agent availability...");
-      createApplicationMenu(window, cliService);
-      return availability;
-    }),
-  ]);
-
-  results.forEach((result, index) => {
-    if (result.status === "rejected") {
-      const serviceName = ["CliAvailabilityService"][index];
-      console.error(`[MAIN] ${serviceName} initialization failed:`, result.reason);
-    }
-  });
-
-  initializeHibernationService();
-  console.log("[MAIN] HibernationService initialized");
-
-  initializeIdleTerminalNotificationService();
-  console.log("[MAIN] IdleTerminalNotificationService initialized");
-
-  initializeSystemSleepService();
-  console.log("[MAIN] SystemSleepService initialized");
-
-  eventBuf.start();
-  console.log("[MAIN] EventBuffer started");
-
-  if (windowRegistry) {
-    mcpServerService.start(windowRegistry).catch((err) => {
-      console.error("[MAIN] MCP server failed to start:", err);
-    });
-  }
-
-  // Fire-and-forget session file eviction
-  (async () => {
-    try {
-      const allProjects = projectStore.getAllProjects();
-      const knownIds = new Set<string>();
-
-      const states = await Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id)));
-      for (const state of states) {
-        if (state?.terminals) {
-          for (const t of state.terminals) {
-            knownIds.add(t.id);
-          }
-        }
-      }
-
-      const appTerminals = store.get("appState")?.terminals;
-      if (Array.isArray(appTerminals)) {
-        for (const t of appTerminals) {
+    const states = await Promise.all(allProjects.map((p) => projectStore.getProjectState(p.id)));
+    for (const state of states) {
+      if (state?.terminals) {
+        for (const t of state.terminals) {
           knownIds.add(t.id);
         }
       }
-
-      const result = await evictSessionFiles({
-        ttlMs: SESSION_EVICTION_TTL_MS,
-        maxBytes: SESSION_EVICTION_MAX_BYTES,
-        knownIds,
-      });
-
-      if (result.deleted > 0) {
-        console.log(
-          `[MAIN] Session eviction: deleted ${result.deleted} file(s), freed ${(result.bytesFreed / 1024 / 1024).toFixed(1)} MB`
-        );
-      }
-    } catch (err) {
-      console.warn("[MAIN] Session eviction failed:", err);
     }
-  })();
 
-  const elapsed = Date.now() - startTime;
-  markPerformance(PERF_MARKS.DEFERRED_SERVICES_COMPLETE, { durationMs: elapsed });
-  console.log(`[MAIN] All deferred services initialized in ${elapsed}ms`);
+    const appTerminals = store.get("appState")?.terminals;
+    if (Array.isArray(appTerminals)) {
+      for (const t of appTerminals) {
+        knownIds.add(t.id);
+      }
+    }
+
+    const result = await evictSessionFiles({
+      ttlMs: SESSION_EVICTION_TTL_MS,
+      maxBytes: SESSION_EVICTION_MAX_BYTES,
+      knownIds,
+    });
+
+    if (result.deleted > 0) {
+      console.log(
+        `[MAIN] Session eviction: deleted ${result.deleted} file(s), freed ${(result.bytesFreed / 1024 / 1024).toFixed(1)} MB`
+      );
+    }
+  } catch (err) {
+    console.warn("[MAIN] Session eviction failed:", err);
+  }
 }
 
 export interface SetupWindowServicesOptions {
@@ -321,16 +276,19 @@ export async function setupWindowServices(
       return;
     }
 
-    // Initialize Sentry after migrations — reads privacy.telemetryLevel,
-    // which is guaranteed populated by migration014. Once the SDK is ready,
-    // stamp the `onboarding_complete` scope tag so every subsequent event
-    // (crashes, analytics) is filterable by whether the user has finished
-    // first-run onboarding.
-    void initializeTelemetry().then(() => {
-      setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
+    // Sentry and GitHub token validation are deferred to after the renderer
+    // reports first-interactive to avoid contending for the event loop while
+    // React hydrates. GitHubAuth.initializeStorage must stay eager because
+    // other services read tokens synchronously during startup.
+    registerDeferredTask({
+      name: "telemetry",
+      run: async () => {
+        await initializeTelemetry();
+        setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
+      },
     });
 
-    // Initialize GitHubAuth
+    // Initialize GitHubAuth storage (must stay eager — synchronous reads)
     GitHubAuth.initializeStorage({
       get: () => secureStorage.get("userConfig.githubToken"),
       set: (token) => secureStorage.set("userConfig.githubToken", token),
@@ -342,21 +300,25 @@ export async function setupWindowServices(
       const token = GitHubAuth.getToken();
       if (token) {
         const versionAtStart = GitHubAuth.getTokenVersion();
-        GitHubAuth.validate(token)
-          .then((validation) => {
-            if (validation.valid && validation.username) {
-              GitHubAuth.setValidatedUserInfo(
-                validation.username,
-                validation.avatarUrl,
-                validation.scopes,
-                versionAtStart
-              );
-              console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
+        registerDeferredTask({
+          name: "github-auth-validate",
+          run: async () => {
+            try {
+              const validation = await GitHubAuth.validate(token);
+              if (validation.valid && validation.username) {
+                GitHubAuth.setValidatedUserInfo(
+                  validation.username,
+                  validation.avatarUrl,
+                  validation.scopes,
+                  versionAtStart
+                );
+                console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
+              }
+            } catch (err) {
+              console.warn("[MAIN] Failed to validate stored GitHub token:", err);
             }
-          })
-          .catch((err) => {
-            console.warn("[MAIN] Failed to validate stored GitHub token:", err);
-          });
+          },
+        });
       }
     }
 
@@ -373,7 +335,12 @@ export async function setupWindowServices(
     getActionBreadcrumbService().initialize();
 
     // Auto-updater
-    autoUpdaterService.initialize();
+    registerDeferredTask({
+      name: "auto-updater",
+      run: () => {
+        autoUpdaterService.initialize();
+      },
+    });
 
     // CCR config — discover Claude Code Router models as agent presets
     try {
@@ -385,6 +352,193 @@ export async function setupWindowServices(
     } catch (err) {
       console.warn("[MAIN] CcrConfigService init failed (non-fatal):", err);
     }
+
+    // ── Deferred global service starts ──
+    // These were previously run on the same tick as loadRenderer(), contending
+    // with the renderer for event-loop time while React hydrated and painted.
+    // They now drain sequentially after the renderer signals first-interactive
+    // (or after a fallback timeout), with `setImmediate` interleaved between
+    // tasks so IPC from the renderer stays responsive during drain.
+
+    registerDeferredTask({
+      name: "crash-recovery-backup-timer",
+      run: () => {
+        getCrashRecoveryService().startBackupTimer();
+      },
+    });
+
+    registerDeferredTask({
+      name: "hibernation-service",
+      run: () => {
+        initializeHibernationService();
+      },
+    });
+
+    registerDeferredTask({
+      name: "idle-terminal-notification-service",
+      run: () => {
+        initializeIdleTerminalNotificationService();
+      },
+    });
+
+    registerDeferredTask({
+      name: "system-sleep-service",
+      run: () => {
+        initializeSystemSleepService();
+      },
+    });
+
+    registerDeferredTask({
+      name: "disk-space-monitor",
+      run: () => {
+        if (stopDiskSpaceMonitor) return;
+        stopDiskSpaceMonitor = startDiskSpaceMonitor({
+          sendStatus: (payload) => {
+            if (windowRegistry) {
+              for (const wCtx of windowRegistry.all()) {
+                if (!wCtx.browserWindow.isDestroyed()) {
+                  sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_DISK_SPACE_STATUS, payload);
+                }
+              }
+            }
+          },
+          onCriticalChange: (isCritical) => {
+            if (isCritical) {
+              getCrashRecoveryService().stopBackupTimer();
+              ptyClient?.suppressSessionPersistence(true);
+            } else {
+              getCrashRecoveryService().startBackupTimer();
+              ptyClient?.suppressSessionPersistence(false);
+            }
+          },
+          showNativeNotification: (title, body) => {
+            notificationService.showNativeNotification(title, body);
+          },
+          isWindowFocused: () => notificationService.isWindowFocused(),
+        });
+      },
+    });
+
+    registerDeferredTask({
+      name: "event-loop-lag-monitor",
+      run: () => {
+        if (!stopEventLoopLagMonitor) {
+          stopEventLoopLagMonitor = startEventLoopLagMonitor();
+        }
+        if (process.env.DAINTREE_PERF_CAPTURE === "1" && !stopProcessMemoryMonitor) {
+          stopProcessMemoryMonitor = startProcessMemoryMonitor();
+        }
+      },
+    });
+
+    registerDeferredTask({
+      name: "app-metrics-monitor",
+      run: () => {
+        if (stopAppMetricsMonitor) return;
+        stopAppMetricsMonitor = startAppMetricsMonitor({
+          clearCaches: async () => {
+            try {
+              await session.defaultSession.clearCache();
+            } catch {
+              /* non-critical */
+            }
+            try {
+              await session.defaultSession.clearStorageData({
+                storages: ["shadercache", "cachestorage"],
+              });
+            } catch {
+              /* non-critical */
+            }
+            try {
+              exposeGc?.();
+            } catch {
+              /* non-critical */
+            }
+            if (windowRegistry) {
+              for (const wCtx of windowRegistry.all()) {
+                if (!wCtx.browserWindow.isDestroyed()) {
+                  try {
+                    sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_RECLAIM_MEMORY, {
+                      reason: "memory-pressure",
+                    });
+                  } catch {
+                    /* non-critical */
+                  }
+                }
+              }
+            }
+          },
+          destroyHiddenWebviews: async (tier) => {
+            if (windowRegistry) {
+              for (const wCtx of windowRegistry.all()) {
+                if (wCtx.browserWindow.isDestroyed()) continue;
+                try {
+                  if (wCtx.services.portalManager) {
+                    const evictedTabIds = await wCtx.services.portalManager.destroyHiddenTabs();
+                    if (evictedTabIds.length > 0) {
+                      sendToRenderer(wCtx.browserWindow, CHANNELS.PORTAL_TABS_EVICTED, {
+                        tabIds: evictedTabIds,
+                      });
+                    }
+                  }
+                } catch {
+                  /* non-critical */
+                }
+                try {
+                  sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_DESTROY_HIDDEN_WEBVIEWS, {
+                    tier,
+                  });
+                } catch {
+                  /* non-critical */
+                }
+              }
+            }
+          },
+          hibernateIdleProjects: async () => {
+            await getHibernationService().hibernateUnderMemoryPressure();
+          },
+          trimPtyHostState: () => {
+            ptyClient?.trimState(SCROLLBACK_BACKGROUND);
+          },
+        });
+      },
+    });
+
+    // Must register AFTER event-loop-lag and app-metrics monitors so it can
+    // read their data once its own start() fires.
+    registerDeferredTask({
+      name: "resource-profile-service",
+      run: () => {
+        if (resourceProfileService) return;
+        resourceProfileService = new ResourceProfileService({
+          getPtyClient: () => ptyClient,
+          getWorkspaceClient: () => workspaceClient,
+          getHibernationService: () => getHibernationService(),
+          getProjectViewManager: () => getProjectViewManager(),
+          getUserCachedViewLimit: () =>
+            store.get("terminalConfig")?.cachedProjectViews ??
+            (process.env.DAINTREE_E2E_MODE ? 4 : 1),
+        });
+        resourceProfileService.start();
+      },
+    });
+
+    if (windowRegistry) {
+      const registryRef = windowRegistry;
+      registerDeferredTask({
+        name: "mcp-server",
+        run: () => {
+          mcpServerService.start(registryRef).catch((err) => {
+            console.error("[MAIN] MCP server failed to start:", err);
+          });
+        },
+      });
+    }
+
+    registerDeferredTask({
+      name: "session-eviction",
+      run: () => evictStaleSessionFiles(),
+    });
   }
 
   // ── Per-window initialization ──
@@ -499,6 +653,10 @@ export async function setupWindowServices(
 
   // Per-window services
   ctx.services.eventBuffer = new EventBuffer(1000);
+  // EventBuffer.start() must run eagerly — it subscribes to the internal event
+  // bus so early-boot events (migrations, PTY init, hydration) reach the
+  // inspector. Deferring would drop those events.
+  ctx.services.eventBuffer.start();
   ctx.services.portalManager = new PortalManager(win);
   ctx.services.projectSwitchService = new ProjectSwitchService({
     mainWindow: win,
@@ -884,46 +1042,24 @@ export async function setupWindowServices(
     return;
   }
 
-  // Deferred services
-  initializeDeferredServices(
-    win,
-    cliAvailabilityService!,
-    ctx.services.eventBuffer!,
-    windowRegistry
-  ).catch((error) => {
-    console.error("[MAIN] Deferred services initialization failed:", error);
+  // Per-window deferred work. The menu is window-specific, so each window
+  // queues its own CLI-availability check + menu rebuild. Second-window
+  // registrations arrive after the global queue has drained; the queue runs
+  // late tasks inline, which is fine for a cheap per-window operation.
+  registerDeferredTask({
+    name: `cli-availability-check:${win.id}`,
+    run: async () => {
+      try {
+        const availability = await cliAvailabilityService!.checkAvailability();
+        console.log("[MAIN] CLI availability checked:", availability);
+        if (!win.isDestroyed()) {
+          createApplicationMenu(win, cliAvailabilityService!);
+        }
+      } catch (err) {
+        console.error("[MAIN] CliAvailabilityService initialization failed:", err);
+      }
+    },
   });
-
-  getCrashRecoveryService().startBackupTimer();
-
-  // Disk space monitor (global)
-  if (!stopDiskSpaceMonitor) {
-    stopDiskSpaceMonitor = startDiskSpaceMonitor({
-      sendStatus: (payload) => {
-        // Broadcast to all windows
-        if (windowRegistry) {
-          for (const wCtx of windowRegistry.all()) {
-            if (!wCtx.browserWindow.isDestroyed()) {
-              sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_DISK_SPACE_STATUS, payload);
-            }
-          }
-        }
-      },
-      onCriticalChange: (isCritical) => {
-        if (isCritical) {
-          getCrashRecoveryService().stopBackupTimer();
-          ptyClient?.suppressSessionPersistence(true);
-        } else {
-          getCrashRecoveryService().startBackupTimer();
-          ptyClient?.suppressSessionPersistence(false);
-        }
-      },
-      showNativeNotification: (title, body) => {
-        notificationService.showNativeNotification(title, body);
-      },
-      isWindowFocused: () => notificationService.isWindowFocused(),
-    });
-  }
 
   // CLI path handling — skip if this window was opened with an explicit initialProjectPath
   if (!opts.initialProjectPath) {
@@ -944,97 +1080,10 @@ export async function setupWindowServices(
     );
   }
 
-  // Performance monitors (global)
-  if (!stopEventLoopLagMonitor) {
-    stopEventLoopLagMonitor = startEventLoopLagMonitor();
-  }
-  if (process.env.DAINTREE_PERF_CAPTURE === "1" && !stopProcessMemoryMonitor) {
-    stopProcessMemoryMonitor = startProcessMemoryMonitor();
-  }
-
-  if (!stopAppMetricsMonitor) {
-    stopAppMetricsMonitor = startAppMetricsMonitor({
-      clearCaches: async () => {
-        try {
-          await session.defaultSession.clearCache();
-        } catch {
-          /* non-critical */
-        }
-        try {
-          await session.defaultSession.clearStorageData({
-            storages: ["shadercache", "cachestorage"],
-          });
-        } catch {
-          /* non-critical */
-        }
-        try {
-          exposeGc?.();
-        } catch {
-          /* non-critical */
-        }
-        // Broadcast to all windows
-        if (windowRegistry) {
-          for (const wCtx of windowRegistry.all()) {
-            if (!wCtx.browserWindow.isDestroyed()) {
-              try {
-                sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_RECLAIM_MEMORY, {
-                  reason: "memory-pressure",
-                });
-              } catch {
-                /* non-critical */
-              }
-            }
-          }
-        }
-      },
-      destroyHiddenWebviews: async (tier) => {
-        // Destroy hidden portal tabs for ALL windows
-        if (windowRegistry) {
-          for (const wCtx of windowRegistry.all()) {
-            if (wCtx.browserWindow.isDestroyed()) continue;
-            try {
-              if (wCtx.services.portalManager) {
-                const evictedTabIds = await wCtx.services.portalManager.destroyHiddenTabs();
-                if (evictedTabIds.length > 0) {
-                  sendToRenderer(wCtx.browserWindow, CHANNELS.PORTAL_TABS_EVICTED, {
-                    tabIds: evictedTabIds,
-                  });
-                }
-              }
-            } catch {
-              /* non-critical */
-            }
-            try {
-              sendToRenderer(wCtx.browserWindow, CHANNELS.WINDOW_DESTROY_HIDDEN_WEBVIEWS, {
-                tier,
-              });
-            } catch {
-              /* non-critical */
-            }
-          }
-        }
-      },
-      hibernateIdleProjects: async () => {
-        await getHibernationService().hibernateUnderMemoryPressure();
-      },
-      trimPtyHostState: () => {
-        ptyClient?.trimState(SCROLLBACK_BACKGROUND);
-      },
-    });
-  }
-
-  // Resource Profile Service
-  if (!resourceProfileService) {
-    resourceProfileService = new ResourceProfileService({
-      getPtyClient: () => ptyClient,
-      getWorkspaceClient: () => workspaceClient,
-      getHibernationService: () => getHibernationService(),
-      getProjectViewManager: () => getProjectViewManager(),
-      getUserCachedViewLimit: () =>
-        store.get("terminalConfig")?.cachedProjectViews ?? (process.env.DAINTREE_E2E_MODE ? 4 : 1),
-    });
-    resourceProfileService.start();
-  }
+  // All deferred tasks for this window have been registered. Arm the drain
+  // trigger: either the renderer's `app:first-interactive` IPC fires (happy
+  // path) or the 10s fallback timer runs the queue anyway.
+  finalizeDeferredRegistration();
 
   // ── Last-window-close: dispose global services ──
   // Per-window cleanup is handled by ctx.cleanup (run by WindowRegistry.unregister).
@@ -1093,6 +1142,7 @@ export async function setupWindowServices(
     }
     ipcHandlersRegistered = false;
     globalServicesInitialized = false;
+    resetDeferredQueue();
 
     getSystemSleepService().dispose();
     gitHubTokenHealthService.dispose();

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -527,11 +527,10 @@ export async function setupWindowServices(
       const registryRef = windowRegistry;
       registerDeferredTask({
         name: "mcp-server",
-        run: () => {
+        run: () =>
           mcpServerService.start(registryRef).catch((err) => {
             console.error("[MAIN] MCP server failed to start:", err);
-          });
-        },
+          }),
       });
     }
 
@@ -549,6 +548,32 @@ export async function setupWindowServices(
     cliAvailabilityService = new CliAvailabilityService();
   }
   createApplicationMenu(win, cliAvailabilityService);
+
+  // Per-window deferred work. Menu is window-specific, so each window queues
+  // its own CLI check + menu rebuild. Registered here (before any awaits that
+  // could hang) so finalize below is guaranteed to run.
+  const cliService = cliAvailabilityService;
+  registerDeferredTask({
+    name: `cli-availability-check:${win.id}`,
+    run: async () => {
+      try {
+        const availability = await cliService.checkAvailability();
+        console.log("[MAIN] CLI availability checked:", availability);
+        if (!win.isDestroyed()) {
+          createApplicationMenu(win, cliService);
+        }
+      } catch (err) {
+        console.error("[MAIN] CliAvailabilityService initialization failed:", err);
+      }
+    },
+  });
+
+  // Arm the drain trigger immediately. All tasks for this window are now
+  // registered; any subsequent `await` in setupWindowServices could hang
+  // (PTY host, workspace loadProject, plugin init) and must not block the
+  // deferred queue from becoming drainable. The renderer's first-interactive
+  // IPC fires on the happy path; the 10s fallback drains on hang.
+  finalizeDeferredRegistration();
 
   if (windowRegistry) {
     notificationService.initialize(windowRegistry);
@@ -1042,25 +1067,6 @@ export async function setupWindowServices(
     return;
   }
 
-  // Per-window deferred work. The menu is window-specific, so each window
-  // queues its own CLI-availability check + menu rebuild. Second-window
-  // registrations arrive after the global queue has drained; the queue runs
-  // late tasks inline, which is fine for a cheap per-window operation.
-  registerDeferredTask({
-    name: `cli-availability-check:${win.id}`,
-    run: async () => {
-      try {
-        const availability = await cliAvailabilityService!.checkAvailability();
-        console.log("[MAIN] CLI availability checked:", availability);
-        if (!win.isDestroyed()) {
-          createApplicationMenu(win, cliAvailabilityService!);
-        }
-      } catch (err) {
-        console.error("[MAIN] CliAvailabilityService initialization failed:", err);
-      }
-    },
-  });
-
   // CLI path handling — skip if this window was opened with an explicit initialProjectPath
   if (!opts.initialProjectPath) {
     const firstLaunchCliPath = !processArgvCliHandled ? extractCliPath(process.argv) : null;
@@ -1079,11 +1085,6 @@ export async function setupWindowServices(
       (err) => console.error("[MAIN] Failed to open initial project path:", err)
     );
   }
-
-  // All deferred tasks for this window have been registered. Arm the drain
-  // trigger: either the renderer's `app:first-interactive` IPC fires (happy
-  // path) or the 10s fallback timer runs the queue anyway.
-  finalizeDeferredRegistration();
 
   // ── Last-window-close: dispose global services ──
   // Per-window cleanup is handled by ctx.cleanup (run by WindowRegistry.unregister).

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -2,6 +2,7 @@ export const PERF_MARKS = {
   APP_BOOT_START: "app_boot_start",
   MAIN_WINDOW_CREATED: "main_window_created",
   RENDERER_READY: "renderer_ready",
+  RENDERER_FIRST_INTERACTIVE: "renderer_first_interactive",
 
   SERVICE_INIT_START: "service_init_start",
   SERVICE_INIT_MIGRATIONS_DONE: "service_init_migrations_done",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -359,6 +359,7 @@ export interface ElectronAPI {
     hydrate(): Promise<HydrateResult>;
     quit(): Promise<void>;
     forceQuit(): Promise<void>;
+    notifyFirstInteractive(): Promise<void>;
     onMenuAction(callback: (action: string) => void): () => void;
     reloadConfig(): Promise<{ success: boolean }>;
     onConfigReloaded(callback: () => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -574,6 +574,10 @@ export interface IpcInvokeMap {
     args: [];
     result: void;
   };
+  "app:first-interactive": {
+    args: [];
+    result: void;
+  };
   "app:reload-config": {
     args: [];
     result: { success: boolean };

--- a/src/utils/__tests__/removeStartupSkeleton.test.ts
+++ b/src/utils/__tests__/removeStartupSkeleton.test.ts
@@ -1,17 +1,25 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { removeStartupSkeleton } from "../removeStartupSkeleton";
 
 describe("removeStartupSkeleton", () => {
   let rafQueue: FrameRequestCallback[];
+  let notifyFirstInteractive: ReturnType<typeof vi.fn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     rafQueue = [];
+    notifyFirstInteractive = vi.fn(() => Promise.resolve());
 
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
       rafQueue.push(cb);
       return rafQueue.length;
     });
+
+    (
+      window as unknown as { electron: { app: { notifyFirstInteractive: () => Promise<void> } } }
+    ).electron = {
+      app: { notifyFirstInteractive: notifyFirstInteractive as unknown as () => Promise<void> },
+    };
 
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   });
@@ -20,6 +28,7 @@ describe("removeStartupSkeleton", () => {
     document.getElementById("startup-skeleton")?.remove();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+    delete (window as unknown as { electron?: unknown }).electron;
   });
 
   function addSkeleton(): HTMLDivElement {
@@ -34,30 +43,37 @@ describe("removeStartupSkeleton", () => {
     for (const cb of batch) cb(performance.now());
   }
 
-  it("adds fade-out class after two RAF ticks and removes element after timeout", () => {
+  it("adds fade-out class after two RAF ticks and removes element after timeout", async () => {
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
     const el = addSkeleton();
     removeStartupSkeleton();
 
     expect(el.classList.contains("fade-out")).toBe(false);
+    expect(notifyFirstInteractive).not.toHaveBeenCalled();
 
     flushRaf(); // outer RAF — schedules inner
     expect(el.classList.contains("fade-out")).toBe(false);
+    expect(notifyFirstInteractive).not.toHaveBeenCalled();
 
-    flushRaf(); // inner RAF — adds fade-out, schedules setTimeout
+    flushRaf(); // inner RAF — fires signal, adds fade-out, schedules setTimeout
     expect(el.classList.contains("fade-out")).toBe(true);
     expect(el.getAttribute("aria-busy")).toBe("false");
+    expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
     expect(document.getElementById("startup-skeleton")).toBe(el);
 
     vi.advanceTimersByTime(250);
     expect(document.getElementById("startup-skeleton")).toBeNull();
   });
 
-  it("does nothing if element is absent", () => {
+  it("signals first-interactive even when skeleton is absent", async () => {
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
     removeStartupSkeleton();
     expect(rafQueue.length).toBe(0);
+    expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
   });
 
-  it("tolerates repeated calls", () => {
+  it("only notifies first-interactive once across repeated calls", async () => {
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
     addSkeleton();
     removeStartupSkeleton();
     removeStartupSkeleton();
@@ -65,9 +81,26 @@ describe("removeStartupSkeleton", () => {
     flushRaf(); // both outer RAFs run
     flushRaf(); // both inner RAFs run
 
+    expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
+
     vi.advanceTimersByTime(250);
     expect(document.getElementById("startup-skeleton")).toBeNull();
 
     removeStartupSkeleton(); // no-op, should not throw
+    expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows errors from the IPC bridge", async () => {
+    const throwing = vi.fn(() => {
+      throw new Error("bridge unavailable");
+    });
+    (
+      window as unknown as { electron: { app: { notifyFirstInteractive: () => Promise<void> } } }
+    ).electron = {
+      app: { notifyFirstInteractive: throwing as unknown as () => Promise<void> },
+    };
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+    expect(() => removeStartupSkeleton()).not.toThrow();
+    expect(throwing).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/removeStartupSkeleton.ts
+++ b/src/utils/removeStartupSkeleton.ts
@@ -1,17 +1,37 @@
 const SKELETON_ID = "startup-skeleton";
 const FADE_DURATION_MS = 250;
 
+let firstInteractiveNotified = false;
+
+function notifyFirstInteractive(): void {
+  if (firstInteractiveNotified) return;
+  firstInteractiveNotified = true;
+  try {
+    window.electron?.app?.notifyFirstInteractive?.().catch(() => {
+      // Main process may already have drained the queue or fallback fired — safe to ignore
+    });
+  } catch {
+    // Preload bridge may be unavailable in exotic test contexts — safe to ignore
+  }
+}
+
 /**
- * Fade out and remove the startup skeleton overlay.
- * Uses requestAnimationFrame to ensure React has painted real content
- * before the fade begins, preventing a flash of empty background.
+ * Fade out and remove the startup skeleton overlay, and signal the main
+ * process that the renderer is interactive so it can drain its deferred
+ * service queue. Uses requestAnimationFrame to ensure React has painted
+ * real content before both the fade and the signal fire.
  */
 export function removeStartupSkeleton(): void {
   const el = document.getElementById(SKELETON_ID);
-  if (!el) return;
+  if (!el) {
+    notifyFirstInteractive();
+    return;
+  }
 
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
+      notifyFirstInteractive();
+
       el.setAttribute("aria-busy", "false");
       el.classList.add("fade-out");
 


### PR DESCRIPTION
## Summary

- Introduces a real `DeferredInitQueue` module that drains only after the renderer signals a painted interactive frame, replacing the same-tick fake deferral in `initializeDeferredServices`
- The renderer sends a `renderer:first-interactive` IPC from a React effect wrapped in two nested `requestAnimationFrame` calls, guaranteeing at least one fully-shipped frame before any deferred task runs
- The queue drains tasks sequentially with `setImmediate` between each, keeping the main-thread event loop free to service renderer IPC during startup

Resolves #5403

## Changes

- `electron/window/deferredInitQueue.ts` — new queue module with `enqueue`, `drain`, and `cancel` API; drains on `renderer:first-interactive` signal
- `electron/window/windowServices.ts` — moves telemetry, GitHub auth, auto-updater, crash recovery timer, monitors, resource profile, MCP server, and the hibernation/idle/sleep services into the queue; crash reporter, crash-loop guard, migrations, project store, and PTY client remain eager
- `electron/window/__tests__/deferredInitQueue.test.ts` — unit tests covering sequential drain, setImmediate yielding, signal-before-enqueue fast-path, and cancellation
- `src/utils/removeStartupSkeleton.ts` — updated to fire the `renderer:first-interactive` IPC after two nested rAFs; test updated to cover the timing contract
- IPC plumbing: new `renderer:first-interactive` channel in `channels.ts`, handler in `app/state.ts`, preload exposure, and shared type definitions

## Testing

Unit tests cover the queue module directly (sequential ordering, yield behaviour, pre-signal enqueue, cancellation). The `removeStartupSkeleton` timing contract is covered by the updated unit test. Typecheck and lint pass clean.