### PR TITLE
feat(fleet): add Fleet scope primitive behind fleetScopeMode flag

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -463,6 +463,13 @@ export function registerAppStateHandlers(): () => void {
         }
       }
 
+      if ("fleetScopeMode" in partialState) {
+        const mode = partialState.fleetScopeMode;
+        if (mode === "legacy" || mode === "scoped") {
+          updates.fleetScopeMode = mode;
+        }
+      }
+
       store.set("appState", { ...currentState, ...updates });
 
       // Note: We intentionally do NOT save per-project terminal state.

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -108,6 +108,7 @@ export interface StoreSchema {
     fleetDeckEdge?: "right" | "left" | "bottom";
     fleetDeckWidth?: number;
     fleetDeckHeight?: number;
+    fleetScopeMode?: "legacy" | "scoped";
   };
   userConfig: {
     githubToken?: string;

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -306,6 +306,8 @@ export type BuiltInActionId =
   | "fleet.scope.save"
   | "fleet.scope.recall"
   | "fleet.scope.delete"
+  | "fleet.scope.enter"
+  | "fleet.scope.exit"
   | "fleet.dryRun"
   | "fleet.retryFailed"
   | "terminal.focusFleetComposer";

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -95,6 +95,8 @@ export interface AppState {
   fleetDeckAlwaysPreview?: boolean;
   /** Number of armed targets that triggers quorum confirmation */
   fleetDeckQuorumThreshold?: number;
+  /** Whether Fleet scope primitive is active ("scoped") or feature is disabled ("legacy", default) */
+  fleetScopeMode?: "legacy" | "scoped";
 }
 
 /** Describes how the settings store recovered from corruption at startup */

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -13,6 +13,7 @@ import { DemoCaptureBridge, DemoCursor, DemoOverlay } from "../Demo";
 
 import { AllClearOverlay } from "../AllClearOverlay";
 import { useDiagnosticsStore, useDockStore, useFleetDeckStore, type PanelState } from "@/store";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { useCcrPresetsSubscription } from "@/hooks/useCcrPresetsSubscription";
@@ -100,6 +101,7 @@ export function AppLayout({
           width: appState.fleetDeckWidth,
           height: appState.fleetDeckHeight,
         });
+        useFleetScopeFlagStore.getState().hydrate(appState.fleetScopeMode);
       } catch (error) {
         console.error("Failed to restore app state:", error);
       }

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -265,3 +265,80 @@ describe("fleet actions — threshold confirmation", () => {
     expect(terminalClient.batchDoubleEscape).toHaveBeenCalledWith(["a", "b", "c"]);
   });
 });
+
+describe("fleet scope actions — flag gating", () => {
+  beforeEach(async () => {
+    resetStores();
+    vi.clearAllMocks();
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: false });
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: null,
+      isFleetScopeActive: false,
+      _previousActiveWorktreeId: null,
+    });
+  });
+
+  it("fleet.scope.enter is a no-op in legacy mode", async () => {
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.scope.enter");
+    expect(useWorktreeSelectionStore.getState().isFleetScopeActive).toBe(false);
+  });
+
+  it("fleet.scope.enter activates scope and captures worktree in scoped mode", async () => {
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.scope.enter");
+    const state = useWorktreeSelectionStore.getState();
+    expect(state.isFleetScopeActive).toBe(true);
+    expect(state._previousActiveWorktreeId).toBe("wt-1");
+  });
+
+  it("fleet.scope.exit is a no-op in legacy mode", async () => {
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: null,
+      isFleetScopeActive: true,
+      _previousActiveWorktreeId: "wt-stale",
+    });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.scope.exit");
+    expect(useWorktreeSelectionStore.getState().isFleetScopeActive).toBe(true);
+  });
+
+  it("fleet.scope.exit restores prior worktree in scoped mode", async () => {
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    const registry = await buildRegistry();
+    await run(registry, "fleet.scope.enter");
+    useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+    await run(registry, "fleet.scope.exit");
+    const state = useWorktreeSelectionStore.getState();
+    expect(state.isFleetScopeActive).toBe(false);
+    expect(state.activeWorktreeId).toBe("wt-1");
+  });
+
+  it("flag is read at execution time, not at registration time", async () => {
+    const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
+    const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
+    useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
+    const registry = await buildRegistry();
+    // Flip the flag AFTER registry build
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    await run(registry, "fleet.scope.enter");
+    expect(useWorktreeSelectionStore.getState().isFleetScopeActive).toBe(true);
+  });
+});

