### PR TITLE
feat(fleet): render armed terminals in main grid when Fleet scope active

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -911,6 +911,12 @@
     "error": 0,
     "pipeline": 0
   },
+  "src/components/Settings/AddPresetDialog.tsx": {
+    "success": 2,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
   "src/components/Settings/AgentHelpOutput.tsx": {
     "success": 0,
     "skip": 0,
@@ -1238,7 +1244,7 @@
   "src/components/Terminal/ContentGrid.tsx": {
     "success": 1,
     "skip": 0,
-    "error": 2,
+    "error": 3,
     "pipeline": 0
   },
   "src/components/Terminal/DockedPanel.tsx": {
@@ -1650,7 +1656,7 @@
     "pipeline": 0
   },
   "src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx": {
-    "success": 4,
+    "success": 5,
     "skip": 0,
     "error": 0,
     "pipeline": 0
@@ -2155,6 +2161,12 @@
   },
   "src/components/ui/popover.tsx": {
     "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0
+  },
+  "src/components/ui/select.tsx": {
+    "success": 7,
     "skip": 0,
     "error": 0,
     "pipeline": 0

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -36,6 +36,7 @@ import { ProjectPulseCard } from "@/components/Pulse";
 import { Kbd } from "@/components/ui/Kbd";
 import { svgToDataUrl, sanitizeSvg } from "@/lib/svg";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { TerminalRefreshTier } from "@shared/types/panel";
 import {
   computeGridColumns,
   MIN_TERMINAL_HEIGHT_PX,
@@ -432,7 +433,7 @@ export function ContentGrid({
   const { armedIds, armOrder } = useFleetArmingStore(
     useShallow((state) => ({ armedIds: state.armedIds, armOrder: state.armOrder }))
   );
-  const isFleetScopeRender = fleetScopeMode === "scoped" && isFleetScopeActive && armedIds.size > 0;
+  const isFleetScopeEnabled = fleetScopeMode === "scoped" && isFleetScopeActive;
 
   // Grid terminals filtered by location and active worktree
   const gridTerminals = useMemo(() => {
@@ -713,7 +714,7 @@ export function ContentGrid({
   // that have since been pruned, trashed, or moved to the dock. We resolve
   // against panelsById once here so GridPanel cells receive stable refs.
   const fleetPanels = useMemo(() => {
-    if (!isFleetScopeRender) return [];
+    if (!isFleetScopeEnabled) return [];
     const result: TerminalInstance[] = [];
     for (const id of armOrder) {
       if (!armedIds.has(id)) continue;
@@ -723,7 +724,13 @@ export function ContentGrid({
       result.push(t);
     }
     return result;
-  }, [isFleetScopeRender, armOrder, armedIds, panelsById]);
+  }, [isFleetScopeEnabled, armOrder, armedIds, panelsById]);
+
+  // Only render the fleet grid if at least one armed panel is actually
+  // grid-renderable. Otherwise fall through to the normal active-worktree
+  // grid so the user isn't trapped in an empty fleet view when every
+  // armed terminal has been moved to the dock or trashed.
+  const isFleetScopeRender = isFleetScopeEnabled && fleetPanels.length > 0;
 
   const fleetNeedsWorktreePrefix = useMemo(() => {
     if (fleetPanels.length <= 1) return false;
@@ -741,10 +748,16 @@ export function ContentGrid({
   // `gridTerminals` and can't be redirected at the current armed set, which
   // spans worktrees. Stagger fits via rAF to let xterm reattach per cell
   // without starving the renderer — lesson #5092 flagged simultaneous cross-
-  // worktree mounts as a risk for IntersectionObserver misfires.
+  // worktree mounts as a risk for IntersectionObserver misfires. We also
+  // promote every mounted fleet cell to VISIBLE so cross-worktree terminals
+  // keep streaming output — worktreeStore's per-worktree policy would
+  // otherwise demote them to BACKGROUND (showing stale frames).
   useEffect(() => {
     if (!isFleetScopeRender) return;
     const ids = fleetPanels.map((t) => t.id);
+    for (const id of ids) {
+      terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+    }
     const cancelRef = { cancelled: false };
     const timeoutId = window.setTimeout(() => {
       if (isDraggingRef.current) return;

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -12,6 +12,8 @@ import {
   useTwoPaneSplitStore,
   type TerminalInstance,
 } from "@/store";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
 import { isAgentReady } from "../../../shared/utils/agentAvailability";
 import { computeGridCanLaunch, computeGridSelectedAgentIds } from "./contentGridAgentFilter";
@@ -422,6 +424,16 @@ export function ContentGrid({
   // Two-pane split mode settings
   const twoPaneSplitEnabled = useTwoPaneSplitStore((state) => state.config.enabled);
 
+  // Fleet scope render state — when the flag is "scoped" and scope is active
+  // the grid paints the armed set (across every worktree) as a flat grid of
+  // input-locked cells. Scope is a no-op in "legacy" mode.
+  const isFleetScopeActive = useWorktreeSelectionStore((state) => state.isFleetScopeActive);
+  const fleetScopeMode = useFleetScopeFlagStore((state) => state.mode);
+  const { armedIds, armOrder } = useFleetArmingStore(
+    useShallow((state) => ({ armedIds: state.armedIds, armOrder: state.armOrder }))
+  );
+  const isFleetScopeRender = fleetScopeMode === "scoped" && isFleetScopeActive && armedIds.size > 0;
+
   // Grid terminals filtered by location and active worktree
   const gridTerminals = useMemo(() => {
     const result: TerminalInstance[] = [];
@@ -697,6 +709,64 @@ export function ContentGrid({
     return ids;
   }, [tabGroups, showPlaceholder, placeholderIndex, placeholderInGrid]);
 
+  // Fleet scope projection: order is the user's arm order, dropping any ids
+  // that have since been pruned, trashed, or moved to the dock. We resolve
+  // against panelsById once here so GridPanel cells receive stable refs.
+  const fleetPanels = useMemo(() => {
+    if (!isFleetScopeRender) return [];
+    const result: TerminalInstance[] = [];
+    for (const id of armOrder) {
+      if (!armedIds.has(id)) continue;
+      const t = panelsById[id];
+      if (!t) continue;
+      if (t.location === "trash" || t.location === "background" || t.location === "dock") continue;
+      result.push(t);
+    }
+    return result;
+  }, [isFleetScopeRender, armOrder, armedIds, panelsById]);
+
+  const fleetNeedsWorktreePrefix = useMemo(() => {
+    if (fleetPanels.length <= 1) return false;
+    const firstWorktreeId = fleetPanels[0]?.worktreeId ?? null;
+    return fleetPanels.some((t) => (t.worktreeId ?? null) !== firstWorktreeId);
+  }, [fleetPanels]);
+
+  const fleetGridCols = useMemo(() => {
+    if (!isFleetScopeRender) return 1;
+    const { strategy, value } = layoutConfig;
+    return computeGridColumns(Math.max(fleetPanels.length, 1), gridWidth, strategy, value);
+  }, [isFleetScopeRender, fleetPanels.length, layoutConfig, gridWidth]);
+
+  // Dedicated fleet batch-fit: the main startBatchFit closure reads
+  // `gridTerminals` and can't be redirected at the current armed set, which
+  // spans worktrees. Stagger fits via rAF to let xterm reattach per cell
+  // without starving the renderer — lesson #5092 flagged simultaneous cross-
+  // worktree mounts as a risk for IntersectionObserver misfires.
+  useEffect(() => {
+    if (!isFleetScopeRender) return;
+    const ids = fleetPanels.map((t) => t.id);
+    const cancelRef = { cancelled: false };
+    const timeoutId = window.setTimeout(() => {
+      if (isDraggingRef.current) return;
+      let index = 0;
+      const processNext = () => {
+        if (cancelRef.cancelled || index >= ids.length) return;
+        if (isDraggingRef.current) return;
+        const id = ids[index++]!;
+        const managed = terminalInstanceService.get(id);
+        if (managed?.hostElement.isConnected) {
+          terminalInstanceService.fit(id);
+        }
+        requestAnimationFrame(processNext);
+      };
+      processNext();
+    }, GRID_FIT_DELAY_MS);
+    return () => {
+      cancelRef.cancelled = true;
+      clearTimeout(timeoutId);
+    };
+  }, [isFleetScopeRender, fleetPanels, fleetGridCols]);
+
   // Batch-fit grid terminals when layout (gridCols/count) changes.
   // gridTerminals is read via useEffectEvent so the effect doesn't re-run on
   // worktree switch (which mutates gridTerminals without changing layout).
@@ -888,6 +958,99 @@ export function ContentGrid({
       </ContextMenuItem>
     </ContextMenuContent>
   );
+
+  // Fleet scope render path: a flat grid of armed terminals from every
+  // worktree, each input-locked with a broadcast overlay. Deliberately
+  // placed before the maximize branch — a maximize captured against a
+  // different worktree must not shadow the fleet view. DnD, two-pane, and
+  // tab-group logic are bypassed entirely; the armed set is the source of
+  // truth for both membership and order.
+  if (isFleetScopeRender) {
+    return (
+      <div
+        key="fleet-scope-mode"
+        ref={gridRegionRef}
+        role="region"
+        tabIndex={-1}
+        aria-label="Fleet scope grid"
+        data-fleet-scope="true"
+        data-macro-focus={isMacroFocused ? "true" : undefined}
+        onKeyDown={handleGridRegionKeyDown}
+        className={cn(
+          "h-full flex flex-col outline-none",
+          "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
+          className
+        )}
+      >
+        <GridNotificationBar className="mx-1 mt-1 shrink-0" />
+        <TerminalCountWarning className="mx-1 mt-1 shrink-0" />
+        <div className="relative flex-1 min-h-0">
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <div
+                ref={combinedGridRef}
+                className="h-full bg-noise p-1"
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: `repeat(${fleetGridCols}, minmax(0, 1fr))`,
+                  gridAutoRows: `minmax(${MIN_TERMINAL_HEIGHT_PX}px, 1fr)`,
+                  gap: "4px",
+                  backgroundColor: "var(--color-grid-bg)",
+                  transition: isProjectSwitching
+                    ? "none"
+                    : `grid-template-columns ${GRID_TRANSITION_DURATION_MS}ms ease-out`,
+                  overflowY: "auto",
+                }}
+                id="panel-grid"
+                data-grid-container="true"
+              >
+                {fleetPanels.length === 0 ? (
+                  <div className="col-span-full row-span-full">
+                    <EmptyState
+                      hasActiveWorktree={hasActiveWorktree}
+                      activeWorktreeName={activeWorktreeName}
+                      activeWorktreeId={activeWorktreeId}
+                      showProjectPulse={showProjectPulse}
+                      projectIconSvg={projectIconSvg}
+                      defaultCwd={defaultCwd}
+                    />
+                  </div>
+                ) : (
+                  fleetPanels.map((terminal) => {
+                    let titleOverride: string | undefined;
+                    if (fleetNeedsWorktreePrefix) {
+                      const worktreeId = terminal.worktreeId ?? null;
+                      const worktree = worktreeId ? worktreeMap.get(worktreeId) : null;
+                      const prefix = worktree
+                        ? worktree.isMainWorktree
+                          ? worktree.name?.trim() || worktree.branch?.trim() || "Unknown Worktree"
+                          : worktree.branch?.trim() || worktree.name?.trim() || "Unknown Worktree"
+                        : null;
+                      if (prefix) {
+                        titleOverride = `${prefix} — ${terminal.title}`;
+                      }
+                    }
+                    return (
+                      <GridPanel
+                        key={terminal.id}
+                        terminal={terminal}
+                        isFocused={terminal.id === focusedId}
+                        gridPanelCount={fleetPanels.length}
+                        gridCols={fleetGridCols}
+                        isFleetScope
+                        titleOverride={titleOverride}
+                      />
+                    );
+                  })
+                )}
+              </div>
+            </ContextMenuTrigger>
+            {gridContextMenuContent}
+          </ContextMenu>
+        </div>
+      </div>
+    );
+  }
 
   // Maximized terminal or group takes full screen
   if (maximizedId && maximizeTarget) {

--- a/src/components/Terminal/GridPanel.tsx
+++ b/src/components/Terminal/GridPanel.tsx
@@ -17,6 +17,11 @@ export interface GridPanelProps {
   gridCols?: number;
   // Group-level ambient agent state (highest urgency across all tabs in a tab group)
   ambientAgentState?: AgentState;
+  // Fleet scope render overrides: force input lock, surface broadcast overlay,
+  // and let the caller disambiguate titles when the armed set spans multiple
+  // worktrees. These are transient render-only flags; the store is untouched.
+  isFleetScope?: boolean;
+  titleOverride?: string;
   // Tab support
   tabs?: TabInfo[];
   groupId?: string;
@@ -43,6 +48,8 @@ export function gridPanelPropsAreEqual(prev: GridPanelProps, next: GridPanelProp
     prev.gridPanelCount !== next.gridPanelCount ||
     prev.gridCols !== next.gridCols ||
     prev.ambientAgentState !== next.ambientAgentState ||
+    prev.isFleetScope !== next.isFleetScope ||
+    prev.titleOverride !== next.titleOverride ||
     prev.groupId !== next.groupId
   ) {
     return false;
@@ -119,6 +126,8 @@ export const GridPanel = React.memo(function GridPanel({
   gridPanelCount,
   gridCols,
   ambientAgentState,
+  isFleetScope = false,
+  titleOverride,
   tabs,
   groupId,
   onTabClick,
@@ -187,16 +196,22 @@ export const GridPanel = React.memo(function GridPanel({
           ambientAgentState,
           onFocus: handleFocus,
           onClose: handleClose,
-          onToggleMaximize: handleToggleMaximize,
+          // Fleet scope disables per-panel maximize — the armed grid is a single
+          // read-only composite view; promoting one cell would drop the rest.
+          onToggleMaximize: isFleetScope ? undefined : handleToggleMaximize,
           onTitleChange: handleTitleChange,
-          onMinimize: handleMinimize,
+          onMinimize: isFleetScope ? undefined : handleMinimize,
           tabs,
           groupId,
           onTabClick,
           onTabClose,
           onTabRename,
-          onAddTab,
+          // Adding a new tab in scope would create a cross-worktree tab group,
+          // which violates the tab-group invariant in shared/types/panel.ts.
+          onAddTab: isFleetScope ? undefined : onAddTab,
           onTabReorder,
+          ...(isFleetScope ? { isInputLocked: true, isFleetScope: true } : undefined),
+          ...(titleOverride !== undefined ? { title: titleOverride } : undefined),
         },
       }),
     [
@@ -218,6 +233,8 @@ export const GridPanel = React.memo(function GridPanel({
       onTabRename,
       onAddTab,
       onTabReorder,
+      isFleetScope,
+      titleOverride,
     ]
   );
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -100,6 +100,11 @@ export interface TerminalPaneProps {
   detectedProcessId?: string;
   // Group-level ambient state: highest-urgency state across all tabs, for container border styling
   ambientAgentState?: AgentState;
+  // Fleet scope render-time overrides: force-locks input and flags a broadcast
+  // overlay without mutating the underlying panel state. When undefined the
+  // pane falls back to the stored TerminalInstance.isInputLocked flag.
+  isInputLocked?: boolean;
+  isFleetScope?: boolean;
   // Tab support
   tabs?: import("@/components/Panel/TabButton").TabInfo[];
   onTabClick?: (tabId: string) => void;
@@ -138,6 +143,8 @@ function TerminalPaneComponent({
   gridPanelCount,
   detectedProcessId,
   ambientAgentState,
+  isInputLocked: isInputLockedOverride,
+  isFleetScope = false,
   tabs,
   onTabClick,
   onTabClose,
@@ -207,8 +214,17 @@ function TerminalPaneComponent({
     })
   );
 
-  const { isInputLocked, stateChangeTrigger, isRestarting, exitBehavior, isTrashedOrRemoved } =
-    terminalState;
+  const {
+    isInputLocked: storeInputLocked,
+    stateChangeTrigger,
+    isRestarting,
+    exitBehavior,
+    isTrashedOrRemoved,
+  } = terminalState;
+  // Fleet-scope mounts pass `isInputLocked: true` to render the panel as a
+  // read-only broadcast view. Prop takes precedence over the stored flag so
+  // unwinding scope reverts to the user-toggled lock state automatically.
+  const isInputLocked = isInputLockedOverride ?? storeInputLocked;
 
   const isBackendDisconnected = backendStatus === "disconnected";
   const isBackendRecovering = backendStatus === "recovering";
@@ -704,6 +720,7 @@ function TerminalPaneComponent({
       className={cn(
         "terminal-pane",
         isExited && "opacity-75 grayscale",
+        isFleetScope && "fleet-broadcast-overlay",
         isPinged &&
           allowPing &&
           (wasJustSelected ? "animate-terminal-ping-select" : "animate-terminal-ping")

--- a/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
+++ b/src/components/Terminal/__tests__/gridPanelPropsAreEqual.test.ts
@@ -182,4 +182,28 @@ describe("gridPanelPropsAreEqual", () => {
     });
     expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
   });
+
+  it("returns false when isFleetScope toggles", () => {
+    const prev = baseProps({ isFleetScope: false });
+    const next = baseProps({ isFleetScope: true });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns true when both isFleetScope are undefined", () => {
+    const prev = baseProps();
+    const next = baseProps();
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(true);
+  });
+
+  it("returns false when titleOverride changes", () => {
+    const prev = baseProps({ titleOverride: "wt-a — Claude" });
+    const next = baseProps({ titleOverride: "wt-b — Claude" });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
+
+  it("returns false when titleOverride becomes defined", () => {
+    const prev = baseProps({ titleOverride: undefined });
+    const next = baseProps({ titleOverride: "wt-a — Claude" });
+    expect(gridPanelPropsAreEqual(prev, next)).toBe(false);
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -1306,6 +1306,32 @@ body,
   pointer-events: none;
 }
 
+/* Fleet scope broadcast overlay — diagonal stripes signal read-only/armed
+   state on every panel rendered inside the fleet-scope grid. Rendered as a
+   pseudo-element so it never steals pointer events from selection, scroll,
+   or link-clicks inside the underlying xterm instance. */
+.fleet-broadcast-overlay {
+  position: relative;
+  contain: layout style;
+}
+
+.fleet-broadcast-overlay::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in oklab, var(--theme-tint) 10%, transparent) 0,
+    color-mix(in oklab, var(--theme-tint) 10%, transparent) 2px,
+    transparent 2px,
+    transparent 10px
+  );
+  mix-blend-mode: normal;
+  border-radius: inherit;
+}
+
 /* Backwards compatibility for older selection class */
 .terminal-focused {
   border-color: color-mix(in oklab, var(--theme-border-strong) 84%, var(--theme-text-primary));

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -30,9 +30,15 @@ const terminalStoreState = {
   activeDockTerminalId: null as string | null,
   focusedId: null as string | null,
   mruList: [] as string[],
+  maximizedId: null as string | null,
+  maximizeTarget: null as { type: string; id: string } | null,
+  preMaximizeLayout: null as { gridCols: number } | null,
   recordMru: recordMruMock,
   setFocused: setFocusedMock,
 };
+const panelSetStateMock = vi.fn((patch: Record<string, unknown>) => {
+  Object.assign(terminalStoreState, patch);
+});
 function setMockTerminals(terminals: MockTerminal[]) {
   terminalStoreState.panelsById = Object.fromEntries(terminals.map((t) => [t.id, t]));
   terminalStoreState.panelIds = terminals.map((t) => t.id);
@@ -66,6 +72,7 @@ vi.mock("@/store/focusStore", () => ({
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: {
     getState: vi.fn(() => terminalStoreState),
+    setState: panelSetStateMock,
     subscribe: subscribeMock,
   },
 }));
@@ -81,6 +88,9 @@ describe("worktreeStore", () => {
     terminalStoreState.activeDockTerminalId = null;
     terminalStoreState.focusedId = null;
     terminalStoreState.mruList = [];
+    terminalStoreState.maximizedId = null;
+    terminalStoreState.maximizeTarget = null;
+    terminalStoreState.preMaximizeLayout = null;
     focusStateGetterMock.mockReturnValue({ isFocusMode: false });
   });
 
@@ -398,6 +408,43 @@ describe("worktreeStore", () => {
       const state = useWorktreeSelectionStore.getState();
       expect(state.isFleetScopeActive).toBe(false);
       expect(state._previousActiveWorktreeId).toBeNull();
+    });
+
+    it("enterFleetScope clears any active maximize so the scope grid is visible", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-with-maximize" });
+      terminalStoreState.maximizedId = "term-maxed";
+      terminalStoreState.maximizeTarget = { type: "panel", id: "term-maxed" };
+      terminalStoreState.preMaximizeLayout = { gridCols: 2 };
+
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(panelSetStateMock).toHaveBeenCalledWith({
+        maximizedId: null,
+        maximizeTarget: null,
+        preMaximizeLayout: null,
+      });
+      expect(terminalStoreState.maximizedId).toBeNull();
+      expect(terminalStoreState.maximizeTarget).toBeNull();
+      expect(terminalStoreState.preMaximizeLayout).toBeNull();
+    });
+
+    it("exitFleetScope clears any lingering preMaximizeLayout snapshot", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      terminalStoreState.preMaximizeLayout = { gridCols: 3 };
+      panelSetStateMock.mockClear();
+
+      useWorktreeSelectionStore.getState().exitFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(panelSetStateMock).toHaveBeenCalledWith({ preMaximizeLayout: null });
+      expect(terminalStoreState.preMaximizeLayout).toBeNull();
     });
   });
 });

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -9,6 +9,7 @@ const {
   logErrorWithContextMock,
   focusStateGetterMock,
   subscribeMock,
+  panelSetStateMock,
 } = vi.hoisted(() => ({
   appSetStateMock: vi.fn().mockResolvedValue(undefined),
   applyRendererPolicyMock: vi.fn(),
@@ -17,6 +18,7 @@ const {
   logErrorWithContextMock: vi.fn(),
   focusStateGetterMock: vi.fn(() => ({ isFocusMode: false })),
   subscribeMock: vi.fn(() => vi.fn()),
+  panelSetStateMock: vi.fn(),
 }));
 
 type MockTerminal = {
@@ -36,7 +38,7 @@ const terminalStoreState = {
   recordMru: recordMruMock,
   setFocused: setFocusedMock,
 };
-const panelSetStateMock = vi.fn((patch: Record<string, unknown>) => {
+panelSetStateMock.mockImplementation((patch: Record<string, unknown>) => {
   Object.assign(terminalStoreState, patch);
 });
 function setMockTerminals(terminals: MockTerminal[]) {
@@ -77,7 +79,10 @@ vi.mock("@/store/panelStore", () => ({
   },
 }));
 
-import { useWorktreeSelectionStore } from "../worktreeStore";
+import { useWorktreeSelectionStore, setFleetArmedIdsGetter } from "../worktreeStore";
+
+let armedIdsForFleet = new Set<string>();
+setFleetArmedIdsGetter(() => armedIdsForFleet);
 
 describe("worktreeStore", () => {
   beforeEach(() => {
@@ -91,6 +96,12 @@ describe("worktreeStore", () => {
     terminalStoreState.maximizedId = null;
     terminalStoreState.maximizeTarget = null;
     terminalStoreState.preMaximizeLayout = null;
+    // clearAllMocks() wipes the panelSetStateMock implementation too, so
+    // reinstall it on every test — otherwise panelSetStateMock becomes a
+    // noop and the maximize-clear assertions silently miss behavior drift.
+    panelSetStateMock.mockImplementation((patch: Record<string, unknown>) => {
+      Object.assign(terminalStoreState, patch);
+    });
     focusStateGetterMock.mockReturnValue({ isFocusMode: false });
   });
 
@@ -445,6 +456,57 @@ describe("worktreeStore", () => {
 
       expect(panelSetStateMock).toHaveBeenCalledWith({ preMaximizeLayout: null });
       expect(terminalStoreState.preMaximizeLayout).toBeNull();
+    });
+
+    it("enterFleetScope's deferred maximize-clear bails if scope was exited first", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-race" });
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      // Exit scope synchronously before the deferred .then() resolves.
+      useWorktreeSelectionStore.getState().exitFleetScope();
+
+      // Simulate the user manually re-maximizing a panel after the exit.
+      terminalStoreState.maximizedId = "term-user-maxed";
+      terminalStoreState.maximizeTarget = { type: "panel", id: "term-user-maxed" };
+      panelSetStateMock.mockClear();
+
+      // Flush the microtask queue so the deferred import/then runs.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The enterFleetScope .then() MUST NOT wipe the user's new maximize.
+      expect(panelSetStateMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({ maximizedId: null })
+      );
+      expect(terminalStoreState.maximizedId).toBe("term-user-maxed");
+    });
+
+    it("enterFleetScope pins armed cross-worktree terminals to VISIBLE", async () => {
+      setMockTerminals([
+        { id: "term-active", worktreeId: "wt-pre-scope", location: "grid" },
+        { id: "term-armed-remote", worktreeId: "wt-other", location: "grid" },
+        { id: "term-idle-remote", worktreeId: "wt-other", location: "grid" },
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-pre-scope" });
+      armedIdsForFleet = new Set(["term-armed-remote"]);
+      applyRendererPolicyMock.mockClear();
+
+      useWorktreeSelectionStore.getState().enterFleetScope();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(applyRendererPolicyMock).toHaveBeenCalledWith(
+        "term-active",
+        TerminalRefreshTier.VISIBLE
+      );
+      expect(applyRendererPolicyMock).toHaveBeenCalledWith(
+        "term-armed-remote",
+        TerminalRefreshTier.VISIBLE
+      );
+      expect(applyRendererPolicyMock).toHaveBeenCalledWith(
+        "term-idle-remote",
+        TerminalRefreshTier.BACKGROUND
+      );
+      armedIdsForFleet = new Set();
     });
   });
 });

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { usePanelStore } from "@/store/panelStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useWorktreeSelectionStore, setFleetArmedIdsGetter } from "@/store/worktreeStore";
 import { setFleetArmingClear } from "@/store/projectStore";
 import { isAgentTerminal } from "@/utils/terminalType";
 import type { TerminalInstance } from "@shared/types";
@@ -253,6 +253,12 @@ function getActiveWorktreeId(): string | null {
 setFleetArmingClear(() => {
   useFleetArmingStore.getState().clear();
 });
+
+// Expose the armed-id set to worktreeStore so its terminal-streaming policy
+// can keep armed cross-worktree terminals at VISIBLE during fleet scope.
+// Using a getter-injection pattern (identical to `setFleetArmingClear`)
+// avoids an otherwise cyclic module import.
+setFleetArmedIdsGetter(() => useFleetArmingStore.getState().armedIds);
 
 /**
  * Module-scope subscription: when panels are removed, relocated to trash/background,

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -8,6 +8,15 @@ import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { setWorktreeSelectionStoreGetter } from "./projectStore";
 
+// Getter injected by fleetArmingStore at module init to break the import
+// cycle (fleetArmingStore imports worktreeStore). Returns the current armed
+// terminal id set so `applyWorktreeTerminalPolicy` can keep armed
+// cross-worktree terminals at VISIBLE while fleet scope is active.
+let _getArmedIds: (() => Set<string>) | null = null;
+export function setFleetArmedIdsGetter(getter: () => Set<string>): void {
+  _getArmedIds = getter;
+}
+
 interface CreateDialogState {
   isOpen: boolean;
   initialIssue: GitHubIssue | null;
@@ -519,16 +528,24 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     // Idempotent: first pre-scope activeWorktreeId wins so the restoration
     // target isn't corrupted by a double-enter.
     if (get().isFleetScopeActive) return;
+    const activeWorktreeId = get().activeWorktreeId;
+    const generation = get()._policyGeneration + 1;
     set({
       isFleetScopeActive: true,
-      _previousActiveWorktreeId: get().activeWorktreeId,
+      _previousActiveWorktreeId: activeWorktreeId,
+      _policyGeneration: generation,
     });
     // Clear any active maximize so the fleet-scope render path isn't shadowed
     // by the single-panel/group maximize branch in ContentGrid. Also clear the
     // preMaximizeLayout snapshot so exiting scope later doesn't restore a
     // stale layout captured against a different worktree.
+    //
+    // Guard inside the resolved callback: the dynamic import resolves on a
+    // later microtask, so if the caller entered and exited scope back-to-back
+    // we must not wipe a maximize the user set after the exit.
     void loadTerminalStoreModule()
       .then(({ usePanelStore }) => {
+        if (!get().isFleetScopeActive) return;
         usePanelStore.setState({
           maximizedId: null,
           maximizeTarget: null,
@@ -536,6 +553,10 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
         });
       })
       .catch(() => {});
+    // Promote armed cross-worktree terminals to VISIBLE so their xterm
+    // instances actually stream live output inside the fleet grid. The
+    // policy function consults `isFleetScopeActive` + the armed set.
+    applyWorktreeTerminalPolicy(get, set, activeWorktreeId, generation);
   },
 
   exitFleetScope: () => {
@@ -613,6 +634,15 @@ function applyWorktreeTerminalPolicy(
       const { panelsById, panelIds } = usePanelStore.getState();
       const activeDockTerminalId = usePanelStore.getState().activeDockTerminalId;
 
+      // Fleet scope pins armed grid/agent terminals to VISIBLE regardless of
+      // worktree affiliation — the whole point of the scope view is to see
+      // live output across worktrees. Without this, cross-worktree armed
+      // terminals would get demoted to BACKGROUND and show stale/frozen
+      // content even though they are mounted in the fleet grid. We fetch the
+      // armed set through an injected getter to avoid a cyclic import.
+      const fleetActive = get().isFleetScopeActive;
+      const armedIds = fleetActive && _getArmedIds ? _getArmedIds() : null;
+
       for (const id of panelIds) {
         const terminal = panelsById[id];
         if (!terminal) continue;
@@ -627,8 +657,10 @@ function applyWorktreeTerminalPolicy(
           continue;
         }
 
+        const isArmedInFleetScope = armedIds?.has(terminal.id) && !isDockOrTrash;
+
         const targetTier =
-          isInActiveWorktree && !isDockOrTrash
+          isArmedInFleetScope || (isInActiveWorktree && !isDockOrTrash)
             ? TerminalRefreshTier.VISIBLE
             : TerminalRefreshTier.BACKGROUND;
 

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -523,6 +523,19 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       isFleetScopeActive: true,
       _previousActiveWorktreeId: get().activeWorktreeId,
     });
+    // Clear any active maximize so the fleet-scope render path isn't shadowed
+    // by the single-panel/group maximize branch in ContentGrid. Also clear the
+    // preMaximizeLayout snapshot so exiting scope later doesn't restore a
+    // stale layout captured against a different worktree.
+    void loadTerminalStoreModule()
+      .then(({ usePanelStore }) => {
+        usePanelStore.setState({
+          maximizedId: null,
+          maximizeTarget: null,
+          preMaximizeLayout: null,
+        });
+      })
+      .catch(() => {});
   },
 
   exitFleetScope: () => {
@@ -537,6 +550,13 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
       _policyGeneration: generation,
     });
     persistActiveWorktree(restoreId);
+    // Defensive: drop any preMaximizeLayout snapshot that may have survived
+    // scope entry. The restored worktree's layout should be computed fresh.
+    void loadTerminalStoreModule()
+      .then(({ usePanelStore }) => {
+        usePanelStore.setState({ preMaximizeLayout: null });
+      })
+      .catch(() => {});
     // Reconcile terminal streaming tiers: consumers may have mutated
     // activeWorktreeId during scope, so the renderer policy must be
     // reapplied for the restored worktree.


### PR DESCRIPTION
## Summary

- When Fleet scope is active (`fleetScopeMode === "scoped"` and `isFleetScopeActive`), the main ContentGrid replaces its normal worktree-filtered panel list with the full armed terminal set. Terminals from multiple worktrees render together as a flat, ungrouped grid.
- Every panel in this view has keyboard input locked (read-only scroll, copy, and search still work), with a diagonal-stripe overlay signalling broadcast mode. DnD, maximize, and tab-group rendering are all bypassed.
- Maximize state is cleared on scope enter and exit to prevent stale layout bleed. Armed cross-worktree terminals are promoted to the VISIBLE streaming tier so they stay live in the grid.

Resolves #5560

## Changes

- `ContentGrid.tsx`: new Fleet scope render branch before the maximize branch; handles title disambiguation when the armed set spans more than one worktree, a dedicated batch-fit effect, and VISIBLE tier promotion for armed panels
- `GridPanel.tsx`: `isFleetScope` and `titleOverride` props added; maximize/minimize/add-tab handlers suppressed in scope; `gridPanelPropsAreEqual` updated to match
- `TerminalPane.tsx`: optional `isInputLocked` override prop (takes precedence over store value); optional `isFleetScope` prop applies the `fleet-broadcast-overlay` CSS class to the panel
- `worktreeStore.ts`: `enterFleetScope` clears maximize and pre-maximize layout with a deferred-bail guard against exit-races; re-applies terminal streaming policy to promote armed terminals; `exitFleetScope` defensively drops `preMaximizeLayout`; `setFleetArmedIdsGetter` injection point breaks the import cycle
- `fleetArmingStore.ts`: registers the armed-ids getter during module init
- `index.css`: `.fleet-broadcast-overlay` — repeating 45° stripe pattern via `::after`, `pointer-events: none`, `z-index: 2`, `contain: layout style`

## Testing

- Unit tests extended: 4 new cases in `worktreeStore.test.ts` (maximize clear on enter, pre-maximize layout clear on exit, stale-callback race guard, armed cross-worktree VISIBLE pinning); `gridPanelPropsAreEqual.test.ts` extended with `isFleetScope` and `titleOverride` cases