### PR TITLE
feat(diagnostics): zip-wrap diagnostic bundle with pre-save review step

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -132,7 +132,7 @@
     "pipeline": 0
   },
   "src/components/Diagnostics/DiagnosticsActions.tsx": {
-    "success": 3,
+    "success": 4,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -157,6 +157,12 @@
   },
   "src/components/Diagnostics/ProblemsContent.tsx": {
     "success": 2,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/Diagnostics/TelemetryContent.tsx": {
+    "success": 4,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -354,7 +360,7 @@
     "pipeline": 0
   },
   "src/components/GitHub/GitHubResourceList.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
     "error": 2,
     "pipeline": 0
@@ -557,6 +563,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/LogLevelPalette/LogLevelPalette.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Logs/LogEntry.tsx": {
     "success": 1,
     "skip": 0,
@@ -608,7 +620,7 @@
   "src/components/Notes/NotesPane.tsx": {
     "success": 0,
     "skip": 0,
-    "error": 2,
+    "error": 1,
     "pipeline": 0
   },
   "src/components/Notes/NotesPaneSkeleton.tsx": {
@@ -929,6 +941,12 @@
     "error": 1,
     "pipeline": 0
   },
+  "src/components/Settings/DiagnosticsReviewDialog.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Settings/DockDensityPicker.tsx": {
     "success": 1,
     "skip": 0,
@@ -996,7 +1014,7 @@
     "pipeline": 0
   },
   "src/components/Settings/NotificationSettingsTab.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -1079,6 +1097,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Settings/SettingsSwitch.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Settings/SettingsSwitchCard.tsx": {
     "success": 1,
     "skip": 0,
@@ -1118,7 +1142,7 @@
   "src/components/Settings/TroubleshootingTab.tsx": {
     "success": 1,
     "skip": 0,
-    "error": 5,
+    "error": 6,
     "pipeline": 0
   },
   "src/components/Settings/VoiceInputSettingsTab.tsx": {
@@ -2387,6 +2411,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/hooks/useGitHubTokenHealth.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/hooks/useGitHubTooltip.ts": {
     "success": 0,
     "skip": 0,
@@ -2568,6 +2598,12 @@
     "pipeline": 0
   },
   "src/hooks/useProjectMruSwitcher.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/hooks/useProjectPresetsSubscription.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,

--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1133,
-  "moduleCount": 1133,
+  "count": 1416,
+  "moduleCount": 1416,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -9,6 +9,7 @@
     "electron/ipc/handlers/app/state.ts",
     "electron/ipc/handlers/appTheme.ts",
     "electron/ipc/handlers/demo.ts",
+    "electron/ipc/handlers/diagnostics.ts",
     "electron/ipc/handlers/git-write.ts",
     "electron/ipc/handlers/globalEnv.ts",
     "electron/ipc/handlers/keybinding.ts",
@@ -150,6 +151,16 @@
     {
       "file": "electron/ipc/handlers/demo.ts",
       "line": 285,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 44,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/ipc/handlers/diagnostics.ts",
+      "line": 51,
       "pattern": "sync-fs"
     },
     {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -119,6 +119,8 @@ export const CHANNELS = {
   SYSTEM_HEALTH_CHECK_SPECS: "system:health-check-specs",
   SYSTEM_CHECK_TOOL: "system:check-tool",
   SYSTEM_DOWNLOAD_DIAGNOSTICS: "system:download-diagnostics",
+  SYSTEM_COLLECT_DIAGNOSTICS_FOR_REVIEW: "system:collect-diagnostics-for-review",
+  SYSTEM_SAVE_DIAGNOSTICS_BUNDLE: "system:save-diagnostics-bundle",
   SYSTEM_GET_APP_METRICS: "system:get-app-metrics",
   SYSTEM_GET_HARDWARE_INFO: "system:get-hardware-info",
   DIAGNOSTICS_GET_PROCESS_METRICS: "diagnostics:get-process-metrics",

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -2,7 +2,7 @@ import { app, dialog, shell } from "electron";
 import os from "node:os";
 import v8 from "node:v8";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
-import { promises as fs } from "node:fs";
+import { promises as fs, createWriteStream } from "node:fs";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import archiver from "archiver";
@@ -34,7 +34,7 @@ async function writeBundleZip(zipPath: string, jsonContent: string): Promise<voi
   const logFile = getLogFilePath();
 
   return new Promise((resolve, reject) => {
-    const output = require("node:fs").createWriteStream(zipPath);
+    const output = createWriteStream(zipPath);
     const archive = archiver("zip", { zlib: { level: 6 } });
 
     output.on("close", resolve);
@@ -147,7 +147,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_HARDWARE_INFO, handleGetHardwareInfo));
 
   const handleDownloadDiagnostics = async (): Promise<boolean> => {
-    const payload = await collectDiagnosticsWithKeys(deps);
+    const { payload } = await collectDiagnosticsWithKeys(deps);
     const json = JSON.stringify(payload, null, 2);
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -180,7 +180,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   const handleSaveDiagnosticsBundle = async (
     savePayload: DiagnosticsBundleSavePayload
   ): Promise<boolean> => {
-    const { payload, sectionKeys } = await collectDiagnosticsWithKeys(deps);
+    const { payload } = await collectDiagnosticsWithKeys(deps);
     const filtered = filterSections(payload, savePayload.enabledSections);
     let json = safeStringify(filtered, 2);
     json = applyReplacements(json, savePayload.replacements as ReplacementRule[]);

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -1,8 +1,11 @@
-import { app, dialog } from "electron";
+import { app, dialog, shell } from "electron";
 import os from "node:os";
 import v8 from "node:v8";
 import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
 import { promises as fs } from "node:fs";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import archiver from "archiver";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
@@ -11,11 +14,50 @@ import type {
   ProcessMetricEntry,
   HeapStats,
   DiagnosticsInfo,
+  DiagnosticsReviewPayload,
+  DiagnosticsBundleSavePayload,
 } from "../../../shared/types/ipc/system.js";
-import { collectDiagnostics } from "../../services/DiagnosticsCollector.js";
+import { collectDiagnosticsWithKeys } from "../../services/DiagnosticsCollector.js";
+import { getLogFilePath, getLogDirectory } from "../../utils/logger.js";
+import { safeStringify } from "../../utils/safeStringify.js";
+import {
+  filterSections,
+  applyReplacements,
+  type ReplacementRule,
+} from "../../../shared/utils/diagnosticsTransform.js";
 import { typedHandle } from "../utils.js";
 
 let eventLoopHistogram: IntervalHistogram | null = null;
+
+async function writeBundleZip(zipPath: string, jsonContent: string): Promise<void> {
+  const logDir = getLogDirectory();
+  const logFile = getLogFilePath();
+
+  return new Promise((resolve, reject) => {
+    const output = require("node:fs").createWriteStream(zipPath);
+    const archive = archiver("zip", { zlib: { level: 6 } });
+
+    output.on("close", resolve);
+    archive.on("error", reject);
+
+    archive.pipe(output);
+    archive.append(jsonContent, { name: "diagnostics.json" });
+
+    if (existsSync(logFile)) {
+      archive.file(logFile, { name: "daintree.log" });
+    }
+
+    // Include rotated logs (.1 through .5)
+    for (let i = 1; i <= 5; i++) {
+      const rotated = path.join(logDir, `daintree.log.${i}`);
+      if (existsSync(rotated)) {
+        archive.file(rotated, { name: `daintree.log.${i}` });
+      }
+    }
+
+    void archive.finalize();
+  });
+}
 
 function ensureEventLoopHistogram(): IntervalHistogram {
   if (!eventLoopHistogram) {
@@ -105,7 +147,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_HARDWARE_INFO, handleGetHardwareInfo));
 
   const handleDownloadDiagnostics = async (): Promise<boolean> => {
-    const payload = await collectDiagnostics(deps);
+    const payload = await collectDiagnosticsWithKeys(deps);
     const json = JSON.stringify(payload, null, 2);
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -125,6 +167,42 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
     return true;
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_DOWNLOAD_DIAGNOSTICS, handleDownloadDiagnostics));
+
+  const handleCollectDiagnosticsForReview = async (): Promise<DiagnosticsReviewPayload> => {
+    const { payload, sectionKeys } = await collectDiagnosticsWithKeys(deps);
+    const previewJson = safeStringify(payload, 2);
+    return { payload, sectionKeys, previewJson };
+  };
+  handlers.push(
+    typedHandle(CHANNELS.SYSTEM_COLLECT_DIAGNOSTICS_FOR_REVIEW, handleCollectDiagnosticsForReview)
+  );
+
+  const handleSaveDiagnosticsBundle = async (
+    savePayload: DiagnosticsBundleSavePayload
+  ): Promise<boolean> => {
+    const { payload, sectionKeys } = await collectDiagnosticsWithKeys(deps);
+    const filtered = filterSections(payload, savePayload.enabledSections);
+    let json = safeStringify(filtered, 2);
+    json = applyReplacements(json, savePayload.replacements as ReplacementRule[]);
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
+    const dialogOpts = {
+      title: "Save Diagnostics Bundle",
+      defaultPath: `daintree-diagnostics-${timestamp}.zip`,
+      filters: [{ name: "ZIP", extensions: ["zip"] }],
+    };
+    const { filePath, canceled } = win
+      ? await dialog.showSaveDialog(win, dialogOpts)
+      : await dialog.showSaveDialog(dialogOpts);
+
+    if (canceled || !filePath) return false;
+
+    await writeBundleZip(filePath, json);
+    shell.showItemInFolder(filePath);
+    return true;
+  };
+  handlers.push(typedHandle(CHANNELS.SYSTEM_SAVE_DIAGNOSTICS_BUNDLE, handleSaveDiagnosticsBundle));
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -29,30 +29,48 @@ import { typedHandle } from "../utils.js";
 
 let eventLoopHistogram: IntervalHistogram | null = null;
 
-async function writeBundleZip(zipPath: string, jsonContent: string): Promise<void> {
+async function writeBundleZip(
+  zipPath: string,
+  jsonContent: string,
+  includeLogs: boolean,
+  replacements: ReplacementRule[]
+): Promise<void> {
   const logDir = getLogDirectory();
   const logFile = getLogFilePath();
+
+  const logEntries: Array<{ name: string; content: string }> = [];
+
+  if (includeLogs) {
+    if (existsSync(logFile)) {
+      const raw = await fs.readFile(logFile, "utf-8");
+      logEntries.push({ name: "daintree.log", content: applyReplacements(raw, replacements) });
+    }
+
+    for (let i = 1; i <= 5; i++) {
+      const rotated = path.join(logDir, `daintree.log.${i}`);
+      if (existsSync(rotated)) {
+        const raw = await fs.readFile(rotated, "utf-8");
+        logEntries.push({
+          name: `daintree.log.${i}`,
+          content: applyReplacements(raw, replacements),
+        });
+      }
+    }
+  }
 
   return new Promise((resolve, reject) => {
     const output = createWriteStream(zipPath);
     const archive = archiver("zip", { zlib: { level: 6 } });
 
     output.on("close", resolve);
+    output.on("error", reject);
     archive.on("error", reject);
 
     archive.pipe(output);
     archive.append(jsonContent, { name: "diagnostics.json" });
 
-    if (existsSync(logFile)) {
-      archive.file(logFile, { name: "daintree.log" });
-    }
-
-    // Include rotated logs (.1 through .5)
-    for (let i = 1; i <= 5; i++) {
-      const rotated = path.join(logDir, `daintree.log.${i}`);
-      if (existsSync(rotated)) {
-        archive.file(rotated, { name: `daintree.log.${i}` });
-      }
+    for (const entry of logEntries) {
+      archive.append(entry.content, { name: entry.name });
     }
 
     void archive.finalize();
@@ -180,10 +198,11 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
   const handleSaveDiagnosticsBundle = async (
     savePayload: DiagnosticsBundleSavePayload
   ): Promise<boolean> => {
-    const { payload } = await collectDiagnosticsWithKeys(deps);
-    const filtered = filterSections(payload, savePayload.enabledSections);
+    const filtered = filterSections(savePayload.payload, savePayload.enabledSections);
     let json = safeStringify(filtered, 2);
     json = applyReplacements(json, savePayload.replacements as ReplacementRule[]);
+
+    const includeLogs = savePayload.enabledSections.logs !== false;
 
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
@@ -198,7 +217,12 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
 
     if (canceled || !filePath) return false;
 
-    await writeBundleZip(filePath, json);
+    await writeBundleZip(
+      filePath,
+      json,
+      includeLogs,
+      savePayload.replacements as ReplacementRule[]
+    );
     shell.showItemInFolder(filePath);
     return true;
   };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -612,6 +612,8 @@ const CHANNELS = {
   SYSTEM_HEALTH_CHECK_SPECS: "system:health-check-specs",
   SYSTEM_CHECK_TOOL: "system:check-tool",
   SYSTEM_DOWNLOAD_DIAGNOSTICS: "system:download-diagnostics",
+  SYSTEM_COLLECT_DIAGNOSTICS_FOR_REVIEW: "system:collect-diagnostics-for-review",
+  SYSTEM_SAVE_DIAGNOSTICS_BUNDLE: "system:save-diagnostics-bundle",
   SYSTEM_GET_APP_METRICS: "system:get-app-metrics",
   SYSTEM_GET_HARDWARE_INFO: "system:get-hardware-info",
   DIAGNOSTICS_GET_PROCESS_METRICS: "diagnostics:get-process-metrics",
@@ -1546,6 +1548,13 @@ const api: ElectronAPI = {
     }) => _unwrappingInvoke(CHANNELS.SYSTEM_CHECK_TOOL, spec),
 
     downloadDiagnostics: () => _unwrappingInvoke(CHANNELS.SYSTEM_DOWNLOAD_DIAGNOSTICS),
+
+    collectDiagnosticsForReview: () =>
+      _unwrappingInvoke(CHANNELS.SYSTEM_COLLECT_DIAGNOSTICS_FOR_REVIEW),
+
+    saveDiagnosticsBundle: (
+      payload: import("../shared/types/ipc/system.js").DiagnosticsBundleSavePayload
+    ) => _unwrappingInvoke(CHANNELS.SYSTEM_SAVE_DIAGNOSTICS_BUNDLE, payload),
 
     getAppMetrics: () => _unwrappingInvoke(CHANNELS.SYSTEM_GET_APP_METRICS),
 

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -402,6 +402,13 @@ async function collectEvents(deps: HandlerDependencies) {
 }
 
 export async function collectDiagnostics(deps: HandlerDependencies): Promise<unknown> {
+  const { payload } = await collectDiagnosticsWithKeys(deps);
+  return payload;
+}
+
+export async function collectDiagnosticsWithKeys(
+  deps: HandlerDependencies
+): Promise<{ payload: Record<string, unknown>; sectionKeys: string[] }> {
   const sections = [
     { key: "metadata", fn: collectMetadata },
     { key: "runtime", fn: collectRuntime },
@@ -439,5 +446,8 @@ export async function collectDiagnostics(deps: HandlerDependencies): Promise<unk
     }
   }
 
-  return redactDeep(payload);
+  return {
+    payload: redactDeep(payload) as Record<string, unknown>,
+    sectionKeys: sections.map((s) => s.key),
+  };
 }

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -242,7 +242,7 @@ export function pruneOldLogs(basePath: string, retentionDays: number | 0): void 
   }
 }
 
-function getLogDirectory(): string {
+export function getLogDirectory(): string {
   // Priority 1: Environment variable (Utility Processes)
   if (process.env.DAINTREE_USER_DATA) {
     return join(process.env.DAINTREE_USER_DATA, "logs");

--- a/electron/utils/safeStringify.ts
+++ b/electron/utils/safeStringify.ts
@@ -1,0 +1,29 @@
+/**
+ * Safely stringify a value, handling BigInt, circular references, and other
+ * non-serializable types. For use in the main process (diagnostics, exports).
+ */
+export function safeStringify(value: unknown, space?: string | number): string {
+  const seen = new WeakSet<object>();
+
+  const replacer = (_key: string, val: unknown): unknown => {
+    if (typeof val === "bigint") return val.toString();
+    if (typeof val === "symbol") return val.toString();
+    if (typeof val === "function") return `[Function: ${val.name || "anonymous"}]`;
+    if (val instanceof Error) return { name: val.name, message: val.message, stack: val.stack };
+    if (val !== null && typeof val === "object") {
+      if (seen.has(val)) return "[Circular]";
+      seen.add(val);
+    }
+    return val;
+  };
+
+  try {
+    return JSON.stringify(value, replacer, space);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return Object.prototype.toString.call(value);
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@xterm/addon-webgl": "^0.19.0",
+        "archiver": "^7.0.1",
         "better-sqlite3": "^12.8.0",
         "copytree": "^0.14.2",
         "js-yaml": "^4.1.1",
@@ -44,6 +45,7 @@
         "@tailwindcss/vite": "^4.1.17",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
+        "@types/archiver": "^7.0.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "@types/jsdom": "^28.0.0",
@@ -3111,7 +3113,6 @@
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -3127,7 +3128,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
       "version": "6.2.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3138,12 +3138,10 @@
     },
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -3159,7 +3157,6 @@
     },
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -4166,7 +4163,6 @@
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -5881,6 +5877,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/archiver": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-7.0.0.tgz",
+      "integrity": "sha512-/3vwGwx9n+mCQdYZ2IKGGHEFL30I96UgBlk8EtRDDFQ9uxM1l4O5Ci6r00EMAkiDaTqD9DQ6nVrWRICnBPtzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/readdir-glob": "*"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
@@ -6089,6 +6095,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/readdir-glob": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/readdir-glob/-/readdir-glob-1.1.5.tgz",
+      "integrity": "sha512-raiuEPUYqXu+nvtY2Pe8s8FEmZ3x5yAH4VkLdihcPdalvsHltomrRC9BzuStrJ9yk06470hS0Crw0f1pXqD+Hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -6635,6 +6651,18 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "dev": true,
@@ -6751,7 +6779,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6759,7 +6786,6 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6955,6 +6981,206 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/tar-stream": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0"
@@ -7006,7 +7232,6 @@
     },
     "node_modules/async": {
       "version": "3.2.6",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-exit-hook": {
@@ -7067,6 +7292,20 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+      "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/babel-plugin-react-compiler": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
@@ -7091,6 +7330,97 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+      "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+      "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.1.tgz",
+      "integrity": "sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -7947,7 +8277,6 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7958,7 +8287,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -7999,6 +8327,74 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/concat-map": {
@@ -8277,9 +8673,7 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -8304,6 +8698,71 @@
       "optional": true,
       "dependencies": {
         "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/crelt": {
@@ -9455,7 +9914,6 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ee-first": {
@@ -9687,7 +10145,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -10184,6 +10641,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "dev": true,
@@ -10191,10 +10657,18 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/eventsource": {
@@ -10423,6 +10897,12 @@
       "version": "1.3.0",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -10728,7 +11208,6 @@
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -11994,6 +12473,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
       "dev": true,
@@ -12011,7 +12496,6 @@
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -12246,6 +12730,48 @@
       "version": "1.0.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -13837,7 +14363,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -14369,7 +14894,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14690,7 +15214,6 @@
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parse-cache-control": {
@@ -14799,7 +15322,6 @@
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -14814,7 +15336,6 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
@@ -15175,6 +15696,21 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -15549,6 +16085,42 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/readdirp": {
@@ -16639,6 +17211,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "license": "MIT",
@@ -16656,7 +17239,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -16670,7 +17252,6 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -16683,7 +17264,6 @@
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16691,7 +17271,6 @@
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16702,7 +17281,6 @@
     },
     "node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16710,7 +17288,6 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16748,7 +17325,6 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16995,6 +17571,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/temp": {
       "version": "0.9.4",
       "dev": true,
@@ -17038,6 +17623,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tiny-async-pool": {
@@ -18236,7 +18830,6 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -18252,7 +18845,6 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -18439,6 +19031,60 @@
     "node_modules/yoga-layout": {
       "version": "3.2.1",
       "license": "MIT"
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@xterm/addon-webgl": "^0.19.0",
+    "archiver": "^7.0.1",
     "better-sqlite3": "^12.8.0",
     "copytree": "^0.14.2",
     "js-yaml": "^4.1.1",
@@ -116,6 +117,7 @@
     "@tailwindcss/vite": "^4.1.17",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
+    "@types/archiver": "^7.0.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/js-yaml": "^4.0.9",
     "@types/jsdom": "^28.0.0",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -346,6 +346,10 @@ export interface ElectronAPI {
     getHealthCheckSpecs(agentIds?: string[]): Promise<PrerequisiteSpec[]>;
     checkTool(spec: PrerequisiteSpec): Promise<PrerequisiteCheckResult>;
     downloadDiagnostics(): Promise<boolean>;
+    collectDiagnosticsForReview(): Promise<import("./system.js").DiagnosticsReviewPayload>;
+    saveDiagnosticsBundle(
+      payload: import("./system.js").DiagnosticsBundleSavePayload
+    ): Promise<boolean>;
     getAppMetrics(): Promise<import("./system.js").AppMetricsSummary>;
     getHardwareInfo(): Promise<import("./system.js").HardwareInfo>;
     getProcessMetrics(): Promise<import("./system.js").ProcessMetricEntry[]>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -168,7 +168,12 @@ import type {
   DemoWaitForIdlePayload,
 } from "./demo.js";
 import type { BulkProjectStats } from "./project.js";
-import type { PrerequisiteSpec, PrerequisiteCheckResult } from "./system.js";
+import type {
+  PrerequisiteSpec,
+  PrerequisiteCheckResult,
+  DiagnosticsReviewPayload,
+  DiagnosticsBundleSavePayload,
+} from "./system.js";
 import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
 import type { AppAgentConfig } from "../appAgent.js";
 import type { AgentSessionRecord } from "./agentSessionHistory.js";
@@ -531,6 +536,14 @@ export interface IpcInvokeMap {
   };
   "system:download-diagnostics": {
     args: [];
+    result: boolean;
+  };
+  "system:collect-diagnostics-for-review": {
+    args: [];
+    result: DiagnosticsReviewPayload;
+  };
+  "system:save-diagnostics-bundle": {
+    args: [DiagnosticsBundleSavePayload];
     result: boolean;
   };
   "system:get-app-metrics": {

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -209,6 +209,24 @@ export interface DiagnosticsInfo {
   eventLoopP99Ms: number;
 }
 
+/** Payload returned by the review collection IPC. */
+export interface DiagnosticsReviewPayload {
+  /** Raw diagnostic data (keyed by section). */
+  payload: Record<string, unknown>;
+  /** Ordered section keys for the review dialog. */
+  sectionKeys: string[];
+  /** Safe-stringified JSON preview (already redacted). */
+  previewJson: string;
+}
+
+/** User selections sent to the save-bundle IPC. */
+export interface DiagnosticsBundleSavePayload {
+  /** Sections the user chose to include. */
+  enabledSections: Record<string, boolean>;
+  /** Find-and-replace redaction rules. */
+  replacements: Array<{ find: string; replace: string }>;
+}
+
 /** Payload for starting an agent install via setup wizard */
 export interface AgentInstallPayload {
   agentId: string;

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -221,6 +221,8 @@ export interface DiagnosticsReviewPayload {
 
 /** User selections sent to the save-bundle IPC. */
 export interface DiagnosticsBundleSavePayload {
+  /** The reviewed and filtered payload (what the user saw in preview). */
+  payload: Record<string, unknown>;
   /** Sections the user chose to include. */
   enabledSections: Record<string, boolean>;
   /** Find-and-replace redaction rules. */

--- a/shared/utils/diagnosticsTransform.ts
+++ b/shared/utils/diagnosticsTransform.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure transform utilities for diagnostic bundles. Used by both renderer
+ * (preview) and main process (final save) so the preview always matches the
+ * saved output.
+ */
+
+export interface ReplacementRule {
+  find: string;
+  replace: string;
+}
+
+/** Remove unchecked sections from the payload. */
+export function filterSections(
+  payload: Record<string, unknown>,
+  enabledSections: Record<string, boolean>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (enabledSections[key] !== false) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/** Apply find-and-replace redactions to a JSON string. */
+export function applyReplacements(json: string, rules: ReplacementRule[]): string {
+  let out = json;
+  for (const { find, replace } of rules) {
+    if (!find) continue;
+    try {
+      out = out.split(find).join(replace);
+    } catch {
+      // Skip invalid replacements
+    }
+  }
+  return out;
+}
+
+/** Section metadata for the review dialog. */
+export interface DiagnosticSectionMeta {
+  key: string;
+  label: string;
+}
+
+/** Human-readable labels for the twelve diagnostic sections. */
+export const SECTION_LABELS: Record<string, string> = {
+  metadata: "Metadata",
+  runtime: "Runtime",
+  os: "Operating System",
+  display: "Display",
+  gpu: "GPU",
+  process: "Process",
+  tools: "Tools",
+  git: "Git",
+  config: "Configuration",
+  terminals: "Terminals",
+  logs: "Logs",
+  events: "Events",
+};

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -61,6 +61,18 @@ export const systemClient = {
     return window.electron.system.downloadDiagnostics();
   },
 
+  collectDiagnosticsForReview: (): Promise<
+    import("@shared/types/ipc/system").DiagnosticsReviewPayload
+  > => {
+    return window.electron.system.collectDiagnosticsForReview();
+  },
+
+  saveDiagnosticsBundle: (
+    payload: import("@shared/types/ipc/system").DiagnosticsBundleSavePayload
+  ): Promise<boolean> => {
+    return window.electron.system.saveDiagnosticsBundle(payload);
+  },
+
   getAppMetrics: (): ReturnType<typeof window.electron.system.getAppMetrics> => {
     return window.electron.system.getAppMetrics();
   },

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -1,0 +1,234 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { Button } from "@/components/ui/button";
+import { CheckIcon, Download, Eye, Replace } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  SECTION_LABELS,
+  filterSections,
+  applyReplacements,
+  type ReplacementRule,
+} from "@shared/utils/diagnosticsTransform";
+import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
+import { safeStringify } from "@/lib/safeStringify";
+
+interface DiagnosticsReviewDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  reviewPayload: DiagnosticsReviewPayload | null;
+  onSave: (enabledSections: Record<string, boolean>, replacements: ReplacementRule[]) => void;
+  isSaving: boolean;
+}
+
+export function DiagnosticsReviewDialog({
+  isOpen,
+  onClose,
+  reviewPayload,
+  onSave,
+  isSaving,
+}: DiagnosticsReviewDialogProps) {
+  const [enabledSections, setEnabledSections] = useState<Record<string, boolean>>({});
+  const [replacements, setReplacements] = useState<ReplacementRule[]>([
+    { find: "", replace: "[REDACTED]" },
+  ]);
+  const [showPreview, setShowPreview] = useState(false);
+
+  useEffect(() => {
+    if (isOpen && reviewPayload) {
+      const initial: Record<string, boolean> = {};
+      for (const key of reviewPayload.sectionKeys) {
+        initial[key] = true;
+      }
+      setEnabledSections(initial);
+      setReplacements([{ find: "", replace: "[REDACTED]" }]);
+      setShowPreview(false);
+    }
+  }, [isOpen, reviewPayload]);
+
+  const previewJson = useMemo(() => {
+    if (!reviewPayload) return "";
+    const filtered = filterSections(reviewPayload.payload, enabledSections);
+    let json = safeStringify(filtered, 2);
+    json = applyReplacements(
+      json,
+      replacements.filter((r) => r.find)
+    );
+    return json;
+  }, [reviewPayload, enabledSections, replacements]);
+
+  const toggleSection = useCallback((key: string) => {
+    setEnabledSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const addReplacement = useCallback(() => {
+    setReplacements((prev) => [...prev, { find: "", replace: "[REDACTED]" }]);
+  }, []);
+
+  const updateReplacement = useCallback(
+    (index: number, field: "find" | "replace", value: string) => {
+      setReplacements((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+    },
+    []
+  );
+
+  const removeReplacement = useCallback((index: number) => {
+    setReplacements((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleSave = useCallback(() => {
+    onSave(
+      enabledSections,
+      replacements.filter((r) => r.find)
+    );
+  }, [enabledSections, replacements, onSave]);
+
+  const allEnabled = reviewPayload
+    ? reviewPayload.sectionKeys.every((k) => enabledSections[k])
+    : false;
+
+  const toggleAll = useCallback(() => {
+    if (!reviewPayload) return;
+    const newState = !allEnabled;
+    const updated: Record<string, boolean> = {};
+    for (const key of reviewPayload.sectionKeys) {
+      updated[key] = newState;
+    }
+    setEnabledSections(updated);
+  }, [reviewPayload, allEnabled]);
+
+  if (!reviewPayload) return null;
+
+  return (
+    <AppDialog isOpen={isOpen} onClose={onClose} size="lg" data-testid="diagnostics-review-dialog">
+      <AppDialog.Header>
+        <AppDialog.Title icon={<Download className="w-5 h-5" />}>
+          Review Diagnostics
+        </AppDialog.Title>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <AppDialog.Body className="space-y-4">
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <h4 className="text-sm font-medium text-daintree-text">Sections</h4>
+            <Button variant="ghost" size="sm" onClick={toggleAll} className="text-xs h-6 px-2">
+              {allEnabled ? "Deselect All" : "Select All"}
+            </Button>
+          </div>
+          <div className="grid grid-cols-2 gap-1.5">
+            {reviewPayload.sectionKeys.map((key) => (
+              <label
+                key={key}
+                className={cn(
+                  "flex items-center gap-2 px-2.5 py-1.5 rounded border text-xs cursor-pointer transition-colors",
+                  enabledSections[key]
+                    ? "border-daintree-border bg-daintree-bg/50 text-daintree-text"
+                    : "border-daintree-border/40 bg-transparent text-daintree-text/40 line-through"
+                )}
+              >
+                <CheckboxPrimitive.Root
+                  checked={enabledSections[key]}
+                  onCheckedChange={() => toggleSection(key)}
+                  className={cn(
+                    "flex shrink-0 w-3.5 h-3.5 rounded border transition-colors",
+                    "bg-daintree-bg border-border-strong",
+                    "data-[state=checked]:bg-daintree-accent data-[state=checked]:border-daintree-accent",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                  )}
+                >
+                  <CheckboxPrimitive.Indicator className="flex items-center justify-center text-text-inverse">
+                    <CheckIcon className="w-2.5 h-2.5" />
+                  </CheckboxPrimitive.Indicator>
+                </CheckboxPrimitive.Root>
+                {SECTION_LABELS[key] ?? key}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <h4 className="text-sm font-medium text-daintree-text flex items-center gap-1.5">
+              <Replace className="w-3.5 h-3.5" />
+              Find &amp; Replace
+            </h4>
+            <Button variant="ghost" size="sm" onClick={addReplacement} className="text-xs h-6 px-2">
+              Add Rule
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {replacements.map((rule, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={rule.find}
+                  onChange={(e) => updateReplacement(i, "find", e.target.value)}
+                  placeholder="Find text"
+                  className={cn(
+                    "h-7 text-xs flex-1 px-2 rounded border border-daintree-border bg-daintree-bg",
+                    "text-daintree-text placeholder:text-daintree-text/30",
+                    "focus:outline-none focus:border-daintree-accent"
+                  )}
+                />
+                <span className="text-daintree-text/40 text-xs">→</span>
+                <input
+                  type="text"
+                  value={rule.replace}
+                  onChange={(e) => updateReplacement(i, "replace", e.target.value)}
+                  placeholder="Replace with"
+                  className={cn(
+                    "h-7 text-xs flex-1 px-2 rounded border border-daintree-border bg-daintree-bg",
+                    "text-daintree-text placeholder:text-daintree-text/30",
+                    "focus:outline-none focus:border-daintree-accent"
+                  )}
+                />
+                {replacements.length > 1 && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeReplacement(i)}
+                    className="text-xs h-7 px-1.5 text-daintree-text/40 hover:text-status-error"
+                  >
+                    ×
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowPreview(!showPreview)}
+            className="text-xs flex items-center gap-1.5 mb-2"
+          >
+            <Eye className="w-3.5 h-3.5" />
+            {showPreview ? "Hide Preview" : "Show Preview"}
+          </Button>
+          {showPreview && (
+            <pre className="text-[10px] leading-relaxed font-mono bg-daintree-bg border border-daintree-border rounded p-3 max-h-64 overflow-auto text-daintree-text/80 whitespace-pre-wrap break-all">
+              {previewJson}
+            </pre>
+          )}
+        </div>
+      </AppDialog.Body>
+
+      <AppDialog.Footer
+        primaryAction={{
+          label: isSaving ? "Saving..." : "Save Bundle",
+          onClick: handleSave,
+          disabled: isSaving,
+          loading: isSaving,
+          intent: "default",
+        }}
+        secondaryAction={{
+          label: "Cancel",
+          onClick: onClose,
+        }}
+      />
+    </AppDialog>
+  );
+}

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -16,9 +16,12 @@ import {
 import { cn } from "@/lib/utils";
 import { appClient, systemClient, logsClient } from "@/clients";
 import type { AppState, SystemHealthCheckResult } from "@shared/types";
+import type { DiagnosticsReviewPayload } from "@shared/types/ipc/system";
+import type { ReplacementRule } from "@shared/utils/diagnosticsTransform";
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { DiagnosticsReviewDialog } from "./DiagnosticsReviewDialog";
 
 function SystemHealthSection() {
   const [result, setResult] = useState<SystemHealthCheckResult | null>(null);
@@ -87,20 +90,40 @@ function SystemHealthSection() {
 }
 
 function DownloadDiagnosticsSection() {
-  const [isDownloading, setIsDownloading] = useState(false);
+  const [isCollecting, setIsCollecting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [reviewPayload, setReviewPayload] = useState<DiagnosticsReviewPayload | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
 
-  const handleDownload = useCallback(async () => {
-    setIsDownloading(true);
+  const handleOpenReview = useCallback(async () => {
+    setIsCollecting(true);
     setDownloadError(null);
     try {
-      await systemClient.downloadDiagnostics();
+      const payload = await systemClient.collectDiagnosticsForReview();
+      setReviewPayload(payload);
+      setReviewOpen(true);
     } catch (err) {
-      setDownloadError(err instanceof Error ? err.message : "Failed to download diagnostics");
+      setDownloadError(err instanceof Error ? err.message : "Failed to collect diagnostics");
     } finally {
-      setIsDownloading(false);
+      setIsCollecting(false);
     }
   }, []);
+
+  const handleSave = useCallback(
+    async (enabledSections: Record<string, boolean>, replacements: ReplacementRule[]) => {
+      setIsSaving(true);
+      try {
+        await systemClient.saveDiagnosticsBundle({ enabledSections, replacements });
+        setReviewOpen(false);
+      } catch (err) {
+        setDownloadError(err instanceof Error ? err.message : "Failed to save diagnostics bundle");
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    []
+  );
 
   return (
     <SettingsSection
@@ -111,14 +134,21 @@ function DownloadDiagnosticsSection() {
       <Button
         variant="outline"
         size="sm"
-        onClick={() => void handleDownload()}
-        disabled={isDownloading}
+        onClick={() => void handleOpenReview()}
+        disabled={isCollecting}
         className="text-daintree-text border-daintree-border hover:bg-daintree-border hover:text-daintree-text mb-3"
       >
-        <Download className={cn("w-4 h-4", isDownloading && "animate-spin")} />
-        {isDownloading ? "Collecting..." : "Download Diagnostics"}
+        <Download className={cn("w-4 h-4", isCollecting && "animate-spin")} />
+        {isCollecting ? "Collecting..." : "Download Diagnostics"}
       </Button>
       {downloadError && <p className="text-xs text-status-error mb-3">{downloadError}</p>}
+      <DiagnosticsReviewDialog
+        isOpen={reviewOpen}
+        onClose={() => setReviewOpen(false)}
+        reviewPayload={reviewPayload}
+        onSave={handleSave}
+        isSaving={isSaving}
+      />
     </SettingsSection>
   );
 }

--- a/src/components/Settings/TroubleshootingTab.tsx
+++ b/src/components/Settings/TroubleshootingTab.tsx
@@ -114,15 +114,22 @@ function DownloadDiagnosticsSection() {
     async (enabledSections: Record<string, boolean>, replacements: ReplacementRule[]) => {
       setIsSaving(true);
       try {
-        await systemClient.saveDiagnosticsBundle({ enabledSections, replacements });
-        setReviewOpen(false);
+        const payload = reviewPayload?.payload ?? {};
+        const saved = await systemClient.saveDiagnosticsBundle({
+          payload,
+          enabledSections,
+          replacements,
+        });
+        if (saved) {
+          setReviewOpen(false);
+        }
       } catch (err) {
         setDownloadError(err instanceof Error ? err.message : "Failed to save diagnostics bundle");
       } finally {
         setIsSaving(false);
       }
     },
-    []
+    [reviewPayload]
   );
 
   return (


### PR DESCRIPTION
## Summary
- Replaces single JSON export with a zip archive containing both the sanitised diagnostics JSON and the live log file
- Adds a pre-save review modal showing all sections with per‑section checkboxes, a plaintext JSON preview, and a find‑and‑replace field for last‑mile redaction
- Opens the saved zip location via `shell.showItemInFolder` so users can verify before attaching to issues or support tickets

Resolves #5428

## Changes
- **DiagnosticsCollector.ts**: Switches from writing JSON directly to creating a zip archive via `archiver`, includes the live log file alongside the JSON
- **TroubleshootingTab.tsx**: Updates UI flow to collect diagnostics, open the review modal, then save after review
- **DiagnosticsReviewDialog.tsx**: New component providing section‑by‑section review, JSON preview, and redaction controls
- **IPC channels**: Adds `system:diagnostics:collect`, `system:diagnostics:review`, `system:diagnostics:save` with proper type safety in preload and maps
- **safeStringify.ts**: New utility for safe JSON serialisation with circular reference handling and configurable redaction
- **diagnosticsTransform.ts**: Shared transformation logic for redacting secrets from logs before bundling

## Testing
- Verified zip creation includes both `diagnostics.json` and `daintree.log`
- Confirmed the review modal shows all twelve sections, checkboxes work, and redactions apply before save
- Tested cancel flow returns to the Troubleshooting tab without saving
- Ensured IPC type safety with new channels added to `IpcInvokeMap`
- Manual validation of the saved zip opens in Finder/Explorer via `shell.showItemInFolder`