### PR TITLE
fix(notes): route IPC handlers through per-window project context

### DIFF
--- a/electron/ipc/handlers/__tests__/notes.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/notes.handlers.test.ts
@@ -21,14 +21,12 @@ const NotesServiceMock = vi.hoisted(() =>
   ) {
     const instance = {
       create: vi.fn().mockResolvedValue({ path: "/note.md", metadata: { id: "n1" } }),
-      read: vi
-        .fn()
-        .mockResolvedValue({
-          content: "",
-          metadata: { id: "n1" },
-          path: "/note.md",
-          lastModified: 0,
-        }),
+      read: vi.fn().mockResolvedValue({
+        content: "",
+        metadata: { id: "n1" },
+        path: "/note.md",
+        lastModified: 0,
+      }),
       write: vi.fn().mockResolvedValue({ lastModified: 1 }),
       list: vi.fn().mockResolvedValue([]),
       delete: vi.fn().mockResolvedValue(undefined),
@@ -181,5 +179,49 @@ describe("notes handlers", () => {
 
     const projectIds = notesServiceInstances.map((e) => e.projectId);
     expect(projectIds).toEqual(["project-A", "project-B"]);
+  });
+
+  it("threads write arguments through to the project's NotesService", async () => {
+    mockProjectFor(1, "project-A");
+
+    const writeHandler = getInvokeHandler(CHANNELS.NOTES_WRITE);
+    const metadata = {
+      id: "note-1",
+      title: "Hello",
+      scope: "project" as const,
+      createdAt: 123,
+    };
+    await writeHandler(makeEvent(1), "notes/hello.md", "body", metadata, 99);
+
+    const service = notesServiceInstances[0].instance;
+    expect(service.write).toHaveBeenCalledWith("notes/hello.md", "body", metadata, 99);
+  });
+
+  it("recovers from a NoteConflictError by creating a conflict copy and force-writing", async () => {
+    mockProjectFor(1, "project-A");
+
+    const writeHandler = getInvokeHandler(CHANNELS.NOTES_WRITE);
+    const metadata = {
+      id: "note-1",
+      title: "Hello",
+      scope: "project" as const,
+      createdAt: 123,
+    };
+
+    // First invocation creates the cached service and primes a conflict on the
+    // next write. The handler re-resolves the service on its second write call,
+    // so we must mutate the cached instance rather than building a fresh one.
+    await writeHandler(makeEvent(1), "notes/hello.md", "body", metadata);
+    const service = notesServiceInstances[0].instance;
+    service.write.mockReset();
+    service.write
+      .mockRejectedValueOnce(new NoteConflictErrorStub("conflict"))
+      .mockResolvedValueOnce({ lastModified: 42 });
+
+    const result = await writeHandler(makeEvent(1), "notes/hello.md", "body", metadata);
+
+    expect(service.createConflictCopy).toHaveBeenCalledWith("notes/hello.md");
+    expect(service.write).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ lastModified: 42, conflictPath: "/note.conflict.md" });
   });
 });

