### PR TITLE
feat(agent): automatic fallback chain when a preset's provider is unavailable

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -74,6 +74,7 @@ export const CHANNELS = {
   AGENT_ALL_CLEAR: "agent:all-clear",
   AGENT_DETECTED: "agent:detected",
   AGENT_EXITED: "agent:exited",
+  AGENT_FALLBACK_TRIGGERED: "agent:fallback-triggered",
 
   TERMINAL_ACTIVITY: "terminal:activity",
 

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -77,6 +77,11 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   });
   handlers.push(unsubAgentExited);
 
+  const unsubFallbackTriggered = events.on("agent:fallback-triggered", (payload: unknown) => {
+    broadcastToRenderer(CHANNELS.AGENT_FALLBACK_TRIGGERED, payload);
+  });
+  handlers.push(unsubFallbackTriggered);
+
   // Artifact events
   const unsubArtifactDetected = events.on("artifact:detected", (payload: unknown) => {
     broadcastToRenderer(CHANNELS.ARTIFACT_DETECTED, payload);

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -190,6 +190,9 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         agentLaunchFlags: validatedOptions.agentLaunchFlags,
         agentModelId: validatedOptions.agentModelId,
         worktreeId: validatedOptions.worktreeId,
+        agentPresetId: validatedOptions.agentPresetId,
+        originalAgentPresetId:
+          validatedOptions.originalAgentPresetId ?? validatedOptions.agentPresetId,
       });
 
       // For non-agent terminals (or Windows agent terminals), write command to stdin

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -46,6 +46,7 @@ import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
+  AgentFallbackTriggeredPayload,
   ArtifactDetectedPayload,
   SaveArtifactOptions,
   ApplyPatchOptions,