--- a/src/services/actions/definitions/__tests__/fleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/fleetActions.test.ts
@@ -280,14 +280,23 @@ describe("fleet scope actions — flag gating", () => {
     });
   });
 
-  it("fleet.scope.enter is a no-op in legacy mode", async () => {
+  it("fleet.scope.enter is a full no-op in legacy mode (no side effects)", async () => {
     const { useFleetScopeFlagStore } = await import("@/store/fleetScopeFlagStore");
     const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
     useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
-    useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+    useWorktreeSelectionStore.setState({
+      activeWorktreeId: "wt-1",
+      focusedWorktreeId: "wt-1",
+      isFleetScopeActive: false,
+      _previousActiveWorktreeId: null,
+    });
     const registry = await buildRegistry();
     await run(registry, "fleet.scope.enter");
-    expect(useWorktreeSelectionStore.getState().isFleetScopeActive).toBe(false);
+    const state = useWorktreeSelectionStore.getState();
+    expect(state.isFleetScopeActive).toBe(false);
+    expect(state.activeWorktreeId).toBe("wt-1");
+    expect(state.focusedWorktreeId).toBe("wt-1");
+    expect(state._previousActiveWorktreeId).toBeNull();
   });
 
   it("fleet.scope.enter activates scope and captures worktree in scoped mode", async () => {

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -13,6 +13,7 @@ import {
 import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import { useFleetSavedScopesStore } from "@/store/fleetSavedScopesStore";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { terminalClient } from "@/clients";
@@ -348,6 +349,36 @@ export function registerFleetActions(actions: ActionRegistry): void {
         const ids = collectEligibleIds(scope.filter.scope as "current" | "all", activeWorktreeId);
         useFleetArmingStore.getState().armIds(ids);
       }
+    },
+  }));
+
+  actions.set("fleet.scope.enter", () => ({
+    id: "fleet.scope.enter",
+    title: "Fleet: Enter Scope Mode",
+    description:
+      "Activate Fleet scope mode (primitive — gated by fleetScopeMode flag; no-op in legacy mode)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      if (useFleetScopeFlagStore.getState().mode !== "scoped") return;
+      useWorktreeSelectionStore.getState().enterFleetScope();
+    },
+  }));
+
+  actions.set("fleet.scope.exit", () => ({
+    id: "fleet.scope.exit",
+    title: "Fleet: Exit Scope Mode",
+    description:
+      "Exit Fleet scope mode, restoring the pre-scope active worktree (no-op in legacy mode)",
+    category: "terminal",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    run: async () => {
+      if (useFleetScopeFlagStore.getState().mode !== "scoped") return;
+      useWorktreeSelectionStore.getState().exitFleetScope();
     },
   }));
 

