### PR TITLE
feat(fleet): pin composer to grid header when scope active

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -6,6 +6,7 @@ import { useEscapeStack } from "@/hooks";
 import { useFleetArmingStore, type FleetArmStatePreset } from "@/store/fleetArmingStore";
 import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import {
   useFleetPendingActionStore,
   type FleetPendingActionKind,
@@ -116,9 +117,14 @@ export function FleetArmingRibbon(): ReactElement | null {
   const clearPending = useFleetPendingActionStore((s) => s.clear);
   const isDeckOpen = useFleetDeckStore((s) => s.isOpen);
   // When Fleet scope is active, the composer renders in the pinned grid
-  // header (FleetScopeComposerHeader) above ContentGrid instead of here —
-  // avoid double-mounting which would duplicate the focus handler.
-  const isFleetScopeActive = useFleetScopeFlagStore((s) => s.mode === "scoped");
+  // header (FleetScopeComposerHeader) above ContentGrid instead of here.
+  // Mirror ContentGrid's `isFleetScopeEnabled` predicate exactly (mode flag
+  // AND session-level `isFleetScopeActive`) — if we hid the ribbon composer
+  // whenever mode="scoped" the user would briefly lose the composer while
+  // the flag is on but scope has not been entered yet.
+  const fleetScopeMode = useFleetScopeFlagStore((s) => s.mode);
+  const isWorktreeScopeActive = useWorktreeSelectionStore((s) => s.isFleetScopeActive);
+  const isFleetScopeHeaderMounted = fleetScopeMode === "scoped" && isWorktreeScopeActive;
 
   // Escape stack: confirmation cancel sits above the fleet-disarm entry, so
   // the first Escape while confirming clears the pending action and a
@@ -354,7 +360,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
-      {!isDeckOpen && !isFleetScopeActive && <FleetComposer />}
+      {!isDeckOpen && !isFleetScopeHeaderMounted && <FleetComposer />}
     </div>
   );
 }

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { useEscapeStack } from "@/hooks";
 import { useFleetArmingStore, type FleetArmStatePreset } from "@/store/fleetArmingStore";
 import { useFleetDeckStore } from "@/store/fleetDeckStore";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import {
   useFleetPendingActionStore,
   type FleetPendingActionKind,
@@ -114,6 +115,10 @@ export function FleetArmingRibbon(): ReactElement | null {
   const pending = useFleetPendingActionStore((s) => s.pending);
   const clearPending = useFleetPendingActionStore((s) => s.clear);
   const isDeckOpen = useFleetDeckStore((s) => s.isOpen);
+  // When Fleet scope is active, the composer renders in the pinned grid
+  // header (FleetScopeComposerHeader) above ContentGrid instead of here —
+  // avoid double-mounting which would duplicate the focus handler.
+  const isFleetScopeActive = useFleetScopeFlagStore((s) => s.mode === "scoped");
 
   // Escape stack: confirmation cancel sits above the fleet-disarm entry, so
   // the first Escape while confirming clears the pending action and a
@@ -349,7 +354,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           <X className="h-3.5 w-3.5" />
         </button>
       </div>
-      {!isDeckOpen && <FleetComposer />}
+      {!isDeckOpen && !isFleetScopeActive && <FleetComposer />}
     </div>
   );
 }

--- a/src/components/Fleet/FleetScopeComposerHeader.tsx
+++ b/src/components/Fleet/FleetScopeComposerHeader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactElement } from "react";
 import { cn } from "@/lib/utils";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import { FleetComposer } from "./FleetComposer";
 import { focusFleetComposer } from "./fleetComposerFocus";
 
@@ -14,12 +15,18 @@ export function FleetScopeComposerHeader({
   worktreeCount,
   className,
 }: FleetScopeComposerHeaderProps): ReactElement {
+  // When the deck is open, the deck renders its own FleetComposer. Skip the
+  // header's composer to avoid double-mount — the single-slot focus registry
+  // would otherwise be hijacked by whichever composer mounts second.
+  const isDeckOpen = useFleetDeckStore((s) => s.isOpen);
+
   // Autofocus the composer when the header first mounts (scope entry).
   // Child effects fire before parent effects, so FleetComposer's
   // registerFleetComposerFocusHandler runs before this call.
   useEffect(() => {
+    if (isDeckOpen) return;
     focusFleetComposer();
-  }, []);
+  }, [isDeckOpen]);
 
   const agentWord = agentCount === 1 ? "agent" : "agents";
   const worktreeWord = worktreeCount === 1 ? "worktree" : "worktrees";
