### PR TITLE
fix(worktree): surface manual restart after workspace host fatal crash

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -22,6 +22,7 @@ export const CHANNELS = {
   WORKTREE_GET_ISSUE_ASSOCIATION: "worktree:get-issue-association",
   WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS: "worktree:get-all-issue-associations",
   WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
+  WORKTREE_RESTART_SERVICE: "worktree:restart-service",
 
   TERMINAL_SPAWN: "terminal:spawn",
   TERMINAL_SPAWN_RESULT: "terminal:spawn-result",

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -63,6 +63,21 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
   };
   handlers.push(typedHandle(CHANNELS.WORKTREE_CREATE, handleWorktreeCreate));
 
+  const handleWorktreeRestartService = async (ctx: IpcContext): Promise<void> => {
+    if (!deps.worktreeService) return;
+    const windowId = ctx.senderWindow?.id;
+    if (windowId === undefined) {
+      console.warn(
+        "[worktree.restart-service] No sender window; cannot route manual restart to a host"
+      );
+      return;
+    }
+    deps.worktreeService.manualRestartForWindow(windowId);
+  };
+  handlers.push(
+    typedHandleWithContext(CHANNELS.WORKTREE_RESTART_SERVICE, handleWorktreeRestartService)
+  );
+
   const handleWorktreeDelete = async (ctx: IpcContext, payload: WorktreeDeletePayload) => {
     checkRateLimit(CHANNELS.WORKTREE_DELETE, 10, 10_000);
     if (!deps.worktreeService) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -508,6 +508,7 @@ const CHANNELS = {
   WORKTREE_GET_ISSUE_ASSOCIATION: "worktree:get-issue-association",
   WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS: "worktree:get-all-issue-associations",
   WORKTREE_HOST_DISCONNECTED: "worktree:host-disconnected",
+  WORKTREE_RESTART_SERVICE: "worktree:restart-service",
 
   // Terminal channels
   TERMINAL_SPAWN: "terminal:spawn",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1207,6 +1207,8 @@ const api: ElectronAPI = {
     getAllIssueAssociations: (): Promise<Record<string, IssueAssociation>> =>
       _unwrappingInvoke(CHANNELS.WORKTREE_GET_ALL_ISSUE_ASSOCIATIONS),
 
+    restartService: (): Promise<void> => _unwrappingInvoke(CHANNELS.WORKTREE_RESTART_SERVICE),
+
     onUpdate: (callback: (state: WorktreeState) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: { worktree: WorktreeState }) =>
         callback(payload.worktree);

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -884,6 +884,27 @@ export class WorkspaceClient extends EventEmitter {
     this.releaseWindow(windowId);
   }
 
+  /**
+   * User-initiated restart of the workspace host for a window's project after
+   * the auto-restart budget was exhausted. Resolves the host via the existing
+   * entry (kept alive after a fatal crash) and re-spawns its child process.
+   * The existing `"restarted"` listener in `wireHostEvents` drives
+   * `reloadProjectAfterRestart` so ports re-broker and worktree state refreshes.
+   */
+  manualRestartForWindow(windowId: number): void {
+    if (this.isDisposed) return;
+
+    const entry = this.resolveEntryForWindow(windowId);
+    if (!entry) {
+      console.warn(
+        `[WorkspaceClient] No entry for window ${windowId}; cannot manual-restart workspace host`
+      );
+      return;
+    }
+
+    entry.host.manualRestart();
+  }
+
   async listBranches(rootPath: string): Promise<BranchInfo[]> {
     const host = this.resolveHostForPath(rootPath);
     if (!host) return [];

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -241,7 +241,15 @@ export class WorkspaceHostProcess extends EventEmitter {
 
     console.log(`[WorkspaceHost:${this.serviceName}] Manual restart initiated`);
     this.startHost();
-    this.emit("restarted");
+
+    // Only signal "restarted" when the fork actually produced a child —
+    // `startHost()` emits `host-crash` on fork failure and leaves `child`
+    // null; emitting `restarted` in that case would poison
+    // `reloadProjectAfterRestart` by awaiting a `waitForReady()` that will
+    // never resolve.
+    if (this.child !== null) {
+      this.emit("restarted");
+    }
   }
 
   dispose(): void {

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -212,6 +212,38 @@ export class WorkspaceHostProcess extends EventEmitter {
     }, 5000);
   }
 
+  /**
+   * Restart the host after its auto-restart budget has been exhausted.
+   * Resets `restartAttempts` so future crashes get a fresh budget, respawns
+   * the child, and emits `"restarted"` so `WorkspaceClient` can re-broker
+   * ports and reload the project — the auto-restart path emits this from
+   * its `setTimeout` callback which `manualRestart()` bypasses.
+   */
+  manualRestart(): void {
+    if (this.isDisposed) {
+      console.warn(`[WorkspaceHost:${this.serviceName}] Cannot manual restart - already disposed`);
+      return;
+    }
+
+    if (this.child !== null) {
+      console.warn(
+        `[WorkspaceHost:${this.serviceName}] Cannot manual restart - host process already exists`
+      );
+      return;
+    }
+
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+
+    this.restartAttempts = 0;
+
+    console.log(`[WorkspaceHost:${this.serviceName}] Manual restart initiated`);
+    this.startHost();
+    this.emit("restarted");
+  }
+
   dispose(): void {
     if (this.isDisposed) return;
     this.isDisposed = true;

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -52,6 +52,12 @@ const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
       this._isDisposed = true;
     });
 
+    manualRestart = vi.fn(() => {
+      // Emulate the real host: a manual restart emits "restarted" so
+      // `WorkspaceClient` runs reloadProjectAfterRestart.
+      this.emit("restarted");
+    });
+
     setLogLevelOverrides = vi.fn();
 
     // Test helpers
@@ -829,6 +835,41 @@ describe("WorkspaceClient multi-process manager", () => {
         .getAllRequests()
         .filter((r: any) => r.type === "load-project")[1];
       expect(reloadReq.rootPath).toBe(path.resolve("/project-a"));
+    });
+  });
+
+  describe("manualRestartForWindow", () => {
+    it("resolves the window's host and invokes manualRestart", async () => {
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+
+      client.manualRestartForWindow(1);
+
+      expect(h(0).manualRestart).toHaveBeenCalledTimes(1);
+    });
+
+    it("triggers reloadProjectAfterRestart via the emitted 'restarted' event", async () => {
+      const load = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load;
+
+      client.manualRestartForWindow(1);
+
+      // The mock's manualRestart() emits "restarted"; the real
+      // WorkspaceClient listener should enqueue a fresh load-project.
+      await vi.waitFor(() => {
+        const reqs = h(0)
+          .getAllRequests()
+          .filter((r: any) => r.type === "load-project");
+        expect(reqs).toHaveLength(2);
+      });
+    });
+
+    it("no-ops when the window has no associated project", () => {
+      // No loadProject — window is not tracked.
+      expect(() => client.manualRestartForWindow(999)).not.toThrow();
+      expect(mockHosts).toHaveLength(0);
     });
   });
 

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -139,6 +139,7 @@ export type BuiltInActionId =
   | "telemetry.clearPreview"
   | "worktree.refresh"
   | "worktree.refreshPullRequests"
