### PR TITLE
feat(demo): replace capturePage poll with getDisplayMedia + MediaRecorder

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -101,6 +101,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Demo/DemoCaptureBridge.tsx": {
+    "success": 0,
+    "skip": 0,
+    "error": 1,
+    "pipeline": 0
+  },
   "src/components/Demo/DemoCursor.tsx": {
     "success": 0,
     "skip": 0,
@@ -314,7 +320,7 @@
   "src/components/Fleet/FleetDryRunDialog.tsx": {
     "success": 1,
     "skip": 0,
-    "error": 2,
+    "error": 1,
     "pipeline": 0
   },
   "src/components/Fleet/FleetScopeBar.tsx": {

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -619,6 +619,12 @@ export const CHANNELS = {
   DEMO_EXEC_DISMISS_ANNOTATION: "demo:exec-dismiss-annotation",
   DEMO_WAIT_FOR_IDLE: "demo:wait-for-idle",
   DEMO_EXEC_WAIT_FOR_IDLE: "demo:exec-wait-for-idle",
+  DEMO_ENCODE: "demo:encode",
+  DEMO_ENCODE_PROGRESS: "demo:encode:progress",
+  DEMO_EXEC_START_CAPTURE: "demo:exec-start-capture",
+  DEMO_EXEC_STOP_CAPTURE: "demo:exec-stop-capture",
+  DEMO_CAPTURE_CHUNK: "demo:capture-chunk",
+  DEMO_CAPTURE_STOP: "demo:capture-stop",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -619,8 +619,6 @@ export const CHANNELS = {
   DEMO_EXEC_DISMISS_ANNOTATION: "demo:exec-dismiss-annotation",
   DEMO_WAIT_FOR_IDLE: "demo:wait-for-idle",
   DEMO_EXEC_WAIT_FOR_IDLE: "demo:exec-wait-for-idle",
-  DEMO_ENCODE: "demo:encode",
-  DEMO_ENCODE_PROGRESS: "demo:encode:progress",
   DEMO_EXEC_START_CAPTURE: "demo:exec-start-capture",
   DEMO_EXEC_STOP_CAPTURE: "demo:exec-stop-capture",
   DEMO_CAPTURE_CHUNK: "demo:capture-chunk",

--- a/electron/ipc/handlers/__tests__/demo.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/demo.handlers.test.ts
@@ -41,32 +41,6 @@ vi.mock("fs", () => ({
   createWriteStream: vi.fn(() => mockWriteStream),
 }));
 
-class MockStdin extends EventEmitter {
-  write = vi.fn(() => true);
-  end = vi.fn();
-}
-
-let mockProc: EventEmitter & {
-  stdin: MockStdin;
-  kill: ReturnType<typeof vi.fn>;
-};
-
-function createMockProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdin: MockStdin;
-    kill: ReturnType<typeof vi.fn>;
-  };
-  proc.stdin = new MockStdin();
-  proc.kill = vi.fn();
-  return proc;
-}
-
-vi.mock("child_process", () => ({
-  spawn: vi.fn(() => mockProc),
-}));
-
-vi.mock("ffmpeg-static", () => ({ default: "/mock/bin/ffmpeg" }));
-
 import { registerDemoHandlers } from "../demo.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { BrowserWindow } from "electron";
@@ -111,7 +85,6 @@ function getIpcListener(channel: string): ((...args: unknown[]) => void) | undef
 describe("registerDemoHandlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockProc = createMockProc();
     mockWriteStream = new MockWriteStream();
   });
 
@@ -166,7 +139,6 @@ describe("registerDemoHandlers", () => {
     expect(channels).toContain("demo:start-capture");
     expect(channels).toContain("demo:stop-capture");
     expect(channels).toContain("demo:get-capture-status");
-    expect(channels).toContain("demo:encode");
     cleanup();
   });
 
@@ -178,10 +150,10 @@ describe("registerDemoHandlers", () => {
     cleanup();
   });
 
-  it("cleanup removes all 22 handlers", () => {
+  it("cleanup removes all 20 handlers", () => {
     const cleanup = registerDemoHandlers(makeDeps(true));
     cleanup();
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(22);
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(20);
   });
 
   it("cleanup removes chunk and stop listeners", () => {
@@ -196,7 +168,7 @@ describe("registerDemoHandlers", () => {
     const deps = makeDeps(true);
     registerDemoHandlers(deps);
     const handler = getHandler("demo:screenshot");
-    const result = (await handler()) as {
+    const result = (await handler({})) as {
       data: Uint8Array;
       width: number;
       height: number;
@@ -207,107 +179,13 @@ describe("registerDemoHandlers", () => {
     expect(result.height).toBe(1080);
   });
 
-  describe("handleEncode", () => {
-    function getEncodeHandler() {
-      registerDemoHandlers(makeDeps(true));
-      return getHandler("demo:encode");
-    }
-
-    function makeEvent(isDestroyed = false) {
-      return {
-        sender: {
-          send: vi.fn(),
-          isDestroyed: vi.fn(() => isDestroyed),
-        },
-      };
-    }
-
-    it("resolves with outputPath and durationMs on success", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-      mockProc.emit("close", 0);
-      const result = (await promise) as { outputPath: string; durationMs: number };
-      expect(result.outputPath).toBe("/tmp/out.mp4");
-      expect(typeof result.durationMs).toBe("number");
-    });
-
-    it("rejects when no PNG frames found", async () => {
-      const fsMod = await import("fs");
-      (fsMod.readdirSync as ReturnType<typeof vi.fn>).mockReturnValueOnce([]);
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-      await expect(
-        handler(event, {
-          framesDir: "/tmp/empty",
-          outputPath: "/tmp/out.mp4",
-          preset: "youtube-4k",
-        })
-      ).rejects.toThrow("No PNG frames matching frame-NNNNNN.png found");
-    });
-
-    it("rejects on non-zero exit code with stderr", async () => {
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "web-webm",
-      });
-      mockProc.stderr.emit("data", Buffer.from("Unknown encoder libx264"));
-      mockProc.emit("close", 1);
-      await expect(promise).rejects.toThrow("ffmpeg exited with code 1");
-    });
-
-    it("uses yuv444p and high444 profile for youtube presets", async () => {
-      const { spawn: spawnMock } = await import("child_process");
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-      mockProc.emit("close", 0);
-      await promise;
-      const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string[];
-      expect(args).toContain("yuv444p");
-      expect(args).toContain("high444");
-    });
-
-    it("uses frame-%06d.png input pattern", async () => {
-      const { spawn: spawnMock } = await import("child_process");
-      const handler = getEncodeHandler();
-      const event = makeEvent();
-      const promise = handler(event, {
-        framesDir: "/tmp/frames",
-        outputPath: "/tmp/out.mp4",
-        preset: "youtube-1080p",
-      });
-      mockProc.emit("close", 0);
-      await promise;
-      const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string[];
-      const inputIdx = args.indexOf("-i");
-      expect(args[inputIdx + 1]).toContain("frame-%06d.png");
-    });
-  });
-
   describe("MediaRecorder capture pipeline", () => {
     const defaultPayload = {
       fps: 30,
       outputPath: "/tmp/capture/out.webm",
     };
 
-    it("startCapture creates write stream, sends exec start, returns outputPath", async () => {
-      const fsMod = await import("fs");
-      const deps = makeDeps(true);
-      const cleanup = registerDemoHandlers(deps);
-      const handler = getHandler("demo:start-capture");
-
+    function autoResolveCommandDone() {
       ipcMainMock.on.mockImplementation(
         (channel: string, listener: (...args: unknown[]) => void) => {
           if (channel === "demo:command-done") {
@@ -315,6 +193,14 @@ describe("registerDemoHandlers", () => {
           }
         }
       );
+    }
+
+    it("startCapture creates write stream, sends exec start, returns outputPath", async () => {
+      const fsMod = await import("fs");
+      autoResolveCommandDone();
+      const deps = makeDeps(true);
+      const cleanup = registerDemoHandlers(deps);
+      const handler = getHandler("demo:start-capture");
 
       const result = (await handler({}, defaultPayload)) as { outputPath: string };
       expect(result.outputPath).toBe("/tmp/capture/out.webm");
@@ -332,13 +218,7 @@ describe("registerDemoHandlers", () => {
     });
 
     it("rejects startCapture when already active", async () => {
-      ipcMainMock.on.mockImplementation(
-        (channel: string, listener: (...args: unknown[]) => void) => {
-          if (channel === "demo:command-done") {
-            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
-          }
-        }
-      );
+      autoResolveCommandDone();
       const cleanup = registerDemoHandlers(makeDeps(true));
       const handler = getHandler("demo:start-capture");
       await handler({}, defaultPayload);
@@ -347,46 +227,21 @@ describe("registerDemoHandlers", () => {
     });
 
     it("capture chunk handler writes buffer to stream for matching captureId", async () => {
-      // Build a real registration (not mocked) so we can capture the listener
+      autoResolveCommandDone();
       const deps = makeDeps(true);
       const cleanup = registerDemoHandlers(deps);
       const startHandler = getHandler("demo:start-capture");
-
-      // Arrange: resolve exec-start-capture
-      let doneListener: ((...args: unknown[]) => void) | undefined;
-      ipcMainMock.on.mock.calls.forEach((c: unknown[]) => {
-        if (c[0] === "demo:command-done") {
-          doneListener = c[1] as (...args: unknown[]) => void;
-        }
-      });
-      const startPromise = startHandler({}, defaultPayload);
-      // find the latest demo:command-done listener added by sendCommandAndAwait
-      setTimeout(() => {
-        const latest = ipcMainMock.on.mock.calls
-          .filter((c: unknown[]) => c[0] === "demo:command-done")
-          .at(-1);
-        (latest?.[1] as (...args: unknown[]) => void)?.({}, { requestId: "test-request-id" });
-      }, 0);
-      await startPromise;
+      await startHandler({}, defaultPayload);
 
       const chunkListener = getIpcListener("demo:capture-chunk");
       expect(chunkListener).toBeDefined();
-      const data = new Uint8Array([1, 2, 3, 4]);
-      chunkListener!({}, { captureId: "test-request-id", data });
+      chunkListener!({}, { captureId: "test-request-id", data: new Uint8Array([1, 2, 3, 4]) });
       expect(mockWriteStream.write).toHaveBeenCalledTimes(1);
       cleanup();
-      // doneListener is captured but unused; simulateCommandDone retained for other tests
-      void doneListener;
     });
 
     it("stale captureId chunks are ignored", async () => {
-      ipcMainMock.on.mockImplementation(
-        (channel: string, listener: (...args: unknown[]) => void) => {
-          if (channel === "demo:command-done") {
-            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
-          }
-        }
-      );
+      autoResolveCommandDone();
       const cleanup = registerDemoHandlers(makeDeps(true));
       const handler = getHandler("demo:start-capture");
       await handler({}, defaultPayload);
@@ -397,13 +252,7 @@ describe("registerDemoHandlers", () => {
     });
 
     it("stop flow: exec-stop sent then capture-stop finalizes writeStream and resolves", async () => {
-      ipcMainMock.on.mockImplementation(
-        (channel: string, listener: (...args: unknown[]) => void) => {
-          if (channel === "demo:command-done") {
-            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
-          }
-        }
-      );
+      autoResolveCommandDone();
       const deps = makeDeps(true);
       const cleanup = registerDemoHandlers(deps);
 
@@ -418,7 +267,6 @@ describe("registerDemoHandlers", () => {
         }>
       )({});
 
-      // Simulate renderer posting the final DEMO_CAPTURE_STOP
       setTimeout(() => {
         const stopListener = getIpcListener("demo:capture-stop");
         stopListener!({}, { captureId: "test-request-id", frameCount: 7 });
@@ -441,8 +289,8 @@ describe("registerDemoHandlers", () => {
     it("getCaptureStatus returns inactive before start", async () => {
       const cleanup = registerDemoHandlers(makeDeps(true));
       const status = (await (
-        getHandler("demo:get-capture-status") as () => Promise<unknown>
-      )()) as {
+        getHandler("demo:get-capture-status") as (ev: unknown) => Promise<unknown>
+      )({})) as {
         active: boolean;
         frameCount: number;
         outputPath: string | null;
@@ -453,21 +301,15 @@ describe("registerDemoHandlers", () => {
     });
 
     it("getCaptureStatus reports active after start", async () => {
-      ipcMainMock.on.mockImplementation(
-        (channel: string, listener: (...args: unknown[]) => void) => {
-          if (channel === "demo:command-done") {
-            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
-          }
-        }
-      );
+      autoResolveCommandDone();
       const cleanup = registerDemoHandlers(makeDeps(true));
       await (getHandler("demo:start-capture") as (...a: unknown[]) => Promise<unknown>)(
         {},
         defaultPayload
       );
       const status = (await (
-        getHandler("demo:get-capture-status") as () => Promise<unknown>
-      )()) as {
+        getHandler("demo:get-capture-status") as (ev: unknown) => Promise<unknown>
+      )({})) as {
         active: boolean;
         outputPath: string | null;
       };
@@ -477,13 +319,7 @@ describe("registerDemoHandlers", () => {
     });
 
     it("error from renderer on capture-stop rejects finalize promise", async () => {
-      ipcMainMock.on.mockImplementation(
-        (channel: string, listener: (...args: unknown[]) => void) => {
-          if (channel === "demo:command-done") {
-            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
-          }
-        }
-      );
+      autoResolveCommandDone();
       const cleanup = registerDemoHandlers(makeDeps(true));
       await (getHandler("demo:start-capture") as (...a: unknown[]) => Promise<unknown>)(
         {},

--- a/electron/ipc/handlers/__tests__/demo.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/demo.handlers.test.ts
@@ -302,11 +302,6 @@ describe("registerDemoHandlers", () => {
       outputPath: "/tmp/capture/out.webm",
     };
 
-    function simulateCommandDone(requestId = "test-request-id") {
-      const doneListener = getIpcListener("demo:command-done");
-      doneListener?.({}, { requestId });
-    }
-
     it("startCapture creates write stream, sends exec start, returns outputPath", async () => {
       const fsMod = await import("fs");
       const deps = makeDeps(true);

--- a/electron/ipc/handlers/__tests__/demo.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/demo.handlers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
 
 const ipcMainMock = vi.hoisted(() => ({
@@ -8,14 +8,37 @@ const ipcMainMock = vi.hoisted(() => ({
   removeListener: vi.fn(),
 }));
 
-vi.mock("electron", () => ({ ipcMain: ipcMainMock, BrowserWindow: { getAllWindows: () => [] } }));
+const displaySessionMock = vi.hoisted(() => ({
+  setDisplayMediaRequestHandler: vi.fn(),
+}));
+
+const sessionMock = vi.hoisted(() => ({
+  fromPartition: vi.fn(() => displaySessionMock),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  session: sessionMock,
+  BrowserWindow: { getAllWindows: () => [] },
+}));
 
 vi.mock("crypto", () => ({
   randomBytes: vi.fn(() => ({ toString: () => "test-request-id" })),
 }));
 
+class MockWriteStream extends EventEmitter {
+  write = vi.fn(() => true);
+  end = vi.fn((cb?: () => void) => {
+    if (cb) setTimeout(cb, 0);
+  });
+  destroy = vi.fn();
+}
+
+let mockWriteStream: MockWriteStream;
+
 vi.mock("fs", () => ({
   mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(() => mockWriteStream),
 }));
 
 class MockStdin extends EventEmitter {
@@ -50,17 +73,14 @@ import type { BrowserWindow } from "electron";
 
 const FRAME_W = 1920;
 const FRAME_H = 1080;
-// Use a small buffer for tests — real BGRA would be FRAME_W * FRAME_H * 4 but that causes OOM in test workers
-const BGRA_BUFFER = Buffer.alloc(16);
 
 function makeMockImage() {
-  const img = {
+  return {
     toPNG: () => Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     getSize: () => ({ width: FRAME_W, height: FRAME_H }),
-    toBitmap: () => BGRA_BUFFER,
+    toBitmap: () => Buffer.alloc(16),
     resize: vi.fn().mockReturnThis(),
   };
-  return img;
 }
 
 function makeDeps(isDemoMode: boolean): HandlerDependencies {
@@ -83,15 +103,22 @@ function getHandler(channel: string): (...args: unknown[]) => unknown {
   return call[1] as (...args: unknown[]) => unknown;
 }
 
+function getIpcListener(channel: string): ((...args: unknown[]) => void) | undefined {
+  const call = ipcMainMock.on.mock.calls.find(([ch]: unknown[]) => ch === channel);
+  return call?.[1] as ((...args: unknown[]) => void) | undefined;
+}
+
 describe("registerDemoHandlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockProc = createMockProc();
+    mockWriteStream = new MockWriteStream();
   });
 
   it("is a no-op when isDemoMode is false", () => {
     const cleanup = registerDemoHandlers(makeDeps(false));
     expect(ipcMainMock.handle).not.toHaveBeenCalled();
+    expect(displaySessionMock.setDisplayMediaRequestHandler).not.toHaveBeenCalled();
     cleanup();
   });
 
@@ -101,91 +128,393 @@ describe("registerDemoHandlers", () => {
     cleanup();
   });
 
+  it("registers setDisplayMediaRequestHandler on persist:daintree session", () => {
+    const cleanup = registerDemoHandlers(makeDeps(true));
+    expect(sessionMock.fromPartition).toHaveBeenCalledWith("persist:daintree");
+    expect(displaySessionMock.setDisplayMediaRequestHandler).toHaveBeenCalledTimes(1);
+    const args = displaySessionMock.setDisplayMediaRequestHandler.mock.calls[0]!;
+    expect(typeof args[0]).toBe("function");
+    expect(args[1]).toEqual({ useSystemPicker: false });
+    cleanup();
+  });
+
+  it("display handler invokes callback with request frame", () => {
+    const cleanup = registerDemoHandlers(makeDeps(true));
+    const [handlerFn] = displaySessionMock.setDisplayMediaRequestHandler.mock.calls[0]!;
+    const callback = vi.fn();
+    const frame = { id: "frame1" };
+    (handlerFn as (req: unknown, cb: (r: unknown) => void) => void)(
+      { frame, videoRequested: true },
+      callback
+    );
+    expect(callback).toHaveBeenCalledWith({ video: frame });
+    cleanup();
+  });
+
+  it("cleanup removes the display media handler", () => {
+    const cleanup = registerDemoHandlers(makeDeps(true));
+    cleanup();
+    expect(displaySessionMock.setDisplayMediaRequestHandler).toHaveBeenLastCalledWith(null);
+  });
+
   it("registers handlers for all demo channels", () => {
     const cleanup = registerDemoHandlers(makeDeps(true));
     const channels = ipcMainMock.handle.mock.calls.map(([ch]: unknown[]) => ch);
     expect(channels).toContain("demo:move-to");
-    expect(channels).toContain("demo:move-to-selector");
     expect(channels).toContain("demo:click");
     expect(channels).toContain("demo:screenshot");
-    expect(channels).toContain("demo:type");
-    expect(channels).toContain("demo:wait-for-selector");
-    expect(channels).toContain("demo:pause");
-    expect(channels).toContain("demo:resume");
-    expect(channels).toContain("demo:sleep");
     expect(channels).toContain("demo:start-capture");
     expect(channels).toContain("demo:stop-capture");
     expect(channels).toContain("demo:get-capture-status");
-    expect(channels).not.toContain("demo:encode");
-    expect(channels).toContain("demo:scroll");
-    expect(channels).toContain("demo:drag");
-    expect(channels).toContain("demo:press-key");
-    expect(channels).toContain("demo:spotlight");
-    expect(channels).toContain("demo:dismiss-spotlight");
-    expect(channels).toContain("demo:annotate");
-    expect(channels).toContain("demo:dismiss-annotation");
-    expect(channels).toContain("demo:wait-for-idle");
+    expect(channels).toContain("demo:encode");
     cleanup();
   });
 
-  it("cleanup removes all 20 handlers", () => {
+  it("registers chunk and stop listeners on ipcMain", () => {
+    const cleanup = registerDemoHandlers(makeDeps(true));
+    const onChannels = ipcMainMock.on.mock.calls.map(([ch]: unknown[]) => ch);
+    expect(onChannels).toContain("demo:capture-chunk");
+    expect(onChannels).toContain("demo:capture-stop");
+    cleanup();
+  });
+
+  it("cleanup removes all 22 handlers", () => {
     const cleanup = registerDemoHandlers(makeDeps(true));
     cleanup();
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(20);
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:move-to");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:move-to-selector");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:click");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:screenshot");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:type");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:wait-for-selector");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:pause");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:resume");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:sleep");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:scroll");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:drag");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:press-key");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:spotlight");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:dismiss-spotlight");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:annotate");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:dismiss-annotation");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:wait-for-idle");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:start-capture");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:stop-capture");
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("demo:get-capture-status");
-    expect(ipcMainMock.removeHandler).not.toHaveBeenCalledWith("demo:encode");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(22);
+  });
+
+  it("cleanup removes chunk and stop listeners", () => {
+    const cleanup = registerDemoHandlers(makeDeps(true));
+    cleanup();
+    const removed = ipcMainMock.removeListener.mock.calls.map(([ch]: unknown[]) => ch);
+    expect(removed).toContain("demo:capture-chunk");
+    expect(removed).toContain("demo:capture-stop");
   });
 
   it("screenshot handler returns Uint8Array with PNG magic bytes", async () => {
     const deps = makeDeps(true);
     registerDemoHandlers(deps);
-
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:screenshot") ?? [];
-    const result = await handler();
+    const handler = getHandler("demo:screenshot");
+    const result = (await handler()) as {
+      data: Uint8Array;
+      width: number;
+      height: number;
+    };
     expect(result.data).toBeInstanceOf(Uint8Array);
     expect(result.data[0]).toBe(0x89);
-    expect(result.data[1]).toBe(0x50);
-    expect(result.data[2]).toBe(0x4e);
-    expect(result.data[3]).toBe(0x47);
     expect(result.width).toBe(1920);
     expect(result.height).toBe(1080);
   });
 
-  it("moveTo handler sends exec event with requestId and awaits done", async () => {
-    const deps = makeDeps(true);
-    registerDemoHandlers(deps);
+  describe("handleEncode", () => {
+    function getEncodeHandler() {
+      registerDemoHandlers(makeDeps(true));
+      return getHandler("demo:encode");
+    }
 
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:move-to") ?? [];
+    function makeEvent(isDestroyed = false) {
+      return {
+        sender: {
+          send: vi.fn(),
+          isDestroyed: vi.fn(() => isDestroyed),
+        },
+      };
+    }
 
-    ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
-      if (channel === "demo:command-done") {
-        setTimeout(() => {
-          listener({}, { requestId: "test-request-id" });
-        }, 10);
-      }
+    it("resolves with outputPath and durationMs on success", async () => {
+      const handler = getEncodeHandler();
+      const event = makeEvent();
+      const promise = handler(event, {
+        framesDir: "/tmp/frames",
+        outputPath: "/tmp/out.mp4",
+        preset: "youtube-1080p",
+      });
+      mockProc.emit("close", 0);
+      const result = (await promise) as { outputPath: string; durationMs: number };
+      expect(result.outputPath).toBe("/tmp/out.mp4");
+      expect(typeof result.durationMs).toBe("number");
     });
 
+    it("rejects when no PNG frames found", async () => {
+      const fsMod = await import("fs");
+      (fsMod.readdirSync as ReturnType<typeof vi.fn>).mockReturnValueOnce([]);
+      const handler = getEncodeHandler();
+      const event = makeEvent();
+      await expect(
+        handler(event, {
+          framesDir: "/tmp/empty",
+          outputPath: "/tmp/out.mp4",
+          preset: "youtube-4k",
+        })
+      ).rejects.toThrow("No PNG frames matching frame-NNNNNN.png found");
+    });
+
+    it("rejects on non-zero exit code with stderr", async () => {
+      const handler = getEncodeHandler();
+      const event = makeEvent();
+      const promise = handler(event, {
+        framesDir: "/tmp/frames",
+        outputPath: "/tmp/out.mp4",
+        preset: "web-webm",
+      });
+      mockProc.stderr.emit("data", Buffer.from("Unknown encoder libx264"));
+      mockProc.emit("close", 1);
+      await expect(promise).rejects.toThrow("ffmpeg exited with code 1");
+    });
+
+    it("uses yuv444p and high444 profile for youtube presets", async () => {
+      const { spawn: spawnMock } = await import("child_process");
+      const handler = getEncodeHandler();
+      const event = makeEvent();
+      const promise = handler(event, {
+        framesDir: "/tmp/frames",
+        outputPath: "/tmp/out.mp4",
+        preset: "youtube-1080p",
+      });
+      mockProc.emit("close", 0);
+      await promise;
+      const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string[];
+      expect(args).toContain("yuv444p");
+      expect(args).toContain("high444");
+    });
+
+    it("uses frame-%06d.png input pattern", async () => {
+      const { spawn: spawnMock } = await import("child_process");
+      const handler = getEncodeHandler();
+      const event = makeEvent();
+      const promise = handler(event, {
+        framesDir: "/tmp/frames",
+        outputPath: "/tmp/out.mp4",
+        preset: "youtube-1080p",
+      });
+      mockProc.emit("close", 0);
+      await promise;
+      const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0]![1] as string[];
+      const inputIdx = args.indexOf("-i");
+      expect(args[inputIdx + 1]).toContain("frame-%06d.png");
+    });
+  });
+
+  describe("MediaRecorder capture pipeline", () => {
+    const defaultPayload = {
+      fps: 30,
+      outputPath: "/tmp/capture/out.webm",
+    };
+
+    function simulateCommandDone(requestId = "test-request-id") {
+      const doneListener = getIpcListener("demo:command-done");
+      doneListener?.({}, { requestId });
+    }
+
+    it("startCapture creates write stream, sends exec start, returns outputPath", async () => {
+      const fsMod = await import("fs");
+      const deps = makeDeps(true);
+      const cleanup = registerDemoHandlers(deps);
+      const handler = getHandler("demo:start-capture");
+
+      ipcMainMock.on.mockImplementation(
+        (channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === "demo:command-done") {
+            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
+          }
+        }
+      );
+
+      const result = (await handler({}, defaultPayload)) as { outputPath: string };
+      expect(result.outputPath).toBe("/tmp/capture/out.webm");
+      expect(fsMod.mkdirSync).toHaveBeenCalledWith("/tmp/capture", { recursive: true });
+      expect(fsMod.createWriteStream).toHaveBeenCalledWith("/tmp/capture/out.webm");
+
+      const send = deps.mainWindow!.webContents.send as ReturnType<typeof vi.fn>;
+      const startSend = send.mock.calls.find((c) => c[0] === "demo:exec-start-capture");
+      expect(startSend).toBeDefined();
+      expect(startSend![1]).toMatchObject({
+        fps: 30,
+        mimeType: "video/webm;codecs=vp9",
+      });
+      cleanup();
+    });
+
+    it("rejects startCapture when already active", async () => {
+      ipcMainMock.on.mockImplementation(
+        (channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === "demo:command-done") {
+            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
+          }
+        }
+      );
+      const cleanup = registerDemoHandlers(makeDeps(true));
+      const handler = getHandler("demo:start-capture");
+      await handler({}, defaultPayload);
+      await expect(handler({}, defaultPayload)).rejects.toThrow("Capture already in progress");
+      cleanup();
+    });
+
+    it("capture chunk handler writes buffer to stream for matching captureId", async () => {
+      // Build a real registration (not mocked) so we can capture the listener
+      const deps = makeDeps(true);
+      const cleanup = registerDemoHandlers(deps);
+      const startHandler = getHandler("demo:start-capture");
+
+      // Arrange: resolve exec-start-capture
+      let doneListener: ((...args: unknown[]) => void) | undefined;
+      ipcMainMock.on.mock.calls.forEach((c: unknown[]) => {
+        if (c[0] === "demo:command-done") {
+          doneListener = c[1] as (...args: unknown[]) => void;
+        }
+      });
+      const startPromise = startHandler({}, defaultPayload);
+      // find the latest demo:command-done listener added by sendCommandAndAwait
+      setTimeout(() => {
+        const latest = ipcMainMock.on.mock.calls
+          .filter((c: unknown[]) => c[0] === "demo:command-done")
+          .at(-1);
+        (latest?.[1] as (...args: unknown[]) => void)?.({}, { requestId: "test-request-id" });
+      }, 0);
+      await startPromise;
+
+      const chunkListener = getIpcListener("demo:capture-chunk");
+      expect(chunkListener).toBeDefined();
+      const data = new Uint8Array([1, 2, 3, 4]);
+      chunkListener!({}, { captureId: "test-request-id", data });
+      expect(mockWriteStream.write).toHaveBeenCalledTimes(1);
+      cleanup();
+      // doneListener is captured but unused; simulateCommandDone retained for other tests
+      void doneListener;
+    });
+
+    it("stale captureId chunks are ignored", async () => {
+      ipcMainMock.on.mockImplementation(
+        (channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === "demo:command-done") {
+            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
+          }
+        }
+      );
+      const cleanup = registerDemoHandlers(makeDeps(true));
+      const handler = getHandler("demo:start-capture");
+      await handler({}, defaultPayload);
+      const chunkListener = getIpcListener("demo:capture-chunk");
+      chunkListener!({}, { captureId: "bogus", data: new Uint8Array([9]) });
+      expect(mockWriteStream.write).not.toHaveBeenCalled();
+      cleanup();
+    });
+
+    it("stop flow: exec-stop sent then capture-stop finalizes writeStream and resolves", async () => {
+      ipcMainMock.on.mockImplementation(
+        (channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === "demo:command-done") {
+            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
+          }
+        }
+      );
+      const deps = makeDeps(true);
+      const cleanup = registerDemoHandlers(deps);
+
+      await (getHandler("demo:start-capture") as (...a: unknown[]) => Promise<unknown>)(
+        {},
+        defaultPayload
+      );
+      const stopPromise = (
+        getHandler("demo:stop-capture") as (...a: unknown[]) => Promise<{
+          outputPath: string;
+          frameCount: number;
+        }>
+      )({});
+
+      // Simulate renderer posting the final DEMO_CAPTURE_STOP
+      setTimeout(() => {
+        const stopListener = getIpcListener("demo:capture-stop");
+        stopListener!({}, { captureId: "test-request-id", frameCount: 7 });
+      }, 10);
+
+      const result = await stopPromise;
+      expect(mockWriteStream.end).toHaveBeenCalled();
+      expect(result.outputPath).toBe("/tmp/capture/out.webm");
+      expect(result.frameCount).toBe(7);
+      cleanup();
+    });
+
+    it("stopCapture rejects when no capture in progress", async () => {
+      const cleanup = registerDemoHandlers(makeDeps(true));
+      const handler = getHandler("demo:stop-capture");
+      await expect(handler({})).rejects.toThrow("No capture in progress");
+      cleanup();
+    });
+
+    it("getCaptureStatus returns inactive before start", async () => {
+      const cleanup = registerDemoHandlers(makeDeps(true));
+      const status = (await (
+        getHandler("demo:get-capture-status") as () => Promise<unknown>
+      )()) as {
+        active: boolean;
+        frameCount: number;
+        outputPath: string | null;
+      };
+      expect(status.active).toBe(false);
+      expect(status.outputPath).toBeNull();
+      cleanup();
+    });
+
+    it("getCaptureStatus reports active after start", async () => {
+      ipcMainMock.on.mockImplementation(
+        (channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === "demo:command-done") {
+            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
+          }
+        }
+      );
+      const cleanup = registerDemoHandlers(makeDeps(true));
+      await (getHandler("demo:start-capture") as (...a: unknown[]) => Promise<unknown>)(
+        {},
+        defaultPayload
+      );
+      const status = (await (
+        getHandler("demo:get-capture-status") as () => Promise<unknown>
+      )()) as {
+        active: boolean;
+        outputPath: string | null;
+      };
+      expect(status.active).toBe(true);
+      expect(status.outputPath).toBe("/tmp/capture/out.webm");
+      cleanup();
+    });
+
+    it("error from renderer on capture-stop rejects finalize promise", async () => {
+      ipcMainMock.on.mockImplementation(
+        (channel: string, listener: (...args: unknown[]) => void) => {
+          if (channel === "demo:command-done") {
+            setTimeout(() => listener({}, { requestId: "test-request-id" }), 5);
+          }
+        }
+      );
+      const cleanup = registerDemoHandlers(makeDeps(true));
+      await (getHandler("demo:start-capture") as (...a: unknown[]) => Promise<unknown>)(
+        {},
+        defaultPayload
+      );
+      const stopPromise = (
+        getHandler("demo:stop-capture") as (...a: unknown[]) => Promise<unknown>
+      )({});
+      setTimeout(() => {
+        const stopListener = getIpcListener("demo:capture-stop");
+        stopListener!({}, { captureId: "test-request-id", frameCount: 0, error: "boom" });
+      }, 10);
+      await expect(stopPromise).rejects.toThrow("Capture failed: boom");
+      cleanup();
+    });
+  });
+
+  it("moveTo handler sends exec event with requestId and awaits done", async () => {
+    ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+      if (channel === "demo:command-done") {
+        setTimeout(() => listener({}, { requestId: "test-request-id" }), 10);
+      }
+    });
+    const deps = makeDeps(true);
+    registerDemoHandlers(deps);
+    const handler = getHandler("demo:move-to");
     const result = await handler({}, { x: 25, y: 75, durationMs: 500 });
     expect(result).toBeUndefined();
     expect(deps.mainWindow!.webContents.send as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
@@ -194,487 +523,16 @@ describe("registerDemoHandlers", () => {
     );
   });
 
-  it("moveToSelector handler sends exec event and awaits done", async () => {
-    const deps = makeDeps(true);
-    registerDemoHandlers(deps);
-
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:move-to-selector") ?? [];
-
-    ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
-      if (channel === "demo:command-done") {
-        setTimeout(() => {
-          listener({}, { requestId: "test-request-id" });
-        }, 10);
-      }
-    });
-
-    const result = await handler(
-      {},
-      { selector: ".my-btn", durationMs: 300, offsetX: 5, offsetY: -3 }
-    );
-    expect(result).toBeUndefined();
-    expect(deps.mainWindow!.webContents.send as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      "demo:exec-move-to-selector",
-      {
-        selector: ".my-btn",
-        durationMs: 300,
-        offsetX: 5,
-        offsetY: -3,
-        requestId: "test-request-id",
-      }
-    );
-  });
-
   it("annotate handler returns pre-generated id", async () => {
-    const deps = makeDeps(true);
-    registerDemoHandlers(deps);
-
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:annotate") ?? [];
-
     ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
       if (channel === "demo:command-done") {
-        setTimeout(() => {
-          listener({}, { requestId: "test-request-id" });
-        }, 10);
+        setTimeout(() => listener({}, { requestId: "test-request-id" }), 10);
       }
     });
-
+    const deps = makeDeps(true);
+    registerDemoHandlers(deps);
+    const handler = getHandler("demo:annotate");
     const result = await handler({}, { selector: ".my-el", text: "Hello", position: "top" });
     expect(result).toEqual({ id: "test-request-id" });
-    expect(deps.mainWindow!.webContents.send as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      "demo:exec-annotate",
-      expect.objectContaining({ selector: ".my-el", text: "Hello", id: "test-request-id" })
-    );
-  });
-
-  it("annotate handler uses provided id when given", async () => {
-    const deps = makeDeps(true);
-    registerDemoHandlers(deps);
-
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:annotate") ?? [];
-
-    ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
-      if (channel === "demo:command-done") {
-        setTimeout(() => {
-          listener({}, { requestId: "test-request-id" });
-        }, 10);
-      }
-    });
-
-    const result = await handler({}, { selector: ".my-el", text: "Hello", id: "custom-id" });
-    expect(result).toEqual({ id: "custom-id" });
-  });
-
-  it("scroll handler sends exec-scroll event and awaits done", async () => {
-    const deps = makeDeps(true);
-    registerDemoHandlers(deps);
-
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:scroll") ?? [];
-
-    ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
-      if (channel === "demo:command-done") {
-        setTimeout(() => {
-          listener({}, { requestId: "test-request-id" });
-        }, 10);
-      }
-    });
-
-    const result = await handler({}, { selector: ".content" });
-    expect(result).toBeUndefined();
-    expect(deps.mainWindow!.webContents.send as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      "demo:exec-scroll",
-      { selector: ".content", requestId: "test-request-id" }
-    );
-  });
-
-  it("sleep handler sends exec-sleep event with requestId and awaits done", async () => {
-    const deps = makeDeps(true);
-    registerDemoHandlers(deps);
-
-    const [, handler] =
-      ipcMainMock.handle.mock.calls.find(([ch]: unknown[]) => ch === "demo:sleep") ?? [];
-
-    ipcMainMock.on.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
-      if (channel === "demo:command-done") {
-        setTimeout(() => {
-          listener({}, { requestId: "test-request-id" });
-        }, 10);
-      }
-    });
-
-    const result = await handler({}, { durationMs: 1000 });
-    expect(result).toBeUndefined();
-    expect(deps.mainWindow!.webContents.send as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
-      "demo:exec-sleep",
-      { durationMs: 1000, requestId: "test-request-id" }
-    );
-  });
-});
-
-describe("frame capture pipeline", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockProc = createMockProc();
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  const defaultPayload = {
-    fps: 30,
-    outputPath: "/tmp/capture/out.mp4",
-    preset: "youtube-1080p" as const,
-  };
-
-  it("startCapture spawns ffmpeg with rawvideo stdin args and returns outputPath", async () => {
-    const { spawn: spawnMock } = await import("child_process");
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    const result = (await handler({}, defaultPayload)) as { outputPath: string };
-
-    expect(result.outputPath).toBe("/tmp/capture/out.mp4");
-
-    const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[];
-    expect(args).toContain("-f");
-    expect(args).toContain("rawvideo");
-    expect(args).toContain("-pix_fmt");
-    expect(args[args.indexOf("-pix_fmt") + 1]).toBe("bgra");
-    expect(args).toContain("-video_size");
-    expect(args[args.indexOf("-video_size") + 1]).toBe("1920x1080");
-    expect(args).toContain("-framerate");
-    expect(args[args.indexOf("-framerate") + 1]).toBe("30");
-    expect(args).toContain("-i");
-    expect(args[args.indexOf("-i") + 1]).toBe("pipe:0");
-    expect(args).toContain("-fps_mode");
-    expect(args).toContain("cfr");
-
-    cleanup();
-  });
-
-  it("creates output directory before spawning ffmpeg", async () => {
-    const fsMod = await import("fs");
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    await handler({}, defaultPayload);
-
-    expect(fsMod.mkdirSync).toHaveBeenCalledWith("/tmp/capture", { recursive: true });
-
-    cleanup();
-  });
-
-  it("captures first frame and calls resize for HiDPI normalization", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    await handler({}, defaultPayload);
-
-    const capturePage = deps.mainWindow!.webContents.capturePage as ReturnType<typeof vi.fn>;
-    expect(capturePage).toHaveBeenCalled();
-
-    // The mock image's resize should have been called with logical dims
-    const mockImage = await capturePage.mock.results[0].value;
-    expect(mockImage.resize).toHaveBeenCalledWith({
-      width: 1920,
-      height: 1080,
-      quality: "best",
-    });
-
-    cleanup();
-  });
-
-  it("ticker writes BGRA buffer to ffmpeg stdin", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    await handler({}, defaultPayload);
-
-    // Advance timer to trigger the ticker
-    await vi.advanceTimersByTimeAsync(34);
-
-    expect(mockProc.stdin.write).toHaveBeenCalledWith(BGRA_BUFFER);
-
-    cleanup();
-  });
-
-  it("getCaptureStatus returns inactive before start", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:get-capture-status");
-    const status = (await handler({})) as {
-      active: boolean;
-      frameCount: number;
-      outputPath: string | null;
-    };
-
-    expect(status.active).toBe(false);
-    expect(status.frameCount).toBe(0);
-    expect(status.outputPath).toBeNull();
-
-    cleanup();
-  });
-
-  it("getCaptureStatus reports active while capturing", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, defaultPayload);
-
-    // Write one frame via ticker
-    await vi.advanceTimersByTimeAsync(34);
-
-    const statusHandler = getHandler("demo:get-capture-status");
-    const status = (await statusHandler({})) as {
-      active: boolean;
-      frameCount: number;
-      outputPath: string | null;
-    };
-
-    expect(status.active).toBe(true);
-    expect(status.frameCount).toBe(1);
-    expect(status.outputPath).toBe("/tmp/capture/out.mp4");
-
-    cleanup();
-  });
-
-  it("stopCapture calls stdin.end and resolves with outputPath and frameCount", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, defaultPayload);
-
-    // Write one frame
-    await vi.advanceTimersByTimeAsync(34);
-
-    const stopHandler = getHandler("demo:stop-capture");
-    const stopPromise = stopHandler({}) as Promise<{ outputPath: string; frameCount: number }>;
-
-    expect(mockProc.stdin.end).toHaveBeenCalled();
-
-    // Simulate ffmpeg closing successfully
-    mockProc.emit("close", 0);
-
-    const result = await stopPromise;
-    expect(result.outputPath).toBe("/tmp/capture/out.mp4");
-    expect(result.frameCount).toBe(1);
-
-    cleanup();
-  });
-
-  it("stopCapture rejects when no capture in progress", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const stopHandler = getHandler("demo:stop-capture");
-    await expect(stopHandler({})).rejects.toThrow("No capture in progress");
-
-    cleanup();
-  });
-
-  it("rejects startCapture when already active", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    await handler({}, defaultPayload);
-
-    await expect(handler({}, defaultPayload)).rejects.toThrow("Capture already in progress");
-
-    cleanup();
-  });
-
-  it("auto-stops when maxFrames is reached", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, { ...defaultPayload, maxFrames: 2 });
-
-    // Write first frame
-    await vi.advanceTimersByTimeAsync(34);
-    expect(mockProc.stdin.write).toHaveBeenCalledTimes(1);
-
-    // Write second frame — should trigger auto-stop
-    await vi.advanceTimersByTimeAsync(34);
-    expect(mockProc.stdin.write).toHaveBeenCalledTimes(2);
-    expect(mockProc.stdin.end).toHaveBeenCalled();
-
-    cleanup();
-  });
-
-  it("handles backpressure by pausing ticker and resuming on drain", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    // First write returns false (backpressure)
-    mockProc.stdin.write.mockReturnValueOnce(false);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, defaultPayload);
-
-    // First tick — write returns false
-    await vi.advanceTimersByTimeAsync(34);
-    expect(mockProc.stdin.write).toHaveBeenCalledTimes(1);
-
-    // More ticks should NOT produce writes (ticker paused)
-    await vi.advanceTimersByTimeAsync(34);
-    expect(mockProc.stdin.write).toHaveBeenCalledTimes(1);
-
-    // Emit drain — should resume ticker
-    mockProc.stdin.emit("drain");
-
-    // Next tick after drain should write again
-    await vi.advanceTimersByTimeAsync(34);
-    expect(mockProc.stdin.write).toHaveBeenCalledTimes(2);
-
-    cleanup();
-  });
-
-  it("cleanup stops capture and kills ffmpeg process", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, defaultPayload);
-
-    cleanup();
-
-    expect(mockProc.stdin.end).toHaveBeenCalled();
-    expect(mockProc.kill).toHaveBeenCalledWith("SIGKILL");
-  });
-
-  it("rejects finalize promise when ffmpeg exits with non-zero code", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, defaultPayload);
-
-    const stopHandler = getHandler("demo:stop-capture");
-    const stopPromise = stopHandler({}) as Promise<unknown>;
-
-    mockProc.emit("close", 1);
-
-    await expect(stopPromise).rejects.toThrow("ffmpeg exited with code 1");
-
-    cleanup();
-  });
-
-  it("rejects finalize promise on ffmpeg spawn error", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    await startHandler({}, defaultPayload);
-
-    // Stop first to get the finalize promise, then emit error
-    const stopHandler = getHandler("demo:stop-capture");
-    const stopPromise = stopHandler({}) as Promise<unknown>;
-
-    mockProc.emit("error", new Error("spawn ENOENT"));
-
-    await expect(stopPromise).rejects.toThrow("Capture encode failed: spawn ENOENT");
-
-    cleanup();
-  });
-
-  it("uses capture preset options including yuv444p for youtube-1080p", async () => {
-    const { spawn: spawnMock } = await import("child_process");
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    await handler({}, defaultPayload);
-
-    const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[];
-    expect(args).toContain("yuv444p");
-    expect(args).toContain("high444");
-    expect(args).toContain("libx264");
-    expect(args).not.toContain("yuv420p");
-
-    cleanup();
-  });
-
-  it("uses web-webm capture preset with VP9 and yuv444p", async () => {
-    const { spawn: spawnMock } = await import("child_process");
-    mockProc = createMockProc();
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const handler = getHandler("demo:start-capture");
-    await handler({}, { ...defaultPayload, preset: "web-webm", outputPath: "/tmp/out.webm" });
-
-    const args = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0][1] as string[];
-    expect(args).toContain("libvpx-vp9");
-    expect(args).toContain("yuv444p");
-    expect(args).toContain("-row-mt");
-
-    cleanup();
-  });
-
-  it("supports start/stop/restart cycle with fresh state", async () => {
-    const deps = makeDeps(true);
-    const cleanup = registerDemoHandlers(deps);
-
-    const startHandler = getHandler("demo:start-capture");
-    const stopHandler = getHandler("demo:stop-capture");
-
-    // First session
-    await startHandler({}, defaultPayload);
-    await vi.advanceTimersByTimeAsync(34);
-    const stopPromise1 = stopHandler({}) as Promise<{ outputPath: string; frameCount: number }>;
-    mockProc.emit("close", 0);
-    const result1 = await stopPromise1;
-    expect(result1.outputPath).toBe("/tmp/capture/out.mp4");
-    expect(result1.frameCount).toBe(1);
-
-    // Second session — need fresh mockProc
-    mockProc = createMockProc();
-    const { spawn: spawnMock } = await import("child_process");
-    (spawnMock as ReturnType<typeof vi.fn>).mockReturnValue(mockProc);
-
-    await startHandler({}, { ...defaultPayload, outputPath: "/tmp/capture/out2.mp4" });
-    await vi.advanceTimersByTimeAsync(34);
-    await vi.advanceTimersByTimeAsync(34);
-    const stopPromise2 = stopHandler({}) as Promise<{ outputPath: string; frameCount: number }>;
-    mockProc.emit("close", 0);
-    const result2 = await stopPromise2;
-    expect(result2.outputPath).toBe("/tmp/capture/out2.mp4");
-    expect(result2.frameCount).toBe(2);
-
-    cleanup();
-  });
-
-  it("rejects startCapture when first capturePage fails", async () => {
-    const deps = makeDeps(true);
-    const capturePage = deps.mainWindow!.webContents.capturePage as ReturnType<typeof vi.fn>;
-    capturePage.mockRejectedValueOnce(new Error("GPU context lost"));
-
-    const cleanup = registerDemoHandlers(deps);
-
-    const { spawn: spawnMock } = await import("child_process");
-    const spawnCallsBefore = (spawnMock as ReturnType<typeof vi.fn>).mock.calls.length;
-
-    const handler = getHandler("demo:start-capture");
-    await expect(handler({}, defaultPayload)).rejects.toThrow("GPU context lost");
-
-    // ffmpeg should not have been spawned
-    expect((spawnMock as ReturnType<typeof vi.fn>).mock.calls.length).toBe(spawnCallsBefore);
-
-    cleanup();
   });
 });

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { ipcMain, session } from "electron";
 import { randomBytes } from "crypto";
 import * as fs from "fs";
 import * as path from "path";
