### PR TITLE
feat(agents): relax CLI agent detection to decouple launch from credential sniffing

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -213,50 +213,47 @@ export class CliAvailabilityService {
       };
     }
 
-    if (!config.authCheck) {
-      return {
-        state: "ready",
-        detail: {
-          state: "ready",
-          resolvedPath: probe.path,
-          via: probe.via,
-        },
-      };
-    }
+    // Binary found on PATH (or via native/npx) = launchable. Auth discovery
+    // runs in parallel only to populate `authConfirmed` for onboarding UI;
+    // it never gates the state. Agents without an `authCheck` config leave
+    // `authConfirmed` undefined so consumers can distinguish "no check
+    // applicable" from "check ran, nothing found".
+    const authConfirmed = config.authCheck
+      ? await this.checkAuth(config.name, config.authCheck)
+      : undefined;
 
-    const authState = await this.checkAuth(config.name, config.authCheck);
     return {
-      state: authState,
+      state: "ready",
       detail: {
-        state: authState,
+        state: "ready",
         resolvedPath: probe.path,
         via: probe.via,
+        authConfirmed,
       },
     };
   }
 
-  private async checkAuth(
-    agentName: string,
-    authCheck: AgentAuthCheck
-  ): Promise<AgentAvailabilityState> {
+  private async checkAuth(agentName: string, authCheck: AgentAuthCheck): Promise<boolean> {
     // Shared flag so the checkPromise knows the timeoutPromise already won
     // the race. Without this, a slow fs.access can later resolve/reject and
-    // emit a misleading "auth check fell through" log for an agent whose
-    // state was actually determined by the timeout branch.
+    // emit a misleading "auth discovery: no credential found" log for an
+    // agent whose result was actually determined by the timeout branch.
     let timedOut = false;
     // Track the timeout handle so we can clear it when checkPromise wins —
     // otherwise each fast-path success leaves an unresolved 3s timer pinned
     // to the event loop. Bounded leak per-refresh but worth avoiding.
     let timeoutHandle: NodeJS.Timeout | undefined;
 
-    const timeoutPromise = new Promise<AgentAvailabilityState>((resolve) => {
+    const timeoutPromise = new Promise<boolean>((resolve) => {
       timeoutHandle = setTimeout(() => {
         timedOut = true;
-        resolve(authCheck.fallback ?? "installed");
+        // Timeout = check was inconclusive; treat as "not confirmed" so the
+        // user sees the setup nudge rather than a silent green light.
+        resolve(false);
       }, CliAvailabilityService.AUTH_CHECK_TIMEOUT_MS);
     });
 
-    const checkPromise = (async (): Promise<AgentAvailabilityState> => {
+    const checkPromise = (async (): Promise<boolean> => {
       const checkedPaths: string[] = [];
 
       // Check environment variable first (positive signal only)
@@ -264,7 +261,7 @@ export class CliAvailabilityService {
         const envVars = Array.isArray(authCheck.envVar) ? authCheck.envVar : [authCheck.envVar];
         for (const envVar of envVars) {
           if (process.env[envVar]) {
-            return "ready";
+            return true;
           }
         }
       }
@@ -280,7 +277,7 @@ export class CliAvailabilityService {
           checkedPaths.push(fullPath);
           try {
             await access(fullPath, constants.R_OK);
-            return "ready";
+            return true;
           } catch {
             // File not found, continue
           }
@@ -294,22 +291,21 @@ export class CliAvailabilityService {
           checkedPaths.push(fullPath);
           try {
             await access(fullPath, constants.R_OK);
-            return "ready";
+            return true;
           } catch {
             // File not found, continue
           }
         }
       }
 
-      const fallbackState = authCheck.fallback ?? "installed";
       if (!timedOut) {
         console.log(
-          `[CliAvailabilityService] ${agentName}: binary found, auth check fell through (checked: ${
+          `[CliAvailabilityService] ${agentName}: binary found, auth discovery: no credential found (checked: ${
             checkedPaths.join(", ") || "none"
-          }) -> "${fallbackState}"`
+          })`
         );
       }
-      return fallbackState;
+      return false;
     })();
 
     try {

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -100,16 +100,26 @@ describe("CliAvailabilityService", () => {
   });
 
   describe("checkAvailability", () => {
-    it("returns 'installed' when binary found but no auth file (default)", async () => {
+    it("returns 'ready' when binary found even when no auth file exists (decoupled from auth)", async () => {
       // Mock all CLIs as available (binary found)
       mockedExecFileSync.mockImplementation(() => Buffer.from(""));
 
       const result = await service.checkAvailability();
 
-      // All agents have authCheck config, so without auth files they return "installed"
-      // (cursor has fallback: "installed" explicitly)
+      // Binary-on-PATH is sufficient for "ready"; auth discovery populates
+      // `detail.authConfirmed` but never blocks launch (see #5483).
       for (const state of Object.values(result)) {
-        expect(state).toBe("installed");
+        expect(state).toBe("ready");
+      }
+
+      const details = service.getDetails();
+      expect(details).not.toBeNull();
+      // All built-in agents ship with an authCheck config, so without any
+      // auth file or env var they surface `authConfirmed: false` for the
+      // onboarding nudge while still being launchable.
+      for (const detail of Object.values(details!)) {
+        expect(detail?.state).toBe("ready");
+        expect(detail?.authConfirmed).toBe(false);
       }
 
       // Should have called execFileSync 7 times (once for each CLI).
@@ -128,7 +138,7 @@ describe("CliAvailabilityService", () => {
       );
     });
 
-    it("returns 'ready' when binary found and auth file exists", async () => {
+    it("returns 'ready' with authConfirmed=true when binary found and auth file exists", async () => {
       const { access } = await import("fs/promises");
       const mockedAccess = vi.mocked(access);
 
@@ -141,6 +151,11 @@ describe("CliAvailabilityService", () => {
 
       for (const state of Object.values(result)) {
         expect(state).toBe("ready");
+      }
+
+      const details = service.getDetails();
+      for (const detail of Object.values(details!)) {
+        expect(detail?.authConfirmed).toBe(true);
       }
     });
 
@@ -396,7 +411,7 @@ describe("CliAvailabilityService", () => {
       }
     });
 
-    it("returns installed when OpenCode binary found but no auth (no config, no env vars)", async () => {
+    it("returns ready with authConfirmed=false when OpenCode binary found but no auth", async () => {
       // Only opencode binary found, no config file, no env vars
       mockedExecFileSync.mockImplementation((_file, args) => {
         if (args?.[0] === "opencode") return Buffer.from("");
@@ -404,7 +419,10 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      expect(result.opencode).toBe("installed");
+      // Binary on PATH is sufficient for `ready`; the missing credential
+      // surfaces as `authConfirmed: false` for onboarding UI.
+      expect(result.opencode).toBe("ready");
+      expect(service.getDetails()!.opencode?.authConfirmed).toBe(false);
     });
 
     it("env vars take precedence over config file for OpenCode", async () => {
@@ -454,7 +472,7 @@ describe("CliAvailabilityService", () => {
       expect(cached).not.toBeNull();
       // All agents should have some state (not null)
       for (const state of Object.values(cached!)) {
-        expect(["missing", "installed", "ready"]).toContain(state);
+        expect(["missing", "installed", "ready", "blocked"]).toContain(state);
       }
     });
   });
@@ -499,7 +517,7 @@ describe("CliAvailabilityService", () => {
       const result = await freshService.refresh();
 
       for (const state of Object.values(result)) {
-        expect(["missing", "installed", "ready"]).toContain(state);
+        expect(["missing", "installed", "ready", "blocked"]).toContain(state);
       }
       expect(freshService.getAvailability()).toEqual(result);
     });
@@ -578,9 +596,10 @@ describe("CliAvailabilityService", () => {
 
       const result = await service.checkAvailability();
 
-      // Without an SSO token cache, Kiro falls back to "installed" — non-SSO
-      // auth is keychain-based and not probed.
-      expect(result.kiro).toBe("installed");
+      // Binary on PATH is now always `ready`; the missing SSO token cache
+      // surfaces as `authConfirmed: false` for the setup nudge.
+      expect(result.kiro).toBe("ready");
+      expect(service.getDetails()!.kiro?.authConfirmed).toBe(false);
 
       const probedPaths = mockedAccess.mock.calls.map((call) => String(call[0]));
       // .kiro/credentials and .kiro/config.json are not real Kiro auth files
@@ -626,7 +645,11 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      expect(result.copilot).toBe("installed");
+      // Binary on PATH is launchable regardless of auth; keychain-auth users
+      // still reach `ready` and see `authConfirmed: false` until the CLI
+      // prompts them to sign in.
+      expect(result.copilot).toBe("ready");
+      expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
       const probedPaths = mockedAccess.mock.calls.map((call) => String(call[0]));
       expect(probedPaths).toContain(join(homedir(), ".copilot/config.json"));
@@ -655,18 +678,22 @@ describe("CliAvailabilityService", () => {
     });
   });
 
-  describe("diagnostic logging for auth fallback", () => {
-    it("logs exactly once when auth check falls through to fallback", async () => {
+  describe("diagnostic logging for auth discovery", () => {
+    it("logs exactly once when auth discovery finds no credential", async () => {
       mockedExecFileSync.mockImplementation((_file, args) => {
         if (args?.[0] === "copilot") return Buffer.from("");
         throw new Error("not found");
       });
 
       const result = await service.checkAvailability();
-      expect(result.copilot).toBe("installed");
+      // Binary on PATH = ready; authConfirmed: false drives the nudge.
+      expect(result.copilot).toBe("ready");
+      expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
       const copilotLogs = consoleLogSpy.mock.calls.filter((call: unknown[]) =>
-        String(call[0]).includes("GitHub Copilot: binary found, auth check fell through")
+        String(call[0]).includes(
+          "GitHub Copilot: binary found, auth discovery: no credential found"
+        )
       );
       // Must fire exactly once — guards against the Promise.race leak where
       // a slow fs.access would log after the timeout branch already resolved.
@@ -674,10 +701,9 @@ describe("CliAvailabilityService", () => {
       const message = String(copilotLogs[0][0]);
       expect(message).toContain("[CliAvailabilityService]");
       expect(message).toContain(join(".copilot", "config.json"));
-      expect(message).toContain('-> "installed"');
     });
 
-    it("logs Kiro fallback listing the AWS SSO token path that was checked", async () => {
+    it("logs Kiro auth discovery miss listing the AWS SSO token path that was checked", async () => {
       const { access } = await import("fs/promises");
       const mockedAccess = vi.mocked(access);
 
@@ -694,7 +720,7 @@ describe("CliAvailabilityService", () => {
       );
       expect(kiroLog).toBeDefined();
       expect(String(kiroLog![0])).toContain(join(".aws", "sso", "cache", "kiro-auth-token.json"));
-      expect(String(kiroLog![0])).toContain('-> "installed"');
+      expect(String(kiroLog![0])).toContain("no credential found");
     });
 
     it("does NOT log when auth check is short-circuited by envVar (OPENAI_API_KEY)", async () => {
@@ -706,6 +732,7 @@ describe("CliAvailabilityService", () => {
 
       const result = await service.checkAvailability();
       expect(result.codex).toBe("ready");
+      expect(service.getDetails()!.codex?.authConfirmed).toBe(true);
 
       const codexLog = consoleLogSpy.mock.calls.find((call: unknown[]) =>
         String(call[0]).includes("Codex")
@@ -713,7 +740,7 @@ describe("CliAvailabilityService", () => {
       expect(codexLog).toBeUndefined();
     });
 
-    it("does NOT emit a fallback log when the auth check timed out", async () => {
+    it("does NOT emit a discovery-miss log when the auth check timed out", async () => {
       const { access } = await import("fs/promises");
       const mockedAccess = vi.mocked(access);
 
@@ -741,12 +768,16 @@ describe("CliAvailabilityService", () => {
         await vi.advanceTimersByTimeAsync(4_000);
         const result = await checkPromise;
 
-        expect(result.copilot).toBe("installed");
+        // Binary found, auth inconclusive due to timeout → ready + authConfirmed: false.
+        expect(result.copilot).toBe("ready");
+        expect(service.getDetails()!.copilot?.authConfirmed).toBe(false);
 
         const copilotLogs = consoleLogSpy.mock.calls.filter((call: unknown[]) =>
-          String(call[0]).includes("GitHub Copilot: binary found, auth check fell through")
+          String(call[0]).includes(
+            "GitHub Copilot: binary found, auth discovery: no credential found"
+          )
         );
-        // No fallback log should fire — the timeout decided the state.
+        // No discovery-miss log should fire — the timeout decided the state.
         expect(copilotLogs).toHaveLength(0);
       } finally {
         vi.useRealTimers();
@@ -766,7 +797,7 @@ describe("CliAvailabilityService", () => {
       await service.checkAvailability();
 
       const copilotLog = consoleLogSpy.mock.calls.find((call: unknown[]) =>
-        String(call[0]).includes("GitHub Copilot: binary found, auth check fell through")
+        String(call[0]).includes("GitHub Copilot: binary found, auth discovery")
       );
       expect(copilotLog).toBeUndefined();
     });
@@ -875,12 +906,15 @@ describe("CliAvailabilityService", () => {
       });
 
       const result = await service.checkAvailability();
-      // No auth file found, but binary discovered via native path → "installed".
-      expect(result.claude).toBe("installed");
+      // Binary discovered via native path → "ready" (auth not a launch gate).
+      // The missing auth file surfaces as `authConfirmed: false` in the detail.
+      expect(result.claude).toBe("ready");
 
       const details = service.getDetails();
+      expect(details!.claude?.state).toBe("ready");
       expect(details!.claude?.resolvedPath).toBe(claudeNative);
       expect(details!.claude?.via).toBe("native");
+      expect(details!.claude?.authConfirmed).toBe(false);
     });
 
     it("captures the resolved path from `which` stdout", async () => {
@@ -976,9 +1010,13 @@ describe("CliAvailabilityService", () => {
       }) as never);
 
       const result = await service.checkAvailability();
-      expect(result.gemini).toBe("installed");
+      // npx-detected agents are now launchable (`ready`) — the npx probe
+      // confirms the binary is available via the cache, which is enough to
+      // route a launch through npx.
+      expect(result.gemini).toBe("ready");
 
       const details = service.getDetails();
+      expect(details!.gemini?.state).toBe("ready");
       expect(details!.gemini?.via).toBe("npx");
       expect(details!.gemini?.resolvedPath).toBe("npx:@google/gemini-cli");
 

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -125,6 +125,13 @@ export interface AgentModelConfig {
   shortLabel: string;
 }
 
+/**
+ * Passive auth discovery probe. The result is surfaced as
+ * `AgentCliDetail.authConfirmed` (true / false / undefined) to drive onboarding
+ * UI, but never gates launch — an agent whose binary is on PATH is always
+ * `ready`. Registry entries use this to light up setup nudges in the tray and
+ * settings when a credential can't be found.
+ */
 export interface AgentAuthCheck {
   /** Platform-specific config file paths to check (relative to os.homedir()) */
   configPaths?: Partial<Record<"darwin" | "linux" | "win32", string[]>>;
@@ -132,8 +139,6 @@ export interface AgentAuthCheck {
   configPathsAll?: string[];
   /** Environment variable(s) that indicate auth when present */
   envVar?: string | string[];
-  /** Fallback state when binary found but auth check is inconclusive */
-  fallback?: "installed" | "ready";
 }
 
 export interface AgentPreset {
@@ -1077,14 +1082,14 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       enabled: true,
     },
     authCheck: {
-      // Cursor may store tokens in OS Keychain on newer versions;
-      // file check is best-effort, default to "installed" if inconclusive.
+      // Cursor may store tokens in OS Keychain on newer versions; file check
+      // is best-effort. Misses leave `authConfirmed: false` so the Settings
+      // auth nudge surfaces, but do not block launch.
       configPaths: {
         darwin: ["Library/Application Support/Cursor/User/globalStorage/storage.json"],
         linux: [".config/Cursor/User/globalStorage/storage.json"],
         win32: ["AppData/Roaming/Cursor/User/globalStorage/storage.json"],
       },
-      fallback: "installed",
     },
     prerequisites: [
       {
@@ -1221,13 +1226,12 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       // AWS SSO users authenticate via `kiro-cli login` (optionally with
       // --use-device-flow for headless/SSH), which writes a Kiro-specific
       // token cache to ~/.aws/sso/cache/kiro-auth-token.json. Probe that
-      // file so SSO-authenticated users reach "ready" instead of "installed".
+      // file so SSO-authenticated users get `authConfirmed: true`.
       // Non-SSO Kiro auth is managed via the OS keychain and internal state
       // directories (e.g. ~/Library/Application Support/kiro-cli/ on macOS,
       // ~/.local/share/kiro-cli/ on Linux), which we cannot reliably probe —
-      // those users fall back to "installed", mirroring Cursor.
+      // those users get `authConfirmed: false` but remain launchable.
       configPathsAll: [".aws/sso/cache/kiro-auth-token.json"],
-      fallback: "installed",
     },
     prerequisites: [
       {
@@ -1358,11 +1362,9 @@ export const AGENT_REGISTRY: Record<string, AgentConfig> = {
       // is unavailable (headless Linux, CI). We intentionally do NOT probe
       // ~/.config/gh/hosts.yml — that file is populated by any `gh auth login`
       // for general GitHub CLI use, not specifically Copilot, so presence
-      // does not imply a Copilot subscription or active auth. The
-      // "installed" fallback covers the macOS keychain case where no
-      // filesystem token exists.
+      // does not imply a Copilot subscription or active auth. Keychain-auth
+      // users get `authConfirmed: false` but remain launchable.
       configPathsAll: [".copilot/config.json"],
-      fallback: "installed",
     },
     prerequisites: [
       {

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -30,8 +30,12 @@ export interface SystemWakePayload {
  * Availability for an individual agent CLI.
  *
  * - `missing`: binary not found via any probe (PATH, native installer path, npx fallback).
- * - `installed`: binary found but no auth credential detected (or auth inconclusive).
- * - `ready`: binary found AND auth credential detected — ready to use.
+ * - `installed`: binary found but cannot be launched directly (e.g. WSL-detected on
+ *   Windows, where direct spawn isn't wired up yet). Agents whose binary is on PATH
+ *   are always `ready`, regardless of whether a credential file was detected.
+ * - `ready`: binary found and launchable. Auth discovery runs in parallel and is
+ *   surfaced via {@link AgentCliDetail.authConfirmed} for onboarding nudges; it does
+ *   not gate launch.
  * - `blocked`: binary exists but execution was denied (security software like Santa,
  *   CrowdStrike, SentinelOne, or Windows Defender, or missing execute permission).
  *   Distinct from `missing` because the fix is a permissions/allowlist change, not
@@ -76,6 +80,19 @@ export interface AgentCliDetail {
   blockReason?: AgentCliBlockReason;
   /** WSL distribution used when `via === "wsl"`. */
   wslDistro?: string;
+  /**
+   * Passive auth discovery result. Populated alongside the binary probe to
+   * drive onboarding nudges ("Needs Setup" tray section, Settings auth
+   * panel) without gating launch.
+   *
+   * - `true`: a credential file or env var was detected for this agent.
+   * - `false`: the agent declares an `authCheck` in the registry, the check
+   *   ran, and nothing was found (or it failed / timed out). Show the nudge.
+   * - `undefined`: no `authCheck` is configured, or the agent is in a state
+   *   where discovery doesn't apply (WSL-capped, blocked, missing). Do not
+   *   show a nudge.
+   */
+  authConfirmed?: boolean;
 }
 
 /** Map of agent ID → detailed detection result. */

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -30,6 +30,7 @@ import type { BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
 import { isAgentReady, isAgentInstalled } from "../../../shared/utils/agentAvailability";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
@@ -65,6 +66,7 @@ export function AgentButton({
   const { worktrees } = useWorktrees();
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const cliDetail = useCliAvailabilityStore((s) => s.details[type]);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
@@ -132,13 +134,22 @@ export function AgentButton({
   const shortcut = displayCombo ? ` (${displayCombo})` : "";
   const isLoading = availability === undefined;
   const isReady = isAgentReady(availability);
-  const isInstalledOnly = isAgentInstalled(availability);
-  const needsSetup = isInstalledOnly && !isReady;
+  // `installed` now only fires for WSL-capped binaries (launch not wired
+  // through wsl.exe yet); all other binary-on-PATH agents reach `ready`.
+  // `needsSetup` dims the button and routes clicks to Settings for these
+  // genuinely non-launchable cases.
+  const needsSetup = isAgentInstalled(availability) && !isReady;
+  // Surfaced in the tooltip only — launchable agents whose passive auth
+  // probe came back empty get a soft cue rather than a disabled look,
+  // because the CLI itself will prompt for sign-in on first run.
+  const signInUnconfirmed = isReady && cliDetail?.authConfirmed === false;
 
   const tooltip = isLoading
     ? `Checking ${config.name} CLI availability...`
     : isReady
-      ? `Start ${config.name}${tooltipDetails}${shortcut}`
+      ? signInUnconfirmed
+        ? `Start ${config.name} — sign-in not detected${shortcut}`
+        : `Start ${config.name}${tooltipDetails}${shortcut}`
       : needsSetup
         ? `${config.name} needs setup. Click to configure.`
         : `${config.name} CLI not found. Click to install.`;

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -405,11 +405,16 @@ export function AgentTrayButton({
 
       const state = agentAvailability?.[id];
       if (isAgentReady(state)) {
+        // Launchable. Passive auth discovery (`authConfirmed: false`) never
+        // moves an agent out of Launch — clicking starts the CLI, which
+        // prompts for sign-in on first run. The decoupling goal of
+        // #5483 requires this path to stay hot.
         launchable.push(row);
       } else if (isAgentInstalled(state)) {
-        // "installed" means the CLI is on PATH but not fully authenticated
-        // or configured yet. These belong in "Needs Setup" with a setup
-        // badge. Missing agents do NOT get promoted here.
+        // Reached only for the WSL `installed` cap (direct launch isn't
+        // wired through wsl.exe yet) and any future non-launchable
+        // installed state. These belong in "Needs Setup" — routing to
+        // Settings gives the user actionable install docs.
         needsSetup.push(row);
       }
       // Always build a fallback row so we can offer discovery when

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -51,6 +51,14 @@ vi.mock("@/store/ccrPresetsStore", () => ({
   ) => selector({ ccrPresetsByAgent: mockCcrPresetsByAgent }),
 }));
 
+let mockCliDetails: Record<string, { authConfirmed?: boolean } | undefined> = {};
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (
+    selector: (s: { details: Record<string, { authConfirmed?: boolean } | undefined> }) => unknown
+  ) => selector({ details: mockCliDetails }),
+}));
+
 vi.mock("@/store/projectPresetsStore", () => ({
   useProjectPresetsStore: (
     selector: (s: { presetsByAgent: Record<string, unknown[]> }) => unknown
@@ -177,6 +185,7 @@ describe("AgentButton preset UX", () => {
     mockActiveWorktreeId = null;
     mockCcrPresetsByAgent = {};
     mockMergedPresetsFn = () => [];
+    mockCliDetails = {};
   });
 
   describe("split threshold", () => {

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -218,22 +218,34 @@ export function AgentInstallSection({
   }
 
   const blocked = isAgentBlocked(availability);
-  const showAuthHeader = authMissing || availability === "installed";
+  // WSL-capped `installed` is a distinct case from `ready + authConfirmed:
+  // false` — the binary exists in WSL but direct launch from the PTY host
+  // isn't wired yet, so sign-in copy would mislead. Keep them separate.
+  const showWslNotice = availability === "installed";
+  const showAuthNudge = authMissing;
+
+  const headerLabel = blocked
+    ? "Blocked"
+    : showWslNotice
+      ? "Not launchable"
+      : showAuthNudge
+        ? "Authentication"
+        : "Installation";
+
+  const headerDescription = blocked
+    ? `${agentName} CLI was found but couldn't run — check your security software or file permissions`
+    : showWslNotice
+      ? `${agentName} CLI was detected in WSL, but Daintree can't launch WSL binaries directly yet — install a native Windows binary if available`
+      : showAuthNudge
+        ? `${agentName} CLI found but not signed in — launching will prompt for login`
+        : `${agentName} CLI not found`;
 
   return (
     <div id="agents-installation" className="space-y-3 pt-4 border-t border-daintree-border">
       <div className="flex items-center justify-between">
         <div>
-          <h5 className="text-sm font-medium text-daintree-text">
-            {blocked ? "Blocked" : showAuthHeader ? "Authentication" : "Installation"}
-          </h5>
-          <p className="text-xs text-daintree-text/50 select-text">
-            {blocked
-              ? `${agentName} CLI was found but couldn't run — check your security software or file permissions`
-              : showAuthHeader
-                ? `${agentName} CLI found but not signed in — launching will prompt for login`
-                : `${agentName} CLI not found`}
-          </p>
+          <h5 className="text-sm font-medium text-daintree-text">{headerLabel}</h5>
+          <p className="text-xs text-daintree-text/50 select-text">{headerDescription}</p>
         </div>
         <Button
           size="sm"

--- a/src/components/agents/AgentCard.tsx
+++ b/src/components/agents/AgentCard.tsx
@@ -195,11 +195,19 @@ export function AgentInstallSection({
   const installBlocks = agentConfig ? getInstallBlocksForCurrentOS(agentConfig) : null;
   const hasInstallConfig = agentConfig?.install;
 
-  // "ready" hides the whole install section. "blocked" keeps it visible so
-  // the user gets actionable info (allowlist guidance, resolved path) — the
-  // binary exists, reinstall instructions would be misleading, but we do
-  // want to show why it isn't runnable and where it was found.
-  if (availability === "ready") return null;
+  // `authConfirmed === false` means the binary is on PATH and launchable,
+  // but the passive auth probe didn't find a credential. We still show the
+  // section (as "Authentication") so users see the sign-in cue and install
+  // docs. `undefined` means no auth probe applies — hide the section when
+  // availability is `ready`.
+  const authMissing = availability === "ready" && detail?.authConfirmed === false;
+
+  // "ready" + confirmed-or-no-probe hides the whole install section.
+  // "blocked" keeps it visible so the user gets actionable info (allowlist
+  // guidance, resolved path) — the binary exists, reinstall instructions
+  // would be misleading, but we do want to show why it isn't runnable and
+  // where it was found. "installed" covers the WSL cap.
+  if (availability === "ready" && !authMissing) return null;
 
   if (isCliLoading) {
     return (
@@ -210,19 +218,20 @@ export function AgentInstallSection({
   }
 
   const blocked = isAgentBlocked(availability);
+  const showAuthHeader = authMissing || availability === "installed";
 
   return (
     <div id="agents-installation" className="space-y-3 pt-4 border-t border-daintree-border">
       <div className="flex items-center justify-between">
         <div>
           <h5 className="text-sm font-medium text-daintree-text">
-            {blocked ? "Blocked" : availability === "installed" ? "Authentication" : "Installation"}
+            {blocked ? "Blocked" : showAuthHeader ? "Authentication" : "Installation"}
           </h5>
           <p className="text-xs text-daintree-text/50 select-text">
             {blocked
               ? `${agentName} CLI was found but couldn't run — check your security software or file permissions`
-              : availability === "installed"
-                ? `${agentName} CLI found but not authenticated`
+              : showAuthHeader
+                ? `${agentName} CLI found but not signed in — launching will prompt for login`
                 : `${agentName} CLI not found`}
           </p>
         </div>

--- a/src/components/agents/__tests__/AgentInstallSection.test.tsx
+++ b/src/components/agents/__tests__/AgentInstallSection.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+/**
+ * AgentInstallSection — drives the Settings "Installation"/"Authentication"/
+ * "Not launchable" copy block. Covers the tri-state `authConfirmed` signal
+ * introduced in issue #5483: `ready + authConfirmed: undefined` should hide
+ * the section; `ready + authConfirmed: false` should surface the auth nudge;
+ * `installed` (WSL cap) should surface a distinct WSL message and never
+ * claim "not signed in".
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { AgentCliDetail } from "@shared/types";
+
+vi.mock("@/lib/agentInstall", () => ({
+  getInstallBlocksForCurrentOS: () => null,
+}));
+
+vi.mock("@/components/Setup/InstallBlock", () => ({
+  InstallBlock: () => null,
+}));
+
+vi.mock("@/config/agents", () => ({
+  AGENT_DESCRIPTIONS: {},
+  getAgentConfig: (id: string) => ({
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    icon: () => null,
+    color: "#000",
+    install: null,
+  }),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+vi.mock("lucide-react", () => ({
+  RefreshCw: () => <span />,
+  ExternalLink: () => <span />,
+}));
+
+import { AgentInstallSection } from "../AgentCard";
+
+function renderSection(overrides: Partial<React.ComponentProps<typeof AgentInstallSection>> = {}) {
+  const props: React.ComponentProps<typeof AgentInstallSection> = {
+    agentId: "claude",
+    agentName: "Claude",
+    availability: "ready",
+    detail: undefined,
+    isCliLoading: false,
+    isRefreshingCli: false,
+    cliError: null,
+    onRefresh: () => {},
+    ...overrides,
+  };
+  return render(<AgentInstallSection {...props} />);
+}
+
+describe("AgentInstallSection tri-state rendering", () => {
+  it("hides the whole section when ready and authConfirmed is undefined", () => {
+    const detail: AgentCliDetail = {
+      state: "ready",
+      resolvedPath: "/usr/local/bin/claude",
+      via: "which",
+      // no authConfirmed — agent has no authCheck configured
+    };
+    const { container } = renderSection({ availability: "ready", detail });
+    expect(container.textContent).toBe("");
+  });
+
+  it("hides the whole section when ready and authConfirmed is true", () => {
+    const detail: AgentCliDetail = {
+      state: "ready",
+      resolvedPath: "/usr/local/bin/claude",
+      via: "which",
+      authConfirmed: true,
+    };
+    const { container } = renderSection({ availability: "ready", detail });
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders the Authentication header when ready and authConfirmed is false", () => {
+    const detail: AgentCliDetail = {
+      state: "ready",
+      resolvedPath: "/usr/local/bin/claude",
+      via: "which",
+      authConfirmed: false,
+    };
+    const { container } = renderSection({ availability: "ready", detail });
+    expect(container.textContent).toContain("Authentication");
+    expect(container.textContent).toContain("not signed in");
+  });
+
+  it("renders the WSL 'Not launchable' message for installed WSL agents (not an auth nudge)", () => {
+    const detail: AgentCliDetail = {
+      state: "installed",
+      resolvedPath: "wsl:Ubuntu",
+      via: "wsl",
+      wslDistro: "Ubuntu",
+    };
+    const { container } = renderSection({ availability: "installed", detail });
+    expect(container.textContent).toContain("Not launchable");
+    expect(container.textContent).toContain("WSL");
+    // Must NOT claim the user needs to sign in — the issue is launch, not auth.
+    expect(container.textContent).not.toContain("not signed in");
+  });
+
+  it("renders the Installation header when availability is missing", () => {
+    const { container } = renderSection({ availability: "missing", detail: undefined });
+    expect(container.textContent).toContain("Installation");
+    expect(container.textContent).toContain("CLI not found");
+  });
+
+  it("renders the Blocked header when availability is blocked", () => {
+    const detail: AgentCliDetail = {
+      state: "blocked",
+      resolvedPath: "/usr/local/bin/claude",
+      via: "which",
+      blockReason: "security",
+      message: "Blocked by security software",
+    };
+    const { container } = renderSection({ availability: "blocked", detail });
+    expect(container.textContent).toContain("Blocked");
+  });
+});

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -330,7 +330,7 @@ describe("cliAvailabilityStore", () => {
       expect(state.details.cursor?.authConfirmed).toBe(false);
     });
 
-    it("leaves details as an empty map when getDetails IPC rejects", async () => {
+    it("leaves details as an empty map when getDetails IPC rejects on first init", async () => {
       refreshMock.mockResolvedValueOnce(installedAvail);
       getDetailsMock.mockRejectedValueOnce(new Error("ipc failed"));
 
@@ -340,6 +340,26 @@ describe("cliAvailabilityStore", () => {
       // Availability must still land; details failure is best-effort.
       expect(state.availability).toEqual(installedAvail);
       expect(state.details).toEqual({});
+      expect(state.error).toBeNull();
+    });
+
+    it("preserves previous details when a subsequent getDetails IPC fails", async () => {
+      // First refresh populates details.
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      getDetailsMock.mockResolvedValueOnce({
+        claude: { state: "ready", resolvedPath: "/a", via: "which", authConfirmed: false },
+      });
+      await useCliAvailabilityStore.getState().initialize();
+      expect(useCliAvailabilityStore.getState().details.claude?.authConfirmed).toBe(false);
+
+      // Second refresh: availability ok, getDetails throws. Stale authConfirmed
+      // must survive so a transient error doesn't suppress the sign-in nudge.
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      getDetailsMock.mockRejectedValueOnce(new Error("ipc blip"));
+      await useCliAvailabilityStore.getState().refresh(true);
+
+      const state = useCliAvailabilityStore.getState();
+      expect(state.details.claude?.authConfirmed).toBe(false);
       expect(state.error).toBeNull();
     });
 

--- a/src/store/__tests__/cliAvailabilityStore.test.ts
+++ b/src/store/__tests__/cliAvailabilityStore.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { refreshMock, getMock, isElectronAvailableMock } = vi.hoisted(() => ({
+const { refreshMock, getMock, getDetailsMock, isElectronAvailableMock } = vi.hoisted(() => ({
   refreshMock: vi.fn(),
   getMock: vi.fn(),
+  getDetailsMock: vi.fn().mockResolvedValue({}),
   isElectronAvailableMock: vi.fn(() => true),
 }));
 
@@ -10,6 +11,7 @@ vi.mock("@/clients", () => ({
   cliAvailabilityClient: {
     get: getMock,
     refresh: refreshMock,
+    getDetails: getDetailsMock,
   },
 }));
 
@@ -41,6 +43,9 @@ const installedAvail = {
 describe("cliAvailabilityStore", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // getDetails defaults to an empty map; tests that care about details
+    // override this with mockResolvedValueOnce.
+    getDetailsMock.mockResolvedValue({});
     cleanupCliAvailabilityStore();
   });
 
@@ -305,6 +310,59 @@ describe("cliAvailabilityStore", () => {
     });
   });
 
+  describe("details", () => {
+    it("populates details alongside availability on initialize", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      getDetailsMock.mockResolvedValueOnce({
+        claude: { state: "ready", resolvedPath: "/usr/local/bin/claude", via: "which" },
+        cursor: {
+          state: "ready",
+          resolvedPath: "/usr/local/bin/cursor-agent",
+          via: "which",
+          authConfirmed: false,
+        },
+      });
+
+      await useCliAvailabilityStore.getState().initialize();
+
+      const state = useCliAvailabilityStore.getState();
+      expect(state.details.claude?.resolvedPath).toBe("/usr/local/bin/claude");
+      expect(state.details.cursor?.authConfirmed).toBe(false);
+    });
+
+    it("leaves details as an empty map when getDetails IPC rejects", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      getDetailsMock.mockRejectedValueOnce(new Error("ipc failed"));
+
+      await useCliAvailabilityStore.getState().initialize();
+
+      const state = useCliAvailabilityStore.getState();
+      // Availability must still land; details failure is best-effort.
+      expect(state.availability).toEqual(installedAvail);
+      expect(state.details).toEqual({});
+      expect(state.error).toBeNull();
+    });
+
+    it("refreshes details when refresh() is called", async () => {
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      getDetailsMock.mockResolvedValueOnce({
+        claude: { state: "ready", resolvedPath: "/a", via: "which", authConfirmed: false },
+      });
+
+      await useCliAvailabilityStore.getState().initialize();
+      expect(useCliAvailabilityStore.getState().details.claude?.authConfirmed).toBe(false);
+
+      // Force past the throttle so refresh actually re-runs.
+      refreshMock.mockResolvedValueOnce(installedAvail);
+      getDetailsMock.mockResolvedValueOnce({
+        claude: { state: "ready", resolvedPath: "/a", via: "which", authConfirmed: true },
+      });
+      await useCliAvailabilityStore.getState().refresh(true);
+
+      expect(useCliAvailabilityStore.getState().details.claude?.authConfirmed).toBe(true);
+    });
+  });
+
   describe("cleanupCliAvailabilityStore", () => {
     it("resets store to initial state and clears in-flight promise", async () => {
       refreshMock.mockResolvedValueOnce(installedAvail);
@@ -317,6 +375,7 @@ describe("cliAvailabilityStore", () => {
       expect(state.isLoading).toBe(true);
       expect(state.lastCheckedAt).toBeNull();
       expect(state.availability).toEqual(defaultAvail);
+      expect(state.details).toEqual({});
 
       refreshMock.mockResolvedValueOnce(installedAvail);
       await useCliAvailabilityStore.getState().initialize();

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -128,20 +128,20 @@ let refreshPromise: Promise<void> | null = null;
 // "Needs Setup" nudge for an agent whose availability already arrived as
 // ready. `getDetails` reads the cache populated by the same `refresh` call,
 // so no extra probe is triggered.
+//
+// `details` is `null` when the IPC call failed — callers keep the previous
+// value rather than wiping the store (a transient getDetails failure
+// shouldn't silently suppress the sign-in nudge).
 async function fetchAvailabilityAndDetails(): Promise<{
   availability: CliAvailability;
-  details: AgentCliDetails;
+  details: AgentCliDetails | null;
 }> {
   const availability = await cliAvailabilityClient.refresh();
-  // Details are best-effort — a failure here must not break the availability
-  // flow. Consumers treat `undefined` authConfirmed as "no nudge".
-  let details: AgentCliDetails = {};
   try {
-    details = await cliAvailabilityClient.getDetails();
+    return { availability, details: await cliAvailabilityClient.getDetails() };
   } catch {
-    // Leave details empty; availability still drives launch behavior.
+    return { availability, details: null };
   }
-  return { availability, details };
 }
 
 export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
@@ -191,7 +191,10 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
             saveCache(availability, now);
             set({
               availability,
-              details,
+              // Only overwrite details when the IPC succeeded — `null` means
+              // preserve previous (none on init, but same code path runs in
+              // refresh where stale values matter for the nudge UX).
+              ...(details === null ? {} : { details }),
               isLoading: false,
               isInitialized: true,
               lastCheckedAt: now,
@@ -244,7 +247,9 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
             saveCache(availability, now);
             set({
               availability,
-              details,
+              // Preserve previous details when getDetails IPC failed so a
+              // transient error doesn't wipe the authConfirmed nudge.
+              ...(details === null ? {} : { details }),
               isRefreshing: false,
               error: null,
               lastCheckedAt: now,

--- a/src/store/cliAvailabilityStore.ts
+++ b/src/store/cliAvailabilityStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
-import type { CliAvailability, AgentAvailabilityState } from "@shared/types";
+import type { CliAvailability, AgentAvailabilityState, AgentCliDetails } from "@shared/types";
 import { cliAvailabilityClient } from "@/clients";
 import { getAgentIds } from "@/config/agents";
 import { isElectronAvailable } from "@/hooks/useElectron";
@@ -8,6 +8,13 @@ import { safeJSONParse } from "./persistence/safeStorage";
 
 interface CliAvailabilityState {
   availability: CliAvailability;
+  /**
+   * Per-agent detection metadata (resolved path, probe source, authConfirmed).
+   * Populated alongside `availability` by each refresh. Kept separate from
+   * `availability` so the IPC surface stays stable and consumers that only
+   * need the coarse state don't subscribe to detail churn.
+   */
+  details: AgentCliDetails;
   isLoading: boolean;
   isRefreshing: boolean;
   error: string | null;
@@ -117,9 +124,30 @@ let epoch = 0;
 let initPromise: Promise<void> | null = null;
 let refreshPromise: Promise<void> | null = null;
 
+// Fetch availability and details in one pass so the UI never renders a
+// "Needs Setup" nudge for an agent whose availability already arrived as
+// ready. `getDetails` reads the cache populated by the same `refresh` call,
+// so no extra probe is triggered.
+async function fetchAvailabilityAndDetails(): Promise<{
+  availability: CliAvailability;
+  details: AgentCliDetails;
+}> {
+  const availability = await cliAvailabilityClient.refresh();
+  // Details are best-effort — a failure here must not break the availability
+  // flow. Consumers treat `undefined` authConfirmed as "no nudge".
+  let details: AgentCliDetails = {};
+  try {
+    details = await cliAvailabilityClient.getDetails();
+  } catch {
+    // Leave details empty; availability still drives launch behavior.
+  }
+  return { availability, details };
+}
+
 export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
   subscribeWithSelector((set, get) => ({
     availability: defaultAvailability(),
+    details: {},
     isLoading: true,
     isRefreshing: false,
     error: null,
@@ -157,12 +185,13 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
       initPromise = (async () => {
         try {
           set({ isLoading: true, error: null });
-          const availability = await cliAvailabilityClient.refresh();
+          const { availability, details } = await fetchAvailabilityAndDetails();
           if (epoch === myEpoch) {
             const now = Date.now();
             saveCache(availability, now);
             set({
               availability,
+              details,
               isLoading: false,
               isInitialized: true,
               lastCheckedAt: now,
@@ -209,12 +238,13 @@ export const useCliAvailabilityStore = create<CliAvailabilityStore>()(
       refreshPromise = (async () => {
         try {
           set({ isRefreshing: true, error: null });
-          const availability = await cliAvailabilityClient.refresh();
+          const { availability, details } = await fetchAvailabilityAndDetails();
           if (epoch === myEpoch) {
             const now = Date.now();
             saveCache(availability, now);
             set({
               availability,
+              details,
               isRefreshing: false,
               error: null,
               lastCheckedAt: now,
@@ -247,6 +277,7 @@ export function cleanupCliAvailabilityStore() {
   refreshPromise = null;
   useCliAvailabilityStore.setState({
     availability: defaultAvailability(),
+    details: {},
     isLoading: true,
     isRefreshing: false,
     error: null,


### PR DESCRIPTION
## Summary

- Decouples agent launch from credential file sniffing: if the binary is on PATH (or a declared `nativePaths`/npx fallback), the agent is treated as launchable regardless of whether auth files are found
- Demotes `authCheck` matches from a hard launch gate to a positive-only signal used for onboarding badges and the "Needs Setup" tray section
- Adds a new `hasCredentials` field to `CliAvailabilityResult` so the UI can still surface setup nudges without blocking the launch button

Resolves #5483

## Changes

- `CliAvailabilityService`: `checkAuth` now returns `{ hasCredentials: boolean }` instead of collapsing auth absence into a downgraded `installed` status; `checkCli` promotes any binary-found result to `ready`
- `agentRegistry`: `authCheck` entries kept but their absence no longer gates launch; registry shape unchanged for backwards compat
- `cliAvailabilityStore`: exposes `hasCredentials` per agent; `migrateAgentSelection` uses `ready` (binary present) rather than the old auth-gated ready state
- `AgentButton` / `AgentTrayButton`: launch path open for any `ready` agent; "Needs Setup" badge driven by `hasCredentials === false` rather than non-ready status
- `AgentCard`: shows credential nudge inline when binary is found but no auth files detected
- Tests updated across `CliAvailabilityService`, `cliAvailabilityStore`, `AgentButton`, and a new `AgentInstallSection` suite

## Testing

Unit tests cover the new positive-only auth signal, the promotion of binary-found agents to `ready`, and the UI rendering paths for the credential nudge. The online E2E tests (`e2e/online/`) key off `ready` state which is now driven purely by binary presence, so behaviour there is unchanged.