+  | "worktree.restartService"
   | "worktree.setActive"
   | "worktree.create"
   | "worktree.delete"

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -215,6 +215,7 @@ export interface ElectronAPI {
     detachIssue(worktreeId: string): Promise<void>;
     getIssueAssociation(worktreeId: string): Promise<IssueAssociation | null>;
     getAllIssueAssociations(): Promise<Record<string, IssueAssociation>>;
+    restartService(): Promise<void>;
     onUpdate(callback: (state: WorktreeState) => void): () => void;
     onRemove(callback: (data: { worktreeId: string }) => void): () => void;
     onActivated(callback: (data: { worktreeId: string }) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -309,6 +309,10 @@ export interface IpcInvokeMap {
     args: [];
     result: Record<string, IssueAssociation>;
   };
+  "worktree:restart-service": {
+    args: [];
+    result: void;
+  };
 
   // Terminal channels
   "terminal:spawn": {

--- a/src/clients/worktreeClient.ts
+++ b/src/clients/worktreeClient.ts
@@ -85,6 +85,10 @@ export const worktreeClient = {
     return window.electron.worktree.getAllIssueAssociations();
   },
 
+  restartService: (): Promise<void> => {
+    return window.electron.worktree.restartService();
+  },
+
   onRemove: (callback: (data: { worktreeId: string }) => void): (() => void) => {
     return window.electron.worktree.onRemove(callback);
   },

--- a/src/components/Fleet/__tests__/FleetComposer.test.tsx
+++ b/src/components/Fleet/__tests__/FleetComposer.test.tsx
@@ -70,6 +70,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     applyRemove: () => {},
     setLoading: () => {},
     setError: () => {},
+    setFatalError: () => {},
     setReconnecting: () => {},
   }));
   setCurrentViewStore(store);

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -81,6 +81,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     applyRemove: () => {},
     setLoading: () => {},
     setError: () => {},
