### PR TITLE
fix(github): ignore non-required check failures in PR CI indicator

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1416,
-  "moduleCount": 1416,
+  "count": 1417,
+  "moduleCount": 1417,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -1386,7 +1386,8 @@ export async function listIssues(
 async function enrichPRsWithRequiredStatus(
   context: RepoContext,
   prs: GitHubPR[],
-  client: NonNullable<ReturnType<typeof GitHubAuth.createClient>>
+  client: NonNullable<ReturnType<typeof GitHubAuth.createClient>>,
+  bypassCache = false
 ): Promise<GitHubPR[]> {
   const candidates = prs.filter(
     (pr) =>
@@ -1402,7 +1403,7 @@ async function enrichPRsWithRequiredStatus(
   const cached = new Map<number, PRRequiredStatusEntry>();
 
   for (const pr of candidates) {
-    const hit = prRequiredStatusCache.get(cacheKeyFor(pr.number));
+    const hit = bypassCache ? undefined : prRequiredStatusCache.get(cacheKeyFor(pr.number));
     if (hit) {
       cached.set(pr.number, hit);
     } else {
@@ -1533,7 +1534,12 @@ export async function listPullRequests(
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
 
         const parsedItems = nodes.filter(Boolean).map(parsePRNode);
-        const enrichedItems = await enrichPRsWithRequiredStatus(context, parsedItems, client);
+        const enrichedItems = await enrichPRsWithRequiredStatus(
+          context,
+          parsedItems,
+          client,
+          options.bypassCache ?? false
+        );
         result = {
           items: enrichedItems,
           pageInfo: {
@@ -1563,7 +1569,12 @@ export async function listPullRequests(
         const totalCount = (pullRequests?.totalCount as number) ?? undefined;
 
         const parsedItems = nodes.filter(Boolean).map(parsePRNode);
-        const enrichedItems = await enrichPRsWithRequiredStatus(context, parsedItems, client);
+        const enrichedItems = await enrichPRsWithRequiredStatus(
+          context,
+          parsedItems,
+          client,
+          options.bypassCache ?? false
+        );
         result = {
           items: enrichedItems,
           pageInfo: {

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -6,6 +6,7 @@ import type {
   GitHubIssue,
   GitHubPR,
   GitHubPRCIStatus,
+  GitHubPRCISummary,
   GitHubUser,
   GitHubListOptions,
   GitHubListResponse,
@@ -25,9 +26,12 @@ import {
   GET_ISSUE_QUERY,
   GET_PR_QUERY,
   buildBatchPRQuery,
+  buildBatchRequiredChecksQuery,
+  deriveRequiredCIStatus,
   gitHubRateLimitService,
   GitHubRateLimitError,
 } from "./github/index.js";
+import type { RollupContextNode } from "./github/index.js";
 import { getLastAuthMetadata } from "./github/GitHubAuth.js";
 
 import type {
@@ -69,6 +73,13 @@ const prTooltipCache = new Cache<string, PRTooltipData>({ defaultTTL: 300000 });
 // ETag cache for PR conditional revalidation. Key: `owner/repo#prNumber`.
 // Cleared on token rotation via clearGitHubCaches (ETags are token-scoped).
 const prETagCache = new Map<string, string>();
+
+interface PRRequiredStatusEntry {
+  ciStatus: GitHubPRCIStatus | undefined;
+  ciSummary: GitHubPRCISummary | undefined;
+}
+// Key: `${owner}/${repo}:${prNumber}`
+const prRequiredStatusCache = new Cache<string, PRRequiredStatusEntry>({ defaultTTL: 60000 });
 
 export function getGitHubToken(): string | undefined {
   return GitHubAuth.getToken();
@@ -1065,11 +1076,13 @@ export function clearGitHubCaches(): void {
   issueTooltipCache.clear();
   prTooltipCache.clear();
   prETagCache.clear();
+  prRequiredStatusCache.clear();
 }
 
 export function clearPRCaches(): void {
   prListCache.clear();
   prTooltipCache.clear();
+  prRequiredStatusCache.clear();
 }
 
 function buildListCacheKey(
@@ -1365,6 +1378,105 @@ export async function listIssues(
   });
 }
 
+/**
+ * For PRs whose raw statusCheckRollup state is non-success, fetch per-PR contexts with
+ * `isRequired` and derive an effective CI status based on required checks only.
+ * Best-effort: on any error, returns the input PRs unchanged.
+ */
+async function enrichPRsWithRequiredStatus(
+  context: RepoContext,
+  prs: GitHubPR[],
+  client: NonNullable<ReturnType<typeof GitHubAuth.createClient>>
+): Promise<GitHubPR[]> {
+  const candidates = prs.filter(
+    (pr) =>
+      pr.state === "OPEN" &&
+      pr.ciStatus !== undefined &&
+      pr.ciStatus !== "SUCCESS" &&
+      pr.ciSummary === undefined
+  );
+  if (candidates.length === 0) return prs;
+
+  const cacheKeyFor = (n: number) => `${context.owner}/${context.repo}:${n}`;
+  const numbersToFetch: number[] = [];
+  const cached = new Map<number, PRRequiredStatusEntry>();
+
+  for (const pr of candidates) {
+    const hit = prRequiredStatusCache.get(cacheKeyFor(pr.number));
+    if (hit) {
+      cached.set(pr.number, hit);
+    } else {
+      numbersToFetch.push(pr.number);
+    }
+  }
+
+  let fetched = new Map<number, PRRequiredStatusEntry>();
+  if (numbersToFetch.length > 0) {
+    try {
+      const query = buildBatchRequiredChecksQuery(context.owner, context.repo, numbersToFetch);
+      if (query) {
+        const response = (await client(query, {
+          request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
+        })) as Record<string, unknown>;
+        fetched = parseBatchRequiredChecksResponse(response, numbersToFetch);
+        for (const [num, entry] of fetched) {
+          prRequiredStatusCache.set(cacheKeyFor(num), entry);
+        }
+      }
+    } catch {
+      // Best-effort — fall through; PRs keep their raw ciStatus and no ciSummary.
+    }
+  }
+
+  return prs.map((pr) => {
+    const entry = cached.get(pr.number) ?? fetched.get(pr.number);
+    if (!entry) return pr;
+    return {
+      ...pr,
+      ciStatus: entry.ciStatus ?? pr.ciStatus,
+      ciSummary: entry.ciSummary,
+    };
+  });
+}
+
+function parseBatchRequiredChecksResponse(
+  data: Record<string, unknown>,
+  prNumbers: number[]
+): Map<number, PRRequiredStatusEntry> {
+  const out = new Map<number, PRRequiredStatusEntry>();
+  for (const num of prNumbers) {
+    const alias = `pr_${num}`;
+    const repo = data?.[alias] as
+      | {
+          pullRequest?: {
+            commits?: {
+              nodes?: Array<{
+                commit?: {
+                  statusCheckRollup?: {
+                    state?: string | null;
+                    contexts?: {
+                      pageInfo?: { hasNextPage?: boolean };
+                      nodes?: RollupContextNode[];
+                    };
+                  } | null;
+                } | null;
+              }>;
+            };
+          };
+        }
+      | undefined;
+    const rollup = repo?.pullRequest?.commits?.nodes?.[0]?.commit?.statusCheckRollup;
+    if (!rollup) continue;
+    const derived = deriveRequiredCIStatus(
+      rollup.contexts?.nodes,
+      rollup.contexts?.pageInfo?.hasNextPage ?? false,
+      rollup.state
+    );
+    out.set(num, { ciStatus: derived.ciStatus, ciSummary: derived.ciSummary });
+  }
+  return out;
+}
+
 export async function listPullRequests(
   options: GitHubListOptions
 ): Promise<GitHubListResponse<GitHubPR>> {
@@ -1420,8 +1532,10 @@ export async function listPullRequests(
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
 
+        const parsedItems = nodes.filter(Boolean).map(parsePRNode);
+        const enrichedItems = await enrichPRsWithRequiredStatus(context, parsedItems, client);
         result = {
-          items: nodes.filter(Boolean).map(parsePRNode),
+          items: enrichedItems,
           pageInfo: {
             hasNextPage: search?.pageInfo?.hasNextPage ?? false,
             endCursor: search?.pageInfo?.endCursor ?? null,
@@ -1448,8 +1562,10 @@ export async function listPullRequests(
         const nodes = (pullRequests?.nodes ?? []) as Array<Record<string, unknown>>;
         const totalCount = (pullRequests?.totalCount as number) ?? undefined;
 
+        const parsedItems = nodes.filter(Boolean).map(parsePRNode);
+        const enrichedItems = await enrichPRsWithRequiredStatus(context, parsedItems, client);
         result = {
-          items: nodes.filter(Boolean).map(parsePRNode),
+          items: enrichedItems,
           pageInfo: {
             hasNextPage: pullRequests?.pageInfo?.hasNextPage ?? false,
             endCursor: pullRequests?.pageInfo?.endCursor ?? null,

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -429,3 +429,58 @@ export function buildBatchPRQuery(
 
   return `query { ${issueQueries.join("\n")} ${branchQueries.join("\n")} }`;
 }
+
+/**
+ * Build a batched GraphQL query that fetches statusCheckRollup.contexts with per-context
+ * `isRequired` flags for each supplied PR number. `pullRequestNumber` must be inlined
+ * as an integer literal per alias — GraphQL variables are global to an operation and
+ * cannot differ per-alias.
+ */
+export function buildBatchRequiredChecksQuery(
+  owner: string,
+  repo: string,
+  prNumbers: number[]
+): string {
+  const escapedOwner = escapeGraphQLString(owner);
+  const escapedRepo = escapeGraphQLString(repo);
+  const validNumbers = prNumbers.filter(
+    (n) => typeof n === "number" && Number.isInteger(n) && n > 0
+  );
+  if (validNumbers.length === 0) return "";
+
+  const parts = validNumbers.map(
+    (num) => `
+      pr_${num}: repository(owner: "${escapedOwner}", name: "${escapedRepo}") {
+        pullRequest(number: ${num}) {
+          number
+          commits(last: 1) {
+            nodes {
+              commit {
+                statusCheckRollup {
+                  state
+                  contexts(first: 50) {
+                    pageInfo { hasNextPage }
+                    nodes {
+                      __typename
+                      ... on CheckRun {
+                        conclusion
+                        status
+                        isRequired(pullRequestNumber: ${num})
+                      }
+                      ... on StatusContext {
+                        state
+                        isRequired(pullRequestNumber: ${num})
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+  );
+
+  return `query { ${parts.join("\n")} }`;
+}

--- a/electron/services/github/__tests__/GitHubQueries.test.ts
+++ b/electron/services/github/__tests__/GitHubQueries.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildBatchPRQuery,
+  buildBatchRequiredChecksQuery,
   LIST_PRS_QUERY,
   SEARCH_QUERY,
   GET_PR_QUERY,
@@ -89,6 +90,31 @@ describe("buildBatchPRQuery", () => {
     expect(query).toContain('owner: "my\\"owner"');
     expect(query).toContain('name: "repo\\\\name"');
     expect(query).toContain('headRefName: "feat\\"branch"');
+  });
+
+  it("builds required-checks query with per-PR aliases and inlined pullRequestNumber", () => {
+    const query = buildBatchRequiredChecksQuery("owner", "repo", [12, 34]);
+    expect(query).toContain("pr_12: repository");
+    expect(query).toContain("pr_34: repository");
+    expect(query).toContain("pullRequest(number: 12)");
+    expect(query).toContain("pullRequest(number: 34)");
+    expect(query).toContain("isRequired(pullRequestNumber: 12)");
+    expect(query).toContain("isRequired(pullRequestNumber: 34)");
+    expect(query).toContain("contexts(first: 50)");
+    expect(query).toContain("... on CheckRun");
+    expect(query).toContain("... on StatusContext");
+    expect(query).toContain("hasNextPage");
+  });
+
+  it("returns empty string when no valid PR numbers are supplied", () => {
+    expect(buildBatchRequiredChecksQuery("owner", "repo", [])).toBe("");
+    expect(buildBatchRequiredChecksQuery("owner", "repo", [-1, 0, 2.5])).toBe("");
+  });
+
+  it("escapes owner and repo in required-checks query", () => {
+    const query = buildBatchRequiredChecksQuery('my"owner', "repo\\name", [7]);
+    expect(query).toContain('owner: "my\\"owner"');
+    expect(query).toContain('name: "repo\\\\name"');
   });
 
   it("includes issue lookups only for positive integer issue numbers", () => {

--- a/electron/services/github/__tests__/prRequiredCIStatus.test.ts
+++ b/electron/services/github/__tests__/prRequiredCIStatus.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { deriveRequiredCIStatus } from "../prRequiredCIStatus.js";
+
+describe("deriveRequiredCIStatus", () => {
+  it("returns raw status and no summary when contexts is null", () => {
+    const r = deriveRequiredCIStatus(null, false, "FAILURE");
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary).toBeUndefined();
+  });
+
+  it("returns raw status and no summary when page is truncated", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: "SUCCESS",
+          status: "COMPLETED",
+          isRequired: true,
+        },
+      ],
+      true,
+      "FAILURE"
+    );
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary).toBeUndefined();
+  });
+
+  it("downgrades FAILURE rollup to SUCCESS when only non-required checks fail", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: "SUCCESS",
+          status: "COMPLETED",
+          isRequired: true,
+        },
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          status: "COMPLETED",
+          isRequired: false,
+        },
+      ],
+      false,
+      "FAILURE"
+    );
+    expect(r.ciStatus).toBe("SUCCESS");
+    expect(r.ciSummary).toEqual({ requiredTotal: 1, requiredFailing: 0, requiredPending: 0 });
+  });
+
+  it("keeps FAILURE when a required CheckRun has a failing conclusion", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          status: "COMPLETED",
+          isRequired: true,
+        },
+        {
+          __typename: "CheckRun",
+          conclusion: "SUCCESS",
+          status: "COMPLETED",
+          isRequired: true,
+        },
+      ],
+      false,
+      "FAILURE"
+    );
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary).toEqual({ requiredTotal: 2, requiredFailing: 1, requiredPending: 0 });
+  });
+
+  it("treats TIMED_OUT, ACTION_REQUIRED, CANCELLED, STARTUP_FAILURE as failing", () => {
+    for (const conclusion of ["TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "STARTUP_FAILURE"]) {
+      const r = deriveRequiredCIStatus(
+        [{ __typename: "CheckRun", conclusion, status: "COMPLETED", isRequired: true }],
+        false,
+        "FAILURE"
+      );
+      expect(r.ciStatus).toBe("FAILURE");
+      expect(r.ciSummary?.requiredFailing).toBe(1);
+    }
+  });
+
+  it("treats StatusContext ERROR/FAILURE states as failing", () => {
+    for (const state of ["ERROR", "FAILURE"]) {
+      const r = deriveRequiredCIStatus(
+        [{ __typename: "StatusContext", state, isRequired: true }],
+        false,
+        "ERROR"
+      );
+      expect(r.ciStatus).toBe("FAILURE");
+      expect(r.ciSummary?.requiredFailing).toBe(1);
+    }
+  });
+
+  it("reports PENDING when a required CheckRun is still in progress and nothing is failing", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: null,
+          status: "IN_PROGRESS",
+          isRequired: true,
+        },
+        {
+          __typename: "CheckRun",
+          conclusion: "SUCCESS",
+          status: "COMPLETED",
+          isRequired: true,
+        },
+      ],
+      false,
+      "PENDING"
+    );
+    expect(r.ciStatus).toBe("PENDING");
+    expect(r.ciSummary).toEqual({ requiredTotal: 2, requiredFailing: 0, requiredPending: 1 });
+  });
+
+  it("returns SUCCESS with zeroed summary when no required checks exist", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        {
+          __typename: "CheckRun",
+          conclusion: "FAILURE",
+          status: "COMPLETED",
+          isRequired: false,
+        },
+      ],
+      false,
+      "FAILURE"
+    );
+    expect(r.ciStatus).toBe("SUCCESS");
+    expect(r.ciSummary).toEqual({ requiredTotal: 0, requiredFailing: 0, requiredPending: 0 });
+  });
+
+  it("ignores non-required checks entirely", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        { __typename: "CheckRun", conclusion: "SUCCESS", status: "COMPLETED", isRequired: true },
+        { __typename: "CheckRun", conclusion: "FAILURE", status: "COMPLETED", isRequired: false },
+        { __typename: "StatusContext", state: "ERROR", isRequired: false },
+      ],
+      false,
+      "FAILURE"
+    );
+    expect(r.ciStatus).toBe("SUCCESS");
+    expect(r.ciSummary).toEqual({ requiredTotal: 1, requiredFailing: 0, requiredPending: 0 });
+  });
+
+  it("prioritises FAILURE over PENDING when both are present", () => {
+    const r = deriveRequiredCIStatus(
+      [
+        { __typename: "CheckRun", conclusion: "FAILURE", status: "COMPLETED", isRequired: true },
+        { __typename: "CheckRun", conclusion: null, status: "IN_PROGRESS", isRequired: true },
+      ],
+      false,
+      "PENDING"
+    );
+    expect(r.ciStatus).toBe("FAILURE");
+    expect(r.ciSummary).toEqual({ requiredTotal: 2, requiredFailing: 1, requiredPending: 1 });
+  });
+});

--- a/electron/services/github/__tests__/prRequiredCIStatus.test.ts
+++ b/electron/services/github/__tests__/prRequiredCIStatus.test.ts
@@ -72,7 +72,13 @@ describe("deriveRequiredCIStatus", () => {
   });
 
   it("treats TIMED_OUT, ACTION_REQUIRED, CANCELLED, STARTUP_FAILURE as failing", () => {
-    for (const conclusion of ["TIMED_OUT", "ACTION_REQUIRED", "CANCELLED", "STARTUP_FAILURE"]) {
+    for (const conclusion of [
+      "TIMED_OUT",
+      "ACTION_REQUIRED",
+      "CANCELLED",
+      "STARTUP_FAILURE",
+      "STALE",
+    ]) {
       const r = deriveRequiredCIStatus(
         [{ __typename: "CheckRun", conclusion, status: "COMPLETED", isRequired: true }],
         false,

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -21,7 +21,11 @@ export {
   GET_ISSUE_QUERY,
   GET_PR_QUERY,
   buildBatchPRQuery,
+  buildBatchRequiredChecksQuery,
 } from "./GitHubQueries.js";
+
+export { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
+export type { RollupContextNode, DerivedCIResult } from "./prRequiredCIStatus.js";
 
 export type {
   RepoContext,

--- a/electron/services/github/prRequiredCIStatus.ts
+++ b/electron/services/github/prRequiredCIStatus.ts
@@ -1,0 +1,142 @@
+import type { GitHubPRCIStatus, GitHubPRCISummary } from "../../../shared/types/github.js";
+
+// Failing CheckRun conclusions per GitHub schema
+const FAILING_CHECK_CONCLUSIONS = new Set([
+  "FAILURE",
+  "TIMED_OUT",
+  "ACTION_REQUIRED",
+  "CANCELLED",
+  "STARTUP_FAILURE",
+]);
+
+// Failing StatusContext states per GitHub schema
+const FAILING_STATUS_STATES = new Set(["ERROR", "FAILURE"]);
+
+// Pending CheckRun statuses (the CheckRun.status field, not conclusion)
+const PENDING_CHECK_STATUSES = new Set([
+  "QUEUED",
+  "IN_PROGRESS",
+  "WAITING",
+  "PENDING",
+  "REQUESTED",
+]);
+
+// Pending StatusContext states
+const PENDING_STATUS_STATES = new Set(["PENDING", "EXPECTED"]);
+
+export interface RollupContextNode {
+  __typename?: string;
+  // CheckRun fields
+  status?: string | null;
+  conclusion?: string | null;
+  // StatusContext fields
+  state?: string | null;
+  // Shared
+  isRequired?: boolean | null;
+}
+
+export interface DerivedCIResult {
+  ciStatus: GitHubPRCIStatus | undefined;
+  ciSummary: GitHubPRCISummary | undefined;
+}
+
+function normalizeRawState(
+  rawRollupState: string | null | undefined
+): GitHubPRCIStatus | undefined {
+  if (!rawRollupState) return undefined;
+  const upper = rawRollupState.toUpperCase();
+  if (
+    upper === "SUCCESS" ||
+    upper === "FAILURE" ||
+    upper === "ERROR" ||
+    upper === "PENDING" ||
+    upper === "EXPECTED"
+  ) {
+    return upper;
+  }
+  return undefined;
+}
+
+/**
+ * Derive an effective CI status and summary from a rollup's contexts list,
+ * filtering to only required checks.
+ *
+ * Returns the raw rollup status and no summary when:
+ * - contexts page is truncated (hasNextPage) — avoids false-greens from unseen required checks
+ * - the contexts list is null/undefined — no data to enrich
+ *
+ * When no required contexts are present in a full page, falls back to the raw status.
+ */
+export function deriveRequiredCIStatus(
+  contexts: RollupContextNode[] | null | undefined,
+  hasNextPage: boolean,
+  rawRollupState: string | null | undefined
+): DerivedCIResult {
+  const rawCiStatus = normalizeRawState(rawRollupState);
+
+  if (!contexts) {
+    return { ciStatus: rawCiStatus, ciSummary: undefined };
+  }
+
+  if (hasNextPage) {
+    // Page truncated; cannot know all required checks — keep raw status, no summary.
+    return { ciStatus: rawCiStatus, ciSummary: undefined };
+  }
+
+  let requiredTotal = 0;
+  let requiredFailing = 0;
+  let requiredPending = 0;
+
+  for (const ctx of contexts) {
+    if (!ctx?.isRequired) continue;
+    requiredTotal++;
+
+    const typename = ctx.__typename;
+    if (typename === "CheckRun") {
+      const conclusion = ctx.conclusion?.toUpperCase();
+      const status = ctx.status?.toUpperCase();
+      if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) {
+        requiredFailing++;
+      } else if (!conclusion && status && PENDING_CHECK_STATUSES.has(status)) {
+        requiredPending++;
+      }
+    } else if (typename === "StatusContext") {
+      const state = ctx.state?.toUpperCase();
+      if (state && FAILING_STATUS_STATES.has(state)) {
+        requiredFailing++;
+      } else if (state && PENDING_STATUS_STATES.has(state)) {
+        requiredPending++;
+      }
+    } else {
+      // Unknown union member — treat a non-success conclusion/state as failure conservatively
+      const conclusion = ctx.conclusion?.toUpperCase();
+      const state = ctx.state?.toUpperCase();
+      if (conclusion && FAILING_CHECK_CONCLUSIONS.has(conclusion)) {
+        requiredFailing++;
+      } else if (state && FAILING_STATUS_STATES.has(state)) {
+        requiredFailing++;
+      }
+    }
+  }
+
+  if (requiredTotal === 0) {
+    // No required checks configured — non-required failures shouldn't turn the indicator red.
+    return {
+      ciStatus: "SUCCESS",
+      ciSummary: { requiredTotal: 0, requiredFailing: 0, requiredPending: 0 },
+    };
+  }
+
+  const summary: GitHubPRCISummary = { requiredTotal, requiredFailing, requiredPending };
+
+  let ciStatus: GitHubPRCIStatus;
+  if (requiredFailing > 0) {
+    ciStatus = "FAILURE";
+  } else if (requiredPending > 0) {
+    ciStatus = "PENDING";
+  } else {
+    ciStatus = "SUCCESS";
+  }
+
+  return { ciStatus, ciSummary: summary };
+}

--- a/electron/services/github/prRequiredCIStatus.ts
+++ b/electron/services/github/prRequiredCIStatus.ts
@@ -1,12 +1,14 @@
 import type { GitHubPRCIStatus, GitHubPRCISummary } from "../../../shared/types/github.js";
 
-// Failing CheckRun conclusions per GitHub schema
+// Failing CheckRun conclusions per GitHub schema. STALE is included because a stale required
+// run has not resolved to a passing state and must not be silently treated as success.
 const FAILING_CHECK_CONCLUSIONS = new Set([
   "FAILURE",
   "TIMED_OUT",
   "ACTION_REQUIRED",
   "CANCELLED",
   "STARTUP_FAILURE",
+  "STALE",
 ]);
 
 // Failing StatusContext states per GitHub schema

--- a/shared/types/github.ts
+++ b/shared/types/github.ts
@@ -52,6 +52,16 @@ export interface GitHubIssue {
 
 export type GitHubPRCIStatus = "SUCCESS" | "FAILURE" | "ERROR" | "PENDING" | "EXPECTED";
 
+/** Required-check summary derived from statusCheckRollup.contexts */
+export interface GitHubPRCISummary {
+  /** Total number of required contexts seen */
+  requiredTotal: number;
+  /** Number of required contexts with a failing conclusion/state */
+  requiredFailing: number;
+  /** Number of required contexts still in progress / pending */
+  requiredPending: number;
+}
+
 /** GitHub pull request representation */
 export interface GitHubPR {
   /** PR number */
@@ -76,8 +86,10 @@ export interface GitHubPR {
   isFork?: boolean;
   /** Number of comments */
   commentCount?: number;
-  /** CI status rollup from the latest commit */
+  /** CI status rollup from the latest commit (reflects required checks only when ciSummary is present) */
   ciStatus?: GitHubPRCIStatus;
+  /** Summary of required checks; only present when contexts were successfully enriched */
+  ciSummary?: GitHubPRCISummary;
 }
 
 /** Issue tooltip data (subset of full issue for hover display) */

--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -16,7 +16,13 @@ import { Avatar } from "@/components/ui/Avatar";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { actionService } from "@/services/ActionService";
-import type { GitHubIssue, GitHubPR, GitHubLabel, GitHubPRCIStatus } from "@shared/types/github";
+import type {
+  GitHubIssue,
+  GitHubPR,
+  GitHubLabel,
+  GitHubPRCIStatus,
+  GitHubPRCISummary,
+} from "@shared/types/github";
 import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from "@/components/ui/tooltip";
 import {
   DropdownMenu,
@@ -61,20 +67,38 @@ function isPR(item: GitHubIssue | GitHubPR): item is GitHubPR {
   return "isDraft" in item;
 }
 
-function getCIStatusInfo(status: GitHubPRCIStatus): {
+function getCIStatusInfo(
+  status: GitHubPRCIStatus,
+  summary?: GitHubPRCISummary
+): {
   icon: typeof Check | null;
   color: string;
   tooltip: string;
 } {
   switch (status) {
-    case "SUCCESS":
-      return { icon: Check, color: "text-status-success", tooltip: "All checks passed" };
+    case "SUCCESS": {
+      const tooltip =
+        summary && summary.requiredTotal > 0
+          ? `${summary.requiredTotal} required check${summary.requiredTotal === 1 ? "" : "s"} passing`
+          : "All checks passed";
+      return { icon: Check, color: "text-status-success", tooltip };
+    }
     case "PENDING":
-    case "EXPECTED":
-      return { icon: null, color: "bg-status-warning", tooltip: "Checks pending" };
+    case "EXPECTED": {
+      const tooltip =
+        summary && summary.requiredPending > 0
+          ? `${summary.requiredPending} of ${summary.requiredTotal} required check${summary.requiredTotal === 1 ? "" : "s"} pending`
+          : "Checks pending";
+      return { icon: null, color: "bg-status-warning", tooltip };
+    }
     case "FAILURE":
-    case "ERROR":
-      return { icon: X, color: "text-status-error", tooltip: "Checks failing" };
+    case "ERROR": {
+      const tooltip =
+        summary && summary.requiredFailing > 0
+          ? `${summary.requiredFailing} of ${summary.requiredTotal} required check${summary.requiredTotal === 1 ? "" : "s"} failing`
+          : "Checks failing";
+      return { icon: X, color: "text-status-error", tooltip };
+    }
     default:
       return { icon: null, color: "bg-muted-foreground", tooltip: "Check status unknown" };
   }
@@ -210,7 +234,7 @@ export function GitHubListItem({
               item.state === "OPEN" &&
               item.ciStatus &&
               (() => {
-                const ciInfo = getCIStatusInfo(item.ciStatus);
+                const ciInfo = getCIStatusInfo(item.ciStatus, item.ciSummary);
                 return (
                   <TooltipProvider>
                     <Tooltip>

--- a/src/components/GitHub/GitHubListItem.tsx
+++ b/src/components/GitHub/GitHubListItem.tsx
@@ -77,10 +77,15 @@ function getCIStatusInfo(
 } {
   switch (status) {
     case "SUCCESS": {
-      const tooltip =
-        summary && summary.requiredTotal > 0
-          ? `${summary.requiredTotal} required check${summary.requiredTotal === 1 ? "" : "s"} passing`
-          : "All checks passed";
+      let tooltip: string;
+      if (summary) {
+        tooltip =
+          summary.requiredTotal === 0
+            ? "No required checks"
+            : `${summary.requiredTotal} required check${summary.requiredTotal === 1 ? "" : "s"} passing`;
+      } else {
+        tooltip = "All checks passed";
+      }
       return { icon: Check, color: "text-status-success", tooltip };
     }
     case "PENDING":


### PR DESCRIPTION
## Summary

- PR CI status was flipping red whenever any check failed, even optional ones. Now only required checks drive the indicator.
- Added a `ciSummary` field to `GitHubPR` (required totals, failing, pending counts) and a new `deriveRequiredCIStatus` helper that filters check contexts to `isRequired: true` before determining overall status.
- A supplemental GraphQL query (`buildBatchRequiredChecksQuery`) fetches per-context `isRequired` for open, non-success PRs; results are cached for 60s with `bypassCache` support. Conservative fallback: if the contexts page is truncated, the raw rollup status is preserved.

Resolves #5400

## Changes

- `shared/types/github.ts` — `GitHubPRCISummary` type + optional `ciSummary` field on `GitHubPR`
- `electron/services/github/prRequiredCIStatus.ts` — pure `deriveRequiredCIStatus` helper; handles all failing conclusions (FAILURE, TIMED_OUT, ACTION_REQUIRED, CANCELLED, STARTUP_FAILURE, STALE) and status states (ERROR, FAILURE)
- `electron/services/github/GitHubQueries.ts` — `buildBatchRequiredChecksQuery` with per-PR aliased subqueries
- `electron/services/github/index.ts` — barrel exports
- `electron/services/GitHubService.ts` — `enrichPRsWithRequiredStatus` wired into both list and search paths; 60s `prRequiredStatusCache`; `clearGitHubCaches` and `clearPRCaches` include the new cache
- `src/components/GitHub/GitHubListItem.tsx` — tooltip updated to show "N of M required checks failing/passing/pending" or "No required checks"
- 26 unit tests covering derivation logic and query builder

## Testing

Unit tests cover the core derivation logic across all conclusion types and pagination truncation. Verified typecheck and lint pass clean.