--- a/electron/ipc/handlers/__tests__/notes.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/notes.handlers.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const appMock = vi.hoisted(() => ({
+  getPath: vi.fn(() => "/tmp/userData"),
+}));
+
+const notesServiceInstances = vi.hoisted<
+  Array<{ projectId: string; instance: Record<string, Mock> }>
+>(() => []);
+
+const NotesServiceMock = vi.hoisted(() =>
+  vi.fn().mockImplementation(function (
+    this: Record<string, unknown>,
+    _userData: string,
+    projectId: string
+  ) {
+    const instance = {
+      create: vi.fn().mockResolvedValue({ path: "/note.md", metadata: { id: "n1" } }),
+      read: vi
+        .fn()
+        .mockResolvedValue({
+          content: "",
+          metadata: { id: "n1" },
+          path: "/note.md",
+          lastModified: 0,
+        }),
+      write: vi.fn().mockResolvedValue({ lastModified: 1 }),
+      list: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+      search: vi.fn().mockResolvedValue({ notes: [], query: "" }),
+      saveAttachment: vi.fn().mockResolvedValue({ path: "/attach.png", filename: "attach.png" }),
+      getDirPath: vi.fn(() => `/notes/${projectId}`),
+      getProjectId: vi.fn(() => projectId),
+      createConflictCopy: vi.fn().mockResolvedValue({ conflictPath: "/note.conflict.md" }),
+    };
+    notesServiceInstances.push({ projectId, instance });
+    Object.assign(this, instance);
+  })
+);
+
+const NoteConflictErrorStub = vi.hoisted(
+  () =>
+    class NoteConflictErrorStub extends Error {
+      constructor(message = "conflict") {
+        super(message);
+      }
+    }
+);
+
+const getProjectViewManagerMock = vi.hoisted(() => vi.fn());
+const getWindowForWebContentsMock = vi.hoisted(() => vi.fn(() => null));
+const getAllAppWebContentsMock = vi.hoisted(() => vi.fn(() => []));
+const getAppWebContentsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  app: appMock,
+  BrowserWindow: {
+    fromWebContents: vi.fn(() => null),
+    getAllWindows: vi.fn(() => []),
+  },
+}));
+
+vi.mock("../../../services/NotesService.js", () => ({
+  NotesService: NotesServiceMock,
+  NoteConflictError: NoteConflictErrorStub,
+}));
+
+vi.mock("../../../window/webContentsRegistry.js", () => ({
+  getWindowForWebContents: getWindowForWebContentsMock,
+  getAllAppWebContents: getAllAppWebContentsMock,
+  getAppWebContents: getAppWebContentsMock,
+}));
+
+vi.mock("../../../window/windowRef.js", () => ({
+  getProjectViewManager: getProjectViewManagerMock,
+}));
+
+import { CHANNELS } from "../../channels.js";
+import { registerNotesHandlers, _resetNotesServicesForTest } from "../notes.js";
+
+function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([registered]) => registered === channel
+  );
+  if (!call) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+function makeEvent(webContentsId: number) {
+  return { sender: { id: webContentsId } } as never;
+}
+
+function mockProjectFor(webContentsId: number, projectId: string | null) {
+  getProjectViewManagerMock.mockReturnValue({
+    getProjectIdForWebContents: (id: number) => (id === webContentsId ? projectId : null),
+  });
+}
+
+describe("notes handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    notesServiceInstances.length = 0;
+    _resetNotesServicesForTest();
+    registerNotesHandlers({} as never);
+  });
+
+  const NOTES_CHANNELS = [
+    CHANNELS.NOTES_CREATE,
+    CHANNELS.NOTES_READ,
+    CHANNELS.NOTES_WRITE,
+    CHANNELS.NOTES_LIST,
+    CHANNELS.NOTES_DELETE,
+    CHANNELS.NOTES_SEARCH,
+    CHANNELS.NOTES_WRITE_ATTACHMENT,
+    CHANNELS.NOTES_GET_DIR,
+  ] as const;
+
+  it("registers all eight notes channels via context-aware dispatch", () => {
+    const registered = (ipcMainMock.handle as Mock).mock.calls.map(([c]) => c);
+    for (const channel of NOTES_CHANNELS) {
+      expect(registered).toContain(channel);
+    }
+  });
+
+  it("throws 'No active project' when ctx.projectId is null", async () => {
+    mockProjectFor(1, null);
+    for (const channel of NOTES_CHANNELS) {
+      const handler = getInvokeHandler(channel);
+      await expect(handler(makeEvent(1))).rejects.toThrow(/No active project/);
+    }
+  });
+
+  it("resolves a distinct NotesService instance for each project id", async () => {
+    // Window A → project A
+    getProjectViewManagerMock.mockReturnValue({
+      getProjectIdForWebContents: (id: number) => (id === 1 ? "project-A" : "project-B"),
+    });
+
+    const listHandler = getInvokeHandler(CHANNELS.NOTES_LIST);
+    await listHandler(makeEvent(1));
+    await listHandler(makeEvent(2));
+
+    expect(NotesServiceMock).toHaveBeenCalledTimes(2);
+    expect(notesServiceInstances[0].projectId).toBe("project-A");
+    expect(notesServiceInstances[1].projectId).toBe("project-B");
+  });
+
+  it("reuses the cached NotesService for repeated calls from the same project", async () => {
+    mockProjectFor(1, "project-A");
+
+    const listHandler = getInvokeHandler(CHANNELS.NOTES_LIST);
+    await listHandler(makeEvent(1));
+    await listHandler(makeEvent(1));
+    await listHandler(makeEvent(1));
+
+    expect(NotesServiceMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes ctx.projectId — not a global singleton — when the active view changes", async () => {
+    // First call: window on project-A
+    getProjectViewManagerMock.mockReturnValue({
+      getProjectIdForWebContents: () => "project-A",
+    });
+    const listHandler = getInvokeHandler(CHANNELS.NOTES_LIST);
+    await listHandler(makeEvent(1));
+
+    // Second call: same webContents id, but the view manager now reports project-B
+    // (simulates a second window/view scenario where "current project" diverges).
+    getProjectViewManagerMock.mockReturnValue({
+      getProjectIdForWebContents: () => "project-B",
+    });
+    await listHandler(makeEvent(1));
+
+    const projectIds = notesServiceInstances.map((e) => e.projectId);
+    expect(projectIds).toEqual(["project-A", "project-B"]);
+  });
+});