+    setFatalError: () => {},
     setReconnecting: () => {},
   }));
   setCurrentViewStore(store);

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -810,10 +810,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <div className="px-4 py-4">
           <div className="text-[var(--color-status-error)] text-sm mb-2">{error}</div>
           <button
-            onClick={refresh}
+            onClick={() => {
+              void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
+            }}
             className="text-xs px-2 py-1 border border-divider rounded hover:bg-tint/[0.06] text-daintree-text"
           >
-            Retry
+            Restart Service
           </button>
         </div>
       </div>

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -282,12 +282,16 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
 
     // If the host exhausts its restart budget, no replacement port will
     // arrive — transition to a terminal error state instead of leaving the
-    // spinner stuck indefinitely.
+    // spinner stuck indefinitely.  `setFatalError` also resets
+    // `isInitialized` so a successful manual restart re-hydrates as a cold
+    // fetch rather than a silent wake refresh.
     cleanups.push(
       worktreePort.onFatalDisconnect(() => {
-        const state = store.getState();
-        state.setReconnecting(false);
-        state.setError("Workspace host crashed and could not recover. Please restart Daintree.");
+        store
+          .getState()
+          .setFatalError(
+            "Workspace service crashed and could not recover automatically. Restart the service to reconnect."
+          );
       })
     );
 

--- a/src/services/actions/definitions/worktreeActions.ts
+++ b/src/services/actions/definitions/worktreeActions.ts
@@ -107,6 +107,21 @@ export function registerWorktreeActions(actions: ActionRegistry, callbacks: Acti
     },
   }));
 
+  actions.set("worktree.restartService", () => ({
+    id: "worktree.restartService",
+    title: "Restart Workspace Service",
+    description:
+      "Restart the workspace host. Available after the service has crashed and could not recover automatically.",
+    category: "worktree",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    isEnabled: () => getCurrentViewStore().getState().error !== null,
+    run: async () => {
+      await worktreeClient.restartService();
+    },
+  }));
+
   actions.set("worktree.setActive", () =>
     defineAction({
       id: "worktree.setActive",

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -98,6 +98,22 @@ describe("createWorktreeStore — fatal error state", () => {
     expect(store.getState().isInitialized).toBe(false);
   });
 
+  it("setFatalError clears isLoading so the error UI surfaces before first hydration", () => {
+    // If the host exhausts its restart budget before the first snapshot
+    // ever arrives, `isLoading` is still `true` and `worktrees` is empty.
+    // `SidebarContent` checks `isLoading && worktrees.length === 0` BEFORE
+    // the error branch — so without clearing `isLoading`, the Restart
+    // Service button would never appear.
+    const store = createWorktreeStore();
+    expect(store.getState().isLoading).toBe(true);
+    expect(store.getState().worktrees.size).toBe(0);
+
+    store.getState().setFatalError("host crashed before first fetch");
+
+    expect(store.getState().isLoading).toBe(false);
+    expect(store.getState().error).toBe("host crashed before first fetch");
+  });
+
   it("applySnapshot after setFatalError clears error and restores isInitialized", () => {
     const store = createWorktreeStore();
     store.getState().setFatalError("host crashed");

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -78,3 +78,37 @@ describe("createWorktreeStore — reconnecting state", () => {
     expect(store.getState().isReconnecting).toBe(false);
   });
 });
+
+describe("createWorktreeStore — fatal error state", () => {
+  it("setFatalError sets error, clears isReconnecting, and resets isInitialized", () => {
+    const store = createWorktreeStore();
+
+    // Simulate a fully-hydrated store before the host crashes
+    const v1 = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], v1);
+    store.getState().setReconnecting(true);
+    expect(store.getState().isInitialized).toBe(true);
+
+    store.getState().setFatalError("host crashed");
+
+    expect(store.getState().error).toBe("host crashed");
+    expect(store.getState().isReconnecting).toBe(false);
+    // isInitialized must be reset so the next fetch is treated as a cold
+    // start, not a silent wake refresh (which swallows fetch errors).
+    expect(store.getState().isInitialized).toBe(false);
+  });
+
+  it("applySnapshot after setFatalError clears error and restores isInitialized", () => {
+    const store = createWorktreeStore();
+    store.getState().setFatalError("host crashed");
+    expect(store.getState().error).toBe("host crashed");
+    expect(store.getState().isInitialized).toBe(false);
+
+    const version = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], version);
+
+    expect(store.getState().error).toBeNull();
+    expect(store.getState().isInitialized).toBe(true);
+    expect(store.getState().worktrees.size).toBe(1);
+  });
+});

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -34,6 +34,7 @@ export interface WorktreeViewActions {
   applyRemove(worktreeId: string, version: number): void;
   setLoading(loading: boolean): void;
   setError(error: string | null): void;
+  setFatalError(message: string): void;
   setReconnecting(reconnecting: boolean): void;
 }
 
