### PR TITLE
feat(dev-preview): responsive viewport presets for mobile and tablet widths

### DIFF
--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -1,4 +1,10 @@
-import type { PanelKind, PanelLocation, TerminalType, PanelExitBehavior } from "./panel.js";
+import type {
+  PanelKind,
+  PanelLocation,
+  TerminalType,
+  PanelExitBehavior,
+  ViewportPresetId,
+} from "./panel.js";
 import type { BrowserHistory } from "./browser.js";
 import type { AgentState } from "./agent.js";
 import type { TerminalSpawnSource } from "./panel.js";
@@ -117,6 +123,8 @@ export interface DevPreviewPanelOptions extends AddPanelOptionsBase {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active viewport preset for responsive emulation (undefined = fill) */
+  viewportPreset?: ViewportPresetId;
 }
 
 /**

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -52,6 +52,7 @@ export type {
   DockMode,
   DockRenderState,
   PanelExitBehavior,
+  ViewportPresetId,
 } from "./panel.js";
 
 // Panel type guards and enums (value exports)

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -297,6 +297,9 @@ export interface NotesPanelData extends BasePanelData {
   createdAt: number;
 }
 
+/** Viewport preset IDs for dev-preview responsive emulation */
+export type ViewportPresetId = "iphone" | "pixel" | "ipad";
+
 export interface DevPreviewPanelData extends BasePanelData {
   kind: "dev-preview";
   /** Current working directory for the dev server */
@@ -321,6 +324,8 @@ export interface DevPreviewPanelData extends BasePanelData {
   devServerTerminalId?: string;
   /** Behavior when dev server exits */
   exitBehavior?: PanelExitBehavior;
+  /** Active viewport preset (undefined = fill/full-width) */
+  viewportPreset?: ViewportPresetId;
 }
 
 export type PanelInstance = PtyPanelData | BrowserPanelData | NotesPanelData | DevPreviewPanelData;
@@ -418,6 +423,8 @@ export interface TerminalInstance {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active viewport preset for dev-preview responsive emulation (undefined = fill) */
+  viewportPreset?: ViewportPresetId;
   /** Behavior when terminal exits: "keep" preserves for review, "trash" sends to trash, "remove" deletes completely */
   exitBehavior?: PanelExitBehavior;
   /** Whether this terminal has an active PTY process (false for orphaned terminals that exited) */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -6,6 +6,7 @@ import type {
   PanelLocation,
   TabGroup,
   PanelExitBehavior,
+  ViewportPresetId,
 } from "./panel.js";
 import type { CommandOverride } from "./commands.js";
 import type { EditorConfig } from "./editor.js";
@@ -86,6 +87,8 @@ export interface PanelSnapshot {
   devServerTerminalId?: string;
   /** Whether the dev-preview console drawer is open */
   devPreviewConsoleOpen?: boolean;
+  /** Active viewport preset for dev-preview responsive emulation */
+  viewportPreset?: ViewportPresetId;
   /** Path to note file (kind === 'notes') */
   notePath?: string;
   /** Note ID (kind === 'notes') */

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -12,12 +12,15 @@ import {
   Camera,
   SquareTerminal,
   Code,
+  Smartphone,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { normalizeBrowserUrl, getDisplayUrl } from "./browserUtils";
 import { actionService } from "@/services/ActionService";
 import { useUrlHistoryStore, getFrecencySuggestions } from "@/store/urlHistoryStore";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
+import type { ViewportPresetId } from "@shared/types/panel";
+import { VIEWPORT_PRESET_LIST, getViewportPreset } from "@/panels/dev-preview/viewportPresets";
 
 const ZOOM_PRESETS = [
   { value: 0.25, label: "25%" },
@@ -42,6 +45,7 @@ interface BrowserToolbarProps {
   zoomFactor?: number;
   isConsoleOpen?: boolean;
   isWebviewReady?: boolean;
+  viewportPreset?: ViewportPresetId;
   onNavigate: (url: string) => void;
   onBack: () => void;
   onForward: () => void;
@@ -52,6 +56,7 @@ interface BrowserToolbarProps {
   onCaptureScreenshot?: () => void;
   onToggleConsole?: () => void;
   onToggleDevTools?: () => void;
+  onViewportPresetChange?: (preset: ViewportPresetId | undefined) => void;
 }
 
 export function BrowserToolbar({
@@ -65,6 +70,7 @@ export function BrowserToolbar({
   zoomFactor = 1.0,
   isConsoleOpen = false,
   isWebviewReady = false,
+  viewportPreset,
   onNavigate,
   onBack,
   onForward,
@@ -75,6 +81,7 @@ export function BrowserToolbar({
   onCaptureScreenshot,
   onToggleConsole,
   onToggleDevTools,
+  onViewportPresetChange,
 }: BrowserToolbarProps) {
   const [inputValue, setInputValue] = useState(getDisplayUrl(url));
   const [isEditing, setIsEditing] = useState(false);
@@ -376,6 +383,65 @@ export function BrowserToolbar({
               <TooltipContent side="bottom">Zoom in</TooltipContent>
             </Tooltip>
           </TooltipProvider>
+        </div>
+      )}
+
+      {/* Viewport preset selector (dev-preview only) */}
+      {onViewportPresetChange && (
+        <div className="flex items-center">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (viewportPreset) {
+                      onViewportPresetChange(undefined);
+                    } else {
+                      onViewportPresetChange("iphone");
+                    }
+                  }}
+                  className={cn(
+                    buttonClass,
+                    viewportPreset && "bg-overlay-emphasis text-daintree-text"
+                  )}
+                  aria-label="Viewport preset"
+                  aria-pressed={!!viewportPreset}
+                >
+                  <Smartphone className="w-4 h-4" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {viewportPreset
+                  ? `Viewport: ${getViewportPreset(viewportPreset).label}`
+                  : "Responsive viewport"}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          {viewportPreset && (
+            <div className="flex items-center ml-0.5">
+              {VIEWPORT_PRESET_LIST.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() =>
+                    onViewportPresetChange(viewportPreset === preset.id ? undefined : preset.id)
+                  }
+                  className={cn(
+                    "px-1.5 py-1 rounded text-[10px] font-medium transition-colors",
+                    "hover:bg-overlay-medium",
+                    viewportPreset === preset.id
+                      ? "bg-overlay-emphasis text-daintree-text"
+                      : "text-daintree-text/50"
+                  )}
+                  aria-label={preset.label}
+                  aria-pressed={viewportPreset === preset.id}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -216,7 +216,7 @@ export function BrowserToolbar({
       const maxZoom = ZOOM_VALUES[ZOOM_VALUES.length - 1]!;
       const clampedZoom = Math.max(minZoom, Math.min(maxZoom, zoomFactor));
       const exactIndex = ZOOM_VALUES.findIndex((value) => Math.abs(value - clampedZoom) < 0.01);
-      let nextZoom = clampedZoom;
+      let nextZoom: number;
 
       if (exactIndex !== -1) {
         const nextIndex =

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -637,16 +637,22 @@ export function DevPreviewPane({
     const handleDomReady = () => {
       setIsWebviewReady(true);
       webview.setZoomFactor(zoomFactor);
-      if (viewportPreset) {
-        const preset = getViewportPreset(viewportPreset);
-        try {
-          const wc = (
-            webview as unknown as { getWebContents(): { setUserAgent(ua: string): void } }
-          ).getWebContents();
-          wc.setUserAgent(preset.userAgent);
-        } catch {
-          // WebContents not available yet
+      // Capture original UA before any override
+      try {
+        const wc = (
+          webview as unknown as {
+            getWebContents(): { setUserAgent(ua: string): void; getUserAgent(): string };
+          }
+        ).getWebContents();
+        if (originalUaRef.current === null) {
+          originalUaRef.current = wc.getUserAgent();
         }
+        // Apply preset UA if active
+        if (viewportPreset) {
+          wc.setUserAgent(getViewportPreset(viewportPreset).userAgent);
+        }
+      } catch {
+        // WebContents not available yet
       }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
@@ -671,16 +677,20 @@ export function DevPreviewPane({
       if (existingUrl && existingUrl !== "about:blank" && !webview.isLoading()) {
         setIsWebviewReady(true);
         webview.setZoomFactor(zoomFactor);
-        if (viewportPreset) {
-          const preset = getViewportPreset(viewportPreset);
-          try {
-            const wc = (
-              webview as unknown as { getWebContents(): { setUserAgent(ua: string): void } }
-            ).getWebContents();
-            wc.setUserAgent(preset.userAgent);
-          } catch {
-            // WebContents not available
+        try {
+          const wc = (
+            webview as unknown as {
+              getWebContents(): { setUserAgent(ua: string): void; getUserAgent(): string };
+            }
+          ).getWebContents();
+          if (originalUaRef.current === null) {
+            originalUaRef.current = wc.getUserAgent();
           }
+          if (viewportPreset) {
+            wc.setUserAgent(getViewportPreset(viewportPreset).userAgent);
+          }
+        } catch {
+          // WebContents not available
         }
       }
     } catch {
@@ -755,11 +765,16 @@ export function DevPreviewPane({
 
   useWebviewThrottle(id, location, isEvicted ? null : webviewElement, isWebviewReady && !isEvicted);
 
+  // Store the original guest UA so we can restore it when clearing a preset
+  const originalUaRef = useRef<string | null>(null);
+
   // Apply UA override when viewport preset changes on an already-ready webview
-  const prevViewportPresetRef = useRef<ViewportPresetId | undefined>(viewportPreset);
+  // Initialize to undefined so restored presets trigger the effect on first render
+  const prevViewportPresetRef = useRef<ViewportPresetId | undefined>(undefined);
   useEffect(() => {
     if (!isWebviewReady || !webviewElement) return;
     if (prevViewportPresetRef.current === viewportPreset) return;
+    const previousPreset = prevViewportPresetRef.current;
     prevViewportPresetRef.current = viewportPreset;
 
     try {
@@ -768,17 +783,23 @@ export function DevPreviewPane({
           getWebContents(): { setUserAgent(ua: string): void; getUserAgent(): string };
         }
       ).getWebContents();
+      // Capture original UA on first override
+      if (originalUaRef.current === null) {
+        originalUaRef.current = wc.getUserAgent();
+      }
       if (viewportPreset) {
         const preset = getViewportPreset(viewportPreset);
         wc.setUserAgent(preset.userAgent);
-      } else {
-        // Reset to default Chromium UA
-        const defaultUA = `Mozilla/5.0 (${navigator.platform}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${navigator.userAgent.match(/Chrome\/([\d.]+)/)?.[1] ?? "125.0.0.0"} Safari/537.36`;
-        wc.setUserAgent(defaultUA);
+      } else if (previousPreset !== undefined) {
+        // Only restore if we previously overrode (not first mount with no preset)
+        wc.setUserAgent(originalUaRef.current!);
       }
-      webviewElement.reload();
+      // Reload so the page re-evaluates with the new UA
+      if (previousPreset !== undefined) {
+        webviewElement.reload();
+      }
     } catch {
-      // WebContents not available
+      // WebContents not available (webview detached)
     }
   }, [viewportPreset, isWebviewReady, webviewElement]);
   const { currentDialog, handleDialogRespond } = useWebviewDialog(
@@ -1003,9 +1024,10 @@ export function DevPreviewPane({
             <div className={cn("h-full", viewportPreset && "flex items-start justify-center pt-5")}>
               <div
                 className={cn(
-                  "h-full relative",
-                  viewportPreset &&
-                    "rounded-lg border border-overlay/50 shadow-[var(--theme-shadow-floating)] overflow-hidden"
+                  "relative",
+                  viewportPreset
+                    ? "rounded-lg border border-overlay/50 shadow-[var(--theme-shadow-floating)] overflow-hidden"
+                    : "h-full"
                 )}
                 style={
                   viewportPreset

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -31,6 +31,8 @@ import { useWebviewDialog } from "@/hooks/useWebviewDialog";
 import { WebviewDialog } from "../Browser/WebviewDialog";
 import { FindBar } from "../Browser/FindBar";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
+import type { ViewportPresetId } from "@shared/types/panel";
 
 const scrollCache = new Map<string, { url: string; scrollY: number }>();
 
@@ -191,6 +193,7 @@ export function DevPreviewPane({
   const setBrowserHistory = usePanelStore((state) => state.setBrowserHistory);
   const setBrowserZoom = usePanelStore((state) => state.setBrowserZoom);
   const setDevPreviewConsoleOpen = usePanelStore((state) => state.setDevPreviewConsoleOpen);
+  const setViewportPreset = usePanelStore((state) => state.setViewportPreset);
   const currentProjectId = useProjectStore((state) => state.currentProject?.id);
   const projectSettings = useProjectSettingsStore((state) => state.settings);
   const projectEnv = projectSettings?.environmentVariables;
@@ -199,6 +202,7 @@ export function DevPreviewPane({
   const terminal = usePanelStore((state) => state.getTerminal(id));
   const devCommand =
     terminal?.devCommand?.trim() || projectSettings?.devServerCommand?.trim() || "";
+  const viewportPreset = terminal?.viewportPreset;
 
   const { status, url, terminalId, error, start, restart, isRestarting } = useDevServer({
     panelId: id,
@@ -470,6 +474,13 @@ export function DevPreviewPane({
     void actionService.dispatch("project.settings.open", undefined, { source: "user" });
   }, []);
 
+  const handleViewportPresetChange = useCallback(
+    (preset: ViewportPresetId | undefined) => {
+      setViewportPreset(id, preset);
+    },
+    [id, setViewportPreset]
+  );
+
   useEffect(() => {
     const webview = webviewElement;
     if (!webview) {
@@ -626,6 +637,17 @@ export function DevPreviewPane({
     const handleDomReady = () => {
       setIsWebviewReady(true);
       webview.setZoomFactor(zoomFactor);
+      if (viewportPreset) {
+        const preset = getViewportPreset(viewportPreset);
+        try {
+          const wc = (
+            webview as unknown as { getWebContents(): { setUserAgent(ua: string): void } }
+          ).getWebContents();
+          wc.setUserAgent(preset.userAgent);
+        } catch {
+          // WebContents not available yet
+        }
+      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -649,6 +671,17 @@ export function DevPreviewPane({
       if (existingUrl && existingUrl !== "about:blank" && !webview.isLoading()) {
         setIsWebviewReady(true);
         webview.setZoomFactor(zoomFactor);
+        if (viewportPreset) {
+          const preset = getViewportPreset(viewportPreset);
+          try {
+            const wc = (
+              webview as unknown as { getWebContents(): { setUserAgent(ua: string): void } }
+            ).getWebContents();
+            wc.setUserAgent(preset.userAgent);
+          } catch {
+            // WebContents not available
+          }
+        }
       }
     } catch {
       // Webview not yet attached to DOM - dom-ready handler will take over
@@ -658,7 +691,7 @@ export function DevPreviewPane({
     return () => {
       webview.removeEventListener("dom-ready", handleDomReady);
     };
-  }, [id, zoomFactor, webviewElement]);
+  }, [id, zoomFactor, webviewElement, viewportPreset]);
 
   useEffect(() => {
     if (isWebviewReady && currentUrl && currentUrl !== lastSetUrlRef.current) {
@@ -721,6 +754,33 @@ export function DevPreviewPane({
   }, [isEvicted, id]);
 
   useWebviewThrottle(id, location, isEvicted ? null : webviewElement, isWebviewReady && !isEvicted);
+
+  // Apply UA override when viewport preset changes on an already-ready webview
+  const prevViewportPresetRef = useRef<ViewportPresetId | undefined>(viewportPreset);
+  useEffect(() => {
+    if (!isWebviewReady || !webviewElement) return;
+    if (prevViewportPresetRef.current === viewportPreset) return;
+    prevViewportPresetRef.current = viewportPreset;
+
+    try {
+      const wc = (
+        webviewElement as unknown as {
+          getWebContents(): { setUserAgent(ua: string): void; getUserAgent(): string };
+        }
+      ).getWebContents();
+      if (viewportPreset) {
+        const preset = getViewportPreset(viewportPreset);
+        wc.setUserAgent(preset.userAgent);
+      } else {
+        // Reset to default Chromium UA
+        const defaultUA = `Mozilla/5.0 (${navigator.platform}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${navigator.userAgent.match(/Chrome\/([\d.]+)/)?.[1] ?? "125.0.0.0"} Safari/537.36`;
+        wc.setUserAgent(defaultUA);
+      }
+      webviewElement.reload();
+    } catch {
+      // WebContents not available
+    }
+  }, [viewportPreset, isWebviewReady, webviewElement]);
   const { currentDialog, handleDialogRespond } = useWebviewDialog(
     id,
     isEvicted ? null : webviewElement,
@@ -813,6 +873,7 @@ export function DevPreviewPane({
           canGoForward={canGoForward}
           isLoading={isLoading}
           zoomFactor={zoomFactor}
+          viewportPreset={viewportPreset}
           onNavigate={handleNavigate}
           onBack={handleBack}
           onForward={handleForward}
@@ -820,9 +881,16 @@ export function DevPreviewPane({
           onHardReload={handleHardReload}
           onOpenExternal={handleOpenExternal}
           onZoomChange={handleZoomChange}
+          onViewportPresetChange={handleViewportPresetChange}
         />
 
-        <div className="relative flex-1 min-h-0 bg-surface-canvas">
+        <div className="relative flex-1 min-h-0 bg-surface-canvas overflow-auto">
+          {viewportPreset && (
+            <div className="absolute top-1 left-1/2 -translate-x-1/2 z-10 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface/90 text-daintree-text/60 border border-overlay/50">
+              {getViewportPreset(viewportPreset).label} · {getViewportPreset(viewportPreset).width}×
+              {getViewportPreset(viewportPreset).height}
+            </div>
+          )}
           {isRestarting || status === "starting" || status === "installing" ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg">
               <Spinner size="2xl" className="text-status-info mb-4" />
@@ -932,50 +1000,69 @@ export function DevPreviewPane({
               <p className="text-xs text-daintree-text/50">Reclaimed for memory</p>
             </div>
           ) : (
-            <>
-              {webviewLoadError && (
-                <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-                  <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
-                  <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Dev Server Unreachable
-                  </h3>
-                  <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                    {webviewLoadError}
-                  </p>
-                  <Button
-                    onClick={handleHardRestart}
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
-                  >
-                    <RotateCw className="h-3.5 w-3.5" />
-                    <span className="text-xs">Hard Restart</span>
-                  </Button>
-                </div>
-              )}
-              {blockedNav && (
-                <BlockedNavBanner
-                  blockedNav={blockedNav}
-                  panelId={id}
-                  webviewElement={webviewElement}
-                  onDismiss={() => setBlockedNav(null)}
-                />
-              )}
-              {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
-              {findInPage.isOpen && <FindBar find={findInPage} />}
-              <webview
-                ref={setWebviewNode}
-                src={currentUrl}
-                partition={webviewPartition}
-                // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
-                allowpopups=""
+            <div className={cn("h-full", viewportPreset && "flex items-start justify-center pt-5")}>
+              <div
                 className={cn(
-                  "w-full h-full border-0",
-                  isDragging && "invisible pointer-events-none"
+                  "h-full relative",
+                  viewportPreset &&
+                    "rounded-lg border border-overlay/50 shadow-[var(--theme-shadow-floating)] overflow-hidden"
                 )}
-              />
-              <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
-            </>
+                style={
+                  viewportPreset
+                    ? {
+                        maxWidth: getViewportPreset(viewportPreset).width,
+                        width: "100%",
+                        aspectRatio: `${getViewportPreset(viewportPreset).width} / ${getViewportPreset(viewportPreset).height}`,
+                      }
+                    : undefined
+                }
+              >
+                <>
+                  {webviewLoadError && (
+                    <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
+                      <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
+                      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
+                        Dev Server Unreachable
+                      </h3>
+                      <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
+                        {webviewLoadError}
+                      </p>
+                      <Button
+                        onClick={handleHardRestart}
+                        variant="ghost"
+                        size="sm"
+                        className="gap-1.5 px-2.5 py-1.5 group text-daintree-accent/70 hover:text-daintree-accent"
+                      >
+                        <RotateCw className="h-3.5 w-3.5" />
+                        <span className="text-xs">Hard Restart</span>
+                      </Button>
+                    </div>
+                  )}
+                  {blockedNav && (
+                    <BlockedNavBanner
+                      blockedNav={blockedNav}
+                      panelId={id}
+                      webviewElement={webviewElement}
+                      onDismiss={() => setBlockedNav(null)}
+                    />
+                  )}
+                  {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
+                  {findInPage.isOpen && <FindBar find={findInPage} />}
+                  <webview
+                    ref={setWebviewNode}
+                    src={currentUrl}
+                    partition={webviewPartition}
+                    // @ts-expect-error React 19 requires "" to emit the attribute; boolean true is silently dropped
+                    allowpopups=""
+                    className={cn(
+                      "w-full h-full border-0",
+                      isDragging && "invisible pointer-events-none"
+                    )}
+                  />
+                  <WebviewDialog dialog={currentDialog} onRespond={handleDialogRespond} />
+                </>
+              </div>
+            </div>
           )}
         </div>
 

--- a/src/config/panelKindSerialisers.ts
+++ b/src/config/panelKindSerialisers.ts
@@ -1,4 +1,4 @@
-import type { PanelKind } from "@/types";
+import type { PanelKind, ViewportPresetId } from "@/types";
 import type { AddTerminalArgs, SavedTerminalData } from "@/utils/stateHydration/statePatcher";
 
 type PanelKindDeserializer = (saved: SavedTerminalData) => Partial<AddTerminalArgs>;
@@ -27,6 +27,7 @@ const DESERIALIZERS: Record<string, PanelKindDeserializer> = {
       browserHistory: saved.browserHistory,
       browserZoom: saved.browserZoom,
       devPreviewConsoleOpen: saved.devPreviewConsoleOpen,
+      viewportPreset: saved.viewportPreset as ViewportPresetId | undefined,
       createdAt: saved.createdAt,
     };
   },

--- a/src/panels/dev-preview/defaults.ts
+++ b/src/panels/dev-preview/defaults.ts
@@ -16,5 +16,6 @@ export function createDevPreviewDefaults(
     devServerTerminalId: options.devServerTerminalId,
     devPreviewConsoleOpen: options.devPreviewConsoleOpen,
     exitBehavior: options.exitBehavior,
+    viewportPreset: options.viewportPreset,
   };
 }

--- a/src/panels/dev-preview/index.ts
+++ b/src/panels/dev-preview/index.ts
@@ -1,2 +1,4 @@
 export { serializeDevPreview } from "./serializer";
 export { createDevPreviewDefaults } from "./defaults";
+export { VIEWPORT_PRESETS, VIEWPORT_PRESET_LIST, getViewportPreset } from "./viewportPresets";
+export type { ViewportPreset } from "./viewportPresets";

--- a/src/panels/dev-preview/serializer.ts
+++ b/src/panels/dev-preview/serializer.ts
@@ -21,6 +21,7 @@ export function serializeDevPreview(t: DevPreviewSerializeInput): Partial<PanelS
     ...(t.devPreviewConsoleOpen !== undefined && {
       devPreviewConsoleOpen: t.devPreviewConsoleOpen,
     }),
+    ...(t.viewportPreset !== undefined && { viewportPreset: t.viewportPreset }),
     ...(t.createdAt !== undefined && { createdAt: t.createdAt }),
     ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
   };

--- a/src/panels/dev-preview/viewportPresets.ts
+++ b/src/panels/dev-preview/viewportPresets.ts
@@ -1,0 +1,42 @@
+import type { ViewportPresetId } from "@shared/types/panel";
+
+export interface ViewportPreset {
+  id: ViewportPresetId;
+  label: string;
+  width: number;
+  height: number;
+  userAgent: string;
+}
+
+export const VIEWPORT_PRESETS: Record<ViewportPresetId, ViewportPreset> = {
+  iphone: {
+    id: "iphone",
+    label: "iPhone 15",
+    width: 393,
+    height: 852,
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+  },
+  pixel: {
+    id: "pixel",
+    label: "Pixel 8",
+    width: 412,
+    height: 915,
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36",
+  },
+  ipad: {
+    id: "ipad",
+    label: "iPad Air",
+    width: 820,
+    height: 1180,
+    userAgent:
+      "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+  },
+};
+
+export const VIEWPORT_PRESET_LIST: ViewportPreset[] = Object.values(VIEWPORT_PRESETS);
+
+export function getViewportPreset(id: ViewportPresetId): ViewportPreset {
+  return VIEWPORT_PRESETS[id];
+}

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -13,6 +13,7 @@ export const createBrowserActions = (
   | "setBrowserZoom"
   | "setBrowserConsoleOpen"
   | "setDevPreviewConsoleOpen"
+  | "setViewportPreset"
   | "setDevServerState"
   | "setSpawnError"
   | "clearSpawnError"
@@ -84,6 +85,22 @@ export const createBrowserActions = (
       const newById = {
         ...state.panelsById,
         [id]: { ...terminal, devPreviewConsoleOpen: isOpen },
+      };
+      saveNormalized(newById, state.panelIds);
+      return { panelsById: newById };
+    });
+  },
+
+  setViewportPreset: (id, preset) => {
+    set((state) => {
+      const terminal = state.panelsById[id];
+      if (!terminal) return state;
+      if (terminal.kind !== "dev-preview") return state;
+      if (terminal.viewportPreset === preset) return state;
+
+      const newById = {
+        ...state.panelsById,
+        [id]: { ...terminal, viewportPreset: preset },
       };
       saveNormalized(newById, state.panelIds);
       return { panelsById: newById };

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -158,6 +158,10 @@ export interface PanelRegistrySlice {
   setBrowserZoom: (id: string, zoom: number) => void;
   setBrowserConsoleOpen: (id: string, isOpen: boolean) => void;
   setDevPreviewConsoleOpen: (id: string, isOpen: boolean) => void;
+  setViewportPreset: (
+    id: string,
+    preset: import("@shared/types/panel.js").ViewportPresetId | undefined
+  ) => void;
   setDevServerState: (
     id: string,
     status: "stopped" | "starting" | "installing" | "running" | "error",

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -41,6 +41,7 @@ export interface AddTerminalArgs extends AddPanelOptionsBase {
   devServerError?: { type: string; message: string } | null;
   devServerTerminalId?: string | null;
   devPreviewConsoleOpen?: boolean;
+  viewportPreset?: string;
 }
 
 export interface SavedTerminalData {
@@ -64,6 +65,7 @@ export interface SavedTerminalData {
   createdAt?: number;
   devCommand?: string;
   devPreviewConsoleOpen?: boolean;
+  viewportPreset?: string;
   exitBehavior?: PanelExitBehavior;
   agentSessionId?: string;
   agentLaunchFlags?: string[];


### PR DESCRIPTION
## Summary
- Adds viewport preset selector to Dev Preview toolbar with iPhone (390×844), Pixel (412×915), iPad (820×1180), and Fill options
- When a preset is active, constrains the webview's rendered width via CSS frame and overrides the user-agent string to match the device
- Preset device specs ported from Puppeteer's KnownDevices registry (Apache 2.0)
- Includes persistence across panel reloads and proper aspect ratio maintenance

Resolves #5388

## Changes
- Added `viewportPresets.ts` with device definitions
- Updated `DevPreviewPane.tsx` with CSS framing logic and UA override via `webContents.setUserAgent()`
- Extended `BrowserToolbar.tsx` with preset selector UI
- Added viewport preset state to panel serialization
- Updated shared types for viewport preset options
- Fixed lint warning in browser zoom logic

## Testing
- Verified preset switching visually with dev tools open
- Confirmed UA string changes using `navigator.userAgent`
- Tested persistence across panel close/reopen
- Checked aspect ratio preservation when panel resizes