@@ -561,6 +562,7 @@ const CHANNELS = {
   AGENT_ALL_CLEAR: "agent:all-clear",
   AGENT_DETECTED: "agent:detected",
   AGENT_EXITED: "agent:exited",
+  AGENT_FALLBACK_TRIGGERED: "agent:fallback-triggered",
 
   // Terminal activity channels
   TERMINAL_ACTIVITY: "terminal:activity",
@@ -1270,6 +1272,9 @@ const api: ElectronAPI = {
 
     onAgentExited: (callback: (data: AgentExitedPayload) => void) =>
       _typedOn(CHANNELS.AGENT_EXITED, callback),
+
+    onFallbackTriggered: (callback: (data: AgentFallbackTriggeredPayload) => void) =>
+      _typedOn(CHANNELS.AGENT_FALLBACK_TRIGGERED, callback),
 
     onAllAgentsClear: (callback: (data: { timestamp: number }) => void) =>
       _typedOn(CHANNELS.AGENT_ALL_CLEAR, callback),

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -249,6 +249,8 @@ export const TerminalSpawnOptionsSchema = z.object({
   agentLaunchFlags: z.array(z.string()).optional(),
   agentModelId: z.string().optional(),
   worktreeId: z.string().optional(),
+  agentPresetId: z.string().optional(),
+  originalAgentPresetId: z.string().optional(),
 });
 
 export const TerminalResizePayloadSchema = z.object({

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -181,6 +181,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Agent process spawned in terminal",
   },
+  "agent:fallback-triggered": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "Agent preset exited with a fallback-eligible error",
+  },
   "agent:state-changed": {
     category: "agent",
     requiresContext: true,
@@ -573,6 +579,21 @@ export type DaintreeEventMap = {
   }>;
 
   /**
+   * Emitted when an agent PTY exits with output matching a fallback-eligible
+   * error class (connection failure or hard auth). The renderer consumes this
+   * to walk the preset's `fallbacks` chain and respawn.
+   */
+  "agent:fallback-triggered": {
+    terminalId: string;
+    agentId: string;
+    fromPresetId: string;
+    originalPresetId?: string;
+    reason: "connection" | "auth";
+    exitCode: number;
+    timestamp: number;
+  };
+
+  /**
    * Emitted when artifacts (code blocks or patches) are extracted from agent output.
    */
   "artifact:detected": WithContext<{
@@ -802,6 +823,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "agent:output",
   "agent:completed",
   "agent:killed",
+  "agent:fallback-triggered",
   "artifact:detected",
   "action:dispatched",
   "terminal:trashed",

--- a/electron/services/pty/FallbackErrorClassifier.ts
+++ b/electron/services/pty/FallbackErrorClassifier.ts
@@ -82,6 +82,11 @@ export interface ClassifyInput {
  */
 export function classifyExitOutput(input: ClassifyInput): FallbackExitClass {
   if (input.wasKilled) return "clean";
+  // A clean exit means the agent handled the error itself and chose to quit —
+  // scanning the tail for leftover "UNAVAILABLE" / "5xx" chatter would produce
+  // false positives, e.g. an agent that retried a 503, succeeded, and then
+  // exited normally.
+  if (input.exitCode === 0) return "clean";
   const stripped = stripAnsiCodes(input.recentOutput ?? "");
   if (!stripped.trim()) return "clean";
 

--- a/electron/services/pty/FallbackErrorClassifier.ts
+++ b/electron/services/pty/FallbackErrorClassifier.ts
@@ -1,0 +1,101 @@
+import { stripAnsiCodes } from "../../../shared/utils/artifactParser.js";
+
+/**
+ * Classification of why an agent PTY exited. Only `connection` and `auth`
+ * indicate a fallback is warranted — `rate-limit` and `user-error` are the
+ * provider/user's problem and the user should see/fix them directly.
+ */
+export type FallbackExitClass =
+  | "connection" // 5xx, ECONNREFUSED, DNS, timeout
+  | "auth" // 401/403-class, revoked tokens, "Not logged in"
+  | "rate-limit" // 429, quota, RESOURCE_EXHAUSTED — NEVER triggers fallback
+  | "user-error" // prompt too long, context overflow, tool rejection
+  | "clean"; // no matching signal
+
+const CONNECTION_PATTERNS: RegExp[] = [
+  // HTTP 5xx server-class
+  /\bAPI Error:\s*(?:5\d\d|Repeated\s+5\d\d|Repeated\s+529\s+Overloaded|Overloaded)/i,
+  /\b(?:502|503|504)\s+(?:Bad Gateway|Service Unavailable|Gateway Timeout)/i,
+  /INTERNAL|UNAVAILABLE/,
+
+  // Connection/DNS/timeout
+  /\bECONNREFUSED|\bENOTFOUND|\bETIMEDOUT|\bECONNRESET/,
+  /\bUnable to connect to (?:the )?API/i,
+  /\bgetaddrinfo\s+ENOTFOUND/i,
+  /\bCould not resolve host/i,
+  /\bfailed to connect to\b/i,
+  /\bError on conversation request\b/i,
+  /\bpoor internet connection/i,
+];
+
+const AUTH_PATTERNS: RegExp[] = [
+  // Generic
+  /\bNot logged in\b/i,
+  /\bInvalid API key\b/i,
+  /\bUNAUTHENTICATED\b|\bPERMISSION_DENIED\b/,
+  /\b401\s+Unauthorized\b|\b403\s+Forbidden\b/i,
+  /\borganization has been (?:disabled|suspended)\b/i,
+
+  // Claude-specific
+  /\bPlease run\s+\/login\b/i,
+  /\bOAuth token (?:revoked|has expired|is invalid)/i,
+
+  // Codex-specific
+  /\bTo use .*? must be logged in\b/i,
+  /\bInvalid OAuth token\b/i,
+];
+
+// Evaluated before connection/auth so a 429 cannot be misread as a 5xx.
+const RATE_LIMIT_PATTERNS: RegExp[] = [
+  /\bAPI Error:\s*Rate limit/i,
+  /\b429\b/,
+  /\brate[\s-]?limit(?:ed|ing)?\b/i,
+  /\bRESOURCE_EXHAUSTED\b/,
+  /\brateLimitExceeded\b/i,
+  /\bquota exceeded\b/i,
+  /\bToo Many Requests\b/i,
+];
+
+const USER_ERROR_PATTERNS: RegExp[] = [
+  /\bPrompt is too long\b/i,
+  /\bRequest too large\b/i,
+  /\bcontext (?:window|length) exceeded\b/i,
+  /\binput is too long\b/i,
+];
+
+export interface ClassifyInput {
+  /** Recent PTY output (ANSI sequences allowed; they are stripped before matching). */
+  recentOutput: string;
+  /** Process exit code (optional — used only for `clean` short-circuit). */
+  exitCode?: number | null;
+  /** True when the terminal was intentionally killed by the user/app. */
+  wasKilled?: boolean;
+}
+
+/**
+ * Classifies the tail of a PTY output stream at exit-time. Pure function, no
+ * side effects. Safe to call synchronously inside onExit handlers.
+ *
+ * Precedence: rate-limit and user-error patterns are evaluated first so they
+ * can short-circuit connection-class matching (a 429 response often contains
+ * the substring "API Error:" which would otherwise match a 5xx pattern).
+ */
+export function classifyExitOutput(input: ClassifyInput): FallbackExitClass {
+  if (input.wasKilled) return "clean";
+  const stripped = stripAnsiCodes(input.recentOutput ?? "");
+  if (!stripped.trim()) return "clean";
+
+  // Scan only the tail — connection/auth failures always print near the end.
+  const tail = stripped.length > 4000 ? stripped.slice(-4000) : stripped;
+
+  if (RATE_LIMIT_PATTERNS.some((p) => p.test(tail))) return "rate-limit";
+  if (USER_ERROR_PATTERNS.some((p) => p.test(tail))) return "user-error";
+  if (AUTH_PATTERNS.some((p) => p.test(tail))) return "auth";
+  if (CONNECTION_PATTERNS.some((p) => p.test(tail))) return "connection";
+  return "clean";
+}
+
+/** Whether a classification warrants switching to the next fallback preset. */
+export function shouldTriggerFallback(cls: FallbackExitClass): boolean {
+  return cls === "connection" || cls === "auth";
+}

--- a/electron/services/pty/TerminalForensicsBuffer.ts
+++ b/electron/services/pty/TerminalForensicsBuffer.ts
@@ -16,6 +16,14 @@ export class TerminalForensicsBuffer {
     }
   }
 
+  /**
+   * Read the current forensic buffer snapshot without disturbing it. Used by
+   * the fallback classifier to inspect exit-time output before teardown runs.
+   */
+  getRecentOutput(): string {
+    return this.recentOutputBuffer;
+  }
+
   logForensics(
     terminalId: string,
     exitCode: number,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1315,7 +1315,9 @@ export class TerminalProcess {
       ) {
         const cls = classifyExitOutput({
           recentOutput: this.forensicsBuffer.getRecentOutput(),
-          exitCode: exitCode ?? 0,
+          // Pass through as-is so a null/undefined code (crash, signal) does
+          // NOT short-circuit the scan. Only an explicit exit 0 skips the tail.
+          exitCode: exitCode,
           wasKilled: terminal.wasKilled,
         });
         if (shouldTriggerFallback(cls)) {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -28,6 +28,7 @@ import { events } from "../events.js";
 import { AgentSpawnedSchema } from "../../schemas/agent.js";
 import type { PtyPool } from "../PtyPool.js";
 import { installHeadlessResponder } from "./headlessResponder.js";
+import { classifyExitOutput, shouldTriggerFallback } from "./FallbackErrorClassifier.js";
 
 // Extracted modules
 import {
@@ -302,6 +303,8 @@ export class TerminalProcess {
       agentLaunchFlags: options.agentLaunchFlags,
       agentModelId: options.agentModelId,
       worktreeId: options.worktreeId,
+      agentPresetId: options.agentPresetId,
+      originalAgentPresetId: options.originalAgentPresetId ?? options.agentPresetId,
       spawnArgs,
     };
 
@@ -1298,6 +1301,34 @@ export class TerminalProcess {
 
       if (this.isAgentTerminal && terminal.agentId && !terminal.wasKilled) {
         this.deps.agentStateService.emitAgentCompleted(terminal, exitCode ?? 0);
+      }
+
+      // Fallback detection: inspect the forensic buffer BEFORE teardown clears
+      // anything and emit a fallback-triggered event so the renderer can walk
+      // the preset's fallbacks[] chain. Passive observation only — we do not
+      // modify the terminal, spawn anything, or touch user config here.
+      if (
+        this.isAgentTerminal &&
+        terminal.agentId &&
+        terminal.agentPresetId &&
+        !terminal.wasKilled
+      ) {
+        const cls = classifyExitOutput({
+          recentOutput: this.forensicsBuffer.getRecentOutput(),
+          exitCode: exitCode ?? 0,
+          wasKilled: terminal.wasKilled,
+        });
+        if (shouldTriggerFallback(cls)) {
+          events.emit("agent:fallback-triggered", {
+            terminalId: this.id,
+            agentId: terminal.agentId,
+            fromPresetId: terminal.agentPresetId,
+            originalPresetId: terminal.originalAgentPresetId ?? terminal.agentPresetId,
+            reason: cls as "connection" | "auth",
+            exitCode: exitCode ?? 0,
+            timestamp: Date.now(),
+          });
+        }
       }
 
       if (this.shouldPreserveOnExit(exitCode ?? 0)) {

--- a/electron/services/pty/__tests__/FallbackErrorClassifier.test.ts
+++ b/electron/services/pty/__tests__/FallbackErrorClassifier.test.ts
@@ -103,6 +103,17 @@ describe("classifyExitOutput: short-circuits", () => {
     expect(classifyExitOutput({ recentOutput: output, wasKilled: true })).toBe("clean");
   });
 
+  it("returns 'clean' for exit code 0 even with matching error text in tail (retry-then-succeed)", () => {
+    const output =
+      "API Error: 503 Service Unavailable\nRetrying in 2s…\nTask completed successfully\nDone.";
+    expect(classifyExitOutput({ recentOutput: output, exitCode: 0 })).toBe("clean");
+  });
+
+  it("returns 'clean' for exit code 0 with UNAVAILABLE in the tail", () => {
+    const output = "Error: UNAVAILABLE: dns resolution failed\nRecovered.\nTask complete!";
+    expect(classifyExitOutput({ recentOutput: output, exitCode: 0 })).toBe("clean");
+  });
+
   it("strips ANSI sequences before matching", () => {
     const output = "\x1b[31mAPI Error: 500\x1b[0m Internal server error";
     expect(classifyExitOutput({ recentOutput: output })).toBe("connection");

--- a/electron/services/pty/__tests__/FallbackErrorClassifier.test.ts
+++ b/electron/services/pty/__tests__/FallbackErrorClassifier.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyExitOutput,
+  shouldTriggerFallback,
+  type FallbackExitClass,
+} from "../FallbackErrorClassifier.js";
+
+function cases(
+  label: string,
+  expected: FallbackExitClass,
+  samples: string[],
+  options: { wasKilled?: boolean; exitCode?: number } = {}
+) {
+  describe(label, () => {
+    for (const sample of samples) {
+      it(`classifies: ${sample.slice(0, 60)}…`, () => {
+        expect(
+          classifyExitOutput({
+            recentOutput: sample,
+            wasKilled: options.wasKilled,
+            exitCode: options.exitCode,
+          })
+        ).toBe(expected);
+      });
+    }
+  });
+}
+
+cases("connection: Claude patterns", "connection", [
+  "Unable to connect to API — check your internet connection",
+  "API Error: 500 Internal server error",
+  "API Error: 529 Overloaded",
+  "API Error: Repeated 529 Overloaded errors",
+  "API Error: connect ECONNREFUSED 127.0.0.1:443",
+  "API Error: getaddrinfo ENOTFOUND api.anthropic.com",
+  "Unable to connect to API due to poor internet connection. Retrying in 3 seconds…",
+]);
+
+cases("connection: Gemini patterns", "connection", [
+  "Error: INTERNAL",
+  "Error: UNAVAILABLE: failed to connect to google.generativeai",
+  "ENOTFOUND generativelanguage.googleapis.com",
+  "ETIMEDOUT when contacting the API",
+  "ECONNRESET reading response body",
+]);
+
+cases("connection: Codex patterns", "connection", [
+  "Error: Could not resolve host: api.openai.com",
+  "failed to connect to the server",
+  "Error on conversation request: 502 Bad Gateway",
+  "503 Service Unavailable",
+  "504 Gateway Timeout",
+]);
+
+cases("auth: Claude patterns", "auth", [
+  "Error: Not logged in. Please run /login to authenticate.",
+  "Please run /login first",
+  "Invalid API key",
+  "OAuth token has expired",
+  "OAuth token revoked",
+  "Your organization has been disabled",
+  "Your organization has been suspended",
+]);
+
+cases("auth: Gemini patterns", "auth", [
+  "Error: UNAUTHENTICATED",
+  "Error: PERMISSION_DENIED",
+  "403 Forbidden: API key lacks permission",
+]);
+
+cases("auth: Codex patterns", "auth", [
+  "To use codex you must be logged in",
+  "Error: Invalid OAuth token",
+  "401 Unauthorized",
+]);
+
+cases("rate-limit: must NOT trigger fallback", "rate-limit", [
+  "API Error: Rate limit reached for requests",
+  "Request rejected (429)",
+  "Error 429: Too Many Requests",
+  "RESOURCE_EXHAUSTED",
+  "rateLimitExceeded",
+  "quota exceeded",
+]);
+
+cases("user-error: must NOT trigger fallback", "user-error", [
+  "Error: Prompt is too long for this model",
+  "Error: Request too large",
+  "context window exceeded",
+  "input is too long, try /compact",
+]);
+
+cases("clean: empty or non-matching tail", "clean", [
+  "",
+  "Hello, world!",
+  "Running tests…",
+  "✓ 42 passed",
+]);
+
+describe("classifyExitOutput: short-circuits", () => {
+  it("returns 'clean' when wasKilled is true, regardless of output", () => {
+    const output = "API Error: 500 Internal server error";
+    expect(classifyExitOutput({ recentOutput: output, wasKilled: true })).toBe("clean");
+  });
+
+  it("strips ANSI sequences before matching", () => {
+    const output = "\x1b[31mAPI Error: 500\x1b[0m Internal server error";
+    expect(classifyExitOutput({ recentOutput: output })).toBe("connection");
+  });
+
+  it("prefers rate-limit over connection when both appear (429 lookahead)", () => {
+    // If the output contains "API Error:" and "429", treat as rate-limit.
+    const output = "API Error: 429 Rate limit reached — slow down";
+    expect(classifyExitOutput({ recentOutput: output })).toBe("rate-limit");
+  });
+
+  it("scans only the last 4000 chars of output", () => {
+    const padding = "noise ".repeat(5000);
+    const output = padding + "\nAPI Error: 500 Internal server error\n";
+    expect(classifyExitOutput({ recentOutput: output })).toBe("connection");
+  });
+
+  it("does not match unrelated 'Error:' chatter", () => {
+    const output = "Error: file not found in workspace\nTask completed";
+    expect(classifyExitOutput({ recentOutput: output })).toBe("clean");
+  });
+});
+
+describe("shouldTriggerFallback", () => {
+  it.each([
+    ["connection", true],
+    ["auth", true],
+    ["rate-limit", false],
+    ["user-error", false],
+    ["clean", false],
+  ] as const)("%s → %s", (cls, expected) => {
+    expect(shouldTriggerFallback(cls)).toBe(expected);
+  });
+});

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -59,6 +59,10 @@ export interface TerminalPublicState {
   worktreeId?: string;
   /** Last non-useless title observed from xterm OSC updates (renderer-synced) */
   lastObservedTitle?: string;
+  /** Currently active preset ID (updated on each fallback hop). */
+  agentPresetId?: string;
+  /** User-originally-selected preset ID; immutable across fallback hops. */
+  originalAgentPresetId?: string;
 }
 
 /**

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -150,7 +150,18 @@ export interface AgentPreset {
   inlineMode?: boolean;
   /** Optional brand color (CSS hex) used to tint the agent icon for this preset */
   color?: string;
+  /**
+   * Ordered list of preset IDs to try when this preset's provider becomes
+   * unavailable (connection errors, hard auth failures). Each entry must be
+   * an ID of another preset for the SAME agent. Self-references, duplicates,
+   * and unknown IDs are stripped by `getMergedPresets` validation. Capped at
+   * `FALLBACK_CHAIN_MAX` entries.
+   */
+  fallbacks?: string[];
 }
+
+/** Max fallback presets that can be chained after the primary. */
+export const FALLBACK_CHAIN_MAX = 3;
 
 export interface AgentConfig {
   id: string;

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -48,6 +48,12 @@ export interface AddPanelOptionsBase {
   agentPresetId?: string;
   /** Preset brand color (hex) captured at launch time for per-panel icon tinting */
   agentPresetColor?: string;
+  /** Original user-selected preset ID; immutable across fallback hops. */
+  originalPresetId?: string;
+  /** Whether this panel is currently running on a fallback preset. */
+  isUsingFallback?: boolean;
+  /** Chain index consumed so far from the primary preset's fallback list. */
+  fallbackChainIndex?: number;
 }
 
 /** Options for creating a terminal panel */

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -102,6 +102,8 @@ export interface AgentSettingsEntry {
     customFlags?: string;
     inlineMode?: boolean;
     color?: string;
+    /** Ordered preset IDs to fall over to when provider is unreachable. */
+    fallbacks?: string[];
   }>;
   /**
    * Environment variables applied to every launch of this agent, regardless of preset.

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -195,6 +195,7 @@ export type {
   // Agent detection
   AgentDetectedPayload,
   AgentExitedPayload,
+  AgentFallbackTriggeredPayload,
   // Artifact types
   ArtifactDetectedPayload,
   SaveArtifactOptions,

--- a/shared/types/ipc/agent.ts
+++ b/shared/types/ipc/agent.ts
@@ -84,6 +84,24 @@ export interface AgentExitedPayload {
   timestamp: number;
 }
 
+/**
+ * Emitted when an agent PTY exits with an error classified as fallback-eligible
+ * (connection failure or hard auth). The renderer consumes this to walk the
+ * preset's `fallbacks` chain and respawn the panel with the next preset.
+ */
+export interface AgentFallbackTriggeredPayload {
+  terminalId: string;
+  agentId: string;
+  /** Preset that was active when the PTY exited. */
+  fromPresetId: string;
+  /** Original user-selected preset ID; unchanged across fallback hops. */
+  originalPresetId?: string;
+  /** Why the classifier decided this was a fallback-eligible exit. */
+  reason: "connection" | "auth";
+  exitCode: number;
+  timestamp: number;
+}
+
 /** Artifact detected payload */
 export interface ArtifactDetectedPayload {
   /** Agent ID that generated the artifacts */

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -39,6 +39,7 @@ import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
+  AgentFallbackTriggeredPayload,
   ArtifactDetectedPayload,
   AgentHelpRequest,
   AgentHelpResult,
@@ -247,6 +248,7 @@ export interface ElectronAPI {
     onAgentStateChanged(callback: (data: AgentStateChangePayload) => void): () => void;
     onAgentDetected(callback: (data: AgentDetectedPayload) => void): () => void;
     onAgentExited(callback: (data: AgentExitedPayload) => void): () => void;
+    onFallbackTriggered(callback: (data: AgentFallbackTriggeredPayload) => void): () => void;
     onAllAgentsClear(callback: (data: { timestamp: number }) => void): () => void;
     onActivity(callback: (data: TerminalActivityPayload) => void): () => void;
     onTrashed(callback: (data: { id: string; expiresAt: number }) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -43,6 +43,7 @@ import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
+  AgentFallbackTriggeredPayload,
   ArtifactDetectedPayload,
   AgentHelpRequest,
   AgentHelpResult,
@@ -2207,6 +2208,7 @@ export interface IpcEventMap {
   "agent:all-clear": { timestamp: number };
   "agent:detected": AgentDetectedPayload;
   "agent:exited": AgentExitedPayload;
+  "agent:fallback-triggered": AgentFallbackTriggeredPayload;
 
   // Terminal activity events
   "terminal:activity": TerminalActivityPayload;

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -38,6 +38,10 @@ export interface TerminalSpawnOptions {
   agentModelId?: string;
   /** Worktree the terminal is spawned in; persisted in agent session history */
   worktreeId?: string;
+  /** Preset ID the agent is being launched with (needed for fallback chain lookup on exit). */
+  agentPresetId?: string;
+  /** Original user-selected preset ID; unchanged across fallback hops. */
+  originalAgentPresetId?: string;
 }
 
 /** Terminal state for app state persistence */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -262,6 +262,15 @@ export interface PtyPanelData extends BasePanelData {
   startedAt?: number;
   /** Exit code from the last process exit */
   exitCode?: number;
+  /**
+   * Original user-selected preset ID. Set on first spawn, never overwritten
+   * when a fallback activates. Used to display "was {original} → {active}".
+   */
+  originalPresetId?: string;
+  /** Whether this panel is currently running on a fallback preset. */
+  isUsingFallback?: boolean;
+  /** How many fallback hops have been consumed from the primary's chain (0-based index into fallbacks[]). */
+  fallbackChainIndex?: number;
 }
 
 export interface BrowserPanelData extends BasePanelData {
@@ -431,6 +440,12 @@ export interface TerminalInstance {
   startedAt?: number;
   /** Exit code from the last process exit */
   exitCode?: number;
+  /** Original user-selected preset ID; immutable across fallback hops. */
+  originalPresetId?: string;
+  /** Whether this panel is currently running on a fallback preset. */
+  isUsingFallback?: boolean;
+  /** How many fallback hops have been consumed from the primary's chain. */
+  fallbackChainIndex?: number;
   /** Opaque state bag for extension panels — survives the save/restore round-trip */
   extensionState?: Record<string, unknown>;
   // Note: Tab membership is now stored in TabGroup objects, not on panels

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -106,6 +106,12 @@ export interface PanelSnapshot {
   agentPresetId?: string;
   /** Preset hex color captured at launch time; fallback when preset is later deleted */
   agentPresetColor?: string;
+  /** Original user-selected preset ID; immutable across fallback hops. */
+  originalPresetId?: string;
+  /** Whether this panel is currently running on a fallback preset. */
+  isUsingFallback?: boolean;
+  /** How many fallback hops have been consumed from the primary's chain. */
+  fallbackChainIndex?: number;
   /** Last known agent state for crash recovery display */
   agentState?: AgentState;
   /** Timestamp of last agent state change */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -36,6 +36,10 @@ export interface PtyHostSpawnOptions {
   agentModelId?: string;
   /** Worktree the terminal was spawned in; used when persisting agent session history */
   worktreeId?: string;
+  /** Preset ID the agent was launched with (needed for fallback chain lookup on exit). */
+  agentPresetId?: string;
+  /** Original user-selected preset ID; unchanged across fallback hops for revert UX. */
+  originalAgentPresetId?: string;
 }
 
 /**
@@ -276,6 +280,10 @@ export interface PtyHostTerminalInfo {
   agentModelId?: string;
   /** Worktree the terminal was spawned in; used when persisting agent session history */
   worktreeId?: string;
+  /** Preset ID the agent was launched with. */
+  agentPresetId?: string;
+  /** Original user-selected preset ID; unchanged across fallback hops. */
+  originalAgentPresetId?: string;
 }
 
 /** Payload for agent:spawned event */

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -3,6 +3,7 @@ import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
+  AgentFallbackTriggeredPayload,
   TerminalActivityPayload,
   BackendTerminalInfo,
   TerminalReconnectResult,
@@ -270,6 +271,10 @@ export const terminalClient = {
 
   onAgentExited: (callback: (data: AgentExitedPayload) => void): (() => void) => {
     return window.electron.terminal.onAgentExited(callback);
+  },
+
+  onFallbackTriggered: (callback: (data: AgentFallbackTriggeredPayload) => void): (() => void) => {
+    return window.electron.terminal.onFallbackTriggered(callback);
   },
 
   onActivity: (callback: (data: TerminalActivityPayload) => void): (() => void) => {

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -546,6 +546,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   agentState={panel.agentState}
                   isActive={panel.id === activeTabId}
                   presetColor={panelPresetColors.get(panel.id)}
+                  isUsingFallback={panel.isUsingFallback}
                   onClick={() => handleTabClick(panel.id)}
                   onClose={() => handleTabClose(panel.id)}
                   onRename={(newTitle) => handleTabRename(panel.id, newTitle)}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -501,6 +501,8 @@ function PanelHeaderComponent({
                         agentState={tab.agentState}
                         isActive={tab.isActive}
                         presetColor={tab.presetColor}
+                        isUsingFallback={tab.isUsingFallback}
+                        fallbackTooltip={tab.fallbackTooltip}
                         onClick={() => onTabClick?.(tab.id)}
                         onClose={() => onTabClose?.(tab.id)}
                         onRename={
@@ -597,6 +599,8 @@ function PanelHeaderComponent({
                     agentState={tab.agentState}
                     isActive={tab.isActive}
                     presetColor={tab.presetColor}
+                    isUsingFallback={tab.isUsingFallback}
+                    fallbackTooltip={tab.fallbackTooltip}
                     onClick={() => onTabClick?.(tab.id)}
                     onClose={() => onTabClose?.(tab.id)}
                     onRename={onTabRename ? (newTitle) => onTabRename(tab.id, newTitle) : undefined}

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useRef, useEffect, forwardRef } from "react";
 import type { DraggableAttributes, DraggableSyntheticListeners } from "@dnd-kit/core";
-import { X } from "lucide-react";
+import { X, AlertTriangle } from "lucide-react";
 import type { PanelKind, TerminalType, AgentState } from "@/types";
 import type { WaitingReason } from "@shared/types/agent";
 import { cn } from "@/lib/utils";
@@ -23,6 +23,8 @@ export interface TabInfo {
   agentState?: AgentState;
   isActive: boolean;
   presetColor?: string;
+  isUsingFallback?: boolean;
+  fallbackTooltip?: string;
 }
 
 export interface TabButtonProps {
@@ -40,6 +42,8 @@ export interface TabButtonProps {
   sortableListeners?: DraggableSyntheticListeners;
   sortableAttributes?: DraggableAttributes;
   onRename?: (newTitle: string) => void;
+  isUsingFallback?: boolean;
+  fallbackTooltip?: string;
 }
 
 const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function TabButtonComponent(
@@ -58,6 +62,8 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     sortableListeners,
     sortableAttributes,
     onRename,
+    isUsingFallback,
+    fallbackTooltip,
   },
   ref
 ) {
@@ -283,6 +289,23 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
                 )}
                 aria-hidden="true"
               />
+            )}
+
+            {isUsingFallback && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <AlertTriangle
+                      className="w-3 h-3 shrink-0 text-status-warning"
+                      aria-label="Running on fallback preset"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {fallbackTooltip ??
+                      "Running on fallback preset — original provider unavailable"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
 
             {/* Close button - visible on hover */}

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -11,7 +11,8 @@ import {
   type AgentCliDetails,
 } from "@shared/types";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
-import { RotateCcw, ExternalLink, Plus, Copy, Trash2, Pencil } from "lucide-react";
+import { RotateCcw, ExternalLink, Plus, Copy, Trash2, Pencil, X as XIcon } from "lucide-react";
+import { FALLBACK_CHAIN_MAX } from "../../../shared/config/agentRegistry";
 import { DaintreeAgentIcon } from "@/components/icons";
 import { AgentSelectorDropdown } from "./AgentSelectorDropdown";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
@@ -823,6 +824,106 @@ export function AgentSettings({
 
                       {/* Behavioral settings */}
                       <div className="px-3 py-2.5">{behavioralSettings}</div>
+
+                      {/* Fallback chain editor */}
+                      <div className="px-3 py-2.5 space-y-1.5">
+                        <div>
+                          <label className="text-sm font-medium text-daintree-text">
+                            Fallback presets
+                          </label>
+                          <p className="text-xs text-daintree-text/40 select-text">
+                            Tried in order if this preset's provider is unreachable. No retry for
+                            rate limits or prompt errors.
+                          </p>
+                        </div>
+                        {(() => {
+                          const chain = selectedPreset.fallbacks ?? [];
+                          const candidates = allPresets.filter(
+                            (p) => p.id !== selectedPreset.id && !chain.includes(p.id)
+                          );
+                          const removeFallback = (id: string) => {
+                            handleUpdatePreset(selectedPreset.id, {
+                              fallbacks: chain.filter((f) => f !== id),
+                            });
+                          };
+                          const addFallback = (id: string) => {
+                            if (!id || chain.includes(id) || chain.length >= FALLBACK_CHAIN_MAX)
+                              return;
+                            handleUpdatePreset(selectedPreset.id, {
+                              fallbacks: [...chain, id],
+                            });
+                          };
+                          return (
+                            <>
+                              {chain.length > 0 && (
+                                <ul className="space-y-1">
+                                  {chain.map((id, idx) => {
+                                    const preset = allPresets.find((p) => p.id === id);
+                                    const name = preset?.name ?? id;
+                                    const missing = !preset;
+                                    return (
+                                      <li
+                                        key={id}
+                                        className="flex items-center gap-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30 px-2 py-1.5"
+                                      >
+                                        <span className="text-[10px] text-daintree-text/40 font-mono shrink-0">
+                                          {idx + 1}.
+                                        </span>
+                                        <span
+                                          className={
+                                            missing
+                                              ? "text-xs text-status-error truncate"
+                                              : "text-xs text-daintree-text truncate"
+                                          }
+                                        >
+                                          {name}
+                                          {missing && " (missing)"}
+                                        </span>
+                                        <button
+                                          className="ml-auto text-daintree-text/30 hover:text-status-error transition-colors shrink-0"
+                                          onClick={() => removeFallback(id)}
+                                          aria-label={`Remove ${name} from fallback chain`}
+                                          title="Remove"
+                                        >
+                                          <XIcon size={13} />
+                                        </button>
+                                      </li>
+                                    );
+                                  })}
+                                </ul>
+                              )}
+                              {chain.length < FALLBACK_CHAIN_MAX && candidates.length > 0 && (
+                                <select
+                                  className="w-full rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-2 text-sm"
+                                  value=""
+                                  onChange={(e) => {
+                                    const v = e.target.value;
+                                    if (v) addFallback(v);
+                                  }}
+                                  aria-label="Add fallback preset"
+                                >
+                                  <option value="">Add fallback preset…</option>
+                                  {candidates.map((p) => (
+                                    <option key={p.id} value={p.id}>
+                                      {p.name}
+                                    </option>
+                                  ))}
+                                </select>
+                              )}
+                              {chain.length >= FALLBACK_CHAIN_MAX && (
+                                <p className="text-[11px] text-daintree-text/40">
+                                  Maximum of {FALLBACK_CHAIN_MAX} fallbacks reached.
+                                </p>
+                              )}
+                              {chain.length < FALLBACK_CHAIN_MAX && candidates.length === 0 && (
+                                <p className="text-[11px] text-daintree-text/40">
+                                  No other presets available for this agent.
+                                </p>
+                              )}
+                            </>
+                          );
+                        })()}
+                      </div>
                     </div>
                   )}
 

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -158,6 +158,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const tabs: TabInfo[] = useMemo(() => {
     return panels.map((p) => {
       let presetColor = p.agentPresetColor;
+      let fallbackTooltip: string | undefined;
       if (p.agentId && p.agentPresetId) {
         const presets = getMergedPresets(
           p.agentId,
@@ -166,6 +167,12 @@ export const GridTabGroup = React.memo(function GridTabGroup({
         );
         const live = presets.find((f) => f.id === p.agentPresetId);
         if (live) presetColor = live.color ?? presetColor;
+        if (p.isUsingFallback && p.originalPresetId) {
+          const original = presets.find((f) => f.id === p.originalPresetId);
+          const originalName = original?.name ?? p.originalPresetId;
+          const activeName = live?.name ?? p.agentPresetId;
+          fallbackTooltip = `Using fallback "${activeName}" — "${originalName}" unavailable`;
+        }
       }
       return {
         id: p.id,
@@ -177,6 +184,8 @@ export const GridTabGroup = React.memo(function GridTabGroup({
         agentState: p.agentState,
         isActive: p.id === activeTabId,
         presetColor,
+        isUsingFallback: p.isUsingFallback,
+        fallbackTooltip,
       };
     });
   }, [panels, activeTabId, agentSettings, ccrPresetsByAgent]);

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/config/agents", () => ({
     return undefined;
   },
   isRegisteredAgent: (id: string) => id === "claude" || id === "gemini",
+  getAgentIds: () => ["claude", "gemini"],
 }));
 
 function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {

--- a/src/config/__tests__/agents-adversarial.test.ts
+++ b/src/config/__tests__/agents-adversarial.test.ts
@@ -397,3 +397,92 @@ describe("Adversarial: sanitizeAgentEnv exported function", () => {
     expect(result).toEqual({ SAFE: "yes" });
   });
 });
+
+describe("Preset fallback chain sanitization", () => {
+  const customPresets = [
+    { id: "primary", name: "Primary", fallbacks: ["backup-a", "backup-b"] },
+    { id: "backup-a", name: "Backup A" },
+    { id: "backup-b", name: "Backup B" },
+    { id: "backup-c", name: "Backup C" },
+  ];
+
+  it("preserves valid fallback chains", () => {
+    const result = getMergedPresets("claude", customPresets);
+    const primary = result.find((p) => p.id === "primary");
+    expect(primary?.fallbacks).toEqual(["backup-a", "backup-b"]);
+  });
+
+  it("strips self-references from fallbacks", () => {
+    const bad = [
+      { id: "me", name: "Me", fallbacks: ["me", "other"] },
+      { id: "other", name: "O" },
+    ];
+    const result = getMergedPresets("claude", bad);
+    const me = result.find((p) => p.id === "me");
+    expect(me?.fallbacks).toEqual(["other"]);
+  });
+
+  it("deduplicates repeated IDs in fallbacks", () => {
+    const dup = [
+      { id: "p", name: "P", fallbacks: ["a", "a", "b", "a"] },
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+    ];
+    const result = getMergedPresets("claude", dup);
+    const p = result.find((x) => x.id === "p");
+    expect(p?.fallbacks).toEqual(["a", "b"]);
+  });
+
+  it("caps fallbacks array at FALLBACK_CHAIN_MAX (3)", () => {
+    const long = [
+      { id: "p", name: "P", fallbacks: ["a", "b", "c", "d", "e"] },
+      { id: "a", name: "A" },
+      { id: "b", name: "B" },
+      { id: "c", name: "C" },
+      { id: "d", name: "D" },
+      { id: "e", name: "E" },
+    ];
+    const result = getMergedPresets("claude", long);
+    const p = result.find((x) => x.id === "p");
+    expect(p?.fallbacks?.length).toBe(3);
+    expect(p?.fallbacks).toEqual(["a", "b", "c"]);
+  });
+
+  it("filters out references to unknown preset IDs", () => {
+    const withUnknown = [
+      { id: "p", name: "P", fallbacks: ["real", "does-not-exist"] },
+      { id: "real", name: "Real" },
+    ];
+    const result = getMergedPresets("claude", withUnknown);
+    const p = result.find((x) => x.id === "p");
+    expect(p?.fallbacks).toEqual(["real"]);
+  });
+
+  it("drops invalid ID characters in fallbacks", () => {
+    const bad = [
+      { id: "p", name: "P", fallbacks: ["valid", "with space", "semi;colon", ""] },
+      { id: "valid", name: "Valid" },
+    ];
+    const result = getMergedPresets("claude", bad);
+    const p = result.find((x) => x.id === "p");
+    expect(p?.fallbacks).toEqual(["valid"]);
+  });
+
+  it("returns undefined when all fallbacks are invalid or unknown", () => {
+    const bad = [{ id: "p", name: "P", fallbacks: ["p", "", ";bad"] }];
+    const result = getMergedPresets("claude", bad);
+    const p = result.find((x) => x.id === "p");
+    expect(p?.fallbacks).toBeUndefined();
+  });
+
+  it("tolerates non-array fallbacks field", () => {
+    const bad = [
+      {
+        id: "p",
+        name: "P",
+        fallbacks: "not-an-array" as unknown as string[],
+      },
+    ];
+    expect(() => getMergedPresets("claude", bad)).not.toThrow();
+  });
+});

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -3,6 +3,7 @@ import {
   AGENT_REGISTRY as BASE_AGENT_REGISTRY,
   type AgentConfig as BaseAgentConfig,
   type AgentPreset,
+  FALLBACK_CHAIN_MAX,
   getEffectiveAgentConfig,
   getEffectiveAgentIds,
   isEffectivelyRegisteredAgent,
@@ -121,6 +122,24 @@ export function getMergedPresets(
       return safe.length > 0 ? safe : undefined;
     };
 
+    const sanitizeFallbacks = (fallbacks?: string[], selfId?: string): string[] | undefined => {
+      if (!Array.isArray(fallbacks)) return undefined;
+      const seen = new Set<string>();
+      const safe: string[] = [];
+      for (const entry of fallbacks) {
+        if (typeof entry !== "string") continue;
+        const trimmed = entry.trim();
+        if (!trimmed || trimmed.length > 100) continue;
+        if (!/^[a-zA-Z0-9_.-]+$/.test(trimmed)) continue;
+        if (trimmed === selfId) continue;
+        if (seen.has(trimmed)) continue;
+        seen.add(trimmed);
+        safe.push(trimmed);
+        if (safe.length >= FALLBACK_CHAIN_MAX) break;
+      }
+      return safe.length > 0 ? safe : undefined;
+    };
+
     return {
       ...preset,
       name: trimmedName,
@@ -142,6 +161,7 @@ export function getMergedPresets(
         /^#[0-9a-fA-F]{3,4}$|^#[0-9a-fA-F]{6}$|^#[0-9a-fA-F]{8}$/.test(preset.color)
           ? preset.color
           : undefined,
+      fallbacks: sanitizeFallbacks(preset.fallbacks, preset.id),
     };
   };
 
@@ -157,6 +177,16 @@ export function getMergedPresets(
     if (!seenIds.has(preset.id)) {
       seenIds.add(preset.id);
       result.push(preset);
+    }
+  }
+
+  // Second pass: filter fallbacks[] against known preset IDs so unknown
+  // references don't propagate to the launcher.
+  const knownIds = new Set(result.map((p) => p.id));
+  for (const preset of result) {
+    if (preset.fallbacks?.length) {
+      const filtered = preset.fallbacks.filter((id) => knownIds.has(id));
+      preset.fallbacks = filtered.length > 0 ? filtered : undefined;
     }
   }
 

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -20,6 +20,7 @@ import type {
   AgentStateChangePayload,
   AgentDetectedPayload,
   AgentExitedPayload,
+  AgentFallbackTriggeredPayload,
   TerminalActivityPayload,
   TerminalStatusPayload,
   SpawnResult,
@@ -294,6 +295,10 @@ class TerminalRegistryController {
 
   onAgentExited(handler: (data: AgentExitedPayload) => void) {
     return terminalClient.onAgentExited(handler);
+  }
+
+  onFallbackTriggered(handler: (data: AgentFallbackTriggeredPayload) => void) {
+    return terminalClient.onFallbackTriggered(handler);
   }
 
   onActivity(handler: (data: TerminalActivityPayload) => void) {

--- a/src/panels/terminal/serializer.ts
+++ b/src/panels/terminal/serializer.ts
@@ -20,6 +20,9 @@ export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> 
     ...(t.agentModelId && { agentModelId: t.agentModelId }),
     ...(t.agentPresetId && { agentPresetId: t.agentPresetId }),
     ...(t.agentPresetColor && { agentPresetColor: t.agentPresetColor }),
+    ...(t.originalPresetId && { originalPresetId: t.originalPresetId }),
+    ...(t.isUsingFallback && { isUsingFallback: true }),
+    ...(typeof t.fallbackChainIndex === "number" && { fallbackChainIndex: t.fallbackChainIndex }),
     ...(t.agentState && { agentState: t.agentState }),
     ...(t.lastStateChange !== undefined && { lastStateChange: t.lastStateChange }),
   };

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -130,6 +130,7 @@ vi.mock("@/clients", () => ({
     onAgentStateChanged: onAgentStateChangedMock,
     onAgentDetected: onAgentDetectedMock,
     onAgentExited: onAgentExitedMock,
+    onFallbackTriggered: vi.fn(() => vi.fn()),
     onActivity: onActivityMock,
     onTrashed: onTrashedMock,
     onRestored: onRestoredMock,

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -98,6 +98,11 @@ async function handleFallbackTriggered(data: {
   if (!panel) return;
   if (panel.isRestarting) return;
 
+  // Drop stale duplicate events: if the panel has already advanced past the
+  // preset this event refers to, the exit was from a now-replaced process
+  // and advancing the chain again would skip a preset.
+  if (panel.agentPresetId !== fromPresetId) return;
+
   const originalPresetId = panel.originalPresetId ?? data.originalPresetId ?? fromPresetId;
 
   // Resolve the original preset's fallbacks[] chain from the agent settings store

--- a/src/store/panelStoreListeners.ts
+++ b/src/store/panelStoreListeners.ts
@@ -15,6 +15,10 @@ import { SCROLLBACK_BACKGROUND } from "@shared/config/scrollback";
 import { clearAllRestartGuards, isTerminalRestarting } from "./restartExitSuppression";
 import { usePanelStore, type PanelGridState } from "./panelStore";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
+import { getMergedPresets } from "@/config/agents";
+import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useNotificationStore } from "@/store/notificationStore";
 
 function normalizeCrashType(value: unknown): CrashType | null {
   const validTypes: CrashType[] = [
@@ -31,6 +35,14 @@ let store: DisposableStore | null = null;
 // Managed dynamically inside backendCrashed / backendReady callbacks — set and
 // cleared mid-flight, so it cannot be registered with `store` at setup time.
 let recoveryTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Per-terminal reentrancy guard for fallback activations. A single slow exit
+ * can produce duplicate `agent:fallback-triggered` events if respawn races
+ * with cleanup — we ignore re-entries for the same terminalId until the
+ * activation resolves.
+ */
+const fallbackInFlight = new Set<string>();
 
 const activityBuffer = new Map<string, TerminalActivityPayload>();
 let activityRafId: number | null = null;
@@ -68,6 +80,101 @@ export function cleanupTerminalStoreListeners() {
   if (recoveryTimer) {
     clearTimeout(recoveryTimer);
     recoveryTimer = null;
+  }
+  fallbackInFlight.clear();
+}
+
+async function handleFallbackTriggered(data: {
+  terminalId: string;
+  agentId: string;
+  fromPresetId: string;
+  originalPresetId?: string;
+  reason: "connection" | "auth";
+}): Promise<void> {
+  const { terminalId, agentId, fromPresetId, reason } = data;
+  if (fallbackInFlight.has(terminalId)) return;
+
+  const panel = usePanelStore.getState().panelsById[terminalId];
+  if (!panel) return;
+  if (panel.isRestarting) return;
+
+  const originalPresetId = panel.originalPresetId ?? data.originalPresetId ?? fromPresetId;
+
+  // Resolve the original preset's fallbacks[] chain from the agent settings store
+  // (renderer-local mirror of user settings; no IPC needed here).
+  const agentSettings = useAgentSettingsStore.getState().settings;
+  const entry = agentSettings?.agents?.[agentId] ?? {};
+  const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
+  const mergedPresets = getMergedPresets(agentId, entry.customPresets, ccrPresets);
+  const originalPreset = mergedPresets.find((p) => p.id === originalPresetId);
+
+  const chain = originalPreset?.fallbacks ?? [];
+  const currentIndex = panel.fallbackChainIndex ?? 0;
+  const nextPresetId = chain[currentIndex];
+
+  // Always lookup a fresh preset name, using the panel title as last resort.
+  const fromPreset = mergedPresets.find((p) => p.id === fromPresetId);
+  const fromName = fromPreset?.name ?? fromPresetId;
+
+  if (!nextPresetId) {
+    // Chain exhausted: surface a single error notification. No respawn.
+    const isExhausted = chain.length > 0;
+    useNotificationStore.getState().addNotification({
+      type: "error",
+      priority: "high",
+      title: isExhausted ? "Fallback chain exhausted" : `${fromName} unavailable`,
+      message: isExhausted
+        ? `All fallback presets tried. Terminal will stay exited.`
+        : `${fromName} provider is unreachable. Configure fallbacks in Settings to auto-recover.`,
+    });
+    return;
+  }
+
+  const nextPreset = mergedPresets.find((p) => p.id === nextPresetId);
+  if (!nextPreset) {
+    useNotificationStore.getState().addNotification({
+      type: "error",
+      priority: "high",
+      title: "Fallback preset missing",
+      message: `Preset "${nextPresetId}" is no longer configured. Skipping.`,
+    });
+    return;
+  }
+
+  fallbackInFlight.add(terminalId);
+  try {
+    logInfo("[TerminalStore] Activating fallback preset", {
+      terminalId,
+      agentId,
+      fromPresetId,
+      toPresetId: nextPresetId,
+      reason,
+    });
+
+    const result = await usePanelStore
+      .getState()
+      .activateFallbackPreset(terminalId, nextPresetId, originalPresetId);
+
+    if (result.success) {
+      useNotificationStore.getState().addNotification({
+        type: "info",
+        priority: "low",
+        title: "Switched to fallback preset",
+        message:
+          reason === "auth"
+            ? `${fromName} authentication failed — now running "${nextPreset.name}".`
+            : `${fromName} unreachable — now running "${nextPreset.name}".`,
+      });
+    } else {
+      useNotificationStore.getState().addNotification({
+        type: "error",
+        priority: "high",
+        title: "Fallback activation failed",
+        message: `Could not switch to "${nextPreset.name}": ${result.error ?? "unknown error"}`,
+      });
+    }
+  } finally {
+    fallbackInFlight.delete(terminalId);
   }
 }
 
@@ -184,6 +291,19 @@ export function setupTerminalStoreListeners() {
               [terminalId]: { ...terminal, detectedProcessId: undefined },
             },
           };
+        });
+      })
+    )
+  );
+
+  disposables.add(
+    toDisposable(
+      terminalRegistryController.onFallbackTriggered((data) => {
+        void handleFallbackTriggered(data).catch((err) => {
+          logError("[TerminalStore] Unhandled error in fallback listener", err, {
+            terminalId: data.terminalId,
+          });
+          fallbackInFlight.delete(data.terminalId);
         });
       })
     )

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -90,11 +90,22 @@ vi.mock("@/utils/terminalValidation", () => ({
 vi.mock("@/config/agents", () => ({
   isRegisteredAgent: (type: string) => type === "claude" || type === "gemini",
   getAgentConfig: vi.fn().mockReturnValue({ command: "claude" }),
+  getAgentIds: () => ["claude", "gemini", "codex"],
+  getMergedPreset: vi.fn().mockReturnValue(undefined),
+  sanitizeAgentEnv: (env: Record<string, string> | undefined) => env,
 }));
 
 vi.mock("@shared/types", () => ({
   generateAgentCommand: vi.fn().mockReturnValue("claude --resume"),
+  buildAgentLaunchFlags: vi.fn().mockReturnValue([]),
   buildResumeCommand: vi.fn().mockReturnValue(null),
+  buildLaunchCommandFromFlags: vi.fn().mockReturnValue("claude"),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: {
+    getState: () => ({ ccrPresetsByAgent: {} }),
+  },
 }));
 
 const { usePanelStore } = await import("../../../panelStore");

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -415,6 +415,8 @@ export const createCorePanelActions = (
           agentLaunchFlags: options.agentLaunchFlags,
           agentModelId: options.agentModelId,
           worktreeId: options.worktreeId,
+          agentPresetId: options.agentPresetId,
+          originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
         });
       }
 
@@ -455,6 +457,9 @@ export const createCorePanelActions = (
         agentModelId: options.agentModelId,
         agentPresetId: options.agentPresetId,
         agentPresetColor: options.agentPresetColor,
+        originalPresetId: options.originalPresetId ?? options.agentPresetId,
+        isUsingFallback: options.isUsingFallback,
+        fallbackChainIndex: options.fallbackChainIndex,
         extensionState: options.extensionState,
         spawnedBy: options.spawnedBy,
         startedAt: Date.now(),

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -853,6 +853,20 @@ export const createRestartActions = (
       }))
     );
 
+    // Snapshot pre-mutation preset fields for rollback on spawn failure.
+    // Without this, a failed respawn leaves the panel permanently stamped as
+    // "using fallback N" while no process is running, corrupting any retry
+    // that reads fallbackChainIndex.
+    const priorSnapshot = {
+      command: terminal.command,
+      agentPresetId: terminal.agentPresetId,
+      agentPresetColor: terminal.agentPresetColor,
+      originalPresetId: terminal.originalPresetId,
+      isUsingFallback: terminal.isUsingFallback,
+      fallbackChainIndex: terminal.fallbackChainIndex,
+      agentLaunchFlags: terminal.agentLaunchFlags,
+    };
+
     try {
       const [agentSettings, tmpDir] = await Promise.all([
         agentSettingsClient.get(),
@@ -896,9 +910,15 @@ export const createRestartActions = (
         modelId: terminal.agentModelId,
         presetArgs: nextPreset.args?.join(" "),
       });
-      const nextLaunchFlags = buildAgentLaunchFlags(effectiveEntry, effectiveAgentId, {
+      const baseLaunchFlags = buildAgentLaunchFlags(effectiveEntry, effectiveAgentId, {
         modelId: terminal.agentModelId,
       });
+      // Merge preset args into persisted launch flags so a later restart
+      // (via restartTerminal) using buildLaunchCommandFromFlags reproduces
+      // the exact same preset spawn, not a settings-default one.
+      const nextLaunchFlags = nextPreset.args?.length
+        ? [...baseLaunchFlags, ...nextPreset.args]
+        : baseLaunchFlags;
 
       // Capture live terminal dimensions before teardown
       const managedInstance = terminalInstanceService.get(id);
@@ -1005,6 +1025,11 @@ export const createRestartActions = (
         updateTerminal(state, id, (t) => ({
           ...t,
           isRestarting: false,
+          // Restore pre-mutation fields so fallbackChainIndex and presetId
+          // accurately reflect "we are NOT running the next preset". Without
+          // rollback, any subsequent fallback trigger would jump past this
+          // preset even though the PTY never started.
+          ...priorSnapshot,
           restartError: {
             message: errorMessage,
             timestamp: Date.now(),

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -3,6 +3,7 @@ import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
 import { terminalClient, agentSettingsClient, projectClient, systemClient } from "@/clients";
 import {
   generateAgentCommand,
+  buildAgentLaunchFlags,
   buildResumeCommand,
   buildLaunchCommandFromFlags,
 } from "@shared/types";
@@ -10,7 +11,13 @@ import type { AgentState } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { validateTerminalConfig } from "@/utils/terminalValidation";
-import { isRegisteredAgent, getAgentConfig } from "@/config/agents";
+import {
+  isRegisteredAgent,
+  getAgentConfig,
+  getMergedPreset,
+  sanitizeAgentEnv,
+} from "@/config/agents";
+import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { markTerminalRestarting, unmarkTerminalRestarting } from "@/store/restartExitSuppression";
 import { useLayoutConfigStore } from "@/store/layoutConfigStore";
@@ -93,6 +100,7 @@ export const createRestartActions = (
   | "setInputLocked"
   | "toggleInputLocked"
   | "convertTerminalType"
+  | "activateFallbackPreset"
 > => ({
   restartTerminal: async (id) => {
     const terminal = get().panelsById[id];
@@ -816,6 +824,204 @@ export const createRestartActions = (
       );
 
       logError("[TerminalStore] Failed to convert terminal", error, { id });
+    }
+  },
+
+  activateFallbackPreset: async (id, nextPresetId, originalPresetId) => {
+    const terminal = get().panelsById[id];
+    if (!terminal) {
+      return { success: false, error: "terminal not found" };
+    }
+    if (terminal.isRestarting) {
+      return { success: false, error: "already restarting" };
+    }
+
+    const effectiveAgentId =
+      terminal.agentId ??
+      (terminal.type && isRegisteredAgent(terminal.type) ? terminal.type : undefined);
+    if (!effectiveAgentId) {
+      return { success: false, error: "panel is not an agent" };
+    }
+
+    markTerminalRestarting(id);
+    set((state) =>
+      updateTerminal(state, id, (t) => ({
+        ...t,
+        restartError: undefined,
+        spawnError: undefined,
+        isRestarting: true,
+      }))
+    );
+
+    try {
+      const [agentSettings, tmpDir] = await Promise.all([
+        agentSettingsClient.get(),
+        systemClient.getTmpDir().catch(() => ""),
+      ]);
+      const entry = agentSettings?.agents?.[effectiveAgentId] ?? {};
+      const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[effectiveAgentId];
+      const nextPreset = getMergedPreset(
+        effectiveAgentId,
+        nextPresetId,
+        entry.customPresets,
+        ccrPresets
+      );
+      if (!nextPreset) {
+        throw new Error(`fallback preset "${nextPresetId}" not found`);
+      }
+
+      const sanitizedGlobal = sanitizeAgentEnv(entry.globalEnv as Record<string, unknown>);
+      const sanitizedPreset = nextPreset.env;
+      const presetEnv: Record<string, string> | undefined =
+        sanitizedGlobal || sanitizedPreset ? { ...sanitizedGlobal, ...sanitizedPreset } : undefined;
+
+      const effectiveEntry = {
+        ...entry,
+        ...(nextPreset.dangerousEnabled !== undefined && {
+          dangerousEnabled: nextPreset.dangerousEnabled,
+        }),
+        ...(nextPreset.customFlags !== undefined && { customFlags: nextPreset.customFlags }),
+        ...(nextPreset.inlineMode !== undefined && { inlineMode: nextPreset.inlineMode }),
+      };
+
+      let clipboardDirectory: string | undefined;
+      if (effectiveAgentId === "gemini" && effectiveEntry.shareClipboardDirectory !== false) {
+        clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
+      }
+
+      const agentConfig = getAgentConfig(effectiveAgentId);
+      const baseCommand = agentConfig?.command || effectiveAgentId;
+      const commandToRun = generateAgentCommand(baseCommand, effectiveEntry, effectiveAgentId, {
+        clipboardDirectory,
+        modelId: terminal.agentModelId,
+        presetArgs: nextPreset.args?.join(" "),
+      });
+      const nextLaunchFlags = buildAgentLaunchFlags(effectiveEntry, effectiveAgentId, {
+        modelId: terminal.agentModelId,
+      });
+
+      // Capture live terminal dimensions before teardown
+      const managedInstance = terminalInstanceService.get(id);
+      let spawnCols = terminal.cols || 80;
+      let spawnRows = terminal.rows || 24;
+      if (managedInstance?.terminal) {
+        spawnCols = managedInstance.terminal.cols || spawnCols;
+        spawnRows = managedInstance.terminal.rows || spawnRows;
+      }
+
+      terminalInstanceService.destroy(id);
+      terminalInstanceService.suppressNextExit(id, 10000);
+      try {
+        await terminalClient.kill(id);
+      } catch (error) {
+        logWarn("[TerminalStore] kill failed during fallback activation; continuing", {
+          id,
+          error,
+        });
+      }
+
+      const nextChainIndex = (terminal.fallbackChainIndex ?? 0) + 1;
+
+      set((state) => {
+        const t = state.panelsById[id];
+        if (!t) return state;
+        const updated = {
+          ...t,
+          restartKey: (t.restartKey ?? 0) + 1,
+          agentState: "working" as AgentState,
+          lastStateChange: Date.now(),
+          stateChangeTrigger: undefined,
+          stateChangeConfidence: undefined,
+          command: commandToRun,
+          agentPresetId: nextPreset.id,
+          agentPresetColor: nextPreset.color,
+          originalPresetId: originalPresetId,
+          isUsingFallback: true,
+          fallbackChainIndex: nextChainIndex,
+          agentLaunchFlags: nextLaunchFlags,
+          agentSessionId: undefined,
+          isRestarting: true,
+          restartError: undefined,
+          exitCode: undefined,
+          startedAt: Date.now(),
+        };
+        const newById = { ...state.panelsById, [id]: updated };
+        saveNormalized(newById, state.panelIds);
+        return { panelsById: newById };
+      });
+
+      await terminalInstanceService.waitForInstance(id, { timeoutMs: 5000 });
+
+      const projectStore = await resolveProjectStore();
+      const capturedProjectId = projectStore.getState().currentProject?.id;
+
+      let restartEnv: Record<string, string> | undefined = presetEnv;
+      try {
+        if (capturedProjectId) {
+          const projectSettings = await projectClient.getSettings(capturedProjectId);
+          if (
+            projectSettings?.environmentVariables &&
+            Object.keys(projectSettings.environmentVariables).length > 0
+          ) {
+            restartEnv = { ...projectSettings.environmentVariables, ...(presetEnv ?? {}) };
+          }
+        }
+      } catch (error) {
+        logWarn("[TerminalStore] Failed to fetch project env for fallback", { error });
+      }
+
+      await terminalClient.spawn({
+        id,
+        projectId: capturedProjectId,
+        cwd: terminal.cwd,
+        cols: spawnCols,
+        rows: spawnRows,
+        kind: terminal.kind ?? "agent",
+        type: terminal.type,
+        agentId: terminal.agentId,
+        title: terminal.title,
+        command: commandToRun,
+        restore: false,
+        env: restartEnv,
+        agentLaunchFlags: nextLaunchFlags,
+        agentModelId: terminal.agentModelId,
+        agentPresetId: nextPreset.id,
+        originalAgentPresetId: originalPresetId,
+      });
+
+      if (terminal.location === "dock") {
+        optimizeForDock(id);
+      } else {
+        terminalInstanceService.fit(id);
+      }
+
+      unmarkTerminalRestarting(id);
+      set((state) => updateTerminal(state, id, (t) => ({ ...t, isRestarting: false })));
+      return { success: true };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      unmarkTerminalRestarting(id);
+      set((state) =>
+        updateTerminal(state, id, (t) => ({
+          ...t,
+          isRestarting: false,
+          restartError: {
+            message: errorMessage,
+            timestamp: Date.now(),
+            recoverable: false,
+            context: {
+              failedCwd: terminal.cwd,
+              phase: "fallback-activation",
+              nextPresetId,
+            },
+          },
+        }))
+      );
+      logError("[TerminalStore] Failed to activate fallback preset", error, {
+        id,
+        nextPresetId,
+      });
+      return { success: false, error: errorMessage };
     }
   },
 });

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -142,6 +142,17 @@ export interface PanelRegistrySlice {
   setInputLocked: (id: string, locked: boolean) => void;
   toggleInputLocked: (id: string) => void;
   convertTerminalType: (id: string, newType: TerminalType, newAgentId?: string) => Promise<void>;
+  /**
+   * Kill the current PTY and respawn it in the same panel slot using a
+   * different preset. Fires as part of the fallback chain when a preset's
+   * provider is unavailable. No session resume (fresh spawn), since the
+   * upstream session we were talking to is the very thing that failed.
+   */
+  activateFallbackPreset: (
+    id: string,
+    nextPresetId: string,
+    originalPresetId: string
+  ) => Promise<{ success: boolean; error?: string }>;
   setBrowserUrl: (id: string, url: string) => void;
   setBrowserHistory: (id: string, history: BrowserHistory) => void;
   setBrowserZoom: (id: string, zoom: number) => void;


### PR DESCRIPTION
## Summary

- Agent presets can now declare an ordered `fallbacks: string[]` (capped at 3). When a PTY exits with a fallback-eligible error (5xx, connection, DNS, timeout, or hard auth failure) the renderer automatically respawns the panel on the next preset in the chain.
- `FallbackErrorClassifier` classifies Claude/Gemini/Codex exit output tails using pure regex with correct precedence (rate-limit beats connection, so 429 can't be misread as a 5xx). Clean exits and rate-limits never trigger a fallback.
- `TabButton` shows an `AlertTriangle` badge when a panel is running on a fallback preset, and a toast notifies the user on each transition.

Resolves #5463

## Changes

- `FallbackErrorClassifier` (56 unit tests) in `electron/services/pty/` with forensic buffer integration in `TerminalProcess.onExit`
- `activateFallbackPreset` panel action: kills PTY, respawns under the same terminal ID with the next preset's env/args, rolls back on spawn failure
- Renderer listener in `panelStoreListeners.ts`: walks the chain, deduplicates concurrent events, ignores stale events for preset IDs the panel has already advanced past
- `AgentSettings` preset editor: add/remove fallback-chain picker for custom presets (capped at 3, no self-reference, no duplicates)
- Shared types updated: `fallbacks` field on preset types, `isFallbackActive` / `fallbackPresetId` on panel state, `agent:fallback-triggered` IPC event

## Testing

- 56 classifier unit tests covering all error categories and edge cases across Claude, Gemini, and Codex output patterns
- 9 validation tests for the preset editor constraints
- 12 304 unit tests pass with no new failures
- Typecheck clean, lint warnings unchanged from baseline (368)