### PR TITLE
fix(github): show token-missing state in issue/PR badges

### DIFF
--- a/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
+++ b/src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
-import { User, Users, Calendar } from "lucide-react";
+import { User, Users, Calendar, KeyRound } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
 
@@ -22,6 +22,21 @@ export const TooltipLoading = memo(function TooltipLoading({ type }: TooltipLoad
     <div className="flex items-center gap-2 text-daintree-text/70 py-1">
       <Spinner size="xs" />
       <span className="text-xs">Loading {type} details...</span>
+    </div>
+  );
+});
+
+interface TokenMissingTooltipProps {
+  type: "issue" | "pr";
+}
+
+export const TokenMissingTooltip = memo(function TokenMissingTooltip({
+  type,
+}: TokenMissingTooltipProps) {
+  return (
+    <div className="flex items-center gap-2 text-daintree-text/60 py-1">
+      <KeyRound className="w-3.5 h-3.5 shrink-0 text-daintree-accent/60" aria-hidden="true" />
+      <span className="text-xs">Configure GitHub token to see {type} details</span>
     </div>
   );
 });

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -47,7 +47,13 @@ import {
 } from "lucide-react";
 import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { useIssueTooltip, usePRTooltip } from "@/hooks/useGitHubTooltip";
-import { IssueTooltipContent, PRTooltipContent, TooltipLoading } from "./GitHubTooltipContent";
+import {
+  IssueTooltipContent,
+  PRTooltipContent,
+  TooltipLoading,
+  TokenMissingTooltip,
+} from "./GitHubTooltipContent";
+import { actionService } from "@/services/ActionService";
 
 const ENVIRONMENT_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   Server,