@@ -34,7 +41,7 @@ export function FleetScopeComposerHeader({
           Broadcasting to {agentCount} {agentWord} across {worktreeCount} {worktreeWord}
         </span>
       </div>
-      <FleetComposer />
+      {!isDeckOpen && <FleetComposer />}
     </div>
   );
 }

--- a/src/components/Fleet/FleetScopeComposerHeader.tsx
+++ b/src/components/Fleet/FleetScopeComposerHeader.tsx
@@ -1,0 +1,40 @@
+import { useEffect, type ReactElement } from "react";
+import { cn } from "@/lib/utils";
+import { FleetComposer } from "./FleetComposer";
+import { focusFleetComposer } from "./fleetComposerFocus";
+
+interface FleetScopeComposerHeaderProps {
+  agentCount: number;
+  worktreeCount: number;
+  className?: string;
+}
+
+export function FleetScopeComposerHeader({
+  agentCount,
+  worktreeCount,
+  className,
+}: FleetScopeComposerHeaderProps): ReactElement {
+  // Autofocus the composer when the header first mounts (scope entry).
+  // Child effects fire before parent effects, so FleetComposer's
+  // registerFleetComposerFocusHandler runs before this call.
+  useEffect(() => {
+    focusFleetComposer();
+  }, []);
+
+  const agentWord = agentCount === 1 ? "agent" : "agents";
+  const worktreeWord = worktreeCount === 1 ? "worktree" : "worktrees";
+
+  return (
+    <div
+      className={cn("shrink-0 border-b border-daintree-accent/40 bg-daintree-accent/5", className)}
+      data-testid="fleet-scope-composer-header"
+    >
+      <div className="flex items-center gap-2 px-3 pt-1.5 text-[11px] font-medium uppercase tracking-wide text-daintree-accent/90">
+        <span aria-live="polite">
+          Broadcasting to {agentCount} {agentWord} across {worktreeCount} {worktreeWord}
+        </span>
+      </div>
+      <FleetComposer />
+    </div>
+  );
+}

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -22,7 +22,7 @@ function resetStores() {
   useFleetDeckStore.setState({ isOpen: false });
   useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
-  useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
+  useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1", isFleetScopeActive: false });
   useAnnouncerStore.setState({ polite: null, assertive: null });
 }
 
@@ -233,6 +233,10 @@ describe("FleetArmingRibbon", () => {
       useFleetArmingStore.getState().armIds(["a"]);
       useFleetDeckStore.setState({ isOpen: false });
       useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+      useWorktreeSelectionStore.setState({
+        activeWorktreeId: "wt-1",
+        isFleetScopeActive: true,
+      });
       render(<FleetArmingRibbon />);
       // Composer moves to the pinned grid header when scope is active.
       expect(screen.queryByTestId("fleet-composer")).toBeNull();
@@ -240,6 +244,21 @@ describe("FleetArmingRibbon", () => {
       expect(screen.queryByTestId("fleet-arming-ribbon")).toBeTruthy();
       expect(screen.queryByTestId("fleet-quick-accept")).toBeTruthy();
       expect(screen.queryByTestId("fleet-quick-kill")).toBeTruthy();
+    });
+
+    it("keeps the embedded FleetComposer when flag is 'scoped' but scope not entered", () => {
+      // Feature flag on, but user has not dispatched fleet.scope.enter yet —
+      // ContentGrid wouldn't render its pinned header in this state, so the
+      // ribbon must keep the composer to avoid leaving the user without one.
+      useFleetArmingStore.getState().armIds(["a"]);
+      useFleetDeckStore.setState({ isOpen: false });
+      useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+      useWorktreeSelectionStore.setState({
+        activeWorktreeId: "wt-1",
+        isFleetScopeActive: false,
+      });
+      render(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-composer")).toBeTruthy();
     });
   });
 });

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -5,6 +5,7 @@ import { FleetArmingRibbon } from "../FleetArmingRibbon";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
 import { useFleetDeckStore } from "@/store/fleetDeckStore";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -19,6 +20,7 @@ function resetStores() {
   });
   useFleetPendingActionStore.setState({ pending: null });
   useFleetDeckStore.setState({ isOpen: false });
