### PR TITLE
fix(accessibility): prevent screen reader double-speak in announcers

### DIFF
--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -11,7 +11,7 @@ export function AccessibilityAnnouncer() {
   const pendingSetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    const announce = (msg: string | null, ref: React.RefObject<HTMLDivElement>) => {
+    const announce = (msg: string | null, ref: React.RefObject<HTMLDivElement | null>) => {
       const el = ref.current;
       if (!el) return;
 

--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -8,22 +8,12 @@ export function AccessibilityAnnouncer() {
   const politeRef = useRef<HTMLDivElement>(null);
   const assertiveRef = useRef<HTMLDivElement>(null);
 
-  const pendingClearRef = useRef<ReturnType<typeof queueMicrotask> | null>(null);
-  const pendingSetRef = useRef<ReturnType<typeof queueMicrotask> | null>(null);
+  const pendingSetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const announce = (msg: string | null, ref: React.RefObject<HTMLDivElement>) => {
       const el = ref.current;
       if (!el) return;
-
-      if (pendingClearRef.current) {
-        pendingClearRef.current();
-        pendingClearRef.current = null;
-      }
-      if (pendingSetRef.current) {
-        pendingSetRef.current();
-        pendingSetRef.current = null;
-      }
 
       if (!msg) {
         el.textContent = "";
@@ -31,22 +21,19 @@ export function AccessibilityAnnouncer() {
       }
 
       el.textContent = "";
-      pendingSetRef.current = queueMicrotask(() => {
+      pendingSetRef.current = setTimeout(() => {
         if (ref.current) {
           ref.current.textContent = msg;
         }
-      });
+      }, 0);
     };
 
     announce(polite?.msg ?? null, politeRef);
     announce(assertive?.msg ?? null, assertiveRef);
 
     return () => {
-      if (pendingClearRef.current) {
-        pendingClearRef.current();
-      }
       if (pendingSetRef.current) {
-        pendingSetRef.current();
+        clearTimeout(pendingSetRef.current);
       }
     };
   }, [polite, assertive]);

--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -1,17 +1,60 @@
+import { useEffect, useRef } from "react";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
 export function AccessibilityAnnouncer() {
   const polite = useAnnouncerStore((s) => s.polite);
   const assertive = useAnnouncerStore((s) => s.assertive);
 
+  const politeRef = useRef<HTMLDivElement>(null);
+  const assertiveRef = useRef<HTMLDivElement>(null);
+
+  const pendingClearRef = useRef<ReturnType<typeof queueMicrotask> | null>(null);
+  const pendingSetRef = useRef<ReturnType<typeof queueMicrotask> | null>(null);
+
+  useEffect(() => {
+    const announce = (msg: string | null, ref: React.RefObject<HTMLDivElement>) => {
+      const el = ref.current;
+      if (!el) return;
+
+      if (pendingClearRef.current) {
+        pendingClearRef.current();
+        pendingClearRef.current = null;
+      }
+      if (pendingSetRef.current) {
+        pendingSetRef.current();
+        pendingSetRef.current = null;
+      }
+
+      if (!msg) {
+        el.textContent = "";
+        return;
+      }
+
+      el.textContent = "";
+      pendingSetRef.current = queueMicrotask(() => {
+        if (ref.current) {
+          ref.current.textContent = msg;
+        }
+      });
+    };
+
+    announce(polite?.msg ?? null, politeRef);
+    announce(assertive?.msg ?? null, assertiveRef);
+
+    return () => {
+      if (pendingClearRef.current) {
+        pendingClearRef.current();
+      }
+      if (pendingSetRef.current) {
+        pendingSetRef.current();
+      }
+    };
+  }, [polite, assertive]);
+
   return (
     <>
-      <div className="sr-only" aria-live="polite" aria-atomic="true">
-        {polite ? <span key={polite.id}>{polite.msg}</span> : null}
-      </div>
-      <div className="sr-only" aria-live="assertive" aria-atomic="true">
-        {assertive ? <span key={assertive.id}>{assertive.msg}</span> : null}
-      </div>
+      <div ref={politeRef} className="sr-only" aria-live="polite" aria-atomic="false" />
+      <div ref={assertiveRef} className="sr-only" aria-live="assertive" aria-atomic="false" />
     </>
   );
 }

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
 import { AccessibilityAnnouncer } from "../AccessibilityAnnouncer";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
 describe("AccessibilityAnnouncer", () => {
   beforeEach(() => {
     useAnnouncerStore.setState({ polite: null, assertive: null });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
   });
 
   it("renders two aria-live regions", () => {
@@ -17,25 +23,27 @@ describe("AccessibilityAnnouncer", () => {
     expect(assertiveRegion).toBeTruthy();
   });
 
-  it("both regions have aria-atomic=true", () => {
+  it("both regions have aria-atomic=false", () => {
     const { container } = render(<AccessibilityAnnouncer />);
     const regions = container.querySelectorAll("[aria-atomic]");
     expect(regions.length).toBe(2);
     for (const region of regions) {
-      expect(region.getAttribute("aria-atomic")).toBe("true");
+      expect(region.getAttribute("aria-atomic")).toBe("false");
     }
   });
 
-  it("displays polite announcement text", () => {
+  it("displays polite announcement text", async () => {
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 1 } });
     const { container } = render(<AccessibilityAnnouncer />);
+    await Promise.resolve();
     const politeRegion = container.querySelector('[aria-live="polite"]');
     expect(politeRegion?.textContent).toBe("Panel focused");
   });
 
-  it("displays assertive announcement text", () => {
+  it("displays assertive announcement text", async () => {
     useAnnouncerStore.setState({ assertive: { msg: "Error occurred", id: 1 } });
     const { container } = render(<AccessibilityAnnouncer />);
+    await Promise.resolve();
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
     expect(assertiveRegion?.textContent).toBe("Error occurred");
   });
@@ -46,5 +54,69 @@ describe("AccessibilityAnnouncer", () => {
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
     expect(politeRegion?.textContent).toBe("");
     expect(assertiveRegion?.textContent).toBe("");
+  });
+
+  it("preserves DOM node identity across announcements", () => {
+    useAnnouncerStore.setState({ polite: { msg: "First", id: 1 } });
+    const { container, rerender } = render(<AccessibilityAnnouncer />);
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+
+    useAnnouncerStore.setState({ polite: { msg: "Second", id: 2 } });
+    rerender(<AccessibilityAnnouncer />);
+    const politeRegionAfter = container.querySelector('[aria-live="polite"]');
+
+    expect(politeRegion).toBe(politeRegionAfter);
+  });
+
+  it("delivers duplicate messages via clear-then-set cycle", async () => {
+    useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 1 } });
+    const { container, rerender } = render(<AccessibilityAnnouncer />);
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+
+    useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 2 } });
+    rerender(<AccessibilityAnnouncer />);
+    await Promise.resolve();
+
+    expect(politeRegion?.textContent).toBe("Panel focused");
+  });
+
+  it("rapid announcements end with only newest text present", async () => {
+    useAnnouncerStore.setState({ polite: { msg: "First", id: 1 } });
+    const { container, rerender } = render(<AccessibilityAnnouncer />);
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+
+    useAnnouncerStore.setState({ polite: { msg: "Second", id: 2 } });
+    rerender(<AccessibilityAnnouncer />);
+
+    useAnnouncerStore.setState({ polite: { msg: "Third", id: 3 } });
+    rerender(<AccessibilityAnnouncer />);
+    await Promise.resolve();
+
+    expect(politeRegion?.textContent).toBe("Third");
+  });
+
+  it("empty message clears the region", () => {
+    useAnnouncerStore.setState({ polite: { msg: "Message", id: 1 } });
+    const { container, rerender } = render(<AccessibilityAnnouncer />);
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+
+    useAnnouncerStore.setState({ polite: null });
+    rerender(<AccessibilityAnnouncer />);
+
+    expect(politeRegion?.textContent).toBe("");
+  });
+
+  it("handles both polite and assertive independently", async () => {
+    useAnnouncerStore.setState({
+      polite: { msg: "Polite message", id: 1 },
+      assertive: { msg: "Assertive message", id: 1 },
+    });
+    const { container } = render(<AccessibilityAnnouncer />);
+    await Promise.resolve();
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+    const assertiveRegion = container.querySelector('[aria-live="assertive"]');
+
+    expect(politeRegion?.textContent).toBe("Polite message");
+    expect(assertiveRegion?.textContent).toBe("Assertive message");
   });
 });

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 import { AccessibilityAnnouncer } from "../AccessibilityAnnouncer";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -32,24 +32,25 @@ describe("AccessibilityAnnouncer", () => {
     }
   });
 
-  it("displays polite announcement text", async () => {
+  it("displays polite announcement text", () => {
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 1 } });
     const { container } = render(<AccessibilityAnnouncer />);
-    await Promise.resolve();
+    vi.runAllTimers();
     const politeRegion = container.querySelector('[aria-live="polite"]');
     expect(politeRegion?.textContent).toBe("Panel focused");
   });
 
