### PR TITLE
feat(agents): committable shared presets via .daintree/presets

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -25,6 +25,7 @@ const registerMocks = vi.hoisted(() => ({
   registerAgentCliHandlers: vi.fn(),
   registerProjectCrudHandlers: vi.fn(),
   registerProjectRecipesHandlers: vi.fn(),
+  registerProjectPresetsHandlers: vi.fn(),
   registerGlobalRecipesHandlers: vi.fn(),
   registerTerminalLayoutHandlers: vi.fn(),
   registerProjectInRepoSettingsHandlers: vi.fn(),
@@ -99,6 +100,9 @@ vi.mock("../handlers/projectCrud.js", () => ({
 }));
 vi.mock("../handlers/projectRecipes.js", () => ({
   registerProjectRecipesHandlers: registerMocks.registerProjectRecipesHandlers,
+}));
+vi.mock("../handlers/projectPresets.js", () => ({
+  registerProjectPresetsHandlers: registerMocks.registerProjectPresetsHandlers,
 }));
 vi.mock("../handlers/globalRecipes.js", () => ({
   registerGlobalRecipesHandlers: registerMocks.registerGlobalRecipesHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -228,6 +228,7 @@ export const CHANNELS = {
   PROJECT_SYNC_INREPO_RECIPES: "project:sync-inrepo-recipes",
   PROJECT_UPDATE_INREPO_RECIPE: "project:update-inrepo-recipe",
   PROJECT_DELETE_INREPO_RECIPE: "project:delete-inrepo-recipe",
+  PROJECT_GET_INREPO_PRESETS: "project:get-inrepo-presets",
 
   GLOBAL_GET_RECIPES: "global:get-recipes",
   GLOBAL_ADD_RECIPE: "global:add-recipe",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -8,6 +8,7 @@ import { registerEditorConfigHandlers } from "./handlers/editorConfig.js";
 import { registerAgentCliHandlers } from "./handlers/agentCli.js";
 import { registerProjectCrudHandlers } from "./handlers/projectCrud.js";
 import { registerProjectRecipesHandlers } from "./handlers/projectRecipes.js";
+import { registerProjectPresetsHandlers } from "./handlers/projectPresets.js";
 import { registerGlobalRecipesHandlers } from "./handlers/globalRecipes.js";
 import { registerGlobalEnvHandlers } from "./handlers/globalEnv.js";
 import { registerTerminalLayoutHandlers } from "./handlers/terminalLayout.js";
@@ -106,6 +107,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerAgentCliHandlers(deps));
     register(() => registerProjectCrudHandlers(deps));
     register(() => registerProjectRecipesHandlers(deps));
+    register(() => registerProjectPresetsHandlers(deps));
     register(() => registerGlobalRecipesHandlers(deps));
     register(() => registerGlobalEnvHandlers(deps));
     register(() => registerTerminalLayoutHandlers(deps));

--- a/electron/ipc/handlers/projectPresets.ts
+++ b/electron/ipc/handlers/projectPresets.ts
@@ -1,0 +1,25 @@
+import { CHANNELS } from "../channels.js";
+import { projectStore } from "../../services/ProjectStore.js";
+import type { HandlerDependencies } from "../types.js";
+import type { AgentPreset } from "../../../shared/config/agentRegistry.js";
+import { typedHandle } from "../utils.js";
+
+export function registerProjectPresetsHandlers(_deps: HandlerDependencies): () => void {
+  const handlers: Array<() => void> = [];
+
+  const handleGetInRepoPresets = async (
+    projectId: string
+  ): Promise<Record<string, AgentPreset[]>> => {
+    if (typeof projectId !== "string" || !projectId) {
+      throw new Error("Invalid project ID");
+    }
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+    return projectStore.readInRepoPresets(project.path);
+  };
+  handlers.push(typedHandle(CHANNELS.PROJECT_GET_INREPO_PRESETS, handleGetInRepoPresets));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -744,6 +744,7 @@ const CHANNELS = {
   PROJECT_SYNC_INREPO_RECIPES: "project:sync-inrepo-recipes",
   PROJECT_UPDATE_INREPO_RECIPE: "project:update-inrepo-recipe",
   PROJECT_DELETE_INREPO_RECIPE: "project:delete-inrepo-recipe",
+  PROJECT_GET_INREPO_PRESETS: "project:get-inrepo-presets",
   GLOBAL_GET_RECIPES: "global:get-recipes",
   GLOBAL_ADD_RECIPE: "global:add-recipe",
   GLOBAL_UPDATE_RECIPE: "global:update-recipe",
@@ -1818,6 +1819,11 @@ const api: ElectronAPI = {
 
     deleteInRepoRecipe: (projectId: string, recipeName: string): Promise<void> =>
       _unwrappingInvoke(CHANNELS.PROJECT_DELETE_INREPO_RECIPE, { projectId, recipeName }),
+
+    getInRepoPresets: (
+      projectId: string
+    ): Promise<Record<string, import("../shared/config/agentRegistry.js").AgentPreset[]>> =>
+      _unwrappingInvoke(CHANNELS.PROJECT_GET_INREPO_PRESETS, projectId),
 
     getTerminals: (
       projectId: string

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -1,5 +1,6 @@
 import type { ProjectSettings, TerminalRecipe } from "../types/index.js";
 import type { RunCommand, CopyTreeSettings } from "../../shared/types/project.js";
+import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
 import fs from "fs/promises";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
@@ -12,6 +13,12 @@ const DAINTREE_DIR = ".daintree";
 const DAINTREE_PROJECT_JSON = `${DAINTREE_DIR}/project.json`;
 const DAINTREE_SETTINGS_JSON = `${DAINTREE_DIR}/settings.json`;
 const DAINTREE_RECIPES_DIR = `${DAINTREE_DIR}/recipes`;
+const DAINTREE_PRESETS_DIR = `${DAINTREE_DIR}/presets`;
+
+// Only accept safe agent subdirectory names: letters, numbers, dot, dash,
+// underscore. Prevents path traversal via a crafted `.daintree/presets/../x`
+// subdirectory entry.
+const SAFE_AGENT_ID = /^[a-zA-Z0-9_.-]+$/;
 
 export class ProjectIdentityFiles {
   async readInRepoProjectIdentity(
@@ -277,6 +284,71 @@ export class ProjectIdentityFiles {
       }
     }
     return recipes;
+  }
+
+  /**
+   * Reads per-team shared agent presets committed to `.daintree/presets/{agentId}/*.json`.
+   * Returns a map keyed by agent id; malformed or unrecognized files are skipped with a warn.
+   */
+  async readInRepoPresets(projectPath: string): Promise<Record<string, AgentPreset[]>> {
+    await ensureDaintreeDirMigrated(projectPath);
+    const presetsDir = path.join(projectPath, DAINTREE_PRESETS_DIR);
+    let agentDirs;
+    try {
+      agentDirs = await fs.readdir(presetsDir, { withFileTypes: true });
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return {};
+      throw error;
+    }
+
+    const result: Record<string, AgentPreset[]> = {};
+
+    for (const agentEntry of agentDirs) {
+      if (!agentEntry.isDirectory()) continue;
+      const agentId = agentEntry.name;
+      if (!SAFE_AGENT_ID.test(agentId)) {
+        console.warn(`[ProjectIdentityFiles] Skipping unsafe preset subdir: ${agentId}`);
+        continue;
+      }
+
+      const agentDir = path.join(presetsDir, agentId);
+      let fileEntries;
+      try {
+        fileEntries = await fs.readdir(agentDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+
+      const presets: AgentPreset[] = [];
+      for (const entry of fileEntries) {
+        if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+        try {
+          const content = await fs.readFile(path.join(agentDir, entry.name), "utf-8");
+          const parsed = JSON.parse(content);
+          if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            Array.isArray(parsed) ||
+            typeof parsed.id !== "string" ||
+            typeof parsed.name !== "string" ||
+            !parsed.id ||
+            !parsed.name
+          ) {
+            console.warn(
+              `[ProjectIdentityFiles] Skipping invalid preset: ${agentId}/${entry.name}`
+            );
+            continue;
+          }
+          presets.push(parsed as AgentPreset);
+        } catch {
+          console.warn(`[ProjectIdentityFiles] Skipping malformed preset file: ${entry.name}`);
+        }
+      }
+
+      if (presets.length > 0) result[agentId] = presets;
+    }
+
+    return result;
   }
 
   async deleteInRepoRecipe(projectPath: string, recipeName: string): Promise<void> {

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -320,6 +320,7 @@ export class ProjectIdentityFiles {
       }
 
       const presets: AgentPreset[] = [];
+      const seenIds = new Set<string>();
       for (const entry of fileEntries) {
         if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
         try {
@@ -339,6 +340,17 @@ export class ProjectIdentityFiles {
             );
             continue;
           }
+          if (seenIds.has(parsed.id)) {
+            // Filesystem readdir order is non-deterministic across machines,
+            // so a duplicate id would resolve differently on different dev
+            // machines. Keep the first occurrence and warn loudly so the
+            // contributor renames one.
+            console.warn(
+              `[ProjectIdentityFiles] Duplicate preset id "${parsed.id}" in ${agentId}/${entry.name} — keeping first occurrence, rename this file`
+            );
+            continue;
+          }
+          seenIds.add(parsed.id);
           presets.push(parsed as AgentPreset);
         } catch {
           console.warn(`[ProjectIdentityFiles] Skipping malformed preset file: ${entry.name}`);

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -6,6 +6,7 @@ import type {
   TerminalRecipe,
 } from "../types/index.js";
 import type { NotificationSettings } from "../../shared/types/ipc/api.js";
+import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
 import fs from "fs/promises";
 import { existsSync } from "fs";
@@ -110,6 +111,10 @@ export class ProjectStore {
 
   async deleteInRepoRecipe(projectPath: string, recipeName: string): Promise<void> {
     return this.identityFiles.deleteInRepoRecipe(projectPath, recipeName);
+  }
+
+  async readInRepoPresets(projectPath: string): Promise<Record<string, AgentPreset[]>> {
+    return this.identityFiles.readInRepoPresets(projectPath);
   }
 
   // --- DB CRUD ---

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -384,3 +384,100 @@ describe("deleteInRepoRecipe", () => {
     await expect(identityFiles.deleteInRepoRecipe(tmpDir, "Nonexistent")).resolves.toBeUndefined();
   });
 });
+
+describe("readInRepoPresets", () => {
+  let tmpDir: string;
+  let identityFiles: ProjectIdentityFiles;
+  const PRESETS_DIR = ".daintree/presets";
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-presets-read-test-"));
+    identityFiles = new ProjectIdentityFiles();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty object when presets directory is absent", async () => {
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result).toEqual({});
+  });
+
+  it("loads presets from per-agent subdirectories", async () => {
+    const agentDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "team-opus.json"),
+      JSON.stringify({ id: "team-opus", name: "Team Opus", env: { MODEL: "opus" } })
+    );
+
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result).toHaveProperty("claude");
+    expect(result.claude).toHaveLength(1);
+    expect(result.claude?.[0]?.id).toBe("team-opus");
+    expect(result.claude?.[0]?.name).toBe("Team Opus");
+  });
+
+  it("groups presets by the agent subdirectory they live in", async () => {
+    const claudeDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    const codexDir = path.join(tmpDir, PRESETS_DIR, "codex");
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.mkdir(codexDir, { recursive: true });
+    await fs.writeFile(path.join(claudeDir, "a.json"), JSON.stringify({ id: "a", name: "A" }));
+    await fs.writeFile(path.join(codexDir, "b.json"), JSON.stringify({ id: "b", name: "B" }));
+
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result.claude?.map((p) => p.id)).toEqual(["a"]);
+    expect(result.codex?.map((p) => p.id)).toEqual(["b"]);
+  });
+
+  it("skips malformed JSON files without throwing", async () => {
+    const agentDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(path.join(agentDir, "broken.json"), "{ not valid json");
+    await fs.writeFile(
+      path.join(agentDir, "valid.json"),
+      JSON.stringify({ id: "valid", name: "Valid" })
+    );
+
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result.claude).toHaveLength(1);
+    expect(result.claude?.[0]?.id).toBe("valid");
+  });
+
+  it("skips files missing required id or name fields", async () => {
+    const agentDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(path.join(agentDir, "no-id.json"), JSON.stringify({ name: "No ID" }));
+    await fs.writeFile(path.join(agentDir, "no-name.json"), JSON.stringify({ id: "no-name" }));
+    await fs.writeFile(path.join(agentDir, "ok.json"), JSON.stringify({ id: "ok", name: "OK" }));
+
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result.claude).toHaveLength(1);
+    expect(result.claude?.[0]?.id).toBe("ok");
+  });
+
+  it("ignores non-.json files in agent directories", async () => {
+    const agentDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(path.join(agentDir, "README.md"), "# Notes");
+    await fs.writeFile(path.join(agentDir, "p.json"), JSON.stringify({ id: "p", name: "P" }));
+
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result.claude).toHaveLength(1);
+  });
+
+  it("rejects unsafe agent subdirectory names", async () => {
+    const presetsDir = path.join(tmpDir, PRESETS_DIR);
+    await fs.mkdir(presetsDir, { recursive: true });
+    // "bad/name" can't be created as a directory name but "..hidden" passes
+    // normal filesystem rules and must be rejected by the SAFE_AGENT_ID check.
+    const unsafeDir = path.join(presetsDir, "has space");
+    await fs.mkdir(unsafeDir, { recursive: true });
+    await fs.writeFile(path.join(unsafeDir, "x.json"), JSON.stringify({ id: "x", name: "X" }));
+
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result).not.toHaveProperty("has space");
+  });
+});

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
@@ -466,6 +466,24 @@ describe("readInRepoPresets", () => {
 
     const result = await identityFiles.readInRepoPresets(tmpDir);
     expect(result.claude).toHaveLength(1);
+  });
+
+  it("deduplicates presets with the same id within an agent directory and warns", async () => {
+    const agentDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    await fs.mkdir(agentDir, { recursive: true });
+    // Two files, same id. Filesystem readdir order is non-deterministic;
+    // the behavior we pin is: at most one entry, with a warning.
+    await fs.writeFile(path.join(agentDir, "a.json"), JSON.stringify({ id: "dup", name: "First" }));
+    await fs.writeFile(
+      path.join(agentDir, "b.json"),
+      JSON.stringify({ id: "dup", name: "Second" })
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await identityFiles.readInRepoPresets(tmpDir);
+    expect(result.claude).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Duplicate preset id"));
+    warnSpy.mockRestore();
   });
 
   it("rejects unsafe agent subdirectory names", async () => {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -12,6 +12,7 @@ import type {
 } from "../project.js";
 import type { OnboardingState, ChecklistState, ChecklistItemId } from "./maps.js";
 import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
+import type { AgentPreset } from "../../config/agentRegistry.js";
 import type { VoiceInputStatus } from "../voice.js";
 export type { VoiceInputStatus };
 import type { ResourceProfilePayload } from "../resourceProfile.js";
@@ -469,6 +470,7 @@ export interface ElectronAPI {
       previousName?: string
     ): Promise<void>;
     deleteInRepoRecipe(projectId: string, recipeName: string): Promise<void>;
+    getInRepoPresets(projectId: string): Promise<Record<string, AgentPreset[]>>;
     /**
      * Get saved terminal snapshots for a project (per-project panel state).
      * Used for restoring panel layout when switching projects.

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2073,6 +2073,10 @@ export interface IpcInvokeMap {
     args: [payload: { projectId: string; recipeName: string }];
     result: void;
   };
+  "project:get-inrepo-presets": {
+    args: [projectId: string];
+    result: Record<string, AgentPreset[]>;
+  };
 
   // Recipe import/export
   "recipe:export-file": {

--- a/src/__tests__/adversarial-logic.test.ts
+++ b/src/__tests__/adversarial-logic.test.ts
@@ -133,4 +133,40 @@ describe("Adversarial Unit Tests: Logic Vulnerabilities", () => {
       expect(result?.name).toBe("Custom Version");
     });
   });
+
+  describe("getMergedPresets - Project preset precedence", () => {
+    it("custom preset shadows project preset with same ID", () => {
+      const custom = [{ id: "shared", name: "User Custom" }];
+      const project = [{ id: "shared", name: "Team Project" }];
+      const result = getMergedPresets("claude", custom, [], project);
+      const shared = result.filter((f) => f.id === "shared");
+      expect(shared).toHaveLength(1);
+      expect(shared[0]!.name).toBe("User Custom");
+    });
+
+    it("project preset shadows CCR preset with same ID", () => {
+      const ccr = [{ id: "shared", name: "CCR Version" }];
+      const project = [{ id: "shared", name: "Team Project" }];
+      const result = getMergedPresets("claude", [], ccr, project);
+      const shared = result.filter((f) => f.id === "shared");
+      expect(shared).toHaveLength(1);
+      expect(shared[0]!.name).toBe("Team Project");
+    });
+
+    it("project presets appear alongside custom and CCR with distinct IDs", () => {
+      const custom = [{ id: "user-a", name: "User A" }];
+      const ccr = [{ id: "ccr-a", name: "CCR A" }];
+      const project = [{ id: "team-a", name: "Team A" }];
+      const result = getMergedPresets("claude", custom, ccr, project);
+      expect(result.map((f) => f.id)).toEqual(
+        expect.arrayContaining(["user-a", "ccr-a", "team-a"])
+      );
+    });
+
+    it("getMergedPreset resolves project preset when no custom override exists", () => {
+      const project = [{ id: "team-a", name: "Team Opus" }];
+      const result = getMergedPreset("claude", "team-a", [], [], project);
+      expect(result?.name).toBe("Team Opus");
+    });
+  });
 });

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -9,6 +9,7 @@ import type {
   TerminalSnapshot,
   TabGroup,
 } from "@shared/types";
+import type { AgentPreset } from "@shared/config/agentRegistry";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
 import type {
   GitInitOptions,
@@ -225,6 +226,10 @@ export const projectClient = {
 
   deleteInRepoRecipe: (projectId: string, recipeName: string): Promise<void> => {
     return window.electron.project.deleteInRepoRecipe(projectId, recipeName);
+  },
+
+  getInRepoPresets: (projectId: string): Promise<Record<string, AgentPreset[]>> => {
+    return window.electron.project.getInRepoPresets(projectId);
   },
 
   getTerminals: (projectId: string): Promise<TerminalSnapshot[]> => {

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -31,6 +31,7 @@ import type { AgentAvailabilityState, AgentState } from "@shared/types";
 import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useShallow } from "zustand/react/shallow";
@@ -64,6 +65,7 @@ export function AgentButton({
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
+  const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
   const panelsById = usePanelStore(useShallow((s) => s.panelsById));
   const panelIds = usePanelStore(useShallow((s) => s.panelIds));
@@ -98,14 +100,25 @@ export function AgentButton({
   const dominantState = activeSession?.dominantState ?? null;
 
   const entry = agentSettings?.agents?.[type] ?? {};
-  const presets = getMergedPresets(type, entry.customPresets, ccrPresets);
+  const presets = getMergedPresets(type, entry.customPresets, ccrPresets, projectPresets);
   // Only show the split/chevron UI when there are at least 2 presets; a single
   // preset is implicitly the default and doesn't warrant a picker.
   const hasPresets = presets.length >= 2;
   const savedPresetId = agentSettings?.agents?.[type]?.presetId;
+  const customPresetIds = new Set((entry.customPresets ?? []).map((f) => f.id));
+  const projectPresetIds = new Set((projectPresets ?? []).map((f) => f.id));
   const ccrPresetGroup = presets.filter((f) => f.id.startsWith("ccr-"));
-  const customPresetGroup = presets.filter((f) => !f.id.startsWith("ccr-"));
-  const hasBothPresetGroups = ccrPresetGroup.length > 0 && customPresetGroup.length > 0;
+  const projectPresetGroup = presets.filter(
+    (f) => !f.id.startsWith("ccr-") && !customPresetIds.has(f.id) && projectPresetIds.has(f.id)
+  );
+  const customPresetGroup = presets.filter(
+    (f) => !f.id.startsWith("ccr-") && !projectPresetGroup.includes(f)
+  );
+  const presetGroupCount =
+    (ccrPresetGroup.length > 0 ? 1 : 0) +
+    (projectPresetGroup.length > 0 ? 1 : 0) +
+    (customPresetGroup.length > 0 ? 1 : 0);
+  const hasMultiplePresetGroups = presetGroupCount > 1;
 
   const tooltipDetails = config.tooltip ? ` — ${config.tooltip}` : "";
   const shortcut = displayCombo ? ` (${displayCombo})` : "";
@@ -342,8 +355,10 @@ export function AgentButton({
                     </DropdownMenuItem>
                     {ccrPresetGroup.length > 0 && (
                       <>
-                        {hasBothPresetGroups && <DropdownMenuSeparator />}
-                        {hasBothPresetGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
+                        {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                        {hasMultiplePresetGroups && (
+                          <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>
+                        )}
                         {ccrPresetGroup.map((preset) => (
                           <DropdownMenuItem
                             key={preset.id}
@@ -364,10 +379,36 @@ export function AgentButton({
                         ))}
                       </>
                     )}
+                    {projectPresetGroup.length > 0 && (
+                      <>
+                        {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                        {hasMultiplePresetGroups && (
+                          <DropdownMenuLabel>Project Shared</DropdownMenuLabel>
+                        )}
+                        {projectPresetGroup.map((preset) => (
+                          <DropdownMenuItem
+                            key={preset.id}
+                            className={cn(savedPresetId === preset.id && "font-medium")}
+                            onSelect={() => {
+                              void actionService.dispatch(
+                                "agent.launch",
+                                { agentId: type, presetId: preset.id },
+                                { source: "user" }
+                              );
+                            }}
+                          >
+                            <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                              <config.icon brandColor={preset.color ?? getBrandColorHex(type)} />
+                            </span>
+                            {preset.name}
+                          </DropdownMenuItem>
+                        ))}
+                      </>
+                    )}
                     {customPresetGroup.length > 0 && (
                       <>
-                        {hasBothPresetGroups && <DropdownMenuSeparator />}
-                        {hasBothPresetGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
+                        {hasMultiplePresetGroups && <DropdownMenuSeparator />}
+                        {hasMultiplePresetGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
                         {customPresetGroup.map((preset) => (
                           <DropdownMenuItem
                             key={preset.id}

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -105,14 +105,19 @@ export function AgentButton({
   // preset is implicitly the default and doesn't warrant a picker.
   const hasPresets = presets.length >= 2;
   const savedPresetId = agentSettings?.agents?.[type]?.presetId;
-  const customPresetIds = new Set((entry.customPresets ?? []).map((f) => f.id));
+  // Group by source. Project presets are identified by membership so that a
+  // project preset whose id happens to start with "ccr-" still lands in
+  // "Project Shared" rather than being stolen by the CCR group. Everything
+  // that isn't CCR-prefixed or project-member falls through to the "Custom"
+  // bucket — this preserves the historical rendering for user-authored
+  // presets regardless of whether they're also in `entry.customPresets`.
   const projectPresetIds = new Set((projectPresets ?? []).map((f) => f.id));
-  const ccrPresetGroup = presets.filter((f) => f.id.startsWith("ccr-"));
-  const projectPresetGroup = presets.filter(
-    (f) => !f.id.startsWith("ccr-") && !customPresetIds.has(f.id) && projectPresetIds.has(f.id)
+  const projectPresetGroup = presets.filter((f) => projectPresetIds.has(f.id));
+  const ccrPresetGroup = presets.filter(
+    (f) => !projectPresetIds.has(f.id) && f.id.startsWith("ccr-")
   );
   const customPresetGroup = presets.filter(
-    (f) => !f.id.startsWith("ccr-") && !projectPresetGroup.includes(f)
+    (f) => !projectPresetIds.has(f.id) && !f.id.startsWith("ccr-")
   );
   const presetGroupCount =
     (ccrPresetGroup.length > 0 ? 1 : 0) +

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -35,6 +35,7 @@ import { useActionMruStore } from "@/store/actionMruStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useShallow } from "zustand/react/shallow";
@@ -63,6 +64,8 @@ type AgentRow = {
   dominantState: AgentState | null;
   isNew: boolean;
   presets?: AgentPreset[];
+  customPresetIds: Set<string>;
+  projectPresetIds: Set<string>;
 };
 
 const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentState | undefined>([
@@ -79,11 +82,12 @@ function buildAgentRow(
   dominantState: AgentState | null,
   isNew: boolean,
   customPresets?: AgentPreset[],
-  ccrPresets?: AgentPreset[]
+  ccrPresets?: AgentPreset[],
+  projectPresets?: AgentPreset[]
 ): AgentRow | null {
   const config = getAgentConfig(id);
   if (!config) return null;
-  const presets = getMergedPresets(id, customPresets, ccrPresets);
+  const presets = getMergedPresets(id, customPresets, ccrPresets, projectPresets);
   const hasPresets = presets.length > 1;
   return {
     id,
@@ -93,6 +97,8 @@ function buildAgentRow(
     dominantState,
     isNew,
     presets: hasPresets ? presets : undefined,
+    customPresetIds: new Set((customPresets ?? []).map((f) => f.id)),
+    projectPresetIds: new Set((projectPresets ?? []).map((f) => f.id)),
   };
 }
 
@@ -143,8 +149,18 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
   };
 
   const ccrPresets = (row.presets ?? []).filter((f) => f.id.startsWith("ccr-"));
-  const customPresets = (row.presets ?? []).filter((f) => !f.id.startsWith("ccr-"));
-  const hasBothGroups = ccrPresets.length > 0 && customPresets.length > 0;
+  const projectPresets = (row.presets ?? []).filter(
+    (f) =>
+      !f.id.startsWith("ccr-") && !row.customPresetIds.has(f.id) && row.projectPresetIds.has(f.id)
+  );
+  const customPresets = (row.presets ?? []).filter(
+    (f) => !f.id.startsWith("ccr-") && !projectPresets.includes(f)
+  );
+  const groupCount =
+    (ccrPresets.length > 0 ? 1 : 0) +
+    (projectPresets.length > 0 ? 1 : 0) +
+    (customPresets.length > 0 ? 1 : 0);
+  const hasMultipleGroups = groupCount > 1;
 
   return (
     <DropdownMenuSub>
@@ -176,8 +192,8 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
         </DropdownMenuItem>
         {ccrPresets.length > 0 && (
           <>
-            {hasBothGroups && <DropdownMenuSeparator />}
-            {hasBothGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
+            {hasMultipleGroups && <DropdownMenuSeparator />}
+            {hasMultipleGroups && <DropdownMenuLabel>CCR Routes</DropdownMenuLabel>}
             {ccrPresets.map((preset) => (
               <DropdownMenuItem key={preset.id} onSelect={() => onLaunch(row.id, preset.id)}>
                 <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
@@ -188,10 +204,24 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
             ))}
           </>
         )}
+        {projectPresets.length > 0 && (
+          <>
+            {hasMultipleGroups && <DropdownMenuSeparator />}
+            {hasMultipleGroups && <DropdownMenuLabel>Project Shared</DropdownMenuLabel>}
+            {projectPresets.map((preset) => (
+              <DropdownMenuItem key={preset.id} onSelect={() => onLaunch(row.id, preset.id)}>
+                <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
+                  <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
+                </span>
+                {preset.name}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
         {customPresets.length > 0 && (
           <>
-            {hasBothGroups && <DropdownMenuSeparator />}
-            {hasBothGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
+            {hasMultipleGroups && <DropdownMenuSeparator />}
+            {hasMultipleGroups && <DropdownMenuLabel>Custom</DropdownMenuLabel>}
             {customPresets.map((preset) => (
               <DropdownMenuItem key={preset.id} onSelect={() => onLaunch(row.id, preset.id)}>
                 <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
@@ -213,6 +243,7 @@ export function AgentTrayButton({
 }: AgentTrayButtonProps) {
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const ccrPresetsByAgent = useCcrPresetsStore((s) => s.ccrPresetsByAgent);
+  const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
 
   const getSortedActionMruList = useActionMruStore(useShallow((s) => s.getSortedActionMruList));
@@ -358,13 +389,15 @@ export function AgentTrayButton({
       const dominant = agentDominantStates.get(id) ?? null;
       const customPresets = agentSettings?.agents?.[id]?.customPresets;
       const ccrPresets = ccrPresetsByAgent[id];
+      const projectPresets = projectPresetsByAgent[id];
       const row = buildAgentRow(
         id,
         pinned,
         dominant,
         newAgentIds.has(id),
         customPresets,
-        ccrPresets
+        ccrPresets,
+        projectPresets
       );
       if (!row) continue;
 
@@ -407,6 +440,7 @@ export function AgentTrayButton({
     getSortedActionMruList,
     newAgentIds,
     ccrPresetsByAgent,
+    projectPresetsByAgent,
   ]);
 
   const handleLaunch = useCallback((agentId: BuiltInAgentId, presetId?: string | null) => {

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -64,7 +64,6 @@ type AgentRow = {
   dominantState: AgentState | null;
   isNew: boolean;
   presets?: AgentPreset[];
-  customPresetIds: Set<string>;
   projectPresetIds: Set<string>;
 };
 
@@ -97,7 +96,6 @@ function buildAgentRow(
     dominantState,
     isNew,
     presets: hasPresets ? presets : undefined,
-    customPresetIds: new Set((customPresets ?? []).map((f) => f.id)),
     projectPresetIds: new Set((projectPresets ?? []).map((f) => f.id)),
   };
 }
@@ -148,13 +146,16 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
     }
   };
 
-  const ccrPresets = (row.presets ?? []).filter((f) => f.id.startsWith("ccr-"));
-  const projectPresets = (row.presets ?? []).filter(
-    (f) =>
-      !f.id.startsWith("ccr-") && !row.customPresetIds.has(f.id) && row.projectPresetIds.has(f.id)
+  // Project membership beats the ccr- prefix so a project preset with a
+  // ccr-* id still lands under "Project Shared". Everything not-ccr and
+  // not-project falls through to "Custom" — preserves historical display
+  // for presets whose provenance can't be determined from id alone.
+  const projectPresets = (row.presets ?? []).filter((f) => row.projectPresetIds.has(f.id));
+  const ccrPresets = (row.presets ?? []).filter(
+    (f) => !row.projectPresetIds.has(f.id) && f.id.startsWith("ccr-")
   );
   const customPresets = (row.presets ?? []).filter(
-    (f) => !f.id.startsWith("ccr-") && !projectPresets.includes(f)
+    (f) => !row.projectPresetIds.has(f.id) && !f.id.startsWith("ccr-")
   );
   const groupCount =
     (ccrPresets.length > 0 ? 1 : 0) +

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -16,6 +16,7 @@ import { useDiagnosticsStore, useDockStore, useFleetDeckStore, type PanelState }
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { useCcrPresetsSubscription } from "@/hooks/useCcrPresetsSubscription";
+import { useProjectPresetsSubscription } from "@/hooks/useProjectPresetsSubscription";
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 import type { CliAvailability, AgentSettings } from "@shared/types";
@@ -54,6 +55,7 @@ export function AppLayout({
   projectSwitcherPalette,
 }: AppLayoutProps) {
   useCcrPresetsSubscription();
+  useProjectPresetsSubscription();
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
   const currentProject = useProjectStore((state) => state.currentProject);
   const layout = useLayoutState();

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -358,6 +359,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
 
   const agentSettingsAll = useAgentSettingsStore((s) => s.settings);
   const ccrPresetsByAgent = useCcrPresetsStore((s) => s.ccrPresetsByAgent);
+  const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
 
   // Per-panel preset colors for tab bar
   const panelPresetColors = useMemo(() => {
@@ -368,13 +370,14 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         const presets = getMergedPresets(
           p.agentId,
           agentSettingsAll?.agents?.[p.agentId]?.customPresets,
-          ccrPresetsByAgent[p.agentId]
+          ccrPresetsByAgent[p.agentId],
+          projectPresetsByAgent[p.agentId]
         );
         const preset = presets.find((f) => f.id === p.agentPresetId);
         return [p.id, preset?.color ?? p.agentPresetColor ?? fallbackColor] as const;
       })
     );
-  }, [panels, agentSettingsAll, ccrPresetsByAgent]);
+  }, [panels, agentSettingsAll, ccrPresetsByAgent, projectPresetsByAgent]);
 
   if (!activePanel || panels.length === 0) {
     return null;

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { getMergedPresets } from "@/config/agents";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
@@ -189,12 +190,18 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const presetCcrPresets = useCcrPresetsStore((s) =>
     terminal.agentId ? s.ccrPresetsByAgent[terminal.agentId] : undefined
   );
+  const presetProjectPresets = useProjectPresetsStore((s) =>
+    terminal.agentId ? s.presetsByAgent[terminal.agentId] : undefined
+  );
   const brandColor = useMemo(() => {
     const fallbackColor = getBrandColorHex(terminal.agentId ?? terminal.type);
     if (!terminal.agentPresetId || !terminal.agentId) return fallbackColor;
-    const preset = getMergedPresets(terminal.agentId, presetCustomPresets, presetCcrPresets).find(
-      (f) => f.id === terminal.agentPresetId
-    );
+    const preset = getMergedPresets(
+      terminal.agentId,
+      presetCustomPresets,
+      presetCcrPresets,
+      presetProjectPresets
+    ).find((f) => f.id === terminal.agentPresetId);
     return preset?.color ?? terminal.agentPresetColor ?? fallbackColor;
   }, [
     terminal.agentId,
@@ -203,6 +210,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     terminal.agentPresetColor,
     presetCustomPresets,
     presetCcrPresets,
+    presetProjectPresets,
   ]);
 
   const isWorking = terminal.agentState === "working";

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -46,6 +46,12 @@ vi.mock("@/store/ccrPresetsStore", () => ({
   ) => selector({ ccrPresetsByAgent: mockCcrPresetsByAgent }),
 }));
 
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (
+    selector: (s: { presetsByAgent: Record<string, unknown[]> }) => unknown
+  ) => selector({ presetsByAgent: {} }),
+}));
+
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({ panelsById: {}, panelIds: [] }),

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -107,6 +107,12 @@ vi.mock("@/store/ccrPresetsStore", () => ({
   ) => selector({ ccrPresetsByAgent: mockCcrPresetsByAgent }),
 }));
 
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (
+    selector: (s: { presetsByAgent: Record<string, unknown[]> }) => unknown
+  ) => selector({ presetsByAgent: {} }),
+}));
+
 vi.mock("@shared/config/agentIds", () => ({
   BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"] as const,
 }));

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -3,6 +3,7 @@ import { getAgentIds, getAgentConfig, getMergedPresets, type AgentPreset } from 
 import { useAgentSettingsStore, useCliAvailabilityStore, useAgentPreferencesStore } from "@/store";
 import { cliAvailabilityClient } from "@/clients";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { Button } from "@/components/ui/button";
 import {
   DEFAULT_AGENT_SETTINGS,
@@ -103,6 +104,7 @@ export function AgentSettings({
   const setDefaultAgent = useAgentPreferencesStore((state) => state.setDefaultAgent);
 
   const ccrPresetsByAgent = useCcrPresetsStore((s) => s.ccrPresetsByAgent);
+  const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
 
   // Rate limiting refs
   const lastAddTimeRef = useRef(0);
@@ -141,7 +143,8 @@ export function AgentSettings({
     const entry = settings?.agents?.[activeAgentId];
     if (!entry?.presetId) return;
     const ccr = ccrPresetsByAgent[activeAgentId];
-    const merged = getMergedPresets(activeAgentId, entry.customPresets, ccr);
+    const project = projectPresetsByAgent[activeAgentId];
+    const merged = getMergedPresets(activeAgentId, entry.customPresets, ccr, project);
     const stillExists = merged.some((f) => f.id === entry.presetId);
     if (!stillExists) {
       void (async () => {
@@ -154,8 +157,9 @@ export function AgentSettings({
     void activeAgentId;
     void settings;
     void ccrPresetsByAgent;
+    void projectPresetsByAgent;
     clearStalePreset();
-  }, [activeAgentId, settings, ccrPresetsByAgent]);
+  }, [activeAgentId, settings, ccrPresetsByAgent, projectPresetsByAgent]);
 
   const agentOptions = useMemo(
     () =>
@@ -360,14 +364,32 @@ export function AgentSettings({
             {/* Preset section — picker + all per-preset settings inside */}
             {(() => {
               const ccrPresets = ccrPresetsByAgent[activeAgent.id];
+              const projectPresets = projectPresetsByAgent[activeAgent.id];
               const customPresets = activeEntry.customPresets;
-              const allPresets = getMergedPresets(activeAgent.id, customPresets, ccrPresets);
+              const allPresets = getMergedPresets(
+                activeAgent.id,
+                customPresets,
+                ccrPresets,
+                projectPresets
+              );
               const agentCfg = getAgentConfig(activeAgent.id);
               const supportsInlineMode = !!agentCfg?.capabilities?.inlineModeFlag;
 
               const selectedPreset = allPresets.find((f) => f.id === activeEntry.presetId);
-              const selectedIsCcr = selectedPreset?.id.startsWith("ccr-") ?? false;
-              const selectedIsCustom = selectedPreset?.id.startsWith("user-") ?? false;
+              // A custom preset with the same ID overrides CCR/project in
+              // getMergedPresets, so membership in customPresets is the
+              // canonical signal for "selected is custom" — prefix-based
+              // checks would mis-classify a project preset that happened to
+              // start with "user-".
+              const selectedIsCustom =
+                !!selectedPreset && (customPresets ?? []).some((f) => f.id === selectedPreset.id);
+              const selectedIsCcr =
+                !!selectedPreset && !selectedIsCustom && selectedPreset.id.startsWith("ccr-");
+              const selectedIsProject =
+                !!selectedPreset &&
+                !selectedIsCustom &&
+                !selectedIsCcr &&
+                (projectPresets ?? []).some((f) => f.id === selectedPreset.id);
               const isDefault = !selectedPreset;
 
               // ── handlers ──────────────────────────────────────────────────
@@ -666,6 +688,7 @@ export function AgentSettings({
                     selectedPresetId={activeEntry.presetId ?? undefined}
                     allPresets={allPresets}
                     ccrPresets={ccrPresets ?? []}
+                    projectPresets={projectPresets ?? []}
                     customPresets={customPresets ?? []}
                     onChange={(presetId) => {
                       void (async () => {
@@ -725,6 +748,56 @@ export function AgentSettings({
                             {selectedPreset.description}
                           </p>
                         )}
+                      </div>
+                      <div className="px-3 py-2.5">{behavioralSettings}</div>
+                    </div>
+                  )}
+
+                  {/* Detail view for selected project-shared preset — read-only, mirrors CCR */}
+                  {selectedPreset && selectedIsProject && (
+                    <div className="rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30 divide-y divide-daintree-border/50">
+                      <div className="px-3 py-2.5 space-y-2">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-xs font-medium text-daintree-text">
+                            {selectedPreset.name}
+                          </span>
+                          <span
+                            data-testid="preset-badge-project"
+                            className="text-[10px] text-daintree-text/40 bg-daintree-text/10 px-1.5 py-0.5 rounded"
+                          >
+                            project
+                          </span>
+                          <button
+                            className="ml-auto text-daintree-text/30 hover:text-daintree-text transition-colors"
+                            onClick={() => handleDuplicatePreset(selectedPreset)}
+                            aria-label={`Duplicate ${selectedPreset.name}`}
+                            title="Duplicate as custom"
+                          >
+                            <Copy size={13} />
+                          </button>
+                        </div>
+                        {selectedPreset.env && Object.keys(selectedPreset.env).length > 0 && (
+                          <div className="space-y-1">
+                            {Object.entries(selectedPreset.env).map(([k, v]) => (
+                              <div
+                                key={k}
+                                className="flex items-center gap-2 font-mono text-[11px]"
+                              >
+                                <span className="text-daintree-text/50 shrink-0">{k}</span>
+                                <span className="text-daintree-text/30">=</span>
+                                <span className="text-daintree-accent/70 truncate">{v}</span>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                        {selectedPreset.description && (
+                          <p className="text-[11px] text-daintree-text/40 select-text">
+                            {selectedPreset.description}
+                          </p>
+                        )}
+                        <p className="text-[10px] text-daintree-text/40 select-text">
+                          Sourced from <code>.daintree/presets/</code> in this project.
+                        </p>
                       </div>
                       <div className="px-3 py-2.5">{behavioralSettings}</div>
                     </div>

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -381,15 +381,21 @@ export function AgentSettings({
               // canonical signal for "selected is custom" — prefix-based
               // checks would mis-classify a project preset that happened to
               // start with "user-".
+              // Source precedence for display classification (custom > project > CCR):
+              // membership checks must beat the ccr- prefix heuristic so that a
+              // project preset whose id happens to start with "ccr-" is still
+              // surfaced under its true source in the detail view.
               const selectedIsCustom =
                 !!selectedPreset && (customPresets ?? []).some((f) => f.id === selectedPreset.id);
-              const selectedIsCcr =
-                !!selectedPreset && !selectedIsCustom && selectedPreset.id.startsWith("ccr-");
               const selectedIsProject =
                 !!selectedPreset &&
                 !selectedIsCustom &&
-                !selectedIsCcr &&
                 (projectPresets ?? []).some((f) => f.id === selectedPreset.id);
+              const selectedIsCcr =
+                !!selectedPreset &&
+                !selectedIsCustom &&
+                !selectedIsProject &&
+                selectedPreset.id.startsWith("ccr-");
               const isDefault = !selectedPreset;
 
               // ── handlers ──────────────────────────────────────────────────

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -18,12 +18,19 @@ export interface PresetSelectorProps {
   selectedPresetId: string | undefined;
   allPresets: AgentPreset[];
   ccrPresets: AgentPreset[];
+  /** Per-team shared presets sourced from `.daintree/presets/`. Defaults to empty. */
+  projectPresets?: AgentPreset[];
   customPresets: AgentPreset[];
   onChange: (presetId: string | undefined) => void;
   agentColor: string;
 }
 
-type Item = { id: string; label: string; color: string; source: "default" | "ccr" | "custom" };
+type Item = {
+  id: string;
+  label: string;
+  color: string;
+  source: "default" | "ccr" | "project" | "custom";
+};
 
 function stripCcrPrefix(name: string): string {
   return name.replace(/^CCR:\s*/, "");
@@ -33,6 +40,7 @@ export function PresetSelector({
   selectedPresetId,
   allPresets: _allPresets,
   ccrPresets,
+  projectPresets = [],
   customPresets,
   onChange,
   agentColor,
@@ -43,15 +51,9 @@ export function PresetSelector({
     if (!selectedPresetId) {
       return { id: "", label: "Default (no overrides)", color: agentColor, source: "default" };
     }
-    const ccr = ccrPresets.find((f) => f.id === selectedPresetId);
-    if (ccr) {
-      return {
-        id: ccr.id,
-        label: stripCcrPrefix(ccr.name),
-        color: ccr.color ?? agentColor,
-        source: "ccr",
-      };
-    }
+    // Match precedence order from getMergedPresets: custom wins over project
+    // wins over CCR on ID collision. Resolve the badge/label against the
+    // entry that actually wins so the trigger reflects the effective preset.
     const custom = customPresets.find((f) => f.id === selectedPresetId);
     if (custom) {
       return {
@@ -61,10 +63,28 @@ export function PresetSelector({
         source: "custom",
       };
     }
+    const project = projectPresets.find((f) => f.id === selectedPresetId);
+    if (project) {
+      return {
+        id: project.id,
+        label: project.name,
+        color: project.color ?? agentColor,
+        source: "project",
+      };
+    }
+    const ccr = ccrPresets.find((f) => f.id === selectedPresetId);
+    if (ccr) {
+      return {
+        id: ccr.id,
+        label: stripCcrPrefix(ccr.name),
+        color: ccr.color ?? agentColor,
+        source: "ccr",
+      };
+    }
     // Stale selection — fall back to default presentation but don't clear
     // state here (the parent clears stale IDs on launch).
     return { id: "", label: "Default (no overrides)", color: agentColor, source: "default" };
-  }, [selectedPresetId, ccrPresets, customPresets, agentColor]);
+  }, [selectedPresetId, ccrPresets, projectPresets, customPresets, agentColor]);
 
   const handleSelect = (id: string) => {
     onChange(id || undefined);
@@ -98,6 +118,14 @@ export function PresetSelector({
               aria-hidden="true"
             >
               CCR
+            </span>
+          )}
+          {selectedItem.source === "project" && (
+            <span
+              className="text-[9px] uppercase tracking-wide text-daintree-text/40 bg-daintree-text/5 px-1 py-0.5 rounded shrink-0"
+              aria-hidden="true"
+            >
+              Project
             </span>
           )}
           <ChevronDown
@@ -138,6 +166,23 @@ export function PresetSelector({
                   isSelected={selectedPresetId === f.id}
                   onSelect={handleSelect}
                   testid={`preset-option-${f.id}`}
+                />
+              ))}
+            </>
+          )}
+          {projectPresets.length > 0 && (
+            <>
+              <Divider label="Project Shared" />
+              {projectPresets.map((f) => (
+                <PresetOption
+                  key={`project-${f.id}`}
+                  id={f.id}
+                  label={f.name}
+                  color={f.color ?? agentColor}
+                  badge="Project"
+                  isSelected={selectedPresetId === f.id}
+                  onSelect={handleSelect}
+                  testid={`preset-option-project-${f.id}`}
                 />
               ))}
             </>

--- a/src/components/Settings/__tests__/PresetSelector.test.tsx
+++ b/src/components/Settings/__tests__/PresetSelector.test.tsx
@@ -142,6 +142,39 @@ describe("PresetSelector", () => {
     expect(getByTestId("preset-option-default").getAttribute("aria-selected")).toBe("false");
   });
 
+  it("renders 'Project Shared' group and badge when project presets are present", () => {
+    const project = mkPreset("team-opus", "Team Opus");
+    const { getByTestId, queryByTestId } = render(
+      <PresetSelector
+        selectedPresetId="team-opus"
+        allPresets={[project]}
+        ccrPresets={[]}
+        projectPresets={[project]}
+        customPresets={[]}
+        onChange={onChange}
+        agentColor="#888"
+      />
+    );
+    expect(queryByTestId("preset-group-project-shared")).toBeTruthy();
+    expect(getByTestId("preset-selector-trigger").textContent).toContain("Project");
+    expect(getByTestId("preset-option-project-team-opus")).toBeTruthy();
+  });
+
+  it("project group is absent when projectPresets is empty", () => {
+    const { queryByTestId } = render(
+      <PresetSelector
+        selectedPresetId={undefined}
+        allPresets={[]}
+        ccrPresets={[]}
+        projectPresets={[]}
+        customPresets={[]}
+        onChange={onChange}
+        agentColor="#888"
+      />
+    );
+    expect(queryByTestId("preset-group-project-shared")).toBeNull();
+  });
+
   it("keyboard Enter on an option invokes onChange", () => {
     const custom = mkPreset("user-x", "X");
     const { getByTestId } = render(

--- a/src/components/Settings/__tests__/PresetSelector.test.tsx
+++ b/src/components/Settings/__tests__/PresetSelector.test.tsx
@@ -160,6 +160,29 @@ describe("PresetSelector", () => {
     expect(getByTestId("preset-option-project-team-opus")).toBeTruthy();
   });
 
+  it("project preset with a ccr- prefixed id still renders as Project, not CCR", () => {
+    // Regression guard: without a membership-first source classification,
+    // a project preset authored with id `ccr-team` would get stolen by the
+    // CCR badge/group path and appear under "CCR Routes".
+    const project = mkPreset("ccr-team", "Team Route");
+    const { getByTestId, queryByTestId } = render(
+      <PresetSelector
+        selectedPresetId="ccr-team"
+        allPresets={[project]}
+        ccrPresets={[]}
+        projectPresets={[project]}
+        customPresets={[]}
+        onChange={onChange}
+        agentColor="#888"
+      />
+    );
+    expect(queryByTestId("preset-group-project-shared")).toBeTruthy();
+    expect(queryByTestId("preset-group-ccr-routes")).toBeNull();
+    const triggerText = getByTestId("preset-selector-trigger").textContent ?? "";
+    expect(triggerText).toContain("Project");
+    expect(triggerText).not.toContain("CCR");
+  });
+
   it("project group is absent when projectPresets is empty", () => {
     const { queryByTestId } = render(
       <PresetSelector

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef } from "
 import { usePanelStore, type TerminalInstance } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { getMergedPresets } from "@/config/agents";
 import { GridPanel } from "./GridPanel";
 import type { TabGroup } from "@/types";
@@ -153,6 +154,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
 
   const agentSettings = useAgentSettingsStore((s) => s.settings);
   const ccrPresetsByAgent = useCcrPresetsStore((s) => s.ccrPresetsByAgent);
+  const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
 
   // Build tabs array for PanelHeader
   const tabs: TabInfo[] = useMemo(() => {
@@ -163,7 +165,8 @@ export const GridTabGroup = React.memo(function GridTabGroup({
         const presets = getMergedPresets(
           p.agentId,
           agentSettings?.agents?.[p.agentId]?.customPresets,
-          ccrPresetsByAgent[p.agentId]
+          ccrPresetsByAgent[p.agentId],
+          projectPresetsByAgent[p.agentId]
         );
         const live = presets.find((f) => f.id === p.agentPresetId);
         if (live) presetColor = live.color ?? presetColor;
@@ -188,7 +191,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
         fallbackTooltip,
       };
     });
-  }, [panels, activeTabId, agentSettings, ccrPresetsByAgent]);
+  }, [panels, activeTabId, agentSettings, ccrPresetsByAgent, projectPresetsByAgent]);
 
   // Check if this group is currently focused
   const isGroupFocused = useMemo(() => panels.some((p) => p.id === focusedId), [panels, focusedId]);

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -50,6 +50,7 @@ import { InputTracker } from "@/services/clearCommandDetection";
 import { getAgentConfig, getMergedPresets, isRegisteredAgent } from "@/config/agents";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { terminalClient } from "@/clients";
 import type { HybridInputBarHandle } from "./HybridInputBar";
 const LazyHybridInputBar = lazy(() =>
@@ -250,13 +251,26 @@ function TerminalPaneComponent({
   const presetCcrPresets = useCcrPresetsStore((s) =>
     agentId ? s.ccrPresetsByAgent[agentId] : undefined
   );
+  const presetProjectPresets = useProjectPresetsStore((s) =>
+    agentId ? s.presetsByAgent[agentId] : undefined
+  );
   const livePresetColor = useMemo(() => {
     if (!agentPresetId || !agentId) return presetColor;
-    const preset = getMergedPresets(agentId, presetCustomPresets, presetCcrPresets).find(
-      (f) => f.id === agentPresetId
-    );
+    const preset = getMergedPresets(
+      agentId,
+      presetCustomPresets,
+      presetCcrPresets,
+      presetProjectPresets
+    ).find((f) => f.id === agentPresetId);
     return preset?.color ?? presetColor;
-  }, [agentPresetId, agentId, presetCustomPresets, presetCcrPresets, presetColor]);
+  }, [
+    agentPresetId,
+    agentId,
+    presetCustomPresets,
+    presetCcrPresets,
+    presetProjectPresets,
+    presetColor,
+  ]);
 
   const pingedIdSelector = useMemo(
     () => (state: ReturnType<typeof usePanelStore.getState>) => state.pingedId === id,

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -82,6 +82,11 @@ vi.mock("@/store/ccrPresetsStore", () => ({
     selector({ ccrPresetsByAgent: {} }),
 }));
 
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
 vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
   useAgentDiscoveryOnboarding: () => ({
     loaded: true,

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -89,10 +89,12 @@ export function sanitizeAgentEnv(
 export function getMergedPresets(
   agentId: string,
   customPresets?: AgentPreset[],
-  ccrPresets?: AgentPreset[]
+  ccrPresets?: AgentPreset[],
+  projectPresets?: AgentPreset[]
 ): AgentPreset[] {
   const registryPresets = ccrPresets ?? getAgentConfig(agentId)?.presets ?? [];
   const custom = customPresets ?? [];
+  const project = projectPresets ?? [];
 
   // Validate and sanitize preset objects
   const validatePreset = (preset: AgentPreset): AgentPreset | null => {
@@ -167,13 +169,15 @@ export function getMergedPresets(
 
   const sanitizedRegistry = registryPresets.map(validatePreset).filter(Boolean) as AgentPreset[];
   const sanitizedCustom = custom.map(validatePreset).filter(Boolean) as AgentPreset[];
+  const sanitizedProject = project.map(validatePreset).filter(Boolean) as AgentPreset[];
 
-  // Remove duplicates by ID (custom presets take precedence)
+  // Precedence (first-seen-wins): custom > project > CCR/registry. Custom
+  // overrides team-shared project presets, which override CCR-discovered or
+  // built-in registry defaults on ID collision.
   const seenIds = new Set<string>();
   const result: AgentPreset[] = [];
 
-  // Add custom first (they override registry)
-  for (const preset of [...sanitizedCustom, ...sanitizedRegistry]) {
+  for (const preset of [...sanitizedCustom, ...sanitizedProject, ...sanitizedRegistry]) {
     if (!seenIds.has(preset.id)) {
       seenIds.add(preset.id);
       result.push(preset);
@@ -197,11 +201,17 @@ export function getMergedPreset(
   agentId: string,
   presetId: string | undefined,
   customPresets?: AgentPreset[],
-  ccrPresets?: AgentPreset[]
+  ccrPresets?: AgentPreset[],
+  projectPresets?: AgentPreset[]
 ): AgentPreset | undefined {
   if (presetId !== undefined && !presetId) return undefined;
   const config = getAgentConfig(agentId);
-  const merged = getMergedPresets(agentId, customPresets, ccrPresets ?? config?.presets ?? []);
+  const merged = getMergedPresets(
+    agentId,
+    customPresets,
+    ccrPresets ?? config?.presets ?? [],
+    projectPresets
+  );
   if (presetId === undefined) {
     const defaultId = config?.defaultPresetId;
     if (defaultId) return merged.find((f) => f.id === defaultId);

--- a/src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts
@@ -18,7 +18,8 @@ const getMergedPresetMock = vi.hoisted(() =>
       agentId: string,
       presetId: string | undefined,
       customPresets: AgentPreset[] | undefined,
-      ccrPresets: AgentPreset[] | undefined
+      ccrPresets: AgentPreset[] | undefined,
+      projectPresets?: AgentPreset[] | undefined
     ) => AgentPreset | undefined
   >()
 );
@@ -40,12 +41,13 @@ function resolvePresetForLaunch(
   entry: { presetId?: string; customPresets?: AgentPreset[] },
   ccrPresets: AgentPreset[] | undefined,
   agentId: string,
-  isAgent: boolean
+  isAgent: boolean,
+  projectPresets?: AgentPreset[] | undefined
 ): AgentPreset | undefined {
   const explicitDefault = presetId === null;
   const resolvedPresetId = explicitDefault ? undefined : (presetId ?? entry.presetId);
   return isAgent && !explicitDefault
-    ? getMergedPreset(agentId, resolvedPresetId, entry.customPresets, ccrPresets)
+    ? getMergedPreset(agentId, resolvedPresetId, entry.customPresets, ccrPresets, projectPresets)
     : undefined;
 }
 
@@ -97,7 +99,13 @@ describe("saved default: presetId === undefined", () => {
   it("calls getMergedPreset with the saved entry.presetId", () => {
     getMergedPresetMock.mockReturnValue(CUSTOM_PRESET);
     resolvePresetForLaunch(undefined, { presetId: "user-111" }, undefined, "claude", true);
-    expect(getMergedPresetMock).toHaveBeenCalledWith("claude", "user-111", undefined, undefined);
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      "user-111",
+      undefined,
+      undefined,
+      undefined
+    );
   });
 
   it("returns the preset resolved from the saved ID", () => {
@@ -125,8 +133,23 @@ describe("saved default: presetId === undefined", () => {
       "claude",
       "ccr-abc",
       [CUSTOM_PRESET],
-      [CCR_PRESET]
+      [CCR_PRESET],
+      undefined
     );
+  });
+
+  it("forwards projectPresets to getMergedPreset", () => {
+    const PROJECT_PRESET: AgentPreset = {
+      id: "team-opus",
+      name: "Team Opus",
+    };
+    getMergedPresetMock.mockReturnValue(PROJECT_PRESET);
+    resolvePresetForLaunch(undefined, { presetId: "team-opus" }, undefined, "claude", true, [
+      PROJECT_PRESET,
+    ]);
+    expect(getMergedPresetMock).toHaveBeenCalledWith("claude", "team-opus", undefined, undefined, [
+      PROJECT_PRESET,
+    ]);
   });
 });
 
@@ -134,7 +157,13 @@ describe("explicit preset ID provided (presetId is a string)", () => {
   it("calls getMergedPreset with the explicit ID, ignoring saved entry.presetId", () => {
     getMergedPresetMock.mockReturnValue(CUSTOM_PRESET);
     resolvePresetForLaunch("user-222", { presetId: "user-old" }, undefined, "claude", true);
-    expect(getMergedPresetMock).toHaveBeenCalledWith("claude", "user-222", undefined, undefined);
+    expect(getMergedPresetMock).toHaveBeenCalledWith(
+      "claude",
+      "user-222",
+      undefined,
+      undefined,
+      undefined
+    );
   });
 });
 

--- a/src/hooks/__tests__/useProjectPresetsSubscription.test.tsx
+++ b/src/hooks/__tests__/useProjectPresetsSubscription.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { AgentPreset } from "@shared/config/agentRegistry";
+
+let mockCurrentProjectId: string | null = null;
+const getInRepoPresetsMock = vi.fn<(projectId: string) => Promise<Record<string, AgentPreset[]>>>();
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
+    selector({
+      currentProject: mockCurrentProjectId ? { id: mockCurrentProjectId } : null,
+    }),
+}));
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    getInRepoPresets: (projectId: string) => getInRepoPresetsMock(projectId),
+  },
+}));
+
+import { useProjectPresetsSubscription } from "../useProjectPresetsSubscription";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
+
+beforeEach(() => {
+  mockCurrentProjectId = null;
+  getInRepoPresetsMock.mockReset();
+  useProjectPresetsStore.getState().reset();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useProjectPresetsSubscription", () => {
+  it("resets the store when the current project becomes null", async () => {
+    mockCurrentProjectId = "project-a";
+    getInRepoPresetsMock.mockResolvedValueOnce({
+      claude: [{ id: "team-a", name: "Team A" }],
+    });
+
+    const { rerender } = renderHook(() => useProjectPresetsSubscription());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useProjectPresetsStore.getState().presetsByAgent.claude).toBeDefined();
+
+    mockCurrentProjectId = null;
+    rerender();
+
+    expect(useProjectPresetsStore.getState().presetsByAgent).toEqual({});
+  });
+
+  it("clears previous project's presets when the new project's load fails", async () => {
+    mockCurrentProjectId = "project-a";
+    getInRepoPresetsMock.mockResolvedValueOnce({
+      claude: [{ id: "team-a", name: "Team A" }],
+    });
+
+    const { rerender } = renderHook(() => useProjectPresetsSubscription());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useProjectPresetsStore.getState().presetsByAgent.claude?.[0]?.id).toBe("team-a");
+
+    // Switch to project-b, and make its IPC fail.
+    mockCurrentProjectId = "project-b";
+    getInRepoPresetsMock.mockRejectedValueOnce(new Error("IPC failure"));
+    // Silence the console.warn from the hook's catch block during this test.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    rerender();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(useProjectPresetsStore.getState().presetsByAgent).toEqual({});
+    warnSpy.mockRestore();
+  });
+
+  it("drops a stale response from the previous project", async () => {
+    let resolveA: (v: Record<string, AgentPreset[]>) => void = () => {};
+    const pendingA = new Promise<Record<string, AgentPreset[]>>((r) => {
+      resolveA = r;
+    });
+
+    mockCurrentProjectId = "project-a";
+    getInRepoPresetsMock.mockReturnValueOnce(pendingA);
+
+    const { rerender } = renderHook(() => useProjectPresetsSubscription());
+
+    // Switch to project-b before A resolves.
+    mockCurrentProjectId = "project-b";
+    getInRepoPresetsMock.mockResolvedValueOnce({
+      claude: [{ id: "team-b", name: "Team B" }],
+    });
+    rerender();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useProjectPresetsStore.getState().presetsByAgent.claude?.[0]?.id).toBe("team-b");
+
+    // Now resolve A's stale request — must NOT overwrite B's state.
+    await act(async () => {
+      resolveA({ claude: [{ id: "team-a", name: "Team A" }] });
+      await Promise.resolve();
+    });
+    expect(useProjectPresetsStore.getState().presetsByAgent.claude?.[0]?.id).toBe("team-b");
+  });
+});

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -9,6 +9,7 @@ import { isElectronAvailable } from "./useElectron";
 import { agentSettingsClient, systemClient } from "@/clients";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 import { generateAgentCommand, buildAgentLaunchFlags } from "@shared/types";
@@ -176,9 +177,16 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           ? undefined
           : (launchOptions?.presetId ?? entry.presetId);
         const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
+        const projectPresets = useProjectPresetsStore.getState().presetsByAgent[agentId];
         preset =
           isAgent && !explicitDefault
-            ? getMergedPreset(agentId, resolvedPresetId, entry.customPresets, ccrPresets)
+            ? getMergedPreset(
+                agentId,
+                resolvedPresetId,
+                entry.customPresets,
+                ccrPresets,
+                projectPresets
+              )
             : undefined;
 
         // Stale presetId cleanup: if saved preset no longer exists, clear it

--- a/src/hooks/useProjectPresetsSubscription.ts
+++ b/src/hooks/useProjectPresetsSubscription.ts
@@ -26,6 +26,11 @@ export function useProjectPresetsSubscription(): void {
 
     const projectId = currentProjectId;
 
+    // Pre-clear so the previous project's presets don't leak through if the
+    // first load for the new project fails. Without this, a failed IPC would
+    // leave stale presets in the store until the next 30s poll succeeds.
+    reset();
+
     const load = async () => {
       try {
         const presets = await projectClient.getInRepoPresets(projectId);

--- a/src/hooks/useProjectPresetsSubscription.ts
+++ b/src/hooks/useProjectPresetsSubscription.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from "react";
+import { useProjectStore } from "@/store/projectStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
+import { projectClient } from "@/clients";
+
+const POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Loads `.daintree/presets/{agentId}/*.json` into the project presets store
+ * when the current project changes, and re-polls every 30 seconds so that
+ * team-pulled or hand-edited preset files surface without restart.
+ */
+export function useProjectPresetsSubscription(): void {
+  const currentProjectId = useProjectStore((s) => s.currentProject?.id ?? null);
+  const setPresetsByAgent = useProjectPresetsStore((s) => s.setPresetsByAgent);
+  const reset = useProjectPresetsStore((s) => s.reset);
+  const activeIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    activeIdRef.current = currentProjectId;
+
+    if (!currentProjectId) {
+      reset();
+      return;
+    }
+
+    const projectId = currentProjectId;
+
+    const load = async () => {
+      try {
+        const presets = await projectClient.getInRepoPresets(projectId);
+        if (activeIdRef.current !== projectId) return;
+        setPresetsByAgent(presets);
+      } catch (error) {
+        console.warn("[useProjectPresetsSubscription] Failed to load project presets:", error);
+      }
+    };
+
+    void load();
+    const interval = setInterval(() => void load(), POLL_INTERVAL_MS);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [currentProjectId, setPresetsByAgent, reset]);
+}

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -65,6 +65,7 @@ const createMockProjectClient = () => ({
   syncInRepoRecipes: vi.fn().mockResolvedValue(undefined),
   updateInRepoRecipe: vi.fn().mockResolvedValue(undefined),
   deleteInRepoRecipe: vi.fn().mockResolvedValue(undefined),
+  getInRepoPresets: vi.fn().mockResolvedValue({}),
 });
 
 describe("PanelPersistence", () => {

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -56,6 +56,7 @@ const createMockProjectClient = () => ({
   syncInRepoRecipes: vi.fn().mockResolvedValue(undefined),
   updateInRepoRecipe: vi.fn().mockResolvedValue(undefined),
   deleteInRepoRecipe: vi.fn().mockResolvedValue(undefined),
+  getInRepoPresets: vi.fn().mockResolvedValue({}),
 });
 
 describe("PanelPersistence.saveTabGroups", () => {

--- a/src/store/projectPresetsStore.ts
+++ b/src/store/projectPresetsStore.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+import type { AgentPreset } from "@shared/config/agentRegistry";
+
+interface ProjectPresetsState {
+  presetsByAgent: Record<string, AgentPreset[]>;
+  setPresetsByAgent: (byAgent: Record<string, AgentPreset[]>) => void;
+  reset: () => void;
+}
+
+export const useProjectPresetsStore = create<ProjectPresetsState>((set) => ({
+  presetsByAgent: {},
+  setPresetsByAgent: (byAgent) => set({ presetsByAgent: byAgent }),
+  reset: () => set({ presetsByAgent: {} }),
+}));


### PR DESCRIPTION
## Summary

- Adds `.daintree/presets/{agentId}/*.json` as a git-tracked preset store, mirroring the existing `.daintree/recipes/` pattern so teams can version and review shared agent presets in code review.
- Merge order is `custom > project-shared > CCR-discovered`, with first-seen-wins dedup. The UI shows a "Project" badge and a dedicated "Project Shared" group in the preset picker, preset selector, and agent dropdowns.
- Writes from the Settings UI continue going to per-user storage. Authoring project presets is a file-edit operation for now, per the scope note in the issue.

Resolves #5462

## Changes

- `readInRepoPresets()` in `ProjectIdentityFiles.ts` reads and validates `.daintree/presets/{agentId}/*.json`, checks safe subdir names, required `id`/`name` fields, and deduplicates within a directory (warns on collisions).
- New IPC channel `project:get-inrepo-presets` exposes this to the renderer.
- `useProjectPresetsStore` (transient Zustand) + `useProjectPresetsSubscription` hook with 30s polling and pre-clear on project switch, mounted in `AppLayout`.
- `getMergedPresets()` extended with an optional fourth `projectPresets` arg; merge order `[custom, project, ccr]`. Source classification uses membership checks first so a CCR-prefixed project preset doesn't get mis-grouped.
- `PresetSelector`, `AgentSettings`, `AgentButton`, and `AgentTrayButton` all updated to surface the project group and a read-only detail view with "Duplicate as custom" action.
- `TerminalPane`, `DockedTerminalItem`, `DockedTabGroup`, and `GridTabGroup` thread `projectPresets` through for correct colour resolution.

## Testing

- `electron/services/__tests__/writeInRepoFiles.test.ts` — 7 tests covering `readInRepoPresets`: missing dir, valid subdirs, malformed JSON, missing id/name, non-JSON files, unsafe subdir names, duplicate-id warning.
- `src/__tests__/adversarial-logic.test.ts` — precedence pins: custom overrides project, project shadows CCR, separate IDs coexist, CCR-prefixed project preset stays in project group.
- `src/hooks/__tests__/useProjectPresetsSubscription.test.tsx` — project-switch reset, failed IPC clears stale state, stale-response drop via `activeIdRef`.
- `src/components/Settings/__tests__/PresetSelector.test.tsx` — project group + badge rendering, CCR-prefixed regression guard, empty project hides group.
- `src/hooks/__tests__/useAgentLauncher.presetResolution.test.ts` — fourth-arg forwarding verified.
- All 12261 unit tests pass. Typecheck, lint, and format clean.