+  useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
   useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-1" });
   useAnnouncerStore.setState({ polite: null, assertive: null });
@@ -225,6 +227,19 @@ describe("FleetArmingRibbon", () => {
       expect(screen.queryByTestId("fleet-composer")).toBeNull();
       // The ribbon itself still renders — only the composer is suppressed.
       expect(screen.queryByTestId("fleet-arming-ribbon")).toBeTruthy();
+    });
+
+    it("suppresses the embedded FleetComposer when Fleet scope is active", () => {
+      useFleetArmingStore.getState().armIds(["a"]);
+      useFleetDeckStore.setState({ isOpen: false });
+      useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+      render(<FleetArmingRibbon />);
+      // Composer moves to the pinned grid header when scope is active.
+      expect(screen.queryByTestId("fleet-composer")).toBeNull();
+      // The ribbon itself — including quick-action buttons — still renders.
+      expect(screen.queryByTestId("fleet-arming-ribbon")).toBeTruthy();
+      expect(screen.queryByTestId("fleet-quick-accept")).toBeTruthy();
+      expect(screen.queryByTestId("fleet-quick-kill")).toBeTruthy();
     });
   });
 });

--- a/src/components/Fleet/__tests__/FleetScopeComposerHeader.test.tsx
+++ b/src/components/Fleet/__tests__/FleetScopeComposerHeader.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { FleetScopeComposerHeader } from "../FleetScopeComposerHeader";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import { useFleetDeckStore } from "@/store/fleetDeckStore";
 import { usePanelStore } from "@/store/panelStore";
 
 function resetStores() {
@@ -19,6 +20,7 @@ function resetStores() {
     lastFailedIds: [],
     lastBroadcastPrompt: "",
   });
+  useFleetDeckStore.setState({ isOpen: false });
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
 }
 
@@ -59,5 +61,17 @@ describe("FleetScopeComposerHeader", () => {
     } finally {
       HTMLTextAreaElement.prototype.focus = originalFocus;
     }
+  });
+
+  it("suppresses its own FleetComposer when the Fleet Deck is open", () => {
+    // The deck renders its own FleetComposer; double-mounting would cause
+    // the single-slot focus registry to be hijacked by whichever mounts
+    // second, misdirecting terminal.focusFleetComposer.
+    useFleetArmingStore.getState().armIds(["a"]);
+    useFleetDeckStore.setState({ isOpen: true });
+    render(<FleetScopeComposerHeader agentCount={1} worktreeCount={1} />);
+    expect(screen.queryByTestId("fleet-composer")).toBeNull();
+    // The label is still shown so users know they are in broadcast context.
+    expect(screen.getByText("Broadcasting to 1 agent across 1 worktree")).toBeTruthy();
   });
 });