-  it("displays assertive announcement text", async () => {
+  it("displays assertive announcement text", () => {
     useAnnouncerStore.setState({ assertive: { msg: "Error occurred", id: 1 } });
     const { container } = render(<AccessibilityAnnouncer />);
-    await Promise.resolve();
+    vi.runAllTimers();
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
     expect(assertiveRegion?.textContent).toBe("Error occurred");
   });
 
   it("renders empty when no announcements", () => {
     const { container } = render(<AccessibilityAnnouncer />);
+    vi.runAllTimers();
     const politeRegion = container.querySelector('[aria-live="polite"]');
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
     expect(politeRegion?.textContent).toBe("");
@@ -59,28 +60,31 @@ describe("AccessibilityAnnouncer", () => {
   it("preserves DOM node identity across announcements", () => {
     useAnnouncerStore.setState({ polite: { msg: "First", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
+    vi.runAllTimers();
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
     useAnnouncerStore.setState({ polite: { msg: "Second", id: 2 } });
     rerender(<AccessibilityAnnouncer />);
+    vi.runAllTimers();
     const politeRegionAfter = container.querySelector('[aria-live="polite"]');
 
     expect(politeRegion).toBe(politeRegionAfter);
   });
 
-  it("delivers duplicate messages via clear-then-set cycle", async () => {
+  it("delivers duplicate messages via clear-then-set cycle", () => {
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
+    vi.runAllTimers();
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 2 } });
     rerender(<AccessibilityAnnouncer />);
-    await Promise.resolve();
+    vi.runAllTimers();
 
     expect(politeRegion?.textContent).toBe("Panel focused");
   });
 
-  it("rapid announcements end with only newest text present", async () => {
+  it("rapid announcements end with only newest text present", () => {
     useAnnouncerStore.setState({ polite: { msg: "First", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
     const politeRegion = container.querySelector('[aria-live="polite"]');
@@ -90,7 +94,7 @@ describe("AccessibilityAnnouncer", () => {
 
     useAnnouncerStore.setState({ polite: { msg: "Third", id: 3 } });
     rerender(<AccessibilityAnnouncer />);
-    await Promise.resolve();
+    vi.runAllTimers();
 
     expect(politeRegion?.textContent).toBe("Third");
   });
@@ -98,6 +102,7 @@ describe("AccessibilityAnnouncer", () => {
   it("empty message clears the region", () => {
     useAnnouncerStore.setState({ polite: { msg: "Message", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
+    vi.runAllTimers();
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
     useAnnouncerStore.setState({ polite: null });
@@ -106,13 +111,13 @@ describe("AccessibilityAnnouncer", () => {
     expect(politeRegion?.textContent).toBe("");
   });
 
-  it("handles both polite and assertive independently", async () => {
+  it("handles both polite and assertive independently", () => {
     useAnnouncerStore.setState({
       polite: { msg: "Polite message", id: 1 },
       assertive: { msg: "Assertive message", id: 1 },
     });
     const { container } = render(<AccessibilityAnnouncer />);
-    await Promise.resolve();
+    vi.runAllTimers();
     const politeRegion = container.querySelector('[aria-live="polite"]');
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
 

--- a/src/components/Terminal/VoiceRecordingAnnouncer.tsx
+++ b/src/components/Terminal/VoiceRecordingAnnouncer.tsx
@@ -5,16 +5,11 @@ export function VoiceRecordingAnnouncer() {
   const announcement = useVoiceRecordingStore((state) => state.announcement);
   const ref = useRef<HTMLDivElement>(null);
 
-  const pendingSetRef = useRef<ReturnType<typeof queueMicrotask> | null>(null);
+  const pendingSetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
-
-    if (pendingSetRef.current) {
-      pendingSetRef.current();
-      pendingSetRef.current = null;
-    }
 
     if (!announcement?.text) {
       el.textContent = "";
@@ -22,11 +17,17 @@ export function VoiceRecordingAnnouncer() {
     }
 
     el.textContent = "";
-    pendingSetRef.current = queueMicrotask(() => {
+    pendingSetRef.current = setTimeout(() => {
       if (ref.current) {
         ref.current.textContent = announcement.text;
       }
-    });
+    }, 0);
+
+    return () => {
+      if (pendingSetRef.current) {
+        clearTimeout(pendingSetRef.current);
+      }
+    };
   }, [announcement]);
 
   return <div ref={ref} className="sr-only" role="status" aria-live="polite" aria-atomic="false" />;

--- a/src/components/Terminal/VoiceRecordingAnnouncer.tsx
+++ b/src/components/Terminal/VoiceRecordingAnnouncer.tsx
@@ -1,11 +1,33 @@
+import { useEffect, useRef } from "react";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 
 export function VoiceRecordingAnnouncer() {
   const announcement = useVoiceRecordingStore((state) => state.announcement);
+  const ref = useRef<HTMLDivElement>(null);
 
-  return (
-    <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-      {announcement ? <span key={announcement.id}>{announcement.text}</span> : null}
-    </div>
-  );
+  const pendingSetRef = useRef<ReturnType<typeof queueMicrotask> | null>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    if (pendingSetRef.current) {
+      pendingSetRef.current();
+      pendingSetRef.current = null;
+    }
+
+    if (!announcement?.text) {
+      el.textContent = "";
+      return;
+    }
+
+    el.textContent = "";
+    pendingSetRef.current = queueMicrotask(() => {
+      if (ref.current) {
+        ref.current.textContent = announcement.text;
+      }
+    });
+  }, [announcement]);
+
+  return <div ref={ref} className="sr-only" role="status" aria-live="polite" aria-atomic="false" />;
 }


### PR DESCRIPTION
## Summary
- Removed `aria-atomic="true"` from live regions, which caused screen readers to re-announce all previous messages with each new toast
- Replaced React key-based remounting with a clear-then-set-text cycle to force re-announcement of duplicate messages without triggering double-speak
- Applied the same fix to `VoiceRecordingAnnouncer` for consistency

Resolves #5393

## Changes
- `src/components/Accessibility/AccessibilityAnnouncer.tsx`: Updated to use persistent DOM nodes and clear-then-set pattern
- `src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx`: Added comprehensive tests for duplicate handling and proper screen reader behaviour
- `src/components/Accessibility/VoiceRecordingAnnouncer.tsx`: Applied the same pattern for consistency

## Testing
- Added unit tests covering duplicate announcement handling, clear-then-set behaviour, and edge cases
- Verified the fix follows the same pattern as Adobe's `@react-aria/live-announcer`
- All existing tests pass