--- a/src/store/__tests__/fleetScopeFlagStore.test.ts
+++ b/src/store/__tests__/fleetScopeFlagStore.test.ts
@@ -59,14 +59,20 @@ describe("fleetScopeFlagStore", () => {
   });
 
   describe("setMode", () => {
-    it("updates mode and persists", () => {
+    it("updates mode and persists", async () => {
       useFleetScopeFlagStore.getState().setMode("scoped");
       expect(useFleetScopeFlagStore.getState().mode).toBe("scoped");
-      expect(setStateMock).toHaveBeenCalledWith({ fleetScopeMode: "scoped" });
+      // persistMode dynamically imports @/clients, so the setState call
+      // resolves after several microtasks. Wait for the mock instead of
+      // guessing how many Promise.resolve() ticks are needed.
+      await vi.waitFor(() =>
+        expect(setStateMock).toHaveBeenCalledWith({ fleetScopeMode: "scoped" })
+      );
     });
 
-    it("is a no-op when mode is unchanged", () => {
+    it("is a no-op when mode is unchanged", async () => {
       useFleetScopeFlagStore.getState().setMode("legacy");
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(setStateMock).not.toHaveBeenCalled();
     });
 

--- a/src/store/__tests__/fleetScopeFlagStore.test.ts
+++ b/src/store/__tests__/fleetScopeFlagStore.test.ts
@@ -37,6 +37,19 @@ describe("fleetScopeFlagStore", () => {
       expect(state.isHydrated).toBe(true);
     });
 
+    it("normalizes malformed values to 'legacy'", () => {
+      // Defensive path — legacy persisted values or mid-migration garbage
+      // should not enable scoped mode.
+      useFleetScopeFlagStore.getState().hydrate("SCOPED" as never);
+      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+      resetStore();
+      useFleetScopeFlagStore.getState().hydrate(null as never);
+      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+      resetStore();
+      useFleetScopeFlagStore.getState().hydrate(42 as never);
+      expect(useFleetScopeFlagStore.getState().mode).toBe("legacy");
+    });
+
     it("is idempotent — later hydrate calls cannot clobber user interaction", () => {
       useFleetScopeFlagStore.getState().setMode("scoped");
       setStateMock.mockClear();

--- a/src/store/__tests__/fleetScopeFlagStore.test.ts
+++ b/src/store/__tests__/fleetScopeFlagStore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { setStateMock } = vi.hoisted(() => ({
+  setStateMock: vi.fn((_patch: Record<string, unknown>) => Promise.resolve()),
+}));
+
+vi.mock("@/clients", () => ({
+  appClient: {
+    setState: setStateMock,
+  },
+}));
+
+import { useFleetScopeFlagStore } from "../fleetScopeFlagStore";
+
+function resetStore(): void {
+  useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: false });
+  setStateMock.mockClear();
+}
+
+describe("fleetScopeFlagStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  describe("hydrate", () => {
+    it("applies persisted 'scoped' value and marks hydrated", () => {
+      useFleetScopeFlagStore.getState().hydrate("scoped");
+      const state = useFleetScopeFlagStore.getState();
+      expect(state.mode).toBe("scoped");
+      expect(state.isHydrated).toBe(true);
+    });
+
+    it("falls back to 'legacy' when persisted value is undefined", () => {
+      useFleetScopeFlagStore.getState().hydrate(undefined);
+      const state = useFleetScopeFlagStore.getState();
+      expect(state.mode).toBe("legacy");
+      expect(state.isHydrated).toBe(true);
+    });
+
+    it("is idempotent — later hydrate calls cannot clobber user interaction", () => {
+      useFleetScopeFlagStore.getState().setMode("scoped");
+      setStateMock.mockClear();
+      useFleetScopeFlagStore.getState().hydrate("legacy");
+      expect(useFleetScopeFlagStore.getState().mode).toBe("scoped");
+    });
+  });
+
+  describe("setMode", () => {
+    it("updates mode and persists", () => {
+      useFleetScopeFlagStore.getState().setMode("scoped");
+      expect(useFleetScopeFlagStore.getState().mode).toBe("scoped");
+      expect(setStateMock).toHaveBeenCalledWith({ fleetScopeMode: "scoped" });
+    });
+
+    it("is a no-op when mode is unchanged", () => {
+      useFleetScopeFlagStore.getState().setMode("legacy");
+      expect(setStateMock).not.toHaveBeenCalled();
+    });
+
+    it("marks hydrated so later async hydrate does not clobber", () => {
+      useFleetScopeFlagStore.getState().setMode("scoped");
+      expect(useFleetScopeFlagStore.getState().isHydrated).toBe(true);
+    });
+  });
+});

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -348,6 +348,41 @@ describe("worktreeStore", () => {
       expect(state.activeWorktreeId).toBe("wt-original");
     });
 
+    it("exitFleetScope persists the restored activeWorktreeId", async () => {
+      // Unique id to avoid module-level persistActiveWorktree dedup bleeding
+      // from earlier tests that touched "wt-original" via setActiveWorktree.
+      const restoreId = "wt-fleet-exit-persist";
+      useWorktreeSelectionStore.setState({ activeWorktreeId: restoreId });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      appSetStateMock.mockClear();
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      // persistActiveWorktree loads the clients module via dynamic import,
+      // so the setState call is deferred to a microtask.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(appSetStateMock).toHaveBeenCalledWith({ activeWorktreeId: restoreId });
+    });
+
+    it("exitFleetScope reapplies terminal streaming policy for the restored worktree", async () => {
+      setMockTerminals([
+        { id: "term-a", worktreeId: "wt-original", location: "grid" },
+        { id: "term-b", worktreeId: "wt-other", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-original" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      applyRendererPolicyMock.mockClear();
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(applyRendererPolicyMock).toHaveBeenCalledWith("term-a", TerminalRefreshTier.VISIBLE);
+      expect(applyRendererPolicyMock).toHaveBeenCalledWith(
+        "term-b",
+        TerminalRefreshTier.BACKGROUND
+      );
+    });
+
     it("exitFleetScope is a no-op when scope is not active", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-current" });
       useWorktreeSelectionStore.getState().exitFleetScope();

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -313,4 +313,56 @@ describe("worktreeStore", () => {
 
     expect(setFocusedMock).not.toHaveBeenCalledWith("term-a");
   });
+
+  describe("fleet scope", () => {
+    it("starts inactive with no previous worktree captured", () => {
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.isFleetScopeActive).toBe(false);
+      expect(state._previousActiveWorktreeId).toBeNull();
+    });
+
+    it("enterFleetScope captures current activeWorktreeId", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-active" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.isFleetScopeActive).toBe(true);
+      expect(state._previousActiveWorktreeId).toBe("wt-active");
+    });
+
+    it("enterFleetScope is idempotent — repeated calls preserve the original capture", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-original" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-changed" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      expect(useWorktreeSelectionStore.getState()._previousActiveWorktreeId).toBe("wt-original");
+    });
+
+    it("exitFleetScope restores the previously captured activeWorktreeId", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-original" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.isFleetScopeActive).toBe(false);
+      expect(state._previousActiveWorktreeId).toBeNull();
+      expect(state.activeWorktreeId).toBe("wt-original");
+    });
+
+    it("exitFleetScope is a no-op when scope is not active", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-current" });
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.isFleetScopeActive).toBe(false);
+      expect(state.activeWorktreeId).toBe("wt-current");
+    });
+
+    it("reset clears fleet scope state", () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-active" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      useWorktreeSelectionStore.getState().reset();
+      const state = useWorktreeSelectionStore.getState();
+      expect(state.isFleetScopeActive).toBe(false);
+      expect(state._previousActiveWorktreeId).toBeNull();
+    });
+  });
 });