@@ -99,6 +100,14 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
     setError(error: string | null) {
       set({ error });
+    },
+
+    setFatalError(message: string) {
+      // Clear `isInitialized` alongside setting the error so the next
+      // `fetchInitialState` treats the post-restart fetch as a cold start
+      // instead of a silent wake refresh — otherwise fetch errors on the
+      // restarted host would be swallowed.
+      set({ error: message, isInitialized: false, isReconnecting: false });
     },
 
     setReconnecting(reconnecting: boolean) {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -103,11 +103,19 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     },
 
     setFatalError(message: string) {
-      // Clear `isInitialized` alongside setting the error so the next
-      // `fetchInitialState` treats the post-restart fetch as a cold start
-      // instead of a silent wake refresh — otherwise fetch errors on the
-      // restarted host would be swallowed.
-      set({ error: message, isInitialized: false, isReconnecting: false });
+      // Also clear `isLoading` so the sidebar renders the error branch (and
+      // its Restart Service button) even when the host crashes before the
+      // first snapshot hydrates — otherwise `SidebarContent` keeps showing
+      // "Loading worktrees…" and the restart action is never surfaced.
+      // `isInitialized` is reset so the next `fetchInitialState` treats the
+      // post-restart fetch as a cold start rather than a silent wake refresh
+      // (which swallows fetch errors).
+      set({
+        error: message,
+        isInitialized: false,
+        isReconnecting: false,
+        isLoading: false,
+      });
     },
 
     setReconnecting(reconnecting: boolean) {


### PR DESCRIPTION
## Summary

- When the workspace host exhausts its restart budget, the sidebar now shows a "Restart Service" button instead of a dead-end error message, matching the precedent set by `terminal.restartService`.
- Wired the full stack: `WorkspaceHostProcess.manualRestart()` resets the attempt counter and only emits `restarted` on a successful fork; `WorkspaceClient.manualRestartForWindow()` routes the call through the existing per-project `ProcessEntry`; a new `worktree:restart-service` IPC channel connects the renderer to the host via handler, preload, and `worktreeClient`.
- `createWorktreeStore.setFatalError()` now atomically clears `isLoading`/`isReconnecting` and resets `isInitialized`, so the error UI surfaces correctly even before first hydration and the post-restart fetch is treated as a cold load rather than a silent wake-refresh.

Resolves #5380

## Changes

- `electron/services/WorkspaceHostProcess.ts` — `manualRestart()` resets `restartAttempts`, guards `restarted` emit behind fork success
- `electron/services/WorkspaceClient.ts` — `manualRestartForWindow(windowId)` routes through `ProcessEntry`
- `electron/ipc/channels.ts` + `handlers/worktree/lifecycle.ts` + `shared/types/ipc/` — new `worktree:restart-service` channel wired end-to-end
- `electron/preload.cts` + `src/clients/worktreeClient.ts` + `src/types/electron.d.ts` — renderer-side plumbing
- `shared/types/actions.ts` + `src/services/actions/definitions/worktreeActions.ts` — new `worktree.restartService` action, enabled only when the backend is disconnected
- `src/components/Sidebar/SidebarContent.tsx` — replaces the dead-end Retry button with the new action
- `src/contexts/WorktreeStoreContext.tsx` — `onFatalDisconnect` calls `setFatalError()`
- `src/store/createWorktreeStore.ts` — `setFatalError()` atomically sets error state and resets loading/init flags

## Testing

57 unit tests pass across the WorkspaceClient resilience suite, worktree store reconnection suite, and Fleet broadcast tests. Typecheck, lint, and format all clean.