--- a/electron/ipc/handlers/notes.ts
+++ b/electron/ipc/handlers/notes.ts
@@ -1,9 +1,9 @@
 import { app } from "electron";
 import { CHANNELS } from "../channels.js";
-import { broadcastToRenderer, typedHandle } from "../utils.js";
+import { broadcastToRenderer, typedHandleWithContext } from "../utils.js";
 import type { HandlerDependencies } from "../types.js";
+import type { IpcContext } from "../types.js";
 import { NotesService, NoteConflictError, type NoteMetadata } from "../../services/NotesService.js";
-import { projectStore } from "../../services/ProjectStore.js";
 
 export interface NoteUpdatedPayload {
   notePath: string;
@@ -50,19 +50,23 @@ function validateNoteMetadata(metadata: unknown): NoteMetadata {
   };
 }
 
-let notesService: NotesService | null = null;
+const notesServices = new Map<string, NotesService>();
 
-function getNotesService(): NotesService {
-  const currentProject = projectStore.getCurrentProject();
-  if (!currentProject) {
+function resolveNotesService(ctx: IpcContext): NotesService {
+  if (!ctx.projectId) {
     throw new Error("No active project");
   }
 
-  if (!notesService || notesService.getProjectId() !== currentProject.id) {
-    notesService = new NotesService(app.getPath("userData"), currentProject.id);
+  let service = notesServices.get(ctx.projectId);
+  if (!service) {
+    service = new NotesService(app.getPath("userData"), ctx.projectId);
+    notesServices.set(ctx.projectId, service);
   }
+  return service;
+}
 
-  return notesService;
+export function _resetNotesServicesForTest(): void {
+  notesServices.clear();
 }
 
 export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
@@ -73,30 +77,32 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
   };
 
   const handleNotesCreate = async (
+    ctx: IpcContext,
     title: string,
     scope: "worktree" | "project",
     worktreeId?: string
   ) => {
-    const service = getNotesService();
+    const service = resolveNotesService(ctx);
     const result = await service.create(title, scope, worktreeId);
     broadcastUpdate({ notePath: result.path, title, action: "created" });
     return result;
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_CREATE, handleNotesCreate));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_CREATE, handleNotesCreate));
 
-  const handleNotesRead = async (notePath: string) => {
-    const service = getNotesService();
+  const handleNotesRead = async (ctx: IpcContext, notePath: string) => {
+    const service = resolveNotesService(ctx);
     return await service.read(notePath);
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_READ, handleNotesRead));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_READ, handleNotesRead));
 
   const handleNotesWrite = async (
+    ctx: IpcContext,
     notePath: string,
     content: string,
     metadata: unknown,
     expectedLastModified?: number
   ) => {
-    const service = getNotesService();
+    const service = resolveNotesService(ctx);
     const validatedMetadata = validateNoteMetadata(metadata);
     try {
       const result = await service.write(
@@ -142,43 +148,46 @@ export function registerNotesHandlers(_deps: HandlerDependencies): () => void {
       return { ...result, conflictPath };
     }
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_WRITE, handleNotesWrite));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_WRITE, handleNotesWrite));
 
-  const handleNotesList = async () => {
-    const service = getNotesService();
+  const handleNotesList = async (ctx: IpcContext) => {
+    const service = resolveNotesService(ctx);
     return await service.list();
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_LIST, handleNotesList));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_LIST, handleNotesList));
 
-  const handleNotesDelete = async (notePath: string) => {
-    const service = getNotesService();
+  const handleNotesDelete = async (ctx: IpcContext, notePath: string) => {
+    const service = resolveNotesService(ctx);
     await service.delete(notePath);
     broadcastUpdate({ notePath, title: "", action: "deleted" });
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_DELETE, handleNotesDelete));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_DELETE, handleNotesDelete));
 
-  const handleNotesSearch = async (query: string) => {
-    const service = getNotesService();
+  const handleNotesSearch = async (ctx: IpcContext, query: string) => {
+    const service = resolveNotesService(ctx);
     return await service.search(query);
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_SEARCH, handleNotesSearch));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_SEARCH, handleNotesSearch));
 
   const handleNotesWriteAttachment = async (
+    ctx: IpcContext,
     data: Uint8Array,
     mimeType: string,
     originalName?: string
   ) => {
-    const service = getNotesService();
+    const service = resolveNotesService(ctx);
     const buffer = Buffer.from(data.buffer, data.byteOffset, data.byteLength);
     return await service.saveAttachment(buffer, mimeType, originalName);
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_WRITE_ATTACHMENT, handleNotesWriteAttachment));
+  handlers.push(
+    typedHandleWithContext(CHANNELS.NOTES_WRITE_ATTACHMENT, handleNotesWriteAttachment)
+  );
 
