### PR TITLE
feat(dev-preview): add hard-reload action that bypasses HTTP cache

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -350,6 +350,7 @@ export const CHANNELS = {
   WEBVIEW_STOP_CONSOLE_CAPTURE: "webview:stop-console-capture",
   WEBVIEW_CLEAR_CONSOLE_CAPTURE: "webview:clear-console-capture",
   WEBVIEW_GET_CONSOLE_PROPERTIES: "webview:get-console-properties",
+  WEBVIEW_RELOAD_IGNORING_CACHE: "webview:reload-ignoring-cache",
   WEBVIEW_CONSOLE_MESSAGE: "webview:console-message",
   WEBVIEW_CONSOLE_CONTEXT_CLEARED: "webview:console-context-cleared",
 

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -780,12 +780,15 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     return { success: true };
   };
 
-  const handleReloadIgnoringCache = async (webContentsId: unknown): Promise<void> => {
-    if (typeof webContentsId !== "number") {
-      throw new Error("Invalid arguments: webContentsId must be number");
+  const handleReloadIgnoringCache = async (
+    webContentsId: unknown,
+    panelId: unknown
+  ): Promise<void> => {
+    if (typeof webContentsId !== "number" || typeof panelId !== "string") {
+      throw new Error("Invalid arguments: webContentsId must be number, panelId must be string");
     }
 
-    if (!getWebviewDialogService().getPanelId(webContentsId)) return;
+    if (getWebviewDialogService().getPanelId(webContentsId) !== panelId) return;
 
     const wc = webContents.fromId(webContentsId);
     if (!wc || wc.isDestroyed()) return;

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -780,6 +780,19 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     return { success: true };
   };
 
+  const handleReloadIgnoringCache = async (webContentsId: unknown): Promise<void> => {
+    if (typeof webContentsId !== "number") {
+      throw new Error("Invalid arguments: webContentsId must be number");
+    }
+
+    if (!getWebviewDialogService().getPanelId(webContentsId)) return;
+
+    const wc = webContents.fromId(webContentsId);
+    if (!wc || wc.isDestroyed()) return;
+
+    wc.reloadIgnoringCache();
+  };
+
   const cleanups: Array<() => void> = [
     typedHandle(CHANNELS.WEBVIEW_SET_LIFECYCLE_STATE, handleSetLifecycleState),
     typedHandle(CHANNELS.WEBVIEW_REGISTER_PANEL, handleRegisterPanel),
@@ -789,6 +802,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     typedHandle(CHANNELS.WEBVIEW_CLEAR_CONSOLE_CAPTURE, handleClearConsoleCapture),
     typedHandle(CHANNELS.WEBVIEW_GET_CONSOLE_PROPERTIES, handleGetConsoleProperties),
     typedHandle(CHANNELS.WEBVIEW_OAUTH_LOOPBACK, handleOAuthLoopback),
+    typedHandle(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, handleReloadIgnoringCache),
   ];
 
   return () => {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -867,6 +867,7 @@ const CHANNELS = {
   WEBVIEW_GET_CONSOLE_PROPERTIES: "webview:get-console-properties",
   WEBVIEW_CONSOLE_MESSAGE: "webview:console-message",
   WEBVIEW_CONSOLE_CONTEXT_CLEARED: "webview:console-context-cleared",
+  WEBVIEW_RELOAD_IGNORING_CACHE: "webview:reload-ignoring-cache",
 
   // Hibernation channels
   HIBERNATION_GET_CONFIG: "hibernation:get-config",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2360,8 +2360,8 @@ const api: ElectronAPI = {
     onConsoleContextCleared: (
       callback: (payload: { paneId: string; navigationGeneration: number }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED, callback),
-    reloadIgnoringCache: (webContentsId: number): Promise<void> =>
-      _unwrappingInvoke(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, webContentsId),
+    reloadIgnoringCache: (webContentsId: number, panelId: string): Promise<void> =>
+      _unwrappingInvoke(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, webContentsId, panelId),
   },
 
   // Hibernation API

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2360,6 +2360,8 @@ const api: ElectronAPI = {
     onConsoleContextCleared: (
       callback: (payload: { paneId: string; navigationGeneration: number }) => void
     ): (() => void) => _typedOn(CHANNELS.WEBVIEW_CONSOLE_CONTEXT_CLEARED, callback),
+    reloadIgnoringCache: (webContentsId: number): Promise<void> =>
+      _unwrappingInvoke(CHANNELS.WEBVIEW_RELOAD_IGNORING_CACHE, webContentsId),
   },
 
   // Hibernation API

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -214,6 +214,7 @@ export type BuiltInActionId =
   | "browser.toggleConsole"
   | "browser.clearConsole"
   | "browser.toggleDevTools"
+  | "browser.hardReload"
   | "nav.toggleFocusMode"
   | "nav.quickSwitcher"
   | "find.inFocusedPanel"

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -915,7 +915,7 @@ export interface ElectronAPI {
       callback: (payload: { paneId: string; navigationGeneration: number }) => void
     ): () => void;
     /** Reload a webview bypassing HTTP cache */
-    reloadIgnoringCache(webContentsId: number): Promise<void>;
+    reloadIgnoringCache(webContentsId: number, panelId: string): Promise<void>;
   };
   hibernation: {
     getConfig(): Promise<HibernationConfig>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -914,6 +914,8 @@ export interface ElectronAPI {
     onConsoleContextCleared(
       callback: (payload: { paneId: string; navigationGeneration: number }) => void
     ): () => void;
+    /** Reload a webview bypassing HTTP cache */
+    reloadIgnoringCache(webContentsId: number): Promise<void>;
   };
   hibernation: {
     getConfig(): Promise<HibernationConfig>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1868,7 +1868,7 @@ export interface IpcInvokeMap {
     result: import("./webviewConsole.js").CdpGetPropertiesResult;
   };
   "webview:reload-ignoring-cache": {
-    args: [webContentsId: number];
+    args: [webContentsId: number, panelId: string];
     result: void;
   };
 

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1867,6 +1867,10 @@ export interface IpcInvokeMap {
     args: [webContentsId: number, objectId: string];
     result: import("./webviewConsole.js").CdpGetPropertiesResult;
   };
+  "webview:reload-ignoring-cache": {
+    args: [webContentsId: number];
+    result: void;
+  };
 
   // Demo mode channels (dev-only, gated by --demo-mode flag)
   "demo:move-to": {

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -486,11 +486,11 @@ export function BrowserPane({
     if (!webview || !isWebviewReady) return;
     try {
       const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
-      void window.electron.webview.reloadIgnoringCache(wcId);
+      void window.electron.webview.reloadIgnoringCache(wcId, id);
     } catch {
       webview.reload();
     }
-  }, [isWebviewReady]);
+  }, [isWebviewReady, id]);
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -478,6 +478,20 @@ export function BrowserPane({
     }
   }, [isWebviewReady]);
 
+  const handleHardReload = useCallback(() => {
+    setBlockedNav(null);
+    setIsLoading(true);
+    setLoadError(null);
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return;
+    try {
+      const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
+      void window.electron.webview.reloadIgnoringCache(wcId);
+    } catch {
+      webview.reload();
+    }
+  }, [isWebviewReady]);
+
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
@@ -614,6 +628,15 @@ export function BrowserPane({
       }
     };
 
+    const handleHardReloadEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        handleHardReload();
+      }
+    };
+
     const controller = new AbortController();
     window.addEventListener("daintree:reload-browser", handleReloadEvent, {
       signal: controller.signal,
@@ -642,6 +665,9 @@ export function BrowserPane({
     window.addEventListener("daintree:browser-toggle-devtools", handleToggleDevToolsEvent, {
       signal: controller.signal,
     });
+    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
+      signal: controller.signal,
+    });
     return () => controller.abort();
   }, [
     id,
@@ -653,6 +679,7 @@ export function BrowserPane({
     handleToggleConsole,
     handleClearConsole,
     handleToggleDevTools,
+    handleHardReload,
   ]);
 
   // Blank the webview before React unmounts it for faster memory reclamation
@@ -712,6 +739,9 @@ export function BrowserPane({
       }
       onReload={() =>
         void actionService.dispatch("browser.reload", { terminalId: id }, { source: "user" })
+      }
+      onHardReload={() =>
+        void actionService.dispatch("browser.hardReload", { terminalId: id }, { source: "user" })
       }
       onOpenExternal={handleOpenExternal}
       onZoomChange={(factor) =>

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -46,6 +46,7 @@ interface BrowserToolbarProps {
   onBack: () => void;
   onForward: () => void;
   onReload: () => void;
+  onHardReload?: () => void;
   onOpenExternal: () => void;
   onZoomChange?: (zoomFactor: number) => void;
   onCaptureScreenshot?: () => void;
@@ -68,6 +69,7 @@ export function BrowserToolbar({
   onBack,
   onForward,
   onReload,
+  onHardReload,
   onOpenExternal,
   onZoomChange,
   onCaptureScreenshot,
@@ -293,7 +295,13 @@ export function BrowserToolbar({
           <TooltipTrigger asChild>
             <button
               type="button"
-              onClick={onReload}
+              onClick={(e) => {
+                if (e.shiftKey && onHardReload) {
+                  onHardReload();
+                } else {
+                  onReload();
+                }
+              }}
               className={cn(buttonClass, isLoading && "animate-spin")}
               aria-label="Reload"
               data-testid="browser-reload"
@@ -301,7 +309,9 @@ export function BrowserToolbar({
               <RotateCw className="w-4 h-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom">Reload</TooltipContent>
+          <TooltipContent side="bottom">
+            {onHardReload ? "Reload (Shift+click for hard reload)" : "Reload"}
+          </TooltipContent>
         </Tooltip>
       </TooltipProvider>
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -393,11 +393,11 @@ export function DevPreviewPane({
     if (!webview || !isWebviewReady) return;
     try {
       const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
-      void window.electron.webview.reloadIgnoringCache(wcId);
+      void window.electron.webview.reloadIgnoringCache(wcId, id);
     } catch {
       webview.reload();
     }
-  }, [isWebviewReady]);
+  }, [isWebviewReady, id]);
 
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -388,6 +388,17 @@ export function DevPreviewPane({
     webviewRef.current?.reload();
   }, []);
 
+  const handleHardReload = useCallback(() => {
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return;
+    try {
+      const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
+      void window.electron.webview.reloadIgnoringCache(wcId);
+    } catch {
+      webview.reload();
+    }
+  }, [isWebviewReady]);
+
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {
       window.electron.system.openExternal(currentUrl);
@@ -759,6 +770,24 @@ export function DevPreviewPane({
     return () => clearTimeout(timer);
   }, [blockedNav]);
 
+  // Listen for action-driven hard-reload events
+  useEffect(() => {
+    const handleHardReloadEvent = (e: Event) => {
+      if (!(e instanceof CustomEvent)) return;
+      const detail = e.detail as unknown;
+      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
+      if ((detail as { id: string }).id === id) {
+        handleHardReload();
+      }
+    };
+
+    const controller = new AbortController();
+    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
+      signal: controller.signal,
+    });
+    return () => controller.abort();
+  }, [id, handleHardReload]);
+
   return (
     <ContentPanel
       id={id}
@@ -788,6 +817,7 @@ export function DevPreviewPane({
           onBack={handleBack}
           onForward={handleForward}
           onReload={handleReload}
+          onHardReload={handleHardReload}
           onOpenExternal={handleOpenExternal}
           onZoomChange={handleZoomChange}
         />

--- a/src/services/actions/definitions/browserActions.ts
+++ b/src/services/actions/definitions/browserActions.ts
@@ -226,4 +226,24 @@ export function registerBrowserActions(actions: ActionRegistry, _callbacks: Acti
       );
     },
   }));
+
+  actions.set("browser.hardReload", () => ({
+    id: "browser.hardReload",
+    title: "Hard Reload Browser",
+    description: "Reload the browser panel bypassing HTTP cache",
+    category: "browser",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({ terminalId: z.string().optional() }),
+    run: async (args: unknown) => {
+      const { terminalId } = args as { terminalId?: string };
+      const targetId = terminalId ?? usePanelStore.getState().focusedId;
+      if (targetId) {
+        window.dispatchEvent(
+          new CustomEvent("daintree:hard-reload-browser", { detail: { id: targetId } })
+        );
+      }
+    },
+  }));
 }


### PR DESCRIPTION
## Summary

- Adds a Hard Reload action to Dev Preview that bypasses HTTP cache using Electron's `webContents.reloadIgnoringCache()`
- Surface via Shift+click on the reload button in the toolbar, matching Chrome's pattern
- Distinct from Hard Restart—leaves the dev server process running while clearing cached assets

## Changes

- New `browser.hardReload` action definition in `src/services/actions/definitions/browserActions.ts`
- IPC channel `WEBVIEW_RELOAD_IGNORING_CACHE` with handler in `electron/ipc/handlers/webview.ts`
- Exposed via `window.electron.webview.reloadIgnoringCache()` in preload
- Integrated into `DevPreviewPane` with `handleHardReload` callback and event listener
- Browser toolbar shift‑click detection and tooltip update in `BrowserToolbar`
- Type definitions updated across `shared/types/actions.ts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts`

## Testing

- Manual verification that Shift+click triggers cache‑bypassing reload
- Hard reload does not restart the dev server PTY process
- Works with both Dev Preview and regular browser panels
- Edge cases handled: webview not ready, missing webContentsId

Resolves #5395