### PR TITLE
feat(notes): wire CodeMirror find panel into Notes editor

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -587,6 +587,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Notes/NotesFindBar.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Notes/NotesPalette.tsx": {
     "success": 0,
     "skip": 0,
@@ -2367,6 +2373,12 @@
     "success": 1,
     "skip": 0,
     "error": 0,
+    "pipeline": 0
+  },
+  "src/hooks/useFindInNote.ts": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
     "pipeline": 0
   },
   "src/hooks/useFindInPage.ts": {

--- a/src/components/FileViewer/CodeViewer.tsx
+++ b/src/components/FileViewer/CodeViewer.tsx
@@ -14,6 +14,7 @@ import { type Extension, StateEffect, StateField } from "@codemirror/state";
 import { LanguageDescription } from "@codemirror/language";
 import { search, openSearchPanel, gotoLine } from "@codemirror/search";
 import { daintreeTheme } from "@/components/Notes/editorTheme";
+import { editorSearchHighlightTheme } from "@/components/Notes/editorSearchTheme";
 import { cn } from "@/lib/utils";
 
 export interface CodeViewerHandle {
@@ -106,12 +107,6 @@ const searchPanelTheme = EditorView.theme({
     borderRadius: "3px",
     outline: "none",
   },
-  ".cm-searchMatch": {
-    backgroundColor: "rgba(234, 179, 8, 0.3)",
-  },
-  ".cm-searchMatch.cm-searchMatch-selected": {
-    backgroundColor: "rgba(234, 179, 8, 0.6)",
-  },
 });
 
 const BASE_EXTENSIONS: Extension[] = [
@@ -120,6 +115,7 @@ const BASE_EXTENSIONS: Extension[] = [
   search({ top: true }),
   keymap.of([{ key: "Mod-l", run: gotoLine }]),
   searchPanelTheme,
+  editorSearchHighlightTheme,
 ];
 
 export const CodeViewer = forwardRef<CodeViewerHandle, CodeViewerProps>(function CodeViewer(

--- a/src/components/Notes/NotesFindBar.tsx
+++ b/src/components/Notes/NotesFindBar.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { ChevronUp, ChevronDown, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { FindInNoteState } from "@/hooks/useFindInNote";
@@ -14,17 +15,20 @@ export function NotesFindBar({ find }: NotesFindBarProps) {
     caseSensitive,
     regexp,
     inputRef,
-    isComposingRef,
     setQuery,
     toggleCase,
     toggleRegexp,
     goNext,
     goPrev,
     close,
+    onCompositionStart,
+    onCompositionEnd,
   } = find;
 
+  const localComposingRef = useRef(false);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (isComposingRef.current) return;
+    if (localComposingRef.current) return;
     if (e.key === "Escape") {
       e.preventDefault();
       close();
@@ -54,11 +58,12 @@ export function NotesFindBar({ find }: NotesFindBarProps) {
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={handleKeyDown}
         onCompositionStart={() => {
-          isComposingRef.current = true;
+          localComposingRef.current = true;
+          onCompositionStart();
         }}
         onCompositionEnd={(e) => {
-          isComposingRef.current = false;
-          setQuery(e.currentTarget.value);
+          localComposingRef.current = false;
+          onCompositionEnd(e.currentTarget.value);
         }}
         placeholder="Find in note"
         className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-daintree-text/40 outline-none"

--- a/src/components/Notes/NotesFindBar.tsx
+++ b/src/components/Notes/NotesFindBar.tsx
@@ -1,0 +1,130 @@
+import { ChevronUp, ChevronDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FindInNoteState } from "@/hooks/useFindInNote";
+
+interface NotesFindBarProps {
+  find: FindInNoteState;
+}
+
+export function NotesFindBar({ find }: NotesFindBarProps) {
+  const {
+    query,
+    activeMatch,
+    matchCount,
+    caseSensitive,
+    regexp,
+    inputRef,
+    isComposingRef,
+    setQuery,
+    toggleCase,
+    toggleRegexp,
+    goNext,
+    goPrev,
+    close,
+  } = find;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (isComposingRef.current) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) {
+        goPrev();
+      } else {
+        goNext();
+      }
+    } else if (e.key.toLowerCase() === "g" && (e.metaKey || e.ctrlKey) && !e.altKey) {
+      e.preventDefault();
+      if (e.shiftKey) {
+        goPrev();
+      } else {
+        goNext();
+      }
+    }
+  };
+
+  return (
+    <div className="absolute top-2 right-2 z-20 flex items-center gap-1 rounded-md bg-surface-panel-elevated border border-daintree-border shadow-[var(--theme-shadow-floating)] px-2 py-1">
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onCompositionStart={() => {
+          isComposingRef.current = true;
+        }}
+        onCompositionEnd={(e) => {
+          isComposingRef.current = false;
+          setQuery(e.currentTarget.value);
+        }}
+        placeholder="Find in note"
+        className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-daintree-text/40 outline-none"
+        spellCheck={false}
+      />
+      {query && (
+        <span className="text-[10px] text-daintree-text/50 tabular-nums whitespace-nowrap mr-0.5">
+          {matchCount > 0 ? `${activeMatch || 1} / ${matchCount}` : "No results"}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={toggleCase}
+        aria-pressed={caseSensitive}
+        aria-label="Match case"
+        title="Match case"
+        className={cn(
+          "px-1 py-0.5 rounded text-[10px] font-semibold",
+          caseSensitive
+            ? "bg-daintree-accent/20 text-daintree-accent"
+            : "hover:bg-tint/10 text-daintree-text/70"
+        )}
+      >
+        Aa
+      </button>
+      <button
+        type="button"
+        onClick={toggleRegexp}
+        aria-pressed={regexp}
+        aria-label="Use regular expression"
+        title="Use regular expression"
+        className={cn(
+          "px-1 py-0.5 rounded text-[10px] font-mono",
+          regexp
+            ? "bg-daintree-accent/20 text-daintree-accent"
+            : "hover:bg-tint/10 text-daintree-text/70"
+        )}
+      >
+        .*
+      </button>
+      <button
+        type="button"
+        onClick={goPrev}
+        disabled={matchCount === 0}
+        className="p-0.5 rounded hover:bg-tint/10 disabled:opacity-30 text-daintree-text/70"
+        aria-label="Previous match"
+      >
+        <ChevronUp className="w-3.5 h-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={goNext}
+        disabled={matchCount === 0}
+        className="p-0.5 rounded hover:bg-tint/10 disabled:opacity-30 text-daintree-text/70"
+        aria-label="Next match"
+      >
+        <ChevronDown className="w-3.5 h-3.5" />
+      </button>
+      <button
+        type="button"
+        onClick={close}
+        className="p-0.5 rounded hover:bg-tint/10 text-daintree-text/70"
+        aria-label="Close find bar"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -180,10 +180,8 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
     }
   }, [isOpen]);
 
-  const find = useFindInNote(
-    editorViewRef,
-    isOpen && paletteViewMode === "edit" && !!selectedNote
-  );
+  const find = useFindInNote(editorViewRef, isOpen && paletteViewMode === "edit" && !!selectedNote);
+  const closeFind = find.close;
 
   // Reset view mode on selection change
   useEffect(() => {
@@ -192,9 +190,8 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
 
   // Reset find state when switching notes, closing, or switching to preview
   useEffect(() => {
-    find.close();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNote?.id, paletteViewMode, isOpen]);
+    closeFind();
+  }, [selectedNote?.id, paletteViewMode, isOpen, closeFind]);
 
   // Scroll selected item into view
   useEffect(() => {

--- a/src/components/Notes/NotesPalette.tsx
+++ b/src/components/Notes/NotesPalette.tsx
@@ -18,6 +18,8 @@ import { EditorView } from "@codemirror/view";
 import { daintreeTheme } from "./editorTheme";
 import { notesTypographyExtension } from "./codeBlockExtension";
 import { MarkdownToolbar } from "./MarkdownToolbar";
+import { NotesFindBar } from "./NotesFindBar";
+import { useFindInNote } from "@/hooks/useFindInNote";
 import {
   Plus,
   ExternalLink,
@@ -178,10 +180,21 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
     }
   }, [isOpen]);
 
+  const find = useFindInNote(
+    editorViewRef,
+    isOpen && paletteViewMode === "edit" && !!selectedNote
+  );
+
   // Reset view mode on selection change
   useEffect(() => {
     setPaletteViewMode("edit");
   }, [selectedNote]);
+
+  // Reset find state when switching notes, closing, or switching to preview
+  useEffect(() => {
+    find.close();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedNote?.id, paletteViewMode, isOpen]);
 
   // Scroll selected item into view
   useEffect(() => {
@@ -196,8 +209,9 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
       markdown({ base: markdownLanguage, codeLanguages: languages }),
       EditorView.lineWrapping,
       notesTypographyExtension(),
+      find.searchExtension,
     ],
-    []
+    [find.searchExtension]
   );
 
   if (!isOpen) return null;
@@ -555,7 +569,7 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
                       ) : (
                         <>
                           <MarkdownToolbar editorViewRef={editorViewRef} />
-                          <div className="flex-1 overflow-hidden text-[13px] [&_.cm-editor]:h-full [&_.cm-scroller]:p-4 [&_.cm-placeholder]:text-daintree-text/30 [&_.cm-placeholder]:italic">
+                          <div className="relative flex-1 overflow-hidden text-[13px] [&_.cm-editor]:h-full [&_.cm-scroller]:p-4 [&_.cm-placeholder]:text-daintree-text/30 [&_.cm-placeholder]:italic">
                             <CodeMirror
                               key={selectedNote?.id ?? "empty"}
                               value={editor.noteContent}
@@ -565,16 +579,20 @@ export function NotesPalette({ isOpen, onClose }: NotesPaletteProps) {
                               onChange={editor.handleContentChange}
                               onCreateEditor={(view) => {
                                 editorViewRef.current = view;
+                                find.handleEditorCreated(view);
                               }}
+                              onUpdate={find.handleEditorUpdate}
                               basicSetup={{
                                 lineNumbers: false,
                                 foldGutter: false,
                                 highlightActiveLine: false,
                                 highlightActiveLineGutter: false,
+                                searchKeymap: false,
                               }}
                               className="h-full"
                               placeholder="Start writing..."
                             />
+                            {find.isOpen && <NotesFindBar find={find} />}
                           </div>
                         </>
                       )}

--- a/src/components/Notes/NotesPane.tsx
+++ b/src/components/Notes/NotesPane.tsx
@@ -94,19 +94,18 @@ export function NotesPane({
   useNoteVoiceInput(id, editorViewRef);
 
   const find = useFindInNote(editorViewRef, !!isFocused && viewMode !== "preview");
+  const closeFind = find.close;
 
   useEffect(() => {
     if (viewMode === "preview") {
       editorViewRef.current = null;
-      find.close();
+      closeFind();
     }
-  }, [viewMode, find]);
+  }, [viewMode, closeFind]);
 
   useEffect(() => {
-    find.close();
-    // Reset find state when switching notes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [notePath]);
+    closeFind();
+  }, [notePath, closeFind]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/Notes/NotesPane.tsx
+++ b/src/components/Notes/NotesPane.tsx
@@ -14,6 +14,7 @@ import { daintreeTheme } from "./editorTheme";
 import { notesTypographyExtension } from "./codeBlockExtension";
 import { MarkdownPreview } from "./MarkdownPreview";
 import { MarkdownToolbar } from "./MarkdownToolbar";
+import { NotesFindBar } from "./NotesFindBar";
 import { useNoteVoiceInput } from "./useNoteVoiceInput";
 import {
   buildAttachmentExtension,
@@ -22,6 +23,7 @@ import {
   type AttachItem,
 } from "./attachmentExtension";
 import { useNotificationStore } from "@/store/notificationStore";
+import { useFindInNote } from "@/hooks/useFindInNote";
 
 export interface NotesPaneProps extends BasePanelProps {
   notePath: string;
@@ -91,11 +93,20 @@ export function NotesPane({
 
   useNoteVoiceInput(id, editorViewRef);
 
+  const find = useFindInNote(editorViewRef, !!isFocused && viewMode !== "preview");
+
   useEffect(() => {
     if (viewMode === "preview") {
       editorViewRef.current = null;
+      find.close();
     }
-  }, [viewMode]);
+  }, [viewMode, find]);
+
+  useEffect(() => {
+    find.close();
+    // Reset find state when switching notes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notePath]);
 
   useEffect(() => {
     let cancelled = false;
@@ -419,8 +430,9 @@ export function NotesPane({
         onAttach: (items) => attachHandlerRef.current(items),
         onRejected: (items, reason) => attachRejectedRef.current(items, reason),
       }),
+      find.searchExtension,
     ],
-    []
+    [find.searchExtension]
   );
 
   return (
@@ -486,17 +498,21 @@ export function NotesPane({
                     onChange={handleContentChange}
                     onCreateEditor={(view) => {
                       editorViewRef.current = view;
+                      find.handleEditorCreated(view);
                       setEditorMountKey((k) => k + 1);
                     }}
+                    onUpdate={find.handleEditorUpdate}
                     basicSetup={{
                       lineNumbers: false,
                       foldGutter: false,
                       highlightActiveLine: false,
                       highlightActiveLineGutter: false,
+                      searchKeymap: false,
                     }}
                     className="h-full"
                     placeholder="Start writing your notes..."
                   />
+                  {find.isOpen && <NotesFindBar find={find} />}
                   <div className="absolute bottom-3 right-3 z-10">
                     <VoiceInputButton
                       panelId={id}
@@ -532,16 +548,20 @@ export function NotesPane({
                   onChange={handleContentChange}
                   onCreateEditor={(view) => {
                     editorViewRef.current = view;
+                    find.handleEditorCreated(view);
                   }}
+                  onUpdate={find.handleEditorUpdate}
                   basicSetup={{
                     lineNumbers: false,
                     foldGutter: false,
                     highlightActiveLine: false,
                     highlightActiveLineGutter: false,
+                    searchKeymap: false,
                   }}
                   className="h-full"
                   placeholder="Start writing your notes..."
                 />
+                {find.isOpen && <NotesFindBar find={find} />}
                 <div className="absolute bottom-3 right-3 z-10">
                   <VoiceInputButton
                     panelId={id}

--- a/src/components/Notes/editorSearchTheme.ts
+++ b/src/components/Notes/editorSearchTheme.ts
@@ -1,0 +1,10 @@
+import { EditorView } from "@codemirror/view";
+
+export const editorSearchHighlightTheme = EditorView.theme({
+  ".cm-searchMatch": {
+    backgroundColor: "rgba(234, 179, 8, 0.3)",
+  },
+  ".cm-searchMatch.cm-searchMatch-selected": {
+    backgroundColor: "rgba(234, 179, 8, 0.6)",
+  },
+});

--- a/src/hooks/__tests__/useFindInNote.test.tsx
+++ b/src/hooks/__tests__/useFindInNote.test.tsx
@@ -10,6 +10,7 @@ import {
   setSearchQuery,
   getSearchQuery,
   openSearchPanel,
+  searchPanelOpen,
 } from "@codemirror/search";
 import { useFindInNote } from "../useFindInNote";
 
@@ -214,5 +215,19 @@ describe("useFindInNote", () => {
     });
 
     expect(result.current.matchCount).toBe(3);
+  });
+
+  it("reopens the CM search panel on open after close (regression: highlights persist)", () => {
+    view = createRealEditorView("hello hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.open());
+    expect(searchPanelOpen(view!.state)).toBe(true);
+
+    act(() => result.current.close());
+    expect(searchPanelOpen(view!.state)).toBe(false);
+
+    act(() => result.current.open());
+    expect(searchPanelOpen(view!.state)).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useFindInNote.test.tsx
+++ b/src/hooks/__tests__/useFindInNote.test.tsx
@@ -94,13 +94,17 @@ describe("useFindInNote", () => {
 
     act(() => result.current.open());
     act(() => {
-      result.current.isComposingRef.current = true;
+      result.current.onCompositionStart();
       result.current.setQuery("partial");
     });
 
     expect(result.current.query).toBe("partial");
     const cur = getSearchQuery(view.state);
     expect(cur.search).toBe("");
+
+    act(() => result.current.onCompositionEnd("partial"));
+    const afterCommit = getSearchQuery(view.state);
+    expect(afterCommit.search).toBe("partial");
   });
 
   it("toggleCase updates state and reapplies query with new flag", () => {

--- a/src/hooks/__tests__/useFindInNote.test.tsx
+++ b/src/hooks/__tests__/useFindInNote.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { useRef } from "react";
+import { EditorView } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
+import {
+  search,
+  SearchQuery,
+  setSearchQuery,
+  getSearchQuery,
+  openSearchPanel,
+} from "@codemirror/search";
+import { useFindInNote } from "../useFindInNote";
+
+function createRealEditorView(initialDoc = ""): EditorView {
+  const state = EditorState.create({
+    doc: initialDoc,
+    extensions: [
+      search({
+        createPanel: () => {
+          const dom = document.createElement("div");
+          dom.style.display = "none";
+          return { dom };
+        },
+      }),
+    ],
+  });
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({ state, parent });
+  openSearchPanel(view);
+  return view;
+}
+
+function renderFindHook(isActive: boolean, view: EditorView | null) {
+  return renderHook(() => {
+    const ref = useRef<EditorView | null>(view);
+    return useFindInNote(ref, isActive);
+  });
+}
+
+let view: EditorView | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  view = null;
+});
+
+afterEach(() => {
+  if (view) view.destroy();
+  vi.restoreAllMocks();
+});
+
+describe("useFindInNote", () => {
+  it("starts closed with empty state", () => {
+    const { result } = renderFindHook(false, null);
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe("");
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeMatch).toBe(0);
+    expect(result.current.caseSensitive).toBe(false);
+    expect(result.current.regexp).toBe(false);
+  });
+
+  it("opens and closes the find bar", () => {
+    view = createRealEditorView("hello world hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe("");
+  });
+
+  it("dispatches setSearchQuery when setQuery is called", () => {
+    view = createRealEditorView("hello world hello universe");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.open());
+    act(() => result.current.setQuery("hello"));
+
+    expect(result.current.query).toBe("hello");
+    const cur = getSearchQuery(view.state);
+    expect(cur.search).toBe("hello");
+  });
+
+  it("does not dispatch during IME composition", () => {
+    view = createRealEditorView("hello hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.open());
+    act(() => {
+      result.current.isComposingRef.current = true;
+      result.current.setQuery("partial");
+    });
+
+    expect(result.current.query).toBe("partial");
+    const cur = getSearchQuery(view.state);
+    expect(cur.search).toBe("");
+  });
+
+  it("toggleCase updates state and reapplies query with new flag", () => {
+    view = createRealEditorView("Hello hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.setQuery("hello"));
+    act(() => result.current.toggleCase());
+
+    expect(result.current.caseSensitive).toBe(true);
+    const cur = getSearchQuery(view.state);
+    expect(cur.caseSensitive).toBe(true);
+  });
+
+  it("toggleRegexp updates state and reapplies query with new flag", () => {
+    view = createRealEditorView("abc123");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.setQuery("\\d+"));
+    act(() => result.current.toggleRegexp());
+
+    expect(result.current.regexp).toBe(true);
+    const cur = getSearchQuery(view.state);
+    expect(cur.regexp).toBe(true);
+  });
+
+  it("emptying the query clears counts", () => {
+    view = createRealEditorView("hello hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.setQuery("hello"));
+    act(() => result.current.setQuery(""));
+
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeMatch).toBe(0);
+  });
+
+  it("opens find bar on daintree:find-in-panel when active", () => {
+    view = createRealEditorView("hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => {
+      window.dispatchEvent(new Event("daintree:find-in-panel"));
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("does not open find bar on daintree:find-in-panel when inactive", () => {
+    view = createRealEditorView("hello");
+    const { result } = renderFindHook(false, view);
+
+    act(() => {
+      window.dispatchEvent(new Event("daintree:find-in-panel"));
+    });
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("cleans up window listener on unmount", () => {
+    view = createRealEditorView("hello");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderFindHook(true, view);
+
+    unmount();
+    const calls = removeSpy.mock.calls.filter((c) => c[0] === "daintree:find-in-panel");
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("goNext/goPrev are no-ops when query is empty", () => {
+    view = createRealEditorView("hello");
+    const { result } = renderFindHook(true, view);
+
+    // Should not throw or change state
+    act(() => result.current.goNext());
+    act(() => result.current.goPrev());
+    expect(result.current.matchCount).toBe(0);
+  });
+
+  it("survives invalid regex without throwing", () => {
+    view = createRealEditorView("abc");
+    const { result } = renderFindHook(true, view);
+
+    act(() => result.current.toggleRegexp());
+    act(() => result.current.setQuery("("));
+    // Should not throw; match count stays 0 for invalid regex
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.regexp).toBe(true);
+  });
+
+  it("counts matches after query via editor update", () => {
+    view = createRealEditorView("hello hello hello");
+    const { result } = renderFindHook(true, view);
+
+    act(() => {
+      view!.dispatch({
+        effects: setSearchQuery.of(new SearchQuery({ search: "hello" })),
+      });
+    });
+
+    // handleEditorUpdate is called by CodeMirror on transactions in a real view, but in our
+    // renderHook wrapper it isn't wired — invoke manually to verify the counting logic.
+    act(() => {
+      result.current.handleEditorUpdate({
+        state: view!.state,
+        docChanged: false,
+        selectionSet: false,
+        transactions: [
+          { effects: [setSearchQuery.of(new SearchQuery({ search: "hello" }))] } as never,
+        ],
+      });
+    });
+
+    expect(result.current.matchCount).toBe(3);
+  });
+});

--- a/src/hooks/useFindInNote.ts
+++ b/src/hooks/useFindInNote.ts
@@ -39,13 +39,11 @@ export interface FindInNoteState {
   }) => void;
 }
 
-const HIDDEN_PANEL: { dom: HTMLElement; destroy?: () => void } = {
-  dom: (() => {
-    const d = typeof document !== "undefined" ? document.createElement("div") : ({} as HTMLElement);
-    if (typeof document !== "undefined") d.style.display = "none";
-    return d;
-  })(),
-};
+function createHiddenPanel(): { dom: HTMLElement } {
+  const dom = document.createElement("div");
+  dom.style.display = "none";
+  return { dom };
+}
 
 function countMatches(
   query: SearchQuery,
@@ -88,6 +86,17 @@ export function useFindInNote(
   const openRef = useRef<() => void>(() => {});
 
   const open = useCallback(() => {
+    // Re-open the underlying CM search panel so match highlights render.
+    // close() calls closeSearchPanel() which nulls out panel state; without
+    // reopening it here, highlights stay dark on the second+ open.
+    const view = editorViewRef.current;
+    if (view) {
+      try {
+        openSearchPanel(view);
+      } catch {
+        // View detached; ignore
+      }
+    }
     setIsOpen((prev) => {
       if (prev) {
         requestAnimationFrame(() => {
@@ -98,7 +107,7 @@ export function useFindInNote(
       }
       return true;
     });
-  }, []);
+  }, [editorViewRef]);
 
   useEffect(() => {
     openRef.current = open;
@@ -203,6 +212,11 @@ export function useFindInNote(
       );
       if (!update.docChanged && !update.selectionSet && !queryChanged) return;
       const cur = getSearchQuery(update.state);
+      if (!cur.search) {
+        setMatchCount(0);
+        setActiveMatch(0);
+        return;
+      }
       const { count, active } = countMatches(cur, update.state);
       setMatchCount(count);
       setActiveMatch(active);
@@ -213,7 +227,7 @@ export function useFindInNote(
   const searchExtension = useMemo<Extension>(
     () => [
       editorSearchHighlightTheme,
-      search({ createPanel: () => HIDDEN_PANEL }),
+      search({ createPanel: createHiddenPanel }),
       Prec.highest(
         keymap.of([
           {

--- a/src/hooks/useFindInNote.ts
+++ b/src/hooks/useFindInNote.ts
@@ -98,15 +98,10 @@ export function useFindInNote(
         // View detached; ignore
       }
     }
-    setIsOpen((prev) => {
-      if (prev) {
-        requestAnimationFrame(() => {
-          inputRef.current?.focus();
-          inputRef.current?.select();
-        });
-        return prev;
-      }
-      return true;
+    setIsOpen(true);
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
     });
   }, [editorViewRef]);
 
@@ -175,20 +170,16 @@ export function useFindInNote(
   );
 
   const toggleCase = useCallback(() => {
-    setCaseSensitive((prev) => {
-      const next = !prev;
-      applyQuery(query, { caseSensitive: next });
-      return next;
-    });
-  }, [applyQuery, query]);
+    const next = !caseSensitive;
+    setCaseSensitive(next);
+    applyQuery(query, { caseSensitive: next });
+  }, [applyQuery, caseSensitive, query]);
 
   const toggleRegexp = useCallback(() => {
-    setRegexp((prev) => {
-      const next = !prev;
-      applyQuery(query, { regexp: next });
-      return next;
-    });
-  }, [applyQuery, query]);
+    const next = !regexp;
+    setRegexp(next);
+    applyQuery(query, { regexp: next });
+  }, [applyQuery, regexp, query]);
 
   const goNext = useCallback(() => {
     const view = editorViewRef.current;

--- a/src/hooks/useFindInNote.ts
+++ b/src/hooks/useFindInNote.ts
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EditorView, keymap } from "@codemirror/view";
+import { Prec, type Extension } from "@codemirror/state";
+import {
+  search,
+  SearchQuery,
+  setSearchQuery,
+  getSearchQuery,
+  openSearchPanel,
+  closeSearchPanel,
+  findNext,
+  findPrevious,
+} from "@codemirror/search";
+import { editorSearchHighlightTheme } from "@/components/Notes/editorSearchTheme";
+
+export interface FindInNoteState {
+  isOpen: boolean;
+  query: string;
+  activeMatch: number;
+  matchCount: number;
+  caseSensitive: boolean;
+  regexp: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  isComposingRef: React.RefObject<boolean>;
+  searchExtension: Extension;
+  open: () => void;
+  close: () => void;
+  setQuery: (q: string) => void;
+  toggleCase: () => void;
+  toggleRegexp: () => void;
+  goNext: () => void;
+  goPrev: () => void;
+  handleEditorCreated: (view: EditorView) => void;
+  handleEditorUpdate: (update: {
+    state: import("@codemirror/state").EditorState;
+    docChanged: boolean;
+    selectionSet: boolean;
+    transactions: readonly import("@codemirror/state").Transaction[];
+  }) => void;
+}
+
+const HIDDEN_PANEL: { dom: HTMLElement; destroy?: () => void } = {
+  dom: (() => {
+    const d = typeof document !== "undefined" ? document.createElement("div") : ({} as HTMLElement);
+    if (typeof document !== "undefined") d.style.display = "none";
+    return d;
+  })(),
+};
+
+function countMatches(
+  query: SearchQuery,
+  state: import("@codemirror/state").EditorState
+): { count: number; active: number } {
+  if (!query.search || !query.valid) return { count: 0, active: 0 };
+  let count = 0;
+  let active = 0;
+  const sel = state.selection.main;
+  try {
+    const cursor = query.getCursor(state.doc) as Iterator<{ from: number; to: number }> & {
+      next: () => { done: boolean; value: { from: number; to: number } };
+    };
+    while (true) {
+      const step = cursor.next();
+      if (step.done) break;
+      count++;
+      const { from, to } = step.value;
+      if (from === sel.from && to === sel.to) active = count;
+    }
+  } catch {
+    return { count: 0, active: 0 };
+  }
+  return { count, active };
+}
+
+export function useFindInNote(
+  editorViewRef: React.RefObject<EditorView | null>,
+  isActive: boolean
+): FindInNoteState {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQueryState] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [regexp, setRegexp] = useState(false);
+  const [matchCount, setMatchCount] = useState(0);
+  const [activeMatch, setActiveMatch] = useState(0);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const isComposingRef = useRef(false);
+  const openRef = useRef<() => void>(() => {});
+
+  const open = useCallback(() => {
+    setIsOpen((prev) => {
+      if (prev) {
+        requestAnimationFrame(() => {
+          inputRef.current?.focus();
+          inputRef.current?.select();
+        });
+        return prev;
+      }
+      return true;
+    });
+  }, []);
+
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  const applyQuery = useCallback(
+    (text: string, opts?: { caseSensitive?: boolean; regexp?: boolean }) => {
+      const view = editorViewRef.current;
+      if (!view) return;
+      const cs = opts?.caseSensitive ?? caseSensitive;
+      const rx = opts?.regexp ?? regexp;
+      try {
+        view.dispatch({
+          effects: setSearchQuery.of(
+            new SearchQuery({ search: text, caseSensitive: cs, regexp: rx })
+          ),
+        });
+      } catch {
+        // Invalid regex or unknown failure — let the editor settle
+      }
+    },
+    [editorViewRef, caseSensitive, regexp]
+  );
+
+  const close = useCallback(() => {
+    const view = editorViewRef.current;
+    setIsOpen(false);
+    setQueryState("");
+    setMatchCount(0);
+    setActiveMatch(0);
+    if (view) {
+      try {
+        view.dispatch({ effects: setSearchQuery.of(new SearchQuery({ search: "" })) });
+        closeSearchPanel(view);
+      } catch {
+        // View may be detached
+      }
+    }
+  }, [editorViewRef]);
+
+  const setQuery = useCallback(
+    (q: string) => {
+      setQueryState(q);
+      if (isComposingRef.current) return;
+      applyQuery(q);
+      if (!q) {
+        setMatchCount(0);
+        setActiveMatch(0);
+      }
+    },
+    [applyQuery]
+  );
+
+  const toggleCase = useCallback(() => {
+    setCaseSensitive((prev) => {
+      const next = !prev;
+      applyQuery(query, { caseSensitive: next });
+      return next;
+    });
+  }, [applyQuery, query]);
+
+  const toggleRegexp = useCallback(() => {
+    setRegexp((prev) => {
+      const next = !prev;
+      applyQuery(query, { regexp: next });
+      return next;
+    });
+  }, [applyQuery, query]);
+
+  const goNext = useCallback(() => {
+    const view = editorViewRef.current;
+    if (!view || !query) return;
+    findNext(view);
+  }, [editorViewRef, query]);
+
+  const goPrev = useCallback(() => {
+    const view = editorViewRef.current;
+    if (!view || !query) return;
+    findPrevious(view);
+  }, [editorViewRef, query]);
+
+  const handleEditorCreated = useCallback(
+    (view: EditorView) => {
+      try {
+        openSearchPanel(view);
+      } catch {
+        // Older CM versions may throw if panel state is not ready
+      }
+    },
+    []
+  );
+
+  const handleEditorUpdate = useCallback(
+    (update: {
+      state: import("@codemirror/state").EditorState;
+      docChanged: boolean;
+      selectionSet: boolean;
+      transactions: readonly import("@codemirror/state").Transaction[];
+    }) => {
+      const queryChanged = update.transactions.some((tr) =>
+        tr.effects.some((e) => e.is(setSearchQuery))
+      );
+      if (!update.docChanged && !update.selectionSet && !queryChanged) return;
+      const cur = getSearchQuery(update.state);
+      const { count, active } = countMatches(cur, update.state);
+      setMatchCount(count);
+      setActiveMatch(active);
+    },
+    []
+  );
+
+  const searchExtension = useMemo<Extension>(
+    () => [
+      editorSearchHighlightTheme,
+      search({ createPanel: () => HIDDEN_PANEL }),
+      Prec.highest(
+        keymap.of([
+          {
+            key: "Mod-f",
+            run: () => {
+              openRef.current();
+              return true;
+            },
+          },
+          {
+            key: "Escape",
+            run: (view) => {
+              const panelOpen = getSearchQuery(view.state).search !== "";
+              if (!panelOpen && !isOpen) return false;
+              close();
+              return true;
+            },
+          },
+        ])
+      ),
+    ],
+    [close, isOpen]
+  );
+
+  useEffect(() => {
+    if (!isActive) return;
+    const handler = () => openRef.current();
+    window.addEventListener("daintree:find-in-panel", handler);
+    return () => window.removeEventListener("daintree:find-in-panel", handler);
+  }, [isActive]);
+
+  useEffect(() => {
+    if (isOpen) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    }
+  }, [isOpen]);
+
+  return {
+    isOpen,
+    query,
+    activeMatch,
+    matchCount,
+    caseSensitive,
+    regexp,
+    inputRef,
+    isComposingRef,
+    searchExtension,
+    open,
+    close,
+    setQuery,
+    toggleCase,
+    toggleRegexp,
+    goNext,
+    goPrev,
+    handleEditorCreated,
+    handleEditorUpdate,
+  };
+}

--- a/src/hooks/useFindInNote.ts
+++ b/src/hooks/useFindInNote.ts
@@ -21,7 +21,6 @@ export interface FindInNoteState {
   caseSensitive: boolean;
   regexp: boolean;
   inputRef: React.RefObject<HTMLInputElement | null>;
-  isComposingRef: React.RefObject<boolean>;
   searchExtension: Extension;
   open: () => void;
   close: () => void;
@@ -30,6 +29,8 @@ export interface FindInNoteState {
   toggleRegexp: () => void;
   goNext: () => void;
   goPrev: () => void;
+  onCompositionStart: () => void;
+  onCompositionEnd: (value: string) => void;
   handleEditorCreated: (view: EditorView) => void;
   handleEditorUpdate: (update: {
     state: import("@codemirror/state").EditorState;
@@ -161,6 +162,18 @@ export function useFindInNote(
     [applyQuery]
   );
 
+  const onCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const onCompositionEnd = useCallback(
+    (value: string) => {
+      isComposingRef.current = false;
+      setQuery(value);
+    },
+    [setQuery]
+  );
+
   const toggleCase = useCallback(() => {
     setCaseSensitive((prev) => {
       const next = !prev;
@@ -189,16 +202,13 @@ export function useFindInNote(
     findPrevious(view);
   }, [editorViewRef, query]);
 
-  const handleEditorCreated = useCallback(
-    (view: EditorView) => {
-      try {
-        openSearchPanel(view);
-      } catch {
-        // Older CM versions may throw if panel state is not ready
-      }
-    },
-    []
-  );
+  const handleEditorCreated = useCallback((view: EditorView) => {
+    try {
+      openSearchPanel(view);
+    } catch {
+      // Older CM versions may throw if panel state is not ready
+    }
+  }, []);
 
   const handleEditorUpdate = useCallback(
     (update: {
@@ -276,7 +286,6 @@ export function useFindInNote(
     caseSensitive,
     regexp,
     inputRef,
-    isComposingRef,
     searchExtension,
     open,
     close,
@@ -285,6 +294,8 @@ export function useFindInNote(
     toggleRegexp,
     goNext,
     goPrev,
+    onCompositionStart,
+    onCompositionEnd,
     handleEditorCreated,
     handleEditorUpdate,
   };


### PR DESCRIPTION
## Summary

- Adds a `useFindInNote` hook that drives CodeMirror 6 search programmatically, owning Cmd+F via `Prec.highest` keymap so the built-in CM search panel is bypassed entirely
- `NotesFindBar` overlay matches the visual vocabulary of the existing Browser `FindBar` (case sensitivity + regex toggles, match count, next/prev); shared `editorSearchTheme` extracted so `CodeViewer` benefits too
- Wired into both `NotesPane` (gated on focus + edit mode) and `NotesPalette` (gated on palette open + edit mode + selected note); find bar closes automatically on note switch, preview toggle, or palette close

Resolves #5370

## Changes

- `src/hooks/useFindInNote.ts` — new hook; `searchKeymap: false` in `basicSetup` lets the hook own Cmd+F cleanly
- `src/components/Notes/NotesFindBar.tsx` — overlay find bar with Aa and `.*` toggles
- `src/components/Notes/NotesPane.tsx` + `NotesPalette.tsx` — wiring
- `src/components/Notes/editorSearchTheme.ts` — extracted shared highlight theme
- `src/components/FileViewer/CodeViewer.tsx` — updated to import shared theme
- `src/hooks/__tests__/useFindInNote.test.tsx` — 14 unit tests covering open/close lifecycle, IME composition gating, case/regex toggles, match count, invalid regex, and close→reopen highlight regression

## Testing

14 unit tests added and passing. Tested manually in both `NotesPane` (standalone editor) and `NotesPalette` (palette edit mode). Verified find bar closes correctly on note switch and preview toggle.