--- a/src/store/fleetScopeFlagStore.ts
+++ b/src/store/fleetScopeFlagStore.ts
@@ -1,5 +1,4 @@
 import { create } from "zustand";
-import { appClient } from "@/clients";
 
 export type FleetScopeMode = "legacy" | "scoped";
 
@@ -29,6 +28,7 @@ export const useFleetScopeFlagStore = create<FleetScopeFlagState>()((set, get) =
 
 async function persistMode(mode: FleetScopeMode): Promise<void> {
   try {
+    const { appClient } = await import("@/clients");
     await appClient.setState({ fleetScopeMode: mode });
   } catch (error) {
     console.error("Failed to persist fleet scope mode:", error);

--- a/src/store/fleetScopeFlagStore.ts
+++ b/src/store/fleetScopeFlagStore.ts
@@ -1,0 +1,36 @@
+import { create } from "zustand";
+import { appClient } from "@/clients";
+
+export type FleetScopeMode = "legacy" | "scoped";
+
+interface FleetScopeFlagState {
+  mode: FleetScopeMode;
+  isHydrated: boolean;
+
+  setMode: (mode: FleetScopeMode) => void;
+  hydrate: (mode: FleetScopeMode | undefined) => void;
+}
+
+export const useFleetScopeFlagStore = create<FleetScopeFlagState>()((set, get) => ({
+  mode: "legacy",
+  isHydrated: false,
+
+  setMode: (mode) => {
+    if (get().mode === mode) return;
+    set({ mode, isHydrated: true });
+    void persistMode(mode);
+  },
+
+  hydrate: (mode) => {
+    if (get().isHydrated) return;
+    set({ mode: mode === "scoped" ? "scoped" : "legacy", isHydrated: true });
+  },
+}));
+
+async function persistMode(mode: FleetScopeMode): Promise<void> {
+  try {
+    await appClient.setState({ fleetScopeMode: mode });
+  } catch (error) {
+    console.error("Failed to persist fleet scope mode:", error);
+  }
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -94,6 +94,9 @@ export {
 } from "./fleetDeckStore";
 export type { FleetDeckEdge, FleetDeckScope, FleetDeckStateFilter } from "./fleetDeckStore";
 
+export { useFleetScopeFlagStore } from "./fleetScopeFlagStore";
+export type { FleetScopeMode } from "./fleetScopeFlagStore";
+
 export { useTwoPaneSplitStore } from "./twoPaneSplitStore";
 export type { TwoPaneSplitConfig, WorktreeRatioEntry } from "./twoPaneSplitStore";
 

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -528,13 +528,19 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   exitFleetScope: () => {
     if (!get().isFleetScopeActive) return;
     const restoreId = get()._previousActiveWorktreeId;
+    const generation = get()._policyGeneration + 1;
     set({
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
       activeWorktreeId: restoreId,
       focusedWorktreeId: restoreId,
+      _policyGeneration: generation,
     });
     persistActiveWorktree(restoreId);
+    // Reconcile terminal streaming tiers: consumers may have mutated
+    // activeWorktreeId during scope, so the renderer policy must be
+    // reapplied for the restored worktree.
+    applyWorktreeTerminalPolicy(get, set, restoreId, generation);
   },
 
   reset: () =>

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -46,6 +46,8 @@ interface WorktreeSelectionState {
   crossDiffDialog: CrossDiffDialogState;
   _policyGeneration: number;
   lastFocusedTerminalByWorktree: Map<string, string>;
+  isFleetScopeActive: boolean;
+  _previousActiveWorktreeId: string | null;
 
   setActiveWorktree: (id: string | null) => void;
   setFocusedWorktree: (id: string | null) => void;
@@ -72,6 +74,8 @@ interface WorktreeSelectionState {
   closeCrossWorktreeDiff: () => void;
   trackTerminalFocus: (worktreeId: string, terminalId: string) => void;
   clearWorktreeFocusTracking: (worktreeId: string) => void;
+  enterFleetScope: () => void;
+  exitFleetScope: () => void;
   reset: () => void;
 }
 
@@ -244,6 +248,8 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
   crossDiffDialog: { isOpen: false, initialWorktreeId: null },
   _policyGeneration: 0,
   lastFocusedTerminalByWorktree: new Map<string, string>(),
+  isFleetScopeActive: false,
+  _previousActiveWorktreeId: null,
 
   setActiveWorktree: (id) => {
     const previousId = get().activeWorktreeId;
@@ -509,6 +515,28 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       return { lastFocusedTerminalByWorktree: next };
     }),
 
+  enterFleetScope: () => {
+    // Idempotent: first pre-scope activeWorktreeId wins so the restoration
+    // target isn't corrupted by a double-enter.
+    if (get().isFleetScopeActive) return;
+    set({
+      isFleetScopeActive: true,
+      _previousActiveWorktreeId: get().activeWorktreeId,
+    });
+  },
+
+  exitFleetScope: () => {
+    if (!get().isFleetScopeActive) return;
+    const restoreId = get()._previousActiveWorktreeId;
+    set({
+      isFleetScopeActive: false,
+      _previousActiveWorktreeId: null,
+      activeWorktreeId: restoreId,
+      focusedWorktreeId: restoreId,
+    });
+    persistActiveWorktree(restoreId);
+  },
+
   reset: () =>
     set({
       activeWorktreeId: null,
@@ -527,6 +555,8 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       quickCreate: { isOpen: false, issue: null, pr: null },
       crossDiffDialog: { isOpen: false, initialWorktreeId: null },
       lastFocusedTerminalByWorktree: new Map<string, string>(),
+      isFleetScopeActive: false,
+      _previousActiveWorktreeId: null,
     }),
 });
 


### PR DESCRIPTION
## Summary

- Adds `isFleetScopeActive`, `enterFleetScope()`, and `exitFleetScope()` to `useWorktreeSelectionStore`. Entering preserves the prior `activeWorktreeId` so exiting restores it cleanly.
- Introduces two new action IDs (`fleet.scope.enter` / `fleet.scope.exit`) wired up in `fleetActions.ts`, both no-ops until the flag is on.
- A minimal `fleetScopeMode: "legacy" | "scoped"` flag is persisted via `appClient.setState`, defaulting to `"legacy"` so nothing visible changes after this lands.

Resolves #5559

## Changes

- `src/store/fleetScopeFlagStore.ts` — new flag store, lazy-imports `appClient` to avoid circular dep
- `src/store/worktreeStore.ts` — `isFleetScopeActive` state + enter/exit actions with prior-ID restore
- `src/services/actions/definitions/fleetActions.ts` — `fleet.scope.enter` / `fleet.scope.exit` action definitions
- `shared/types/actions.ts` + `shared/types/ipc/app.ts` — action IDs and IPC state field
- `electron/ipc/handlers/app/state.ts` + `electron/store.ts` — persist flag in main-process store
- `src/components/Layout/AppLayout.tsx` — subscribe store on mount
- Unit tests for the flag store and the new worktree store slices

## Testing

Unit tests cover the flag store round-trip and all three enter/exit/restore paths in `worktreeStore`. Verified with `npm run check` (no errors, warnings are pre-existing).