### PR TITLE
feat(browser): add favicons and per-row history deletion to URL bar

### DIFF
--- a/shared/types/browser.ts
+++ b/shared/types/browser.ts
@@ -9,4 +9,5 @@ export interface UrlHistoryEntry {
   title: string;
   visitCount: number;
   lastVisitAt: number;
+  favicon?: string;
 }

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -376,6 +376,23 @@ export function BrowserPane({
       }
     };
 
+    // Debounce favicon updates to avoid store thrashing on rapid events
+    let faviconDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+    const handlePageFaviconUpdated = (event: Event) => {
+      const detail = event as Event & { favicons?: string[] };
+      if (!projectId || !detail.favicons?.length) return;
+      const favicon = detail.favicons[0]!;
+      if (faviconDebounceTimer) clearTimeout(faviconDebounceTimer);
+      faviconDebounceTimer = setTimeout(() => {
+        faviconDebounceTimer = null;
+        try {
+          useUrlHistoryStore.getState().updateFavicon(projectId, webview.getURL(), favicon);
+        } catch {
+          // webview may be detached
+        }
+      }, 200);
+    };
+
     try {
       const existingUrl = webview.getURL();
       if (existingUrl && existingUrl !== "about:blank" && !webview.isLoading()) {
@@ -397,6 +414,7 @@ export function BrowserPane({
     webview.addEventListener("did-navigate", handleDidNavigate);
     webview.addEventListener("did-navigate-in-page", handleDidNavigateInPage);
     webview.addEventListener("page-title-updated", handlePageTitleUpdated);
+    webview.addEventListener("page-favicon-updated", handlePageFaviconUpdated);
 
     return () => {
       webview.removeEventListener("dom-ready", handleDomReady);
@@ -406,6 +424,11 @@ export function BrowserPane({
       webview.removeEventListener("did-navigate", handleDidNavigate);
       webview.removeEventListener("did-navigate-in-page", handleDidNavigateInPage);
       webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
+      webview.removeEventListener("page-favicon-updated", handlePageFaviconUpdated);
+      if (faviconDebounceTimer) {
+        clearTimeout(faviconDebounceTimer);
+        faviconDebounceTimer = null;
+      }
     };
   }, [
     webviewElement,

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -382,14 +382,21 @@ export function BrowserPane({
       const detail = event as Event & { favicons?: string[] };
       if (!projectId || !detail.favicons?.length) return;
       const favicon = detail.favicons[0]!;
+      // Skip oversized data URLs that could exceed localStorage quota
+      if (favicon.startsWith("data:") && favicon.length > 8192) return;
+      // Capture URL at event time to avoid race with navigation
+      let capturedUrl: string;
+      try {
+        capturedUrl = webview.getURL();
+      } catch {
+        return;
+      }
+      if (!capturedUrl || capturedUrl === "about:blank") return;
       if (faviconDebounceTimer) clearTimeout(faviconDebounceTimer);
+      const url = capturedUrl;
       faviconDebounceTimer = setTimeout(() => {
         faviconDebounceTimer = null;
-        try {
-          useUrlHistoryStore.getState().updateFavicon(projectId, webview.getURL(), favicon);
-        } catch {
-          // webview may be detached
-        }
+        useUrlHistoryStore.getState().updateFavicon(projectId, url, favicon);
       }, 200);
     };
 

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -13,6 +13,7 @@ import {
   SquareTerminal,
   Code,
   Smartphone,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { normalizeBrowserUrl, getDisplayUrl } from "./browserUtils";
@@ -98,7 +99,7 @@ export function BrowserToolbar({
   );
 
   const suggestions = useMemo(
-    () => (isEditing && projectId ? getFrecencySuggestions(projectEntries, inputValue) : []),
+    () => (isEditing && projectId ? getFrecencySuggestions(projectEntries, "") : []),
     [isEditing, projectId, projectEntries, inputValue]
   );
 
@@ -182,6 +183,21 @@ export function BrowserToolbar({
           setHighlightedIndex(-1);
           return;
         }
+        if (e.shiftKey && (e.key === "Delete" || e.key === "Backspace") && highlightedIndex >= 0) {
+          e.preventDefault();
+          const entry = suggestions[highlightedIndex]!;
+          if (projectId) {
+            useUrlHistoryStore.getState().removeUrl(projectId, entry.url);
+          }
+          const remaining = suggestions.length - 1;
+          if (remaining === 0) {
+            setIsDropdownOpen(false);
+            setHighlightedIndex(-1);
+          } else if (highlightedIndex >= remaining) {
+            setHighlightedIndex(remaining - 1);
+          }
+          return;
+        }
       }
       if (e.key === "Escape") {
         setIsEditing(false);
@@ -189,7 +205,7 @@ export function BrowserToolbar({
         inputRef.current?.blur();
       }
     },
-    [isDropdownOpen, suggestions, highlightedIndex, onNavigate]
+    [isDropdownOpen, suggestions, highlightedIndex, onNavigate, projectId]
   );
 
   const handleCopy = useCallback(async () => {
@@ -498,28 +514,66 @@ export function BrowserToolbar({
             className="absolute left-0 right-0 top-full mt-1 z-50 bg-daintree-bg border border-overlay rounded shadow-[var(--theme-shadow-floating)] overflow-hidden"
           >
             {suggestions.map((entry, index) => (
-              <button
+              <div
                 key={entry.url}
-                type="button"
-                tabIndex={-1}
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  setIsEditing(false);
-                  setIsDropdownOpen(false);
-                  setHighlightedIndex(-1);
-                  onNavigate(entry.url);
-                }}
                 onMouseEnter={() => setHighlightedIndex(index)}
                 className={cn(
-                  "w-full text-left px-2.5 py-1.5 flex flex-col gap-0.5 cursor-pointer",
+                  "group/row w-full text-left px-2.5 py-1.5 flex items-center gap-2 cursor-pointer",
                   index === highlightedIndex ? "bg-overlay-medium" : "hover:bg-overlay-soft"
                 )}
               >
-                {entry.title && (
-                  <span className="text-xs text-daintree-text truncate">{entry.title}</span>
+                {entry.favicon ? (
+                  <img
+                    src={entry.favicon}
+                    alt=""
+                    className="w-4 h-4 shrink-0 rounded-sm object-contain"
+                    onError={(e) => {
+                      (e.target as HTMLImageElement).style.display = "none";
+                    }}
+                  />
+                ) : (
+                  <Globe className="w-4 h-4 shrink-0 text-daintree-text/30" />
                 )}
-                <span className="text-xs text-daintree-text/50 truncate">{entry.url}</span>
-              </button>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    setIsEditing(false);
+                    setIsDropdownOpen(false);
+                    setHighlightedIndex(-1);
+                    onNavigate(entry.url);
+                  }}
+                  className="flex-1 min-w-0 flex flex-col gap-0.5 text-left"
+                >
+                  {entry.title && (
+                    <span className="text-xs text-daintree-text truncate">{entry.title}</span>
+                  )}
+                  <span className="text-xs text-daintree-text/50 truncate">{entry.url}</span>
+                </button>
+                {projectId && (
+                  <button
+                    type="button"
+                    tabIndex={-1}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      useUrlHistoryStore.getState().removeUrl(projectId, entry.url);
+                      const remaining = suggestions.length - 1;
+                      if (remaining === 0) {
+                        setIsDropdownOpen(false);
+                        setHighlightedIndex(-1);
+                      } else if (index === highlightedIndex && highlightedIndex >= remaining) {
+                        setHighlightedIndex(remaining - 1);
+                      }
+                    }}
+                    className="shrink-0 p-0.5 rounded opacity-0 group-hover/row:opacity-100 hover:bg-overlay-strong transition-opacity text-daintree-text/40 hover:text-daintree-text/70"
+                    aria-label={`Remove ${entry.url} from history`}
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -99,7 +99,7 @@ export function BrowserToolbar({
   );
 
   const suggestions = useMemo(
-    () => (isEditing && projectId ? getFrecencySuggestions(projectEntries, "") : []),
+    () => (isEditing && projectId ? getFrecencySuggestions(projectEntries, inputValue) : []),
     [isEditing, projectId, projectEntries, inputValue]
   );
 
@@ -523,14 +523,23 @@ export function BrowserToolbar({
                 )}
               >
                 {entry.favicon ? (
-                  <img
-                    src={entry.favicon}
-                    alt=""
-                    className="w-4 h-4 shrink-0 rounded-sm object-contain"
-                    onError={(e) => {
-                      (e.target as HTMLImageElement).style.display = "none";
-                    }}
-                  />
+                  <span className="relative w-4 h-4 shrink-0">
+                    <img
+                      src={entry.favicon}
+                      alt=""
+                      className="w-4 h-4 rounded-sm object-contain"
+                      onError={(e) => {
+                        const img = e.target as HTMLImageElement;
+                        img.style.display = "none";
+                        const fallback = img.nextElementSibling;
+                        if (fallback) (fallback as HTMLElement).style.display = "";
+                      }}
+                    />
+                    <Globe
+                      className="w-4 h-4 text-daintree-text/30 absolute inset-0"
+                      style={{ display: "none" }}
+                    />
+                  </span>
                 ) : (
                   <Globe className="w-4 h-4 shrink-0 text-daintree-text/30" />
                 )}

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -1,11 +1,44 @@
 // @vitest-environment jsdom
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { BrowserToolbar } from "../BrowserToolbar";
 
+const mockRemoveUrl = vi.fn();
+
 vi.mock("@/store/urlHistoryStore", () => ({
-  useUrlHistoryStore: () => [],
-  getFrecencySuggestions: () => [],
+  useUrlHistoryStore: Object.assign(
+    () => [
+      {
+        url: "http://localhost:3000/",
+        title: "Home",
+        visitCount: 5,
+        lastVisitAt: Date.now(),
+        favicon: "https://example.com/favicon.ico",
+      },
+      {
+        url: "http://localhost:5173/",
+        title: "Vite",
+        visitCount: 2,
+        lastVisitAt: Date.now(),
+      },
+    ],
+    { getState: () => ({ removeUrl: mockRemoveUrl }) }
+  ),
+  getFrecencySuggestions: () => [
+    {
+      url: "http://localhost:3000/",
+      title: "Home",
+      visitCount: 5,
+      lastVisitAt: Date.now(),
+      favicon: "https://example.com/favicon.ico",
+    },
+    {
+      url: "http://localhost:5173/",
+      title: "Vite",
+      visitCount: 2,
+      lastVisitAt: Date.now(),
+    },
+  ],
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -14,6 +47,7 @@ vi.mock("@/services/ActionService", () => ({
 
 const defaultProps = {
   url: "http://localhost:5173/",
+  projectId: "proj1",
   canGoBack: false,
   canGoForward: false,
   isLoading: false,
@@ -29,6 +63,12 @@ function renderToolbar(overrides = {}) {
   return render(<BrowserToolbar {...props} />);
 }
 
+function openDropdown(arg: ((id: string) => HTMLElement) | HTMLElement) {
+  const input = typeof arg === "function" ? arg("browser-address-bar") : arg;
+  fireEvent.focus(input);
+  return input;
+}
+
 describe("BrowserToolbar handleSubmit", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,10 +76,8 @@ describe("BrowserToolbar handleSubmit", () => {
 
   it("calls onReload when submitting the same URL", () => {
     const { getByTestId } = renderToolbar();
-    const input = getByTestId("browser-address-bar");
+    const input = openDropdown(getByTestId);
 
-    fireEvent.focus(input);
-    // handleFocus sets inputValue to url prop (http://localhost:5173/)
     fireEvent.submit(input.closest("form")!);
 
     expect(defaultProps.onReload).toHaveBeenCalledOnce();
@@ -48,9 +86,8 @@ describe("BrowserToolbar handleSubmit", () => {
 
   it("calls onNavigate when submitting a different URL", () => {
     const { getByTestId } = renderToolbar();
-    const input = getByTestId("browser-address-bar");
+    const input = openDropdown(getByTestId);
 
-    fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "localhost:3000" } });
     fireEvent.submit(input.closest("form")!);
 
@@ -60,10 +97,8 @@ describe("BrowserToolbar handleSubmit", () => {
 
   it("calls onReload when display-format input normalizes to same URL", () => {
     const { getByTestId } = renderToolbar();
-    const input = getByTestId("browser-address-bar");
+    const input = openDropdown(getByTestId);
 
-    fireEvent.focus(input);
-    // Type the display format (no protocol, no trailing slash) which normalizes to the same URL
     fireEvent.change(input, { target: { value: "localhost:5173" } });
     fireEvent.submit(input.closest("form")!);
 
@@ -73,9 +108,8 @@ describe("BrowserToolbar handleSubmit", () => {
 
   it("shows error for invalid URL and does not call either callback", () => {
     const { getByTestId } = renderToolbar();
-    const input = getByTestId("browser-address-bar");
+    const input = openDropdown(getByTestId);
 
-    fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "not a valid url !!!" } });
     fireEvent.submit(input.closest("form")!);
 
@@ -85,11 +119,9 @@ describe("BrowserToolbar handleSubmit", () => {
 
   it("calls onReload on consecutive same-URL submissions", () => {
     const { getByTestId } = renderToolbar();
-    const input = getByTestId("browser-address-bar");
+    const input = openDropdown(getByTestId);
 
-    fireEvent.focus(input);
     fireEvent.submit(input.closest("form")!);
-    // Focus again and submit again
     fireEvent.focus(input);
     fireEvent.submit(input.closest("form")!);
 
@@ -100,12 +132,49 @@ describe("BrowserToolbar handleSubmit", () => {
   it("calls onReload for URL with path, query, and hash", () => {
     const fullUrl = "http://localhost:5173/app?tab=1#section";
     const { getByTestId } = renderToolbar({ url: fullUrl });
-    const input = getByTestId("browser-address-bar");
+    const input = openDropdown(getByTestId);
 
-    fireEvent.focus(input);
     fireEvent.submit(input.closest("form")!);
 
     expect(defaultProps.onReload).toHaveBeenCalledOnce();
+    expect(defaultProps.onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("BrowserToolbar favicon and delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders favicon image for entries with favicon", () => {
+    const { container } = renderToolbar();
+    openDropdown(container.querySelector("[data-testid='browser-address-bar']")! as HTMLElement);
+    const img = container.querySelector("img[src='https://example.com/favicon.ico']");
+    expect(img).toBeTruthy();
+  });
+
+  it("renders Globe icon for entries without favicon", () => {
+    const { container } = renderToolbar();
+    openDropdown(container.querySelector("[data-testid='browser-address-bar']")! as HTMLElement);
+    // Second entry has no favicon — should have a Globe SVG sibling
+    const rows = container.querySelectorAll(".group\\/row");
+    expect(rows.length).toBe(2);
+  });
+
+  it("delete button calls removeUrl on mousedown", () => {
+    const { container } = renderToolbar();
+    openDropdown(container.querySelector("[data-testid='browser-address-bar']")! as HTMLElement);
+    const deleteButtons = container.querySelectorAll("[aria-label^='Remove']");
+    expect(deleteButtons.length).toBeGreaterThan(0);
+    fireEvent.mouseDown(deleteButtons[0]!);
+    expect(mockRemoveUrl).toHaveBeenCalledWith("proj1", "http://localhost:3000/");
+  });
+
+  it("delete button does not navigate on click", () => {
+    const { container } = renderToolbar();
+    openDropdown(container.querySelector("[data-testid='browser-address-bar']")! as HTMLElement);
+    const deleteButtons = container.querySelectorAll("[aria-label^='Remove']");
+    fireEvent.mouseDown(deleteButtons[0]!);
     expect(defaultProps.onNavigate).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { BrowserToolbar } from "../BrowserToolbar";
 

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -86,11 +86,15 @@ describe("urlHistoryStore", () => {
     expect(entries![0]!.favicon).toBe("https://example.com/favicon.ico");
   });
 
-  it("updateFavicon is a no-op for non-existent URL", () => {
+  it("updateFavicon creates entry for non-existent URL", () => {
     const store = useUrlHistoryStore.getState();
     store.recordVisit("proj1", "http://localhost:3000/", "Title");
     store.updateFavicon("proj1", "http://localhost:5000/", "https://other.com/favicon.ico");
-    expect(useUrlHistoryStore.getState().entries["proj1"]![0]!.favicon).toBeUndefined();
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(2);
+    expect(entries.find((e) => e.url === "http://localhost:5000/")!.favicon).toBe(
+      "https://other.com/favicon.ico"
+    );
   });
 
   it("removeUrl removes a specific entry by URL", () => {

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -78,6 +78,58 @@ describe("urlHistoryStore", () => {
     expect(useUrlHistoryStore.getState().entries["proj2"]).toHaveLength(1);
   });
 
+  it("updateFavicon sets favicon for an existing entry", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "http://localhost:3000/", "Home");
+    store.updateFavicon("proj1", "http://localhost:3000/", "https://example.com/favicon.ico");
+    const entries = useUrlHistoryStore.getState().entries["proj1"];
+    expect(entries![0]!.favicon).toBe("https://example.com/favicon.ico");
+  });
+
+  it("updateFavicon is a no-op for non-existent URL", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "http://localhost:3000/", "Title");
+    store.updateFavicon("proj1", "http://localhost:5000/", "https://other.com/favicon.ico");
+    expect(useUrlHistoryStore.getState().entries["proj1"]![0]!.favicon).toBeUndefined();
+  });
+
+  it("removeUrl removes a specific entry by URL", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "http://localhost:3000/", "A");
+    store.recordVisit("proj1", "http://localhost:5173/", "B");
+    store.removeUrl("proj1", "http://localhost:3000/");
+    const entries = useUrlHistoryStore.getState().entries["proj1"];
+    expect(entries).toHaveLength(1);
+    expect(entries![0]!.url).toBe("http://localhost:5173/");
+  });
+
+  it("removeUrl is a no-op for non-existent URL", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "http://localhost:3000/", "A");
+    store.removeUrl("proj1", "http://localhost:9999/");
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toHaveLength(1);
+  });
+
+  it("hydrates legacy entries without favicon field", () => {
+    useUrlHistoryStore.setState({
+      entries: {
+        proj1: [
+          {
+            url: "http://localhost:3000/",
+            title: "Legacy",
+            visitCount: 1,
+            lastVisitAt: Date.now(),
+          },
+        ],
+      },
+    });
+    const entries = useUrlHistoryStore.getState().entries["proj1"];
+    expect(entries![0]!.favicon).toBeUndefined();
+    // Store methods still work on legacy entries
+    useUrlHistoryStore.getState().updateFavicon("proj1", "http://localhost:3000/", "favicon.ico");
+    expect(useUrlHistoryStore.getState().entries["proj1"]![0]!.favicon).toBe("favicon.ico");
+  });
+
   it("updates lastVisitAt on repeated visits", () => {
     const store = useUrlHistoryStore.getState();
     store.recordVisit("proj1", "http://localhost:3000/", "Home");
@@ -158,9 +210,15 @@ describe("getFrecencySuggestions", () => {
     { url: "http://localhost:5173/", title: "Vite Dev", visitCount: 1, lastVisitAt: now - 1000 },
   ];
 
-  it("returns empty for empty query", () => {
-    expect(getFrecencySuggestions(entries, "")).toEqual([]);
-    expect(getFrecencySuggestions(entries, "   ")).toEqual([]);
+  it("returns top entries for empty query", () => {
+    const results = getFrecencySuggestions(entries, "");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  it("returns top entries for whitespace-only query", () => {
+    const results = getFrecencySuggestions(entries, "   ");
+    expect(results.length).toBeGreaterThan(0);
   });
 
   it("filters by URL substring match", () => {

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -24,7 +24,7 @@ export function getFrecencySuggestions(
   query: string,
   limit = 5
 ): UrlHistoryEntry[] {
-  if (!query.trim()) return [];
+  if (!query.trim()) return entries.slice(0, limit);
   const lowerQuery = query.toLowerCase();
   const now = Date.now();
   return entries
@@ -39,6 +39,8 @@ interface UrlHistoryState {
   entries: Record<string, UrlHistoryEntry[]>;
   recordVisit: (projectId: string, url: string, title?: string) => void;
   updateTitle: (projectId: string, url: string, title: string) => void;
+  updateFavicon: (projectId: string, url: string, favicon: string) => void;
+  removeUrl: (projectId: string, url: string) => void;
   removeProjectHistory: (projectId: string) => void;
 }
 
@@ -87,6 +89,26 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
           const updated = [...projectEntries];
           updated[index] = { ...updated[index]!, title };
           return { entries: { ...state.entries, [projectId]: updated } };
+        }),
+
+      updateFavicon: (projectId, url, favicon) =>
+        set((state) => {
+          const projectEntries = state.entries[projectId];
+          if (!projectEntries) return state;
+          const index = projectEntries.findIndex((e) => e.url === url);
+          if (index < 0) return state;
+          const updated = [...projectEntries];
+          updated[index] = { ...updated[index]!, favicon };
+          return { entries: { ...state.entries, [projectId]: updated } };
+        }),
+
+      removeUrl: (projectId, url) =>
+        set((state) => {
+          const projectEntries = state.entries[projectId];
+          if (!projectEntries) return state;
+          const filtered = projectEntries.filter((e) => e.url !== url);
+          if (filtered.length === projectEntries.length) return state;
+          return { entries: { ...state.entries, [projectId]: filtered } };
         }),
 
       removeProjectHistory: (projectId) =>

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -93,13 +93,14 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
 
       updateFavicon: (projectId, url, favicon) =>
         set((state) => {
-          const projectEntries = state.entries[projectId];
-          if (!projectEntries) return state;
+          const projectEntries = [...(state.entries[projectId] ?? [])];
           const index = projectEntries.findIndex((e) => e.url === url);
-          if (index < 0) return state;
-          const updated = [...projectEntries];
-          updated[index] = { ...updated[index]!, favicon };
-          return { entries: { ...state.entries, [projectId]: updated } };
+          if (index >= 0) {
+            projectEntries[index] = { ...projectEntries[index]!, favicon };
+          } else {
+            projectEntries.push({ url, title: "", visitCount: 0, lastVisitAt: 0, favicon });
+          }
+          return { entries: { ...state.entries, [projectId]: projectEntries } };
         }),
 
       removeUrl: (projectId, url) =>


### PR DESCRIPTION
## Summary
- Adds favicon display to browser URL bar dropdown for quick visual identification of different localhost ports and domains
- Enables per-row history deletion with hover X buttons and Shift+Delete keyboard shortcut
- Maintains existing frecency ordering while making the dropdown more usable for day-to-day dev work

Resolves #5381

## Changes
- Extended `urlHistoryStore` to support favicon URL storage and individual entry deletion
- Updated `BrowserToolbar` to display favicons in dropdown rows with fallback favicon handling
- Added hover X buttons for mouse deletion and Shift+Delete keyboard shortcut
- Enhanced tests to cover new favicon and deletion functionality
- Fixed a few edge cases around URL bar text deletion and focus management

## Testing
- Verified favicons load correctly from page-favicon-updated events
- Tested per-row deletion via hover X and Shift+Delete keyboard shortcut
- Confirmed frecency ordering persists after deletions
- Ran existing browser tests and added new test coverage