--- a/src/components/Fleet/__tests__/FleetScopeComposerHeader.test.tsx
+++ b/src/components/Fleet/__tests__/FleetScopeComposerHeader.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FleetScopeComposerHeader } from "../FleetScopeComposerHeader";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetComposerStore } from "@/store/fleetComposerStore";
+import { usePanelStore } from "@/store/panelStore";
+
+function resetStores() {
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  useFleetComposerStore.setState({
+    draft: "",
+    dryRunRequested: false,
+    lastFailedIds: [],
+    lastBroadcastPrompt: "",
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+}
+
+describe("FleetScopeComposerHeader", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("renders the broadcast label with agent and worktree counts", () => {
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    render(<FleetScopeComposerHeader agentCount={2} worktreeCount={3} />);
+    expect(screen.getByText("Broadcasting to 2 agents across 3 worktrees")).toBeTruthy();
+  });
+
+  it("uses singular forms for a single agent and single worktree", () => {
+    useFleetArmingStore.getState().armIds(["a"]);
+    render(<FleetScopeComposerHeader agentCount={1} worktreeCount={1} />);
+    expect(screen.getByText("Broadcasting to 1 agent across 1 worktree")).toBeTruthy();
+  });
+
+  it("mounts the FleetComposer inside the header", () => {
+    useFleetArmingStore.getState().armIds(["a"]);
+    render(<FleetScopeComposerHeader agentCount={1} worktreeCount={1} />);
+    expect(screen.getByTestId("fleet-composer")).toBeTruthy();
+  });
+
+  it("autofocuses the composer textarea on mount", () => {
+    useFleetArmingStore.getState().armIds(["a"]);
+    const originalFocus = HTMLTextAreaElement.prototype.focus;
+    const spy = vi.fn();
+    HTMLTextAreaElement.prototype.focus = spy;
+    try {
+      // Effect ordering: child (FleetComposer) registers the focus handler
+      // in its mount effect first, then the parent header's mount effect
+      // invokes focusFleetComposer() which calls textarea.focus().
+      render(<FleetScopeComposerHeader agentCount={1} worktreeCount={1} />);
+      expect(spy).toHaveBeenCalled();
+    } finally {
+      HTMLTextAreaElement.prototype.focus = originalFocus;
+    }
+  });
+});

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -745,7 +745,7 @@ export function ContentGrid({
     for (const t of fleetPanels) {
       if (t.worktreeId) ids.add(t.worktreeId);
     }
-    return Math.max(ids.size, 1);
+    return ids.size;
   }, [fleetPanels]);
 
   const fleetGridCols = useMemo(() => {

--- a/src/components/Terminal/ContentGrid.tsx
+++ b/src/components/Terminal/ContentGrid.tsx
@@ -61,6 +61,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { RecipeRunner } from "./RecipeRunner/RecipeRunner";
+import { FleetScopeComposerHeader } from "@/components/Fleet/FleetScopeComposerHeader";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
@@ -738,6 +739,15 @@ export function ContentGrid({
     return fleetPanels.some((t) => (t.worktreeId ?? null) !== firstWorktreeId);
   }, [fleetPanels]);
 
+  const fleetWorktreeCount = useMemo(() => {
+    if (fleetPanels.length === 0) return 0;
+    const ids = new Set<string>();
+    for (const t of fleetPanels) {
+      if (t.worktreeId) ids.add(t.worktreeId);
+    }
+    return Math.max(ids.size, 1);
+  }, [fleetPanels]);
+
   const fleetGridCols = useMemo(() => {
     if (!isFleetScopeRender) return 1;
     const { strategy, value } = layoutConfig;
@@ -997,6 +1007,10 @@ export function ContentGrid({
       >
         <GridNotificationBar className="mx-1 mt-1 shrink-0" />
         <TerminalCountWarning className="mx-1 mt-1 shrink-0" />
+        <FleetScopeComposerHeader
+          agentCount={fleetPanels.length}
+          worktreeCount={fleetWorktreeCount}
+        />
         <div className="relative flex-1 min-h-0">
           <ContextMenu>
             <ContextMenuTrigger asChild>


### PR DESCRIPTION
## Summary

- Adds `FleetScopeComposerHeader` which renders `FleetComposer` as a full-width header above the terminal grid when Fleet scope is active, with a "Broadcasting to N agents across M worktrees" label and autofocus on mount.
- `ContentGrid` gates the header on `isFleetScopeEnabled` (requires both `fleetScopeMode === "scoped"` and an active scope session), keeping the existing ribbon composer path fully intact when scope is inactive.
- `FleetArmingRibbon` suppresses its own composer when `isFleetScopeHeaderMounted` is true, closing the flag-on-but-not-entered gap and preventing a double-mount of the single-slot focus registry when the deck is open.

Resolves #5561

## Changes

- `FleetScopeComposerHeader.tsx` — new component wrapping `FleetComposer` with scope label, autofocus effect, and deck-open guard
- `ContentGrid.tsx` — renders the header above the grid when `isFleetScopeEnabled`; exposes `isFleetScopeHeaderMounted` to the ribbon via store
- `FleetArmingRibbon.tsx` — gates its embedded composer on `!isDeckOpen && !isFleetScopeHeaderMounted`
- Tests covering scope suppression, the flag-vs-session-state gap, and the deck double-mount guard

## Testing

Unit tests added for all three new guard conditions. All existing Fleet composer behaviour (recipes, dry-run, retry, quorum, destructive warnings, history recall) is unchanged — the component moves DOM parents but keeps its full logic intact.