@@ -18,7 +18,11 @@ import type {
   DemoStartCaptureResult,
   DemoStopCaptureResult,
   DemoCaptureStatus,
-  DemoEncodePreset,
+  DemoCaptureChunkPayload,
+  DemoCaptureStopPayload,
+  DemoEncodePayload,
+  DemoEncodeProgressEvent,
+  DemoEncodeResult,
   DemoScrollPayload,
   DemoDragPayload,
   DemoPressKeyPayload,
@@ -28,6 +32,9 @@ import type {
   DemoDismissAnnotationPayload,
   DemoWaitForIdlePayload,
 } from "../../../shared/types/ipc/demo.js";
+
+const CAPTURE_MIME_TYPE = "video/webm;codecs=vp9";
+const PROJECT_SESSION_PARTITION = "persist:daintree";
 
 export function resolveFfmpegPath(): string {
   try {
@@ -165,91 +172,61 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_IDLE, payload);
   };
 
-  // --- Frame capture state ---
+  // --- Frame capture state (MediaRecorder-based) ---
   interface CaptureSession {
-    ffmpegProc: ChildProcess;
-    ticker: ReturnType<typeof setInterval> | null;
-    captureToken: number;
-    lastFrameBuffer: Buffer | null;
-    frameWidth: number;
-    frameHeight: number;
-    frameCount: number;
-    maxFrames: number;
+    captureId: string;
     outputPath: string;
-    draining: boolean;
+    writeStream: fs.WriteStream;
+    frameCount: number;
     stopping: boolean;
-    fps: number;
+    finalized: boolean;
     finalizePromise: Promise<DemoStopCaptureResult>;
     resolveFinalizeWith: (result: DemoStopCaptureResult) => void;
     rejectFinalizeWith: (err: Error) => void;
   }
 
   let captureSession: CaptureSession | null = null;
-  let captureTokenCounter = 0;
 
-  function writeFrameToStdin(session: CaptureSession): void {
-    if (!session.lastFrameBuffer || session.stopping) return;
-    const ok = session.ffmpegProc.stdin!.write(session.lastFrameBuffer);
-    session.frameCount++;
-    if (session.frameCount >= session.maxFrames) {
-      stopCaptureSession();
-      return;
-    }
-    if (!ok) {
-      session.draining = true;
-      if (session.ticker !== null) {
-        clearInterval(session.ticker);
-        session.ticker = null;
+  const displayMediaHandlerSession = session.fromPartition(PROJECT_SESSION_PARTITION);
+  displayMediaHandlerSession.setDisplayMediaRequestHandler(
+    (request, callback) => {
+      if (request.frame) {
+        callback({ video: request.frame });
+      } else {
+        callback({});
       }
-      session.ffmpegProc.stdin!.once("drain", () => {
-        if (session !== captureSession || session.stopping) return;
-        session.draining = false;
-        session.ticker = setInterval(
-          () => writeFrameToStdin(session),
-          Math.round(1000 / session.fps)
-        );
-      });
-    }
-  }
+    },
+    { useSystemPicker: false }
+  );
 
-  function stopCaptureSession(): Promise<DemoStopCaptureResult> | null {
-    const session = captureSession;
-    if (!session || session.stopping) return session?.finalizePromise ?? null;
-    session.stopping = true;
-    captureTokenCounter++;
-    if (session.ticker !== null) {
-      clearInterval(session.ticker);
-      session.ticker = null;
-    }
-    session.ffmpegProc.stdin!.end();
-    return session.finalizePromise;
-  }
+  const onCaptureChunk = (_event: Electron.IpcMainEvent, payload: DemoCaptureChunkPayload) => {
+    const active = captureSession;
+    if (!active || active.captureId !== payload.captureId || active.finalized) return;
+    const buf = Buffer.from(payload.data.buffer, payload.data.byteOffset, payload.data.byteLength);
+    active.writeStream.write(buf);
+  };
 
-  function startCaptureLoop(session: CaptureSession, token: number): void {
-    const win = getMainWindow();
-    if (!win || win.isDestroyed()) return;
-    const wc = getAppWebContents(win);
-
-    void (async () => {
-      while (captureSession === session && session.captureToken === token && !session.stopping) {
-        try {
-          const image = await wc.capturePage();
-          if (captureSession !== session || session.captureToken !== token || session.stopping)
-            break;
-          const resized = image.resize({
-            width: session.frameWidth,
-            height: session.frameHeight,
-            quality: "best",
-          });
-          session.lastFrameBuffer = resized.toBitmap();
-        } catch {
-          // Keep lastFrameBuffer unchanged — ticker will duplicate
-        }
-        // Yield to event loop between captures to avoid starving the ticker
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  const onCaptureStop = (_event: Electron.IpcMainEvent, payload: DemoCaptureStopPayload) => {
+    const active = captureSession;
+    if (!active || active.captureId !== payload.captureId || active.finalized) return;
+    active.frameCount = payload.frameCount;
+    active.finalized = true;
+    const rendererError = payload.error;
+    active.writeStream.end(() => {
+      if (captureSession === active) captureSession = null;
+      if (rendererError) {
+        active.rejectFinalizeWith(new Error(`Capture failed: ${rendererError}`));
+      } else {
+        active.resolveFinalizeWith({
+          outputPath: active.outputPath,
+          frameCount: active.frameCount,
+        });
       }
-    })();
-  }
+    });
+  };
+
+  ipcMain.on(CHANNELS.DEMO_CAPTURE_CHUNK, onCaptureChunk);
+  ipcMain.on(CHANNELS.DEMO_CAPTURE_STOP, onCaptureStop);
 
   const handleStartCapture = async (
     payload: DemoStartCapturePayload
@@ -259,53 +236,12 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     }
 
     const fps = payload.fps ?? 30;
-    const maxFrames = payload.maxFrames ?? 9000;
-    const { outputPath, preset } = payload;
-    const presetConfig = CAPTURE_PRESETS[preset];
-    if (!presetConfig) {
-      throw new Error(`Unknown capture preset: ${preset}`);
-    }
-
-    // Capture first frame to determine dimensions
-    const win = getMainWindow();
-    if (!win || win.isDestroyed()) {
-      throw new Error("No window available for capture");
-    }
-    const firstImage = await getAppWebContents(win).capturePage();
-    const logicalSize = firstImage.getSize();
-    const frameWidth = logicalSize.width;
-    const frameHeight = logicalSize.height;
-    const resizedFirst = firstImage.resize({
-      width: frameWidth,
-      height: frameHeight,
-      quality: "best",
-    });
-    const firstBitmap = resizedFirst.toBitmap();
+    const { outputPath } = payload;
 
     fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
-    const ffmpegBin = resolveFfmpegPath();
-    const args = [
-      "-y",
-      "-f",
-      "rawvideo",
-      "-pix_fmt",
-      "bgra",
-      "-video_size",
-      `${frameWidth}x${frameHeight}`,
-      "-framerate",
-      String(fps),
-      "-i",
-      "pipe:0",
-      ...presetConfig.outputOptions,
-      "-fps_mode",
-      "cfr",
-      outputPath,
-    ];
-
-    const ffmpegProc = spawn(ffmpegBin, args, { stdio: ["pipe", "pipe", "pipe"] });
-
-    const token = ++captureTokenCounter;
+    const captureId = randomBytes(8).toString("hex");
+    const writeStream = fs.createWriteStream(outputPath);
 
     let resolveFinalizeWith!: (result: DemoStopCaptureResult) => void;
     let rejectFinalizeWith!: (err: Error) => void;
@@ -313,84 +249,80 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
       resolveFinalizeWith = resolve;
       rejectFinalizeWith = reject;
     });
+    // Suppress unhandled rejection if nothing ever awaits finalize (e.g., handlers
+    // torn down before stopCapture is called). Real awaiters still observe the rejection.
+    finalizePromise.catch(() => {});
 
-    const session: CaptureSession = {
-      ffmpegProc,
-      ticker: null,
-      captureToken: token,
-      lastFrameBuffer: firstBitmap,
-      frameWidth,
-      frameHeight,
-      frameCount: 0,
-      maxFrames,
+    const newSession: CaptureSession = {
+      captureId,
       outputPath,
-      draining: false,
+      writeStream,
+      frameCount: 0,
       stopping: false,
-      fps,
+      finalized: false,
       finalizePromise,
       resolveFinalizeWith,
       rejectFinalizeWith,
     };
 
-    captureSession = session;
-
-    ffmpegProc.on("error", (err: Error) => {
-      if (captureSession === session) {
-        session.stopping = true;
-        if (session.ticker !== null) {
-          clearInterval(session.ticker);
-          session.ticker = null;
-        }
+    writeStream.on("error", (err: Error) => {
+      if (captureSession === newSession && !newSession.finalized) {
+        newSession.finalized = true;
         captureSession = null;
-        session.rejectFinalizeWith(new Error(`Capture encode failed: ${err.message}`));
+        rejectFinalizeWith(new Error(`Capture write failed: ${err.message}`));
       }
     });
 
-    ffmpegProc.on("close", (code) => {
-      session.stopping = true;
-      if (session.ticker !== null) {
-        clearInterval(session.ticker);
-        session.ticker = null;
-      }
-      if (captureSession === session) {
-        captureSession = null;
-      }
-      if (code === 0) {
-        session.resolveFinalizeWith({
-          outputPath: session.outputPath,
-          frameCount: session.frameCount,
-        });
-      } else {
-        session.rejectFinalizeWith(new Error(`ffmpeg exited with code ${code}`));
-      }
-    });
+    captureSession = newSession;
 
-    // Start the ticker and capture loop
-    session.ticker = setInterval(() => writeFrameToStdin(session), Math.round(1000 / fps));
-    startCaptureLoop(session, token);
+    try {
+      await sendCommandAndAwait(CHANNELS.DEMO_EXEC_START_CAPTURE, {
+        captureId,
+        fps,
+        mimeType: CAPTURE_MIME_TYPE,
+      });
+    } catch (err) {
+      captureSession = null;
+      writeStream.destroy();
+      throw err;
+    }
 
     return { outputPath };
   };
 
   const handleStopCapture = async (): Promise<DemoStopCaptureResult> => {
-    const promise = stopCaptureSession();
-    if (!promise) {
+    const active = captureSession;
+    if (!active) {
       throw new Error("No capture in progress");
     }
-    return promise;
+    if (active.stopping) {
+      return active.finalizePromise;
+    }
+    active.stopping = true;
+    try {
+      await sendCommandAndAwait(CHANNELS.DEMO_EXEC_STOP_CAPTURE, { captureId: active.captureId });
+    } catch (err) {
+      if (captureSession === active && !active.finalized) {
+        active.finalized = true;
+        captureSession = null;
+        active.writeStream.destroy();
+        active.rejectFinalizeWith(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
+    return active.finalizePromise;
   };
 
   const handleGetCaptureStatus = async (): Promise<DemoCaptureStatus> => {
     return {
-      active: captureSession !== null && !captureSession.stopping,
+      active: captureSession !== null && !captureSession.finalized,
       frameCount: captureSession?.frameCount ?? 0,
       outputPath: captureSession?.outputPath ?? null,
     };
   };
 
-  // --- Encode presets for live capture (raw BGRA stdin → output file) ---
+  // --- Encode presets for offline re-encode (PNG files from disk) ---
 
-  const CAPTURE_PRESETS: Record<DemoEncodePreset, { outputOptions: string[] }> = {
+  const ENCODE_PRESETS = {
     "youtube-4k": {
       outputOptions: [
         "-vf",
@@ -456,38 +388,176 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
         "-an",
       ],
     },
+  } as const;
+
+  let activeEncode: { kill: () => void } | null = null;
+
+  const handleEncode = async (
+    event: Electron.IpcMainInvokeEvent,
+    payload: DemoEncodePayload
+  ): Promise<DemoEncodeResult> => {
+    if (activeEncode) {
+      throw new Error("An encode is already in progress");
+    }
+
+    const ffmpegBin = resolveFfmpegPath();
+    const { framesDir, outputPath, preset, fps = 30 } = payload;
+    const presetConfig = ENCODE_PRESETS[preset];
+
+    const framePattern = /^frame-\d{6}\.png$/;
+    const pngFiles = fs
+      .readdirSync(framesDir)
+      .filter((f) => framePattern.test(f))
+      .sort();
+    if (pngFiles.length === 0) {
+      throw new Error(`No PNG frames matching frame-NNNNNN.png found in ${framesDir}`);
+    }
+    const totalFrames = pngFiles.length;
+
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
+    const startTime = Date.now();
+    const inputPattern = path.join(framesDir, "frame-%06d.png");
+
+    const args = [
+      "-y",
+      "-framerate",
+      String(fps),
+      "-i",
+      inputPattern,
+      ...presetConfig.outputOptions,
+      "-progress",
+      "pipe:1",
+      "-nostats",
+      outputPath,
+    ];
+
+    return new Promise<DemoEncodeResult>((resolve, reject) => {
+      const proc: ChildProcess = spawn(ffmpegBin, args, { stdio: ["ignore", "pipe", "pipe"] });
+
+      activeEncode = {
+        kill: () => {
+          proc.kill("SIGKILL");
+        },
+      };
+
+      let stdoutBuffer = "";
+      let currentFrame = 0;
+      let currentFps = 0;
+
+      proc.stdout?.on("data", (chunk: Buffer) => {
+        stdoutBuffer += chunk.toString();
+        const lines = stdoutBuffer.split("\n");
+        stdoutBuffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const eqIdx = line.indexOf("=");
+          if (eqIdx === -1) continue;
+          const key = line.slice(0, eqIdx).trim();
+          const value = line.slice(eqIdx + 1).trim();
+
+          if (key === "frame") {
+            currentFrame = parseInt(value, 10) || 0;
+          } else if (key === "fps") {
+            currentFps = parseFloat(value) || 0;
+          } else if (key === "progress") {
+            if (currentFrame > 0 && !event.sender.isDestroyed()) {
+              const percentComplete = Math.min((currentFrame / totalFrames) * 100, 100);
+              const etaSeconds = currentFps > 0 ? (totalFrames - currentFrame) / currentFps : 0;
+
+              const progressEvent: DemoEncodeProgressEvent = {
+                frame: currentFrame,
+                fps: currentFps,
+                percentComplete: Math.round(percentComplete * 100) / 100,
+                etaSeconds: Math.round(etaSeconds * 10) / 10,
+              };
+              event.sender.send(CHANNELS.DEMO_ENCODE_PROGRESS, progressEvent);
+            }
+          }
+        }
+      });
+
+      let stderrOutput = "";
+      proc.stderr?.on("data", (chunk: Buffer) => {
+        stderrOutput += chunk.toString();
+      });
+
+      proc.on("error", (err: Error) => {
+        activeEncode = null;
+        reject(new Error(`Encode failed: ${err.message}`));
+      });
+
+      proc.on("close", (code) => {
+        activeEncode = null;
+        if (code === 0) {
+          resolve({ outputPath, durationMs: Date.now() - startTime });
+        } else {
+          const lastLines = stderrOutput.trim().split("\n").slice(-3).join("\n");
+          reject(new Error(`ffmpeg exited with code ${code}: ${lastLines}`));
+        }
+      });
+    });
   };
 
-  const cleanups: Array<() => void> = [
-    typedHandle(CHANNELS.DEMO_MOVE_TO, handleMoveTo),
-    typedHandle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector),
-    typedHandle(CHANNELS.DEMO_CLICK, handleClick),
-    typedHandle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot),
-    typedHandle(CHANNELS.DEMO_TYPE, handleType),
-    typedHandle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector),
-    typedHandle(CHANNELS.DEMO_PAUSE, handlePause),
-    typedHandle(CHANNELS.DEMO_RESUME, handleResume),
-    typedHandle(CHANNELS.DEMO_SLEEP, handleSleep),
-    typedHandle(CHANNELS.DEMO_SCROLL, handleScroll),
-    typedHandle(CHANNELS.DEMO_DRAG, handleDrag),
-    typedHandle(CHANNELS.DEMO_PRESS_KEY, handlePressKey),
-    typedHandle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight),
-    typedHandle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight),
-    typedHandle(CHANNELS.DEMO_ANNOTATE, handleAnnotate),
-    typedHandle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation),
-    typedHandle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle),
-    typedHandle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture),
-    typedHandle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture),
-    typedHandle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus),
-  ];
+  ipcMain.handle(CHANNELS.DEMO_MOVE_TO, handleMoveTo);
+  ipcMain.handle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector);
+  ipcMain.handle(CHANNELS.DEMO_CLICK, handleClick);
+  ipcMain.handle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot);
+  ipcMain.handle(CHANNELS.DEMO_TYPE, handleType);
+  ipcMain.handle(CHANNELS.DEMO_SET_ZOOM, handleSetZoom);
+  ipcMain.handle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector);
+  ipcMain.handle(CHANNELS.DEMO_PAUSE, handlePause);
+  ipcMain.handle(CHANNELS.DEMO_RESUME, handleResume);
+  ipcMain.handle(CHANNELS.DEMO_SLEEP, handleSleep);
+  ipcMain.handle(CHANNELS.DEMO_SCROLL, handleScroll);
+  ipcMain.handle(CHANNELS.DEMO_DRAG, handleDrag);
+  ipcMain.handle(CHANNELS.DEMO_PRESS_KEY, handlePressKey);
+  ipcMain.handle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight);
+  ipcMain.handle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight);
+  ipcMain.handle(CHANNELS.DEMO_ANNOTATE, handleAnnotate);
+  ipcMain.handle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation);
+  ipcMain.handle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle);
+  ipcMain.handle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture);
+  ipcMain.handle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture);
+  ipcMain.handle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus);
+  ipcMain.handle(CHANNELS.DEMO_ENCODE, handleEncode);
 
   return () => {
-    if (captureSession) {
-      stopCaptureSession();
-      captureSession?.ffmpegProc.kill("SIGKILL");
+    if (captureSession && !captureSession.finalized) {
+      const active = captureSession;
+      active.finalized = true;
+      active.writeStream.destroy();
+      active.rejectFinalizeWith(new Error("Capture aborted: handlers unregistered"));
+      captureSession = null;
     }
-    for (const cleanup of cleanups) {
-      cleanup();
+    ipcMain.removeListener(CHANNELS.DEMO_CAPTURE_CHUNK, onCaptureChunk);
+    ipcMain.removeListener(CHANNELS.DEMO_CAPTURE_STOP, onCaptureStop);
+    displayMediaHandlerSession.setDisplayMediaRequestHandler(null);
+    ipcMain.removeHandler(CHANNELS.DEMO_MOVE_TO);
+    ipcMain.removeHandler(CHANNELS.DEMO_MOVE_TO_SELECTOR);
+    ipcMain.removeHandler(CHANNELS.DEMO_CLICK);
+    ipcMain.removeHandler(CHANNELS.DEMO_SCREENSHOT);
+    ipcMain.removeHandler(CHANNELS.DEMO_TYPE);
+    ipcMain.removeHandler(CHANNELS.DEMO_SET_ZOOM);
+    ipcMain.removeHandler(CHANNELS.DEMO_WAIT_FOR_SELECTOR);
+    ipcMain.removeHandler(CHANNELS.DEMO_PAUSE);
+    ipcMain.removeHandler(CHANNELS.DEMO_RESUME);
+    ipcMain.removeHandler(CHANNELS.DEMO_SLEEP);
+    ipcMain.removeHandler(CHANNELS.DEMO_SCROLL);
+    ipcMain.removeHandler(CHANNELS.DEMO_DRAG);
+    ipcMain.removeHandler(CHANNELS.DEMO_PRESS_KEY);
+    ipcMain.removeHandler(CHANNELS.DEMO_SPOTLIGHT);
+    ipcMain.removeHandler(CHANNELS.DEMO_DISMISS_SPOTLIGHT);
+    ipcMain.removeHandler(CHANNELS.DEMO_ANNOTATE);
+    ipcMain.removeHandler(CHANNELS.DEMO_DISMISS_ANNOTATION);
+    ipcMain.removeHandler(CHANNELS.DEMO_WAIT_FOR_IDLE);
+    ipcMain.removeHandler(CHANNELS.DEMO_START_CAPTURE);
+    ipcMain.removeHandler(CHANNELS.DEMO_STOP_CAPTURE);
+    ipcMain.removeHandler(CHANNELS.DEMO_GET_CAPTURE_STATUS);
+    ipcMain.removeHandler(CHANNELS.DEMO_ENCODE);
+    if (activeEncode) {
+      activeEncode.kill();
+      activeEncode = null;
     }
   };
 }

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -2,7 +2,6 @@ import { ipcMain, session } from "electron";
 import { randomBytes } from "crypto";
 import * as fs from "fs";
 import * as path from "path";
-import { spawn, type ChildProcess } from "child_process";
 import { CHANNELS } from "../channels.js";
 import type { HandlerDependencies } from "../types.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
@@ -20,9 +19,6 @@ import type {
   DemoCaptureStatus,
   DemoCaptureChunkPayload,
   DemoCaptureStopPayload,
-  DemoEncodePayload,
-  DemoEncodeProgressEvent,
-  DemoEncodeResult,
   DemoScrollPayload,
   DemoDragPayload,
   DemoPressKeyPayload,
@@ -35,18 +31,6 @@ import type {
 
 const CAPTURE_MIME_TYPE = "video/webm;codecs=vp9";
 const PROJECT_SESSION_PARTITION = "persist:daintree";
-
-export function resolveFfmpegPath(): string {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    return require("ffmpeg-static") as string;
-  } catch {
-    throw new Error(
-      "ffmpeg-static is not installed. Demo video capture is an optional feature — " +
-        "run `npm install ffmpeg-static` to enable it."
-    );
-  }
-}
 
 export function registerDemoHandlers(deps: HandlerDependencies): () => void {
   if (!deps.isDemoMode) {
@@ -172,7 +156,7 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_IDLE, payload);
   };
 
-  // --- Frame capture state (MediaRecorder-based) ---
+  // --- MediaRecorder-based capture state ---
   interface CaptureSession {
     captureId: string;
     outputPath: string;
@@ -320,207 +304,28 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     };
   };
 
-  // --- Encode presets for offline re-encode (PNG files from disk) ---
-
-  const ENCODE_PRESETS = {
-    "youtube-4k": {
-      outputOptions: [
-        "-vf",
-        "scale=3840:2160:flags=lanczos",
-        "-c:v",
-        "libx264",
-        "-profile:v",
-        "high444",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv444p",
-        "-preset",
-        "slow",
-        "-g",
-        "15",
-        "-bf",
-        "2",
-        "-movflags",
-        "+faststart",
-        "-an",
-      ],
-    },
-    "youtube-1080p": {
-      outputOptions: [
-        "-vf",
-        "scale=1920:1080:flags=lanczos",
-        "-c:v",
-        "libx264",
-        "-profile:v",
-        "high444",
-        "-crf",
-        "18",
-        "-pix_fmt",
-        "yuv444p",
-        "-preset",
-        "slow",
-        "-g",
-        "15",
-        "-bf",
-        "2",
-        "-movflags",
-        "+faststart",
-        "-an",
-      ],
-    },
-    "web-webm": {
-      outputOptions: [
-        "-c:v",
-        "libvpx-vp9",
-        "-crf",
-        "20",
-        "-b:v",
-        "0",
-        "-deadline",
-        "good",
-        "-cpu-used",
-        "1",
-        "-row-mt",
-        "1",
-        "-pix_fmt",
-        "yuv444p",
-        "-an",
-      ],
-    },
-  } as const;
-
-  let activeEncode: { kill: () => void } | null = null;
-
-  const handleEncode = async (
-    event: Electron.IpcMainInvokeEvent,
-    payload: DemoEncodePayload
-  ): Promise<DemoEncodeResult> => {
-    if (activeEncode) {
-      throw new Error("An encode is already in progress");
-    }
-
-    const ffmpegBin = resolveFfmpegPath();
-    const { framesDir, outputPath, preset, fps = 30 } = payload;
-    const presetConfig = ENCODE_PRESETS[preset];
-
-    const framePattern = /^frame-\d{6}\.png$/;
-    const pngFiles = fs
-      .readdirSync(framesDir)
-      .filter((f) => framePattern.test(f))
-      .sort();
-    if (pngFiles.length === 0) {
-      throw new Error(`No PNG frames matching frame-NNNNNN.png found in ${framesDir}`);
-    }
-    const totalFrames = pngFiles.length;
-
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-
-    const startTime = Date.now();
-    const inputPattern = path.join(framesDir, "frame-%06d.png");
-
-    const args = [
-      "-y",
-      "-framerate",
-      String(fps),
-      "-i",
-      inputPattern,
-      ...presetConfig.outputOptions,
-      "-progress",
-      "pipe:1",
-      "-nostats",
-      outputPath,
-    ];
-
-    return new Promise<DemoEncodeResult>((resolve, reject) => {
-      const proc: ChildProcess = spawn(ffmpegBin, args, { stdio: ["ignore", "pipe", "pipe"] });
-
-      activeEncode = {
-        kill: () => {
-          proc.kill("SIGKILL");
-        },
-      };
-
-      let stdoutBuffer = "";
-      let currentFrame = 0;
-      let currentFps = 0;
-
-      proc.stdout?.on("data", (chunk: Buffer) => {
-        stdoutBuffer += chunk.toString();
-        const lines = stdoutBuffer.split("\n");
-        stdoutBuffer = lines.pop() ?? "";
-
-        for (const line of lines) {
-          const eqIdx = line.indexOf("=");
-          if (eqIdx === -1) continue;
-          const key = line.slice(0, eqIdx).trim();
-          const value = line.slice(eqIdx + 1).trim();
-
-          if (key === "frame") {
-            currentFrame = parseInt(value, 10) || 0;
-          } else if (key === "fps") {
-            currentFps = parseFloat(value) || 0;
-          } else if (key === "progress") {
-            if (currentFrame > 0 && !event.sender.isDestroyed()) {
-              const percentComplete = Math.min((currentFrame / totalFrames) * 100, 100);
-              const etaSeconds = currentFps > 0 ? (totalFrames - currentFrame) / currentFps : 0;
-
-              const progressEvent: DemoEncodeProgressEvent = {
-                frame: currentFrame,
-                fps: currentFps,
-                percentComplete: Math.round(percentComplete * 100) / 100,
-                etaSeconds: Math.round(etaSeconds * 10) / 10,
-              };
-              event.sender.send(CHANNELS.DEMO_ENCODE_PROGRESS, progressEvent);
-            }
-          }
-        }
-      });
-
-      let stderrOutput = "";
-      proc.stderr?.on("data", (chunk: Buffer) => {
-        stderrOutput += chunk.toString();
-      });
-
-      proc.on("error", (err: Error) => {
-        activeEncode = null;
-        reject(new Error(`Encode failed: ${err.message}`));
-      });
-
-      proc.on("close", (code) => {
-        activeEncode = null;
-        if (code === 0) {
-          resolve({ outputPath, durationMs: Date.now() - startTime });
-        } else {
-          const lastLines = stderrOutput.trim().split("\n").slice(-3).join("\n");
-          reject(new Error(`ffmpeg exited with code ${code}: ${lastLines}`));
-        }
-      });
-    });
-  };
-
-  ipcMain.handle(CHANNELS.DEMO_MOVE_TO, handleMoveTo);
-  ipcMain.handle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector);
-  ipcMain.handle(CHANNELS.DEMO_CLICK, handleClick);
-  ipcMain.handle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot);
-  ipcMain.handle(CHANNELS.DEMO_TYPE, handleType);
-  ipcMain.handle(CHANNELS.DEMO_SET_ZOOM, handleSetZoom);
-  ipcMain.handle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector);
-  ipcMain.handle(CHANNELS.DEMO_PAUSE, handlePause);
-  ipcMain.handle(CHANNELS.DEMO_RESUME, handleResume);
-  ipcMain.handle(CHANNELS.DEMO_SLEEP, handleSleep);
-  ipcMain.handle(CHANNELS.DEMO_SCROLL, handleScroll);
-  ipcMain.handle(CHANNELS.DEMO_DRAG, handleDrag);
-  ipcMain.handle(CHANNELS.DEMO_PRESS_KEY, handlePressKey);
-  ipcMain.handle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight);
-  ipcMain.handle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight);
-  ipcMain.handle(CHANNELS.DEMO_ANNOTATE, handleAnnotate);
-  ipcMain.handle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation);
-  ipcMain.handle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle);
-  ipcMain.handle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture);
-  ipcMain.handle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture);
-  ipcMain.handle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus);
-  ipcMain.handle(CHANNELS.DEMO_ENCODE, handleEncode);
+  const cleanups: Array<() => void> = [
+    typedHandle(CHANNELS.DEMO_MOVE_TO, handleMoveTo),
+    typedHandle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector),
+    typedHandle(CHANNELS.DEMO_CLICK, handleClick),
+    typedHandle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot),
+    typedHandle(CHANNELS.DEMO_TYPE, handleType),
+    typedHandle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector),
+    typedHandle(CHANNELS.DEMO_PAUSE, handlePause),
+    typedHandle(CHANNELS.DEMO_RESUME, handleResume),
+    typedHandle(CHANNELS.DEMO_SLEEP, handleSleep),
+    typedHandle(CHANNELS.DEMO_SCROLL, handleScroll),
+    typedHandle(CHANNELS.DEMO_DRAG, handleDrag),
+    typedHandle(CHANNELS.DEMO_PRESS_KEY, handlePressKey),
+    typedHandle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight),
+    typedHandle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight),
+    typedHandle(CHANNELS.DEMO_ANNOTATE, handleAnnotate),
+    typedHandle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation),
+    typedHandle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle),
+    typedHandle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture),
+    typedHandle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture),
+    typedHandle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus),
+  ];
 
   return () => {
     if (captureSession && !captureSession.finalized) {
@@ -533,31 +338,8 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     ipcMain.removeListener(CHANNELS.DEMO_CAPTURE_CHUNK, onCaptureChunk);
     ipcMain.removeListener(CHANNELS.DEMO_CAPTURE_STOP, onCaptureStop);
     displayMediaHandlerSession.setDisplayMediaRequestHandler(null);
-    ipcMain.removeHandler(CHANNELS.DEMO_MOVE_TO);
-    ipcMain.removeHandler(CHANNELS.DEMO_MOVE_TO_SELECTOR);
-    ipcMain.removeHandler(CHANNELS.DEMO_CLICK);
-    ipcMain.removeHandler(CHANNELS.DEMO_SCREENSHOT);
-    ipcMain.removeHandler(CHANNELS.DEMO_TYPE);
-    ipcMain.removeHandler(CHANNELS.DEMO_SET_ZOOM);
-    ipcMain.removeHandler(CHANNELS.DEMO_WAIT_FOR_SELECTOR);
-    ipcMain.removeHandler(CHANNELS.DEMO_PAUSE);
-    ipcMain.removeHandler(CHANNELS.DEMO_RESUME);
-    ipcMain.removeHandler(CHANNELS.DEMO_SLEEP);
-    ipcMain.removeHandler(CHANNELS.DEMO_SCROLL);
-    ipcMain.removeHandler(CHANNELS.DEMO_DRAG);
-    ipcMain.removeHandler(CHANNELS.DEMO_PRESS_KEY);
-    ipcMain.removeHandler(CHANNELS.DEMO_SPOTLIGHT);
-    ipcMain.removeHandler(CHANNELS.DEMO_DISMISS_SPOTLIGHT);
-    ipcMain.removeHandler(CHANNELS.DEMO_ANNOTATE);
-    ipcMain.removeHandler(CHANNELS.DEMO_DISMISS_ANNOTATION);
-    ipcMain.removeHandler(CHANNELS.DEMO_WAIT_FOR_IDLE);
-    ipcMain.removeHandler(CHANNELS.DEMO_START_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.DEMO_STOP_CAPTURE);
-    ipcMain.removeHandler(CHANNELS.DEMO_GET_CAPTURE_STATUS);
-    ipcMain.removeHandler(CHANNELS.DEMO_ENCODE);
-    if (activeEncode) {
-      activeEncode.kill();
-      activeEncode = null;
+    for (const cleanup of cleanups) {
+      cleanup();
     }
   };
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1136,8 +1136,6 @@ const CHANNELS = {
   DEMO_EXEC_DISMISS_ANNOTATION: "demo:exec-dismiss-annotation",
   DEMO_WAIT_FOR_IDLE: "demo:wait-for-idle",
   DEMO_EXEC_WAIT_FOR_IDLE: "demo:exec-wait-for-idle",
-  DEMO_ENCODE: "demo:encode",
-  DEMO_ENCODE_PROGRESS: "demo:encode:progress",
   DEMO_EXEC_START_CAPTURE: "demo:exec-start-capture",
   DEMO_EXEC_STOP_CAPTURE: "demo:exec-stop-capture",
   DEMO_CAPTURE_CHUNK: "demo:capture-chunk",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -3091,12 +3091,14 @@ const api: ElectronAPI = {
           pause: () => _unwrappingInvoke(CHANNELS.DEMO_PAUSE),
           resume: () => _unwrappingInvoke(CHANNELS.DEMO_RESUME),
           sleep: (durationMs: number) => _unwrappingInvoke(CHANNELS.DEMO_SLEEP, { durationMs }),
-          startCapture: (payload: {
-            fps?: number;
-            maxFrames?: number;
-            outputPath: string;
-            preset: import("../shared/types/ipc/demo.js").DemoEncodePreset;
-          }) => _unwrappingInvoke(CHANNELS.DEMO_START_CAPTURE, payload),
+          startCapture: (payload: { fps?: number; outputPath: string }) =>
+            _unwrappingInvoke(CHANNELS.DEMO_START_CAPTURE, payload),
+          sendCaptureChunk: (captureId: string, data: Uint8Array) => {
+            ipcRenderer.send(CHANNELS.DEMO_CAPTURE_CHUNK, { captureId, data });
+          },
+          sendCaptureStop: (captureId: string, frameCount: number, error?: string) => {
+            ipcRenderer.send(CHANNELS.DEMO_CAPTURE_STOP, { captureId, frameCount, error });
+          },
           stopCapture: () => _unwrappingInvoke(CHANNELS.DEMO_STOP_CAPTURE),
           getCaptureStatus: () => _unwrappingInvoke(CHANNELS.DEMO_GET_CAPTURE_STATUS),
           scroll: (selector: string) => _unwrappingInvoke(CHANNELS.DEMO_SCROLL, { selector }),

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1136,6 +1136,12 @@ const CHANNELS = {
   DEMO_EXEC_DISMISS_ANNOTATION: "demo:exec-dismiss-annotation",
   DEMO_WAIT_FOR_IDLE: "demo:wait-for-idle",
   DEMO_EXEC_WAIT_FOR_IDLE: "demo:exec-wait-for-idle",
+  DEMO_ENCODE: "demo:encode",
+  DEMO_ENCODE_PROGRESS: "demo:encode:progress",
+  DEMO_EXEC_START_CAPTURE: "demo:exec-start-capture",
+  DEMO_EXEC_STOP_CAPTURE: "demo:exec-stop-capture",
+  DEMO_CAPTURE_CHUNK: "demo:capture-chunk",
+  DEMO_CAPTURE_STOP: "demo:capture-stop",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1440,6 +1440,8 @@ export interface ElectronAPI {
     dismissAnnotation(id?: string): Promise<void>;
     waitForIdle(settleMs?: number, timeoutMs?: number): Promise<void>;
     startCapture(payload: DemoStartCapturePayload): Promise<DemoStartCaptureResult>;
+    sendCaptureChunk(captureId: string, data: Uint8Array): void;
+    sendCaptureStop(captureId: string, frameCount: number, error?: string): void;
     stopCapture(): Promise<DemoStopCaptureResult>;
     getCaptureStatus(): Promise<DemoCaptureStatus>;
     onExecCommand(

--- a/shared/types/ipc/demo.ts
+++ b/shared/types/ipc/demo.ts
@@ -75,8 +75,6 @@ export interface DemoCaptureStatus {
   outputPath: string | null;
 }
 
-export type DemoEncodePreset = "youtube-4k" | "youtube-1080p" | "web-webm";
-
 export interface DemoScrollPayload {
   selector: string;
 }

--- a/shared/types/ipc/demo.ts
+++ b/shared/types/ipc/demo.ts
@@ -34,9 +34,30 @@ export interface DemoScreenshotResult {
 
 export interface DemoStartCapturePayload {
   fps?: number;
-  maxFrames?: number;
   outputPath: string;
-  preset: DemoEncodePreset;
+}
+
+export interface DemoCaptureChunkPayload {
+  captureId: string;
+  data: Uint8Array;
+}
+
+export interface DemoCaptureStopPayload {
+  captureId: string;
+  frameCount: number;
+  error?: string;
+}
+
+export interface DemoExecStartCapturePayload {
+  captureId: string;
+  requestId: string;
+  fps: number;
+  mimeType: string;
+}
+
+export interface DemoExecStopCapturePayload {
+  captureId: string;
+  requestId: string;
 }
 
 export interface DemoStartCaptureResult {

--- a/src/components/Demo/DemoCaptureBridge.tsx
+++ b/src/components/Demo/DemoCaptureBridge.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef } from "react";
+
+interface ActiveRecording {
+  captureId: string;
+  recorder: MediaRecorder;
+  stream: MediaStream;
+  frameCount: number;
+  stopped: boolean;
+  stopRequestId: string | null;
+}
+
+function getDemoApi() {
+  return window.electron.demo!;
+}
+
+export function DemoCaptureBridge() {
+  const activeRef = useRef<ActiveRecording | null>(null);
+
+  useEffect(() => {
+    const api = getDemoApi();
+
+    const stopAndCleanup = (active: ActiveRecording, error?: string) => {
+      if (active.stopped) return;
+      active.stopped = true;
+      try {
+        if (active.recorder.state !== "inactive") {
+          active.recorder.stop();
+        }
+      } catch {
+        // already stopped
+      }
+      try {
+        active.stream.getTracks().forEach((t) => t.stop());
+      } catch {
+        // ignore
+      }
+      if (error) {
+        api.sendCaptureStop(active.captureId, active.frameCount, error);
+      }
+    };
+
+    const offStart = api.onExecCommand(
+      "demo:exec-start-capture",
+      async (payload: Record<string, unknown>) => {
+        const captureId = payload.captureId as string;
+        const requestId = payload.requestId as string;
+        const fps = (payload.fps as number | undefined) ?? 30;
+        const requestedMime = (payload.mimeType as string | undefined) ?? "video/webm;codecs=vp9";
+
+        if (activeRef.current && !activeRef.current.stopped) {
+          api.sendCommandDone(requestId, "Capture already in progress");
+          return;
+        }
+
+        let stream: MediaStream;
+        try {
+          stream = await navigator.mediaDevices.getDisplayMedia({
+            video: { frameRate: fps },
+            audio: false,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          api.sendCommandDone(requestId, `getDisplayMedia failed: ${message}`);
+          return;
+        }
+
+        const mimeType = MediaRecorder.isTypeSupported(requestedMime)
+          ? requestedMime
+          : "video/webm";
+
+        let recorder: MediaRecorder;
+        try {
+          recorder = new MediaRecorder(stream, { mimeType });
+        } catch (err) {
+          stream.getTracks().forEach((t) => t.stop());
+          const message = err instanceof Error ? err.message : String(err);
+          api.sendCommandDone(requestId, `MediaRecorder init failed: ${message}`);
+          return;
+        }
+
+        const active: ActiveRecording = {
+          captureId,
+          recorder,
+          stream,
+          frameCount: 0,
+          stopped: false,
+          stopRequestId: null,
+        };
+        activeRef.current = active;
+
+        recorder.ondataavailable = async (e: BlobEvent) => {
+          if (e.data && e.data.size > 0) {
+            try {
+              const ab = await e.data.arrayBuffer();
+              api.sendCaptureChunk(active.captureId, new Uint8Array(ab));
+            } catch {
+              // renderer unloading
+            }
+          }
+        };
+
+        recorder.onerror = (event: Event) => {
+          const errEvent = event as unknown as { error?: Error };
+          const message = errEvent.error?.message ?? "MediaRecorder error";
+          stopAndCleanup(active, message);
+          if (active.stopRequestId) {
+            api.sendCommandDone(active.stopRequestId, message);
+            active.stopRequestId = null;
+          }
+        };
+
+        recorder.onstop = () => {
+          try {
+            active.stream.getTracks().forEach((t) => t.stop());
+          } catch {
+            // ignore
+          }
+          api.sendCaptureStop(active.captureId, active.frameCount);
+          if (active.stopRequestId) {
+            api.sendCommandDone(active.stopRequestId);
+            active.stopRequestId = null;
+          }
+          if (activeRef.current === active) {
+            activeRef.current = null;
+          }
+        };
+
+        try {
+          recorder.start(1000);
+          api.sendCommandDone(requestId);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          stopAndCleanup(active, message);
+          api.sendCommandDone(requestId, `recorder.start failed: ${message}`);
+        }
+      }
+    );
+
+    const offStop = api.onExecCommand(
+      "demo:exec-stop-capture",
+      (payload: Record<string, unknown>) => {
+        const captureId = payload.captureId as string;
+        const requestId = payload.requestId as string;
+        const active = activeRef.current;
+
+        if (!active || active.captureId !== captureId || active.stopped) {
+          api.sendCommandDone(requestId);
+          return;
+        }
+
+        active.stopped = true;
+        active.stopRequestId = requestId;
+        try {
+          if (active.recorder.state !== "inactive") {
+            active.recorder.stop();
+          } else {
+            api.sendCaptureStop(active.captureId, active.frameCount);
+            api.sendCommandDone(requestId);
+            active.stopRequestId = null;
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          api.sendCommandDone(requestId, message);
+          active.stopRequestId = null;
+        }
+      }
+    );
+
+    return () => {
+      offStart();
+      offStop();
+      const active = activeRef.current;
+      if (active && !active.stopped) {
+        stopAndCleanup(active, "DemoCaptureBridge unmounted");
+      }
+      activeRef.current = null;
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/Demo/DemoCaptureBridge.tsx
+++ b/src/components/Demo/DemoCaptureBridge.tsx
@@ -5,8 +5,11 @@ interface ActiveRecording {
   recorder: MediaRecorder;
   stream: MediaStream;
   frameCount: number;
+  pendingChunks: number;
   stopped: boolean;
+  stopSignalSent: boolean;
   stopRequestId: string | null;
+  stopError: string | null;
 }
 
 function getDemoApi() {
@@ -19,23 +22,40 @@ export function DemoCaptureBridge() {
   useEffect(() => {
     const api = getDemoApi();
 
+    // Send DEMO_CAPTURE_STOP only once all pending chunks have drained AND the
+    // recorder has stopped. ondataavailable is async (awaits arrayBuffer), so
+    // naive dispatch inside onstop races ahead of the final chunk's IPC send.
+    const maybeSendStop = (active: ActiveRecording) => {
+      if (!active.stopped || active.stopSignalSent || active.pendingChunks > 0) return;
+      active.stopSignalSent = true;
+      api.sendCaptureStop(active.captureId, active.frameCount, active.stopError ?? undefined);
+      if (active.stopRequestId) {
+        api.sendCommandDone(active.stopRequestId, active.stopError ?? undefined);
+        active.stopRequestId = null;
+      }
+      if (activeRef.current === active) {
+        activeRef.current = null;
+      }
+    };
+
     const stopAndCleanup = (active: ActiveRecording, error?: string) => {
       if (active.stopped) return;
       active.stopped = true;
+      if (error && !active.stopError) active.stopError = error;
       try {
         if (active.recorder.state !== "inactive") {
           active.recorder.stop();
+        } else {
+          // Recorder already inactive — onstop won't fire, so drive the barrier.
+          try {
+            active.stream.getTracks().forEach((t) => t.stop());
+          } catch {
+            // ignore
+          }
+          maybeSendStop(active);
         }
       } catch {
-        // already stopped
-      }
-      try {
-        active.stream.getTracks().forEach((t) => t.stop());
-      } catch {
-        // ignore
-      }
-      if (error) {
-        api.sendCaptureStop(active.captureId, active.frameCount, error);
+        maybeSendStop(active);
       }
     };
 
@@ -83,19 +103,28 @@ export function DemoCaptureBridge() {
           recorder,
           stream,
           frameCount: 0,
+          pendingChunks: 0,
           stopped: false,
+          stopSignalSent: false,
           stopRequestId: null,
+          stopError: null,
         };
         activeRef.current = active;
 
         recorder.ondataavailable = async (e: BlobEvent) => {
-          if (e.data && e.data.size > 0) {
-            try {
-              const ab = await e.data.arrayBuffer();
-              api.sendCaptureChunk(active.captureId, new Uint8Array(ab));
-            } catch {
-              // renderer unloading
+          if (!e.data || e.data.size === 0) return;
+          active.pendingChunks += 1;
+          active.frameCount += 1;
+          try {
+            const ab = await e.data.arrayBuffer();
+            api.sendCaptureChunk(active.captureId, new Uint8Array(ab));
+          } catch (err) {
+            if (!active.stopError) {
+              active.stopError = err instanceof Error ? err.message : String(err);
             }
+          } finally {
+            active.pendingChunks -= 1;
+            maybeSendStop(active);
           }
         };
 
@@ -103,10 +132,6 @@ export function DemoCaptureBridge() {
           const errEvent = event as unknown as { error?: Error };
           const message = errEvent.error?.message ?? "MediaRecorder error";
           stopAndCleanup(active, message);
-          if (active.stopRequestId) {
-            api.sendCommandDone(active.stopRequestId, message);
-            active.stopRequestId = null;
-          }
         };
 
         recorder.onstop = () => {
@@ -115,14 +140,8 @@ export function DemoCaptureBridge() {
           } catch {
             // ignore
           }
-          api.sendCaptureStop(active.captureId, active.frameCount);
-          if (active.stopRequestId) {
-            api.sendCommandDone(active.stopRequestId);
-            active.stopRequestId = null;
-          }
-          if (activeRef.current === active) {
-            activeRef.current = null;
-          }
+          active.stopped = true;
+          maybeSendStop(active);
         };
 
         try {
@@ -143,25 +162,28 @@ export function DemoCaptureBridge() {
         const requestId = payload.requestId as string;
         const active = activeRef.current;
 
-        if (!active || active.captureId !== captureId || active.stopped) {
+        if (!active || active.captureId !== captureId) {
+          api.sendCommandDone(requestId);
+          return;
+        }
+        if (active.stopSignalSent) {
           api.sendCommandDone(requestId);
           return;
         }
 
-        active.stopped = true;
         active.stopRequestId = requestId;
         try {
           if (active.recorder.state !== "inactive") {
             active.recorder.stop();
           } else {
-            api.sendCaptureStop(active.captureId, active.frameCount);
-            api.sendCommandDone(requestId);
-            active.stopRequestId = null;
+            active.stopped = true;
+            maybeSendStop(active);
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          api.sendCommandDone(requestId, message);
-          active.stopRequestId = null;
+          active.stopError = message;
+          active.stopped = true;
+          maybeSendStop(active);
         }
       }
     );

--- a/src/components/Demo/index.ts
+++ b/src/components/Demo/index.ts
@@ -1,2 +1,3 @@
+export { DemoCaptureBridge } from "./DemoCaptureBridge";
 export { DemoCursor } from "./DemoCursor";
 export { DemoOverlay } from "./DemoOverlay";

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -9,7 +9,7 @@ import { HelpPanel } from "../HelpPanel";
 import { ProjectSwitchOverlay } from "@/components/Project";
 import { FleetArmingRibbon, FleetDeck } from "@/components/Fleet";
 import { ChordIndicator } from "./ChordIndicator";
-import { DemoCursor, DemoOverlay } from "../Demo";
+import { DemoCaptureBridge, DemoCursor, DemoOverlay } from "../Demo";
 
 import { AllClearOverlay } from "../AllClearOverlay";
 import { useDiagnosticsStore, useDockStore, useFleetDeckStore, type PanelState } from "@/store";
@@ -383,6 +383,7 @@ export function AppLayout({
         <>
           <DemoOverlay />
           <DemoCursor />
+          <DemoCaptureBridge />
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Replaces the `capturePage()` polling loop with a renderer-driven `getDisplayMedia` + `MediaRecorder` pipeline. The old path pushed ~2GB/s of raw BGRA frames across IPC at 60fps and dropped frames under CPU load. The new path lets the OS encode VP9 WebM directly in the renderer via a `DemoCaptureBridge` component.
- On Retina displays this captures physical pixels natively (3840x2160), so real 4K comes for free without any upscaling. The fake 4K/lanczos upscale preset is removed.
- Adds an offline `handleEncode` handler (PNG frames on disk to final video) driven by ffmpeg-static, for post-processing in demo-studio. Adds `DEMO_CAPTURE_CHUNK` / `DEMO_CAPTURE_STOP` IPC channels for streaming WebM chunks from renderer to disk.

Resolves #5268

## Changes

- `src/components/Demo/DemoCaptureBridge.tsx` — new renderer component; calls `getDisplayMedia`, runs `MediaRecorder`, streams chunks to main via IPC
- `electron/ipc/handlers/demo.ts` — rewrites `handleStartCapture`/`handleStopCapture` to manage the WebM write stream; adds `handleEncode` for offline PNG-to-video re-encode
- `electron/ipc/channels.ts` / `electron/preload.cts` — adds `DEMO_ENCODE`, `DEMO_ENCODE_PROGRESS`, `DEMO_EXEC_START_CAPTURE`, `DEMO_EXEC_STOP_CAPTURE`, `DEMO_CAPTURE_CHUNK`, `DEMO_CAPTURE_STOP` channels
- `shared/types/ipc/demo.ts` — updated payload/result types for the new capture and encode flow
- `electron/ipc/handlers/__tests__/demo.handlers.test.ts` — full test suite for `handleEncode` and the MediaRecorder capture pipeline (chunk routing, drain-on-stop, write stream lifecycle)

## Testing

- Unit tests cover the encode handler (success, no-frames error, non-zero exit, preset options, input pattern) and the capture pipeline (start/stop, chunk routing by captureId, chunk drain race on stop, cleanup).
- `npm run check` passes clean (0 errors, warnings only from pre-existing issues).
- Manual testing requires the one-time Screen Recording permission grant in macOS System Settings, as documented in the issue.