-  const handleNotesGetDir = async () => {
-    const service = getNotesService();
+  const handleNotesGetDir = async (ctx: IpcContext) => {
+    const service = resolveNotesService(ctx);
     return service.getDirPath();
   };
-  handlers.push(typedHandle(CHANNELS.NOTES_GET_DIR, handleNotesGetDir));
+  handlers.push(typedHandleWithContext(CHANNELS.NOTES_GET_DIR, handleNotesGetDir));
 
   return () => {
     handlers.forEach((dispose) => dispose());

--- a/src/components/Notes/NotesPane.tsx
+++ b/src/components/Notes/NotesPane.tsx
@@ -205,6 +205,9 @@ export function NotesPane({
 
     async function loadNote() {
       if (!notePath) {
+        setError(
+          "Note path is missing — the panel state may be corrupt. Close it and create a new note."
+        );
         setIsLoading(false);
         return;
       }

--- a/src/panels/__tests__/registry.defaults.test.ts
+++ b/src/panels/__tests__/registry.defaults.test.ts
@@ -30,16 +30,27 @@ describe("panelKindRegistry createDefaults (co-located)", () => {
     expect(result.browserConsoleOpen).toBe(true);
   });
 
-  it("notes factory defaults notePath and noteId to empty strings", () => {
+  it("notes factory omits notePath and noteId when not provided", () => {
     const config = getPanelKindConfig("notes")!;
     const result = config.createDefaults!({ kind: "notes" } as AddPanelOptions);
-    expect(result.notePath).toBe("");
-    expect(result.noteId).toBe("");
+    expect(result.notePath).toBeUndefined();
+    expect(result.noteId).toBeUndefined();
     expect(result.scope).toBe("project");
     expect(result.createdAt).toBeGreaterThan(0);
     expect(result.cwd).toBeUndefined();
     expect(result.cols).toBeUndefined();
     expect(result.rows).toBeUndefined();
+  });
+
+  it("notes factory omits notePath and noteId when provided empty strings", () => {
+    const config = getPanelKindConfig("notes")!;
+    const result = config.createDefaults!({
+      kind: "notes",
+      notePath: "",
+      noteId: "",
+    } as AddPanelOptions);
+    expect(result.notePath).toBeUndefined();
+    expect(result.noteId).toBeUndefined();
   });
 
   it("notes factory preserves provided fields", () => {

--- a/src/panels/notes/defaults.ts
+++ b/src/panels/notes/defaults.ts
@@ -3,8 +3,8 @@ import type { NotesPanelOptions } from "@shared/types/addPanelOptions";
 
 export function createNotesDefaults(options: NotesPanelOptions): Partial<NotesPanelData> {
   return {
-    notePath: options.notePath ?? "",
-    noteId: options.noteId ?? "",
+    ...(options.notePath && { notePath: options.notePath }),
+    ...(options.noteId && { noteId: options.noteId }),
     scope: options.scope ?? "project",
     createdAt: options.createdAt ?? Date.now(),
   };


### PR DESCRIPTION
## Summary

- After the multi-window refactor (#5492), all 8 notes IPC handlers were still using a module-level `NotesService` singleton keyed to `projectStore.getCurrentProject()`. In a WebContentsView-per-project world, that global lookup returned null or the wrong project, so every save and read silently no-opped.
- A secondary issue in `createNotesDefaults` fell back `notePath`/`noteId` to `""`, tripping the early-return guard in `NotesPane` and putting restored panels into a permanent loading state with no visible error.
- Migrated all 8 handlers to `typedHandleWithContext`, replaced the single-slot cache with a `Map<string, NotesService>`, removed the `""` fallback in `createNotesDefaults`, and surfaced the missing restore-state case as a visible error instead of swallowing it silently.

Resolves #5553

## Changes

- `electron/ipc/handlers/notes.ts` — all handlers now use `ctx.projectId`; `NotesService` instances cached per project ID in a `Map`
- `src/panels/notes/defaults.ts` — removed `""` fallback for `notePath`/`noteId`; undefined is now passed through so callers can detect missing state
- `src/components/Notes/NotesPane.tsx` — surfaces missing restore-state as a visible error panel rather than infinite loading
- `electron/ipc/handlers/__tests__/notes.handlers.test.ts` — 7 new tests covering registration, null projectId guard, per-project isolation, cache reuse, write-arg threading, and conflict-branch recovery
- `src/panels/__tests__/registry.defaults.test.ts` — updated to reflect defaults change

## Testing

Targeted vitest suites pass. Lint, format, and typecheck all clean. The existing `e2e/core/core-notes-panel.spec.ts` covers the round-trip and should now work against real IPC rather than direct service calls.