@@ -92,7 +98,10 @@ const IssueBadge = memo(function IssueBadge({
   underlineOnHover,
 }: IssueBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { data, loading, error, fetchTooltip, reset } = useIssueTooltip(worktreePath, issueNumber);
+  const { data, loading, error, missingToken, fetchTooltip, reset } = useIssueTooltip(
+    worktreePath,
+    issueNumber
+  );
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -106,23 +115,37 @@ const IssueBadge = memo(function IssueBadge({
     [fetchTooltip, reset]
   );
 
+  const handleClick = useCallback(() => {
+    if (!isActive) return;
+    if (missingToken) {
+      void actionService.dispatch(
+        "app.settings.openTab",
+        { tab: "github", sectionId: "github-token" },
+        { source: "user" }
+      );
+      return;
+    }
+    onOpen?.();
+  }, [isActive, missingToken, onOpen]);
+
   return (
     <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
       <TooltipTrigger asChild>
         <button
           type="button"
-          onClick={() => {
-            if (isActive) onOpen?.();
-          }}
+          onClick={handleClick}
           className={cn(
             "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
-            isHeadline ? "text-[13px]" : "text-xs"
+            isHeadline ? "text-[13px]" : "text-xs",
+            missingToken && "opacity-60"
           )}
           aria-disabled={!isActive || undefined}
           aria-label={
-            issueTitle
-              ? `Open issue #${issueNumber}: ${issueTitle}`
-              : `Open issue #${issueNumber} on GitHub`
+            missingToken
+              ? "Configure GitHub token to see issue details"
+              : issueTitle
+                ? `Open issue #${issueNumber}: ${issueTitle}`
+                : `Open issue #${issueNumber} on GitHub`
           }
         >
           <CircleDot
@@ -145,7 +168,9 @@ const IssueBadge = memo(function IssueBadge({
         </button>
       </TooltipTrigger>
       <TooltipContent side="right" align="start" className="p-3">
-        {loading ? (
+        {missingToken ? (
+          <TokenMissingTooltip type="issue" />
+        ) : loading ? (
           <TooltipLoading type="issue" />
         ) : data ? (
           <IssueTooltipContent data={data} />
@@ -179,7 +204,10 @@ const PRBadge = memo(function PRBadge({
   underlineOnHover,
 }: PRBadgeProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { data, loading, error, fetchTooltip, reset } = usePRTooltip(worktreePath, prNumber);
+  const { data, loading, error, missingToken, fetchTooltip, reset } = usePRTooltip(
+    worktreePath,
+    prNumber
+  );
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -192,6 +220,19 @@ const PRBadge = memo(function PRBadge({
     },
     [fetchTooltip, reset]
   );
+
+  const handleClick = useCallback(() => {
+    if (!isActive) return;
+    if (missingToken) {
+      void actionService.dispatch(
+        "app.settings.openTab",
+        { tab: "github", sectionId: "github-token" },
+        { source: "user" }
+      );
+      return;
+    }
+    onOpen?.();
+  }, [isActive, missingToken, onOpen]);
 
   const prStateColor =
     prState === "merged"
@@ -207,12 +248,17 @@ const PRBadge = memo(function PRBadge({
       <TooltipTrigger asChild>
         <button
           type="button"
-          onClick={() => {
-            if (isActive) onOpen?.();
-          }}
-          className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0"
+          onClick={handleClick}
+          className={cn(
+            "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
+            missingToken && "opacity-60"
+          )}
           aria-disabled={!isActive || undefined}
-          aria-label={`Open ${prStateLabel} pull request #${prNumber} on GitHub`}
+          aria-label={
+            missingToken
+              ? "Configure GitHub token to see PR details"
+              : `Open ${prStateLabel} pull request #${prNumber} on GitHub`
+          }
         >
           {isSubordinate && (
             <CornerDownRight className="w-3 h-3 text-text-muted shrink-0" aria-hidden="true" />
@@ -224,7 +270,9 @@ const PRBadge = memo(function PRBadge({
         </button>
       </TooltipTrigger>
       <TooltipContent side="right" align="start" className="p-3">
-        {loading ? (
+        {missingToken ? (
+          <TokenMissingTooltip type="pr" />
+        ) : loading ? (
           <TooltipLoading type="pr" />
         ) : data ? (
           <PRTooltipContent data={data} />

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1,23 +1,27 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { WorktreeHeader, type WorktreeHeaderProps } from "../WorktreeHeader";
 import type { WorktreeState } from "@shared/types";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { actionService } from "@/services/ActionService";
 
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
   return { ...actual, createPortal: (children: ReactNode) => children };
 });
 
+let mockMissingToken = false;
+
 vi.mock("@/hooks/useGitHubTooltip", () => ({
   useIssueTooltip: () => ({
     data: null,
     loading: false,
     error: null,
+    missingToken: mockMissingToken,
     fetchTooltip: vi.fn(),
     reset: vi.fn(),
   }),
@@ -25,9 +29,16 @@ vi.mock("@/hooks/useGitHubTooltip", () => ({
     data: null,
     loading: false,
     error: null,
+    missingToken: mockMissingToken,
     fetchTooltip: vi.fn(),
     reset: vi.fn(),
   }),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn(),
+  },
 }));
 
 const noop = () => {};
@@ -879,5 +890,116 @@ describe("WorktreeHeader icon button hit targets", () => {
     renderHeader();
     const menuButton = screen.getByTestId("worktree-actions-menu");
     expect(menuButton.className).toContain("p-1.5");
+  });
+});
+
+describe("WorktreeHeader token-missing badge behavior", () => {
+  beforeEach(() => {
+    mockMissingToken = false;
+    vi.mocked(actionService.dispatch).mockClear();
+  });
+
+  it("issue badge shows token-missing aria-label when no token configured", () => {
+    mockMissingToken = true;
+    renderHeader({
+      worktree: { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" },
+      badges: { onOpenIssue: noop },
+      isActive: true,
+    });
+
+    const issueButton = screen.getByRole("button", {
+      name: /Configure GitHub token to see issue details/,
+    });
+    expect(issueButton).toBeDefined();
+    expect(issueButton.className).toContain("opacity-60");
+  });
+
+  it("issue badge dispatches settings action on click when no token configured", () => {
+    mockMissingToken = true;
+    const onOpenIssue = vi.fn();
+    renderHeader({
+      worktree: { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" },
+      badges: { onOpenIssue },
+      isActive: true,
+    });
+
+    const issueButton = screen.getByRole("button", {
+      name: /Configure GitHub token to see issue details/,
+    });
+    fireEvent.click(issueButton);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "github", sectionId: "github-token" },
+      { source: "user" }
+    );
+    expect(onOpenIssue).not.toHaveBeenCalled();
+  });
+
+  it("PR badge shows token-missing aria-label when no token configured", () => {
+    mockMissingToken = true;
+    renderHeader({
+      worktree: { ...baseWorktree, prNumber: 101, prState: "open" },
+      badges: { onOpenPR: noop },
+      isActive: true,
+    });
+
+    const prButton = screen.getByRole("button", {
+      name: /Configure GitHub token to see PR details/,
+    });
+    expect(prButton).toBeDefined();
+    expect(prButton.className).toContain("opacity-60");
+  });
+
+  it("PR badge dispatches settings action on click when no token configured", () => {
+    mockMissingToken = true;
+    const onOpenPR = vi.fn();
+    renderHeader({
+      worktree: { ...baseWorktree, prNumber: 101, prState: "open" },
+      badges: { onOpenPR },
+      isActive: true,
+    });
+
+    const prButton = screen.getByRole("button", {
+      name: /Configure GitHub token to see PR details/,
+    });
+    fireEvent.click(prButton);
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "github", sectionId: "github-token" },
+      { source: "user" }
+    );
+    expect(onOpenPR).not.toHaveBeenCalled();
+  });
+
+  it("issue badge calls onOpenIssue normally when token is present", () => {
+    mockMissingToken = false;
+    const onOpenIssue = vi.fn();
+    renderHeader({
+      worktree: { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" },
+      badges: { onOpenIssue },
+      isActive: true,
+    });
+
+    const issueButton = screen.getByRole("button", {
+      name: /Open issue #42/,
+    });
+    fireEvent.click(issueButton);
+    expect(actionService.dispatch).not.toHaveBeenCalled();
+    expect(onOpenIssue).toHaveBeenCalledOnce();
+  });
+
+  it("token-missing badge click does nothing on inactive card", () => {
+    mockMissingToken = true;
+    renderHeader({
+      worktree: { ...baseWorktree, issueNumber: 42, issueTitle: "Test issue" },
+      badges: { onOpenIssue: noop },
+      isActive: false,
+    });
+
+    const issueButton = screen.getByRole("button", {
+      name: /Configure GitHub token/,
+    });
+    fireEvent.click(issueButton);
+    expect(actionService.dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
 import { TtlCache } from "@/utils/ttlCache";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
@@ -7,7 +7,6 @@ type TooltipState<T> = {
   data: T | null;
   loading: boolean;
   error: boolean;
-  missingToken: boolean;
 };
 
 const TOOLTIP_CACHE_MAX = 100;
@@ -21,12 +20,13 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
     data: null,
     loading: false,
     error: false,
-    missingToken: false,
   });
   const fetchingKeyRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
   const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
   const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
+
+  const missingToken = useMemo(() => storeInitialized && !hasToken, [storeInitialized, hasToken]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -39,24 +39,19 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
   }, [storeInitialized]);
 
   const fetchTooltip = useCallback(async () => {
-    if (!cwd || !issueNumber) return;
-
-    if (!hasToken) {
-      setState({ data: null, loading: false, error: false, missingToken: true });
-      return;
-    }
+    if (!cwd || !issueNumber || missingToken) return;
 
     const cacheKey = `${cwd}:${issueNumber}`;
     const cached = issueCache.get(cacheKey);
     if (cached) {
-      setState({ data: cached, loading: false, error: false, missingToken: false });
+      setState({ data: cached, loading: false, error: false });
       return;
     }
 
     if (fetchingKeyRef.current === cacheKey) return;
 
     fetchingKeyRef.current = cacheKey;
-    setState((prev) => ({ ...prev, loading: true, error: false, missingToken: false }));
+    setState((prev) => ({ ...prev, loading: true, error: false }));
 
     try {
       const data = await window.electron.github.getIssueTooltip(cwd, issueNumber);
@@ -64,27 +59,27 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
 
       if (data) {
         issueCache.set(cacheKey, data);
-        setState({ data, loading: false, error: false, missingToken: false });
+        setState({ data, loading: false, error: false });
       } else {
-        setState({ data: null, loading: false, error: true, missingToken: false });
+        setState({ data: null, loading: false, error: true });
       }
     } catch {
       if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
-      setState({ data: null, loading: false, error: true, missingToken: false });
+      setState({ data: null, loading: false, error: true });
     } finally {
       if (fetchingKeyRef.current === cacheKey) {
         fetchingKeyRef.current = null;
       }
     }
-  }, [cwd, issueNumber, hasToken]);
+  }, [cwd, issueNumber, missingToken]);
 
   const reset = useCallback(() => {
     if (!fetchingKeyRef.current) {
-      setState({ data: null, loading: false, error: false, missingToken: false });
+      setState({ data: null, loading: false, error: false });
     }
   }, []);
 
-  return { ...state, fetchTooltip, reset };
+  return { ...state, missingToken, fetchTooltip, reset };
 }
 
 export function usePRTooltip(cwd: string | undefined, prNumber: number | undefined) {
@@ -92,12 +87,13 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
     data: null,
     loading: false,
     error: false,
-    missingToken: false,
   });
   const fetchingKeyRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
   const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
   const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
+
+  const missingToken = useMemo(() => storeInitialized && !hasToken, [storeInitialized, hasToken]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -110,24 +106,19 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
   }, [storeInitialized]);
 
   const fetchTooltip = useCallback(async () => {
-    if (!cwd || !prNumber) return;
-
-    if (!hasToken) {
-      setState({ data: null, loading: false, error: false, missingToken: true });
-      return;
-    }
+    if (!cwd || !prNumber || missingToken) return;
 
     const cacheKey = `${cwd}:${prNumber}`;
     const cached = prCache.get(cacheKey);
     if (cached) {
-      setState({ data: cached, loading: false, error: false, missingToken: false });
+      setState({ data: cached, loading: false, error: false });
       return;
     }
 
     if (fetchingKeyRef.current === cacheKey) return;
 
     fetchingKeyRef.current = cacheKey;
-    setState((prev) => ({ ...prev, loading: true, error: false, missingToken: false }));
+    setState((prev) => ({ ...prev, loading: true, error: false }));
 
     try {
       const data = await window.electron.github.getPRTooltip(cwd, prNumber);
@@ -135,25 +126,25 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
 
       if (data) {
         prCache.set(cacheKey, data);
-        setState({ data, loading: false, error: false, missingToken: false });
+        setState({ data, loading: false, error: false });
       } else {
-        setState({ data: null, loading: false, error: true, missingToken: false });
+        setState({ data: null, loading: false, error: true });
       }
     } catch {
       if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
-      setState({ data: null, loading: false, error: true, missingToken: false });
+      setState({ data: null, loading: false, error: true });
     } finally {
       if (fetchingKeyRef.current === cacheKey) {
         fetchingKeyRef.current = null;
       }
     }
-  }, [cwd, prNumber, hasToken]);
+  }, [cwd, prNumber, missingToken]);
 
   const reset = useCallback(() => {
     if (!fetchingKeyRef.current) {
-      setState({ data: null, loading: false, error: false, missingToken: false });
+      setState({ data: null, loading: false, error: false });
     }
   }, []);
 
-  return { ...state, fetchTooltip, reset };
+  return { ...state, missingToken, fetchTooltip, reset };
 }

--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -1,11 +1,13 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
 import { TtlCache } from "@/utils/ttlCache";
+import { useGitHubConfigStore } from "@/store/githubConfigStore";
 
 type TooltipState<T> = {
   data: T | null;
   loading: boolean;
   error: boolean;
+  missingToken: boolean;
 };
 
 const TOOLTIP_CACHE_MAX = 100;
@@ -19,31 +21,42 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
     data: null,
     loading: false,
     error: false,
+    missingToken: false,
   });
   const fetchingKeyRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
+  const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
+  const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
 
   useEffect(() => {
     mountedRef.current = true;
+    if (!storeInitialized) {
+      void useGitHubConfigStore.getState().initialize();
+    }
     return () => {
       mountedRef.current = false;
     };
-  }, []);
+  }, [storeInitialized]);
 
   const fetchTooltip = useCallback(async () => {
     if (!cwd || !issueNumber) return;
 
+    if (!hasToken) {
+      setState({ data: null, loading: false, error: false, missingToken: true });
+      return;
+    }
+
     const cacheKey = `${cwd}:${issueNumber}`;
     const cached = issueCache.get(cacheKey);
     if (cached) {
-      setState({ data: cached, loading: false, error: false });
+      setState({ data: cached, loading: false, error: false, missingToken: false });
       return;
     }
 
     if (fetchingKeyRef.current === cacheKey) return;
 
     fetchingKeyRef.current = cacheKey;
-    setState((prev) => ({ ...prev, loading: true, error: false }));
+    setState((prev) => ({ ...prev, loading: true, error: false, missingToken: false }));
 
     try {
       const data = await window.electron.github.getIssueTooltip(cwd, issueNumber);
@@ -51,23 +64,23 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
 
       if (data) {
         issueCache.set(cacheKey, data);
-        setState({ data, loading: false, error: false });
+        setState({ data, loading: false, error: false, missingToken: false });
       } else {
-        setState({ data: null, loading: false, error: true });
+        setState({ data: null, loading: false, error: true, missingToken: false });
       }
     } catch {
       if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
-      setState({ data: null, loading: false, error: true });
+      setState({ data: null, loading: false, error: true, missingToken: false });
     } finally {
       if (fetchingKeyRef.current === cacheKey) {
         fetchingKeyRef.current = null;
       }
     }
-  }, [cwd, issueNumber]);
+  }, [cwd, issueNumber, hasToken]);
 
   const reset = useCallback(() => {
     if (!fetchingKeyRef.current) {
-      setState({ data: null, loading: false, error: false });
+      setState({ data: null, loading: false, error: false, missingToken: false });
     }
   }, []);
 
@@ -79,31 +92,42 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
     data: null,
     loading: false,
     error: false,
+    missingToken: false,
   });
   const fetchingKeyRef = useRef<string | null>(null);
   const mountedRef = useRef(true);
+  const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
+  const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
 
   useEffect(() => {
     mountedRef.current = true;
+    if (!storeInitialized) {
+      void useGitHubConfigStore.getState().initialize();
+    }
     return () => {
       mountedRef.current = false;
     };
-  }, []);
+  }, [storeInitialized]);
 
   const fetchTooltip = useCallback(async () => {
     if (!cwd || !prNumber) return;
 
+    if (!hasToken) {
+      setState({ data: null, loading: false, error: false, missingToken: true });
+      return;
+    }
+
     const cacheKey = `${cwd}:${prNumber}`;
     const cached = prCache.get(cacheKey);
     if (cached) {
-      setState({ data: cached, loading: false, error: false });
+      setState({ data: cached, loading: false, error: false, missingToken: false });
       return;
     }
 
     if (fetchingKeyRef.current === cacheKey) return;
 
     fetchingKeyRef.current = cacheKey;
-    setState((prev) => ({ ...prev, loading: true, error: false }));
+    setState((prev) => ({ ...prev, loading: true, error: false, missingToken: false }));
 
     try {
       const data = await window.electron.github.getPRTooltip(cwd, prNumber);
@@ -111,23 +135,23 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
 
       if (data) {
         prCache.set(cacheKey, data);
-        setState({ data, loading: false, error: false });
+        setState({ data, loading: false, error: false, missingToken: false });
       } else {
-        setState({ data: null, loading: false, error: true });
+        setState({ data: null, loading: false, error: true, missingToken: false });
       }
     } catch {
       if (!mountedRef.current || fetchingKeyRef.current !== cacheKey) return;
-      setState({ data: null, loading: false, error: true });
+      setState({ data: null, loading: false, error: true, missingToken: false });
     } finally {
       if (fetchingKeyRef.current === cacheKey) {
         fetchingKeyRef.current = null;
       }
     }
-  }, [cwd, prNumber]);
+  }, [cwd, prNumber, hasToken]);
 
   const reset = useCallback(() => {
     if (!fetchingKeyRef.current) {
-      setState({ data: null, loading: false, error: false });
+      setState({ data: null, loading: false, error: false, missingToken: false });
     }
   }, []);
 


### PR DESCRIPTION
## Summary

When a worktree's branch is tied to a GitHub issue or PR, the issue/PR badges previously showed nothing useful if the user hadn't configured a GitHub token. The hover tooltip would render empty, giving no affordance to point the user at where to set the token.

This fix adds clear token-missing states:
- Issue and PR badges now show a "Configure GitHub token" tooltip when no token is configured
- Clicking the badge while missing a token opens the GitHub token settings tab directly
- Added proper ARIA labels and visual affordances (reduced opacity) to signal the token‑missing state

## Changes

- **`src/hooks/useGitHubTooltip.ts`**: derive `missingToken` from the central GitHub config store instead of mutable local state; skip API fetches when token is missing
- **`src/components/Worktree/WorktreeCard/WorktreeHeader.tsx`**: conditionally render token‑missing tooltip content; dispatch settings‑open action on click when token is absent; apply reduced opacity and appropriate ARIA labels
- **`src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx`**: add `TokenMissingTooltip` component with key icon and explanatory text
- **`src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx`**: 6 new unit tests covering token‑missing ARIA labels, click‑to‑settings dispatch, and inactive‑card behaviour

## Testing

- Verified that issue and PR badges show the token‑missing tooltip when no GitHub token is configured
- Confirmed clicking the badge opens Settings › GitHub › GitHub Token tab (active cards only)
- Checked that badges remain fully functional when a token is present (no regression)
- Ran the new unit‑test suite; all pass

Resolves #5552